### PR TITLE
완료되었습니다. 변경 요약:

### DIFF
--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -372,12 +372,12 @@ class IndicatorService:
             raise e
 
     @staticmethod
-    def _compute_ma(df: pd.DataFrame, period: int, method: str = "sma", target_col: str = "ma") -> pd.DataFrame:
-        """이동평균 계산 및 컬럼 추가"""
+    def _compute_ma(df: pd.DataFrame, period: int, method: str = "sma", target_col: str = "ma", source_col: str = "close") -> pd.DataFrame:
+        """이동평균 계산 및 컬럼 추가 (source_col: 계산 대상 컬럼, 기본값 'close')"""
         if method.lower() == "ema":
-            df[target_col] = df['close'].ewm(span=period, adjust=False).mean()
+            df[target_col] = df[source_col].ewm(span=period, adjust=False).mean()
         else:
-            df[target_col] = df['close'].rolling(window=period).mean()
+            df[target_col] = df[source_col].rolling(window=period).mean()
         return df
 
     @staticmethod
@@ -516,6 +516,12 @@ class IndicatorService:
             for p in [5, 10, 20, 50, 60, 120, 150, 200]:
                 df = self._compute_ma(df, p, "sma", target_col=f"ma{p}")
 
+            # 거래량 이동평균 (volume MA 5, 20, 60)
+            if 'volume' in df.columns:
+                df['volume'] = pd.to_numeric(df['volume'], errors='coerce')
+                for p in [5, 20, 60]:
+                    df = self._compute_ma(df, p, "sma", target_col=f"vol_ma{p}", source_col="volume")
+
             # BB (20일, 2.0)
             df = self._compute_bb(df, 20, 2.0, prefix="bb")
 
@@ -560,6 +566,15 @@ class IndicatorService:
                 {"date": str(r.date), "rs": r.rs}
                 for r in df.itertuples(index=False)
             ]
+
+            # 거래량 MA 추출 (vol_ma5, vol_ma20, vol_ma60)
+            for p in [5, 20, 60]:
+                col = f"vol_ma{p}"
+                if col in df.columns:
+                    indicators[col] = [
+                        {"date": str(r.date), "ma": getattr(r, col)}
+                        for r in df.itertuples(index=False)
+                    ]
 
             return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공", data=indicators)
 

--- a/tests/unit_test/services/test_indicator_service.py
+++ b/tests/unit_test/services/test_indicator_service.py
@@ -799,39 +799,54 @@ async def test_service_without_sqs():
 async def test_get_chart_indicators_no_cache_manager(indicator_service):
     """캐시 매니저 없이 차트 지표 계산 (전체 계산)"""
     service, mock_sqs = indicator_service # cache_store is None
-    
-    # 150일치 데이터 (충분한 데이터)
-    data = [{"date": f"202501{i+1:03d}", "close": 10000 + i * 10} for i in range(150)]
-    
+
+    # 150일치 데이터 (충분한 데이터, volume 포함)
+    data = [{"date": f"202501{i+1:03d}", "close": 10000 + i * 10, "volume": 1000 + i * 10} for i in range(150)]
+
     # ohlcv_data 직접 전달
     result = await service.get_chart_indicators("005930", ohlcv_data=data)
-    
+
     assert result.rt_cd == ErrorCode.SUCCESS.value
     indicators = result.data
-    
-    # 키 확인
+
+    # 가격 MA 키 확인
     assert "ma5" in indicators
     assert "ma120" in indicators
     assert "bb" in indicators
     assert "rs" in indicators
-    
+
+    # 거래량 MA 키 확인
+    assert "vol_ma5" in indicators
+    assert "vol_ma20" in indicators
+    assert "vol_ma60" in indicators
+
     # 데이터 길이 확인
     assert len(indicators["ma5"]) == 150
     assert len(indicators["bb"]) == 150
+    assert len(indicators["vol_ma5"]) == 150
+
+    # vol_ma 구조 확인 (date, ma 키 포함)
+    last_vol_ma5 = indicators["vol_ma5"][-1]
+    assert "date" in last_vol_ma5
+    assert "ma" in last_vol_ma5
+    assert last_vol_ma5["ma"] is not None  # 충분한 데이터이므로 None이 아니어야 함
 
 @pytest.mark.asyncio
 async def test_get_chart_indicators_insufficient_data(indicator_service):
     """데이터 부족 시 차트 지표 계산"""
     service, mock_sqs = indicator_service
-    
-    # 100개 (130개 미만)
-    data = [{"date": f"202501{i+1:03d}", "close": 10000} for i in range(100)]
-    
+
+    # 100개 (200개 미만 → 캐싱 미적용), volume 포함
+    data = [{"date": f"202501{i+1:03d}", "close": 10000, "volume": 1000} for i in range(100)]
+
     result = await service.get_chart_indicators("005930", ohlcv_data=data)
-    
+
     # 데이터가 적어도 계산은 수행함 (캐싱만 안함)
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert len(result.data["ma5"]) == 100
+    # volume이 있으므로 vol_ma 키도 존재해야 함
+    assert "vol_ma5" in result.data
+    assert len(result.data["vol_ma5"]) == 100
 
 @pytest.mark.asyncio
 async def test_get_chart_indicators_caching_miss(indicator_service_with_cache):
@@ -1512,7 +1527,134 @@ def test_calc_rs_sync_invalid_close(indicator_service):
 def test_calc_rs_sync_exception(indicator_service):
     """calc_rs_sync: 리스트가 아닌 데이터(None 등) 주입 시 내부 예외(Exception) 발생 처리"""
     service, _ = indicator_service
-    
+
     # None 객체를 전달하여 len() 호출 시 TypeError 유도 -> 내부 try-except로 잡혀서 0.0 반환
     rs_val = service.calc_rs_sync(None, period_days=63)
     assert rs_val == 0.0
+
+
+# ═══════════════════════════════════════════════════════
+# 거래량 이동평균(Volume MA) 테스트
+# ═══════════════════════════════════════════════════════
+
+def test_calculate_indicators_full_volume_ma_values(indicator_service):
+    """_calculate_indicators_full: vol_ma5/20/60 값이 volume 기반으로 정확히 계산되는지 검증"""
+    service, _ = indicator_service
+
+    # 65일치 데이터 (vol_ma60 계산 가능), 거래량은 i+1 (1,2,...,65)
+    data = [
+        {"date": f"202501{i+1:03d}", "close": 10000, "volume": i + 1}
+        for i in range(65)
+    ]
+
+    result = service._calculate_indicators_full("005930", data)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    indicators = result.data
+
+    # vol_ma 키 존재 확인
+    assert "vol_ma5" in indicators
+    assert "vol_ma20" in indicators
+    assert "vol_ma60" in indicators
+
+    # 마지막 vol_ma5 값 검증: volume 61~65 평균 = (61+62+63+64+65)/5 = 63.0
+    assert indicators["vol_ma5"][-1]["ma"] == 63.0
+
+    # 마지막 vol_ma20 값 검증: volume 46~65 평균 = sum(46..65)/20 = 55.5
+    assert indicators["vol_ma20"][-1]["ma"] == 55.5
+
+    # 마지막 vol_ma60 값: volume 6~65 평균 = sum(6..65)/60 = 35.5
+    assert indicators["vol_ma60"][-1]["ma"] == 35.5
+
+
+def test_calculate_indicators_full_volume_ma_no_volume_column(indicator_service):
+    """_calculate_indicators_full: volume 컬럼 없으면 vol_ma 키가 결과에 포함되지 않아야 함"""
+    service, _ = indicator_service
+
+    # volume 없는 데이터
+    data = [{"date": f"202501{i+1:03d}", "close": 10000} for i in range(30)]
+
+    result = service._calculate_indicators_full("005930", data)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    indicators = result.data
+
+    # 가격 MA는 존재
+    assert "ma5" in indicators
+    # volume 컬럼 없으므로 vol_ma 키는 없어야 함
+    assert "vol_ma5" not in indicators
+    assert "vol_ma20" not in indicators
+    assert "vol_ma60" not in indicators
+
+
+def test_calculate_indicators_full_volume_ma_insufficient_data(indicator_service):
+    """_calculate_indicators_full: 데이터 부족 시 vol_ma 초기 항목은 None"""
+    service, _ = indicator_service
+
+    # 10일치 데이터 (vol_ma5는 5일부터 계산, vol_ma20/60은 모두 None)
+    data = [
+        {"date": f"2025010{i+1}", "close": 10000, "volume": 1000}
+        for i in range(10)
+    ]
+
+    result = service._calculate_indicators_full("005930", data)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    indicators = result.data
+
+    # vol_ma5: 처음 4개는 None, 5번째부터 값 있음
+    assert indicators["vol_ma5"][0]["ma"] is None
+    assert indicators["vol_ma5"][4]["ma"] is not None
+
+    # vol_ma20/60: 데이터 부족으로 모두 None
+    assert all(row["ma"] is None for row in indicators["vol_ma20"])
+    assert all(row["ma"] is None for row in indicators["vol_ma60"])
+
+
+def test_compute_ma_source_col_param(indicator_service):
+    """_compute_ma: source_col 파라미터로 volume 컬럼 MA를 계산하는지 검증"""
+    service, _ = indicator_service
+
+    df = pd.DataFrame({
+        "close": [100, 200, 300, 400, 500],
+        "volume": [10, 20, 30, 40, 50],
+    })
+
+    # volume 기반 MA3 계산
+    result_df = service._compute_ma(df.copy(), period=3, method="sma", target_col="vol_ma3", source_col="volume")
+
+    # (10+20+30)/3=20, (20+30+40)/3=30, (30+40+50)/3=40
+    assert result_df["vol_ma3"].iloc[2] == 20.0
+    assert result_df["vol_ma3"].iloc[3] == 30.0
+    assert result_df["vol_ma3"].iloc[4] == 40.0
+
+    # close 컬럼은 변경되지 않아야 함
+    assert list(result_df["close"]) == [100, 200, 300, 400, 500]
+
+
+def test_compute_ma_default_source_col_unchanged(indicator_service):
+    """_compute_ma: source_col 기본값이 'close'여서 기존 동작 그대로인지 검증"""
+    service, _ = indicator_service
+
+    df = pd.DataFrame({"close": [100, 200, 300, 400, 500]})
+
+    result_df = service._compute_ma(df.copy(), period=3, method="sma", target_col="ma3")
+
+    assert result_df["ma3"].iloc[2] == 200.0  # (100+200+300)/3
+
+
+@pytest.mark.asyncio
+async def test_get_chart_indicators_no_volume_no_vol_ma(indicator_service):
+    """get_chart_indicators: volume 컬럼 없는 데이터 → vol_ma 키 미포함 (오류 없음)"""
+    service, _ = indicator_service
+
+    data = [{"date": f"202501{i+1:03d}", "close": 10000 + i} for i in range(150)]
+
+    result = await service.get_chart_indicators("005930", ohlcv_data=data)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    # volume 없으므로 vol_ma 키 없음
+    assert "vol_ma5" not in result.data
+    assert "vol_ma20" not in result.data
+    # 가격 MA는 정상 존재
+    assert "ma5" in result.data

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -141,6 +141,7 @@ function renderStockChart(period) {
     const ma5 = new Array(len), ma10 = new Array(len), ma20 = new Array(len), ma50 = new Array(len);
     const ma60 = new Array(len), ma120 = new Array(len), ma150 = new Array(len), ma200 = new Array(len);
     const bbUpper = new Array(len), bbMiddle = new Array(len), bbLower = new Array(len);
+    const volMa5 = new Array(len), volMa20 = new Array(len), volMa60 = new Array(len);
 
     const currentPrice = slicedRaw[len - 1].close;
     let highestPrice = -Infinity, lowestPrice = Infinity;
@@ -174,6 +175,9 @@ function renderStockChart(period) {
             bbMiddle[i] = { x: i, y: ind.bb[rawIdx].middle };
             bbLower[i]  = { x: i, y: ind.bb[rawIdx].lower };
         }
+        if (ind.vol_ma5  && ind.vol_ma5[rawIdx])  volMa5[i]  = { x: i, y: ind.vol_ma5[rawIdx].ma };
+        if (ind.vol_ma20 && ind.vol_ma20[rawIdx]) volMa20[i] = { x: i, y: ind.vol_ma20[rawIdx].ma };
+        if (ind.vol_ma60 && ind.vol_ma60[rawIdx]) volMa60[i] = { x: i, y: ind.vol_ma60[rawIdx].ma };
     }
 
     const highPct = ((highestPrice - currentPrice) / currentPrice * 100).toFixed(1);
@@ -270,7 +274,10 @@ function renderStockChart(period) {
                 { label: 'BB Upper', data: bbUpper, type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: false, order: 3 },
                 { label: 'BB Lower', data: bbLower, type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: '-1', backgroundColor: 'rgba(200,200,200,0.1)', order: 3 },
                 { label: 'BB Middle', data: bbMiddle, type: 'line', borderColor: 'rgba(255, 215, 0, 0.8)', borderWidth: 1.5, borderDash: [3, 3], pointRadius: 0, yAxisID: 'y', fill: false, order: 3, hidden: true }, // [수정] MA20과 중복되므로 기본 숨김
-                { label: '거래량', data: volumes, type: 'bar', yAxisID: 'y1', backgroundColor: volumeColors, order: 4 }
+                { label: '거래량', data: volumes, type: 'bar', yAxisID: 'y1', backgroundColor: volumeColors, order: 4 },
+                { label: 'Vol MA5',  data: volMa5,  type: 'line', borderColor: '#ff6b6b', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
+                { label: 'Vol MA20', data: volMa20, type: 'line', borderColor: '#feca57', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
+                { label: 'Vol MA60', data: volMa60, type: 'line', borderColor: '#54a0ff', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 }
             ]
         },
         options: {
@@ -308,11 +315,11 @@ function renderStockChart(period) {
                         pointStyle: 'line',
                         boxWidth: 20,
                         filter: function(item, chart) {
-                            return item.text.includes('MA') || item.text.includes('BB');
+                            return item.text.includes('MA') || item.text.includes('BB') || item.text.includes('Vol MA');
                         },
                         generateLabels: function(chart) {
                             const original = Chart.defaults.plugins.legend.labels.generateLabels(chart);
-                            return original.filter(item => item.text.includes('MA') || item.text.includes('BB')).map(item => {
+                            return original.filter(item => item.text.includes('MA') || item.text.includes('BB') || item.text.includes('Vol MA')).map(item => {
                                 item.pointStyle = 'line';
                                 return item;
                             });


### PR DESCRIPTION
수정 파일 2개:

services/indicator_service.py

_compute_ma에 source_col='close' 파라미터 추가 → df['close'] 하드코딩 제거, 볼륨 등 임의 컬럼 재활용 가능 _calculate_indicators_full에서 volume 컬럼 수치 변환 후 vol_ma5/20/60 계산 추가 indicators 결과 dict에 vol_ma5, vol_ma20, vol_ma60 추출 추가 view/web/static/js/candle_chart.js

volMa5/20/60 배열 선언 추가
데이터 루프에서 ind.vol_ma5/20/60 인덱싱으로 채움 (null-safe guard 포함) y1 축에 Vol MA5(빨강), Vol MA20(노랑), Vol MA60(파랑) line 데이터셋 3개 추가 legend filter에 Vol MA 명시 추가
동작 흐름:

API /chart/{code}?indicators=true
  → get_ohlcv_with_indicators
    → _calculate_indicators_full  ← vol_ma5/20/60 추가
      → candle_chart.js           ← y1 축 라인 렌더링

변경 요약:

services/indicator_service.py — _compute_ma에 source_col 파라미터 추가, _calculate_indicators_full에 vol_ma5/20/60 계산 및 추출 추가 view/web/static/js/candle_chart.js — volMa5/20/60 배열 선언, 루프에서 데이터 추출, y1 축에 line 데이터셋 3개 추가, legend filter 정비 tests/unit_test/services/test_indicator_service.py — 기존 TC 2개 수정(volume 필드 추가 + vol_ma 키 assert), 신규 TC 6개 추가