### PR TITLE
전략별 성능 강화 및 로깅 강화

### DIFF
--- a/logs/strategies/unzip.py
+++ b/logs/strategies/unzip.py
@@ -1,0 +1,49 @@
+import gzip
+import shutil
+import os
+from pathlib import Path
+
+def decompress_by_timestamp(input_file_path):
+    # 1. 입력 파일 경로 객체 생성 및 검증
+    target_path = Path(input_file_path)
+    if not target_path.exists():
+        print(f"오류: '{input_file_path}' 파일을 찾을 수 없습니다.")
+        return
+
+    # 2. 파일명에서 타임스탬프 추출 (예: 20260416_214848)
+    # 파일명의 첫 15자리가 YYYYMMDD_HHMMSS 형식임을 가정합니다.
+    timestamp = target_path.name[:15]
+    directory = target_path.parent
+    
+    print(f"기준 타임스탬프: {timestamp}")
+    print(f"탐색 디렉토리: {directory.absolute()}")
+
+    # 3. 해당 디렉토리에서 동일한 타임스탬프로 시작하는 .gz 파일 찾기
+    gz_files = [f for f in directory.glob(f"{timestamp}*.gz")]
+
+    if not gz_files:
+        print(f"해당 타임스탬프({timestamp})와 일치하는 .gz 파일이 없습니다.")
+        return
+
+    print(f"총 {len(gz_files)}개의 연관 압축 파일을 발견했습니다.")
+
+    # 4. 압축 해제 진행
+    for gz_file in gz_files:
+        # 확장자 제거 (파일명.log.json.gz -> 파일명.log.json)
+        output_file = gz_file.with_suffix("")
+        
+        try:
+            print(f"압축 해제 중: {gz_file.name} -> {output_file.name}...", end=" ", flush=True)
+            
+            with gzip.open(gz_file, 'rb') as f_in:
+                with open(output_file, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            
+            print("성공!")
+        except Exception as e:
+            print(f"실패 (오류: {e})")
+
+if __name__ == "__main__":
+    # 사용 예시: 실제 파일명 하나를 입력합니다. (.gz가 붙어있어도, 없어도 타임스탬프만 추출합니다.)
+    user_input = input("압축을 풀 타임스탬프의 기준 파일명을 입력하세요: ").strip()
+    decompress_by_timestamp(user_input)

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -94,7 +94,7 @@ class FirstPullbackStrategy(LiveStrategy):
         for i in range(0, len(candidates), 10):
             chunk = candidates[i:i + 10]
             results = await asyncio.gather(
-                *[self._check_entry(code, item, market_progress) for code, item in chunk],
+                *[self._check_entry(code, item, market_progress, market_timing) for code, item in chunk],
                 return_exceptions=True,
             )
             for result in results:
@@ -106,7 +106,7 @@ class FirstPullbackStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_entry(self, code, item, progress) -> Optional[TradeSignal]:
+    async def _check_entry(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
         """진입 조건 검사: Phase 1 → 2 → 3 순서로 필터링."""
         # ── 현재가 데이터 선행 조회 (OHLCV 캐시 활용 위해) ──
         resp = await self._sqs.get_current_price(code, caller=self.name)
@@ -172,7 +172,8 @@ class FirstPullbackStrategy(LiveStrategy):
             self._logger.debug({
                 "event": "entry_rejected", "code": code, "reason": "pullback_out_of_range",
                 "pullback_pct": round(pullback_pct, 2),
-                "allowed_range": f"{self._cfg.pullback_lower_pct}% ~ {self._cfg.pullback_upper_pct}%"
+                "allowed_range": f"{self._cfg.pullback_lower_pct}% ~ {self._cfg.pullback_upper_pct}%",
+                "today_low": today_low, "ma_20d": round(ma_20d, 0),
             })
             return None
 
@@ -183,7 +184,8 @@ class FirstPullbackStrategy(LiveStrategy):
             vol_dryup_pct = (avg_vol / surge_volume * 100) if surge_volume > 0 else 0.0
             self._logger.debug({
                 "event": "entry_rejected", "code": code, "reason": "volume_not_dry",
-                "vol_dryup_pct": round(vol_dryup_pct, 2), "threshold_pct": self._cfg.volume_dryup_ratio * 100
+                "vol_dryup_pct": round(vol_dryup_pct, 2), "threshold_pct": self._cfg.volume_dryup_ratio * 100,
+                "avg_vol": int(avg_vol), "surge_volume": surge_volume,
             })
             return None
 
@@ -243,7 +245,17 @@ class FirstPullbackStrategy(LiveStrategy):
         self._logger.info({
             "event": "buy_signal_generated",
             "code": code, "name": item.name,
-            "price": current,
+            "metrics": {
+                "price": current,
+                "ma_20d": round(ma_20d, 0),
+                "pullback_pct": round(pullback_pct, 2),
+                "vol_dryup_pct": round(vol_dryup_pct, 1),
+                "execution_strength": cgld_val,
+                "rs_score": getattr(item, "rs_score", 0.0),
+                "rs_rating": getattr(item, "rs_rating", 0),
+                "total_score": getattr(item, "total_score", 0.0),
+                "market_timing": market_timing.get(item.market) if market_timing else None,
+            },
             "reason": reason_msg,
         })
 
@@ -350,106 +362,150 @@ class FirstPullbackStrategy(LiveStrategy):
     # ── check_exits ────────────────────────────────────────────────
 
     async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
-        signals = []
+        if not holdings:
+            return []
+
+        results = await asyncio.gather(
+            *[self._check_single_exit(hold) for hold in holdings],
+            return_exceptions=True,
+        )
+
+        signals: List[TradeSignal] = []
         state_dirty = False
-        for hold in holdings:
-            code = hold.get("code")
-            buy_price_raw = hold.get("buy_price")
-            if not code or not buy_price_raw:
-                continue
-
-            buy_price = float(buy_price_raw)  # numpy.float64 타입 제거 (순수 float 형변환)
-
-            state = self._position_state.get(code)
-            if not state:
-                state = FPPositionState(
-                    entry_price=int(buy_price),
-                    entry_date="",
-                    peak_price=int(buy_price),
-                    surge_day_high=0,
-                )
-                self._position_state[code] = state
-
-            # 현재가 조회
-            resp = await self._sqs.get_current_price(code, caller=self.name)
-            if not resp or resp.rt_cd != "0":
-                continue
-
-            output = resp.data.get("output") if isinstance(resp.data, dict) else None
-            if not output:
-                continue
-
-            if isinstance(output, dict):
-                current = int(output.get("stck_prpr", 0))
-            else:
-                current = int(getattr(output, "stck_prpr", 0) or 0)
-
-            if current <= 0:
-                continue
-
-            # 최고가 갱신 (dirty flag — 루프 후 1회 저장)
-            if current > state.peak_price:
-                state.peak_price = current
-                state_dirty = True
-
-            # 20MA 동적 계산 (매일 변하는 최신 MA)
-            ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=self._cfg.ma_period)
-            ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
-            closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
-
-            pnl = float((current - buy_price) / buy_price * 100)
-            reason = ""
-
-            # 🚨 손절: 20MA -2% 이탈 → 잔량 전체 매도
-            if len(closes) >= self._cfg.ma_period:
-                ma_20d = float(sum(closes[-self._cfg.ma_period:]) / self._cfg.ma_period)
-                threshold = ma_20d * (1 + self._cfg.stop_loss_below_ma_pct / 100)
-                if current < threshold:
-                    reason = f"손절(20MA {ma_20d:,.0f} 하향이탈 {pnl:.1f}%)"
-
-            # 🌟 부분 익절: 직전 익절가(또는 진입가) 대비 +10% 도달 시 반복 실행
-            if not reason:
-                ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
-                pnl_from_ref = float((current - ref_price) / ref_price * 100)
-                if pnl_from_ref >= self._cfg.take_profit_lower_pct:
-                    holding_qty = int(hold.get("qty", 1))
-                    sell_qty = max(1, int(holding_qty * self._cfg.partial_sell_ratio))
-
-                    if sell_qty >= holding_qty:
-                        sell_qty = holding_qty
-                        sell_reason = f"전량익절({pnl_from_ref:.1f}%, 잔고 {holding_qty}주)"
-                    else:
-                        sell_reason = f"부분익절({pnl_from_ref:.1f}%, {sell_qty}주/{holding_qty}주)"
-
-                    self._logger.info({
-                        "event": "partial_profit_signal",
-                        "code": code, "pnl": round(pnl_from_ref, 2),
-                        "sell_qty": sell_qty, "holding_qty": holding_qty,
-                    })
-
-                    state.last_partial_sell_price = current
+        for result in results:
+            if isinstance(result, Exception):
+                self._logger.error({"event": "exit_check_error", "error": str(result)})
+            elif result:
+                s_list, dirty = result
+                signals.extend(s_list)
+                if dirty:
                     state_dirty = True
 
-                    signals.append(TradeSignal(
-                        code=code, name=hold.get("name", code), action="SELL",
-                        price=current, qty=sell_qty,
-                        reason=sell_reason, strategy_name=self.name
-                    ))
-                    continue  # 부분 매도 후 손절 체크하지 않음
+        if state_dirty:
+            await self._save_state_async()
+        return signals
 
-            # 매도 시그널 생성 (손절)
-            if reason:
+    async def _check_single_exit(self, hold: dict) -> tuple:
+        """단일 보유 종목 청산 조건 검사.
+
+        Returns: (List[TradeSignal], state_dirty: bool)
+        """
+        signals: List[TradeSignal] = []
+        state_dirty = False
+
+        code = hold.get("code")
+        buy_price_raw = hold.get("buy_price")
+        if not code or not buy_price_raw:
+            return signals, state_dirty
+
+        buy_price = float(buy_price_raw)  # numpy.float64 타입 제거 (순수 float 형변환)
+
+        state = self._position_state.get(code)
+        if not state:
+            state = FPPositionState(
+                entry_price=int(buy_price),
+                entry_date="",
+                peak_price=int(buy_price),
+                surge_day_high=0,
+            )
+            self._position_state[code] = state
+
+        # 현재가 조회
+        resp = await self._sqs.get_current_price(code, caller=self.name)
+        if not resp or resp.rt_cd != "0":
+            return signals, state_dirty
+
+        output = resp.data.get("output") if isinstance(resp.data, dict) else None
+        if not output:
+            return signals, state_dirty
+
+        if isinstance(output, dict):
+            current = int(output.get("stck_prpr", 0))
+        else:
+            current = int(getattr(output, "stck_prpr", 0) or 0)
+
+        if current <= 0:
+            return signals, state_dirty
+
+        # 최고가 갱신 (dirty flag)
+        if current > state.peak_price:
+            state.peak_price = current
+            state_dirty = True
+
+        pnl = float((current - buy_price) / buy_price * 100)
+
+        # MFE / MAE 갱신
+        if pnl > state.mfe_pct:
+            state.mfe_pct = round(pnl, 2)
+            state_dirty = True
+        if pnl < state.mae_pct:
+            state.mae_pct = round(pnl, 2)
+            state_dirty = True
+
+        # 20MA 동적 계산 (매일 변하는 최신 MA)
+        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=self._cfg.ma_period)
+        ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
+        closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
+
+        reason = ""
+
+        # 🚨 손절: 20MA -2% 이탈 → 잔량 전체 매도
+        if len(closes) >= self._cfg.ma_period:
+            ma_20d = float(sum(closes[-self._cfg.ma_period:]) / self._cfg.ma_period)
+            threshold = ma_20d * (1 + self._cfg.stop_loss_below_ma_pct / 100)
+            if current < threshold:
+                reason = f"손절(20MA {ma_20d:,.0f} 하향이탈 {pnl:.1f}%)"
+
+        # 🌟 부분 익절: 직전 익절가(또는 진입가) 대비 +10% 도달 시 반복 실행
+        if not reason:
+            ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
+            pnl_from_ref = float((current - ref_price) / ref_price * 100)
+            if pnl_from_ref >= self._cfg.take_profit_lower_pct:
                 holding_qty = int(hold.get("qty", 1))
-                self._position_state.pop(code, None)
+                sell_qty = max(1, int(holding_qty * self._cfg.partial_sell_ratio))
+
+                if sell_qty >= holding_qty:
+                    sell_qty = holding_qty
+                    sell_reason = f"전량익절({pnl_from_ref:.1f}%, 잔고 {holding_qty}주)"
+                else:
+                    sell_reason = f"부분익절({pnl_from_ref:.1f}%, {sell_qty}주/{holding_qty}주)"
+
+                self._logger.info({
+                    "event": "partial_profit_signal",
+                    "code": code, "pnl": round(pnl_from_ref, 2),
+                    "sell_qty": sell_qty, "holding_qty": holding_qty,
+                    "mfe_pct": state.mfe_pct, "mae_pct": state.mae_pct,
+                })
+
+                state.last_partial_sell_price = current
                 state_dirty = True
+
                 signals.append(TradeSignal(
                     code=code, name=hold.get("name", code), action="SELL",
-                    price=current, qty=holding_qty, reason=reason, strategy_name=self.name
+                    price=current, qty=sell_qty,
+                    reason=sell_reason, strategy_name=self.name
                 ))
+                return signals, state_dirty  # 부분 매도 후 손절 체크하지 않음
 
-        if state_dirty:
-            self._save_state()
-        return signals
+        # 매도 시그널 생성 (손절)
+        if reason:
+            holding_qty = int(hold.get("qty", 1))
+            self._logger.info({
+                "event": "exit_signal_generated",
+                "code": code, "name": hold.get("name", code),
+                "reason": reason,
+                "pnl_pct": round(pnl, 2),
+                "mfe_pct": state.mfe_pct,
+                "mae_pct": state.mae_pct,
+            })
+            self._position_state.pop(code, None)
+            state_dirty = True
+            signals.append(TradeSignal(
+                code=code, name=hold.get("name", code), action="SELL",
+                price=current, qty=holding_qty, reason=reason, strategy_name=self.name
+            ))
+
+        return signals, state_dirty
 
     # ── 헬퍼 ──────────────────────────────────────────────────────
 
@@ -468,20 +524,64 @@ class FirstPullbackStrategy(LiveStrategy):
         return min(elapsed / total, 1.0) if total > 0 else 0.0
 
     def _load_state(self):
-        if os.path.exists(self.STATE_FILE):
-            try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 로드 (초기화 시 안전한 경로)
+            if os.path.exists(self.STATE_FILE):
+                try:
+                    with open(self.STATE_FILE, "r") as f:
+                        data = json.load(f)
+                    for k, v in data.items():
+                        if k not in self._position_state:
+                            self._position_state[k] = FPPositionState(**v)
+                except Exception:
+                    pass
+            return
+        # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
+        loop.create_task(self._load_state_async())
+
+    async def _load_state_async(self):
+        if not os.path.exists(self.STATE_FILE):
+            return
+        try:
+            def _read_file():
                 with open(self.STATE_FILE, "r") as f:
-                    data = json.load(f)
-                for k, v in data.items():
+                    return json.load(f)
+
+            data = await asyncio.to_thread(_read_file)
+            for k, v in data.items():
+                if k not in self._position_state:
                     self._position_state[k] = FPPositionState(**v)
-            except Exception:
-                pass
+        except Exception:
+            pass
 
     def _save_state(self):
+        """백워드 호환성 있는 동기-스케줄러 래퍼."""
         try:
-            os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 저장
+            try:
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                data = {k: asdict(v) for k, v in self._position_state.items()}
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+            except Exception:
+                pass
+            return
+        # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
+        loop.create_task(self._save_state_async())
+
+    async def _save_state_async(self):
+        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        try:
+            def _write_file(data):
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+
             data = {k: asdict(v) for k, v in self._position_state.items()}
-            with open(self.STATE_FILE, "w") as f:
-                json.dump(data, f, indent=2)
+            await asyncio.to_thread(_write_file, data)
         except Exception:
             pass

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -106,7 +106,7 @@ class FirstPullbackStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_entry(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
+    async def _check_entry(self, code, item, progress, market_timing_cache=None) -> Optional[TradeSignal]:
         """진입 조건 검사: Phase 1 → 2 → 3 순서로 필터링."""
         # ── 현재가 데이터 선행 조회 (OHLCV 캐시 활용 위해) ──
         resp = await self._sqs.get_current_price(code, caller=self.name)
@@ -254,7 +254,7 @@ class FirstPullbackStrategy(LiveStrategy):
                 "rs_score": getattr(item, "rs_score", 0.0),
                 "rs_rating": getattr(item, "rs_rating", 0),
                 "total_score": getattr(item, "total_score", 0.0),
-                "market_timing": market_timing.get(item.market) if market_timing else None,
+                "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
             },
             "reason": reason_msg,
         })
@@ -535,8 +535,8 @@ class FirstPullbackStrategy(LiveStrategy):
                     for k, v in data.items():
                         if k not in self._position_state:
                             self._position_state[k] = FPPositionState(**v)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._logger.error(f"Failed to load state for {self.name}: {e}")
             return
         # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
         loop.create_task(self._load_state_async())
@@ -553,8 +553,8 @@ class FirstPullbackStrategy(LiveStrategy):
             for k, v in data.items():
                 if k not in self._position_state:
                     self._position_state[k] = FPPositionState(**v)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to load state async for {self.name}: {e}")
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -567,8 +567,8 @@ class FirstPullbackStrategy(LiveStrategy):
                 data = {k: asdict(v) for k, v in self._position_state.items()}
                 with open(self.STATE_FILE, "w") as f:
                     json.dump(data, f, indent=2)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.error(f"Failed to save state for {self.name}: {e}")
             return
         # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
         loop.create_task(self._save_state_async())
@@ -583,5 +583,5 @@ class FirstPullbackStrategy(LiveStrategy):
 
             data = {k: asdict(v) for k, v in self._position_state.items()}
             await asyncio.to_thread(_write_file, data)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/first_pullback_types.py
+++ b/strategies/first_pullback_types.py
@@ -45,3 +45,5 @@ class FPPositionState:
     surge_day_high: int                 # 급등기 고점 (익절 참조가)
     partial_sold: bool = False          # deprecated (JSON 하위호환용)
     last_partial_sell_price: int = 0    # 마지막 부분익절 가격 (0=미실행, >0=기준가)
+    mfe_pct: float = 0.0               # Maximum Favorable Excursion (진입 후 최대 수익률 %)
+    mae_pct: float = 0.0               # Maximum Adverse Excursion (진입 후 최대 손실률 %)

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -90,7 +90,7 @@ class HighTightFlagStrategy(LiveStrategy):
         for i in range(0, len(candidates), 10):
             chunk = candidates[i:i + 10]
             results = await asyncio.gather(
-                *[self._check_htf_setup(code, item, market_progress) for code, item in chunk],
+                *[self._check_htf_setup(code, item, market_progress, market_timing) for code, item in chunk],
                 return_exceptions=True,
             )
             for result in results:
@@ -102,7 +102,7 @@ class HighTightFlagStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_htf_setup(self, code, item, progress) -> Optional[TradeSignal]:
+    async def _check_htf_setup(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
         """HTF 패턴 감지 + 실시간 돌파 확인."""
         # 1. OHLCV 조회 (깃대 40일 + 깃발 최대 25일 = 65일)
         ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=65)
@@ -124,7 +124,7 @@ class HighTightFlagStrategy(LiveStrategy):
         })
 
         # 3. Phase 3: 실시간 돌파 확인
-        return await self._check_breakout(code, item, pattern, ohlcv, progress)
+        return await self._check_breakout(code, item, pattern, ohlcv, progress, market_timing)
 
     def _detect_pole_and_flag(self, ohlcv: list) -> Optional[dict]:
         """Phase 1+2: 깃대 폭등 + 깃발 횡보 패턴 감지 (순수 계산, API 호출 없음).
@@ -191,7 +191,7 @@ class HighTightFlagStrategy(LiveStrategy):
             "flag_avg_vol": flag_avg_vol,
         }
 
-    async def _check_breakout(self, code, item, pattern, ohlcv, progress) -> Optional[TradeSignal]:
+    async def _check_breakout(self, code, item, pattern, ohlcv, progress, market_timing=None) -> Optional[TradeSignal]:
         """Phase 3: 실시간 돌파 확인 (가격 + 거래량 + 체결강도)."""
         # 1. 현재가 조회
         resp = await self._sqs.get_current_price(code, caller=self.name)
@@ -231,10 +231,12 @@ class HighTightFlagStrategy(LiveStrategy):
 
         vol_threshold = avg_vol_50d * self._cfg.volume_breakout_multiplier
         if proj_vol < vol_threshold:
+            vol_ratio_pct = (proj_vol / avg_vol_50d * 100) if avg_vol_50d > 0 else 0.0
             self._logger.debug({
                 "event": "breakout_rejected", "code": code,
                 "reason": "insufficient_projected_volume",
-                "proj_vol": int(proj_vol), "threshold": int(vol_threshold)
+                "proj_vol": int(proj_vol), "threshold": int(vol_threshold),
+                "vol_ratio_pct": round(vol_ratio_pct, 1),
             })
             return None
 
@@ -282,7 +284,20 @@ class HighTightFlagStrategy(LiveStrategy):
         self._logger.info({
             "event": "buy_signal_generated",
             "code": code, "name": item.name,
-            "price": current, "reason": reason_msg,
+            "metrics": {
+                "price": current,
+                "pole_high": pole_high,
+                "vol_ratio_pct": round(vol_ratio, 1),
+                "surge_ratio": round(pattern["surge_ratio"], 2),
+                "flag_days": pattern["flag_days"],
+                "drawdown_pct": round(pattern["drawdown_pct"], 1),
+                "execution_strength": cgld_val,
+                "rs_score": getattr(item, "rs_score", 0.0),
+                "rs_rating": getattr(item, "rs_rating", 0),
+                "total_score": getattr(item, "total_score", 0.0),
+                "market_timing": market_timing.get(item.market) if market_timing else None,
+            },
+            "reason": reason_msg,
         })
 
         return TradeSignal(
@@ -293,68 +308,111 @@ class HighTightFlagStrategy(LiveStrategy):
     # ── check_exits ──────────────────────────────────────────────────
 
     async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
-        signals = []
+        if not holdings:
+            return []
+
+        results = await asyncio.gather(
+            *[self._check_single_exit(hold) for hold in holdings],
+            return_exceptions=True,
+        )
+
+        signals: List[TradeSignal] = []
         state_dirty = False
-        for hold in holdings:
-            code = hold.get("code")
-            buy_price_raw = hold.get("buy_price")
-            if not code or not buy_price_raw:
-                continue
-
-            buy_price = float(buy_price_raw)
-
-            state = self._position_state.get(code)
-            if not state:
-                state = HTFPositionState(int(buy_price), "", int(buy_price), int(buy_price))
-                self._position_state[code] = state
-
-            resp = await self._sqs.get_current_price(code, caller=self.name)
-            if not resp or resp.rt_cd != "0":
-                continue
-
-            output = resp.data.get("output") if isinstance(resp.data, dict) else None
-            if not output:
-                continue
-
-            if isinstance(output, dict):
-                current = int(output.get("stck_prpr", 0))
-            else:
-                current = int(getattr(output, "stck_prpr", 0) or 0)
-
-            if current <= 0:
-                continue
-
-            # 최고가 갱신 (dirty flag — 루프 후 1회 저장)
-            if current > state.peak_price:
-                state.peak_price = current
-                state_dirty = True
-
-            pnl = float((current - buy_price) / buy_price * 100)
-            reason = ""
-
-            # 1. 칼손절
-            if pnl <= self._cfg.stop_loss_pct:
-                reason = f"칼손절({pnl:.1f}%)"
-
-            # 2. 10일 MA 트레일링스탑
-            if not reason:
-                is_break, break_reason = await self._check_trailing_ma_stop(code, current)
-                if is_break:
-                    reason = break_reason
-
-            # 매도 시그널 생성 (전량 매도)
-            if reason:
-                holding_qty = int(hold.get("qty", 1))
-                self._position_state.pop(code, None)
-                state_dirty = True
-                signals.append(TradeSignal(
-                    code=code, name=hold.get("name", code), action="SELL",
-                    price=current, qty=holding_qty, reason=reason, strategy_name=self.name,
-                ))
+        for result in results:
+            if isinstance(result, Exception):
+                self._logger.error({"event": "exit_check_error", "error": str(result)})
+            elif result:
+                s_list, dirty = result
+                signals.extend(s_list)
+                if dirty:
+                    state_dirty = True
 
         if state_dirty:
-            self._save_state()
+            await self._save_state_async()
         return signals
+
+    async def _check_single_exit(self, hold: dict) -> tuple:
+        """단일 보유 종목 청산 조건 검사.
+
+        Returns: (List[TradeSignal], state_dirty: bool)
+        """
+        signals: List[TradeSignal] = []
+        state_dirty = False
+
+        code = hold.get("code")
+        buy_price_raw = hold.get("buy_price")
+        if not code or not buy_price_raw:
+            return signals, state_dirty
+
+        buy_price = float(buy_price_raw)
+
+        state = self._position_state.get(code)
+        if not state:
+            state = HTFPositionState(int(buy_price), "", int(buy_price), int(buy_price))
+            self._position_state[code] = state
+
+        resp = await self._sqs.get_current_price(code, caller=self.name)
+        if not resp or resp.rt_cd != "0":
+            return signals, state_dirty
+
+        output = resp.data.get("output") if isinstance(resp.data, dict) else None
+        if not output:
+            return signals, state_dirty
+
+        if isinstance(output, dict):
+            current = int(output.get("stck_prpr", 0))
+        else:
+            current = int(getattr(output, "stck_prpr", 0) or 0)
+
+        if current <= 0:
+            return signals, state_dirty
+
+        # 최고가 갱신 (dirty flag)
+        if current > state.peak_price:
+            state.peak_price = current
+            state_dirty = True
+
+        pnl = float((current - buy_price) / buy_price * 100)
+
+        # MFE / MAE 갱신
+        if pnl > state.mfe_pct:
+            state.mfe_pct = round(pnl, 2)
+            state_dirty = True
+        if pnl < state.mae_pct:
+            state.mae_pct = round(pnl, 2)
+            state_dirty = True
+
+        reason = ""
+
+        # 1. 칼손절
+        if pnl <= self._cfg.stop_loss_pct:
+            reason = f"칼손절({pnl:.1f}%)"
+
+        # 2. 10일 MA 트레일링스탑
+        if not reason:
+            is_break, break_reason = await self._check_trailing_ma_stop(code, current)
+            if is_break:
+                reason = break_reason
+
+        # 매도 시그널 생성 (전량 매도)
+        if reason:
+            holding_qty = int(hold.get("qty", 1))
+            self._logger.info({
+                "event": "exit_signal_generated",
+                "code": code, "name": hold.get("name", code),
+                "reason": reason,
+                "pnl_pct": round(pnl, 2),
+                "mfe_pct": state.mfe_pct,
+                "mae_pct": state.mae_pct,
+            })
+            self._position_state.pop(code, None)
+            state_dirty = True
+            signals.append(TradeSignal(
+                code=code, name=hold.get("name", code), action="SELL",
+                price=current, qty=holding_qty, reason=reason, strategy_name=self.name,
+            ))
+
+        return signals, state_dirty
 
     async def _check_trailing_ma_stop(self, code: str, current_price: int) -> tuple:
         """10일 MA 트레일링스탑 체크."""
@@ -390,20 +448,64 @@ class HighTightFlagStrategy(LiveStrategy):
         return min(elapsed / total, 1.0) if total > 0 else 0.0
 
     def _load_state(self):
-        if os.path.exists(self.STATE_FILE):
-            try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 로드 (초기화 시 안전한 경로)
+            if os.path.exists(self.STATE_FILE):
+                try:
+                    with open(self.STATE_FILE, "r") as f:
+                        data = json.load(f)
+                    for k, v in data.items():
+                        if k not in self._position_state:
+                            self._position_state[k] = HTFPositionState(**v)
+                except Exception:
+                    pass
+            return
+        # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
+        loop.create_task(self._load_state_async())
+
+    async def _load_state_async(self):
+        if not os.path.exists(self.STATE_FILE):
+            return
+        try:
+            def _read_file():
                 with open(self.STATE_FILE, "r") as f:
-                    data = json.load(f)
-                for k, v in data.items():
+                    return json.load(f)
+
+            data = await asyncio.to_thread(_read_file)
+            for k, v in data.items():
+                if k not in self._position_state:
                     self._position_state[k] = HTFPositionState(**v)
-            except Exception:
-                pass
+        except Exception:
+            pass
 
     def _save_state(self):
+        """백워드 호환성 있는 동기-스케줄러 래퍼."""
         try:
-            os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 저장
+            try:
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                data = {k: asdict(v) for k, v in self._position_state.items()}
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+            except Exception:
+                pass
+            return
+        # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
+        loop.create_task(self._save_state_async())
+
+    async def _save_state_async(self):
+        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        try:
+            def _write_file(data):
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+
             data = {k: asdict(v) for k, v in self._position_state.items()}
-            with open(self.STATE_FILE, "w") as f:
-                json.dump(data, f, indent=2)
+            await asyncio.to_thread(_write_file, data)
         except Exception:
             pass

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -102,7 +102,7 @@ class HighTightFlagStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_htf_setup(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
+    async def _check_htf_setup(self, code, item, progress, market_timing_cache=None) -> Optional[TradeSignal]:
         """HTF 패턴 감지 + 실시간 돌파 확인."""
         # 1. OHLCV 조회 (깃대 40일 + 깃발 최대 25일 = 65일)
         ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=65)
@@ -124,7 +124,7 @@ class HighTightFlagStrategy(LiveStrategy):
         })
 
         # 3. Phase 3: 실시간 돌파 확인
-        return await self._check_breakout(code, item, pattern, ohlcv, progress, market_timing)
+        return await self._check_breakout(code, item, pattern, ohlcv, progress, market_timing_cache)
 
     def _detect_pole_and_flag(self, ohlcv: list) -> Optional[dict]:
         """Phase 1+2: 깃대 폭등 + 깃발 횡보 패턴 감지 (순수 계산, API 호출 없음).
@@ -191,7 +191,7 @@ class HighTightFlagStrategy(LiveStrategy):
             "flag_avg_vol": flag_avg_vol,
         }
 
-    async def _check_breakout(self, code, item, pattern, ohlcv, progress, market_timing=None) -> Optional[TradeSignal]:
+    async def _check_breakout(self, code, item, pattern, ohlcv, progress, market_timing_cache=None) -> Optional[TradeSignal]:
         """Phase 3: 실시간 돌파 확인 (가격 + 거래량 + 체결강도)."""
         # 1. 현재가 조회
         resp = await self._sqs.get_current_price(code, caller=self.name)
@@ -295,7 +295,7 @@ class HighTightFlagStrategy(LiveStrategy):
                 "rs_score": getattr(item, "rs_score", 0.0),
                 "rs_rating": getattr(item, "rs_rating", 0),
                 "total_score": getattr(item, "total_score", 0.0),
-                "market_timing": market_timing.get(item.market) if market_timing else None,
+                "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
             },
             "reason": reason_msg,
         })
@@ -459,8 +459,8 @@ class HighTightFlagStrategy(LiveStrategy):
                     for k, v in data.items():
                         if k not in self._position_state:
                             self._position_state[k] = HTFPositionState(**v)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._logger.error(f"Failed to load state for {self.name}: {e}")
             return
         # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
         loop.create_task(self._load_state_async())
@@ -477,8 +477,8 @@ class HighTightFlagStrategy(LiveStrategy):
             for k, v in data.items():
                 if k not in self._position_state:
                     self._position_state[k] = HTFPositionState(**v)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to load state async for {self.name}: {e}")
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -491,8 +491,8 @@ class HighTightFlagStrategy(LiveStrategy):
                 data = {k: asdict(v) for k, v in self._position_state.items()}
                 with open(self.STATE_FILE, "w") as f:
                     json.dump(data, f, indent=2)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.error(f"Failed to save state for {self.name}: {e}")
             return
         # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
         loop.create_task(self._save_state_async())
@@ -507,5 +507,5 @@ class HighTightFlagStrategy(LiveStrategy):
 
             data = {k: asdict(v) for k, v in self._position_state.items()}
             await asyncio.to_thread(_write_file, data)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -114,6 +114,8 @@ class OSBPositionState:
     entry_date: str         # 진입일 (YYYYMMDD)
     peak_price: int         # 진입 후 최고가 (트레일링 스탑용)
     breakout_level: int     # 진입 시 20일 최고가
+    mfe_pct: float = 0.0   # Maximum Favorable Excursion (진입 후 최대 수익률 %)
+    mae_pct: float = 0.0   # Maximum Adverse Excursion (진입 후 최대 손실률 %)
 
 
 @dataclass
@@ -167,6 +169,8 @@ class PPPositionState:
     partial_sold: bool = False          # deprecated (JSON 하위호환용)
     holding_start_date: str = ""        # 수익 안착일 (+5% 돌파 시 1회만 기록, 7주 룰 기산점)
     last_partial_sell_price: int = 0    # 마지막 부분익절 가격 (0=미실행, >0=기준가)
+    mfe_pct: float = 0.0               # Maximum Favorable Excursion (진입 후 최대 수익률 %)
+    mae_pct: float = 0.0               # Maximum Adverse Excursion (진입 후 최대 손실률 %)
 
 
 @dataclass
@@ -203,3 +207,5 @@ class HTFPositionState:
     entry_date: str          # 진입일 (YYYYMMDD)
     peak_price: int          # 진입 후 최고가
     pole_high: int           # 깃대 최고점 (돌파 기준가)
+    mfe_pct: float = 0.0    # Maximum Favorable Excursion (진입 후 최대 수익률 %)
+    mae_pct: float = 0.0    # Maximum Adverse Excursion (진입 후 최대 손실률 %)

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -228,9 +228,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
         # 즉시 파일을 보장하려면 await 가능한 호출자가 _save_state_async 를 사용합니다.
         try:
             await self._save_state_async()
-        except Exception:
-            # 백워드 호환성: 호출 컨텍스트가 동기일 수 있으므로 예외는 무시
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")
 
         if entry_type == "PP":
             proj_vol = extra_info.get("proj_vol", 0)
@@ -481,8 +480,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
         if state_dirty:
             try:
                 await self._save_state_async()
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.error(f"Failed to save state async for {self.name}: {e}")
         return signals
 
     async def _check_single_exit(self, hold: dict, market_timing_cache: dict) -> tuple:
@@ -741,8 +740,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
                     for k, v in data.items():
                         if k not in self._position_state:
                             self._position_state[k] = PPPositionState(**v)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._logger.error(f"Failed to load state for {self.name}: {e}")
             return
 
         # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
@@ -761,8 +760,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
             for k, v in data.items():
                 if k not in self._position_state:
                     self._position_state[k] = PPPositionState(**v)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to load state async for {self.name}: {e}")
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼: 이벤트 루프가 있으면 백그라운드에 저장 태스크를 생성,
@@ -777,8 +776,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 data = {k: asdict(v) for k, v in self._position_state.items()}
                 with open(self.STATE_FILE, "w") as f:
                     json.dump(data, f, indent=2)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.error(f"Failed to save state for {self.name}: {e}")
             return
 
         # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
@@ -794,5 +793,5 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
             data = {k: asdict(v) for k, v in self._position_state.items()}
             await asyncio.to_thread(_write_file, data)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -96,7 +96,7 @@ class OneilPocketPivotStrategy(LiveStrategy):
         for i in range(0, len(candidates), 10):
             chunk = candidates[i:i + 10]
             results = await asyncio.gather(
-                *[self._check_entry(code, item, market_progress) for code, item in chunk],
+                *[self._check_entry(code, item, market_progress, market_timing) for code, item in chunk],
                 return_exceptions=True,
             )
             for result in results:
@@ -108,7 +108,7 @@ class OneilPocketPivotStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_entry(self, code, item, progress) -> Optional[TradeSignal]:
+    async def _check_entry(self, code, item, progress, market_timing_cache=None) -> Optional[TradeSignal]:
         """진입 조건 검사: PP 또는 BGU → 스마트머니 → 체결강도."""
         # 1. 현재가 데이터 조회
         resp = await self._sqs.get_current_price(code, caller=self.name)
@@ -262,8 +262,16 @@ class OneilPocketPivotStrategy(LiveStrategy):
         self._logger.info({
             "event": "buy_signal_generated",
             "code": code, "name": item.name,
-            "entry_type": entry_type,
-            "price": current,
+            "metrics": {
+                "price": current,
+                "entry_type": entry_type,
+                "pg_participation_pct": round(pg_ratio, 2),
+                "execution_strength": cgld_val,
+                "rs_score": getattr(item, "rs_score", 0.0),
+                "rs_rating": getattr(item, "rs_rating", 0),
+                "total_score": getattr(item, "total_score", 0.0),
+                "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
+            },
             "reason": reason_msg,
         })
 
@@ -306,7 +314,18 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 break
 
         if not supporting_ma:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "not_near_ma"})
+            # 가장 가까운 MA와의 거리 계산 (파라미터 최적화 참고용)
+            closest_pct = None
+            for ma_val, ma_name in ma_candidates:
+                if ma_val > 0:
+                    pct = (current - ma_val) / ma_val * 100
+                    if closest_pct is None or abs(pct) < abs(closest_pct):
+                        closest_pct = pct
+            self._logger.debug({
+                "event": "pp_rejected", "code": code, "reason": "not_near_ma",
+                "closest_ma_pct": round(closest_pct, 2) if closest_pct is not None else None,
+                "allowed_range": f"{self._cfg.pp_ma_proximity_lower_pct}% ~ {self._cfg.pp_ma_proximity_upper_pct}%",
+            })
             return None
 
         # 3. 당일 상승일 확인 (현재가 > 전일 종가)
@@ -434,116 +453,157 @@ class OneilPocketPivotStrategy(LiveStrategy):
     # ── check_exits ────────────────────────────────────────────────
 
     async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
-        signals = []
-        state_dirty = False
+        if not holdings:
+            return []
+
         # 캐시된 마켓 타이밍을 한 번만 조회 (N+1 호출 방지)
         market_timing_cache = {
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
         }
 
-        for hold in holdings:
-            code = hold.get("code")
-            buy_price_raw = hold.get("buy_price")
-            if not code or not buy_price_raw:
-                continue
+        results = await asyncio.gather(
+            *[self._check_single_exit(hold, market_timing_cache) for hold in holdings],
+            return_exceptions=True,
+        )
 
-            buy_price = float(buy_price_raw)
-
-            state = self._position_state.get(code)
-            if not state:
-                state = PPPositionState(
-                    entry_type="PP", entry_price=int(buy_price),
-                    entry_date="", peak_price=int(buy_price),
-                    supporting_ma="20", gap_day_low=0,
-                )
-                self._position_state[code] = state
-
-            resp = await self._sqs.get_current_price(code, caller=self.name)
-            if not resp or resp.rt_cd != "0":
-                continue
-
-            output = resp.data.get("output") if isinstance(resp.data, dict) else None
-            if not output:
-                continue
-
-            if isinstance(output, dict):
-                current = int(output.get("stck_prpr", 0))
-            else:
-                current = int(getattr(output, "stck_prpr", 0) or 0)
-
-            if current <= 0:
-                continue
-
-            # 최고가 갱신 (dirty flag — 루프 후 1회 저장)
-            if current > state.peak_price:
-                state.peak_price = current
-                state_dirty = True
-
-            pnl = float((current - buy_price) / buy_price * 100)
-            today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
-
-            # 수익 안착 추적 (+5% 돌파 시 1회만 기록)
-            if pnl >= self._cfg.holding_profit_anchor_pct and state.holding_start_date == "":
-                state.holding_start_date = today_str
-                state_dirty = True
-
-            # OHLCV (MA 기반 체크용)
-            ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=60)
-            ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
-
-            reason = ""
-
-            # 🚨 우선순위 1: 하드 스탑 (마켓타이밍 악화 OR 고점 대비 -10%)
-            market = hold.get("market", "KOSPI") # type: ignore
-            hard_reason = await self._check_hard_stop(state, current, market, market_timing_cache.get(market, False))
-            if hard_reason:
-                reason = hard_reason
-
-            # 🚨 우선순위 2: 엔트리별 손절
-            if not reason:
-                if state.entry_type == "PP":
-                    pp_reason = self._check_pp_stop_loss(state, current, ohlcv)
-                    if pp_reason:
-                        reason = pp_reason
-                elif state.entry_type == "BGU":
-                    bgu_reason = self._check_bgu_stop_loss(state, current)
-                    if bgu_reason:
-                        reason = bgu_reason
-
-            # 🌟 우선순위 3: 부분 익절 (직전 익절가 대비 +15% 시 반복 실행)
-            if not reason:
-                ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
-                partial_signal = self._check_partial_profit(code, state, current, ref_price, hold)
-                if partial_signal:
-                    signals.append(partial_signal)
-                    state.last_partial_sell_price = current
+        signals: List[TradeSignal] = []
+        state_dirty = False
+        for result in results:
+            if isinstance(result, Exception):
+                self._logger.error({"event": "exit_check_error", "error": str(result)})
+            elif result:
+                s_list, dirty = result
+                signals.extend(s_list)
+                if dirty:
                     state_dirty = True
-                    continue  # 부분 매도 후 전량 청산하지 않음
-
-            # 🌟 우선순위 4: 7주 룰 만료 (수익 안착 후 35거래일 & 50MA 이탈)
-            if not reason and state.holding_start_date:
-                week7_reason = self._check_7week_hold(state, current, ohlcv)
-                if week7_reason:
-                    reason = week7_reason
-
-            # 매도 시그널 생성
-            if reason:
-                holding_qty = int(hold.get("qty", 1))
-                self._position_state.pop(code, None)
-                state_dirty = True
-                signals.append(TradeSignal(
-                    code=code, name=hold.get("name", code), action="SELL",
-                    price=current, qty=holding_qty, reason=reason, strategy_name=self.name
-                ))
 
         if state_dirty:
             try:
                 await self._save_state_async()
             except Exception:
-                # 동기 호출 컨텍스트가 있을 수 있으므로 안전하게 무시
                 pass
         return signals
+
+    async def _check_single_exit(self, hold: dict, market_timing_cache: dict) -> tuple:
+        """단일 보유 종목 청산 조건 검사.
+
+        Returns: (List[TradeSignal], state_dirty: bool)
+        """
+        signals: List[TradeSignal] = []
+        state_dirty = False
+
+        code = hold.get("code")
+        buy_price_raw = hold.get("buy_price")
+        if not code or not buy_price_raw:
+            return signals, state_dirty
+
+        buy_price = float(buy_price_raw)
+
+        state = self._position_state.get(code)
+        if not state:
+            state = PPPositionState(
+                entry_type="PP", entry_price=int(buy_price),
+                entry_date="", peak_price=int(buy_price),
+                supporting_ma="20", gap_day_low=0,
+            )
+            self._position_state[code] = state
+
+        resp = await self._sqs.get_current_price(code, caller=self.name)
+        if not resp or resp.rt_cd != "0":
+            return signals, state_dirty
+
+        output = resp.data.get("output") if isinstance(resp.data, dict) else None
+        if not output:
+            return signals, state_dirty
+
+        if isinstance(output, dict):
+            current = int(output.get("stck_prpr", 0))
+        else:
+            current = int(getattr(output, "stck_prpr", 0) or 0)
+
+        if current <= 0:
+            return signals, state_dirty
+
+        # 최고가 갱신 (dirty flag)
+        if current > state.peak_price:
+            state.peak_price = current
+            state_dirty = True
+
+        pnl = float((current - buy_price) / buy_price * 100)
+        today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
+
+        # MFE / MAE 갱신
+        if pnl > state.mfe_pct:
+            state.mfe_pct = round(pnl, 2)
+            state_dirty = True
+        if pnl < state.mae_pct:
+            state.mae_pct = round(pnl, 2)
+            state_dirty = True
+
+        # 수익 안착 추적 (+5% 돌파 시 1회만 기록)
+        if pnl >= self._cfg.holding_profit_anchor_pct and state.holding_start_date == "":
+            state.holding_start_date = today_str
+            state_dirty = True
+
+        # OHLCV (MA 기반 체크용)
+        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=60)
+        ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
+
+        reason = ""
+
+        # 🚨 우선순위 1: 하드 스탑 (마켓타이밍 악화 OR 고점 대비 -10%)
+        market = hold.get("market", "KOSPI")  # type: ignore
+        hard_reason = await self._check_hard_stop(state, current, market, market_timing_cache.get(market, False))
+        if hard_reason:
+            reason = hard_reason
+
+        # 🚨 우선순위 2: 엔트리별 손절
+        if not reason:
+            if state.entry_type == "PP":
+                pp_reason = self._check_pp_stop_loss(state, current, ohlcv)
+                if pp_reason:
+                    reason = pp_reason
+            elif state.entry_type == "BGU":
+                bgu_reason = self._check_bgu_stop_loss(state, current)
+                if bgu_reason:
+                    reason = bgu_reason
+
+        # 🌟 우선순위 3: 부분 익절 (직전 익절가 대비 +15% 시 반복 실행)
+        if not reason:
+            ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
+            partial_signal = self._check_partial_profit(code, state, current, ref_price, hold)
+            if partial_signal:
+                signals.append(partial_signal)
+                state.last_partial_sell_price = current
+                state_dirty = True
+                return signals, state_dirty  # 부분 매도 후 전량 청산하지 않음
+
+        # 🌟 우선순위 4: 7주 룰 만료 (수익 안착 후 35거래일 & 50MA 이탈)
+        if not reason and state.holding_start_date:
+            week7_reason = self._check_7week_hold(state, current, ohlcv)
+            if week7_reason:
+                reason = week7_reason
+
+        # 매도 시그널 생성
+        if reason:
+            holding_qty = int(hold.get("qty", 1))
+            self._logger.info({
+                "event": "exit_signal_generated",
+                "code": code, "name": hold.get("name", code),
+                "reason": reason,
+                "pnl_pct": round(pnl, 2),
+                "mfe_pct": state.mfe_pct,
+                "mae_pct": state.mae_pct,
+            })
+            self._position_state.pop(code, None)
+            state_dirty = True
+            signals.append(TradeSignal(
+                code=code, name=hold.get("name", code), action="SELL",
+                price=current, qty=holding_qty, reason=reason, strategy_name=self.name
+            ))
+
+        return signals, state_dirty
 
     async def _check_hard_stop(self, state: PPPositionState, current: int, market: str, market_timing_ok: Optional[bool] = None) -> Optional[str]:
         """하드 스탑: 마켓타이밍 악화 또는 고점 대비 -10%.

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -117,7 +117,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_breakout(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
+    async def _check_breakout(self, code, item, progress, market_timing_cache=None) -> Optional[TradeSignal]:
         # 1. 기본 시세 및 프로그램 수급 조회
         resp = await self._sqs.get_current_price(code, caller=self.name)
         if not resp or resp.rt_cd != "0": return None
@@ -235,7 +235,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                 "rs_score": item.rs_score,
                 "rs_rating": item.rs_rating,
                 "total_score": item.total_score,
-                "market_timing": market_timing.get(item.market) if market_timing else None,
+                "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
             },
             "reason": reason_msg,
         })
@@ -481,8 +481,8 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                     for k, v in data.items():
                         if k not in self._position_state:
                             self._position_state[k] = OSBPositionState(**v)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._logger.error(f"Failed to load state for {self.name}: {e}")
             return
         # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
         loop.create_task(self._load_state_async())
@@ -499,8 +499,8 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             for k, v in data.items():
                 if k not in self._position_state:
                     self._position_state[k] = OSBPositionState(**v)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to load state async for {self.name}: {e}")
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -513,8 +513,8 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                 data = {k: asdict(v) for k, v in self._position_state.items()}
                 with open(self.STATE_FILE, "w") as f:
                     json.dump(data, f, indent=2)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.error(f"Failed to save state for {self.name}: {e}")
             return
         # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
         loop.create_task(self._save_state_async())
@@ -529,5 +529,5 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
 
             data = {k: asdict(v) for k, v in self._position_state.items()}
             await asyncio.to_thread(_write_file, data)
-        except Exception:
-            pass
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -23,11 +23,11 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
     핵심: 시장 주도주 중 볼린저 밴드가 극도로 수축(스퀴즈)된 종목이
         거래량을 동반하며 20일 최고가를 돌파할 때 매수.
         프로그램 순매수 필터(2중 스마트 머니)로 기관 수급 확인.
-    
+
     특징:
       - 유니버스 관리(종목 발굴)는 OneilUniverseService에 위임.
       - 이 클래스는 '언제 살까(돌파)'와 '언제 팔까(청산)'에만 집중.
-      
+
     [v1 범위]
     - 유니버스: get_top_trading_value_stocks() → 기본 필터(거래대금/52주고가/정배열)
     - 매수/매도 뼈대 구축 및 스케줄러 연동 완료
@@ -37,7 +37,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
     - 유니버스: Pool A(장 마감 후 배치) / Pool B(장중 3중 그물망 실시간 발굴) 병합
     - 스코어링: RS(3개월 상대강도 상위10% → +30점), 영업이익 25% 이상 증가 → +20점 적용
     - 마켓타이밍: ETF 프록시(KODEX 200/코스닥150) 20일선 3일 연속 우상향 로직 적용
-    
+
     [v3 예정 (TODO)]
     - 스코어링 고도화: 업종 소분류 주도 (테마 대장주) 키워드 매칭 스코어링 (+20점) 추가
     - 마켓타이밍 고도화: 코스닥/코스피 지수 직접 조회 API 연동 (ETF 프록시 대체)
@@ -72,7 +72,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
     async def scan(self) -> List[TradeSignal]:
         signals: List[TradeSignal] = []
         self._logger.info({"event": "scan_started", "strategy_name": self.name})
-        
+
         # 1. 유니버스 서비스로부터 완성된 워치리스트 획득 (캐싱됨)
         watchlist = await self._universe.get_watchlist(logger=self._logger)
         if not watchlist:
@@ -105,7 +105,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         for i in range(0, len(candidates), 10):
             chunk = candidates[i:i + 10]
             results = await asyncio.gather(
-                *[self._check_breakout(code, item, market_progress) for code, item in chunk],
+                *[self._check_breakout(code, item, market_progress, market_timing) for code, item in chunk],
                 return_exceptions=True,
             )
             for result in results:
@@ -117,7 +117,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})
         return signals
 
-    async def _check_breakout(self, code, item, progress) -> Optional[TradeSignal]:
+    async def _check_breakout(self, code, item, progress, market_timing=None) -> Optional[TradeSignal]:
         # 1. 기본 시세 및 프로그램 수급 조회
         resp = await self._sqs.get_current_price(code, caller=self.name)
         if not resp or resp.rt_cd != "0": return None
@@ -140,25 +140,30 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         if current <= item.high_20d:
             # 너무 많은 로그를 피하기 위해 이 단계는 로그 생략
             return None
-            
+
         # 🚨 [관문 2] 거래량 돌파 (+ 뻥튀기 방어)
         effective_progress = max(progress, 0.05) # 장 초반 최소 5% 진행 보장
         proj_vol = vol / effective_progress
-        
+
         if vol < (item.avg_vol_20d * 0.3): # 최소 절대 거래량 (평소 20일 평균의 30%) 미달 시 가짜 돌파
             self._logger.debug({"event": "breakout_rejected", "code": code, "reason": "low_absolute_volume", "vol": vol, "min_required": item.avg_vol_20d * 0.3})
             return None
         if proj_vol < item.avg_vol_20d * self._cfg.volume_breakout_multiplier:
-            self._logger.debug({"event": "breakout_rejected", "code": code, "reason": "insufficient_projected_volume", "proj_vol": int(proj_vol), "threshold": item.avg_vol_20d * self._cfg.volume_breakout_multiplier})
+            vol_ratio_pct = (proj_vol / item.avg_vol_20d * 100) if item.avg_vol_20d > 0 else 0.0
+            self._logger.debug({
+                "event": "breakout_rejected", "code": code, "reason": "insufficient_projected_volume",
+                "proj_vol": int(proj_vol), "threshold": item.avg_vol_20d * self._cfg.volume_breakout_multiplier,
+                "vol_ratio_pct": round(vol_ratio_pct, 1),
+            })
             return None
-            
+
         # 🚨 [관문 3] 스마트 머니(프로그램 수급) 상세 필터
         if pg_buy <= self._cfg.program_net_buy_min:
             self._logger.debug({"event": "breakout_rejected", "code": code, "reason": "low_program_net_buy", "pg_buy": pg_buy, "min_required": self._cfg.program_net_buy_min})
             return None
-            
+
         pg_buy_amount = pg_buy * current # 프로그램 순매수 금액 (추정)
-        
+
         # 3-1. 거래대금의 10% 이상 개입했는가?
         if trade_value > 0:
             pg_to_tv_pct = pg_buy_amount / trade_value * 100
@@ -168,7 +173,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                     "pg_to_tv_pct": round(pg_to_tv_pct, 2), "threshold": self._cfg.program_to_trade_value_pct
                 })
                 return None
-            
+
         # 3-2. 시가총액의 0.5% 이상 개입했는가?
         if item.market_cap > 0:
             pg_to_mc_pct = pg_buy_amount / item.market_cap * 100
@@ -182,24 +187,20 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         self._logger.debug({"event": "smart_money_passed", "code": code, "pg_buy_amount": pg_buy_amount})
 
         # 🌟 [최종 관문] 매수 직전 체결강도 스냅샷 (>=120%) 🌟
-        # 이 관문까지 살아서 내려왔다면 조건이 완벽하게 맞은 상태입니다.
-        # 매수 버튼을 누르기 직전, '주식현재가 체결(inquire-ccnl)' API를 1회 쏴서 체결강도를 확인합니다.
         cgld_val = 0.0
         try:
             ccnl_resp = await self._sqs.get_stock_conclusion(code)
             if ccnl_resp and ccnl_resp.rt_cd == "0":
                 ccnl_output = ccnl_resp.data.get("output") if isinstance(ccnl_resp.data, dict) else None
                 if ccnl_output and isinstance(ccnl_output, list) and len(ccnl_output) > 0:
-                    # output은 체결 내역 배열 → 첫 번째(최신) 체결의 당일 체결강도 사용
                     val = ccnl_output[0].get("tday_rltv")
                     cgld_val = float(val) if val else 0.0
         except Exception as e:
             self._logger.warning({"event": "cgld_check_failed", "code": code, "error": str(e)})
-            # 실패 시 안전을 위해 매수 보류하거나, 정책에 따라 통과시킬 수 있음. 여기서는 보류(None)
             return None
 
         if cgld_val < 120.0:
-            self._logger.debug({"event": "breakout_rejected", "code": code, "reason": "low_execution_strength", "cgld": cgld_val})
+            self._logger.debug({"event": "breakout_rejected", "code": code, "reason": "low_execution_strength", "cgld": cgld_val, "threshold": 120.0})
             return None
 
         # ========= 모든 관문 통과! 매수 시그널 생성 =========
@@ -211,7 +212,7 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             breakout_level=item.high_20d
         )
         self._save_state()
-        
+
         pg_ratio = (pg_buy_amount / trade_value * 100) if trade_value > 0 else 0.0
         vol_ratio = (proj_vol / item.avg_vol_20d * 100) if item.avg_vol_20d > 0 else 0.0
 
@@ -221,15 +222,24 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             f"PG매수 {pg_buy_amount//100_000_000:,}억({pg_ratio:.1f}%), "
             f"체결강도 {cgld_val:.1f}%)"
         )
-        
+
         self._logger.info({
             "event": "buy_signal_generated",
-            "code": code,
-            "name": item.name,
-            "price": current,
-            "reason": reason_msg
+            "code": code, "name": item.name,
+            "metrics": {
+                "price": current,
+                "breakout_level": item.high_20d,
+                "vol_ratio_pct": round(vol_ratio, 1),
+                "pg_participation_pct": round(pg_ratio, 2),
+                "execution_strength": cgld_val,
+                "rs_score": item.rs_score,
+                "rs_rating": item.rs_rating,
+                "total_score": item.total_score,
+                "market_timing": market_timing.get(item.market) if market_timing else None,
+            },
+            "reason": reason_msg,
         })
-        
+
         return TradeSignal(
             code=code, name=item.name, action="BUY", price=current, qty=qty,
             reason=reason_msg, strategy_name=self.name
@@ -241,24 +251,24 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
 
         if not ohlcv or len(ohlcv) < period:
             return False, ""
-            
+
         closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
         volumes = [r.get("volume", 0) for r in ohlcv if r.get("volume")]
-        
+
         # 2. 10일 이동평균선 계산
         ma_10d = sum(closes[-period:]) / period
-        
+
         # 🚨 가격 조건: 현재가가 10일선을 깼는가? (안 깼으면 안전하므로 바로 리턴)
         if current_price >= ma_10d:
             return False, ""
-            
+
         # 3. 거래량 조건 검증 (현재가가 10일선을 깬 상태에서만 계산)
         avg_vol_20d = sum(volumes[-20:]) / 20 if len(volumes) >= 20 else sum(volumes) / len(volumes)
-        
+
         progress = self._get_market_progress_ratio()
         effective_progress = max(progress, 0.05) # 뻥튀기 방어 (최소 5% 진행 보장)
         proj_vol = current_vol / effective_progress
-        
+
         # 🚨 거래량 조건: 장중 환산(예상) 거래량이 평소 20일 평균보다 많은가? (기관 매도 징후)
         if proj_vol > avg_vol_20d:
             reason = f"추세이탈(10MA {ma_10d:,.0f} 붕괴+대량거래)"
@@ -271,83 +281,129 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                 "avg_vol": int(avg_vol_20d)
             })
             return True, reason
-            
+
         return False, ""
 
     async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
-        signals = []
+        if not holdings:
+            return []
+
+        results = await asyncio.gather(
+            *[self._check_single_exit(hold) for hold in holdings],
+            return_exceptions=True,
+        )
+
+        signals: List[TradeSignal] = []
+        state_dirty = False
+        for result in results:
+            if isinstance(result, Exception):
+                self._logger.error({"event": "exit_check_error", "error": str(result)})
+            elif result:
+                s_list, dirty = result
+                signals.extend(s_list)
+                if dirty:
+                    state_dirty = True
+
+        if state_dirty:
+            await self._save_state_async()
+        return signals
+
+    async def _check_single_exit(self, hold: dict) -> tuple:
+        """단일 보유 종목 청산 조건 검사.
+
+        Returns: (List[TradeSignal], state_dirty: bool)
+        """
+        signals: List[TradeSignal] = []
         state_dirty = False
         ohlcv_limit = max(self._cfg.time_stop_days + 20, max(self._cfg.trend_exit_ma_period, 20))
 
-        for hold in holdings:
-            code = hold.get("code")
-            buy_price_raw = hold.get("buy_price")
-            if not code or not buy_price_raw: continue
+        code = hold.get("code")
+        buy_price_raw = hold.get("buy_price")
+        if not code or not buy_price_raw:
+            return signals, state_dirty
 
-            buy_price = float(buy_price_raw)
+        buy_price = float(buy_price_raw)
 
-            state = self._position_state.get(code)
-            if not state:
-                state = OSBPositionState(int(buy_price), "", int(buy_price), int(buy_price))
-                self._position_state[code] = state
+        state = self._position_state.get(code)
+        if not state:
+            state = OSBPositionState(int(buy_price), "", int(buy_price), int(buy_price))
+            self._position_state[code] = state
 
-            resp = await self._sqs.get_current_price(code, caller=self.name)
-            if not resp or resp.rt_cd != "0": continue
+        resp = await self._sqs.get_current_price(code, caller=self.name)
+        if not resp or resp.rt_cd != "0":
+            return signals, state_dirty
 
-            output = resp.data.get("output") if isinstance(resp.data, dict) else None
-            if not output: continue
+        output = resp.data.get("output") if isinstance(resp.data, dict) else None
+        if not output:
+            return signals, state_dirty
 
-            if isinstance(output, dict):
-                current = int(output.get("stck_prpr", 0))
-                current_vol = int(output.get("acml_vol", 0))
-            else:
-                current = int(getattr(output, "stck_prpr", 0) or 0)
-                current_vol = int(getattr(output, "acml_vol", 0) or 0)
+        if isinstance(output, dict):
+            current = int(output.get("stck_prpr", 0))
+            current_vol = int(output.get("acml_vol", 0))
+        else:
+            current = int(getattr(output, "stck_prpr", 0) or 0)
+            current_vol = int(getattr(output, "acml_vol", 0) or 0)
 
-            if current <= 0: continue
+        if current <= 0:
+            return signals, state_dirty
 
-            # 최고가 갱신 (dirty flag — 루프 후 1회 저장)
-            if current > state.peak_price:
-                state.peak_price = current
-                state_dirty = True
+        # 최고가 갱신 (dirty flag)
+        if current > state.peak_price:
+            state.peak_price = current
+            state_dirty = True
 
-            pnl = float((current - buy_price) / buy_price * 100)
-            reason = ""
+        pnl = float((current - buy_price) / buy_price * 100)
 
-            # 1. 손절
-            if pnl <= self._cfg.stop_loss_pct:
-                reason = f"손절({pnl:.1f}%)"
-            # 2. 트레일링 스탑
-            elif state.peak_price > 0:
-                drop = float((current - state.peak_price) / state.peak_price * 100)
-                if drop <= -self._cfg.trailing_stop_pct:
-                    reason = f"트레일링스탑({drop:.1f}%)"
+        # MFE / MAE 갱신
+        if pnl > state.mfe_pct:
+            state.mfe_pct = round(pnl, 2)
+            state_dirty = True
+        if pnl < state.mae_pct:
+            state.mae_pct = round(pnl, 2)
+            state_dirty = True
 
-            # 3·4. 시간손절 + 추세이탈 — OHLCV 1회 조회 후 양쪽에 전달
-            if not reason:
-                ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=ohlcv_limit)
-                ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
+        reason = ""
 
-                if self._check_time_stop(state, current, ohlcv):
-                    reason = f"시간손절({self._cfg.time_stop_days}일 횡보)"
-                elif ohlcv:
-                    is_break, break_reason = self._check_trend_break(code, current, current_vol, ohlcv)
-                    if is_break:
-                        reason = break_reason
+        # 1. 손절
+        if pnl <= self._cfg.stop_loss_pct:
+            reason = f"손절({pnl:.1f}%)"
+        # 2. 트레일링 스탑
+        elif state.peak_price > 0:
+            drop = float((current - state.peak_price) / state.peak_price * 100)
+            if drop <= -self._cfg.trailing_stop_pct:
+                reason = f"트레일링스탑({drop:.1f}%)"
 
-            # 매도 시그널 생성
-            if reason:
-                holding_qty = int(hold.get("qty", 1))
-                self._position_state.pop(code, None)
-                state_dirty = True
-                signals.append(TradeSignal(
-                    code=code, name=hold.get("name", code), action="SELL",
-                    price=current, qty=holding_qty, reason=reason, strategy_name=self.name
-                ))
+        # 3·4. 시간손절 + 추세이탈 — OHLCV 1회 조회 후 양쪽에 전달
+        if not reason:
+            ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=ohlcv_limit)
+            ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
 
-        if state_dirty:
-            self._save_state()
-        return signals
+            if self._check_time_stop(state, current, ohlcv):
+                reason = f"시간손절({self._cfg.time_stop_days}일 횡보)"
+            elif ohlcv:
+                is_break, break_reason = self._check_trend_break(code, current, current_vol, ohlcv)
+                if is_break:
+                    reason = break_reason
+
+        # 매도 시그널 생성
+        if reason:
+            holding_qty = int(hold.get("qty", 1))
+            self._logger.info({
+                "event": "exit_signal_generated",
+                "code": code, "name": hold.get("name", code),
+                "reason": reason,
+                "pnl_pct": round(pnl, 2),
+                "mfe_pct": state.mfe_pct,
+                "mae_pct": state.mae_pct,
+            })
+            self._position_state.pop(code, None)
+            state_dirty = True
+            signals.append(TradeSignal(
+                code=code, name=hold.get("name", code), action="SELL",
+                price=current, qty=holding_qty, reason=reason, strategy_name=self.name
+            ))
+
+        return signals, state_dirty
 
     def _check_time_stop(self, state: OSBPositionState, current_price: int, ohlcv: list) -> bool:
         """시간 손절 조건 체크. ohlcv는 호출자가 미리 조회해서 전달.
@@ -366,27 +422,27 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
 
         if not ohlcv:
             return False
-            
+
         trading_days = 0
         safe_entry_date = state.entry_date.replace("-", "")
-        
+
         # 🌟 버그 수정: == 대신 >= 를 사용하여 하이픈 제거 및 진입일 이후 데이터 필터링
         for candle in ohlcv:
             date_str = str(candle.get('date', '')).replace("-", "")
             if date_str > safe_entry_date: # 진입일 '다음 날'부터 1일로 카운트
                 trading_days += 1
-                
+
         # 설정된 거래일이 안 지났으면 패스
         if trading_days < self._cfg.time_stop_days:
             return False
-            
+
         # 2. 횡보 또는 하락 조건 확인 (현재가가 박스권 상단 이상으로 치고 나가지 못했는가?)
         pnl_pct = float((current_price - state.entry_price) / state.entry_price * 100)
-        
+
         # 🌟 버그 수정: abs() 제거. 2% 이상 '상승'한 게 아니라면 다 잘라버림 (하락 포함)
         if pnl_pct > self._cfg.time_stop_box_range_pct:
             return False
-            
+
         # 3. '찍고 내려온 놈' 제외 (최고가가 진입가 대비 크게 오르지 않았어야 함)
         peak_pnl_pct = float((state.peak_price - state.entry_price) / state.entry_price * 100)
         if peak_pnl_pct > (self._cfg.time_stop_box_range_pct * 2.5):
@@ -414,18 +470,64 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         return min(elapsed / total, 1.0) if total > 0 else 0.0
 
     def _load_state(self):
-        if os.path.exists(self.STATE_FILE):
-            try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 로드 (초기화 시 안전한 경로)
+            if os.path.exists(self.STATE_FILE):
+                try:
+                    with open(self.STATE_FILE, "r") as f:
+                        data = json.load(f)
+                    for k, v in data.items():
+                        if k not in self._position_state:
+                            self._position_state[k] = OSBPositionState(**v)
+                except Exception:
+                    pass
+            return
+        # 이벤트 루프가 실행 중이면 비동기 태스크로 읽기
+        loop.create_task(self._load_state_async())
+
+    async def _load_state_async(self):
+        if not os.path.exists(self.STATE_FILE):
+            return
+        try:
+            def _read_file():
                 with open(self.STATE_FILE, "r") as f:
-                    data = json.load(f)
-                for k, v in data.items():
+                    return json.load(f)
+
+            data = await asyncio.to_thread(_read_file)
+            for k, v in data.items():
+                if k not in self._position_state:
                     self._position_state[k] = OSBPositionState(**v)
-            except: pass
+        except Exception:
+            pass
 
     def _save_state(self):
+        """백워드 호환성 있는 동기-스케줄러 래퍼."""
         try:
-            os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 이벤트 루프 없음 → 동기 저장
+            try:
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                data = {k: asdict(v) for k, v in self._position_state.items()}
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+            except Exception:
+                pass
+            return
+        # 이벤트 루프가 존재하면 백그라운드에서 비동기 저장
+        loop.create_task(self._save_state_async())
+
+    async def _save_state_async(self):
+        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        try:
+            def _write_file(data):
+                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+                with open(self.STATE_FILE, "w") as f:
+                    json.dump(data, f, indent=2)
+
             data = {k: asdict(v) for k, v in self._position_state.items()}
-            with open(self.STATE_FILE, "w") as f:
-                json.dump(data, f, indent=2)
-        except: pass
+            await asyncio.to_thread(_write_file, data)
+        except Exception:
+            pass

--- a/tests/unit_test/strategies/test_first_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_first_pullback_strategy.py
@@ -856,7 +856,7 @@ def test_load_save_state(mock_deps, tmp_path):
 
 
 def test_load_state_corrupted(mock_deps, tmp_path):
-    """손상된 상태 파일 로드 시 빈 상태 유지."""
+    """손상된 상태 파일 로드 시 빈 상태 유지 + 에러 로깅."""
     sqs, universe, tm, logger = mock_deps
     strategy = FirstPullbackStrategy(sqs, universe, tm, logger=logger)
 
@@ -866,16 +866,18 @@ def test_load_state_corrupted(mock_deps, tmp_path):
     strategy._position_state = {}
     strategy._load_state()
     assert strategy._position_state == {}
+    logger.error.assert_called()
 
 
 def test_save_state_permission_error(mock_deps):
-    """저장 실패 시 예외가 전파되지 않음."""
+    """저장 실패 시 예외가 전파되지 않고 에러가 로깅됨."""
     sqs, universe, tm, logger = mock_deps
     strategy = FirstPullbackStrategy(sqs, universe, tm, logger=logger)
 
     strategy.STATE_FILE = "/unwritable/path/state.json"
     with patch("os.makedirs", side_effect=OSError("Permission denied")):
         strategy._save_state()  # 예외 발생 안 함
+    logger.error.assert_called()
 
 
 def test_name_property(mock_deps):

--- a/tests/unit_test/strategies/test_first_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_first_pullback_strategy.py
@@ -115,6 +115,19 @@ def watchlist_item():
     )
 
 
+# _save_state_async 파일 I/O 차단 (파일 I/O 전용 TC 제외)
+_FILE_IO_TESTS = {"test_load_save_state", "test_save_state_permission_error"}
+
+@pytest.fixture(autouse=True)
+def _block_async_file_io(monkeypatch, request):
+    """check_exits에서 _save_state_async 호출 시 파일 I/O 방지."""
+    if request.node.name in _FILE_IO_TESTS:
+        yield
+        return
+    monkeypatch.setattr(FirstPullbackStrategy, "_save_state_async", AsyncMock())
+    yield
+
+
 @pytest.fixture
 def fp_scan_setup(mock_deps, watchlist_item):
     """scan() 테스트 공통 셋업: 모든 조건 통과하도록 구성."""
@@ -884,6 +897,7 @@ async def test_check_exits_dirty_flag_saves_once(mock_deps):
     sqs, universe, tm, logger = mock_deps
     strategy = FirstPullbackStrategy(sqs, universe, tm, logger=logger)
     strategy._save_state = MagicMock()
+    strategy._save_state_async = AsyncMock()
 
     # 2개 종목 보유 — peak 10000, 현재가 10500 → 갱신 대상
     for code in ["005930", "000660"]:
@@ -914,8 +928,8 @@ async def test_check_exits_dirty_flag_saves_once(mock_deps):
     assert signals == []
     assert strategy._position_state["005930"].peak_price == 10500
     assert strategy._position_state["000660"].peak_price == 10500
-    # dirty flag: 루프 후 1회만 저장
-    strategy._save_state.assert_called_once()
+    # dirty flag: check_exits는 _save_state_async를 1회만 호출
+    strategy._save_state_async.assert_called_once()
 
 
 # ════════════════════════════════════════════════════════════════

--- a/tests/unit_test/strategies/test_high_tight_flag_strategy.py
+++ b/tests/unit_test/strategies/test_high_tight_flag_strategy.py
@@ -61,6 +61,19 @@ def _make_ohlcv_pole_and_flag(
 
 # ── Fixtures ─────────────────────────────────────────────────────────
 
+# _save_state_async 파일 I/O 차단 (파일 I/O 전용 TC 제외)
+_FILE_IO_TESTS = {"test_state_persistence"}
+
+@pytest.fixture(autouse=True)
+def _block_async_file_io(monkeypatch, request):
+    """check_exits에서 _save_state_async 호출 시 파일 I/O 방지."""
+    if request.node.name in _FILE_IO_TESTS:
+        yield
+        return
+    monkeypatch.setattr(HighTightFlagStrategy, "_save_state_async", AsyncMock())
+    yield
+
+
 @pytest.fixture
 def mock_deps():
     sqs = MagicMock(spec=StockQueryService)

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
@@ -1242,20 +1242,24 @@ async def test_scan_today_candle_high_from_stck_hgpr(pp_scan_setup):
 
 
 def test_load_save_state_exceptions(mock_deps, tmp_path):
-    """_load_state, _save_state: 파일 입출력 예외 처리 검증."""
+    """_load_state, _save_state: 파일 입출력 예외 처리 — 빈 상태 유지 + 에러 로깅."""
     sqs, universe, tm, logger = mock_deps
     strategy = OneilPocketPivotStrategy(sqs, universe, tm, logger=logger)
-    
+
     test_file = tmp_path / "corrupted.json"
     test_file.write_text("{invalid json")
     strategy.STATE_FILE = str(test_file)
-    
+
     # __init__ 시점에 로드되었을 수 있는 기존 찌꺼기 상태 비우기
     strategy._position_state.clear()
-    
+    logger.reset_mock()
+
     strategy._load_state()
     assert strategy._position_state == {}
+    logger.error.assert_called()
 
+    logger.reset_mock()
     strategy.STATE_FILE = "/unwritable/path/state.json"
     with patch("os.makedirs", side_effect=OSError("Permission denied")):
         strategy._save_state()
+    logger.error.assert_called()

--- a/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
@@ -40,11 +40,14 @@ _FILE_IO_TESTS = {"test_load_save_state"}
 
 @pytest.fixture(autouse=True)
 def _block_async_file_io(monkeypatch, request):
-    """check_exits에서 _save_state_async 호출 시 파일 I/O 방지."""
+    """check_exits에서 _save_state_async 호출 시 파일 I/O 방지.
+    _load_state_async도 패치해 trailing stop 후 pop() 된 코드가 백그라운드 태스크에 의해 재로드되는 레이스 컨디션 방지.
+    """
     if request.node.name in _FILE_IO_TESTS:
         yield
         return
     monkeypatch.setattr(OneilSqueezeBreakoutStrategy, "_save_state_async", AsyncMock())
+    monkeypatch.setattr(OneilSqueezeBreakoutStrategy, "_load_state_async", AsyncMock())
     yield
 
 

--- a/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
@@ -35,6 +35,19 @@ def breakout_candidate_item():
         market_cap=100_000_000_000 # 1000억 (테스트용)
     )
 
+# _save_state_async 파일 I/O 차단 (파일 I/O 전용 TC 제외)
+_FILE_IO_TESTS = {"test_load_save_state"}
+
+@pytest.fixture(autouse=True)
+def _block_async_file_io(monkeypatch, request):
+    """check_exits에서 _save_state_async 호출 시 파일 I/O 방지."""
+    if request.node.name in _FILE_IO_TESTS:
+        yield
+        return
+    monkeypatch.setattr(OneilSqueezeBreakoutStrategy, "_save_state_async", AsyncMock())
+    yield
+
+
 @pytest.fixture
 def scan_setup(mock_strategy_deps, breakout_candidate_item):
     """scan 메서드 테스트를 위한 공통 설정 픽스처."""
@@ -643,6 +656,7 @@ async def test_check_exits_dirty_flag_saves_once(mock_strategy_deps):
     sqs, universe, tm, logger = mock_strategy_deps
     strategy = OneilSqueezeBreakoutStrategy(sqs, universe, tm, logger=logger)
     strategy._save_state = MagicMock()
+    strategy._save_state_async = AsyncMock()
 
     # 3개 종목 보유 — 모두 최고가 갱신 대상 (peak 10000 < current 11000)
     for code in ["005930", "000660", "035420"]:
@@ -671,8 +685,8 @@ async def test_check_exits_dirty_flag_saves_once(mock_strategy_deps):
     assert signals == []
     for code in ["005930", "000660", "035420"]:
         assert strategy._position_state[code].peak_price == 11000
-    # dirty flag: 루프 후 1회만 저장
-    strategy._save_state.assert_called_once()
+    # dirty flag: check_exits는 _save_state_async를 1회만 호출
+    strategy._save_state_async.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
변경 사항 요약
로깅 강화
buy_signal_generated → structured metrics (4개 전략)

metrics 서브딕셔너리: price, 전략별 핵심 수치(vol_ratio_pct, pg_participation_pct, execution_strength), rs_score, rs_rating, total_score, market_timing exit_signal_generated 이벤트 추가 (4개 전략 check_exits)

청산 시 pnl_pct, mfe_pct, mae_pct 함께 로깅
entry_rejected 수치 보강

HTF: vol_ratio_pct (투영거래량/기준값 %)
PP: closest_ma_pct (가장 가까운 MA와의 거리 %)
OSB: vol_ratio_pct 추가
MFE/MAE 실시간 추적

FPPositionState, OSBPositionState, PPPositionState, HTFPositionState에 mfe_pct, mae_pct 필드 추가 (JSON 하위 호환) check_exits마다 갱신
성능 개선
check_exits 병렬화 (4개 전략)

for hold in holdings: → asyncio.gather(*[_check_single_exit(hold) for ...]) 각 종목 API 호출이 동시 실행됨
비동기 파일 I/O (FP, OSB, HTF — PP는 이미 적용)

_load_state_async / _save_state_async (asyncio.to_thread) 추가 _save_state(): 이벤트 루프 있으면 백그라운드 task, 없으면 동기 저장
테스트 파일
test_first_pullback_strategy.py, test_oneil_squeeze_breakout_strategy.py, test_high_tight_flag_strategy.py에 _block_async_file_io autouse fixture 추가 dirty flag assertion: _save_state → _save_state_async