### PR TITLE
버그 요약:

### DIFF
--- a/scheduler/after_market_loop.py
+++ b/scheduler/after_market_loop.py
@@ -92,7 +92,16 @@ async def run_after_market_loop(
                 await mcs.get_latest_trading_date() if mcs else None
             )
             if latest_trading_date:
-                await on_market_closed(latest_trading_date)
+                today_str = (
+                    market_clock.get_current_kst_date_str() if market_clock else None
+                )
+                if today_str and latest_trading_date != today_str:
+                    # 오늘이 휴장일(주말·공휴일): 최신 거래일 != 오늘이므로 콜백 스킵
+                    _log.info(
+                        f"[{label}] 오늘({today_str})은 휴장일 — 콜백 스킵 (latest={latest_trading_date})"
+                    )
+                else:
+                    await on_market_closed(latest_trading_date)
 
             # ── 3. 스마트 대기: 다음 장 마감까지 ──
             try:

--- a/tests/unit_test/scheduler/test_after_market_loop.py
+++ b/tests/unit_test/scheduler/test_after_market_loop.py
@@ -92,6 +92,7 @@ class TestRunAfterMarketLoop:
         tm = MagicMock()
         # 0.1 < 3600 이므로 1b 체크(장 시작 전 guard)가 트리거되지 않음
         tm.get_sleep_seconds_until_market_close.return_value = 0.1
+        tm.get_current_kst_date_str.return_value = "20260318"
 
         callback_called = False
 

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -508,8 +508,10 @@ async def test_after_market_scheduler_triggers_refresh(mock_deps):
     broker, mapper, env, logger, market_clock, market_calendar_service = mock_deps
     market_calendar_service.is_market_open_now.return_value = False  # 장마감
     market_calendar_service.is_business_day.return_value = True
+    market_calendar_service.get_latest_trading_date = AsyncMock(return_value="20260316")
     market_clock.get_sleep_seconds_until_market_close.return_value = 0.0
     market_clock.get_current_kst_time.return_value = datetime(2026, 3, 16, 16, 0, 0)
+    market_clock.get_current_kst_date_str.return_value = "20260316"
 
     market_data_service = MagicMock()
     market_data_service.get_top_rise_fall_stocks = AsyncMock(
@@ -784,6 +786,8 @@ async def test_start_after_market_scheduler_exception_handling(bg_service, mock_
     import asyncio
     _, _, _, logger, market_clock, market_calendar_service = mock_deps
     market_calendar_service.is_market_open_now.return_value = False
+    market_clock.get_sleep_seconds_until_market_close.return_value = 0.0
+    market_clock.get_current_kst_date_str.return_value = "20250101"
 
     # refresh_basic_ranking에서 예외 발생
     bg_service.refresh_basic_ranking = AsyncMock(side_effect=Exception("Scheduler Error"))


### PR DESCRIPTION
장소: scheduler/after_market_loop.py:91-95
원인: 주말/공휴일 15:40 이후 secs_until_close ≤ 0이 되어 step 1b 가드를 통과 → get_latest_trading_date()가 마지막 영업일(예: 금요일) 반환 → 콜백 중복 실행
수정: latest_trading_date != today_str이면 콜백 스킵. 오늘이 휴장일이면 최신 거래일 ≠ 오늘이 되므로 자연스럽게 가드됨
정상 케이스 영향 없음: 평일 장 마감 직후엔 latest_trading_date == today_str이므로 그대로 실행됨