### PR TITLE
Phase 1: Pjax 비동기 라우팅

### DIFF
--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -1,3 +1,5 @@
+import json
+import re
 import pytest
 import time
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -226,3 +228,176 @@ def test_logout(mock_web_app_context_cls):
         response = client.get("/logout", follow_redirects=False)
         assert response.status_code == 307
         assert "access_token" in response.headers.get("set-cookie", "")
+
+
+# --- /balance 페이지 테스트 ---
+
+_INITIAL_DATA_RE = re.compile(
+    r'<script id="page-initial-data" type="application/json">(.*?)</script>',
+    re.DOTALL,
+)
+
+
+def _parse_initial_data(html: str) -> dict | None:
+    """balance.html의 page-initial-data 스크립트 태그에서 JSON을 파싱해 반환."""
+    m = _INITIAL_DATA_RE.search(html)
+    return json.loads(m.group(1)) if m else None
+
+
+def _make_balance_ctx(is_paper_trading=True, acc_no_field="stock_account_number", acc_no_value="12345678"):
+    """balance 테스트용 mock ctx 헬퍼."""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": True, "auth": {"secret_key": "tok"}}
+    mock_ctx.stock_query_service.handle_get_account_balance = AsyncMock(return_value=MagicMock())
+
+    mock_env = MagicMock()
+    mock_env.is_paper_trading = is_paper_trading
+    config = {}
+    if acc_no_value is not None:
+        config[acc_no_field] = acc_no_value
+    mock_env.active_config = config
+    mock_env.stock_account_number = None
+    mock_ctx.env = mock_env
+    return mock_ctx, mock_env
+
+
+def test_balance_paper_trading_with_account_number(mock_web_app_context_cls):
+    """모의투자 환경, stock_account_number로 계좌번호 조회 테스트"""
+    mock_ctx, _ = _make_balance_ctx(is_paper_trading=True, acc_no_field="stock_account_number", acc_no_value="99887766")
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert data["account_info"]["number"] == "99887766"
+    assert data["account_info"]["type"] == "모의투자"
+    assert data["account_info"]["exchange"] == "KRX"
+
+
+def test_balance_real_trading_with_cano(mock_web_app_context_cls):
+    """실전투자 환경, CANO로 계좌번호 조회 테스트"""
+    mock_ctx, _ = _make_balance_ctx(is_paper_trading=False, acc_no_field="CANO", acc_no_value="55443322")
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert data["account_info"]["number"] == "55443322"
+    assert data["account_info"]["type"] == "실전투자"
+
+
+def test_balance_acc_no_from_env_attribute(mock_web_app_context_cls):
+    """active_config에 없고 env.stock_account_number로 계좌번호 fallback 테스트"""
+    mock_ctx, mock_env = _make_balance_ctx(acc_no_value=None)
+    mock_env.stock_account_number = "11112222"
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert data["account_info"]["number"] == "11112222"
+
+
+def test_balance_acc_no_fallback_to_default(mock_web_app_context_cls):
+    """계좌번호 모든 소스가 None일 때 '번호없음' fallback 테스트"""
+    mock_ctx, mock_env = _make_balance_ctx(acc_no_value=None)
+    mock_env.stock_account_number = None
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert data["account_info"]["number"] == "번호없음"
+
+
+def test_balance_env_via_broker(mock_web_app_context_cls):
+    """ctx.env가 None이고 ctx.broker.env로 env 조회 fallback 테스트"""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": True, "auth": {"secret_key": "tok"}}
+    mock_ctx.stock_query_service.handle_get_account_balance = AsyncMock(return_value=MagicMock())
+    mock_ctx.env = None  # env 없음
+
+    mock_broker_env = MagicMock()
+    mock_broker_env.is_paper_trading = True
+    mock_broker_env.active_config = {"stock_account_number": "77665544"}
+    mock_broker_env.stock_account_number = None
+    mock_ctx.broker.env = mock_broker_env
+
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert data["account_info"]["number"] == "77665544"
+
+
+def test_balance_no_env_no_account_info(mock_web_app_context_cls):
+    """ctx.env 와 ctx.broker.env 모두 None → account_info 없이 페이지 정상 렌더 테스트"""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": True, "auth": {"secret_key": "tok"}}
+    mock_ctx.stock_query_service.handle_get_account_balance = AsyncMock(return_value=MagicMock())
+    mock_ctx.env = None
+    mock_ctx.broker = None
+
+    fake_result = {"output": []}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    assert "Investment Login" not in response.text
+    data = _parse_initial_data(response.text)
+    assert data is not None
+    assert "account_info" not in data
+
+
+def test_balance_exception_fallback_renders_page(mock_web_app_context_cls):
+    """잔고 API 예외 발생 시 initial_data=None으로 페이지 정상 렌더 테스트"""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": True, "auth": {"secret_key": "tok"}}
+    mock_ctx.stock_query_service.handle_get_account_balance = AsyncMock(
+        side_effect=RuntimeError("API 오류")
+    )
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
+        with TestClient(app) as client:
+            client.cookies.set("access_token", "tok")
+            response = client.get("/balance")
+
+    assert response.status_code == 200
+    assert "Investment Login" not in response.text
+    # 예외 발생 시 initial_data 스크립트 태그가 렌더링되지 않아야 함
+    assert _parse_initial_data(response.text) is None

--- a/view/web/static/js/autocomplete.js
+++ b/view/web/static/js/autocomplete.js
@@ -81,7 +81,7 @@ function StockAutocomplete({ inputId, listId, onSelect, onConfirm }) {
         return results;
     }
 
-    document.addEventListener('DOMContentLoaded', function () {
+    function _initDom() {
         const input = document.getElementById(inputId);
         const list = document.getElementById(listId);
         if (!input || !list) return;
@@ -153,5 +153,10 @@ function StockAutocomplete({ inputId, listId, onSelect, onConfirm }) {
         document.addEventListener('click', function (e) {
             if (!input.contains(e.target) && !list.contains(e.target)) _close();
         });
-    });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _initDom);
+    } else {
+        _initDom(); // Pjax 컨텍스트: DOM 이미 준비됨 → 즉시 실행
+    }
 }

--- a/view/web/static/js/balance.js
+++ b/view/web/static/js/balance.js
@@ -149,6 +149,26 @@ function _showBalanceSkeleton() {
 async function loadBalance(exchange) {
     const exch = exchange || currentBalanceExchange || 'KRX';
     currentBalanceExchange = exch;
+
+    // 서버 하이드레이션 데이터 확인 (초기 fetch 워터폴 제거)
+    if (!exchange) {
+        const dataScript = document.getElementById('page-initial-data');
+        if (dataScript) {
+            try {
+                const json = JSON.parse(dataScript.textContent);
+                dataScript.remove(); // 1회 소비 후 삭제 (상태 오염 방지)
+                if (json && json.rt_cd === "0") {
+                    balanceSummaryCache = (json.data?.output2?.length > 0) ? json.data.output2[0] : {};
+                    balanceStocksCache = json.data?.output1 || [];
+                    balanceAccInfoCache = json.account_info || { number: '-', type: '-' };
+                    balanceSortState = { key: null, dir: 'asc' };
+                    renderBalanceTable();
+                    return;
+                }
+            } catch (_) { /* 파싱 실패 시 일반 fetch로 폴백 */ }
+        }
+    }
+
     _showBalanceSkeleton();
     try {
         const res = await fetchWithTimeout(`/api/balance?exchange=${exch}`);

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -327,6 +327,10 @@ function renderStockChart(period) {
     console.log("ohlcv last date:", g_chartRawData[last].date, "close:", g_chartRawData[last].close)
     console.log("ma5 last date:", g_chartIndicators.ma5[last]?.date, "ma:", g_chartIndicators.ma5[last]?.ma)
 
+    window.currentCharts = window.currentCharts || [];
+    window.currentCharts = window.currentCharts.filter(c => c !== stockChartInstance);
+    window.currentCharts.push(stockChartInstance);
+
     // [성능 측정] 데이터 가공 + Chart.js 생성 시간 로깅
     const tRenderEnd = performance.now();
     console.log(`[Perf] 차트 렌더링(${period}, ${slicedRaw.length}건): 데이터 가공 ${(tChartStart - tRenderStart).toFixed(1)}ms | Chart.js 생성 ${(tRenderEnd - tChartStart).toFixed(1)}ms | 합계 ${(tRenderEnd - tRenderStart).toFixed(1)}ms`);

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -90,19 +90,108 @@ async function withLoading(btn, targetEl, message, asyncFn) {
 }
 
 // ==========================================
-// 페이지 전환 로딩 오버레이
+// Pjax 비동기 라우팅
 // ==========================================
+
+// 이미 로드된 외부 스크립트 src URL 추적 (중복 로드 방지)
+const _loadedScripts = new Set(
+    Array.from(document.querySelectorAll('script[src]')).map(s => s.src)
+);
+
+// Chart.js 인스턴스 전역 레지스트리 — 페이지 전환 전 .destroy() 호출
+window.currentCharts = window.currentCharts || [];
+
+function loadScript(src) {
+    return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = src;
+        script.onload = resolve;
+        script.onerror = reject;
+        document.head.appendChild(script);
+    });
+}
+
+async function executePageScripts(container) {
+    const scripts = Array.from(container.querySelectorAll('script'));
+    for (const oldScript of scripts) {
+        if (oldScript.src) {
+            const normalizedSrc = new URL(oldScript.src, location.href).href;
+            if (!_loadedScripts.has(normalizedSrc)) {
+                _loadedScripts.add(normalizedSrc);
+                try { await loadScript(oldScript.src); } catch (e) { console.error('Script load failed:', oldScript.src, e); }
+            }
+            // 이미 로드된 src 스크립트는 skip (중복 실행 방지)
+        } else if (oldScript.textContent.trim()) {
+            try { new Function(oldScript.textContent)(); } catch (e) { console.error('Inline script error:', e); }
+        }
+    }
+}
+
+function updateNavActive(pathname) {
+    document.querySelectorAll('nav.nav a').forEach(a => {
+        const href = a.getAttribute('href');
+        a.classList.toggle('active', href === pathname || (pathname === '/' && href === '/'));
+    });
+}
+
+async function navigatePjax(href) {
+    const overlay = document.getElementById('page-loading-overlay');
+    if (overlay) overlay.classList.add('active');
+
+    // 페이지 이탈 전 Chart.js 인스턴스 정리
+    if (window.currentCharts && window.currentCharts.length > 0) {
+        window.currentCharts.forEach(chart => { try { chart.destroy(); } catch (_) {} });
+        window.currentCharts = [];
+    }
+
+    try {
+        const response = await fetchWithTimeout(href, {}, 15000);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const html = await response.text();
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const newMain = doc.querySelector('#page-main');
+        if (!newMain) throw new Error('page-main not found');
+
+        const pageMain = document.querySelector('#page-main');
+        pageMain.innerHTML = newMain.innerHTML;
+
+        await executePageScripts(pageMain);
+
+        const targetPath = new URL(href, location.href).pathname;
+        window.history.pushState({path: href}, '', href);
+        updateNavActive(targetPath);
+
+        // 페이지별 외부 JS의 초기화 함수 트리거 (DOMContentLoaded 대체)
+        document.dispatchEvent(new CustomEvent('pjax:ready', { detail: { path: targetPath } }));
+
+    } catch (error) {
+        console.error('Pjax 전환 실패, 일반 이동:', error);
+        window.location.href = href;
+    } finally {
+        if (overlay) overlay.classList.remove('active');
+    }
+}
+
+// 네비게이션 클릭 가로채기
 document.addEventListener('click', (e) => {
     const link = e.target.closest('nav.nav a');
     if (!link) return;
     const href = link.getAttribute('href');
-    if (!href || href === '#' || href === window.location.pathname) return;
+    if (!href || href === '#') return;
+    if (new URL(href, location.href).pathname === location.pathname) return;
 
-    const overlay = document.getElementById('page-loading-overlay');
-    if (overlay) overlay.classList.add('active');
+    e.preventDefault();
+    navigatePjax(href);
 });
 
-// bfcache 복원 시 오버레이 해제
+// 뒤로가기/앞으로가기도 Pjax로 처리
+window.addEventListener('popstate', () => {
+    navigatePjax(location.pathname);
+});
+
+// bfcache 복원 시 오버레이 해제 (폴백)
 window.addEventListener('pageshow', () => {
     const overlay = document.getElementById('page-loading-overlay');
     if (overlay) overlay.classList.remove('active');

--- a/view/web/static/js/favorite.js
+++ b/view/web/static/js/favorite.js
@@ -109,3 +109,18 @@ window.addEventListener('beforeunload', function () {
 
 /* ── 초기 로드 ── */
 document.addEventListener('DOMContentLoaded', loadFavoriteList);
+
+/* ── Pjax 재방문 시 재초기화 ── */
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/favorite') return;
+    StockAutocomplete({
+        inputId: 'fav-search-input',
+        listId: 'fav-autocomplete-list',
+        onSelect: function(code, name) {
+            const input = document.getElementById('fav-search-input');
+            if (input) { input.value = name + ' (' + code + ')'; input.dataset.selectedCode = code; }
+        },
+        onConfirm: function() { addFavoriteFromInput(); }
+    });
+    loadFavoriteList();
+});

--- a/view/web/static/js/program_chart.js
+++ b/view/web/static/js/program_chart.js
@@ -242,6 +242,8 @@ window.initProgramChart = function(timeUnit) {
             }
         }
     });
+    window.currentCharts = window.currentCharts || [];
+    window.currentCharts.push(ptChart);
 };
 
 /**
@@ -330,6 +332,7 @@ window.setPtChartTimeUnit = function(minutes) {
  */
 window.destroyProgramChart = function() {
     if (ptChart) {
+        if (window.currentCharts) window.currentCharts = window.currentCharts.filter(c => c !== ptChart);
         ptChart.destroy();
         ptChart = null;
     }

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -56,6 +56,21 @@ StockAutocomplete({
     onConfirm: function() { searchStock(); }
 });
 
+/* ── Pjax 재방문 시 자동완성 재초기화 ── */
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/stock') return;
+    StockAutocomplete({
+        inputId: 'stock-code-input',
+        listId: 'stock-autocomplete-list',
+        onSelect: function(code) {
+            const input = document.getElementById('stock-code-input');
+            if (input) input.value = code;
+            searchStock(code);
+        },
+        onConfirm: function() { searchStock(); }
+    });
+});
+
 /**
  * 입력값을 종목코드로 변환. 6자리 숫자면 그대로, 아니면 ALL_STOCKS에서 탐색.
  * 반환: { code, error } — code가 있으면 성공, error가 있으면 실패 메시지.

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -509,3 +509,11 @@ async function updateSubscriptionStatus() {
 
 document.addEventListener('DOMContentLoaded', () => setTimeout(updateSubscriptionStatus, 3000));  // 다른 폴링과 시차 분산
 setInterval(updateSubscriptionStatus, 5000);
+
+/* ── Pjax 재방문 시 상태 즉시 갱신 ── */
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/system') return;
+    updateCacheStatus();
+    setTimeout(updateBackgroundStatus, 1500);
+    setTimeout(updateSubscriptionStatus, 3000);
+});

--- a/view/web/static/js/virtual.js
+++ b/view/web/static/js/virtual.js
@@ -19,13 +19,19 @@ let currentVirtualHoldData = [];
 let currentVirtualSoldData = [];
 
 // 모의투자 데이터 자동 갱신 (5분마다)
-document.addEventListener('DOMContentLoaded', () => {
-    setInterval(() => {
+let _virtualRefreshInterval = null;
+function _startVirtualRefresh() {
+    if (_virtualRefreshInterval) clearInterval(_virtualRefreshInterval);
+    _virtualRefreshInterval = setInterval(() => {
         const virtualSection = document.getElementById('section-virtual');
         if (virtualSection && virtualSection.classList.contains('active')) {
             loadVirtualHistory();
         }
     }, 300000);
+}
+document.addEventListener('DOMContentLoaded', _startVirtualRefresh);
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path === '/virtual') _startVirtualRefresh();
 });
 
 function _showVirtualSkeleton() {

--- a/view/web/static/js/virtual_chart.js
+++ b/view/web/static/js/virtual_chart.js
@@ -94,6 +94,8 @@ async function initVirtualChart() {
             }
         }
     });
+    window.currentCharts = window.currentCharts || [];
+    window.currentCharts.push(yieldChart);
 }
 
 /**
@@ -329,3 +331,13 @@ window.invalidateVirtualChartCache = function() {
 }
 
 document.addEventListener('DOMContentLoaded', initVirtualChart);
+
+/* ── Pjax 재방문 시 차트 재초기화 ── */
+document.addEventListener('pjax:ready', async (e) => {
+    if (e.detail?.path !== '/virtual') return;
+    // Pjax 클린업에서 destroy된 인스턴스 → null 리셋 후 재초기화
+    yieldChart = null;
+    chartInitPromise = null;
+    cachedAllChartData = null;
+    await initVirtualChart();
+});

--- a/view/web/templates/balance.html
+++ b/view/web/templates/balance.html
@@ -28,9 +28,10 @@
 
 {% block scripts %}
 <script src="/static/js/balance.js?v=2"></script>
+{% if initial_data %}
+<script id="page-initial-data" type="application/json">{{ initial_data | tojson | safe }}</script>
+{% endif %}
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        loadBalance();
-    });
+    loadBalance();
 </script>
 {% endblock %}

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -84,9 +84,12 @@
     <a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>
 </nav>
 
-<main class="main">
+<main class="main" id="page-main">
     {% block content %}
     <!-- 각 페이지의 콘텐츠가 여기에 들어갑니다 -->
+    {% endblock %}
+    {% block scripts %}
+    <!-- 페이지별 추가 스크립트 -->
     {% endblock %}
 </main>
 
@@ -117,10 +120,6 @@
 <!-- 공통 스크립트 -->
 <script src="/static/js/common.js?v=1"></script>
 <script src="/static/js/notifications.js?v=1"></script>
-
-{% block scripts %}
-<!-- 페이지별 추가 스크립트 -->
-{% endblock %}
 
 <!-- ── 서버 요청 진단 패널 (hang 디버깅용) ─────────────────────────────
      - 모든 페이지에 항상 떠있음 (좌하단 고정)

--- a/view/web/templates/marketcap.html
+++ b/view/web/templates/marketcap.html
@@ -17,8 +17,6 @@
 <script src="/static/js/stock.js?v=1"></script>
 <script src="/static/js/marketcap.js?v=1"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        loadTopMarketCap('0001');
-    });
+    loadTopMarketCap('0001');
 </script>
 {% endblock %}

--- a/view/web/templates/program.html
+++ b/view/web/templates/program.html
@@ -46,8 +46,6 @@
 <script src="/static/js/program_chart.js?v=1"></script>
 <script src="/static/js/program_trading.js?v=1"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        initProgramTrading();
-    });
+    initProgramTrading();
 </script>
 {% endblock %}

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -37,8 +37,6 @@
 {% block scripts %}
 <script src="/static/js/ranking.js?v=1"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        loadRanking('rise');
-    });
+    loadRanking('rise');
 </script>
 {% endblock %}

--- a/view/web/templates/scheduler.html
+++ b/view/web/templates/scheduler.html
@@ -40,8 +40,6 @@
 {% block scripts %}
 <script src="/static/js/scheduler.js?v=1"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        loadSchedulerStatus();
-    });
+    loadSchedulerStatus();
 </script>
 {% endblock %}

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -54,7 +54,7 @@
 <script src="/static/js/autocomplete.js?v=1"></script>
 <script src="/static/js/stock.js?v=7"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    (function() {
         const urlParams = new URLSearchParams(window.location.search);
         const code = urlParams.get('code');
         if (code) {
@@ -62,6 +62,6 @@
             if (input) input.value = code;
             searchStock(code);
         }
-    });
+    })();
 </script>
 {% endblock %}

--- a/view/web/templates/virtual.html
+++ b/view/web/templates/virtual.html
@@ -70,8 +70,6 @@
 <script src="/static/js/stock.js?v=1"></script>
 <script src="/static/js/virtual.js?v=1"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        loadVirtualHistory();
-    });
+    loadVirtualHistory();
 </script>
 {% endblock %}

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -248,7 +248,29 @@ async def stock(request: Request):
 
 @page_router.get("/balance")
 async def balance(request: Request):
-    return await render_page(request, "balance.html", "balance")
+    initial_data = None
+    try:
+        from common.types import Exchange
+        from view.web.api_common import _serialize_response
+        ctx = web_api._get_ctx()
+        resp = await ctx.stock_query_service.handle_get_account_balance(exchange=Exchange.KRX)
+        result = _serialize_response(resp)
+        # account_info 추가 (API 엔드포인트와 동일 로직)
+        env = getattr(ctx, 'env', None) or getattr(getattr(ctx, 'broker', None), 'env', None)
+        if env:
+            config = getattr(env, 'active_config', None) or {}
+            acc_no = (config.get("stock_account_number") or config.get("CANO") or
+                      getattr(env, 'stock_account_number', None) or "번호없음")
+            result['account_info'] = {
+                "number": acc_no,
+                "type": "모의투자" if getattr(env, 'is_paper_trading', False) else "실전투자",
+                "exchange": "KRX",
+            }
+        initial_data = result
+    except Exception:
+        pass
+    extra = {"initial_data": initial_data} if initial_data else None
+    return await render_page(request, "balance.html", "balance", extra_context=extra)
 
 @page_router.get("/order")
 async def order(request: Request):


### PR DESCRIPTION
파일	변경 내용
base.html	{% block scripts %}를 <main id="page-main"> 내부로 이동 common.js	Pjax 엔진 (navigatePjax, executePageScripts, loadScript, Chart 클린업, pjax:ready dispatch, popstate 처리) balance/marketcap/program/ranking/scheduler/stock/virtual.html	인라인 DOMContentLoaded wrapper → 직접 함수 호출 (Pjax 재실행 호환) autocomplete.js	DOMContentLoaded → readyState 체크 (Pjax 컨텍스트에서 즉시 실행) stock.js	pjax:ready 시 StockAutocomplete 재초기화
favorite.js	pjax:ready 시 autocomplete + loadFavoriteList 재초기화 system.js	pjax:ready 시 3개 상태 갱신 함수 재호출
virtual.js	pjax:ready 시 자동갱신 interval 재시작 (좀비 방지)
virtual_chart.js	pjax:ready 시 yieldChart=null 리셋 후 재초기화, window.currentCharts 등록 candle_chart.js	window.currentCharts 등록 + 재생성 시 필터링 program_chart.js	window.currentCharts 등록, destroyProgramChart에서 제거

Phase 2: 데이터 하이드레이션 (balance 페이지)
파일	변경 내용
web_main.py	/balance 라우트에서 서비스 호출 → initial_data 프리페치 balance.html	<script id="page-initial-data" type="application/json"> 주입 balance.js	loadBalance() 시작 시 page-initial-data 우선 소비 (소비 후 즉시 remove())

추가된 테스트 목록:

테스트	검증 내용
test_balance_paper_trading_with_account_number	stock_account_number → 계좌번호, 모의투자 타입 test_balance_real_trading_with_cano	CANO → 계좌번호, 실전투자 타입 test_balance_acc_no_from_env_attribute	env.stock_account_number fallback test_balance_acc_no_fallback_to_default	모든 소스 None → "번호없음" test_balance_env_via_broker	ctx.env=None → ctx.broker.env fallback test_balance_no_env_no_account_info	env 없으면 account_info 미포함 test_balance_exception_fallback_renders_page	API 예외 시 initial_data=None, 스크립트 태그 미렌더 한글 문자열 직접 비교 대신 _parse_initial_data() 헬퍼로 <script id="page-initial-data"> 태그의 JSON을 파싱해 검증하므로 tojson의 Unicode 이스케이프 여부와 무관하게 안정적으로 동작합니다.