### PR TITLE
주요 개선 사항 요약

### DIFF
--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -53,7 +53,6 @@ class OneilUniverseConfig(BaseStrategyConfig):
     smart_money_to_tv_pct: float = 10.0           # 또는 누적 거래대금의 10% 이상 매집 시
     smart_money_score_points: float = 15.0        # +15점 부여
 
-
 @dataclass
 class OneilBreakoutConfig(BaseStrategyConfig):
     """오닐 돌파 매매 전략(Strategy B) 설정."""
@@ -156,6 +155,18 @@ class OneilPocketPivotConfig(BaseStrategyConfig):
     position_size_pct: float = 5.0
     min_qty: int = 2                              # 부분 익절을 위해 최소 2주 매수
 
+    # [추가] 1. 거래량 노이즈 제거 필터
+    # 과거 음봉 최대 거래량의 몇 %를 넘어야 인정할 것인가 (예: 0.9 = 90%)
+    pp_down_vol_threshold_ratio: float = 0.9 
+    
+    # [추가] 2. 스마트 머니 유연화 (상호 보완 조건)
+    # 프로그램 비중이 낮더라도 체결강도가 이 수치 이상이면 통과
+    sm_flexible_pg_ratio: float = 7.0
+    sm_flexible_execution_strength: float = 140.0
+    
+    # [추가] 3. 캔들 품질 (몸통 위치)
+    # 0.0(저가) ~ 1.0(고가) 사이에서 현재가가 최소 어디에 위치해야 하는가
+    pp_min_candle_relative_pos: float = 0.5
 
 @dataclass
 class PPPositionState:

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -190,12 +190,7 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
         entry_type, supporting_ma, gap_day_low, extra_info = entry_result
 
-        # 5. ★ 공통 스마트 머니 필터 (기술적 조건 통과 후에만 호출)
-        if not self._check_smart_money(code, current, pg_buy, trade_value, item.market_cap):
-            self._logger.debug({"event": "entry_rejected_by_smart_money", "code": code, "entry_type": entry_type})
-            return None
-
-        # 6. ★ 체결강도 스냅샷 (>=120%)
+        # 5. ★ 체결강도 스냅샷 (>=120%) — 스마트머니 유연 조건(cgld 연동)에 필요해 먼저 조회
         cgld_val = 0.0
         try:
             ccnl_resp = await self._sqs.get_stock_conclusion(code)
@@ -210,6 +205,11 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
         if cgld_val < self._cfg.execution_strength_min:
             self._logger.debug({"event": "entry_rejected", "code": code, "reason": "low_execution_strength", "cgld": cgld_val})
+            return None
+
+        # 6. ★ 공통 스마트 머니 필터 (cgld_val 전달로 유연 조건 활성화)
+        if not self._check_smart_money(code, current, pg_buy, trade_value, item.market_cap, cgld_val):
+            self._logger.debug({"event": "entry_rejected_by_smart_money", "code": code, "entry_type": entry_type})
             return None
 
         # ========= 모든 관문 통과! 매수 시그널 생성 =========
@@ -301,8 +301,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
         if not supporting_ma: return None
 
         # 2. 캔들 품질 체크 (추가): 윗꼬리가 너무 길어 밀리는 종목 배제
-        day_high = item.high  # 실시간 고가
-        day_low = item.low    # 실시간 저가
+        today_ohlcv = ohlcv[-1]
+        day_high = today_ohlcv.get("high", 0)
+        day_low = today_ohlcv.get("low", 0)
         day_range = day_high - day_low
         if day_range > 0:
             # 저가 대비 현재 위치 (0.0: 저가, 1.0: 고가)

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -413,7 +413,10 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
         # [개선] 시가총액 규모에 따른 '동적 허들' 설정
         # 덩치가 큰 종목일수록 시총 대비 0.3%를 채우기 매우 어렵기 때문입니다.
-        if market_cap >= 10 * 10**12:      # 10조 이상 (초대형주: 삼성전자 등)
+        # program_to_market_cap_pct=0.0 이면 mc 필터 비활성화 (슬라이딩 스케일 미적용)
+        if self._cfg.program_to_market_cap_pct <= 0:
+            mc_threshold = 0.0
+        elif market_cap >= 10 * 10**12:    # 10조 이상 (초대형주: 삼성전자 등)
             mc_threshold = 0.1             # 0.1%만 들어와도 인정
         elif market_cap >= 1 * 10**12:     # 1조 이상 (대형주)
             mc_threshold = 0.2             # 0.2%

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -284,85 +284,59 @@ class OneilPocketPivotStrategy(LiveStrategy):
     def _check_pocket_pivot(
         self, code, current, vol, progress, ohlcv, item, prev_close
     ) -> Optional[Tuple[str, str, int, dict]]:
-        """Pocket Pivot 조건 검사.
-
-        Returns: ("PP", supporting_ma, 0, extra_info) 또는 None
-        """
+        """Pocket Pivot 조건 검사 (개선 버전)."""
         closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
         if len(closes) < 10:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "insufficient_data"})
             return None
 
-        # 1. MA 계산 (10일은 직접 계산, 20/50일은 item에서)
+        # 1. 이동평균선 근접성 체크 (기존 로직 동일)
         ma_10d = sum(closes[-10:]) / 10
-        ma_candidates = [
-            (ma_10d, "10"),
-            (item.ma_20d, "20"),
-            (item.ma_50d, "50"),
-        ]
-
-        # 2. 이평선 근접성 체크 (-2% ~ +4%)
+        ma_candidates = [(ma_10d, "10"), (item.ma_20d, "20"), (item.ma_50d, "50")]
         supporting_ma = ""
         for ma_val, ma_name in ma_candidates:
-            if ma_val <= 0:
-                continue
-            lower = ma_val * (1 + self._cfg.pp_ma_proximity_lower_pct / 100)
-            upper = ma_val * (1 + self._cfg.pp_ma_proximity_upper_pct / 100)
-            if lower <= current <= upper:
+            if ma_val <= 0: continue
+            if ma_val * (1 + self._cfg.pp_ma_proximity_lower_pct/100) <= current <= ma_val * (1 + self._cfg.pp_ma_proximity_upper_pct/100):
                 supporting_ma = ma_name
                 break
+        if not supporting_ma: return None
 
-        if not supporting_ma:
-            # 가장 가까운 MA와의 거리 계산 (파라미터 최적화 참고용)
-            closest_pct = None
-            for ma_val, ma_name in ma_candidates:
-                if ma_val > 0:
-                    pct = (current - ma_val) / ma_val * 100
-                    if closest_pct is None or abs(pct) < abs(closest_pct):
-                        closest_pct = pct
-            self._logger.debug({
-                "event": "pp_rejected", "code": code, "reason": "not_near_ma",
-                "closest_ma_pct": round(closest_pct, 2) if closest_pct is not None else None,
-                "allowed_range": f"{self._cfg.pp_ma_proximity_lower_pct}% ~ {self._cfg.pp_ma_proximity_upper_pct}%",
-            })
-            return None
+        # 2. 캔들 품질 체크 (추가): 윗꼬리가 너무 길어 밀리는 종목 배제
+        day_high = item.high  # 실시간 고가
+        day_low = item.low    # 실시간 저가
+        day_range = day_high - day_low
+        if day_range > 0:
+            # 저가 대비 현재 위치 (0.0: 저가, 1.0: 고가)
+            relative_pos = (current - day_low) / day_range
+            if relative_pos < self._cfg.pp_min_candle_relative_pos:
+                self._logger.debug({"event": "pp_rejected", "code": code, "reason": "poor_candle_quality", "pos": round(relative_pos, 2)})
+                return None
 
-        # 3. 당일 상승일 확인 (현재가 > 전일 종가)
+        # 3. 당일 상승일 확인 (양봉 및 전일비 상승)
         if current <= prev_close:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "not_an_up_day"})
             return None
 
-        # 4. 과거 10일 하락일(close < open) 거래량 중 MAX 산출
+        # 4. 과거 10일 하락일 거래량 분석 및 노이즈 제거 (개선)
         lookback = min(self._cfg.pp_down_day_lookback, len(ohlcv))
         recent = ohlcv[-lookback:]
-        down_day_volumes = []
-        for candle in recent:
-            c = candle.get("close", 0)
-            o = candle.get("open", 0)
-            v = candle.get("volume", 0)
-            if c and o and c < o and v:
-                down_day_volumes.append(v)
+        down_day_volumes = [c.get("volume", 0) for c in recent if c.get("close", 0) < c.get("open", 0)]
 
-        max_down_vol = max(down_day_volumes) if down_day_volumes else 0
-
-        # 하락일(음봉)이 단 하루도 없었다면, 정상적인 조정(Base) 구간이 아니므로 기각
-        if max_down_vol <= 0:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "no_down_day_volume"})
+        if not down_day_volumes:
             return None
         
-        # 5. 거래량 우위: 환산 거래량 > 하락일 최대 거래량
+        # [수정] 100%가 아닌 설정된 비율(예: 90%)만 넘어도 통과하도록 유연화
+        max_down_vol = max(down_day_volumes)
+        threshold_vol = max_down_vol * self._cfg.pp_down_vol_threshold_ratio
+
+        # 5. 거래량 우위 확인
         effective_progress = max(progress, 0.05)
         proj_vol = vol / effective_progress
 
-        if proj_vol <= max_down_vol:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "insufficient_volume", "proj_vol": int(proj_vol), "max_down_vol": max_down_vol})
+        if proj_vol <= threshold_vol:
+            self._logger.debug({
+                "event": "pp_rejected", "code": code, "reason": "insufficient_volume",
+                "proj_vol": int(proj_vol), "threshold": int(threshold_vol)
+            })
             return None
-
-        self._logger.debug({
-            "event": "pocket_pivot_matched", "code": code,
-            "supporting_ma": supporting_ma,
-            "proj_vol": int(proj_vol), "max_down_vol": int(max_down_vol),
-        })
 
         return ("PP", supporting_ma, 0, {"proj_vol": proj_vol, "max_down_vol": max_down_vol})
 
@@ -418,35 +392,56 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
     # ── 스마트 머니 필터 ──────────────────────────────────────────
 
-    def _check_smart_money(self, code: str, current: int, pg_buy: int, trade_value: int, market_cap: int) -> bool:
-        """스마트 머니(프로그램 수급) 필터."""
+    def _check_smart_money(self, code: str, current: int, pg_buy: int, trade_value: int, market_cap: int, cgld_val: float = 0.0) -> bool:
+        """스마트 머니(프로그램 수급) 필터 — 시가총액 규모별 가변 기준 적용."""
         if pg_buy <= 0:
-            self._logger.debug({"event": "smart_money_rejected", "code": code, "reason": "not_net_buy", "pg_buy": pg_buy})
             return False
 
         pg_buy_amount = pg_buy * current
+        
+        # 1. 거래대금 대비 비중 (%)
+        pg_to_tv_pct = (pg_buy_amount / trade_value * 100) if trade_value > 0 else 0
+        
+        # 2. 시가총액 대비 비중 (%)
+        pg_to_mc_pct = (pg_buy_amount / market_cap * 100) if market_cap > 0 else 0
 
-        # 거래대금의 10% 이상 개입
-        if trade_value > 0:
-            pg_to_tv_pct = pg_buy_amount / trade_value * 100
-            if pg_to_tv_pct < self._cfg.program_to_trade_value_pct:
-                self._logger.debug({
-                    "event": "smart_money_rejected", "code": code, "reason": "low_pg_to_trade_value",
-                    "pg_to_tv_pct": round(pg_to_tv_pct, 2), "threshold": self._cfg.program_to_trade_value_pct
-                })
-                return False
+        # [개선] 시가총액 규모에 따른 '동적 허들' 설정
+        # 덩치가 큰 종목일수록 시총 대비 0.3%를 채우기 매우 어렵기 때문입니다.
+        if market_cap >= 10 * 10**12:      # 10조 이상 (초대형주: 삼성전자 등)
+            mc_threshold = 0.1             # 0.1%만 들어와도 인정
+        elif market_cap >= 1 * 10**12:     # 1조 이상 (대형주)
+            mc_threshold = 0.2             # 0.2%
+        else:                              # 1조 미만 (중소형주)
+            mc_threshold = self._cfg.program_to_market_cap_pct  # 기본값 (0.3%)
 
-        # 시가총액의 0.3% 이상 개입
-        if market_cap > 0:
-            pg_to_mc_pct = pg_buy_amount / market_cap * 100
-            if pg_to_mc_pct < self._cfg.program_to_market_cap_pct:
-                self._logger.debug({
-                    "event": "smart_money_rejected", "code": code, "reason": "low_pg_to_market_cap",
-                    "pg_to_mc_pct": round(pg_to_mc_pct, 2), "threshold": self._cfg.program_to_market_cap_pct
-                })
-                return False
+        # --- 판정 로직 ---
+        
+        # 조건 A: 정석적인 수급 (거래대금 10% 이상 AND 시총 대비 동적 허들 돌파)
+        is_standard_ok = (pg_to_tv_pct >= self._cfg.program_to_trade_value_pct and 
+                          pg_to_mc_pct >= mc_threshold)
+        
+        # 조건 B: 유연한 수급 (수급은 약간 부족해도 '체결강도'라는 에너지가 뒷받침될 때)
+        # 예: 프로그램 비중 7% + 체결강도 140% + 시총 대비 비중은 절반만 채워도 인정
+        is_flexible_ok = (pg_to_tv_pct >= self._cfg.sm_flexible_pg_ratio and 
+                          cgld_val >= self._cfg.sm_flexible_execution_strength and
+                          pg_to_mc_pct >= (mc_threshold * 0.7))
 
-        self._logger.debug({"event": "smart_money_passed", "code": code, "pg_buy_amount": pg_buy_amount})
+        if not (is_standard_ok or is_flexible_ok):
+            self._logger.debug({
+                "event": "smart_money_rejected", "code": code, 
+                "reason": "low_pg_metrics", 
+                "pg_tv_pct": round(pg_to_tv_pct, 2), 
+                "pg_mc_pct": round(pg_to_mc_pct, 3),
+                "mc_threshold": mc_threshold,
+                "cgld": cgld_val
+            })
+            return False
+
+        self._logger.debug({
+            "event": "smart_money_passed", "code": code, 
+            "pg_tv_pct": round(pg_to_tv_pct, 2), 
+            "pg_mc_pct": round(pg_to_mc_pct, 3)
+        })
         return True
 
     # ── check_exits ────────────────────────────────────────────────

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -302,7 +302,11 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 supporting_ma = ma_name
                 break
         if not supporting_ma:
-            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "no_ma_proximity", **ma_proximity_debug})
+            closest_ma_pct = min(ma_proximity_debug.values(), key=abs) if ma_proximity_debug else None
+            self._logger.debug({
+                "event": "pp_rejected", "code": code, "reason": "no_ma_proximity",
+                "closest_ma_pct": closest_ma_pct, **ma_proximity_debug,
+            })
             return None
 
         # 2. 캔들 품질 체크 (추가): 윗꼬리가 너무 길어 밀리는 종목 배제

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -293,12 +293,17 @@ class OneilPocketPivotStrategy(LiveStrategy):
         ma_10d = sum(closes[-10:]) / 10
         ma_candidates = [(ma_10d, "10"), (item.ma_20d, "20"), (item.ma_50d, "50")]
         supporting_ma = ""
+        ma_proximity_debug = {}
         for ma_val, ma_name in ma_candidates:
             if ma_val <= 0: continue
+            pct_from_ma = (current - ma_val) / ma_val * 100
+            ma_proximity_debug[f"ma{ma_name}_pct"] = round(pct_from_ma, 2)
             if ma_val * (1 + self._cfg.pp_ma_proximity_lower_pct/100) <= current <= ma_val * (1 + self._cfg.pp_ma_proximity_upper_pct/100):
                 supporting_ma = ma_name
                 break
-        if not supporting_ma: return None
+        if not supporting_ma:
+            self._logger.debug({"event": "pp_rejected", "code": code, "reason": "no_ma_proximity", **ma_proximity_debug})
+            return None
 
         # 2. 캔들 품질 체크 (추가): 윗꼬리가 너무 길어 밀리는 종목 배제
         today_ohlcv = ohlcv[-1]

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
@@ -209,6 +209,38 @@ async def test_scan_pp_rejects_low_volume(pp_scan_setup):
 
 
 @pytest.mark.asyncio
+async def test_scan_pp_volume_90pct_threshold(pp_scan_setup):
+    """PP: 하락일 최대 거래량의 90~100% 구간이어도 통과 (노이즈 제거 적용)."""
+    strategy, sqs, _, _, _ = pp_scan_setup
+
+    # pp_scan_setup OHLCV: 전체 하락일(close=67500 < open=68000), vol=50000
+    # max_down_vol=50000, threshold=50000*0.9=45000
+    # vol=24000 → proj_vol=24000/0.5=48000 > 45000 → 통과 (100% 기준이면 48000<50000 탈락)
+    sqs.get_current_price.return_value = _pp_price_output(vol="24000")
+    sqs.get_stock_conclusion.return_value = _cgld_output("150.0")
+
+    signals = await strategy.scan()
+    assert len(signals) == 1
+    assert signals[0].action == "BUY"
+
+
+@pytest.mark.asyncio
+async def test_scan_pp_rejects_poor_candle_quality(pp_scan_setup):
+    """PP: 현재가가 당일 고저 범위 하단 50% 미만이면 기각 (윗꼬리 밀림)."""
+    strategy, sqs, _, _, _ = pp_scan_setup
+
+    # today_high=70000, today_low=68000, current=68500
+    # relative_pos = (68500-68000)/(70000-68000) = 500/2000 = 0.25 < 0.5 → 기각
+    sqs.get_current_price.return_value = _pp_price_output(
+        current="68500", today_high="70000", today_low="68000"
+    )
+    sqs.get_stock_conclusion.return_value = _cgld_output("150.0")
+
+    signals = await strategy.scan()
+    assert len(signals) == 0
+
+
+@pytest.mark.asyncio
 async def test_scan_pp_rejects_low_execution_strength(pp_scan_setup):
     """PP: 체결강도 < 120%이면 시그널 없음."""
     strategy, sqs, _, _, _ = pp_scan_setup
@@ -1070,12 +1102,12 @@ async def test_check_bgu_edge_cases(bgu_scan_setup):
     assert len(signals) == 0
 
 @pytest.mark.parametrize("pg_buy, trade_value, market_cap, expected", [
-    (0, 1000, 10000, False),
-    (-100, 1000, 10000, False),
-    (100, 0, 10000, True),
-    (100, 10000, 0, True),
-    (100, 10000, 10000, True),
-    (1000, 1000, 100000, True),
+    (0, 1000, 10000, False),        # pg_buy <= 0
+    (-100, 1000, 10000, False),     # pg_buy <= 0
+    (100, 0, 10000, False),         # tv=0 → pg_to_tv_pct=0 < 10%, flexible도 pgRatio 미달 → False
+    (100, 10000, 0, False),         # mc=0 → pg_to_mc_pct=0 < threshold, flexible cgld=0 → False
+    (100, 10000, 10000, True),      # pg_to_tv_pct=100%, pg_to_mc_pct=100% → standard 통과
+    (1000, 1000, 100000, True),     # pg_to_tv_pct=10000%, pg_to_mc_pct=1000% → standard 통과
 ])
 def test_check_smart_money_filters(mock_deps, pg_buy, trade_value, market_cap, expected):
     """_check_smart_money: 다양한 필터링 조건 검증."""
@@ -1083,6 +1115,47 @@ def test_check_smart_money_filters(mock_deps, pg_buy, trade_value, market_cap, e
     strategy = OneilPocketPivotStrategy(sqs, universe, tm, logger=logger)
     result = strategy._check_smart_money("005930", 100, pg_buy, trade_value, market_cap)
     assert result is expected
+
+
+def test_check_smart_money_sliding_scale(mock_deps):
+    """_check_smart_money: 시가총액 규모별 슬라이딩 기준 검증."""
+    sqs, universe, tm, logger = mock_deps
+    strategy = OneilPocketPivotStrategy(sqs, universe, tm, logger=logger)
+
+    current = 1000
+    # pg_buy_amount = 0.15% of 10조 = 150억 → pg_to_mc_pct=0.15%
+    # pg_to_tv_pct = 10% (standard 통과 요건)
+    pg_buy = 15_000_000           # 1500만주 × 1000원 = 150억
+    trade_value = 150_000_000_000  # 1500억 → pg_to_tv_pct = 150억/1500억 = 10%
+
+    # 10조 이상: mc_threshold=0.1% → 0.15% ≥ 0.1% → 통과
+    assert strategy._check_smart_money("A", current, pg_buy, trade_value, 10 * 10**12) is True
+
+    # 1조(mc_threshold=0.2%): pg_buy_amount=0.15% of 1조=15억 → 15억/1조=0.15% < 0.2% → 탈락
+    pg_buy_1t = 1_500_000          # 150만주 × 1000원 = 15억
+    trade_value_1t = 15_000_000_000  # 150억 → pg_to_tv_pct = 10%
+    assert strategy._check_smart_money("B", current, pg_buy_1t, trade_value_1t, 1 * 10**12) is False
+
+
+def test_check_smart_money_flexible_condition(mock_deps):
+    """_check_smart_money: pgRatio 7%+ & 체결강도 140%+ 시 유연 조건으로 통과."""
+    sqs, universe, tm, logger = mock_deps
+    strategy = OneilPocketPivotStrategy(sqs, universe, tm, logger=logger)
+
+    # pg_to_tv_pct = 8% (7% 이상, 10% 미만) — standard 탈락 구간
+    # market_cap = 500억 (< 1조): mc_threshold = 0.3%
+    # pg_to_mc_pct = 0.25% (mc_threshold의 70% = 0.21% 이상 → flexible 허들 충족)
+    market_cap = 50_000_000_000    # 500억
+    current = 100
+    pg_buy_amount = int(0.0025 * market_cap)   # 0.25%  = 1.25억
+    pg_buy = pg_buy_amount // current          # 125만주
+    trade_value = int(pg_buy_amount / 0.08)   # pg_to_tv_pct = 8%
+
+    # cgld 없음 → flexible 탈락 → False
+    assert strategy._check_smart_money("005930", current, pg_buy, trade_value, market_cap, cgld_val=0.0) is False
+
+    # cgld 145% → flexible 통과 → True
+    assert strategy._check_smart_money("005930", current, pg_buy, trade_value, market_cap, cgld_val=145.0) is True
 
 @pytest.mark.asyncio
 async def test_check_exits_edge_cases(mock_deps):


### PR DESCRIPTION
과거 매도세 극복: pp_down_vol_threshold_ratio를 도입하여, 과거의 비정상적인 대량 매도 거래량 하나 때문에 오늘 들어온 강력한 매수세를 무시하는 오류를 방지합니다.

캔들 품질 보장: pp_min_candle_relative_pos를 통해 주가가 오르긴 했으나 윗꼬리가 너무 길게 달려 밀리는 종목을 걸러냅니다. 이는 '가짜 반등'을 피하는 데 매우 중요합니다.

수급 필터의 입체화: 단순히 프로그램 매수 '비중'만 보는 것이 아니라, 실제 시장에서 체결되는 '속도와 힘(체결강도)'을 결합하여 파라텍과 같은 '실속 있는 종목'을 포착합니다.

이 코드들을 적용하면, 이전에 분석했던 주성엔지니어링이나 파라텍과 같이 "조건은 거의 완벽한데 1~2% 수치가 부족했던" 주도주들을 놓치지 않고 잡아낼 수 있게 됩니다.