### PR TITLE
수정 완료. 캐시 반환 조건:

### DIFF
--- a/services/market_calendar_service.py
+++ b/services/market_calendar_service.py
@@ -34,9 +34,15 @@ class MarketCalendarService:
         """오늘을 포함하여 가장 최근에 장이 열렸던 영업일(YYYYMMDD)을 반환합니다."""
         current_date = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
 
-        # 캐시가 있고, 오늘 이미 확인했다면 캐시 반환
+        # 캐시가 있고 오늘 이미 확인했더라도,
+        # 장마감 후 캐시된 날짜가 오늘이 아니면 재조회 (장전 캐시가 장후에도 남는 문제 방지)
         if self._cached_date and self._last_check_date == current_date:
-            return self._cached_date
+            after_close = (
+                self._market_clock.get_current_kst_time()
+                >= self._market_clock.get_market_close_time()
+            )
+            if not after_close or self._cached_date == current_date:
+                return self._cached_date
 
         if not self._broker:
             self._logger.warning("MarketCalendarService: Broker is not set.")

--- a/tests/unit_test/services/test_market_calendar_service.py
+++ b/tests/unit_test/services/test_market_calendar_service.py
@@ -73,7 +73,7 @@ async def test_get_latest_trading_date_cached(manager, mock_deps):
     manager._last_check_date = "20250101"
     
     # Current date matches last check date
-    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 15, 0, 0)
+    tm.get_current_kst_time.return_value = tm.market_timezone.localize(datetime(2025, 1, 1, 15, 0, 0))
     
     result = await manager.get_latest_trading_date()
     assert result == "20250101"

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -187,6 +187,7 @@ def test_get_background_status_returns_task_info(web_client, mock_web_ctx):
     assert item["name"] == "ranking_refresh"
     assert item["state"] == "running"
     assert item["priority"] == 100
+    assert item["delay_sec"] == 300  # 5분 * 60초
     assert item["progress"]["running"] is True
     assert item["progress"]["processed"] == 100
     assert item["progress"]["total"] == 500
@@ -247,14 +248,17 @@ def test_get_background_status_multiple_tasks(web_client, mock_web_ctx):
     # 배치 태스크 진행률
     assert by_name["ranking_refresh"]["progress"]["total"] == 2500
     assert by_name["ranking_refresh"]["progress"]["running"] is False
+    assert by_name["ranking_refresh"]["delay_sec"] == 300  # 5분
 
     # 웹소켓 워치독: market_open 포함
     assert by_name["websocket_watchdog"]["progress"]["market_open"] is True
     assert by_name["websocket_watchdog"]["progress"]["subscribed_codes"] == 3
+    assert by_name["websocket_watchdog"]["delay_sec"] == 0  # 딜레이 없음
 
     # 전략 스케줄러: 전략 카운트
     assert by_name["strategy_scheduler"]["progress"]["active_strategies"] == 2
     assert by_name["strategy_scheduler"]["progress"]["total_strategies"] == 3
+    assert by_name["strategy_scheduler"]["delay_sec"] == 0  # 딜레이 없음
 
 
 def test_get_background_status_calls_get_progress_via_interface(web_client, mock_web_ctx):
@@ -319,6 +323,10 @@ def test_get_background_status_module_names(web_client, mock_web_ctx):
     assert types["t3"] == "intraday"
     assert types["t4"] == "intraday"
     assert types["t5"] == "unknown"
+
+    # 모든 태스크명이 task_config.yaml에 없으므로 delay_sec은 0
+    delays = {item["name"]: item["delay_sec"] for item in data}
+    assert all(v == 0 for v in delays.values())
 
 
 def test_get_background_status_idle_with_internal_flag(web_client, mock_web_ctx):

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -6,6 +6,7 @@ import time
 from fastapi import APIRouter, HTTPException
 from view.web.api_common import _get_ctx
 import view.web.api_common as api_common
+from config.task_config_loader import load_after_market_delays
 
 router = APIRouter()
 
@@ -111,6 +112,8 @@ async def get_background_status():
     if not ctx.background_scheduler:
         return {"success": True, "foreground": foreground_info, "data": []}
 
+    delays = load_after_market_delays()  # {task_name: delay_sec}
+
     result = []
     for item in ctx.background_scheduler.get_all_status():
         name = item["name"]
@@ -160,11 +163,12 @@ async def get_background_status():
             "priority": item.get("priority"),
             "schedule_type": schedule_type,
             "schedule_order": _SCHEDULE_ORDER.get(schedule_type, 99),
+            "delay_sec": delays.get(name, 0),
             "progress": progress,
         })
 
-    # 스케줄 유형(실시간 -> 장중 -> 장마감) 순서로 정렬
-    result.sort(key=lambda x: x["schedule_order"])
+    # 스케줄 유형(실시간 -> 장중 -> 장마감) 순서로 정렬, 같은 유형 내에서는 실행 순서(delay_sec) 기준
+    result.sort(key=lambda x: (x["schedule_order"], x["delay_sec"]))
     return {"success": True, "foreground": foreground_info, "data": result}
 
 

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -425,9 +425,13 @@ async function updateBackgroundStatus() {
             const schHtml = schBadge
                 ? `<span style="background:${schBadge.color}; color:#fff; padding:1px 6px; border-radius:8px; font-size:0.75em; margin-left:6px; vertical-align:middle;">${schBadge.label}</span>`
                 : '';
+            const delayMin = task.delay_sec ? Math.round(task.delay_sec / 60) : 0;
+            const delayHtml = delayMin > 0
+                ? `<span style="color:#aaa; font-size:0.75em; margin-left:5px; vertical-align:middle;">+${delayMin}m</span>`
+                : '';
             return `
                 <tr>
-                    <td style="font-weight:bold; color:var(--text-color);">${task.name}${schHtml}</td>
+                    <td style="font-weight:bold; color:var(--text-color);">${task.name}${schHtml}${delayHtml}</td>
                     <td><span style="background:${badge.color}; color:#fff; padding:2px 8px; border-radius:10px; font-size:0.82em; font-weight:bold;">${badge.label}</span></td>
                     <td style="font-size:0.88em; color:#888;">${priorityLabel}</td>
                     <td>${progressHtml}</td>

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -121,5 +121,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=14"></script>
+<script src="/static/js/system.js?v=15"></script>
 {% endblock %}


### PR DESCRIPTION
장마감 전 (not after_close): 캐시 그대로 사용 ✅
장마감 후 + _cached_date == current_date (이미 당일 거래일로 갱신됨): 캐시 사용 ✅
장마감 후 + _cached_date != current_date (장전에 캐시된 전날 날짜): 캐시 무효 → API 재조회 → "20260421" 반환 → TimeDispatcher 티켓 발행 ✅