### PR TITLE
웹소켓 워치독 백그라운드 태스크의 진행률 반환 함수에서 PROGRAM_TRADING과 UNIFIED_PRICE 두 가지 구독…

### DIFF
--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -247,7 +247,7 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         return {
             "running": self._state == TaskState.RUNNING,
-            "subscribed_codes": subscribed_pt,
+            "subscribed_codes": subscribed_pt + subscribed_price,
             "subscribed_pt_codes": subscribed_pt,
             "subscribed_price_codes": subscribed_price,
             "data_gap_sec": data_gap,

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -231,10 +231,12 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         Watchdog 태스크는 배치 진행률이 없으므로 연결 상태 정보를 반환한다.
         """
-        subscribed = 0
+        subscribed_pt = 0
+        subscribed_price = 0
         if self._streaming_stock_repo:
             from repositories.streaming_stock_repo import StreamingType
-            subscribed = len(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING))
+            subscribed_pt = len(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING))
+            subscribed_price = len(self._streaming_stock_repo.get_desired(StreamingType.UNIFIED_PRICE))
 
         last_ts = 0.0
         data_gap = None
@@ -245,7 +247,9 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         return {
             "running": self._state == TaskState.RUNNING,
-            "subscribed_codes": subscribed,
+            "subscribed_codes": subscribed_pt,
+            "subscribed_pt_codes": subscribed_pt,
+            "subscribed_price_codes": subscribed_price,
             "data_gap_sec": data_gap,
             "market_open": self._market_open,
         }

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -403,7 +403,7 @@ def test_get_progress_with_subscriptions(watchdog_task):
 
     p = watchdog_task.get_progress()
 
-    assert p["subscribed_codes"] == 2
+    assert p["subscribed_codes"] == 3
     assert p["subscribed_pt_codes"] == 2
     assert p["subscribed_price_codes"] == 1
 

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -384,17 +384,28 @@ def test_get_progress_initial_state(watchdog_task):
 
     assert p["running"] is False
     assert p["subscribed_codes"] == 0
+    assert p["subscribed_pt_codes"] == 0
+    assert p["subscribed_price_codes"] == 0
     assert p["data_gap_sec"] is None
     assert p["market_open"] is None
 
 
 def test_get_progress_with_subscriptions(watchdog_task):
-    """구독 종목이 있으면 subscribed_codes에 개수가 반영된다."""
-    watchdog_task._streaming_stock_repo.get_desired.return_value = {"005930", "000660"}
+    """구독 종목이 있으면 각 타입별로 개수가 반영된다."""
+    def mock_get_desired(stream_type):
+        if stream_type == StreamingType.PROGRAM_TRADING:
+            return {"005930", "000660"}
+        if stream_type == StreamingType.UNIFIED_PRICE:
+            return {"035720"}
+        return set()
+        
+    watchdog_task._streaming_stock_repo.get_desired.side_effect = mock_get_desired
 
     p = watchdog_task.get_progress()
 
     assert p["subscribed_codes"] == 2
+    assert p["subscribed_pt_codes"] == 2
+    assert p["subscribed_price_codes"] == 1
 
 
 def test_get_progress_data_gap_calculated(watchdog_task):

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -210,7 +210,7 @@ function renderProgressCell(progress, taskName) {
         } else {
             marketBadge = '<span style="background:#888; color:#fff; padding:1px 7px; border-radius:8px; font-size:0.82em;">장 마감</span>';
         }
-        const subPt = progress.subscribed_pt_codes ?? progress.subscribed_codes ?? 0;
+        const subPt = progress.subscribed_pt_codes ?? 0;
         const subPrice = progress.subscribed_price_codes ?? 0;
         const gap = (progress.data_gap_sec !== null && progress.data_gap_sec !== undefined)
             ? ` · 갭 ${progress.data_gap_sec}s` : '';

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -210,10 +210,11 @@ function renderProgressCell(progress, taskName) {
         } else {
             marketBadge = '<span style="background:#888; color:#fff; padding:1px 7px; border-radius:8px; font-size:0.82em;">장 마감</span>';
         }
-        const sub = progress.subscribed_codes ?? 0;
+        const subPt = progress.subscribed_pt_codes ?? progress.subscribed_codes ?? 0;
+        const subPrice = progress.subscribed_price_codes ?? 0;
         const gap = (progress.data_gap_sec !== null && progress.data_gap_sec !== undefined)
             ? ` · 갭 ${progress.data_gap_sec}s` : '';
-        return `${marketBadge} <span style="font-size:0.85em; color:#888;">구독 ${sub}종목${gap}</span>`;
+        return `${marketBadge} <span style="font-size:0.85em; color:#888;">구독 PT ${subPt} · Price ${subPrice}종목${gap}</span>`;
     }
 
     // ── 전략 스케줄러: 활성 전략 수 표시 ──
@@ -483,9 +484,13 @@ async function updateSubscriptionStatus() {
         _subData = d;
 
         const activeEl = document.getElementById('sub-active-count');
+        const activePtEl = document.getElementById('sub-active-pt-count');
+        const activePriceEl = document.getElementById('sub-active-price-count');
         const maxEl    = document.getElementById('sub-max');
         const pendEl   = document.getElementById('sub-pending-count');
         if (activeEl) activeEl.textContent = d.active_count;
+        if (activePtEl) activePtEl.textContent = d.active_codes_pt ? d.active_codes_pt.length : 0;
+        if (activePriceEl) activePriceEl.textContent = d.active_codes_price ? d.active_codes_price.length : 0;
         if (maxEl)    maxEl.textContent    = d.max_subscriptions;
         if (pendEl)   pendEl.textContent   = d.pending_count;
 

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -29,7 +29,7 @@
         <div class="card" style="padding: 20px 12px;">
             <h3 style="margin-top: 0; margin-bottom: 16px;">📡 실시간 현재가 구독 현황</h3>
             <p style="font-size: 1.05rem; margin: 0 0 12px;">
-                활성 구독: <strong id="sub-active-count">-</strong> / <span id="sub-max">-</span>
+                활성 구독: <strong id="sub-active-count">-</strong> (PT: <span id="sub-active-pt-count">-</span>, Price: <span id="sub-active-price-count">-</span>) / <span id="sub-max">-</span>
                 &nbsp;|&nbsp; 요청 종목: <span id="sub-pending-count">-</span>
             </p>
             <div id="sub-priority-tabs" style="display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;">


### PR DESCRIPTION
… 상태를 모두 전달하도록 수정하고, 이를 기반으로 시스템 모니터링 웹 뷰(system.html, system.js)에서 두 항목의 구독 개수가 각각 나누어 표기되도록 수정했습니다.

(참고: system.py의 get_subscription_status API는 이미 내부적으로 active_codes_price와 active_codes_pt 배열을 반환하고 있어, 별도의 파이썬 백엔드 코드 수정 없이 프론트엔드 변경만으로 데이터 표기가 가능합니다.)