### PR TITLE
Progressive Stock Detail Loading

### DIFF
--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -58,29 +58,30 @@ class MarketDataService:
         self._logger.info(f"MarketDataService - {stock_code} 종목 상세 정보 조회 요청")
         return await self._broker_api_wrapper.get_stock_info_by_code(stock_code, exchange=exchange)
 
-    async def get_current_price(self, stock_code, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown") -> ResCommonResponse:
-        # 1. StockRepository 단기 캐시 확인 (웹소켓 틱 갱신 또는 최근 API 조회 결과)
-        if self._stock_repo:
-            cached_data = self._stock_repo.get_current_price(stock_code, max_age_sec=3.0, count_stats=count_stats, caller=caller)
-            if cached_data:
-                return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(Cache)", data=cached_data)
+    async def get_current_price(self, stock_code, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
+        if not force_fresh:
+            # 1. StockRepository 단기 캐시 확인 (웹소켓 틱 갱신 또는 최근 API 조회 결과)
+            if self._stock_repo:
+                cached_data = self._stock_repo.get_current_price(stock_code, max_age_sec=3.0, count_stats=count_stats, caller=caller)
+                if cached_data:
+                    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(Cache)", data=cached_data)
 
-        # 2. 장 마감 시간대에는 daily_prices DB 스냅샷 확인 (API 호출 절약)
-        is_market_open = (await self._mcs.is_market_open_now()) if self._mcs else self._market_clock.is_market_operating_hours()
-        if self._stock_repo and not is_market_open:
-            db_data = await self._stock_repo.get_latest_daily_snapshot(stock_code)
-            if db_data:
-                # DB 데이터가 최근 거래일 기준인지 확인 (오래된 데이터 방지)
-                latest_trading_date = await self._mcs.get_latest_trading_date() if self._mcs else None
-                db_trade_date = db_data.get("_trade_date") or (db_data.get("output") or {}).get("stck_bsop_date")
-                if not latest_trading_date or db_trade_date != latest_trading_date:
-                    self._logger.debug(
-                        f"MarketDataService - {stock_code} DB 스냅샷 날짜({db_trade_date}) != 최근 거래일({latest_trading_date}), API 조회로 폴백"
-                    )
-                else:
-                    db_data = self._wrap_snapshot_output(db_data)
-                    self._stock_repo.set_current_price(stock_code, db_data)
-                    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(DB)", data=db_data)
+            # 2. 장 마감 시간대에는 daily_prices DB 스냅샷 확인 (API 호출 절약)
+            is_market_open = (await self._mcs.is_market_open_now()) if self._mcs else self._market_clock.is_market_operating_hours()
+            if self._stock_repo and not is_market_open:
+                db_data = await self._stock_repo.get_latest_daily_snapshot(stock_code)
+                if db_data:
+                    # DB 데이터가 최근 거래일 기준인지 확인 (오래된 데이터 방지)
+                    latest_trading_date = await self._mcs.get_latest_trading_date() if self._mcs else None
+                    db_trade_date = db_data.get("_trade_date") or (db_data.get("output") or {}).get("stck_bsop_date")
+                    if not latest_trading_date or db_trade_date != latest_trading_date:
+                        self._logger.debug(
+                            f"MarketDataService - {stock_code} DB 스냅샷 날짜({db_trade_date}) != 최근 거래일({latest_trading_date}), API 조회로 폴백"
+                        )
+                    else:
+                        db_data = self._wrap_snapshot_output(db_data)
+                        self._stock_repo.set_current_price(stock_code, db_data)
+                        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(DB)", data=db_data)
 
         if count_stats:
             self._logger.info(f"MarketDataService - {stock_code} 현재가 조회 요청")

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -37,9 +37,9 @@ class StockQueryService:
         else:  # 3:보합 (또는 기타)
             return ""
 
-    async def get_current_price(self, stock_code: str, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown") -> ResCommonResponse:
+    async def get_current_price(self, stock_code: str, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
         """현재가만 빠르게 조회 (MarketDataService 래퍼)."""
-        return await self.market_data_service.get_current_price(stock_code, exchange=exchange, count_stats=count_stats, caller=caller)
+        return await self.market_data_service.get_current_price(stock_code, exchange=exchange, count_stats=count_stats, caller=caller, force_fresh=force_fresh)
 
     async def get_multi_price(self, stock_codes: list[str]) -> ResCommonResponse:
         """복수종목 현재가 조회 (최대 30종목, MarketDataService 래퍼)."""
@@ -65,10 +65,10 @@ class StockQueryService:
         """체결 정보 조회 (MarketDataService 래퍼)."""
         return await self.market_data_service.get_stock_conclusion(stock_code)
 
-    async def handle_get_current_stock_price(self, stock_code, caller: str = "unknown", exchange: Exchange = Exchange.KRX):
+    async def handle_get_current_stock_price(self, stock_code, caller: str = "unknown", exchange: Exchange = Exchange.KRX, force_fresh: bool = False):
         """주식 현재가 및 상세 정보 조회 요청 및 결과 출력."""
         self.logger.info(f"Stock_Query_Service - {stock_code} 현재가 및 상세 정보 조회 요청")
-        resp: ResCommonResponse = await self.market_data_service.get_current_price(stock_code, exchange=exchange, caller=caller)
+        resp: ResCommonResponse = await self.market_data_service.get_current_price(stock_code, exchange=exchange, caller=caller, force_fresh=force_fresh)
 
         if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
             msg = resp.msg1 if resp else "응답 없음"

--- a/task/background/after_market/daily_price_collector_task.py
+++ b/task/background/after_market/daily_price_collector_task.py
@@ -8,6 +8,7 @@ import logging
 import time
 import pandas as pd
 import FinanceDataReader as fdr
+import pykrx
 
 from typing import Dict, List, Optional, TYPE_CHECKING
 from common.types import ErrorCode

--- a/tests/unit_test/services/test_market_data_service.py
+++ b/tests/unit_test/services/test_market_data_service.py
@@ -82,6 +82,72 @@ async def test_fetch_past_daily_ohlcv(trading_service_fixture, mock_deps):
     assert broker.inquire_daily_itemchartprice.call_count == 3
 
 @pytest.mark.asyncio
+async def test_get_current_price_uses_cache_by_default(trading_service_fixture, mock_deps):
+    """force_fresh=False(기본값)일 때 캐시 데이터가 있으면 broker API를 호출하지 않는다."""
+    service = trading_service_fixture
+    cached = {"stck_prpr": "70000", "code": "005930"}
+    mock_deps.stock_repo.get_current_price.return_value = cached
+
+    result = await service.get_current_price("005930")
+
+    assert result.rt_cd == "0"
+    assert result.msg1 == "성공(Cache)"
+    mock_deps.broker.get_current_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_force_fresh_skips_cache(trading_service_fixture, mock_deps):
+    """force_fresh=True이면 캐시가 있어도 broker API를 직접 호출한다."""
+    service = trading_service_fixture
+    # 캐시에 데이터가 있어도 무시되어야 함
+    mock_deps.stock_repo.get_current_price.return_value = {"stck_prpr": "70000"}
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": {}})
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    result = await service.get_current_price("005930", force_fresh=True)
+
+    mock_deps.broker.get_current_price.assert_awaited_once()
+    assert result == broker_resp
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_force_fresh_skips_db_snapshot(trading_service_fixture, mock_deps):
+    """force_fresh=True이면 DB 스냅샷도 건너뛰고 broker API를 호출한다."""
+    service = trading_service_fixture
+    service._mcs = AsyncMock()
+    service._mcs.is_market_open_now.return_value = False  # 장 마감 상태
+    service._mcs.get_latest_trading_date.return_value = "20260412"
+
+    # 캐시 없음, DB 스냅샷은 있음
+    mock_deps.stock_repo.get_current_price.return_value = None
+    mock_deps.stock_repo.get_latest_daily_snapshot.return_value = {"stck_prpr": "70000", "_trade_date": "20260412"}
+
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": {}})
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    result = await service.get_current_price("005930", force_fresh=True)
+
+    # DB 스냅샷 조회가 호출되지 않아야 함
+    mock_deps.stock_repo.get_latest_daily_snapshot.assert_not_awaited()
+    mock_deps.broker.get_current_price.assert_awaited_once()
+    assert result == broker_resp
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_force_fresh_updates_cache(trading_service_fixture, mock_deps):
+    """force_fresh=True로 broker API 호출 성공 시 결과를 캐시에 저장한다."""
+    service = trading_service_fixture
+    mock_deps.stock_repo.get_current_price.return_value = None
+    broker_data = {"output": {"stck_prpr": "80000"}}
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data=broker_data)
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    await service.get_current_price("005930", force_fresh=True)
+
+    mock_deps.stock_repo.set_current_price.assert_called_once_with("005930", broker_data)
+
+
+@pytest.mark.asyncio
 async def test_get_ohlcv_caching(trading_service_fixture, mock_deps):
     """get_ohlcv 메서드의 로컬 저장소 연동 및 백필 동작 검증"""
     broker = mock_deps.broker

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -136,8 +136,9 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         # Assert
         from common.types import Exchange
-        self.mock_market_data_service.get_current_price.assert_awaited_once_with("005930", exchange=Exchange.KRX, count_stats=True, caller="unknown")
-
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=False
+        )
         self.assertEqual(result, expected_response)
 
     async def test_get_current_price_failure(self):
@@ -151,8 +152,37 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         # Assert
         from common.types import Exchange
-        self.mock_market_data_service.get_current_price.assert_awaited_once_with("005930", exchange=Exchange.KRX, count_stats=True, caller="unknown")
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=False
+        )
         self.assertEqual(result, expected_response)
+
+    async def test_get_current_price_force_fresh_passed_through(self):
+        """force_fresh=True가 market_data_service.get_current_price에 그대로 전달되는지 검증"""
+        from common.types import Exchange
+        expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"stck_prpr": "80000"})
+        self.mock_market_data_service.get_current_price.return_value = expected
+
+        result = await self.stockQueryService.get_current_price("005930", force_fresh=True)
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=True
+        )
+        self.assertEqual(result, expected)
+
+    async def test_handle_get_current_stock_price_force_fresh_passed_through(self):
+        """handle_get_current_stock_price의 force_fresh=True가 market_data_service에 전달되는지 검증"""
+        from common.types import Exchange
+        mock_output = self._create_dummy_stock_info({"stck_prpr": "80000", "stck_shrn_iscd": "005930"})
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd="0", msg1="정상", data={"output": mock_output}
+        )
+        self.mock_market_data_service.get_name_by_code.return_value = "삼성전자"
+
+        await self.stockQueryService.handle_get_current_stock_price("005930", force_fresh=True)
+
+        call_kwargs = self.mock_market_data_service.get_current_price.call_args
+        self.assertTrue(call_kwargs.kwargs.get("force_fresh", False))
 
     # --- New Wrapper Methods Tests ---
     async def test_get_top_trading_value_stocks(self):

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -37,6 +37,57 @@ async def test_get_stock_price(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_stock_detail_success(web_client, mock_web_ctx):
+    """GET /api/stock/{code}/detail — force_fresh=True로 handle_get_current_stock_price 호출"""
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success",
+        data={"code": "005930", "price": 70000, "per": 12.5, "bps": 50000}
+    )
+
+    response = web_client.get("/api/stock/005930/detail")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "0"
+    assert json_resp["data"]["per"] == 12.5
+
+    from common.types import Exchange
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with(
+        "005930",
+        caller="stock.py - get_stock_detail",
+        exchange=Exchange.KRX,
+        force_fresh=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_detail_api_failure(web_client, mock_web_ctx):
+    """GET /api/stock/{code}/detail — 증권사 API 실패 시 rt_cd != 0 반환"""
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd="1", msg1="API 오류", data=None
+    )
+
+    response = web_client.get("/api/stock/005930/detail")
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_get_stock_detail_timeout(web_client, mock_web_ctx):
+    """GET /api/stock/{code}/detail — 타임아웃 시 에러 메시지 반환"""
+    import asyncio
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.side_effect = asyncio.TimeoutError()
+
+    response = web_client.get("/api/stock/005930/detail")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "1"
+    assert "초과" in json_resp["msg1"]
+
+
+@pytest.mark.asyncio
 async def test_get_stock_chart(web_client, mock_web_ctx):
     """GET /api/chart/{code} 엔드포인트 테스트"""
     mock_web_ctx.stock_query_service.get_ohlcv.return_value = ResCommonResponse(

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -66,6 +66,28 @@ async def search_stock_by_name(q: str = ""):
     return {"results": results}
 
 
+@router.get("/stock/{code}/detail")
+async def get_stock_detail(code: str, exchange: str = Query("KRX")):
+    """증권사 API 직접 호출로 PER/PBR/EPS/BPS/업종/52주 등 상세 정보 반환 (캐시·DB 우회)."""
+    ctx = _get_ctx()
+    try:
+        exchange_enum = Exchange(exchange.upper())
+    except ValueError:
+        exchange_enum = Exchange.KRX
+    try:
+        resp = await asyncio.wait_for(
+            ctx.stock_query_service.handle_get_current_stock_price(
+                code, caller="stock.py - get_stock_detail", exchange=exchange_enum,
+                force_fresh=True,
+            ),
+            timeout=12.0,
+        )
+    except asyncio.TimeoutError:
+        ctx.logger.warning(f"[stock] 상세 정보 조회 타임아웃 ({code}, 12s 초과)")
+        return {"rt_cd": "1", "msg1": "API 응답 시간이 초과되었습니다.", "data": None}
+    return _serialize_response(resp)
+
+
 @router.get("/stock/{code}")
 async def get_stock_price(code: str, exchange: str = Query("KRX")):
     """현재가 조회. 종목명이 들어오면 종목코드로 변환 후 조회. exchange=KRX|NXT|UN 선택 가능."""

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -250,6 +250,7 @@ async function searchStock(codeOverride, exchangeOverride) {
                  }
                  .fav-star-btn:hover { transform: scale(1.05); background: var(--bg-card, #e8e8e8); }
                  .fav-star-btn.active { color: #ffc107; border-color: #ffc107; }
+                 .detail-loading { color: var(--text-secondary, #999); font-style: italic; }
             </style>
         `;
 
@@ -261,12 +262,15 @@ async function searchStock(codeOverride, exchangeOverride) {
             </div>
         `;
 
+        // Phase 1 렌더: 캐시/DB 데이터로 즉시 표기 (상세 필드는 로딩 placeholder)
+        const loading = '<span class="detail-loading">조회 중...</span>';
+
         resultDiv.innerHTML = styles + `
             <div class="card stock-info-box" style="position: relative;">
                 <button id="fav-toggle-btn" class="fav-star-btn" onclick="toggleFavorite('${data.code}')" title="관심종목">☆</button>
                 ${exchangeButtons}
                 <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
-                    <h3 class="stock-title" style="margin:0;">${data.name} (${data.code}) ${newHighBadge}${newLowBadge}</h3>
+                    <h3 class="stock-title" style="margin:0;" id="stock-title-area">${data.name} (${data.code}) ${newHighBadge}${newLowBadge}</h3>
                 </div>
                 <p id="rt-price" class="price ${changeClass}">${fnum(data.price, '원')}</p>
                 <p id="rt-change-rate" class="change-rate">전일대비: ${sign}${fnum(data.change_absolute || Math.abs(data.change))} (${frate(data.rate)})</p>
@@ -276,8 +280,8 @@ async function searchStock(codeOverride, exchangeOverride) {
                 <div class="stock-details">
                     <div class="detail-group">
                         <h4>ℹ️ 기본 정보</h4>
-                        <p><strong>업종:</strong> <span>${data.bstp_kor_isnm || 'N/A'}</span></p>
-                        <p><strong>상태:</strong> <span>${data.iscd_stat_cls_code_desc || 'N/A'}</span></p>
+                        <p><strong>업종:</strong> <span id="detail-sector">${data.bstp_kor_isnm || loading}</span></p>
+                        <p><strong>상태:</strong> <span id="detail-status">${data.iscd_stat_cls_code_desc || loading}</span></p>
                     </div>
                     <div class="detail-group">
                         <h4>📊 당일 시세</h4>
@@ -290,35 +294,35 @@ async function searchStock(codeOverride, exchangeOverride) {
                         <h4>📈 거래 정보</h4>
                         <p><strong>누적 거래량:</strong> <span>${fnum(data.acml_vol, ' 주')}</span></p>
                         <p><strong>누적 거래대금:</strong> <span>${formatTradingValue(data.acml_tr_pbmn)}</span></p>
-                        <p><strong>전일 대비 거래량:</strong> <span>${frate(data.prdy_vrss_vol_rate)}</span></p>
+                        <p><strong>전일 대비 거래량:</strong> <span id="detail-vol-rate">${data.prdy_vrss_vol_rate != null ? frate(data.prdy_vrss_vol_rate) : loading}</span></p>
                     </div>
                     <div class="detail-group">
                         <h4>🌐 수급 정보</h4>
-                        <p><strong>외국인 순매수:</strong> <span>${fnum(data.frgn_ntby_qty, ' 주')}</span></p>
-                        <p><strong>프로그램 순매수:</strong> <span>${fnum(data.pgtr_ntby_qty, ' 주')}</span></p>
+                        <p><strong>외국인 순매수:</strong> <span id="detail-frgn">${data.frgn_ntby_qty != null ? fnum(data.frgn_ntby_qty, ' 주') : loading}</span></p>
+                        <p><strong>프로그램 순매수:</strong> <span id="detail-pgtr">${data.pgtr_ntby_qty != null ? fnum(data.pgtr_ntby_qty, ' 주') : loading}</span></p>
                     </div>
                      <div class="detail-group full-width">
                         <h4>💹 투자 지표</h4>
                         <div style="display: flex; justify-content: space-around;">
-                           <p style="flex-direction: column; align-items: center;"><strong>PER:</strong> <span>${frate(data.per, ' 배')}</span></p>
-                           <p style="flex-direction: column; align-items: center;"><strong>PBR:</strong> <span>${frate(data.pbr, ' 배')}</span></p>
-                           <p style="flex-direction: column; align-items: center;"><strong>EPS:</strong> <span>${fnum(data.eps)}</span></p>
-                           <p style="flex-direction: column; align-items: center;"><strong>BPS:</strong> <span>${fnum(data.bps)}</span></p>
+                           <p style="flex-direction: column; align-items: center;"><strong>PER:</strong> <span id="detail-per">${data.per != null ? frate(data.per, ' 배') : loading}</span></p>
+                           <p style="flex-direction: column; align-items: center;"><strong>PBR:</strong> <span id="detail-pbr">${data.pbr != null ? frate(data.pbr, ' 배') : loading}</span></p>
+                           <p style="flex-direction: column; align-items: center;"><strong>EPS:</strong> <span id="detail-eps">${data.eps != null ? fnum(data.eps) : loading}</span></p>
+                           <p style="flex-direction: column; align-items: center;"><strong>BPS:</strong> <span id="detail-bps">${data.bps != null ? fnum(data.bps) : loading}</span></p>
                         </div>
                     </div>
                     <div class="detail-group full-width">
                         <h4>📅 주요 가격 정보</h4>
-                        <p><strong>52주 최고:</strong> <span>${fnum(data.w52_hgpr)} (${data.w52_hgpr_date}) | 대비: ${frate(data.w52_hgpr_vrss_prpr_ctrt)}</span></p>
-                        <p><strong>52주 최저:</strong> <span>${fnum(data.w52_lwpr)} (${data.w52_lwpr_date}) | 대비: ${frate(data.w52_lwpr_vrss_prpr_ctrt)}</span></p>
-                        <p><strong>250일 최고:</strong> <span>${fnum(data.d250_hgpr)} (${data.d250_hgpr_date}) | 대비: ${frate(data.d250_hgpr_vrss_prpr_rate)}</span></p>
-                        <p><strong>250일 최저:</strong> <span>${fnum(data.d250_lwpr)} (${data.d250_lwpr_date}) | 대비: ${frate(data.d250_lwpr_vrss_prpr_rate)}</span></p>
+                        <p><strong>52주 최고:</strong> <span id="detail-w52h">${data.w52_hgpr ? fnum(data.w52_hgpr) + ' (' + (data.w52_hgpr_date||'') + ') | 대비: ' + frate(data.w52_hgpr_vrss_prpr_ctrt) : loading}</span></p>
+                        <p><strong>52주 최저:</strong> <span id="detail-w52l">${data.w52_lwpr ? fnum(data.w52_lwpr) + ' (' + (data.w52_lwpr_date||'') + ') | 대비: ' + frate(data.w52_lwpr_vrss_prpr_ctrt) : loading}</span></p>
+                        <p><strong>250일 최고:</strong> <span id="detail-d250h">${data.d250_hgpr ? fnum(data.d250_hgpr) + ' (' + (data.d250_hgpr_date||'') + ') | 대비: ' + frate(data.d250_hgpr_vrss_prpr_rate) : loading}</span></p>
+                        <p><strong>250일 최저:</strong> <span id="detail-d250l">${data.d250_lwpr ? fnum(data.d250_lwpr) + ' (' + (data.d250_lwpr_date||'') + ') | 대비: ' + frate(data.d250_lwpr_vrss_prpr_rate) : loading}</span></p>
                     </div>
                     <div class="detail-group full-width">
                         <h4>📋 기타 상태</h4>
-                        <p><strong>신용 가능:</strong> <span>${data.crdt_able_yn}</span></p>
-                        <p><strong>관리 종목:</strong> <span>${data.mang_issu_cls_code}</span></p>
-                        <p><strong>단기 과열:</strong> <span>${data.short_over_yn}</span></p>
-                        <p><strong>정리 매매:</strong> <span>${data.sltr_yn}</span></p>
+                        <p><strong>신용 가능:</strong> <span id="detail-crdt">${data.crdt_able_yn || loading}</span></p>
+                        <p><strong>관리 종목:</strong> <span id="detail-mang">${data.mang_issu_cls_code || loading}</span></p>
+                        <p><strong>단기 과열:</strong> <span id="detail-short">${data.short_over_yn || loading}</span></p>
+                        <p><strong>정리 매매:</strong> <span id="detail-sltr">${data.sltr_yn || loading}</span></p>
                     </div>
                 </div>
             </div>
@@ -342,6 +346,9 @@ async function searchStock(codeOverride, exchangeOverride) {
 
         // 관심종목 버튼 초기 상태 설정
         _updateFavBtn(code);
+
+        // Phase 2: 증권사 API 상세 정보 백그라운드 로드
+        _loadStockDetail(code);
 
     } catch (e) {
         console.error("Error in searchStock:", e);
@@ -392,5 +399,81 @@ async function toggleFavorite(code) {
         }
     } catch (e) {
         if (typeof showToast === 'function') showToast(`오류: ${e.message}`, 'error');
+    }
+}
+
+/* ── Phase 2: 증권사 API 상세 정보 로드 & DOM 업데이트 ── */
+async function _loadStockDetail(code) {
+    try {
+        const res = await fetchWithTimeout(`/api/stock/${code}/detail?exchange=${_currentExchange}`, {}, 15000);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (json.rt_cd !== "0" || !json.data) return;
+        _updateDetailDOM(json.data);
+    } catch (e) {
+        // 상세 조회 실패 시 조용히 무시 (Phase 1 데이터는 이미 표기됨)
+        console.debug('[stock] 상세 정보 조회 실패:', e.message);
+    }
+}
+
+function _updateDetailDOM(data) {
+    const fnum = (n, suffix = "") => {
+        if (n === null || n === undefined || String(n).trim() === '' || String(n).toLowerCase() === 'n/a') return 'N/A';
+        try {
+            const val = parseFloat(String(n).replace(/,/g, ''));
+            if (isNaN(val)) return String(n);
+            return val.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 }) + suffix;
+        } catch { return String(n); }
+    };
+    const frate = (n, suffix = "%") => {
+        if (n === null || n === undefined || String(n).trim() === '' || String(n).toLowerCase() === 'n/a') return 'N/A';
+        try {
+            const val = parseFloat(String(n).replace(/,/g, ''));
+            if (isNaN(val)) return String(n);
+            return (val > 0 ? '+' : '') + val.toFixed(2) + suffix;
+        } catch { return String(n); }
+    };
+
+    const set = (id, val) => { const el = document.getElementById(id); if (el && val !== undefined) el.innerHTML = val; };
+
+    // ℹ️ 기본 정보
+    set('detail-sector', data.bstp_kor_isnm || 'N/A');
+    set('detail-status', data.iscd_stat_cls_code_desc || 'N/A');
+
+    // 📈 거래 정보
+    set('detail-vol-rate', frate(data.prdy_vrss_vol_rate));
+
+    // 🌐 수급 정보
+    set('detail-frgn', fnum(data.frgn_ntby_qty, ' 주'));
+    set('detail-pgtr', fnum(data.pgtr_ntby_qty, ' 주'));
+
+    // 💹 투자 지표
+    set('detail-per', frate(data.per, ' 배'));
+    set('detail-pbr', frate(data.pbr, ' 배'));
+    set('detail-eps', fnum(data.eps));
+    set('detail-bps', fnum(data.bps));
+
+    // 📅 주요 가격 정보
+    if (data.w52_hgpr) set('detail-w52h', `${fnum(data.w52_hgpr)} (${data.w52_hgpr_date || ''}) | 대비: ${frate(data.w52_hgpr_vrss_prpr_ctrt)}`);
+    if (data.w52_lwpr) set('detail-w52l', `${fnum(data.w52_lwpr)} (${data.w52_lwpr_date || ''}) | 대비: ${frate(data.w52_lwpr_vrss_prpr_ctrt)}`);
+    if (data.d250_hgpr) set('detail-d250h', `${fnum(data.d250_hgpr)} (${data.d250_hgpr_date || ''}) | 대비: ${frate(data.d250_hgpr_vrss_prpr_rate)}`);
+    if (data.d250_lwpr) set('detail-d250l', `${fnum(data.d250_lwpr)} (${data.d250_lwpr_date || ''}) | 대비: ${frate(data.d250_lwpr_vrss_prpr_rate)}`);
+
+    // 📋 기타 상태
+    set('detail-crdt', data.crdt_able_yn || 'N/A');
+    set('detail-mang', data.mang_issu_cls_code || 'N/A');
+    set('detail-short', data.short_over_yn || 'N/A');
+    set('detail-sltr', data.sltr_yn || 'N/A');
+
+    // 신고가/신저가 배지 업데이트
+    const titleArea = document.getElementById('stock-title-area');
+    if (titleArea && (data.is_new_high !== undefined || data.is_new_low !== undefined)) {
+        const newHighBadge = data.is_new_high ? '<span class="badge new-high">🔥 신고가</span>' : '';
+        const newLowBadge  = data.is_new_low  ? '<span class="badge new-low">💧 신저가</span>'  : '';
+        // 배지만 교체 (종목명·코드 유지)
+        const badges = titleArea.querySelectorAll('.badge');
+        badges.forEach(b => b.remove());
+        if (newHighBadge) titleArea.insertAdjacentHTML('beforeend', newHighBadge);
+        if (newLowBadge)  titleArea.insertAdjacentHTML('beforeend', newLowBadge);
     }
 }


### PR DESCRIPTION
Backend (3개 파일)

services/market_data_service.py — get_current_price에 force_fresh=False 파라미터 추가 (캐시·DB 스킵 후 직접 broker API 호출) view/web/routes/stock.py — GET /api/stock/{code}/detail 엔드포인트 추가 (force_fresh=True 호출) stock_query_service.py — force_fresh 파라미터 전달 체인 확인 Frontend (1개 파일)

view/web/static/js/stock.js — searchStock() 수정:
Phase 1: /api/stock/{code} → 즉시 렌더 (현재가, OHLCV)
Phase 2: /api/stock/{code}/detail → 업종/PER/PBR/BPS/52주/수급 등 DOM 업데이트

수정된 파일 4개

파일	변경 내용
services/market_data_service.py	get_current_price에 force_fresh=False 추가 — True 시 캐시·DB 우회하고 바로 broker API 호출 services/stock_query_service.py	get_current_price, handle_get_current_stock_price 모두에 force_fresh 파라미터 전달 체인 추가 view/web/routes/stock.py	GET /api/stock/{code}/detail 엔드포인트 추가 (force_fresh=True) view/web/static/js/stock.js	Phase 1: 즉시 렌더(캐시 데이터), Phase 2: _loadStockDetail() 백그라운드 호출 → _updateDetailDOM()으로 상세 필드 업데이트 동작 방식

종목 조회 시 /api/stock/{code}가 즉시 응답 → 현재가/시세 바로 표기, 상세 필드는 "조회 중..." 표시 백그라운드에서 /api/stock/{code}/detail 호출 (broker API 직접, ~1-3초) 응답 도착 시 업종·PER·PBR·EPS·BPS·52주·수급·기타 상태 DOM 업데이트
상세 조회 실패해도 Phase 1 데이터는 그대로 유지

추가된 TC 목록:

파일	추가/수정 TC
test_market_data_service.py	test_get_current_price_uses_cache_by_default — 기본값(force_fresh=False)에서 캐시 반환 시 broker API 미호출 확인 test_get_current_price_force_fresh_skips_cache — force_fresh=True 시 캐시 무시하고 broker API 직접 호출 test_get_current_price_force_fresh_skips_db_snapshot — force_fresh=True 시 DB 스냅샷도 우회 test_get_current_price_force_fresh_updates_cache — broker API 성공 후 캐시 업데이트 확인 test_stock_query_service.py	기존 test_get_current_price_success/failure — force_fresh=False 포함하도록 수정 test_get_current_price_force_fresh_passed_through — force_fresh=True가 market_data_service로 전달되는지 확인 test_handle_get_current_stock_price_force_fresh_passed_through — handle 메서드도 force_fresh 전달 확인 test_web_routes_stock.py	test_get_stock_detail_success — /detail 엔드포인트가 force_fresh=True로 호출되는지 검증 test_get_stock_detail_api_failure — API 실패 시 rt_cd != "0" 반환 test_get_stock_detail_timeout — 타임아웃 시 에러 메시지 반환