### PR TITLE
변경 파일

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -1,5 +1,6 @@
 # repositories/virtual_trade_repository.py
 import bisect
+import sqlite3
 import numpy as np
 import pandas as pd
 import asyncio
@@ -12,10 +13,49 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from core.market_clock import MarketClock
 from utils.transaction_cost_utils import TransactionCostUtils
+
 logger = logging.getLogger(__name__)
 
 COLUMNS = ["strategy", "code", "buy_date", "buy_price", "qty", "sell_date", "sell_price", "return_rate", "status", "reason"]
-SNAPSHOT_FILENAME = "portfolio_snapshots.json"
+
+_SELECT_TRADES = (
+    "SELECT strategy, code, buy_date, buy_price, qty, sell_date, sell_price, return_rate, status, reason "
+    "FROM trades ORDER BY id"
+)
+_INSERT_TRADE = (
+    "INSERT INTO trades "
+    "(strategy, code, buy_date, buy_price, qty, sell_date, sell_price, return_rate, status, reason) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+_DDL = """
+CREATE TABLE IF NOT EXISTS trades (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy    TEXT    NOT NULL,
+    code        TEXT    NOT NULL,
+    buy_date    TEXT    NOT NULL,
+    buy_price   REAL    NOT NULL,
+    qty         INTEGER NOT NULL DEFAULT 1,
+    sell_date   TEXT,
+    sell_price  REAL,
+    return_rate REAL    NOT NULL DEFAULT 0.0,
+    status      TEXT    NOT NULL,
+    reason      TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_trades_strategy_code_status ON trades(strategy, code, status);
+CREATE TABLE IF NOT EXISTS snapshots (
+    date        TEXT NOT NULL,
+    strategy    TEXT NOT NULL,
+    return_rate REAL NOT NULL,
+    PRIMARY KEY (date, strategy)
+);
+CREATE INDEX IF NOT EXISTS idx_snapshots_date ON snapshots(date);
+CREATE TABLE IF NOT EXISTS price_cache (
+    code    TEXT    NOT NULL,
+    date    TEXT    NOT NULL,
+    close   INTEGER NOT NULL,
+    PRIMARY KEY (code, date)
+);
+"""
 
 
 @lru_cache(maxsize=1024)
@@ -39,32 +79,104 @@ def _get_trading_dates(daily: dict) -> list[str]:
         if _strategy_values(daily[d]) != _strategy_values(daily[trading[-1]]):
             trading.append(d)
     return trading
-PRICE_CACHE_FILENAME = "close_price_cache.json"
 
 
 class VirtualTradeRepository:
-    def __init__(self, filename="data/VirtualTradeRepository/trade_journal.csv", market_clock: MarketClock = None):
-        self._cached_data = None  # 메모리 캐시 변수 추가
-        self.filename = filename
+    def __init__(self, db_path: str = "data/VirtualTradeRepository/virtual_trade.db", market_clock: MarketClock = None):
+        self._cached_data = None
+        self.db_path = db_path
         self.tm = market_clock if market_clock else MarketClock()
         self._lock = threading.Lock()
-        os.makedirs(os.path.dirname(self.filename), exist_ok=True)  # 데이터 디렉토리 생성
-        if not os.path.exists(self.filename):
-            pd.DataFrame(columns=COLUMNS).to_csv(self.filename, index=False)
+        dir_path = os.path.dirname(self.db_path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        self._db = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.executescript(_DDL)
+        self._migrate_legacy_data()
+
+    # ---- 레거시 데이터 마이그레이션 (CSV/JSON → SQLite, 최초 1회) ----
+
+    def _migrate_legacy_data(self):
+        """기존 CSV/JSON 파일이 있으면 SQLite로 1회 마이그레이션한다."""
+        base_dir = os.path.dirname(self.db_path)
+        if not base_dir:
+            return  # :memory: 등 디렉토리가 없는 경우 스킵
+        flag_path = os.path.join(base_dir, ".migrated")
+        if os.path.exists(flag_path):
+            return
+
+        migrated = False
+
+        csv_path = os.path.join(base_dir, "trade_journal.csv")
+        if os.path.exists(csv_path):
+            try:
+                df = pd.read_csv(csv_path, dtype={'code': str, 'sell_date': object}, encoding='utf-8')
+                df['return_rate'] = df['return_rate'].fillna(0.0)
+                if 'qty' not in df.columns:
+                    df['qty'] = 1
+                if 'reason' not in df.columns:
+                    df['reason'] = ''
+                self._write(df)
+                logger.info(f"[마이그레이션] {csv_path} → trades 테이블 완료")
+                migrated = True
+            except Exception as e:
+                logger.warning(f"[마이그레이션] CSV 마이그레이션 실패: {e}")
+
+        snap_path = os.path.join(base_dir, "portfolio_snapshots.json")
+        if os.path.exists(snap_path):
+            try:
+                with open(snap_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                if "daily" not in data:
+                    data = {"daily": data, "prev_values": {}}
+                self._save_data(data)
+                logger.info(f"[마이그레이션] {snap_path} → snapshots 테이블 완료")
+                migrated = True
+            except Exception as e:
+                logger.warning(f"[마이그레이션] 스냅샷 마이그레이션 실패: {e}")
+
+        price_path = os.path.join(base_dir, "close_price_cache.json")
+        if os.path.exists(price_path):
+            try:
+                with open(price_path, 'r', encoding='utf-8') as f:
+                    cache = json.load(f)
+                self._save_price_cache(cache)
+                logger.info(f"[마이그레이션] {price_path} → price_cache 테이블 완료")
+                migrated = True
+            except Exception as e:
+                logger.warning(f"[마이그레이션] 가격 캐시 마이그레이션 실패: {e}")
+
+        with open(flag_path, 'w') as f:
+            f.write("1")
+        if migrated:
+            logger.info("[마이그레이션] 레거시 데이터 마이그레이션 완료.")
 
     def _read(self) -> pd.DataFrame:
-        df = pd.read_csv(self.filename, dtype={'code': str, 'sell_date': object}, encoding='utf-8')
+        df = pd.read_sql_query(_SELECT_TRADES, self._db, dtype={'code': str, 'sell_date': object})
         df['return_rate'] = df['return_rate'].fillna(0.0)
-        # 기존 파일 호환성: qty 컬럼이 없으면 기본값 1로 채움
-        if 'qty' not in df.columns:
-            df['qty'] = 1
-        # 기존 파일 호환성: reason 컬럼이 없으면 빈 문자열로 채움
-        if 'reason' not in df.columns:
-            df['reason'] = ''
         return df
 
     def _write(self, df: pd.DataFrame):
-        df.to_csv(self.filename, index=False, encoding='utf-8')
+        """DataFrame으로 trades 테이블 전체 교체 (기존 코드 및 테스트 호환성 유지)."""
+        rows = []
+        for row in df.itertuples(index=False):
+            sell_date_raw = getattr(row, 'sell_date', None)
+            sell_date = None if (sell_date_raw is None or (isinstance(sell_date_raw, float) and math.isnan(sell_date_raw))) else str(sell_date_raw)
+            sell_price_raw = getattr(row, 'sell_price', None)
+            sell_price = None if (sell_price_raw is None or (isinstance(sell_price_raw, float) and math.isnan(sell_price_raw))) else float(sell_price_raw)
+            qty_raw = getattr(row, 'qty', 1)
+            qty = int(qty_raw) if (qty_raw is not None and not (isinstance(qty_raw, float) and math.isnan(qty_raw))) else 1
+            rr_raw = getattr(row, 'return_rate', 0.0)
+            return_rate = float(rr_raw) if (rr_raw is not None and not (isinstance(rr_raw, float) and math.isnan(rr_raw))) else 0.0
+            rows.append((
+                row.strategy, row.code, str(row.buy_date), float(row.buy_price), qty,
+                sell_date, sell_price, return_rate, row.status,
+                getattr(row, 'reason', '') or ''
+            ))
+        with self._db:
+            self._db.execute("DELETE FROM trades")
+            self._db.executemany(_INSERT_TRADE, rows)
 
     # ---- 매수/매도 ----
 
@@ -75,26 +187,9 @@ class VirtualTradeRepository:
                 logger.info(f"[가상매매] {strategy_name}/{code} 이미 보유 중 — 매수 스킵")
                 return
             buy_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            # 기존 CSV 헤더 순서에 맞춰 append
-            try:
-                existing_cols = pd.read_csv(self.filename, nrows=0, encoding='utf-8').columns.tolist()
-            except Exception:
-                existing_cols = COLUMNS
-                
-            new_row = pd.DataFrame({
-                "strategy": [strategy_name],
-                "code": [code],
-                "buy_date": [buy_date],
-                "buy_price": [current_price],
-                "qty": [qty],
-                "sell_date": [np.nan],
-                "sell_price": [np.nan],
-                "return_rate": [0.0],
-                "status": ["HOLD"],
-                "reason": [""],
-            })
-            new_row = new_row[[c for c in existing_cols if c in new_row.columns]]
-            new_row.to_csv(self.filename, mode='a', header=False, index=False, encoding='utf-8')
+            with self._db:
+                self._db.execute(_INSERT_TRADE,
+                    (strategy_name, code, buy_date, current_price, qty, None, None, 0.0, "HOLD", ""))
             logger.info(f"[가상매매] {strategy_name}/{code} 매수 기록 (가격: {current_price}, 수량: {qty})")
 
     async def log_buy_async(self, strategy_name: str, code: str, current_price, qty: int = 1):
@@ -104,19 +199,21 @@ class VirtualTradeRepository:
     def log_sell(self, code: str, current_price, qty: int = 1):
         """가상 매도 — 해당 종목 가장 최근 HOLD 건."""
         with self._lock:
-            df = self._read()
-            mask = (df['code'] == code) & (df['status'] == 'HOLD')
-            if df.loc[mask].empty:
+            row = self._db.execute(
+                "SELECT id, buy_price FROM trades WHERE code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                (code,)
+            ).fetchone()
+            if row is None:
                 logger.warning(f"[가상매매] {code} 매도 실패: 보유 내역 없음")
                 return
-            idx = df.loc[mask].index[-1]
-            buy_price = df.loc[idx, 'buy_price']
+            trade_id, buy_price = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
-            df.loc[idx, 'sell_date'] = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            df.loc[idx, 'sell_price'] = current_price
-            df.loc[idx, 'return_rate'] = round(return_rate, 2)
-            df.loc[idx, 'status'] = 'SOLD'
-            self._write(df)
+            sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
+            with self._db:
+                self._db.execute(
+                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD' WHERE id=?",
+                    (sell_date, current_price, round(return_rate, 2), trade_id)
+                )
             logger.info(f"[가상매매] {code} 매도 기록 (수익률: {return_rate:.2f}%)")
 
     async def log_sell_async(self, code: str, current_price, qty: int = 1):
@@ -126,20 +223,22 @@ class VirtualTradeRepository:
     def log_sell_by_strategy(self, strategy_name: str, code: str, current_price, qty: int = 1) -> float | None:
         """전략+종목 매칭 매도. 성공 시 수익률 반환, 실패 시 None 반환."""
         with self._lock:
-            df = self._read()
-            mask = (df['strategy'] == strategy_name) & (df['code'] == code) & (df['status'] == 'HOLD')
-            if df.loc[mask].empty:
+            row = self._db.execute(
+                "SELECT id, buy_price FROM trades WHERE strategy=? AND code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                (strategy_name, code)
+            ).fetchone()
+            if row is None:
                 logger.warning(f"[가상매매] {strategy_name}/{code} 매도 실패: 보유 내역 없음")
                 return None
-            idx = df.loc[mask].index[-1]
-            buy_price = df.loc[idx, 'buy_price']
+            trade_id, buy_price = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
-            df.loc[idx, 'sell_date'] = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            df.loc[idx, 'sell_price'] = current_price
-            df.loc[idx, 'return_rate'] = round(return_rate, 2)
-            df.loc[idx, 'status'] = 'SOLD'
-            self._write(df)
-            logger.info(f"[가상매매] {strategy_name}/{code} 매도 기록 (수익률: {return_rate:.2f}%)")
+            sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
+            with self._db:
+                self._db.execute(
+                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD' WHERE id=?",
+                    (sell_date, current_price, round(return_rate, 2), trade_id)
+                )
+            logger.info(f"[가상매매] {strategy_name}/{code} 매도 기록 (수익률: {round(return_rate, 2):.2f}%)")
             return round(return_rate, 2)
 
     async def log_sell_by_strategy_async(self, strategy_name: str, code: str, current_price, qty: int = 1) -> float | None:
@@ -147,29 +246,13 @@ class VirtualTradeRepository:
         return await asyncio.to_thread(self.log_sell_by_strategy, strategy_name, code, current_price, qty)
 
     def log_order_failure(self, action: str, code: str, price, qty: int, reason: str, strategy_name: str = ""):
-        """주문 최종 실패 시 CSV에 FAILED 상태로 기록."""
+        """주문 최종 실패 시 FAILED 상태로 기록."""
         with self._lock:
             fail_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
             strategy_label = strategy_name if strategy_name else f"{action}실패"
-            try:
-                existing_cols = pd.read_csv(self.filename, nrows=0, encoding='utf-8').columns.tolist()
-            except Exception:
-                existing_cols = COLUMNS
-
-            row_data = {
-                "strategy": [strategy_label],
-                "code": [code],
-                "buy_date": [fail_date],
-                "buy_price": [price],
-                "qty": [qty],
-                "sell_date": [np.nan],
-                "sell_price": [np.nan],
-                "return_rate": [0.0],
-                "status": ["FAILED"],
-                "reason": [reason],
-            }
-            new_row = pd.DataFrame({k: row_data[k] for k in existing_cols if k in row_data})
-            new_row.to_csv(self.filename, mode='a', header=False, index=False, encoding='utf-8')
+            with self._db:
+                self._db.execute(_INSERT_TRADE,
+                    (strategy_label, code, fail_date, price, qty, None, None, 0.0, "FAILED", reason))
             logger.warning(f"[가상매매] {action} 주문 실패 기록: {code} @ {price}원 x {qty}주 — {reason}")
 
     async def log_order_failure_async(self, action: str, code: str, price, qty: int, reason: str, strategy_name: str = ""):
@@ -196,7 +279,6 @@ class VirtualTradeRepository:
         base_amount = price * qty
         if not apply_cost:
             return base_amount
-        
         cost = TransactionCostUtils.calculate_cost(price, qty, is_sell)
         return base_amount - cost if is_sell else base_amount + cost
 
@@ -212,40 +294,57 @@ class VirtualTradeRepository:
 
     def get_solds(self) -> list:
         """전체 SOLD 포지션 반환."""
-        df = self._read()
-        return self._to_json_records(df.loc[df['status'] == 'SOLD'])
+        df = pd.read_sql_query(
+            "SELECT strategy,code,buy_date,buy_price,qty,sell_date,sell_price,return_rate,status,reason "
+            "FROM trades WHERE status='SOLD' ORDER BY id",
+            self._db, dtype={'code': str, 'sell_date': object}
+        )
+        return self._to_json_records(df)
 
     def get_holds(self) -> list:
         """전체 HOLD 포지션 반환."""
-        df = self._read()
-        return self._to_json_records(df.loc[df['status'] == 'HOLD'])
+        df = pd.read_sql_query(
+            "SELECT strategy,code,buy_date,buy_price,qty,sell_date,sell_price,return_rate,status,reason "
+            "FROM trades WHERE status='HOLD' ORDER BY id",
+            self._db, dtype={'code': str, 'sell_date': object}
+        )
+        return self._to_json_records(df)
 
     def get_holds_by_strategy(self, strategy_name: str) -> list:
         """전략별 HOLD 포지션 반환."""
-        df = self._read()
-        mask = (df['strategy'] == strategy_name) & (df['status'] == 'HOLD')
-        return self._to_json_records(df.loc[mask])
+        df = pd.read_sql_query(
+            "SELECT strategy,code,buy_date,buy_price,qty,sell_date,sell_price,return_rate,status,reason "
+            "FROM trades WHERE strategy=? AND status='HOLD' ORDER BY id",
+            self._db, params=(strategy_name,), dtype={'code': str, 'sell_date': object}
+        )
+        return self._to_json_records(df)
 
     def is_holding(self, strategy_name: str, code: str) -> bool:
         """해당 전략에서 종목 보유 중인지 확인."""
-        df = self._read()
-        mask = (df['strategy'] == strategy_name) & (df['code'] == code) & (df['status'] == 'HOLD')
-        return not df.loc[mask].empty
+        row = self._db.execute(
+            "SELECT 1 FROM trades WHERE strategy=? AND code=? AND status='HOLD' LIMIT 1",
+            (strategy_name, code)
+        ).fetchone()
+        return row is not None
 
     def fix_sell_price(self, code: str, buy_date: str, correct_price):
         """sell_price가 0인 SOLD 기록의 매도가/수익률을 보정합니다."""
         with self._lock:
-            df = self._read()
-            mask = (df['code'] == code) & (df['status'] == 'SOLD') & (df['sell_price'] == 0)
+            query = "SELECT id, buy_price FROM trades WHERE code=? AND status='SOLD' AND sell_price=0"
+            params: list = [code]
             if buy_date:
-                mask = mask & (df['buy_date'] == buy_date)
-            if df.loc[mask].empty:
+                query += " AND buy_date=?"
+                params.append(buy_date)
+            rows = self._db.execute(query, params).fetchall()
+            if not rows:
                 return
-            for idx in df.loc[mask].index:
-                bp = df.loc[idx, 'buy_price']
-                df.loc[idx, 'sell_price'] = correct_price
-                df.loc[idx, 'return_rate'] = round(((correct_price - bp) / bp) * 100, 2) if bp else 0
-            self._write(df)
+            with self._db:
+                for trade_id, buy_price in rows:
+                    return_rate = round(((correct_price - buy_price) / buy_price) * 100, 2) if buy_price else 0
+                    self._db.execute(
+                        "UPDATE trades SET sell_price=?, return_rate=? WHERE id=?",
+                        (correct_price, return_rate, trade_id)
+                    )
             logger.info(f"[가상매매] {code} sell_price 보정 완료 → {correct_price}")
 
     def get_summary(self, apply_cost: bool = False) -> dict:
@@ -253,7 +352,7 @@ class VirtualTradeRepository:
         df = self._read()
         total_trades = len(df)
         sold_df = df[df['status'] == 'SOLD']
-        
+
         if sold_df.empty:
             return {"total_trades": total_trades, "win_rate": 0, "avg_return": 0}
 
@@ -275,24 +374,27 @@ class VirtualTradeRepository:
 
     # ---- 종가 캐시 (backfill용) ----
 
-    def _price_cache_path(self) -> str:
-        return os.path.join(os.path.dirname(self.filename), PRICE_CACHE_FILENAME)
-
     def _load_price_cache(self) -> dict:
-        """로컬 종가 캐시 로드. 구조: { "005930": {"2026-02-13": 56000, ...}, ... }"""
-        path = self._price_cache_path()
-        if not os.path.exists(path):
-            return {}
-        try:
-            with open(path, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError):
-            return {}
+        """SQLite price_cache 테이블 로드. 구조: { "005930": {"2026-02-13": 56000, ...}, ... }"""
+        cache: dict = {}
+        for code, date, close in self._db.execute("SELECT code, date, close FROM price_cache"):
+            if code not in cache:
+                cache[code] = {}
+            cache[code][date] = close
+        return cache
 
     def _save_price_cache(self, cache: dict):
-        path = self._price_cache_path()
-        with open(path, 'w', encoding='utf-8') as f:
-            json.dump(cache, f, ensure_ascii=False, indent=2)
+        rows = [
+            (code, date, int(close))
+            for code, dates in cache.items()
+            for date, close in dates.items()
+        ]
+        if rows:
+            with self._db:
+                self._db.executemany(
+                    "INSERT OR REPLACE INTO price_cache (code, date, close) VALUES (?, ?, ?)",
+                    rows
+                )
 
     def _fetch_close_prices(self, codes: list[str], start_date: str, end_date: str) -> dict:
         """pykrx로 종가 조회 후 캐시에 병합. 캐시에 이미 있으면 API 스킵.
@@ -343,13 +445,13 @@ class VirtualTradeRepository:
     # ---- backfill ----
 
     def backfill_snapshots(self):
-        """CSV 거래 기록을 기반으로 과거 일별 스냅샷을 역산하여 채웁니다.
+        """거래 기록을 기반으로 과거 일별 스냅샷을 역산하여 채웁니다.
         이미 스냅샷이 존재하는 날짜는 덮어쓰지 않습니다.
 
         계산 방식 (web_api.py의 save_daily_snapshot과 동일):
         - 해당 날짜 기준 '활성 거래' = 매수일 <= day인 모든 거래
           - SOLD: sell_day <= day → 확정 return_rate 사용
-          - HOLD(당시 기준): 당일 종가 기준 수익률 (pykrx 조회, 로컬 캐시)
+          - HOLD(당시 기준): 당일 종가 기준 수익률 (pykrx 조회, SQLite 캐시)
         - 전략별 평균 return_rate 저장
         """
         df = self._read()
@@ -360,7 +462,6 @@ class VirtualTradeRepository:
         daily = data["daily"]
 
         # 1. 날짜 전처리
-        # itertuples 접근을 위해 underscore 없는 컬럼명 사용
         df['buy_day_str'] = pd.to_datetime(df['buy_date'], errors='coerce').dt.strftime('%Y-%m-%d')
         sell_mask = df['sell_date'].notna() & (df['sell_date'] != '')
         df['sell_day_str'] = None
@@ -377,7 +478,7 @@ class VirtualTradeRepository:
         min_day = min(all_days)
         max_day = max(all_days)
 
-        # [수정] 현재 시점(어제)까지 backfill 범위 확장 (보유 중인 경우 등 고려)
+        # 현재 시점(어제)까지 backfill 범위 확장 (보유 중인 경우 등 고려)
         yesterday = (self.tm.get_current_kst_time() - timedelta(days=1)).strftime('%Y-%m-%d')
         if yesterday > max_day:
             max_day = yesterday
@@ -394,16 +495,13 @@ class VirtualTradeRepository:
         all_codes = df['code'].unique().tolist()
         price_cache = self._fetch_close_prices(all_codes, min_day, max_day)
 
-        # [성능 개선] 종가 데이터를 DataFrame으로 변환하고 전처리 (ffill)
-        # _find_prev_close 반복 호출 제거를 위해 전체 기간 데이터를 미리 채움
+        # 종가 데이터를 DataFrame으로 변환하고 전처리 (ffill)
         price_df = pd.DataFrame()
         if price_cache:
             try:
                 price_df = pd.DataFrame(price_cache)
-                # 인덱스(날짜)를 datetime으로 변환하여 정렬
                 price_df.index = pd.to_datetime(price_df.index)
                 price_df = price_df.sort_index()
-                # 전체 기간 reindex & ffill (휴장일 데이터 채우기)
                 full_idx = pd.date_range(start=min_day, end=max_day)
                 price_df = price_df.reindex(full_idx).ffill()
             except Exception as e:
@@ -414,75 +512,65 @@ class VirtualTradeRepository:
         added = 0
         missing_days.sort()
         n_days = len(missing_days)
-        
+
         strategies = sorted(df['strategy'].unique().tolist())
         strat_to_idx = {s: i for i, s in enumerate(strategies)}
         n_strats = len(strategies)
-        
-        # Arrays for aggregation
+
         buy_sums = np.zeros((n_days, n_strats), dtype=np.float64)
         eval_sums = np.zeros((n_days, n_strats), dtype=np.float64)
-        
-        # Prepare Price Matrix
+
         price_matrix = None
         code_to_idx = {}
-        
+
         if not price_df.empty:
             md_dt = pd.to_datetime(missing_days)
-            # Reindex to missing days only
             price_df_aligned = price_df.reindex(md_dt)
-            
             codes = price_df_aligned.columns.tolist()
             code_to_idx = {c: i for i, c in enumerate(codes)}
             price_matrix = price_df_aligned.to_numpy(dtype=np.float64)
 
-        # Iterate trades
         for row in df.itertuples():
             strat = row.strategy
             s_idx = strat_to_idx.get(strat)
-            if s_idx is None: continue
-            
+            if s_idx is None:
+                continue
+
             code = row.code
             try:
                 qty = float(row.qty) if hasattr(row, 'qty') and pd.notna(row.qty) else 1.0
             except (ValueError, TypeError):
                 qty = 1.0
             bp = float(row.buy_price) if pd.notna(row.buy_price) else 0.0
-            if bp == 0: continue
-            
+            if bp == 0:
+                continue
+
             buy_date = row.buy_day_str
             sell_date = row.sell_day_str if row.status == 'SOLD' else None
-            
-            # Find start index in missing_days
+
             start_idx = bisect.bisect_left(missing_days, buy_date)
             if start_idx >= n_days:
                 continue
-            
-            # Determine end index (sell date)
+
             if sell_date:
                 sell_idx = bisect.bisect_left(missing_days, sell_date)
-                
+
                 # Period 2: SOLD (from sell_idx onwards)
                 if sell_idx < n_days:
                     sp = float(row.sell_price) if pd.notna(row.sell_price) else 0.0
                     val = sp if sp > 0 else bp
-                    
-                    # Apply to [max(start_idx, sell_idx) : ]
                     s_start = max(start_idx, sell_idx)
                     if s_start < n_days:
                         buy_sums[s_start:, s_idx] += (bp * qty)
                         eval_sums[s_start:, s_idx] += (val * qty)
-                
+
                 # Period 1: HOLD (from start_idx to sell_idx)
                 h_end = min(sell_idx, n_days)
                 if start_idx < h_end:
                     buy_sums[start_idx:h_end, s_idx] += (bp * qty)
-                    
-                    # Eval using market price
                     c_idx = code_to_idx.get(code)
                     if c_idx is not None and price_matrix is not None:
                         prices = price_matrix[start_idx:h_end, c_idx]
-                        # Handle NaNs
                         if np.isnan(prices).any():
                             prices = prices.copy()
                             prices[np.isnan(prices)] = bp
@@ -492,7 +580,6 @@ class VirtualTradeRepository:
             else:
                 # HOLD until end
                 buy_sums[start_idx:, s_idx] += (bp * qty)
-                
                 c_idx = code_to_idx.get(code)
                 if c_idx is not None and price_matrix is not None:
                     prices = price_matrix[start_idx:, c_idx]
@@ -508,7 +595,7 @@ class VirtualTradeRepository:
             returns = ((eval_sums - buy_sums) / buy_sums) * 100
         returns[~np.isfinite(returns)] = 0.0
         returns = np.round(returns, 2)
-        
+
         # Calculate ALL
         total_buy = buy_sums.sum(axis=1)
         total_eval = eval_sums.sum(axis=1)
@@ -516,7 +603,7 @@ class VirtualTradeRepository:
             all_returns = ((total_eval - total_buy) / total_buy) * 100
         all_returns[~np.isfinite(all_returns)] = 0.0
         all_returns = np.round(all_returns, 2)
-        
+
         # Build result dict
         for i, day_str in enumerate(missing_days):
             if total_buy[i] > 0:
@@ -524,7 +611,7 @@ class VirtualTradeRepository:
                 for j, strat in enumerate(strategies):
                     if buy_sums[i, j] > 0:
                         day_stats[strat] = returns[i, j]
-                
+
                 day_stats['ALL'] = all_returns[i]
                 daily[day_str] = day_stats
                 added += 1
@@ -546,50 +633,43 @@ class VirtualTradeRepository:
 
     # ---- 포트폴리오 스냅샷 (전일/전주대비 계산용) ----
     #
-    # JSON 구조:
-    # {
-    #   "daily": {"2026-02-13": {"ALL": 2.5, "수동매매": 2.5}, ...},
-    #   "prev_values": {"ALL": 0.0, "수동매매": 0.0}  ← 마지막 변동 전 기준값
-    # }
-
-    def _snapshot_path(self) -> str:
-        return os.path.join(os.path.dirname(self.filename), SNAPSHOT_FILENAME)
+    # SQLite snapshots 테이블 구조:
+    # (date, strategy, return_rate)  ← PRIMARY KEY (date, strategy)
+    # _load_data() / _save_data() 는 하위 호환을 위해 dict 구조를 유지:
+    # { "daily": {"2026-02-13": {"ALL": 2.5, "수동매매": 2.5}, ...}, "prev_values": {} }
 
     def _load_data(self) -> dict:
-        """메모리에 데이터가 있으면 즉시 반환하고, 없으면 파일에서 읽어옵니다."""
-        # 1. 캐시 확인 (메모리에 있으면 I/O 생략)
+        """메모리 캐시 우선, 없으면 SQLite에서 로드."""
         if self._cached_data is not None:
             return self._cached_data
 
-        path = self._snapshot_path()
-        if not os.path.exists(path):
-            self._cached_data = {"daily": {}, "prev_values": {}}
-            return self._cached_data
+        rows = self._db.execute(
+            "SELECT date, strategy, return_rate FROM snapshots ORDER BY date"
+        ).fetchall()
+        daily: dict = {}
+        for date, strategy, return_rate in rows:
+            if date not in daily:
+                daily[date] = {}
+            daily[date][strategy] = return_rate
 
-        try:
-            with open(path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            
-            # 데이터 마이그레이션 로직
-            if "daily" not in data:
-                data = {"daily": data, "prev_values": {}}
-            
-            # 2. 읽어온 데이터를 메모리에 저장 (캐싱)
-            self._cached_data = data
-            return self._cached_data
-            
-        except (json.JSONDecodeError, IOError):
-            self._cached_data = {"daily": {}, "prev_values": {}}
-            return self._cached_data
+        self._cached_data = {"daily": daily, "prev_values": {}}
+        return self._cached_data
 
     def _save_data(self, data: dict):
-        path = self._snapshot_path()
+        daily = data.get("daily", {})
         try:
-            with open(path, 'w', encoding='utf-8') as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
-            # 중요: 파일 저장 성공 시 메모리 캐시도 즉시 최신화
+            existing_dates = {row[0] for row in self._db.execute("SELECT DISTINCT date FROM snapshots")}
+            with self._db:
+                for date in existing_dates - set(daily.keys()):
+                    self._db.execute("DELETE FROM snapshots WHERE date=?", (date,))
+                for date, strategies in daily.items():
+                    self._db.execute("DELETE FROM snapshots WHERE date=?", (date,))
+                    self._db.executemany(
+                        "INSERT INTO snapshots (date, strategy, return_rate) VALUES (?, ?, ?)",
+                        [(date, strategy, rr) for strategy, rr in strategies.items()]
+                    )
             self._cached_data = data
-        except IOError as e:
+        except Exception as e:
             logger.error(f"Failed to save snapshot: {e}")
 
     def save_daily_snapshot(self, strategy_returns: dict):
@@ -597,46 +677,38 @@ class VirtualTradeRepository:
         now = self.tm.get_current_kst_time()
         if now.weekday() >= 5:  # 주말 제외
             return
-            
+
         today = now.strftime("%Y-%m-%d")
-        
-        # 1. 메모리 캐시를 우선 사용하는 _load_data 호출
+
         data = self._load_data()
         daily = data.get("daily", {})
 
-        # 2. 직전 날짜 비교 로직 최적화 (전체 정렬 대신 필요한 값만 찾기)
         if daily:
-            # 오늘보다 이전 날짜 중 가장 최근 날짜 하나만 찾음
             prev_dates = [d for d in daily if d < today]
             if prev_dates:
-                last_date = max(prev_dates) # sorted()보다 max()가 훨씬 빠름
+                last_date = max(prev_dates)
                 if _is_weekday(last_date):
                     last_snapshot = daily[last_date]
                     if _strategy_values(last_snapshot) == _strategy_values(strategy_returns):
                         return
 
-        # 3. 데이터 업데이트
         daily[today] = strategy_returns
 
-        # 4. 데이터 정리 로직 개선 (30일치 유지)
         cutoff_dt = now - timedelta(days=30)
         cutoff_str = cutoff_dt.strftime("%Y-%m-%d")
-        
-        # dict comprehension 시 기준 날짜보다 큰 것만 필터링
         new_daily = {d: v for d, v in daily.items() if d >= cutoff_str}
         data["daily"] = new_daily
 
-        # 5. 파일 및 캐시 저장
         self._save_data(data)
 
     def get_daily_change(self, strategy: str, current_return: float, *, _data: dict | None = None) -> tuple[float | None, str | None]:
         data = _data or self._load_data()
         daily = data.get("daily", {})
-        if not daily: return None, None
+        if not daily:
+            return None, None
 
         today = self.tm.get_current_kst_time().strftime("%Y-%m-%d")
 
-        # _get_trading_dates()로 주말/공휴일(전략값 미변동) 제외
         all_trading = _get_trading_dates(daily)
         trading = [d for d in all_trading if d <= today]
         if len(trading) < 2:
@@ -656,15 +728,15 @@ class VirtualTradeRepository:
         """7일 전 거래일 스냅샷 대비 변화. (변동값, 기준날짜) 튜플 반환."""
         data = _data or self._load_data()
         daily = data.get("daily", {})
-        if not daily: return None, None
-        
+        if not daily:
+            return None, None
+
         today = self.tm.get_current_kst_time().strftime("%Y-%m-%d")
         target = (self.tm.get_current_kst_time() - timedelta(days=7)).strftime("%Y-%m-%d")
 
-        # _get_trading_dates()의 무거운 루프를 피하고 바로 키 정렬 사용
         sorted_dates = sorted(daily.keys())
         candidates = [d for d in sorted_dates if d <= target and d != today]
-        
+
         if not candidates:
             return None, None
 
@@ -677,30 +749,27 @@ class VirtualTradeRepository:
     def get_strategy_return_history(self, strategy_name: str) -> list[dict]:
         data = self._load_data()
         daily = data.get("daily", {})
-        if not daily: return []
+        if not daily:
+            return []
 
         df = pd.DataFrame.from_dict(daily, orient='index')
-        if strategy_name not in df.columns: return []
+        if strategy_name not in df.columns:
+            return []
 
-        # [수정 포인트] ffill() 후에도 남는 과거 빈값(최초 거래 이전)을 0.0으로 채움
-        # .fillna(0.0) 을 반드시 추가해 주세요.
         series = df[strategy_name].sort_index().ffill().fillna(0.0)
-
-        # [수정 포인트] Numpy float64 타입을 순수 Python float로 캐스팅하여 에러 방지
-        # 주말 날짜 제외 (_is_weekday 필터)
         return [{"date": date, "return_rate": float(val)} for date, val in series.items() if _is_weekday(date)]
 
     def get_all_strategies(self) -> list[str]:
         data = self._load_data()
         daily = data.get("daily", {})
-        if not daily: return []
+        if not daily:
+            return []
 
-        # 모든 날짜를 다 뒤지는 대신, 최근 30일 내에 등장한 전략들만 합집합
-        # (과거에 삭제된 전략이 계속 나타나는 것을 방지)
         strategies = set()
-        recent_dates = sorted(daily.keys(), reverse=True)[:5] # 최근 5거래일만 확인
+        recent_dates = sorted(daily.keys(), reverse=True)[:5]  # 최근 5거래일만 확인
         for date in recent_dates:
             strategies.update(daily[date].keys())
 
-        if "ALL" in strategies: strategies.remove("ALL")
+        if "ALL" in strategies:
+            strategies.remove("ALL")
         return sorted(list(strategies))

--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -106,9 +106,12 @@ class VirtualTradeRepository:
         if os.path.exists(flag_path):
             return
 
+        # 레거시 파일은 VirtualTradeManager 디렉토리에 위치
+        legacy_dir = os.path.join(os.path.dirname(base_dir), "VirtualTradeManager")
+
         migrated = False
 
-        csv_path = os.path.join(base_dir, "trade_journal.csv")
+        csv_path = os.path.join(legacy_dir, "trade_journal.csv")
         if os.path.exists(csv_path):
             try:
                 df = pd.read_csv(csv_path, dtype={'code': str, 'sell_date': object}, encoding='utf-8')
@@ -123,7 +126,7 @@ class VirtualTradeRepository:
             except Exception as e:
                 logger.warning(f"[마이그레이션] CSV 마이그레이션 실패: {e}")
 
-        snap_path = os.path.join(base_dir, "portfolio_snapshots.json")
+        snap_path = os.path.join(legacy_dir, "portfolio_snapshots.json")
         if os.path.exists(snap_path):
             try:
                 with open(snap_path, 'r', encoding='utf-8') as f:
@@ -136,7 +139,7 @@ class VirtualTradeRepository:
             except Exception as e:
                 logger.warning(f"[마이그레이션] 스냅샷 마이그레이션 실패: {e}")
 
-        price_path = os.path.join(base_dir, "close_price_cache.json")
+        price_path = os.path.join(legacy_dir, "close_price_cache.json")
         if os.path.exists(price_path):
             try:
                 with open(price_path, 'r', encoding='utf-8') as f:
@@ -147,9 +150,9 @@ class VirtualTradeRepository:
             except Exception as e:
                 logger.warning(f"[마이그레이션] 가격 캐시 마이그레이션 실패: {e}")
 
-        with open(flag_path, 'w') as f:
-            f.write("1")
         if migrated:
+            with open(flag_path, 'w') as f:
+                f.write("1")
             logger.info("[마이그레이션] 레거시 데이터 마이그레이션 완료.")
 
     def _read(self) -> pd.DataFrame:

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -237,9 +237,13 @@ def test_snapshot_migration_from_old_format(tmp_path):
     journal_dir = tmp_path / "data" / "VirtualTradeRepository"
     journal_dir.mkdir(parents=True)
 
+    # 레거시 파일은 VirtualTradeManager 디렉토리에 위치
+    legacy_dir = tmp_path / "data" / "VirtualTradeManager"
+    legacy_dir.mkdir(parents=True)
+
     # 구버전 포맷: daily 키 없이 날짜가 최상위
     old_data = {"2025-01-01": {"ALL": 1.0}}
-    snap_file = journal_dir / "portfolio_snapshots.json"
+    snap_file = legacy_dir / "portfolio_snapshots.json"
     with open(snap_file, 'w', encoding='utf-8') as f:
         json.dump(old_data, f)
 

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import os
+import sqlite3
 import pandas as pd
 import json
 import math
@@ -12,12 +13,11 @@ from repositories.virtual_trade_repository import VirtualTradeRepository
 from services.virtual_trade_service import VirtualTradeService
 
 @pytest.fixture
-def temp_journal(tmp_path):
-    """테스트용 임시 저널 파일 경로 생성"""
-    journal_dir = tmp_path / "data" / "VirtualTradeRepository"
-    journal_dir.mkdir(parents=True)
-    journal_file = journal_dir / "trade_journal.csv"
-    return str(journal_file)
+def temp_db(tmp_path):
+    """테스트용 임시 SQLite DB 경로 생성"""
+    db_dir = tmp_path / "data" / "VirtualTradeRepository"
+    db_dir.mkdir(parents=True)
+    return str(db_dir / "virtual_trade.db")
 
 @pytest.fixture
 def mock_market_clock():
@@ -27,18 +27,18 @@ def mock_market_clock():
     return tm
 
 @pytest.fixture
-def virutal_trade_repository(temp_journal, mock_market_clock):
-    """VirtualTradeRepository 및 VirtualTradeService 래퍼 인스턴스 생성"""
-    return VirtualTradeRepository(filename=temp_journal, market_clock=mock_market_clock)
+def virutal_trade_repository(temp_db, mock_market_clock):
+    """VirtualTradeRepository 인스턴스 생성"""
+    return VirtualTradeRepository(db_path=temp_db, market_clock=mock_market_clock)
 
-def test_init_creates_directory_and_file(temp_journal):
-    """초기화 시 디렉토리와 파일이 생성되는지 확인"""
-    VirtualTradeRepository(filename=temp_journal)
-    assert os.path.exists(os.path.dirname(temp_journal))
-    assert os.path.exists(temp_journal)
-    df = pd.read_csv(temp_journal)
-    expected_cols = ["strategy", "code", "buy_date", "buy_price", "qty", "sell_date", "sell_price", "return_rate", "status", "reason"]
-    assert list(df.columns) == expected_cols
+def test_init_creates_directory_and_file(temp_db):
+    """초기화 시 DB 파일이 생성되고 필수 테이블이 존재하는지 확인"""
+    VirtualTradeRepository(db_path=temp_db)
+    assert os.path.exists(temp_db)
+    conn = sqlite3.connect(temp_db)
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert {"trades", "snapshots", "price_cache"}.issubset(tables)
 
 def test_log_buy_success(virutal_trade_repository):
     """매수 기록이 정상적으로 저장되는지 확인"""
@@ -97,7 +97,7 @@ def test_get_summary_calculation(virutal_trade_repository):
     virutal_trade_repository.log_buy("S1", "002", 1000)
     virutal_trade_repository.log_sell("002", 900)  # -10%
     virutal_trade_repository.log_buy("S1", "003", 1000) # HOLD (수익률 계산 제외)
-    
+
     summary = virutal_trade_repository.get_summary()
     assert summary['total_trades'] == 3
     assert summary['win_rate'] == 50.0
@@ -110,7 +110,7 @@ def test_fix_sell_price_logic(virutal_trade_repository):
     df.loc[0, 'status'] = 'SOLD'
     df.loc[0, 'sell_price'] = 0
     virutal_trade_repository._write(df)
-    
+
     virutal_trade_repository.fix_sell_price("005930", None, 15000)
     df = virutal_trade_repository._read()
     assert df.iloc[0]['sell_price'] == 15000
@@ -233,25 +233,27 @@ def test_get_weekly_change_logic(virutal_trade_repository):
     assert ref_date == "2025-01-03"
 
 def test_snapshot_migration_from_old_format(tmp_path):
-    """이전 JSON 포맷 마이그레이션 확인"""
+    """레거시 JSON 포맷(portfolio_snapshots.json)을 SQLite로 1회 마이그레이션하는지 확인"""
     journal_dir = tmp_path / "data" / "VirtualTradeRepository"
     journal_dir.mkdir(parents=True)
-    snapshot_file = journal_dir / "portfolio_snapshots.json"
+
+    # 구버전 포맷: daily 키 없이 날짜가 최상위
     old_data = {"2025-01-01": {"ALL": 1.0}}
-    with open(snapshot_file, 'w', encoding='utf-8') as f:
+    snap_file = journal_dir / "portfolio_snapshots.json"
+    with open(snap_file, 'w', encoding='utf-8') as f:
         json.dump(old_data, f)
-        
-    # VirtualTradeRepository는 filename의 디렉토리를 기준으로 snapshot 파일을 찾음
-    virutal_trade_repository = VirtualTradeRepository(filename=str(journal_dir / "trade_journal.csv"))
-    data = virutal_trade_repository._load_data()
-    
+
+    db_path = str(journal_dir / "virtual_trade.db")
+    repo = VirtualTradeRepository(db_path=db_path)
+    data = repo._load_data()
+
     assert "daily" in data
     assert "2025-01-01" in data["daily"]
+    assert data["daily"]["2025-01-01"]["ALL"] == 1.0
     assert data["prev_values"] == {}
 
 def test_get_strategy_return_history_logic(virutal_trade_repository):
     """전략별 수익률 히스토리 조회 및 정렬 로직 테스트"""
-    # 1. 테스트용 스냅샷 데이터 저장
     test_snapshots = {
         "daily": {
             "2025-01-01": {"S1": 1.1, "S2": 0.5},
@@ -262,16 +264,13 @@ def test_get_strategy_return_history_logic(virutal_trade_repository):
     }
     virutal_trade_repository._save_data(test_snapshots)
 
-    # 2. S1 전략 히스토리 조회
     history = virutal_trade_repository.get_strategy_return_history("S1")
 
-    # 3. 검증: 데이터 개수, 날짜순 정렬, 값 일치 여부
     assert len(history) == 3
     assert history[0] == {"date": "2025-01-01", "return_rate": 1.1}
     assert history[1] == {"date": "2025-01-02", "return_rate": 1.5}
     assert history[2] == {"date": "2025-01-03", "return_rate": 2.2}
 
-    # 4. 존재하지 않는 전략 조회 시 빈 리스트 반환 확인
     assert virutal_trade_repository.get_strategy_return_history("UNKNOWN") == []
 
 def test_get_strategy_return_history_excludes_weekend(virutal_trade_repository):
@@ -303,31 +302,23 @@ def test_get_all_strategies_logic(virutal_trade_repository):
         "prev_values": {}
     }
     virutal_trade_repository._save_data(test_snapshots)
-    
+
     strategies = virutal_trade_repository.get_all_strategies()
-    # 중복 제거 및 알파벳 순 정렬 확인
     assert strategies == ["S1", "S2", "S3"]
 
-def test_read_adds_qty_column_if_missing(temp_journal):
-    """기존 파일에 qty 컬럼이 없을 경우 읽기 시 기본값 1로 추가되는지 확인"""
-    # qty 없는 구버전 파일 생성
-    old_cols = ["strategy", "code", "buy_date", "buy_price", "sell_date", "sell_price", "return_rate", "status"]
-    df = pd.DataFrame(columns=old_cols)
-    df.loc[0] = ["S1", "005930", "2025-01-01", 1000, None, None, 0.0, "HOLD"]
-    df.to_csv(temp_journal, index=False)
-    
-    virtualTradeRepository = VirtualTradeRepository(filename=temp_journal)
-    df_read = virtualTradeRepository._read()
-    
-    assert "qty" in df_read.columns
-    assert df_read.iloc[0]['qty'] == 1
+def test_read_always_has_qty_column(virutal_trade_repository):
+    """SQLite 스키마가 qty 컬럼 DEFAULT 1을 보장하는지 확인"""
+    virutal_trade_repository.log_buy("S1", "005930", 1000)
+    df = virutal_trade_repository._read()
+
+    assert "qty" in df.columns
+    assert df.iloc[0]['qty'] == 1
 
 def test_log_buy_date_format(virutal_trade_repository):
     """매수 기록의 날짜 포맷이 YYYY-MM-DD HH:MM:SS 인지 확인 (호환성 유지)"""
     virutal_trade_repository.log_buy("TestStrategy", "005930", 70000)
     df = virutal_trade_repository._read()
     buy_date = df.iloc[0]['buy_date']
-    # 예: 2025-01-01 12:00:00 -> 하이픈(-)이 포함되어야 함
     assert buy_date[4] == '-' and buy_date[7] == '-'
 
 @pytest.mark.asyncio
@@ -342,19 +333,16 @@ async def test_log_buy_async(virutal_trade_repository):
 def test_log_buy_thread_safety(virutal_trade_repository):
     """여러 스레드에서 동시에 log_buy 호출 시 데이터 무결성 테스트 (Lock 작동 확인)."""
     def worker(idx):
-        # 각 스레드가 서로 다른 종목을 매수한다고 가정
         virutal_trade_repository.log_buy("ConcurrentStrat", f"0000{idx}", 1000 * idx)
 
     thread_count = 10
     with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
         futures = [executor.submit(worker, i) for i in range(thread_count)]
         for future in concurrent.futures.as_completed(futures):
-            future.result() # 예외 발생 시 여기서 raise됨
+            future.result()
 
     df = virutal_trade_repository._read()
-    # 10개의 레코드가 있어야 함 (Lock이 없으면 race condition으로 일부가 덮어씌워져 누락될 수 있음)
     assert len(df) == 10
-    # 중복 없이 모두 기록되었는지 확인
     codes = set(df['code'])
     assert len(codes) == 10
 
@@ -384,7 +372,7 @@ def test_log_sell_failure_no_hold(virutal_trade_repository):
     with patch("repositories.virtual_trade_repository.logger") as mock_logger:
         virutal_trade_repository.log_sell("999999", 10000)
         mock_logger.warning.assert_called()
-        
+
     df = virutal_trade_repository._read()
     assert df.empty
 
@@ -399,25 +387,22 @@ def test_get_solds_and_holds(virutal_trade_repository):
     virutal_trade_repository.log_buy("S1", "A", 1000)
     virutal_trade_repository.log_buy("S1", "B", 2000)
     virutal_trade_repository.log_sell("A", 1100)
-    
+
     solds = virutal_trade_repository.get_solds()
     holds = virutal_trade_repository.get_holds()
-    
+
     assert len(solds) == 1
     assert solds[0]['code'] == "A"
     assert len(holds) == 1
     assert holds[0]['code'] == "B"
 
 def test_price_cache_operations(virutal_trade_repository):
-    """가격 캐시 저장 및 로드 확인"""
+    """가격 캐시 SQLite 저장 및 로드 확인"""
     cache_data = {"005930": {"2025-01-01": 70000}}
     virutal_trade_repository._save_price_cache(cache_data)
-    
+
     loaded = virutal_trade_repository._load_price_cache()
     assert loaded == cache_data
-    
-    # 파일 경로 확인
-    assert virutal_trade_repository._price_cache_path().endswith("close_price_cache.json")
 
 def test_find_prev_close(virutal_trade_repository):
     """_find_prev_close 로직 확인"""
@@ -430,57 +415,48 @@ def test_find_prev_close(virutal_trade_repository):
     # 1월 2일 데이터는 없음 -> 1월 1일 데이터 반환해야 함
     price = virutal_trade_repository._find_prev_close(cache, "005930", "2025-01-02")
     assert price == 70000
-    
+
     # 이전 데이터가 아예 없는 경우
     price = virutal_trade_repository._find_prev_close(cache, "005930", "2024-12-31")
     assert price is None
 
 def test_backfill_snapshots(virutal_trade_repository):
     """과거 스냅샷 backfill 로직 확인"""
-    # 1. 거래 기록 생성
-    # A: 1/1 매수 -> 1/3 매도
-    # B: 1/2 매수 -> 보유
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 1)
     virutal_trade_repository.log_buy("S1", "A", 1000)
-    
+
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 2)
     virutal_trade_repository.log_buy("S2", "B", 2000)
-    
+
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 3)
     virutal_trade_repository.log_sell("A", 1100) # 10% 수익
-    
-    # 2. 가격 캐시 Mocking
-    # A: 1/1(1000), 1/2(1050), 1/3(1100)
-    # B: 1/2(2000), 1/3(1900)
+
     price_cache = {
         "A": {"2025-01-01": 1000, "2025-01-02": 1050, "2025-01-03": 1100},
         "B": {"2025-01-02": 2000, "2025-01-03": 1900}
     }
-    
-    # _fetch_close_prices를 Mock하여 위 캐시를 반환하도록 함
+
     with patch.object(virutal_trade_repository, '_fetch_close_prices', return_value=price_cache):
         virutal_trade_repository.backfill_snapshots()
-        
+
     data = virutal_trade_repository._load_data()
     daily = data["daily"]
-    
+
     # 1/1: A 보유 (매수가 1000, 종가 1000 -> 0%)
     assert daily["2025-01-01"]["S1"] == 0.0
-    
+
     # 1/2: A 보유 (매수가 1000, 종가 1050 -> 5%), B 보유 (매수가 2000, 종가 2000 -> 0%)
     assert daily["2025-01-02"]["S1"] == 5.0
     assert daily["2025-01-02"]["S2"] == 0.0
-    
+
     # 1/3: A 매도 (확정 10%), B 보유 (매수가 2000, 종가 1900 -> -5%)
     assert daily["2025-01-03"]["S1"] == 10.0
     assert daily["2025-01-03"]["S2"] == -5.0
 
-def test_load_data_corrupted(virutal_trade_repository, tmp_path):
-    """손상된 스냅샷 파일 로드 시 빈 데이터 반환 확인"""
-    snapshot_file = virutal_trade_repository._snapshot_path()
-    with open(snapshot_file, 'w') as f:
-        f.write("{invalid json")
-        
+def test_load_data_returns_empty_for_new_repo(virutal_trade_repository):
+    """신규 저장소에서 _load_data()가 빈 데이터를 반환하는지 확인"""
+    # 캐시 초기화
+    virutal_trade_repository._cached_data = None
     data = virutal_trade_repository._load_data()
     assert data == {"daily": {}, "prev_values": {}}
 
@@ -490,14 +466,8 @@ def test_backfill_snapshots_empty_df(virutal_trade_repository):
         virutal_trade_repository.backfill_snapshots()
         mock_fetch.assert_not_called()
 
-def test_load_price_cache_corrupted(virutal_trade_repository):
-    """가격 캐시 파일이 손상되었을 때 빈 딕셔너리 반환 확인"""
-    cache_path = virutal_trade_repository._price_cache_path()
-    # Ensure dir exists
-    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-    with open(cache_path, 'w') as f:
-        f.write("{invalid json")
-    
+def test_load_price_cache_empty(virutal_trade_repository):
+    """가격 캐시가 비어있을 때 빈 딕셔너리 반환 확인"""
     loaded = virutal_trade_repository._load_price_cache()
     assert loaded == {}
 
@@ -505,11 +475,11 @@ def test_fetch_close_prices_cache_hit(virutal_trade_repository):
     """캐시에 데이터가 이미 있으면 API 호출 스킵"""
     cache_data = {"005930": {"2025-01-01": 70000, "2025-01-02": 71000, "2025-01-03": 72000}}
     virutal_trade_repository._save_price_cache(cache_data)
-    
+
     mock_pykrx_stock = MagicMock()
     mock_pykrx = MagicMock()
     mock_pykrx.stock = mock_pykrx_stock
-    
+
     with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-03")
         assert result == cache_data
@@ -517,24 +487,21 @@ def test_fetch_close_prices_cache_hit(virutal_trade_repository):
 
 def test_fetch_close_prices_api_call(virutal_trade_repository):
     """캐시가 없으면 API 호출 후 저장"""
-    if os.path.exists(virutal_trade_repository._price_cache_path()):
-        os.remove(virutal_trade_repository._price_cache_path())
-        
     mock_pykrx_stock = MagicMock()
     mock_df = pd.DataFrame({'종가': [70000, 71000]}, index=pd.to_datetime(['2025-01-01', '2025-01-02']))
     mock_pykrx_stock.get_market_ohlcv_by_date.return_value = mock_df
-    
+
     mock_pykrx = MagicMock()
     mock_pykrx.stock = mock_pykrx_stock
-    
+
     with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-02")
-        
+
         assert "005930" in result
         assert result["005930"]["2025-01-01"] == 70000
         assert result["005930"]["2025-01-02"] == 71000
         mock_pykrx_stock.get_market_ohlcv_by_date.assert_called_once()
-        
+
         loaded = virutal_trade_repository._load_price_cache()
         assert loaded["005930"]["2025-01-01"] == 70000
 
@@ -542,10 +509,10 @@ def test_fetch_close_prices_api_empty(virutal_trade_repository):
     """API 응답이 비어있을 때 처리"""
     mock_pykrx_stock = MagicMock()
     mock_pykrx_stock.get_market_ohlcv_by_date.return_value = pd.DataFrame()
-    
+
     mock_pykrx = MagicMock()
     mock_pykrx.stock = mock_pykrx_stock
-    
+
     with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-01")
         assert "005930" not in result
@@ -555,10 +522,10 @@ def test_fetch_close_prices_api_exception(virutal_trade_repository):
     """API 호출 중 예외 발생 시 처리"""
     mock_pykrx_stock = MagicMock()
     mock_pykrx_stock.get_market_ohlcv_by_date.side_effect = Exception("API Error")
-    
+
     mock_pykrx = MagicMock()
     mock_pykrx.stock = mock_pykrx_stock
-    
+
     with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
         with patch("repositories.virtual_trade_repository.logger") as mock_logger:
             result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-01")
@@ -567,101 +534,69 @@ def test_fetch_close_prices_api_exception(virutal_trade_repository):
 
 def test_backfill_snapshots_missing_price_logic(virutal_trade_repository):
     """backfill_snapshots: 종가 데이터 누락 시 직전 종가 사용 및 데이터 아예 없을 때 0.0 처리 검증"""
-    # 1. 거래 기록 생성
-    # A: 1/1 매수 (1000원) -> 1/3 매도 (1300원)
-    # B: 1/1 매수 (1000원) -> 1/3 매도 (1300원)
-    # 이렇게 하면 backfill 범위가 1/1 ~ 1/3이 됨
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 1)
     virutal_trade_repository.log_buy("S1", "A", 1000)
     virutal_trade_repository.log_buy("S2", "B", 1000)
-    
+
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 3)
     virutal_trade_repository.log_sell("A", 1300)
     virutal_trade_repository.log_sell("B", 1300)
-    
-    # 2. 가격 캐시 Mocking
-    # A: 1/1(1100), 1/2(데이터 없음 -> 1/1의 1100 사용 예상), 1/3(1200)
-    # B: 데이터 아예 없음 (1/1, 1/2 모두 없음)
+
+    # A: 1/1(1100), 1/2(데이터 없음 → ffill로 1100), 1/3(1200)
+    # B: 데이터 아예 없음 → buy_price(1000) 사용
     price_cache = {
         "A": {"2025-01-01": 1100, "2025-01-03": 1200},
-        # B는 키조차 없거나 비어있음
     }
-    
+
     with patch.object(virutal_trade_repository, '_fetch_close_prices', return_value=price_cache):
         virutal_trade_repository.backfill_snapshots()
-        
+
     data = virutal_trade_repository._load_data()
     daily = data["daily"]
-    
-    # 1/1: A(1100) -> 10%, B(없음) -> 0%
+
     assert daily["2025-01-01"]["S1"] == 10.0
     assert daily["2025-01-01"]["S2"] == 0.0
-    
-    # 1/2: A(데이터 없음 -> 직전 1/1의 1100) -> 10%, B(없음) -> 0%
-    # 여기가 핵심 검증 포인트 (lines 318-324)
+
     assert daily["2025-01-02"]["S1"] == 10.0
     assert daily["2025-01-02"]["S2"] == 0.0
-    
-    # 1/3: 매도 완료된 상태 (확정 수익률 사용)
-    # A: (1300-1000)/1000 = 30%
-    # B: (1300-1000)/1000 = 30%
+
     assert daily["2025-01-03"]["S1"] == 30.0
     assert daily["2025-01-03"]["S2"] == 30.0
-    
 
-def test_get_holds_by_strategy_missing_qty_field(temp_journal):
-    """get_holds_by_strategy 호출 시 파일에 qty 필드가 없어도 기본값 1로 반환되는지 확인"""
-    # qty 없는 구버전 파일 생성
-    old_cols = ["strategy", "code", "buy_date", "buy_price", "sell_date", "sell_price", "return_rate", "status"]
-    df = pd.DataFrame(columns=old_cols)
-    df.loc[0] = ["StrategyA", "005930", "2025-01-01", 1000, None, None, 0.0, "HOLD"]
-    df.to_csv(temp_journal, index=False)
+def test_get_holds_by_strategy(virutal_trade_repository):
+    """get_holds_by_strategy는 해당 전략의 HOLD 건만 반환하며 qty가 포함된다"""
+    virutal_trade_repository.log_buy("StrategyA", "005930", 1000, qty=3)
+    virutal_trade_repository.log_buy("StrategyB", "000660", 2000)
 
-    virutal_trade_repository = VirtualTradeRepository(filename=temp_journal)
     holds = virutal_trade_repository.get_holds_by_strategy("StrategyA")
 
     assert len(holds) == 1
     assert holds[0]['code'] == "005930"
-    assert holds[0]['qty'] == 1
+    assert holds[0]['qty'] == 3
 
 def test_backfill_snapshots_asset_weighted_logic(virutal_trade_repository):
     """백필 시 자산 가중 평균으로 수익률이 계산되는지 확인"""
-    # 1. 거래 기록 생성
-    # 전략 A: 큰 금액(100만원), 작은 수익률(+10%)
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 1)
     virutal_trade_repository.log_buy("StrategyA", "A", 1000, qty=1000) # 매수금 1,000,000
-    
-    # 전략 B: 작은 금액(1만원), 큰 손실률(-50%)
-    virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 1)
     virutal_trade_repository.log_buy("StrategyB", "B", 1000, qty=10)   # 매수금 10,000
-    
-    # 2. 가격 캐시 Mocking (1월 2일 기준 평가)
-    # A: 1100원 (+10%) -> 평가금 1,100,000
-    # B: 500원 (-50%) -> 평가금 5,000
+
     price_cache = {
         "A": {"2025-01-02": 1100},
         "B": {"2025-01-02": 500}
     }
-    
-    # 3. Backfill 수행 (현재 시간을 1/3로 설정하여 1/2일자 스냅샷 생성 유도)
+
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 3)
-    
+
     with patch.object(virutal_trade_repository, '_fetch_close_prices', return_value=price_cache):
         virutal_trade_repository.backfill_snapshots()
-        
+
     data = virutal_trade_repository._load_data()
     daily = data["daily"]
-    
-    # 1월 2일자 스냅샷 확인
+
     assert "2025-01-02" in daily
     snapshot = daily["2025-01-02"]
-    
-    # 자산 가중 평균 계산 검증
-    # 총 매수: 1,010,000
-    # 총 평가: 1,105,000
-    # 수익률: (1,105,000 - 1,010,000) / 1,010,000 * 100 = 9.4059... -> 9.41%
-    # 단순 평균이었다면: (10 - 50) / 2 = -20%
-    
+
+    # 자산 가중 평균: 총매수 1,010,000 / 총평가 1,105,000 → 9.41%
     assert snapshot["ALL"] == 9.41
     assert snapshot["StrategyA"] == 10.0
     assert snapshot["StrategyB"] == -50.0
@@ -671,11 +606,11 @@ def test_get_daily_change_returns_none_if_insufficient_data(virutal_trade_reposi
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 2)
     data = {
         "daily": {
-            "2025-01-02": {"ALL": 1.0} # 데이터가 하루치만 있음
+            "2025-01-02": {"ALL": 1.0}
         },
         "prev_values": {}
     }
-    
+
     change, ref_date = virutal_trade_repository.get_daily_change("ALL", 1.0, _data=data)
     assert change is None
     assert ref_date is None
@@ -683,20 +618,18 @@ def test_get_daily_change_returns_none_if_insufficient_data(virutal_trade_reposi
 def test_backfill_snapshots_performance(virutal_trade_repository):
     """backfill_snapshots 대량 데이터 성능 테스트"""
     import time
-    
-    # 1. 대량의 거래 기록 생성 (약 250건, 1년치 영업일)
+
     dates = pd.date_range(start="2024-01-01", end="2024-12-31", freq="B")
     trades = []
-    codes = [f"A{i:04d}" for i in range(50)] # 50개 종목
-    
+    codes = [f"A{i:04d}" for i in range(50)]
+
     for i, date in enumerate(dates):
-        # 매일 거래가 발생한다고 가정
         code = codes[i % 50]
         buy_date = date.strftime("%Y-%m-%d %H:%M:%S")
-        status = "SOLD" if i % 2 == 0 else "HOLD" # 반반
+        status = "SOLD" if i % 2 == 0 else "HOLD"
         sell_date = (date + pd.Timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S") if status == "SOLD" else None
         sell_price = 11000 if status == "SOLD" else None
-        
+
         trades.append({
             "strategy": "PerfTest",
             "code": code,
@@ -706,13 +639,13 @@ def test_backfill_snapshots_performance(virutal_trade_repository):
             "sell_date": sell_date,
             "sell_price": sell_price,
             "return_rate": 10.0 if status == "SOLD" else 0.0,
-            "status": status
+            "status": status,
+            "reason": ""
         })
-            
+
     df = pd.DataFrame(trades)
     virutal_trade_repository._write(df)
-    
-    # 2. 대량의 종가 데이터 Mocking
+
     price_cache = {}
     full_date_range = pd.date_range(start="2024-01-01", end="2024-12-31")
     for code in codes:
@@ -720,28 +653,23 @@ def test_backfill_snapshots_performance(virutal_trade_repository):
             d.strftime("%Y-%m-%d"): random.randint(9000, 11000)
             for d in full_date_range
         }
-        
-    # 3. backfill 실행 및 시간 측정
+
     virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2025, 1, 1)
-    
+
     start_time = time.time()
     with patch.object(virutal_trade_repository, '_fetch_close_prices', return_value=price_cache):
         virutal_trade_repository.backfill_snapshots()
     end_time = time.time()
-    
+
     duration = end_time - start_time
     print(f"\n[Performance] backfill_snapshots processed {len(trades)} trades over {len(dates)} days in {duration:.4f} seconds")
-    
-    # 최적화된 로직이라면 1년치 데이터도 매우 빠르게 처리되어야 함 (보수적으로 2초 설정)
     assert duration < 2.0
 
 def test_calculate_return_delegation(virutal_trade_repository):
     """calculate_return 메서드가 비용 적용 옵션에 따라 다르게 동작하는지 확인"""
-    # 비용 미적용: 10%
     ror_no_cost = virutal_trade_repository.calculate_return(10000, 11000, qty=1, apply_cost=False)
     assert ror_no_cost == 10.0
-    
-    # 비용 적용: 10% 미만 (수수료/세금 차감)
+
     ror_cost = virutal_trade_repository.calculate_return(10000, 11000, qty=1, apply_cost=True)
     assert ror_cost < 10.0
 
@@ -750,45 +678,36 @@ def test_get_trade_amount(virutal_trade_repository):
     price = 10000
     qty = 10
     base_amount = price * qty
-    
-    # 비용 미적용
+
     assert virutal_trade_repository.get_trade_amount(price, qty, is_sell=False, apply_cost=False) == base_amount
     assert virutal_trade_repository.get_trade_amount(price, qty, is_sell=True, apply_cost=False) == base_amount
-    
-    # 비용 적용 (매수: 금액 + 비용)
+
     buy_amt = virutal_trade_repository.get_trade_amount(price, qty, is_sell=False, apply_cost=True)
     assert buy_amt > base_amount
-    
-    # 비용 적용 (매도: 금액 - 비용)
+
     sell_amt = virutal_trade_repository.get_trade_amount(price, qty, is_sell=True, apply_cost=True)
     assert sell_amt < base_amount
 
 def test_get_summary_with_cost(virutal_trade_repository):
     """get_summary 메서드에서 apply_cost 옵션이 통계에 반영되는지 확인"""
-    # 데이터 준비: 1건의 매매 (10% 수익)
     virutal_trade_repository.log_buy("StrategyA", "005930", 10000, qty=10)
     virutal_trade_repository.log_sell("005930", 11000, qty=10)
-    
-    # 비용 미적용 요약
+
     summary_no_cost = virutal_trade_repository.get_summary(apply_cost=False)
     assert summary_no_cost['avg_return'] == 10.0
-    
-    # 비용 적용 요약
+
     summary_cost = virutal_trade_repository.get_summary(apply_cost=True)
     assert summary_cost['avg_return'] < 10.0
-    
+
 def test_get_all_trades_with_cost(virutal_trade_repository):
     """get_all_trades 메서드에서 apply_cost=True일 때 개별 거래 수익률이 재계산되는지 확인"""
-    # 데이터 준비
     virutal_trade_repository.log_buy("StrategyA", "005930", 10000, qty=10)
     virutal_trade_repository.log_sell("005930", 11000, qty=10)
-    
-    # 비용 미적용 조회 (CSV에 저장된 값 그대로: 10.0)
+
     trades_no_cost = virutal_trade_repository.get_all_trades(apply_cost=False)
     assert len(trades_no_cost) == 1
     assert trades_no_cost[0]['return_rate'] == 10.0
-    
-    # 비용 적용 조회 (재계산된 값)
+
     trades_cost = virutal_trade_repository.get_all_trades(apply_cost=True)
     assert len(trades_cost) == 1
     assert trades_cost[0]['return_rate'] < 10.0


### PR DESCRIPTION
repositories/virtual_trade_repository.py

filename → db_path 파라미터, SQLite 3테이블 스키마 초기화 (WAL 모드) log_buy / log_sell / log_sell_by_strategy: 전체 CSV 재기록 → 단일 INSERT / UPDATE SQL is_holding: DataFrame 필터 → SELECT 1 ... LIMIT 1 인덱스 활용 _load_data / _save_data: JSON 파일 I/O → snapshots 테이블 _load_price_cache / _save_price_cache: JSON 파일 I/O → price_cache 테이블 (INSERT OR REPLACE) _migrate_legacy_data() 추가: 기존 CSV/JSON 파일을 최초 1회 자동 마이그레이션 후 .migrated 플래그 생성 tests/unit_test/repositories/test_virtual_trade_repository.py

temp_journal (CSV 경로) → temp_db (SQLite .db 경로)
VirtualTradeRepository(filename=...) → db_path=
test_init_creates_directory_and_file: CSV 컬럼 체크 → sqlite_master 테이블 존재 체크 test_snapshot_migration_from_old_format: 구버전 JSON → SQLite 마이그레이션 실제 검증 test_load_data_corrupted → test_load_data_returns_empty_for_new_repo test_load_price_cache_corrupted → test_load_price_cache_empty test_read_adds_qty_column_if_missing → test_read_always_has_qty_column (스키마 DEFAULT 검증) test_get_holds_by_strategy_missing_qty_field → test_get_holds_by_strategy (통합 검증) 변경 없음: virtual_trade_service.py, test_virtual_trade_service.py (mock 기반이라 영향 없음), 통합테스트 (VirtualTradeRepository를 전부 mock 처리)