### PR TITLE
[minor]변경 내용 요약:

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -20,11 +20,12 @@ class BrokerAPIWrapper:
 
     def __init__(self, broker: str = "korea_investment", env=None, logger=None, market_clock=None,
                  cache_config=None, market_calendar_service=None,
-                 streaming_logger: Optional["StreamingEventLogger"] = None):
+                 streaming_logger: Optional["StreamingEventLogger"] = None,
+                 stock_code_repository=None):
         self._broker = broker
         self._logger = logger
         self._client = None
-        self._stock_mapper = StockCodeRepository(logger=logger)
+        self._stock_mapper = stock_code_repository if stock_code_repository is not None else StockCodeRepository(logger=logger)
         self.env = env
         self._retry_queue: ApiRequestQueue | None = None
 

--- a/tests/unit_test/brokers/test_broker_api_wrapper.py
+++ b/tests/unit_test/brokers/test_broker_api_wrapper.py
@@ -405,6 +405,31 @@ def test_initialization_success(mock_stock_mapper, mock_client, mock_env, mock_l
     assert wrapper._stock_mapper is mock_stock_mapper.return_value  # _stock_mapper가 mock_stock_mapper 인스턴스를 참조하는지 확인
 
 
+@patch(f"{wrapper_module.__name__}.KoreaInvestApiClient")
+@patch(f"{wrapper_module.__name__}.StockCodeRepository")
+def test_initialization_with_injected_stock_code_repository(mock_stock_mapper, mock_client, mock_env, mock_logger, mock_market_clock):
+    """
+    stock_code_repository를 외부에서 주입하면 StockCodeRepository가 내부에서 생성되지 않고
+    주입된 인스턴스가 _stock_mapper로 사용되는지 검증합니다.
+    """
+    injected_repo = MagicMock()
+
+    with patch(f"{wrapper_module.__name__}.cache_wrap_client", side_effect=lambda c, *a, **kw: c), \
+         patch(f"{wrapper_module.__name__}.retry_queue_wrap_client", side_effect=lambda c, *a, **kw: c):
+        wrapper = BrokerAPIWrapper(
+            broker="korea_investment",
+            env=mock_env,
+            logger=mock_logger,
+            market_clock=mock_market_clock,
+            stock_code_repository=injected_repo,
+        )
+
+    # 주입된 인스턴스가 _stock_mapper로 설정되어야 함
+    assert wrapper._stock_mapper is injected_repo
+    # StockCodeRepository 생성자가 호출되지 않아야 함
+    mock_stock_mapper.assert_not_called()
+
+
 @patch(f"{wrapper_module.__name__}.StockCodeRepository")
 def test_initialization_no_env_raises_error(mock_mapper_class, mock_logger):
     """

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -91,6 +91,9 @@ async def test_initialize_services_success(mock_deps):
     assert ctx.initialized is True
     env_instance.set_trading_mode.assert_called_with(True)
     mock_deps["broker"].assert_called()
+    # StockCodeRepository 인스턴스가 BrokerAPIWrapper에 주입되었는지 검증
+    _, broker_kwargs = mock_deps["broker"].call_args
+    assert broker_kwargs.get("stock_code_repository") is mock_deps["scm"].return_value
     mock_deps["mds"].assert_called()
     mock_deps["ind"].assert_called()
     mock_deps["sqs"].assert_called()

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -177,6 +177,7 @@ class WebAppContext:
             env=self.env, logger=self.logger, market_clock=self.market_clock,
             market_calendar_service=self._mcs,
             streaming_logger=self.streaming_event_logger,
+            stock_code_repository=self.stock_code_repository,
         )
 
         # [수정] MarketCalendarService에 Broker 주입 (Fetcher 로직은 Manager 내부로 이동)


### PR DESCRIPTION
broker_api_wrapper.py: __init__에 stock_code_repository=None 파라미터 추가. 주입된 값이 있으면 사용, 없으면 내부 생성
web_app_initializer.py: BrokerAPIWrapper 생성 시 stock_code_repository=self.stock_code_repository 주입 (line 77에서 이미 생성된 인스턴스 재사용)
test_web_app_initializer.py: test_initialize_services_success에 broker 호출 시 stock_code_repository가 scm mock 인스턴스로 전달됐는지 assertion 추가
test_broker_api_wrapper.py: test_initialization_with_injected_stock_code_repository 신규 TC 추가 — 주입 시 StockCodeRepository 생성자가 호출되지 않음을 검증