### PR TITLE
버그 수정 — web_app_initializer.py

### DIFF
--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -388,3 +388,121 @@ async def test_initialize_services_injects_reporter(mock_deps):
     mock_newhigh_cls = mock_deps["newhigh_task"]
     _, newhigh_kwargs = mock_newhigh_cls.call_args
     assert newhigh_kwargs.get("stock_query_service") == ctx.stock_query_service
+
+
+# ── _initialize_price_subscriptions ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_initialize_price_subscriptions_holdings(mock_deps):
+    """보유 종목 구독: virtual_trade_service.get_holds() 기준으로 HIGH 구독."""
+    from unittest.mock import patch as _patch
+    ctx = WebAppContext(None)
+
+    mock_price_svc = AsyncMock()
+    ctx.price_subscription_service = mock_price_svc
+
+    mock_vts = MagicMock()
+    mock_vts.get_holds.return_value = [
+        {"code": "005930", "name": "삼성전자"},
+        {"code": "000660", "name": "SK하이닉스"},
+    ]
+    ctx.virtual_trade_service = mock_vts
+
+    with _patch("view.web.web_app_initializer.StreamingType") as mock_st, \
+         _patch("view.web.web_app_initializer.SubscriptionPriority", create=True):
+        from services.price_subscription_service import SubscriptionPriority
+        await ctx._initialize_price_subscriptions()
+
+    # get_holds()가 호출되어야 하고, broker API는 호출되지 않아야 함
+    mock_vts.get_holds.assert_called_once()
+    assert mock_price_svc.add_subscription.call_count == 2
+    codes_called = [c.args[0] for c in mock_price_svc.add_subscription.call_args_list]
+    assert "005930" in codes_called
+    assert "000660" in codes_called
+
+
+@pytest.mark.asyncio
+async def test_initialize_price_subscriptions_holdings_no_broker_call(mock_deps):
+    """보유 종목 구독 시 broker.get_account_balance()를 호출하지 않음."""
+    ctx = WebAppContext(None)
+
+    mock_price_svc = AsyncMock()
+    ctx.price_subscription_service = mock_price_svc
+
+    mock_broker = MagicMock()
+    ctx.broker = mock_broker
+
+    mock_vts = MagicMock()
+    mock_vts.get_holds.return_value = []
+    ctx.virtual_trade_service = mock_vts
+
+    await ctx._initialize_price_subscriptions()
+
+    mock_broker.get_account_balance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initialize_price_subscriptions_premium_extracts_code(mock_deps, tmp_path):
+    """프리미엄 종목 구독: dict 항목에서 'code' 필드만 추출하여 sync_subscriptions에 전달."""
+    import json
+    premium_data = {
+        "kospi": [
+            {"code": "001820", "name": "삼화콘덴서", "market": "KOSPI", "rs_score": 0.0},
+            {"code": "005930", "name": "삼성전자", "market": "KOSPI"},
+        ],
+        "kosdaq": [
+            {"code": "086520", "name": "에코프로", "market": "KOSDAQ"},
+        ],
+    }
+    premium_file = tmp_path / "premium_stocks.json"
+    premium_file.write_text(json.dumps(premium_data), encoding="utf-8")
+
+    ctx = WebAppContext(None)
+
+    mock_price_svc = AsyncMock()
+    ctx.price_subscription_service = mock_price_svc
+
+    mock_vts = MagicMock()
+    mock_vts.get_holds.return_value = []
+    ctx.virtual_trade_service = mock_vts
+
+    with patch("os.path.join", return_value=str(premium_file)), \
+         patch("os.path.exists", return_value=True):
+        await ctx._initialize_price_subscriptions()
+
+    mock_price_svc.sync_subscriptions.assert_called_once()
+    call_kwargs = mock_price_svc.sync_subscriptions.call_args[1]
+    codes = call_kwargs["codes"]
+    # 문자열 코드만 들어있어야 함 (dict 아님)
+    assert all(isinstance(c, str) for c in codes), f"dict가 섞임: {codes}"
+    assert set(codes) == {"001820", "005930", "086520"}
+
+
+@pytest.mark.asyncio
+async def test_initialize_price_subscriptions_premium_no_dict_leakage(mock_deps, tmp_path):
+    """프리미엄 종목 codes에 dict가 절대 포함되지 않음을 확인 (버그 재현 방지)."""
+    import json
+    premium_data = {
+        "kospi": [{"code": "001820", "name": "삼화콘덴서"}],
+        "kosdaq": [],
+    }
+    premium_file = tmp_path / "premium_stocks.json"
+    premium_file.write_text(json.dumps(premium_data), encoding="utf-8")
+
+    ctx = WebAppContext(None)
+
+    mock_price_svc = AsyncMock()
+    ctx.price_subscription_service = mock_price_svc
+
+    mock_vts = MagicMock()
+    mock_vts.get_holds.return_value = []
+    ctx.virtual_trade_service = mock_vts
+
+    with patch("os.path.join", return_value=str(premium_file)), \
+         patch("os.path.exists", return_value=True):
+        await ctx._initialize_price_subscriptions()
+
+    call_kwargs = mock_price_svc.sync_subscriptions.call_args[1]
+    codes = call_kwargs["codes"]
+    for c in codes:
+        assert not isinstance(c, dict), f"codes에 dict 포함: {c}"

--- a/todo_list.md
+++ b/todo_list.md
@@ -14,7 +14,8 @@
   1. 백그라운드 태스크 현황의: websocket_watchdog의 구독 종목수가 실시간 현재가 구독현황과 sync가 안맞는문제.
 - [ ] **[현재가조회]** 
   현재가 조회시 stock_repository.py에 있는 현재가 cache를 통해 가지고 오는데, cache가 있으면 PER,PBR 수급정보 등의 API에서 가지고 올수 있는 data를 조회할 수 없음. 가지고 올수 있는 방법이 뭐가 있을지 확인. (장마감 이후 daily_price_update_task에서 pdr로 update 하는데 이때 해당 detail 정보는 못가지고 오는것으로 보임. pdr에 없는지, 없으면 어떻게 할지?)
-    
+
+
 ### 1. 핵심 아키텍처 및 보안 (Core Architecture)
 - [ ] **[아키텍처]** UI 출력 로직 완전 격리: Service 계층 내부에 존재하는 콘솔 출력(`print`) 로직을 제거하고, View 계층에 위임.
 - [ ] **[보안]** 단순 쿠키 기반 인증을 JWT(JSON Web Token) 기반으로 고도화 (세션 만료 및 Secure/HttpOnly 적용).

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -410,17 +410,15 @@ class WebAppContext:
 
         from services.price_subscription_service import SubscriptionPriority
 
-        # 1. 보유 종목 → HIGH 구독
+        # 1. 보유 종목 → HIGH 구독 (전략 스케줄러의 가상 보유 종목 기준)
         try:
-            resp = await self.broker.get_account_balance()
-            if resp and resp.rt_cd == "0" and resp.data:
-                holdings = resp.data.get("output2", []) if isinstance(resp.data, dict) else []
-                for item in holdings:
-                    code = item.get("pdno", "").strip()
-                    if code:
-                        await self.price_subscription_service.add_subscription(
-                            code, SubscriptionPriority.HIGH, "portfolio", StreamingType.UNIFIED_PRICE
-                        )
+            holdings = self.virtual_trade_service.get_holds() if self.virtual_trade_service else []
+            for item in holdings:
+                code = item.get("code", "").strip()
+                if code:
+                    await self.price_subscription_service.add_subscription(
+                        code, SubscriptionPriority.HIGH, "portfolio", StreamingType.UNIFIED_PRICE
+                    )
         except Exception as e:
             self.logger.warning(f"보유 종목 구독 초기화 실패: {e}")
 
@@ -431,7 +429,12 @@ class WebAppContext:
             if os.path.exists(premium_path):
                 with open(premium_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                codes = data.get("kospi", []) + data.get("kosdaq", [])
+                raw = data.get("kospi", []) + data.get("kosdaq", [])
+                codes = [
+                    item["code"] if isinstance(item, dict) else item
+                    for item in raw
+                    if (item.get("code") if isinstance(item, dict) else item)
+                ]
                 if codes:
                     await self.price_subscription_service.sync_subscriptions(
                         codes=codes,


### PR DESCRIPTION
보유종목 구독 (버그 1): broker.get_account_balance() (실계좌 API) → virtual_trade_service.get_holds() (전략 스케줄러의 가상 보유 종목)로 교체. 키도 "pdno" → "code" 수정.

프리미엄 종목 codes (버그 2): data.get("kospi", []) + data.get("kosdaq", []) 결과가 dict 리스트이므로, item["code"] 로 코드 문자열만 추출하도록 수정.

추가된 TC — test_web_app_initializer.py

TC	검증 내용
test_initialize_price_subscriptions_holdings	get_holds() 호출 후 2개 종목 HIGH 구독 test_initialize_price_subscriptions_holdings_no_broker_call	broker.get_account_balance() 미호출 확인 test_initialize_price_subscriptions_premium_extracts_code	dict 항목에서 code 문자열만 추출되는지 확인 test_initialize_price_subscriptions_premium_no_dict_leakage	codes에 dict가 포함되지 않음을 명시적으로 검증