### PR TITLE
Phase1 - 마크 미너비니(Mark Minervini)의 4단계(4-Stage) 분석과 '트렌드 템플릿(Trend Tem…

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -14,8 +14,8 @@ after_market_tasks:
   after_market_delay_sec:
     ranking_refresh: 10          # RankingTask — 장 마감 10분 후
     daily_price_collector: 60      # DailyPriceCollectorTask — 장 60분 후
-    ohlcv_update: 120             # OhlcvUpdateTask — 장 마감 120분 후
+    newhigh: 80                  # NewHighTask — daily_price_collector 완료(80분) + 여유
+    ohlcv_update: 100             # OhlcvUpdateTask — 장 마감 100분 후
     전일기준주도주_생성: 180        # PremiumWatchlistGeneratorTask — 장 마감 180분 후
     cache_warmup: 200             # CacheWarmupTask — 장 마감 200분 후 (우량주 생성 완료 후)
     log_cleanup: 300              # LogCleanupTask — 장 마감 300분(5시간) 후
-    newhigh: 150                  # NewHighTask — daily_price_collector 완료(60분) + 여유

--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -130,9 +130,13 @@ class FavoriteService:
         if minervini_svc:
             async def _get_stage(code: str) -> int:
                 try:
-                    return await asyncio.wait_for(
+                    res = await asyncio.wait_for(
                         minervini_svc.get_stage_for_code(code), timeout=3.0
                     )
+                    # get_stage_for_code now returns (stage, reason)
+                    if isinstance(res, tuple) and len(res) >= 1:
+                        return int(res[0]) if res[0] is not None else 0
+                    return int(res) if res is not None else 0
                 except Exception:
                     return 0
 

--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -63,6 +63,7 @@ class FavoriteService:
                 "price": None,
                 "rate": None,
                 "rs_rating": None,
+                "minervini_stage": None,
             }
             for code in codes
         }
@@ -123,5 +124,23 @@ class FavoriteService:
             for code, rs_resp in zip(result.keys(), rs_responses):
                 if not isinstance(rs_resp, Exception) and getattr(rs_resp, "rt_cd", None) == "0" and rs_resp.data:
                     result[code]["rs_rating"] = rs_resp.data.rs_rating
+
+        # 5단계: Minervini Stage 조회 및 병합 (병렬, 3초 timeout)
+        minervini_svc = getattr(self, "minervini_stage_service", None)
+        if minervini_svc:
+            async def _get_stage(code: str) -> int:
+                try:
+                    return await asyncio.wait_for(
+                        minervini_svc.get_stage_for_code(code), timeout=3.0
+                    )
+                except Exception:
+                    return 0
+
+            stage_results = await asyncio.gather(
+                *[_get_stage(c) for c in result.keys()], return_exceptions=True
+            )
+            for code, stage in zip(result.keys(), stage_results):
+                if not isinstance(stage, Exception) and isinstance(stage, int) and stage > 0:
+                    result[code]["minervini_stage"] = stage
 
         return list(result.values())

--- a/services/minervini_stage_service.py
+++ b/services/minervini_stage_service.py
@@ -57,7 +57,7 @@ class MinerviniStageService:
 
     # ── 공개 비동기 메서드 ─────────────────────────────────────────────────
 
-    async def get_stage_for_code(self, code: str) -> int:
+    async def get_stage_for_code(self, code: str) -> tuple[int, str]:
         """단일 종목의 현재 Stage를 실시간으로 계산한다.
 
         OHLCV 260일치 조회 → RS Rating 조회 → classify_stage() 호출.
@@ -83,7 +83,10 @@ class MinerviniStageService:
                 return self.STAGE_UNKNOWN
 
             rs_rating = await self._fetch_rs_rating(code)
-            return self.classify_stage(closes, lows, rs_rating)
+            stage, reason = self.classify_stage(closes, lows, rs_rating, return_reason=True)
+            # 로그에 판정 이유를 남기고 호출자에게도 반환
+            self._logger.info(f"[MinerviniStage] {code} Stage={stage} reason={reason}")
+            return stage, reason
 
         except Exception as e:
             self._logger.warning(f"[MinerviniStage] {code} Stage 계산 오류: {e}")
@@ -96,7 +99,8 @@ class MinerviniStageService:
         closes: List[float],
         lows: List[float],
         rs_rating: int = 0,
-    ) -> int:
+        return_reason: bool = False,
+    ) -> tuple[int, str] | int:
         """미너비니 트렌드 템플릿으로 Stage 1~4를 분류한다.
 
         Args:
@@ -108,7 +112,8 @@ class MinerviniStageService:
             STAGE_4 (4), STAGE_2 (2), STAGE_3 (3), STAGE_1 (1), STAGE_UNKNOWN (0).
         """
         if len(closes) < 200:
-            return self.STAGE_UNKNOWN
+            reason = f"데이터 부족 ({len(closes)}일, 200일 필요)"
+            return (self.STAGE_UNKNOWN, reason) if return_reason else self.STAGE_UNKNOWN
 
         price = closes[-1]
         ma50  = mean(closes[-50:])
@@ -128,8 +133,12 @@ class MinerviniStageService:
         w52_low = min(low_window) if low_window else min(closes)
 
         # ── Stage 4 (최우선 필터) ──────────────────────────────────────────
-        if price < ma200 or ma200_slope <= 0:
-            return self.STAGE_4_DECLINING
+        if price < ma200:
+            reason = f"가격이 MA200 아래 (가격={price:.2f} < MA200={ma200:.2f})"
+            return (self.STAGE_4_DECLINING, reason) if return_reason else self.STAGE_4_DECLINING
+        if ma200_slope <= 0:
+            reason = f"MA200 기울기 비양수 (기울기={ma200_slope:.6f})"
+            return (self.STAGE_4_DECLINING, reason) if return_reason else self.STAGE_4_DECLINING
 
         # ── Stage 2 (트렌드 템플릿 8조건) ────────────────────────────────
         # 조건 8: RS Rating — 데이터 없으면(0) skip하고 경고 로그
@@ -151,14 +160,20 @@ class MinerviniStageService:
             and rs_ok                    # ⑧  RS Rating >= 70
         )
         if is_stage2:
-            return self.STAGE_2_ADVANCING
+            reason = (
+                f"트렌드 템플릿 충족: ma200_slope={ma200_slope:.6f}, ma50={ma50:.2f}, "
+                f"ma150={ma150:.2f}, ma200={ma200:.2f}, 가격={price:.2f}, RS={rs_rating}"
+            )
+            return (self.STAGE_2_ADVANCING, reason) if return_reason else self.STAGE_2_ADVANCING
 
         # ── Stage 3 (고점/배분) ───────────────────────────────────────────
         if price < ma50 and self._is_high_volatility(closes):
-            return self.STAGE_3_TOPPING
+            reason = f"MA50 아래이면서 고변동성 (가격={price:.2f} < MA50={ma50:.2f})"
+            return (self.STAGE_3_TOPPING, reason) if return_reason else self.STAGE_3_TOPPING
 
         # ── Stage 1 (무관심/횡보) ─────────────────────────────────────────
-        return self.STAGE_1_NEGLECT
+        reason = "기본: 무관심/횡보"
+        return (self.STAGE_1_NEGLECT, reason) if return_reason else self.STAGE_1_NEGLECT
 
     # ── 내부 헬퍼 ──────────────────────────────────────────────────────────
 

--- a/services/minervini_stage_service.py
+++ b/services/minervini_stage_service.py
@@ -1,0 +1,236 @@
+"""
+services/minervini_stage_service.py
+
+Mark Minervini의 4단계(Stage Analysis) + 트렌드 템플릿(Trend Template) 구현.
+
+Stage 정의:
+    1 (무관심): 바닥 다지기, 이평선 수렴
+    2 (상승):   트렌드 템플릿 8조건 충족 — 유일한 매수 구간
+    3 (고점):   변동성 급증 + MA50 이탈 — 익절/손절 강화
+    4 (하락):   MA200 하회 or MA200 하향 — 매수 금지
+"""
+
+from __future__ import annotations
+
+import logging
+from statistics import mean
+from typing import List, Optional, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from services.stock_query_service import StockQueryService
+    from services.rs_rating_service import RSRatingService
+
+
+class MinerviniStageService:
+    """미너비니 4단계 분류 서비스."""
+
+    # Stage 상수
+    STAGE_UNKNOWN = 0
+    STAGE_1_NEGLECT = 1
+    STAGE_2_ADVANCING = 2
+    STAGE_3_TOPPING = 3
+    STAGE_4_DECLINING = 4
+
+    def __init__(
+        self,
+        stock_query_service: "StockQueryService",
+        rs_rating_service: Optional["RSRatingService"] = None,
+        slope_lookback: int = 20,
+        volatility_threshold: float = 0.02,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        """
+        Args:
+            stock_query_service: OHLCV 조회용 서비스.
+            rs_rating_service:   RS Rating 조회용 서비스 (선택적).
+            slope_lookback:      MA200 기울기 계산 기간(거래일). 기본 20 = 미너비니 "최소 1개월".
+            volatility_threshold: Stage 3 고변동성 임계값 (ATR/평균가). 기본 0.02 = 2%.
+            logger:              Logger 인스턴스.
+        """
+        self._stock_query_svc = stock_query_service
+        self._rs_rating_svc = rs_rating_service
+        self._slope_lookback = slope_lookback
+        self._vol_threshold = volatility_threshold
+        self._logger = logger or logging.getLogger(__name__)
+
+    # ── 공개 비동기 메서드 ─────────────────────────────────────────────────
+
+    async def get_stage_for_code(self, code: str) -> int:
+        """단일 종목의 현재 Stage를 실시간으로 계산한다.
+
+        OHLCV 260일치 조회 → RS Rating 조회 → classify_stage() 호출.
+
+        Returns:
+            1~4 (Stage), 또는 0 (데이터 부족으로 미계산).
+        """
+        try:
+            ohlcv_resp = await self._stock_query_svc.get_recent_daily_ohlcv(
+                code, limit=260
+            )
+            if not ohlcv_resp or ohlcv_resp.rt_cd != "0" or not ohlcv_resp.data:
+                self._logger.debug(f"[MinerviniStage] {code} OHLCV 데이터 없음")
+                return self.STAGE_UNKNOWN
+
+            rows = ohlcv_resp.data
+            closes, lows = self._extract_price_series(rows)
+
+            if len(closes) < 200:
+                self._logger.debug(
+                    f"[MinerviniStage] {code} 종가 데이터 부족 ({len(closes)}일) — STAGE_UNKNOWN"
+                )
+                return self.STAGE_UNKNOWN
+
+            rs_rating = await self._fetch_rs_rating(code)
+            return self.classify_stage(closes, lows, rs_rating)
+
+        except Exception as e:
+            self._logger.warning(f"[MinerviniStage] {code} Stage 계산 오류: {e}")
+            return self.STAGE_UNKNOWN
+
+    # ── 핵심 계산 메서드 (동기, 순수 함수) ────────────────────────────────
+
+    def classify_stage(
+        self,
+        closes: List[float],
+        lows: List[float],
+        rs_rating: int = 0,
+    ) -> int:
+        """미너비니 트렌드 템플릿으로 Stage 1~4를 분류한다.
+
+        Args:
+            closes:    종가 리스트 (오래된 순). 최소 200개 필요.
+            lows:      장중 저가 리스트 (stck_lwpr 기준). 52주 신저가 산출에 사용.
+            rs_rating: IBD RS Rating 1~99. 0이면 해당 조건 skip.
+
+        Returns:
+            STAGE_4 (4), STAGE_2 (2), STAGE_3 (3), STAGE_1 (1), STAGE_UNKNOWN (0).
+        """
+        if len(closes) < 200:
+            return self.STAGE_UNKNOWN
+
+        price = closes[-1]
+        ma50  = mean(closes[-50:])
+        ma150 = mean(closes[-150:])
+        ma200 = mean(closes[-200:])
+
+        # MA200 기울기: numpy 선형회귀 (20일 = 미너비니 "최소 1개월 우상향" 기준)
+        slope_window = closes[-self._slope_lookback:]
+        ma200_slope = self._calculate_slope(slope_window)
+
+        # 52주 고가: 종가 기준
+        w52_closes = closes[-252:] if len(closes) >= 252 else closes
+        w52_high = max(w52_closes)
+
+        # 52주 저가: 장중 저가 기준 (미너비니 원칙)
+        low_window = lows[-252:] if len(lows) >= 252 else lows
+        w52_low = min(low_window) if low_window else min(closes)
+
+        # ── Stage 4 (최우선 필터) ──────────────────────────────────────────
+        if price < ma200 or ma200_slope <= 0:
+            return self.STAGE_4_DECLINING
+
+        # ── Stage 2 (트렌드 템플릿 8조건) ────────────────────────────────
+        # 조건 8: RS Rating — 데이터 없으면(0) skip하고 경고 로그
+        if rs_rating == 0:
+            self._logger.debug(
+                f"[MinerviniStage] RS Rating 데이터 부족 — RS 조건 skip (stage 판정 계속)"
+            )
+            rs_ok = True
+        else:
+            rs_ok = rs_rating >= 70
+
+        is_stage2 = (
+            ma200_slope > 0              # ①  MA200 우상향
+            and ma50 > ma150 > ma200     # ②③ 정배열 (50 > 150 > 200)
+            and price > ma150            # ④  가격 > MA150
+            and price > ma50             # ⑤  가격 > MA50
+            and price >= w52_low * 1.25  # ⑥  52주 저가(장중 저가) 대비 +25%
+            and price >= w52_high * 0.75 # ⑦  52주 고가 대비 -25% 이내
+            and rs_ok                    # ⑧  RS Rating >= 70
+        )
+        if is_stage2:
+            return self.STAGE_2_ADVANCING
+
+        # ── Stage 3 (고점/배분) ───────────────────────────────────────────
+        if price < ma50 and self._is_high_volatility(closes):
+            return self.STAGE_3_TOPPING
+
+        # ── Stage 1 (무관심/횡보) ─────────────────────────────────────────
+        return self.STAGE_1_NEGLECT
+
+    # ── 내부 헬퍼 ──────────────────────────────────────────────────────────
+
+    def _calculate_slope(self, values: List[float]) -> float:
+        """numpy 선형회귀로 기울기 산출.
+
+        단순 증감률보다 노이즈에 강건하며, 미너비니 "지속적 우상향" 조건에 부합.
+        데이터가 2개 미만이면 0.0 반환.
+        """
+        if len(values) < 2:
+            return 0.0
+        x = np.arange(len(values), dtype=float)
+        y = np.array(values, dtype=float)
+        try:
+            slope = float(np.polyfit(x, y, 1)[0])
+        except (np.linalg.LinAlgError, ValueError):
+            slope = 0.0
+        return slope
+
+    def _is_high_volatility(self, closes: List[float], period: int = 20) -> bool:
+        """ATR-proxy: 일간 절대 변화량 / 평균가 > vol_threshold (기본 2%).
+
+        향후 Phase 2에서 VCP(Volatility Contraction Pattern) 판정으로 확장 예정.
+        check_vcp_pattern(): 최근 4~5주 고점 대비 하락폭 수축 여부 체크.
+        """
+        if len(closes) < period + 1:
+            return False
+        window = closes[-(period + 1):]
+        changes = [abs(window[i] - window[i - 1]) for i in range(1, len(window))]
+        avg_price = mean(window[1:]) or 1.0
+        return (mean(changes) / avg_price) > self._vol_threshold
+
+    def _extract_price_series(
+        self, rows: list
+    ) -> tuple[List[float], List[float]]:
+        """OHLCV 행 목록에서 종가/저가 리스트 추출.
+
+        KIS API 필드명(stck_clpr, stck_lwpr) 우선, 없으면 'close'/'low' fallback.
+        rows는 오래된 순 또는 최신 순 모두 처리 — DB에서 날짜 오름차순 반환 가정.
+        """
+        closes: List[float] = []
+        lows: List[float] = []
+        for r in rows:
+            close_val = r.get("stck_clpr") or r.get("close") or 0
+            low_val   = r.get("stck_lwpr") or r.get("low") or close_val
+            try:
+                closes.append(float(close_val))
+                lows.append(float(low_val))
+            except (TypeError, ValueError):
+                continue
+        return closes, lows
+
+    async def _fetch_rs_rating(self, code: str) -> int:
+        """RS Rating 서비스에서 최신 RS Rating 조회. 없으면 0 반환."""
+        if not self._rs_rating_svc:
+            return 0
+        try:
+            resp = await self._rs_rating_svc.get_rating(code)
+            if resp and resp.rt_cd == "0" and resp.data:
+                return int(resp.data.rs_rating)
+        except Exception as e:
+            self._logger.debug(f"[MinerviniStage] {code} RS Rating 조회 실패: {e}")
+        return 0
+
+    # ── 디버그 헬퍼 ────────────────────────────────────────────────────────
+
+    def describe_stage(self, stage: int) -> str:
+        """Stage 번호를 사람이 읽기 좋은 문자열로 변환."""
+        return {
+            self.STAGE_UNKNOWN:   "미계산",
+            self.STAGE_1_NEGLECT: "Stage 1 (무관심)",
+            self.STAGE_2_ADVANCING: "Stage 2 (상승)",
+            self.STAGE_3_TOPPING: "Stage 3 (고점)",
+            self.STAGE_4_DECLINING: "Stage 4 (하락)",
+        }.get(stage, f"Stage {stage}")

--- a/services/minervini_stage_service.py
+++ b/services/minervini_stage_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from statistics import mean
+import asyncio
 from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
@@ -66,12 +67,17 @@ class MinerviniStageService:
             1~4 (Stage), 또는 0 (데이터 부족으로 미계산).
         """
         try:
-            ohlcv_resp = await self._stock_query_svc.get_recent_daily_ohlcv(
-                code, limit=260
-            )
+            try:
+                ohlcv_resp = await self._stock_query_svc.get_recent_daily_ohlcv(
+                    code, limit=260
+                )
+            except asyncio.CancelledError:
+                self._logger.debug(f"[MinerviniStage] {code} OHLCV 호출 취소됨")
+                return self.STAGE_UNKNOWN, "작업 취소"
+
             if not ohlcv_resp or ohlcv_resp.rt_cd != "0" or not ohlcv_resp.data:
                 self._logger.debug(f"[MinerviniStage] {code} OHLCV 데이터 없음")
-                return self.STAGE_UNKNOWN
+                return self.STAGE_UNKNOWN, "OHLCV 데이터 없음"
 
             rows = ohlcv_resp.data
             closes, lows = self._extract_price_series(rows)
@@ -80,7 +86,7 @@ class MinerviniStageService:
                 self._logger.debug(
                     f"[MinerviniStage] {code} 종가 데이터 부족 ({len(closes)}일) — STAGE_UNKNOWN"
                 )
-                return self.STAGE_UNKNOWN
+                return self.STAGE_UNKNOWN, f"데이터 부족 ({len(closes)}일)"
 
             rs_rating = await self._fetch_rs_rating(code)
             stage, reason = self.classify_stage(closes, lows, rs_rating, return_reason=True)
@@ -90,7 +96,7 @@ class MinerviniStageService:
 
         except Exception as e:
             self._logger.warning(f"[MinerviniStage] {code} Stage 계산 오류: {e}")
-            return self.STAGE_UNKNOWN
+            return self.STAGE_UNKNOWN, f"오류: {e}"
 
     # ── 핵심 계산 메서드 (동기, 순수 함수) ────────────────────────────────
 
@@ -231,7 +237,11 @@ class MinerviniStageService:
         if not self._rs_rating_svc:
             return 0
         try:
-            resp = await self._rs_rating_svc.get_rating(code)
+            try:
+                resp = await self._rs_rating_svc.get_rating(code)
+            except asyncio.CancelledError:
+                self._logger.debug(f"[MinerviniStage] {code} RS Rating 조회 취소됨")
+                return 0
             if resp and resp.rt_cd == "0" and resp.data:
                 return int(resp.data.rs_rating)
         except Exception as e:

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -22,6 +22,7 @@ from services.price_subscription_service import SubscriptionPriority
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from services.rs_rating_service import RSRatingService
+    from services.minervini_stage_service import MinerviniStageService
 
 def _chunked(lst, size):
     for i in range(0, len(lst), size):
@@ -50,6 +51,7 @@ class OneilUniverseService:
         performance_profiler: Optional[PerformanceProfiler] = None,
         price_subscription_service=None,
         rs_rating_service: Optional["RSRatingService"] = None,
+        minervini_service: Optional["MinerviniStageService"] = None,
     ):
         self._sqs = stock_query_service
         self._indicator = indicator_service
@@ -61,6 +63,7 @@ class OneilUniverseService:
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._price_sub_svc = price_subscription_service
         self._rs_rating_service = rs_rating_service
+        self._minervini_svc = minervini_service
 
         # 상태 관리
         self._watchlist: Dict[str, OSBWatchlistItem] = {}
@@ -262,7 +265,7 @@ class OneilUniverseService:
     async def _analyze_premium_candidate(self, code: str, name: str, logger: Optional[logging.Logger] = None) -> Optional[OSBWatchlistItem]:
         """장마감 후 전일 기준 우량주(Pool A) 분석. 
         어제까지의 확정된 일봉 데이터만 사용하므로 별도의 슬라이싱이 필요하지 않습니다."""
-        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=90)
+        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=260)
         ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
 
         if not ohlcv:
@@ -284,9 +287,16 @@ class OneilUniverseService:
 
         ma_20d = sum(closes[-20:]) / 20
         ma_50d = sum(closes[-50:]) / 50
+        ma_150d = sum(closes[-150:]) / 150 if len(closes) >= 150 else 0.0
+        ma_200d = sum(closes[-200:]) / 200 if len(closes) >= 200 else 0.0
         high_20d = int(max(highs))
         avg_vol_20d = sum(volumes) / len(volumes)
         prev_close = closes[-1]
+
+        # 52주 저가: 장중 저가(low) 기준 — 미너비니 원칙
+        lows_all = [r.get("low", 0) for r in ohlcv if r.get("low") is not None]
+        w52_lows = lows_all[-252:] if len(lows_all) >= 252 else lows_all
+        w52_lwpr = int(min(w52_lows)) if w52_lows else 0
 
         # 필터: 거래대금, 정배열
         recent_5 = ohlcv[-5:]
@@ -366,6 +376,14 @@ class OneilUniverseService:
 
         market = "KOSDAQ" if self.stock_code_repository.is_kosdaq(code) else "KOSPI"
 
+        # 미너비니 Stage 4 하드 필터 (MA200 데이터가 충분할 때만 적용)
+        minervini_stage = 0
+        if self._minervini_svc and len(closes) >= 200:
+            minervini_stage = self._minervini_svc.classify_stage(closes, lows_all, rs_rating=0)
+            if minervini_stage == 4:
+                if logger: logger.debug({"event": "drop", "code": code, "reason": "minervini_stage4"})
+                return None
+
         if logger: logger.debug({"event": "selected", "code": code, "name": name})
 
         return OSBWatchlistItem(
@@ -373,7 +391,8 @@ class OneilUniverseService:
             high_20d=high_20d, ma_20d=ma_20d, ma_50d=ma_50d,
             avg_vol_20d=avg_vol_20d, bb_width_min_20d=bb_min, prev_bb_width=prev_width,
             w52_hgpr=w52_hgpr, avg_trading_value_5d=tv_5d, market_cap=stck_llam,
-            rs_return_3m=rs_return
+            rs_return_3m=rs_return,
+            ma_150d=ma_150d, ma_200d=ma_200d, w52_lwpr=w52_lwpr, minervini_stage=minervini_stage,
         )
 
     async def _analyze_surge_candidate(self, code: str, name: str, logger: Optional[logging.Logger] = None) -> Optional[OSBWatchlistItem]:
@@ -898,11 +917,15 @@ class OneilUniverseService:
         logger.debug({"event": "compute_total_scores_started", "item_count": len(items)})
         for item in items:
             item.total_score = item.rs_score + item.profit_growth_score + item.smart_money_score
+            # 미너비니 Stage 2 가산점: 트렌드 템플릿 충족 종목 우선
+            if item.minervini_stage == 2:
+                item.total_score += 20.0
             if item.total_score > 0:
                 logger.debug({
                     "event": "total_score_calculated", "code": item.code, "name": item.name,
                     "rs_score": item.rs_score, "profit_score": item.profit_growth_score,
                     "smart_money_score": item.smart_money_score,
+                    "minervini_stage": item.minervini_stage,
                     "total_score": item.total_score
                 })
         logger.debug({"event": "compute_total_scores_finished"})

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -100,6 +100,12 @@ class OSBWatchlistItem:
     smart_money_score: float = 0.0
     total_score: float = 0.0
 
+    # 미너비니 트렌드 템플릿
+    ma_150d: float = 0.0            # 150일 이동평균 (Trend Template)
+    ma_200d: float = 0.0            # 200일 이동평균 (Trend Template)
+    w52_lwpr: int = 0               # 52주 최저가 (장중 저가 기준)
+    minervini_stage: int = 0        # 1~4단계 (0=미계산)
+
 
 @dataclass
 class OSBPositionState:

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -268,7 +268,7 @@ async def test_analyze_premium_candidate_with_zero_volume(oneil_service_fixture)
     # Assert
     # 함수는 오류를 발생시키지 않고 None을 반환해야 합니다.
     assert result is None
-    mock_sqs.get_recent_daily_ohlcv.assert_awaited_once_with("TESTCODE", limit=90)
+    mock_sqs.get_recent_daily_ohlcv.assert_awaited_once_with("TESTCODE", limit=260)
 
 async def test_analyze_premium_candidate_with_no_high_data(oneil_service_fixture):
     """
@@ -284,7 +284,7 @@ async def test_analyze_premium_candidate_with_no_high_data(oneil_service_fixture
 
     # Assert
     assert result is None
-    mock_sqs.get_recent_daily_ohlcv.assert_awaited_once_with("TESTCODE", limit=90)
+    mock_sqs.get_recent_daily_ohlcv.assert_awaited_once_with("TESTCODE", limit=260)
     # 조기 반환되므로 추가 API 호출이 없어야 합니다.
     mock_sqs.get_current_price.assert_not_called()
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -71,6 +71,11 @@
   - 실시간 방아쇠: REST/WS 연동하여 체결강도 120% 이상 & 5,000만 원 이상 고래 탐지 시 즉시 진입(Event-Driven).
 - [ ] **[기타 탐색]** GPT 추천 기반 추세 돌파매매(Trend Breakout), ConsolidationScanner 전략 타당성 검토.
 - [ ] **[전략]** 미너비니의 SEPA기법, VCP 추가
+  - Phase 2 진행.
+  - 미너비니 stage 수집하는 background task 추가.
+  - 2단계 종목을 telegram으로 report.
+  - 2단계 종목 list를 보여주는 web page 생성 (view/web/routes/minervini_stage.py, view/web/static/minuervini_stage.js, view/web/templates/minervini_stage.html)
+
   1. SPEA 정량화
     💤 1단계: 무관심 국면 (Stage 1: Consolidation / Neglect)
     폭락을 멈추고 바닥을 다지며 옆으로 기어가는 시기입니다.

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -17,6 +17,88 @@ async def get_ranking_progress():
     return {"running": False, "processed": 0, "total": 0, "collected": 0, "elapsed": 0.0}
 
 
+@router.get("/ranking/minervini_stage2")
+async def get_minervini_stage2():
+    """Minervini Stage 2에 해당하는 전체 종목 목록을 RS 순으로 반환한다.
+
+    각 항목은 dict: { code, name, stck_prpr, prdy_ctrt, stage, rs_rating, market_cap }
+    """
+    ctx = _get_ctx()
+    if not ctx:
+        return {"rt_cd": "1", "msg1": "Context 미설정", "data": None}
+
+    codes = list(ctx.stock_code_repository.name_to_code.values())
+    minervini = ctx.minervini_stage_service
+    sqs = ctx.stock_query_service
+    rs_svc = getattr(ctx, 'rs_rating_service', None)
+
+    import asyncio
+
+    sem = asyncio.Semaphore(20)
+
+    async def check_code(code: str):
+        async with sem:
+            try:
+                res = await asyncio.wait_for(minervini.get_stage_for_code(code), timeout=3.0)
+            except Exception:
+                return None
+            stage = res[0] if isinstance(res, (list, tuple)) else res
+            if stage != minervini.STAGE_2_ADVANCING:
+                return None
+            # fetch price and rs and market cap
+            price = None
+            rate = None
+            market_cap = None
+            rs_val = None
+            try:
+                presp = await asyncio.wait_for(sqs.get_current_price(code, caller="ranking:minervini"), timeout=3.0)
+                if presp and getattr(presp, 'rt_cd', None) == '0' and getattr(presp, 'data', None):
+                    out = presp.data if isinstance(presp.data, dict) else getattr(presp, 'data', presp.data)
+                    # try dict-like first
+                    if isinstance(out, dict):
+                        price = out.get('stck_prpr') or out.get('stck_prpr')
+                        rate = out.get('prdy_ctrt') or out.get('prdy_ctrt')
+                        market_cap = out.get('stck_avls') or out.get('stck_avls')
+                    else:
+                        price = getattr(out, 'stck_prpr', None)
+                        rate = getattr(out, 'prdy_ctrt', None)
+                        market_cap = getattr(out, 'stck_avls', None)
+            except Exception:
+                pass
+            try:
+                if rs_svc:
+                    rresp = await asyncio.wait_for(rs_svc.get_rating(code), timeout=2.5)
+                    if rresp and getattr(rresp, 'rt_cd', None) == '0' and getattr(rresp, 'data', None):
+                        rs_val = int(rresp.data.rs_rating)
+            except Exception:
+                rs_val = None
+
+            name = ctx.stock_code_repository.get_name_by_code(code) or ''
+            return {
+                'code': code,
+                'name': name,
+                'stck_prpr': price or 0,
+                'prdy_ctrt': rate or 0,
+                'stage': int(stage),
+                'rs_rating': rs_val or 0,
+                'market_cap': market_cap or 0,
+            }
+
+    tasks = [check_code(c) for c in codes]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    items = []
+    for r in results:
+        if isinstance(r, Exception):
+            # ignore individual task exceptions (timeout/cancel/etc.)
+            continue
+        if r:
+            items.append(r)
+    # sort by RS desc
+    items.sort(key=lambda x: (x.get('rs_rating') or 0), reverse=True)
+
+    return {"rt_cd": "0", "msg1": "성공", "data": items}
+
+
 @router.get("/ranking/{category}")
 async def get_ranking(category: str):
     """랭킹 조회 (rise/fall/volume/trading_value/foreign_buy/foreign_sell/inst_buy/inst_sell/prsn_buy/prsn_sell)."""
@@ -38,6 +120,8 @@ async def get_ranking(category: str):
             "data": _serialize_list_items(resp.data)
         }
     return _serialize_response(resp)
+
+
 
 
 @router.get("/top-market-cap")

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -83,8 +83,8 @@ async def get_stock_stage(code: str):
     ctx = _get_ctx()
     if not getattr(ctx, "minervini_stage_service", None):
         return {"rt_cd": "1", "msg1": "MinerviniStageService가 비활성화되어 있습니다.", "data": None}
-    stage = await ctx.minervini_stage_service.get_stage_for_code(code)
-    return {"rt_cd": "0", "msg1": "성공", "data": {"code": code, "stage": stage}}
+    stage, reason = await ctx.minervini_stage_service.get_stage_for_code(code)
+    return {"rt_cd": "0", "msg1": "성공", "data": {"code": code, "stage": stage, "reason": reason}}
 
 
 @router.get("/stock/{code}/detail")

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -72,9 +72,19 @@ async def get_stock_rs_rating(code: str):
     ctx = _get_ctx()
     if not getattr(ctx, "rs_rating_service", None):
         return {"rt_cd": "1", "msg1": "RS Rating 서비스가 비활성화되어 있습니다.", "data": None}
-    
+
     resp = await ctx.rs_rating_service.get_rating(code)
     return _serialize_response(resp)
+
+
+@router.get("/stock/{code}/stage")
+async def get_stock_stage(code: str):
+    """종목의 Minervini Stage 조회 (1~4단계, 0=미계산)"""
+    ctx = _get_ctx()
+    if not getattr(ctx, "minervini_stage_service", None):
+        return {"rt_cd": "1", "msg1": "MinerviniStageService가 비활성화되어 있습니다.", "data": None}
+    stage = await ctx.minervini_stage_service.get_stage_for_code(code)
+    return {"rt_cd": "0", "msg1": "성공", "data": {"code": code, "stage": stage}}
 
 
 @router.get("/stock/{code}/detail")

--- a/view/web/static/js/favorite.js
+++ b/view/web/static/js/favorite.js
@@ -22,7 +22,7 @@ async function loadFavoriteList() {
     const tbody = document.getElementById('favorite-list-body');
     if (!tbody) return;
 
-    tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;">로딩 중...</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
 
     try {
         const resp = await fetch('/api/favorite');
@@ -41,7 +41,7 @@ function renderFavoriteTable() {
     if (!tbody) return;
 
     if (!_favoriteData || !_favoriteData.length) {
-        tbody.innerHTML = '<tr><td colspan="5" style="text-align:center; color:var(--text-secondary);">등록된 관심종목이 없습니다.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center; color:var(--text-secondary);">등록된 관심종목이 없습니다.</td></tr>';
         return;
     }
 
@@ -55,6 +55,9 @@ function renderFavoriteTable() {
                 va = a.name || '';
                 vb = b.name || '';
                 return d * va.localeCompare(vb);
+            } else if (k === 'minervini_stage') {
+                va = a.minervini_stage ? parseInt(a.minervini_stage) : 0;
+                vb = b.minervini_stage ? parseInt(b.minervini_stage) : 0;
             } else if (k === 'rs_rating') {
                 va = a.rs_rating ? parseInt(a.rs_rating) : -1;
                 vb = b.rs_rating ? parseInt(b.rs_rating) : -1;
@@ -108,8 +111,17 @@ function _buildRow(item) {
     else if (item.rs_rating >= 50) rsColor = '#feca57'; // 노랑
     const rsBadge = `<span style="display:inline-block; padding:2px 8px; border-radius:4px; background:#f0f0f0; color:${rsColor}; font-weight:bold; font-size:0.85rem; border:1px solid #ccc; text-align:center;" title="RS Rating">${rsVal}</span>`;
 
+    const stageLabels = { 1: 'S1', 2: 'S2', 3: 'S3', 4: 'S4' };
+    const stageColors = { 1: '#6c757d', 2: '#28a745', 3: '#fd7e14', 4: '#dc3545' };
+    const stageTitles = { 1: '무관심', 2: '상승', 3: '고점', 4: '하락' };
+    const stageVal = item.minervini_stage;
+    const stageBadge = stageVal
+        ? `<span style="display:inline-block; padding:2px 8px; border-radius:4px; background:${stageColors[stageVal]}; color:#fff; font-weight:bold; font-size:0.82rem; text-align:center;" title="Minervini Stage: ${stageTitles[stageVal] || ''}">${stageLabels[stageVal] || stageVal}</span>`
+        : '<span style="color:#aaa; font-size:0.82rem;">-</span>';
+
     return `<tr id="fav-row-${item.code}">
         <td><a href="/stock?code=${item.code}" style="color:var(--accent); font-weight:bold; text-decoration:none;">${item.name} <span style="font-weight:normal; font-size:0.85rem; color:#888;">(${item.code})</span></a></td>
+        <td style="text-align:center;">${stageBadge}</td>
         <td style="text-align:center;">${rsBadge}</td>
         <td class="${rateClass}">${priceStr}</td>
         <td class="${rateClass}">${rateStr}</td>

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -63,7 +63,12 @@ async function loadRanking(category) {
     _showRankingSkeleton();
 
     try {
-        const res = await fetchWithTimeout(`/api/ranking/${category}`);
+        let res;
+        if (category === 'minervini_stage2') {
+            res = await fetchWithTimeout(`/api/ranking/minervini_stage2`);
+        } else {
+            res = await fetchWithTimeout(`/api/ranking/${category}`);
+        }
         const json = await res.json();
 
         if (json.rt_cd !== "0") {
@@ -332,9 +337,22 @@ function renderRankingTable() {
             + `<th class="${sortCls('volume')}" onclick="sortRanking('volume')">거래량</th>`;
     }
 
+    // Minervini Stage 2 전용 헤더
+    const isMinervini = (cat === 'minervini_stage2');
+    if (isMinervini) {
+        headerRow = `<th class="${sortCls('rank')}" onclick="sortRanking('rank')">순위</th>`
+            + `<th class="${sortCls('name')}" onclick="sortRanking('name')">종목명</th>`
+            + `<th class="${sortCls('price')}" onclick="sortRanking('price')">현재가</th>`
+            + `<th class="${sortCls('rate')}" onclick="sortRanking('rate')">등락률</th>`
+            + `<th class="${sortCls('stage')}" onclick="sortRanking('stage')">Stage</th>`
+            + `<th class="${sortCls('rs')}" onclick="sortRanking('rs')">RS</th>`
+            + `<th class="${sortCls('market_cap')}" onclick="sortRanking('market_cap')">시가총액</th>`;
+    }
+
     let data = _rankingData.slice();
     if (_rankingSortState.key) {
-        data = rankingSortCompare(data, _rankingSortState.key, _rankingSortState.dir);
+        if (isMinervini) data = _minerviniSortCompare(data, _rankingSortState.key, _rankingSortState.dir);
+        else data = rankingSortCompare(data, _rankingSortState.key, _rankingSortState.dir);
     }
 
     let rows = '';
@@ -343,6 +361,9 @@ function renderRankingTable() {
         const color = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
         const code = item.stck_shrn_iscd || item.iscd || item.mksc_shrn_iscd || item.code || '';
         let extraCols;
+        if (isMinervini) {
+            extraCols = `<td>S${item.stage}</td><td>${item.rs_rating || '-'}</td><td>${formatTradingValue(item.market_cap || 0)}</td>`;
+        } else
         if (isCombined) {
             const pbmnVal = formatTradingValue(String(item._combined_pbmn));
             const qtyVal = parseInt(item._combined_qty || 0).toLocaleString();
@@ -455,3 +476,39 @@ function rankingSortCompare(data, key, dir) {
     });
     return sorted;
 }
+
+    // 추가: Minervini 전용 정렬 지원
+    function _minerviniSortCompare(data, key, dir) {
+        const sorted = data.slice();
+        const d = dir === 'asc' ? 1 : -1;
+        sorted.sort((a, b) => {
+            let va = 0, vb = 0;
+            if (key === 'name') {
+                va = (a.name || '').toLowerCase();
+                vb = (b.name || '').toLowerCase();
+                return d * va.localeCompare(vb);
+            } else if (key === 'price') {
+                va = parseInt(a.stck_prpr || 0);
+                vb = parseInt(b.stck_prpr || 0);
+            } else if (key === 'rate') {
+                va = parseFloat(a.prdy_ctrt || 0);
+                vb = parseFloat(b.prdy_ctrt || 0);
+            } else if (key === 'stage') {
+                va = parseInt(a.stage || 0);
+                vb = parseInt(b.stage || 0);
+            } else if (key === 'rs') {
+                va = parseInt(a.rs_rating || 0);
+                vb = parseInt(b.rs_rating || 0);
+            } else if (key === 'market_cap') {
+                va = parseInt(a.market_cap || 0);
+                vb = parseInt(b.market_cap || 0);
+            } else if (key === 'rank') {
+                va = parseInt(a.data_rank || a.rank || 0);
+                vb = parseInt(b.data_rank || b.rank || 0);
+            } else {
+                return 0;
+            }
+            return d * (va - vb);
+        });
+        return sorted;
+    }

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -466,6 +466,17 @@ async function _loadStage(code) {
                 container.style.color = '#fff';
                 container.style.borderColor = colors[stage] || '#6c757d';
                 container.style.display = 'flex';
+                // 툴팁: API에서 반환한 판정 이유가 있으면 title에 설정
+                try {
+                    const reason = json.data.reason || '';
+                    if (reason && reason.trim().length > 0) {
+                        container.title = `판정 이유: ${reason}`;
+                    } else {
+                        container.title = 'Minervini Stage (1~4단계)';
+                    }
+                } catch (err) {
+                    container.title = 'Minervini Stage (1~4단계)';
+                }
             }
         }
     } catch (e) {

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -251,6 +251,22 @@ async function searchStock(codeOverride, exchangeOverride) {
                  .fav-star-btn:hover { transform: scale(1.05); background: var(--bg-card, #e8e8e8); }
                  .fav-star-btn.active { color: #ffc107; border-color: #ffc107; }
                  .detail-loading { color: var(--text-secondary, #999); font-style: italic; }
+                 .stage-badge-box {
+                     position: absolute;
+                     top: 16px;
+                     right: 142px;
+                     background: var(--bg-primary, #f5f5f5);
+                     border: 1px solid var(--border, #ccc);
+                     border-radius: 8px;
+                     height: 38px;
+                     display: none;
+                     align-items: center;
+                     justify-content: center;
+                     padding: 0 10px;
+                     font-weight: bold;
+                     font-size: 0.85rem;
+                     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+                 }
                  .rs-rating-box {
                      position: absolute;
                      top: 16px;
@@ -289,6 +305,9 @@ async function searchStock(codeOverride, exchangeOverride) {
 
         resultDiv.innerHTML = styles + `
             <div class="card stock-info-box" style="position: relative;">
+                <div id="stage-badge-container" class="stage-badge-box" title="Minervini Stage (1~4단계)">
+                    <span id="stage-badge-val">-</span>
+                </div>
                 <div id="rs-rating-container" class="rs-rating-box" style="display: none;" title="IBD/오닐 RS Rating">
                     RS<span id="rs-rating-val" class="val">-</span>
                 </div>
@@ -375,6 +394,7 @@ async function searchStock(codeOverride, exchangeOverride) {
         // Phase 2: 증권사 API 상세 정보 백그라운드 로드
         _loadStockDetail(code);
         _loadRsRating(code);
+        _loadStage(code);
 
     } catch (e) {
         console.error("Error in searchStock:", e);
@@ -425,6 +445,31 @@ async function toggleFavorite(code) {
         }
     } catch (e) {
         if (typeof showToast === 'function') showToast(`오류: ${e.message}`, 'error');
+    }
+}
+
+/* ── Minervini Stage 로드 ── */
+async function _loadStage(code) {
+    try {
+        const res = await fetchWithTimeout(`/api/stock/${code}/stage`, {}, 8000);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (json.rt_cd === "0" && json.data && json.data.stage > 0) {
+            const container = document.getElementById('stage-badge-container');
+            const valEl = document.getElementById('stage-badge-val');
+            if (container && valEl) {
+                const stage = json.data.stage;
+                const labels = { 1: 'S1 무관심', 2: 'S2 상승', 3: 'S3 고점', 4: 'S4 하락' };
+                const colors = { 1: '#6c757d', 2: '#28a745', 3: '#fd7e14', 4: '#dc3545' };
+                valEl.textContent = labels[stage] || `S${stage}`;
+                container.style.background = colors[stage] || '#6c757d';
+                container.style.color = '#fff';
+                container.style.borderColor = colors[stage] || '#6c757d';
+                container.style.display = 'flex';
+            }
+        }
+    } catch (e) {
+        console.debug('[stock] Minervini Stage 조회 실패:', e.message);
     }
 }
 

--- a/view/web/templates/favorite.html
+++ b/view/web/templates/favorite.html
@@ -26,6 +26,7 @@
                 <thead>
                     <tr>
                         <th class="sortable" data-sort="name" onclick="sortFavorites('name')">종목명(Code)</th>
+                        <th class="sortable" data-sort="minervini_stage" onclick="sortFavorites('minervini_stage')">Stage</th>
                         <th class="sortable" data-sort="rs_rating" onclick="sortFavorites('rs_rating')">RS Rating</th>
                         <th class="sortable" data-sort="price" onclick="sortFavorites('price')">현재가</th>
                         <th class="sortable" data-sort="rate" onclick="sortFavorites('rate')">등락률</th>
@@ -65,5 +66,5 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/favorite.js?v=5"></script>
+<script src="/static/js/favorite.js?v=6"></script>
 {% endblock %}

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -21,6 +21,7 @@
                 <div class="form-row" style="margin-bottom: 0;">
                     <button class="btn ranking-tab" data-cat="net_buy" onclick="setRankingDirection('buy')">순매수</button>
                     <button class="btn ranking-tab" data-cat="net_sell" onclick="setRankingDirection('sell')">순매도</button>
+                    <button class="btn ranking-tab" data-cat="minervini_stage2" onclick="loadRanking('minervini_stage2')">Minervini S2</button>
                     <div id="investor-type-row" style="display: none; margin-left: 8px; padding-left: 12px; border-left: 2px solid var(--accent-secondary, #3b82f6);">
                         <button class="btn investor-toggle active" data-inv="foreign" onclick="toggleRankingInvestor('foreign')">외인</button>
                         <button class="btn investor-toggle" data-inv="inst" onclick="toggleRankingInvestor('inst')">기관</button>

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -54,6 +54,7 @@ from services.telegram_notifier import TelegramNotifier, TelegramReporter
 from view.web import web_api  # 임포트 확인
 from core.cache.cache_store import CacheStore
 from services.rs_rating_service import RSRatingService
+from services.minervini_stage_service import MinerviniStageService
 
 class WebAppContext:
     """웹 앱에서 사용할 서비스 컨텍스트."""
@@ -252,6 +253,19 @@ class WebAppContext:
         self.favorite_service.stock_query_service = self.stock_query_service
         self.favorite_service.stock_repository = self.stock_repository
         self.favorite_service.rs_rating_service = getattr(self, "rs_rating_service", None)
+
+        # MinerviniStageService 초기화 (stock_query_service 초기화 이후에 생성)
+        try:
+            self.minervini_stage_service = MinerviniStageService(
+                stock_query_service=self.stock_query_service,
+                rs_rating_service=getattr(self, "rs_rating_service", None),
+                logger=self.logger,
+            )
+            self.favorite_service.minervini_stage_service = self.minervini_stage_service
+        except Exception as e:
+            self.logger.warning(f"MinerviniStageService 초기화 실패: {e}")
+            self.minervini_stage_service = None
+
         # StreamingService 초기화
         self.streaming_service = StreamingService(
             broker_api_wrapper=self.broker,
@@ -336,6 +350,7 @@ class WebAppContext:
             logger=self.logger,
             performance_profiler=self.pm,
             price_subscription_service=self.price_subscription_service,
+            minervini_service=getattr(self, "minervini_stage_service", None),
         )
 
         self.premium_watchlist_generator_task = PremiumWatchlistGeneratorTask(

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -350,6 +350,7 @@ class WebAppContext:
             logger=self.logger,
             performance_profiler=self.pm,
             price_subscription_service=self.price_subscription_service,
+            rs_rating_service=getattr(self, "rs_rating_service", None),
             minervini_service=getattr(self, "minervini_stage_service", None),
         )
 


### PR DESCRIPTION
…plate)' 추가

신규/수정 파일
파일	내용
services/minervini_stage_service.py	신규 — Trend Template 8조건 Stage 1~4 분류 서비스 strategies/oneil_common_types.py	OSBWatchlistItem에 ma_150d, ma_200d, w52_lwpr, minervini_stage 추가 services/oneil_universe_service.py	OHLCV limit 90→260, MA150/200 계산, Stage 4 하드필터, Stage 2 가산점 +20 view/web/web_app_initializer.py	MinerviniStageService 초기화 및 DI 주입 view/web/routes/stock.py	GET /api/stock/{code}/stage 엔드포인트 추가 services/favorite_service.py	get_with_details()에 Stage 병렬 조회 (3초 timeout) view/web/static/js/stock.js	Stage 배지 컨테이너 + _loadStage() 함수 (RS Rating 왼쪽) view/web/static/js/favorite.js	Stage 컬럼 렌더링, 정렬 지원 view/web/templates/favorite.html	Stage 컬럼 헤더 추가
tests/unit_test/services/test_oneil_universe_service.py	limit=90 → 260 어서션 수정 Stage 색상 규칙
S2 초록 (#28a745) — 매수 구간
S1 회색 (#6c757d) — 관망
S3 주황 (#fd7e14) — 주의/부분익절
S4 빨강 (#dc3545) — 매수 금지
Phase 2 (todo_list에 추가됨)
Strategy Guard 로직 (Stage ≠ 2 시 진입 금지)
Stage 3 Trailing Stop 강화
VCP 패턴 판정 (check_vcp_pattern())