### PR TITLE
현재 문제를 분석해보면:

### DIFF
--- a/scheduler/dispatcher/time_dispatcher.py
+++ b/scheduler/dispatcher/time_dispatcher.py
@@ -32,8 +32,6 @@ class TimeDispatcher:
 
     POLL_INTERVAL: int = 60  # seconds
 
-    _DB_KEY = "last_dispatched_date"
-
     def __init__(
         self,
         broker: MessageBroker,
@@ -52,7 +50,7 @@ class TimeDispatcher:
         self._sleep_task: Optional[asyncio.Task] = None
         self._pending_publish_tasks: Set[asyncio.Task] = set()
         self._db_path = db_path or os.path.join("data", "time_dispatcher_state.db")
-        self._last_dispatched_date: Optional[str] = self._load_state()
+        self._task_dispatched_dates: Dict[str, str] = self._load_state()  # task_name → date
         self._last_dispatched_at: Optional[float] = None
 
     def _init_db(self) -> None:
@@ -63,22 +61,20 @@ class TimeDispatcher:
                 "(key TEXT PRIMARY KEY, value TEXT)"
             )
 
-    def _load_state(self) -> Optional[str]:
+    def _load_state(self) -> Dict[str, str]:
         self._init_db()
         with sqlite3.connect(self._db_path) as conn:
-            row = conn.execute(
-                "SELECT value FROM dispatch_state WHERE key = ?", (self._DB_KEY,)
-            ).fetchone()
-        date = row[0] if row else None
-        if date:
-            self._logger.info(f"[TimeDispatcher] 마지막 발행 거래일 복원: {date}")
-        return date
+            rows = conn.execute("SELECT key, value FROM dispatch_state").fetchall()
+        result = {row[0]: row[1] for row in rows if row[1]}
+        if result:
+            self._logger.info(f"[TimeDispatcher] 태스크별 발행 이력 복원: {result}")
+        return result
 
-    def _save_state(self, date: str) -> None:
+    def _save_state(self, task_name: str, date: str) -> None:
         with sqlite3.connect(self._db_path) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO dispatch_state (key, value) VALUES (?, ?)",
-                (self._DB_KEY, date),
+                (task_name, date),
             )
 
     def register_task(self, task_name: str, priority: int = TaskPriority.LOW, delay_sec: int = 0) -> None:
@@ -118,7 +114,7 @@ class TimeDispatcher:
         self._logger.info("[TimeDispatcher] 폴링 종료")
 
     async def _maybe_dispatch(self) -> None:
-        """조건 충족 시 등록된 모든 태스크 티켓을 발행한다."""
+        """조건 충족 시 미발행 태스크의 티켓을 발행한다."""
         if self._market_clock.is_market_operating_hours():
             return
 
@@ -126,18 +122,23 @@ class TimeDispatcher:
         if not latest_trading_date:
             return
 
-        if latest_trading_date == self._last_dispatched_date:
-            return  # 이미 이 거래일 발행 완료
+        pending = [
+            (name, priority)
+            for name, priority in self._task_schedule.items()
+            if self._task_dispatched_dates.get(name) != latest_trading_date
+        ]
+        if not pending:
+            return
 
         self._logger.info(
             f"[TimeDispatcher] 장 마감 감지 (거래일: {latest_trading_date}) — "
-            f"{len(self._task_schedule)}개 티켓 예약"
+            f"{len(pending)}개 티켓 예약"
         )
-        self._last_dispatched_date = latest_trading_date
         self._last_dispatched_at = time.time()
-        self._save_state(latest_trading_date)
 
-        for task_name, priority in self._task_schedule.items():
+        for task_name, priority in pending:
+            # 메모리에 즉시 기록해 같은 세션에서 중복 발행 방지
+            self._task_dispatched_dates[task_name] = latest_trading_date
             delay = self._task_delays.get(task_name, 0)
             t = asyncio.create_task(
                 self._publish_after_delay(task_name, priority, latest_trading_date, delay)
@@ -153,8 +154,11 @@ class TimeDispatcher:
         ticket = Ticket(priority=priority, task_name=task_name, payload={"date": date})
         published = await self._broker.publish(ticket)
         if published:
+            self._save_state(task_name, date)  # 발행 성공 후에만 DB 영속화
             self._logger.info(f"[TimeDispatcher] 티켓 발행: {task_name} ({date})")
         else:
+            # 메모리에서 제거 → 다음 폴링 주기에 재시도 가능
+            self._task_dispatched_dates.pop(task_name, None)
             self._logger.warning(f"[TimeDispatcher] 티켓 발행 실패 (큐 포화): {task_name}")
 
     def get_status(self) -> dict:
@@ -166,7 +170,7 @@ class TimeDispatcher:
             except Exception:
                 pass
         return {
-            "last_dispatched_date": self._last_dispatched_date,
+            "task_dispatched_dates": dict(self._task_dispatched_dates),
             "last_dispatched_at": self._last_dispatched_at,
             "market_is_open": market_is_open,
             "registered_tasks": [

--- a/tests/unit_test/scheduler/test_time_dispatcher.py
+++ b/tests/unit_test/scheduler/test_time_dispatcher.py
@@ -87,17 +87,17 @@ async def test_stop_exits_run_loop(db_path):
 # ── SQLite 영속화 TC ─────────────────────────────────────────────────────────
 
 async def test_state_updated_in_memory_after_dispatch(db_path):
-    """발행 후 _last_dispatched_date가 즉시 갱신된다."""
+    """발행 후 _task_dispatched_dates가 즉시 갱신된다."""
     dispatcher, _ = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
     dispatcher.register_task("RANKING_UPDATE", priority=100)
 
-    assert dispatcher._last_dispatched_date is None
+    assert dispatcher._task_dispatched_dates.get("RANKING_UPDATE") is None
     await dispatcher._maybe_dispatch()
-    assert dispatcher._last_dispatched_date == "20250417"
+    assert dispatcher._task_dispatched_dates.get("RANKING_UPDATE") == "20250417"
 
 
 async def test_last_dispatched_date_persisted_to_db(db_path):
-    """발행 후 거래일이 SQLite에 저장되어 새 인스턴스에서 복원된다."""
+    """발행 후 거래일이 태스크별로 SQLite에 저장되어 새 인스턴스에서 복원된다."""
     dispatcher, broker = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
     dispatcher.register_task("RANKING_UPDATE", priority=100)
     await dispatcher._maybe_dispatch()
@@ -106,7 +106,7 @@ async def test_last_dispatched_date_persisted_to_db(db_path):
 
     # 새 인스턴스에서 같은 DB를 열면 날짜가 복원됨
     dispatcher2, _ = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
-    assert dispatcher2._last_dispatched_date == "20250417"
+    assert dispatcher2._task_dispatched_dates.get("RANKING_UPDATE") == "20250417"
 
 
 async def test_no_duplicate_ticket_after_restart(db_path):
@@ -144,7 +144,61 @@ async def test_new_date_dispatched_after_restart(db_path):
     assert ticket.payload["date"] == "20250417"
 
 
-async def test_initial_load_none_when_db_is_empty(db_path):
-    """DB가 비어 있으면 _last_dispatched_date는 None으로 초기화된다."""
+async def test_initial_load_empty_when_db_is_empty(db_path):
+    """DB가 비어 있으면 _task_dispatched_dates는 빈 딕셔너리로 초기화된다."""
     dispatcher, _ = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
-    assert dispatcher._last_dispatched_date is None
+    assert dispatcher._task_dispatched_dates == {}
+
+
+# ── 태스크별 개별 발행 이력 TC ───────────────────────────────────────────────
+
+async def test_partial_restart_dispatches_only_pending_tasks(db_path):
+    """재시작 전 일부 태스크만 발행된 경우, 미발행 태스크만 재시작 후 발행된다."""
+    # TASK_A는 이미 발행 성공 → DB에 저장됨, TASK_B는 미발행
+    dispatcher_prep, _ = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
+    dispatcher_prep._save_state("TASK_A", "20250417")
+
+    # 재시작 시뮬레이션
+    dispatcher2, broker2 = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
+    dispatcher2.register_task("TASK_A", priority=100)
+    dispatcher2.register_task("TASK_B", priority=100)
+
+    await dispatcher2._maybe_dispatch()
+    await _drain(dispatcher2)
+
+    assert broker2.qsize == 1
+    ticket = await broker2.consume()
+    broker2.task_done()
+    assert ticket.task_name == "TASK_B"
+
+
+async def test_each_task_tracked_independently(db_path):
+    """태스크별 발행 이력이 독립적으로 관리된다."""
+    dispatcher, broker = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
+    dispatcher.register_task("TASK_A", priority=100)
+    dispatcher.register_task("TASK_B", priority=90)
+
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
+    assert broker.qsize == 2
+    assert dispatcher._task_dispatched_dates.get("TASK_A") == "20250417"
+    assert dispatcher._task_dispatched_dates.get("TASK_B") == "20250417"
+
+
+async def test_new_task_registered_after_dispatch_gets_ticket_on_next_date(db_path):
+    """기존 태스크 발행 후, 새로 등록된 태스크는 다음 거래일에 정상 발행된다."""
+    dispatcher, _ = _make_dispatcher(is_operating=False, latest_date="20250416", db_path=db_path)
+    dispatcher.register_task("TASK_A", priority=100)
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
+    # 재시작 후 새 거래일 + 새 태스크 추가
+    dispatcher2, broker2 = _make_dispatcher(is_operating=False, latest_date="20250417", db_path=db_path)
+    dispatcher2.register_task("TASK_A", priority=100)
+    dispatcher2.register_task("TASK_B", priority=90)  # 새로 추가된 태스크
+
+    await dispatcher2._maybe_dispatch()
+    await _drain(dispatcher2)
+
+    assert broker2.qsize == 2


### PR DESCRIPTION
_maybe_dispatch()에서 _last_dispatched_date를 태스크 생성 시점에 바로 저장 일부 태스크만 발행되고 재시작되면 DB에는 해당 날짜가 기록되어 모든 태스크가 완료된 것으로 오판 수정 방향: 단일 날짜 대신 {task_name → date} 딕셔너리로 태스크별 발행 이력 관리. DB 저장은 발행 성공 후에만.

변경 요약:

time_dispatcher.py

_last_dispatched_date: Optional[str] → _task_dispatched_dates: Dict[str, str] (태스크별 발행 날짜) _maybe_dispatch(): 전체 날짜 비교 대신 태스크별로 미발행 태스크만 필터링
_publish_after_delay(): DB 저장을 발행 성공 후로 이동. 실패 시 메모리에서 제거해 다음 폴링에서 재시도 가능 _DB_KEY 상수 제거, get_status() 반환값 업데이트
test_time_dispatcher.py

기존 TC: _last_dispatched_date → _task_dispatched_dates 참조 수정 신규 TC 3개 추가:
test_partial_restart_dispatches_only_pending_tasks: 핵심 버그 시나리오 검증 test_each_task_tracked_independently: 태스크별 독립 이력 관리 검증 test_new_task_registered_after_dispatch_gets_ticket_on_next_date: 새 태스크 추가 후 다음 거래일 발행 검증