### PR TITLE
Log File data 용량 최적화

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -7,6 +7,7 @@ from logging.handlers import QueueHandler, QueueListener
 from core.loggers.log_config import (
     LOG_MAX_BYTES,
     LOG_BACKUP_COUNT,
+    LOG_LEVEL,
     get_log_timestamp,
     reset_log_timestamp_for_test
 )
@@ -61,7 +62,7 @@ def get_streaming_logger(log_dir: str = "logs") -> "StreamingEventLogger":
     logger = logging.getLogger(logger_name)
 
     if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(LOG_LEVEL)
         logger.propagate = False
 
         timestamp = get_log_timestamp()
@@ -94,7 +95,7 @@ def get_cache_event_logger(log_dir: str = "logs") -> "CacheEventLogger":
     logger = logging.getLogger(logger_name)
 
     if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(LOG_LEVEL)
         logger.propagate = False
 
         timestamp = get_log_timestamp()
@@ -125,7 +126,7 @@ def get_strategy_logger(strategy_name: str, log_dir="logs", sub_dir: str = None)
             handler.close()
             logger.removeHandler(handler)
 
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(LOG_LEVEL)
     logger.propagate = True
 
     strategy_log_dir = os.path.join(log_dir, "strategies")

--- a/core/loggers/app_logger.py
+++ b/core/loggers/app_logger.py
@@ -5,7 +5,7 @@ import http.client
 import queue
 from logging.handlers import QueueHandler, QueueListener
 
-from core.loggers.log_config import get_log_timestamp, LOG_MAX_BYTES, LOG_BACKUP_COUNT
+from core.loggers.log_config import get_log_timestamp, LOG_MAX_BYTES, LOG_BACKUP_COUNT, LOG_LEVEL
 from core.loggers.size_time_rotating_file_handler import SizeTimeRotatingFileHandler
 from core.loggers.strategy_info_filter import StrategyInfoFilter
 from core.loggers.async_handler import DictPreservingQueueHandler
@@ -43,7 +43,7 @@ class Logger:
 
         # 로거 인스턴스 생성
         self.operational_logger = self._setup_logger('operational_logger', self.operational_log_path, logging.INFO)
-        self.debug_logger = self._setup_logger('debug_logger', self.debug_log_path, logging.DEBUG)
+        self.debug_logger = self._setup_logger('debug_logger', self.debug_log_path, LOG_LEVEL)
 
         # 전략 로그 필터 생성 (debug.log 용량 관리용)
         strategy_filter = StrategyInfoFilter()
@@ -54,7 +54,7 @@ class Logger:
 
         # 루트 로거에 통합 로그 핸들러 연결 (전략 로거 등 전파된 로그 수집)
         root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
+        root_logger.setLevel(LOG_LEVEL)
         for h in self.debug_logger.handlers:
             h.addFilter(strategy_filter)  # 전략 로그는 INFO 이상만 debug.log에 기록
             root_logger.addHandler(h)

--- a/core/loggers/cache_event_logger.py
+++ b/core/loggers/cache_event_logger.py
@@ -34,6 +34,7 @@ class CacheEventLogger:
 
     def __init__(self, logger: logging.Logger):
         self._logger = logger
+        self._tick_count = 0
 
     # ── 현재가 캐시 이벤트 ───────────────────────────────────────────
 
@@ -80,14 +81,20 @@ class CacheEventLogger:
             after_price: 갱신 후 stck_prpr
             volume: 누적 거래량
         """
+        self._tick_count += 1
+        
+        # 샘플링: 100번에 1번만 기록 (1%만 로깅)
+        if self._tick_count % 100 != 0:
+            return
+            
         if not self._logger.isEnabledFor(logging.DEBUG):
             return
         self._logger.debug({
-            "action": "price_update_tick",
-            "code": code,
-            "before_price": before_price,
-            "after_price": after_price,
-            "volume": volume,
+            "a": "put",
+            "c": code,
+            "bp": before_price,
+            "ap": after_price,
+            "v": volume,
         })
 
     def log_price_hit(

--- a/core/loggers/log_config.py
+++ b/core/loggers/log_config.py
@@ -11,7 +11,7 @@ LOG_LEVEL = logging.INFO if APP_ENV == "prod" else logging.DEBUG
 LOG_MAX_BYTES = 10 * 1024 * 1024  # 10MB
 LOG_BACKUP_COUNT = 30 if APP_ENV == "prod" else 50
 LOG_COMPRESS_DAYS = 3 if APP_ENV == "prod" else 2
-LOG_DELETE_DAYS = 30 if APP_ENV == "prod" else 50
+LOG_DELETE_DAYS = 7 if APP_ENV == "prod" else 30
 
 # --- Timestamp Singleton ---
 _log_timestamp = None

--- a/core/loggers/log_config.py
+++ b/core/loggers/log_config.py
@@ -1,9 +1,17 @@
 import os
+import logging
 from datetime import datetime
 
+# --- 환경 변수 설정 ---
+# OS 환경변수에서 APP_ENV 읽기 (기본값 dev)
+APP_ENV = os.getenv("APP_ENV", "dev")
+
 # --- Log Rotation Constants ---
+LOG_LEVEL = logging.INFO if APP_ENV == "prod" else logging.DEBUG
 LOG_MAX_BYTES = 10 * 1024 * 1024  # 10MB
-LOG_BACKUP_COUNT = 30
+LOG_BACKUP_COUNT = 30 if APP_ENV == "prod" else 50
+LOG_COMPRESS_DAYS = 3 if APP_ENV == "prod" else 2
+LOG_DELETE_DAYS = 30 if APP_ENV == "prod" else 50
 
 # --- Timestamp Singleton ---
 _log_timestamp = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ filterwarnings =
     ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
     ignore:coroutine '.*' was never awaited:RuntimeWarning
 addopts = -n auto --durations=25 --durations-min=0.05
+timeout = 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ debugpy>=1.8.20
 finance-datareader>=0.9.110
 aiosqlite>=0.19.0
 orjson
+pytest-timeout>=2.1.0

--- a/task/background/after_market/log_cleanup_task.py
+++ b/task/background/after_market/log_cleanup_task.py
@@ -14,8 +14,11 @@ import asyncio
 import logging
 import os
 import time
+import gzip
+import shutil
 from typing import Dict, Optional, TYPE_CHECKING
 
+from core.loggers.log_config import LOG_DELETE_DAYS, LOG_COMPRESS_DAYS
 from task.background.after_market.after_market_task_base import AfterMarketTask
 from interfaces.schedulable_task import TaskPriority, TaskState
 
@@ -30,7 +33,8 @@ class LogCleanupTask(AfterMarketTask):
     def __init__(
         self,
         log_dir: str = "logs",
-        days: int = 30,
+        delete_days: int = LOG_DELETE_DAYS,
+        compress_days: int = LOG_COMPRESS_DAYS,
         market_calendar_service: Optional["MarketCalendarService"] = None,
         market_clock: Optional["MarketClock"] = None,
         logger=None,
@@ -41,7 +45,8 @@ class LogCleanupTask(AfterMarketTask):
             logger=logger or logging.getLogger(__name__),
         )
         self._log_dir = log_dir
-        self._days = days
+        self._delete_days = delete_days
+        self._compress_days = compress_days
         self._last_cleaned_date: Optional[str] = None
         self._progress: Dict = {"running": False}
 
@@ -86,25 +91,40 @@ class LogCleanupTask(AfterMarketTask):
         """logs/ 디렉토리를 순회하며 오래된 로그 파일을 삭제한다."""
         self._progress = {"running": True}
         now = time.time()
-        cutoff = now - (self._days * 86400)
+        delete_cutoff = now - (self._delete_days * 86400)
+        compress_cutoff = now - (self._compress_days * 86400)
         removed = 0
+        compressed = 0
         errors = 0
 
         self._logger.info(
             f"LogCleanupTask 정리 시작 (기준일: {trading_date}, "
-            f"보존 기간: {self._days}일, 경로: {self._log_dir})"
+            f"보존 기간: {self._delete_days}일, 압축 기준: {self._compress_days}일, 경로: {self._log_dir})"
         )
 
         for root, _, files in os.walk(self._log_dir):
             for filename in files:
-                if ".log" not in filename and ".json" not in filename:
+                if not (filename.endswith(".log") or filename.endswith(".json") or filename.endswith(".gz")):
                     continue
                 file_path = os.path.join(root, filename)
+                is_compressed = filename.endswith(".gz")
+
                 try:
-                    if os.path.getmtime(file_path) < cutoff:
+                    file_mtime = os.path.getmtime(file_path)
+                    if file_mtime < delete_cutoff:
                         os.remove(file_path)
                         removed += 1
                         self._logger.debug(f"LogCleanupTask: 삭제 — {file_path}")
+                    elif file_mtime < compress_cutoff and not is_compressed:
+                        gz_file_path = file_path + ".gz"
+                        with open(file_path, 'rb') as f_in:
+                            with gzip.open(gz_file_path, 'wb') as f_out:
+                                shutil.copyfileobj(f_in, f_out)
+                        os.remove(file_path)
+                        compressed += 1
+                        self._logger.debug(f"LogCleanupTask: 압축 — {file_path} -> .gz")
+                    else:
+                        self._logger.debug(f"LogCleanupTask: 스킵 — {file_path}")
                 except Exception as e:
                     self._logger.warning(f"LogCleanupTask: 삭제 실패 — {file_path}: {e}")
                     errors += 1
@@ -113,5 +133,5 @@ class LogCleanupTask(AfterMarketTask):
         self._progress = {"running": False}
         self._logger.info(
             f"LogCleanupTask 정리 완료 (기준일: {trading_date}, "
-            f"삭제: {removed}개, 실패: {errors}개)"
+            f"압축: {compressed}개, 삭제: {removed}개, 실패: {errors}개)"
         )

--- a/tests/unit_test/core/loggers/test_cache_event_logger.py
+++ b/tests/unit_test/core/loggers/test_cache_event_logger.py
@@ -626,3 +626,121 @@ async def test_stock_ohlcv_repo_logs_ohlcv_eviction(tmp_path):
     assert call[1]["capacity"] == 1
 
     await repo.close()
+
+
+# ── sampling / level-guard 분기 커버리지 ────────────────────────────
+
+def test_log_price_update_tick_skips_non_100th(cache_logger_setup):
+    """_tick_count % 100 != 0 이면 로그를 기록하지 않아야 한다."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    # 기본 상태(tick_count=0)에서 99번 호출 → 모두 skip
+    for _ in range(99):
+        cache_logger.log_price_update_tick("005930", "74000", "75000", 100)
+    _flush_cache_logger()
+
+    log_files = list(cache_log_dir.glob("*.log.json"))
+    if log_files:
+        with open(log_files[0], encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 0
+    # 파일 자체가 없어도 통과 (아무것도 기록 안 됨)
+
+
+def test_log_price_update_tick_debug_disabled_skips(cache_logger_setup):
+    """100번째 틱이지만 DEBUG 레벨이 꺼져 있으면 기록하지 않는다."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    inner = logging.getLogger("cache_event")
+    inner.setLevel(logging.INFO)  # DEBUG 비활성화
+
+    cache_logger._tick_count = 99
+    cache_logger.log_price_update_tick("005930", "74000", "75000", 100)
+    _flush_cache_logger()
+
+    log_files = list(cache_log_dir.glob("*.log.json"))
+    if log_files:
+        with open(log_files[0], encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 0
+
+
+def test_debug_methods_skip_when_logger_level_is_info(cache_logger_setup):
+    """INFO 레벨 로거에서 DEBUG 메서드들은 isEnabledFor guard로 모두 skip."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    inner = logging.getLogger("cache_event")
+    inner.setLevel(logging.INFO)
+
+    cache_logger.log_price_hit("005930", "test", 1.0, is_streaming=False)
+    cache_logger.log_price_miss("005930", "test", "not_found")
+    cache_logger.log_ohlcv_hit("005930", "test", ohlcv_count=10, has_today_candle=False)
+    cache_logger.log_ohlcv_miss("005930", "test")
+    cache_logger.log_today_candle("005930", 74000, 75000, high=75000, low=74000, is_new_candle=False)
+    _flush_cache_logger()
+
+    log_files = list(cache_log_dir.glob("*.log.json"))
+    if log_files:
+        with open(log_files[0], encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 0
+
+
+def test_info_methods_skip_when_logger_level_is_warning(cache_logger_setup):
+    """WARNING 레벨 로거에서 INFO 메서드들은 isEnabledFor guard로 모두 skip."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    inner = logging.getLogger("cache_event")
+    inner.setLevel(logging.WARNING)
+
+    cache_logger.log_price_set("005930", "api", None, "75000", is_new=True)
+    cache_logger.log_streaming_mark("005930", streaming_count=1)
+    cache_logger.log_streaming_unmark("005930", streaming_count=0)
+    cache_logger.log_ohlcv_loaded("005930", "test", 10, "20250401")
+    cache_logger.log_ohlcv_invalidated("005930")
+    cache_logger.log_ohlcv_upsert(record_count=1, code_count=1, invalidated_codes=["005930"])
+    cache_logger.log_stats(
+        {"hits": 1, "misses": 0, "hit_rate": 100.0, "current_size": 1},
+        {"hits": 0, "misses": 1, "hit_rate": 0.0, "current_size": 0},
+    )
+    _flush_cache_logger()
+
+    log_files = list(cache_log_dir.glob("*.log.json"))
+    if log_files:
+        with open(log_files[0], encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 0
+
+
+def test_warning_methods_skip_when_logger_level_is_error(cache_logger_setup):
+    """ERROR 레벨 로거에서 WARNING 메서드들은 isEnabledFor guard로 skip."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    inner = logging.getLogger("cache_event")
+    inner.setLevel(logging.ERROR)
+
+    cache_logger.log_price_evicted("005930", capacity=3000)
+    cache_logger.log_ohlcv_evicted("005930", freq=1, ohlcv_count=100, capacity=500)
+    _flush_cache_logger()
+
+    log_files = list(cache_log_dir.glob("*.log.json"))
+    if log_files:
+        with open(log_files[0], encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 0
+
+
+def test_log_price_update_tick_100th_writes_when_debug_enabled(cache_logger_setup):
+    """100번째 틱 + DEBUG 활성 → 기록됨 (기존 test_log_price_update_tick_fields 보완)."""
+    cache_logger, cache_log_dir = cache_logger_setup
+
+    inner = logging.getLogger("cache_event")
+    assert inner.isEnabledFor(logging.DEBUG)  # fixture는 DEBUG
+
+    cache_logger._tick_count = 199
+    cache_logger.log_price_update_tick("000660", "90000", "91000", 50000)
+    _flush_cache_logger()
+
+    lines = _read_json_lines(cache_log_dir)
+    assert lines[0]["data"]["c"] == "000660"
+    assert lines[0]["data"]["ap"] == "91000"

--- a/tests/unit_test/core/loggers/test_cache_event_logger.py
+++ b/tests/unit_test/core/loggers/test_cache_event_logger.py
@@ -177,15 +177,17 @@ def test_log_price_miss_ttl_expired(cache_logger_setup):
 def test_log_price_update_tick_fields(cache_logger_setup):
     cache_logger, cache_log_dir = cache_logger_setup
 
-    cache_logger.log_price_update_tick("005930", "74000", "75000", volume=123456)
+    # 샘플링 테스트 (100번에 한 번 기록되도록 _tick_count 조정)
+    cache_logger._tick_count = 99
+    cache_logger.log_price_update_tick("005930", "74000", "75000", 123456)
     _flush_cache_logger()
 
     lines = _read_json_lines(cache_log_dir)
     d = lines[0]["data"]
-    assert d["action"] == "price_update_tick"
-    assert d["before_price"] == "74000"
-    assert d["after_price"] == "75000"
-    assert d["volume"] == 123456
+    assert d["a"] == "put"
+    assert d["bp"] == "74000"
+    assert d["ap"] == "75000"
+    assert d["v"] == 123456
     assert lines[0]["level"] == "DEBUG"
 
 

--- a/tests/unit_test/core/loggers/test_streaming_event_logger.py
+++ b/tests/unit_test/core/loggers/test_streaming_event_logger.py
@@ -491,3 +491,143 @@ def test_log_force_reconnect_done(streaming_logger_setup):
     assert d["action"] == "force_reconnect_done"
     assert d["trigger"] == "manual"
     assert lines[0]["level"] == "INFO"
+
+
+def test_log_connection_lost(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_connection_lost(reason="no close frame", retry_count=2)
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "connection_lost"
+    assert d["reason"] == "no close frame"
+    assert d["retry_count"] == 2
+    assert lines[0]["level"] == "WARNING"
+
+
+def test_log_appkey_collision(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_appkey_collision(retry_count=1, delay_sec=5.0, max_retries=3)
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "appkey_collision"
+    assert d["retry_count"] == 1
+    assert d["delay_sec"] == 5.0
+    assert d["max_retries"] == 3
+    assert lines[0]["level"] == "WARNING"
+
+
+def test_log_reconnect_attempt(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_reconnect_attempt(attempt_num=2, max_attempts=5, was_collision=True)
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "reconnect_attempt"
+    assert d["attempt_num"] == 2
+    assert d["max_attempts"] == 5
+    assert d["was_collision"] is True
+    assert lines[0]["level"] == "INFO"
+
+
+def test_log_reconnect_success(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_reconnect_success(attempt_num=3, max_attempts=5)
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "reconnect_success"
+    assert d["attempt_num"] == 3
+    assert d["max_attempts"] == 5
+    assert lines[0]["level"] == "INFO"
+
+
+def test_log_watchdog_check(tmp_path):
+    reset_log_timestamp_for_test()
+
+    existing = logging.getLogger("streaming_event")
+    for h in existing.handlers[:]:
+        h.close()
+        existing.removeHandler(h)
+
+    log_dir = tmp_path / "logs"
+    streaming_logger = get_streaming_logger(log_dir=str(log_dir))
+
+    inner = logging.getLogger("streaming_event")
+    inner.setLevel(logging.DEBUG)
+
+    streaming_logger.log_watchdog_check(
+        receive_alive=True,
+        data_gap_sec=12.345,
+        market_open=True,
+        subscribed_count=5,
+    )
+
+    _flush_streaming_logger()
+
+    streaming_log_dir = log_dir / "streaming"
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "watchdog_check"
+    assert d["receive_alive"] is True
+    assert d["data_gap_sec"] == 12.3
+    assert d["market_open"] is True
+    assert d["subscribed_count"] == 5
+    assert lines[0]["level"] == "DEBUG"
+
+    for h in logging.getLogger("streaming_event").handlers[:]:
+        h.close()
+        logging.getLogger("streaming_event").removeHandler(h)
+    for listener in core.logger._active_listeners[:]:
+        listener.stop()
+    core.logger._active_listeners.clear()
+
+
+def test_log_subscription_recovery_start(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_subscription_recovery_start(total=3, codes=["005930", "000660", "035720"])
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "subscription_recovery_start"
+    assert d["total"] == 3
+    assert d["codes"] == ["000660", "005930", "035720"]
+    assert lines[0]["level"] == "INFO"
+
+
+def test_log_subscription_recovery_done(streaming_logger_setup):
+    streaming_logger, streaming_log_dir = streaming_logger_setup
+
+    streaming_logger.log_subscription_recovery_done(
+        success=2,
+        total=3,
+        failed_codes=["035720"],
+        elapsed_ms=123.456,
+    )
+
+    _flush_streaming_logger()
+
+    lines = _read_json_lines(streaming_log_dir)
+    d = lines[0]["data"]
+    assert d["action"] == "subscription_recovery_done"
+    assert d["success"] == 2
+    assert d["total"] == 3
+    assert d["failed_codes"] == ["035720"]
+    assert d["elapsed_ms"] == 123.5
+    assert lines[0]["level"] == "INFO"

--- a/tests/unit_test/task/background/after_market/test_log_cleanup_task.py
+++ b/tests/unit_test/task/background/after_market/test_log_cleanup_task.py
@@ -32,7 +32,8 @@ def mock_market_clock():
 def task(mock_mcs, mock_market_clock):
     return LogCleanupTask(
         log_dir="logs",
-        days=30,
+        delete_days=30,
+        compress_days=7,
         market_calendar_service=mock_mcs,
         market_clock=mock_market_clock,
         logger=MagicMock(),
@@ -176,6 +177,22 @@ class TestCleanup:
         assert mock_remove.call_count == 2
         assert task._last_cleaned_date == "20260320"
 
+    def test_compresses_old_log_files(self, task):
+        """mtime < compress_cutoff 인 파일은 gzip으로 압축된다."""
+        old_mtime = time.time() - (10 * 86400)  # 10일 전 (압축 대상)
+
+        walk_result = [("logs", [], ["old.log"])]
+
+        with patch("os.walk", return_value=walk_result), \
+             patch("os.path.getmtime", return_value=old_mtime), \
+             patch("builtins.open"), \
+             patch("gzip.open"), \
+             patch("shutil.copyfileobj"), \
+             patch("os.remove") as mock_remove:
+            task._cleanup("20260320")
+
+        mock_remove.assert_called_once()
+
     def test_skips_recent_files(self, task):
         """mtime >= cutoff 인 파일은 삭제하지 않는다."""
         recent_mtime = time.time() - (5 * 86400)  # 5일 전
@@ -238,7 +255,8 @@ class TestCleanup:
         """days 파라미터가 cutoff 계산에 정확히 반영된다."""
         task_7days = LogCleanupTask(
             log_dir="logs",
-            days=7,
+            delete_days=7,
+            compress_days=3,
             market_calendar_service=mock_mcs,
             market_clock=mock_market_clock,
             logger=MagicMock(),
@@ -258,7 +276,8 @@ class TestCleanup:
         """log_dir 파라미터가 os.walk에 그대로 전달된다."""
         custom_task = LogCleanupTask(
             log_dir="custom/logs",
-            days=30,
+            delete_days=30,
+            compress_days=7,
             market_calendar_service=mock_mcs,
             market_clock=mock_market_clock,
             logger=MagicMock(),

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -337,7 +337,8 @@ class WebAppContext:
 
         self.log_cleanup_task = LogCleanupTask(
             log_dir=self.logger.log_dir,
-            days=30,
+            delete_days=30,
+            compress_days=7,
             market_calendar_service=self._mcs,
             market_clock=self.market_clock,
             logger=self.logger,


### PR DESCRIPTION
🥇 1. 운영/개발 환경(APP_ENV) 완전 분리 (가장 중요)
운영(Production) 서버에서는 디버그용 틱 로그를 남기지 않도록 차단하여 용량 증가를 원천적으로 막습니다.

📍 파일 1: log_config.py (설정 추가)

📍 파일 2: app_logger.py (동적 레벨 적용)

📍 파일 3: logger.py (이벤트 로거에 적용)

🥈 2. 장 마감 후 자동 압축 및 삭제 (유지보수 종결자)
시스템 부하가 없는 장 마감 이후에 7일 지난 로그는 압축(.gz)하고, 30일 지난 로그는 삭제합니다.

🎯 3. 고빈도 틱 로그 다이어트 (최후의 수단)
운영 서버(APP_ENV=prod)에서도 어쩔 수 없이 틱 로그를 남겨야 할 경우, 기록 빈도나 텍스트 길이를 자체를 줄입니다.