### PR TITLE
실시간 체결가 누락 진단 1차 구현을 끝냈습니다.

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -368,8 +368,6 @@ class KoreaInvestWebSocketAPI:
                     self._logger.info(f"실시간 요청 응답 성공: TR_KEY={tr_key}, MSG={json_object['body']['msg1']}")
                     if tr_type == "1":
                         self._subscribed_items.add((tr_id, tr_key))
-                    elif tr_type == "2":
-                        self._subscribed_items.discard((tr_id, tr_key))
                     # 체결통보용 AES KEY, IV 수신 처리
                     if tr_id in ["H0IFCNI0", "H0STCNI0", "H0STCNI9", "H0MFCNI0", "H0EUCNI0"] and json_object.get("body",
                                                                                                                  {}).get(
@@ -738,6 +736,8 @@ class KoreaInvestWebSocketAPI:
         try:
             await self.ws.send(message_json)
             self._pending_requests[(tr_id, tr_key)] = {"tr_type": tr_type}
+            if tr_type == "2":
+                self._subscribed_items.discard((tr_id, tr_key))
             return True
         except Exception as e:
             self._logger.exception(f"실시간 요청 전송 중 오류 발생: {e}")

--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -69,6 +69,7 @@ class KoreaInvestWebSocketAPI:
 
         # 재연결 시 복구를 위한 구독 목록 저장소 set((tr_id, tr_key))
         self._subscribed_items = set()
+        self._pending_requests = {}
 
         # 서버가 appkey 중복 사용을 거부한 경우 True → 다음 재연결 시 긴 대기 적용
         self._appkey_collision = False
@@ -361,7 +362,14 @@ class KoreaInvestWebSocketAPI:
                     self._logger.debug("PINGPONG 수신됨. PONG 응답.")
                     # websockets 라이브러리 내부에서 PONG 응답 자동 처리 (ping_interval, ping_timeout 설정 시)
                 elif json_object.get("body", {}).get("rt_cd") == '0':
-                    self._logger.info(f"실시간 요청 응답 성공: TR_KEY={header.get('tr_key')}, MSG={json_object['body']['msg1']}")
+                    tr_key = header.get('tr_key')
+                    pending = self._pending_requests.pop((tr_id, tr_key), None)
+                    tr_type = pending.get("tr_type") if pending else header.get("tr_type")
+                    self._logger.info(f"실시간 요청 응답 성공: TR_KEY={tr_key}, MSG={json_object['body']['msg1']}")
+                    if tr_type == "1":
+                        self._subscribed_items.add((tr_id, tr_key))
+                    elif tr_type == "2":
+                        self._subscribed_items.discard((tr_id, tr_key))
                     # 체결통보용 AES KEY, IV 수신 처리
                     if tr_id in ["H0IFCNI0", "H0STCNI0", "H0STCNI9", "H0MFCNI0", "H0EUCNI0"] and json_object.get("body",
                                                                                                                  {}).get(
@@ -370,14 +378,23 @@ class KoreaInvestWebSocketAPI:
                         self._aes_iv = json_object["body"]["output"].get("iv")
                         self._logger.info(f"체결통보용 AES KEY/IV 수신 성공. TRID={tr_id}")
                 else:
+                    tr_key = header.get('tr_key')
+                    pending = self._pending_requests.pop((tr_id, tr_key), None)
+                    tr_type = pending.get("tr_type") if pending else header.get("tr_type")
                     msg1 = json_object.get("body", {}).get("msg1", "")
                     self._logger.error(
-                        f"실시간 요청 응답 오류: TR_KEY={header.get('tr_key')}, RT_CD={json_object.get('body', {}).get('rt_cd')}, MSG={msg1}")
+                        f"실시간 요청 응답 오류: TR_KEY={tr_key}, RT_CD={json_object.get('body', {}).get('rt_cd')}, MSG={msg1}")
                     if msg1 == 'ALREADY IN SUBSCRIBE':
                         self._logger.warning("이미 구독 중인 종목입니다.")
+                        self._subscribed_items.add((tr_id, tr_key))
                     elif 'ALREADY IN USE' in msg1:
                         self._logger.warning("서버가 appkey 중복 사용을 거부했습니다. 재연결 시 대기 시간을 늘립니다.")
                         self._appkey_collision = True
+                    elif self._streaming_logger:
+                        if tr_type == "2":
+                            self._streaming_logger.log_unsubscribe_failure(tr_key or tr_id, msg1 or "ACK error")
+                        else:
+                            self._streaming_logger.log_subscribe_failure(tr_key or tr_id, msg1 or "ACK error")
             except json.JSONDecodeError:
                 self._logger.exception(f"제어 메시지 JSON 디코딩 실패: {message}")
             except Exception as e:
@@ -686,9 +703,19 @@ class KoreaInvestWebSocketAPI:
 
         if not self._is_connected or not self.ws:
             self._logger.error("웹소켓이 연결되어 있지 않아 실시간 요청을 보낼 수 없습니다.")
+            if self._streaming_logger:
+                if tr_type == "2":
+                    self._streaming_logger.log_unsubscribe_failure(tr_key, "WebSocket 미연결")
+                else:
+                    self._streaming_logger.log_subscribe_failure(tr_key, "WebSocket 미연결")
             return False
         if not self.approval_key:
             self._logger.error("approval_key가 없어 실시간 요청을 보낼 수 없습니다.")
+            if self._streaming_logger:
+                if tr_type == "2":
+                    self._streaming_logger.log_unsubscribe_failure(tr_key, "approval_key 없음")
+                else:
+                    self._streaming_logger.log_subscribe_failure(tr_key, "approval_key 없음")
             return False
 
         header = {
@@ -710,15 +737,17 @@ class KoreaInvestWebSocketAPI:
         self._logger.info(f"실시간 요청 전송: TR_ID={tr_id}, TR_KEY={tr_key}, TYPE={tr_type}")
         try:
             await self.ws.send(message_json)
-            
-            # 구독 목록 관리
-            if tr_type == "1":
-                self._subscribed_items.add((tr_id, tr_key))
-            elif tr_type == "2":
-                self._subscribed_items.discard((tr_id, tr_key))
+            self._pending_requests[(tr_id, tr_key)] = {"tr_type": tr_type}
             return True
         except Exception as e:
             self._logger.exception(f"실시간 요청 전송 중 오류 발생: {e}")
+            self._pending_requests.pop((tr_id, tr_key), None)
+            if self._streaming_logger:
+                message = f"실시간 요청 전송 예외: {e}"
+                if tr_type == "2":
+                    self._streaming_logger.log_unsubscribe_failure(tr_key, message)
+                else:
+                    self._streaming_logger.log_subscribe_failure(tr_key, message)
             self._is_connected = False
             self.ws = None
             return False

--- a/core/loggers/streaming_event_logger.py
+++ b/core/loggers/streaming_event_logger.py
@@ -306,9 +306,9 @@ class StreamingEventLogger:
         self,
         receive_alive: bool,
         data_gap_sec: float,
-        price_data_gap_sec: float | None,
         market_open: bool,
         subscribed_count: int,
+        price_data_gap_sec: float | None = None,
     ) -> None:
         """워치독 주기 체크 결과 스냅샷.
 

--- a/core/loggers/streaming_event_logger.py
+++ b/core/loggers/streaming_event_logger.py
@@ -306,6 +306,7 @@ class StreamingEventLogger:
         self,
         receive_alive: bool,
         data_gap_sec: float,
+        price_data_gap_sec: float | None,
         market_open: bool,
         subscribed_count: int,
     ) -> None:
@@ -323,6 +324,7 @@ class StreamingEventLogger:
             "action": "watchdog_check",
             "receive_alive": receive_alive,
             "data_gap_sec": round(data_gap_sec, 1),
+            "price_data_gap_sec": round(price_data_gap_sec, 1) if price_data_gap_sec is not None else None,
             "market_open": market_open,
             "subscribed_count": subscribed_count,
         })
@@ -447,6 +449,31 @@ class StreamingEventLogger:
             "action": "pt_data_gap",
             "data_gap_sec": round(data_gap_sec, 1),
             "threshold_sec": threshold_sec,
+        })
+
+    def log_price_data_gap(self, data_gap_sec: float, threshold_sec: int) -> None:
+        """체결가 데이터 수신 갭이 임계값을 초과함."""
+        self._logger.warning({
+            "action": "price_data_gap",
+            "data_gap_sec": round(data_gap_sec, 1),
+            "threshold_sec": threshold_sec,
+        })
+
+    def log_stale_price_codes(self, codes: list[str]) -> None:
+        """일부 체결가 구독 종목만 stale 상태임."""
+        if not codes:
+            return
+        self._logger.warning({
+            "action": "stale_price_codes",
+            "codes": sorted(codes),
+        })
+
+    def log_missing_reason(self, code: str, reason: str) -> None:
+        """체결가 누락 원인을 구조화 로그로 기록한다."""
+        self._logger.warning({
+            "action": "missing_reason",
+            "code": code,
+            "reason": reason,
         })
 
     def log_watchdog_error(self, message: str) -> None:

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -36,6 +36,9 @@ class PriceStreamService:
         self._logger = logger or logging.getLogger(__name__)
         self._latest_prices: Dict[str, dict] = {}
         self._sse_queues: Dict[str, List[asyncio.Queue]] = {}  # code → SSE 구독 큐 목록
+        self._last_tick_ts: Dict[str, float] = {}
+        self._last_any_tick_ts: float = 0.0
+        self._subscription_requested_ts: Dict[str, float] = {}
 
     def on_price_tick(self, realtime_data: dict) -> None:
         """
@@ -50,12 +53,16 @@ class PriceStreamService:
         if not stock_code or not current_price:
             return
 
+        now_ts = time.time()
+        self._last_tick_ts[stock_code] = now_ts
+        self._last_any_tick_ts = now_ts
+
         self._latest_prices[stock_code] = {
             "price": current_price,
             "change": realtime_data.get('전일대비', '0'),
             "rate": realtime_data.get('전일대비율', '0.00'),
             "sign": realtime_data.get('전일대비부호', '3'),
-            "received_at": time.time(),
+            "received_at": now_ts,
         }
 
         try:
@@ -92,6 +99,51 @@ class PriceStreamService:
     def get_cached_price(self, code: str) -> Optional[dict]:
         """메모리 캐시에서 최신가 정보를 반환한다."""
         return self._latest_prices.get(code)
+
+    def mark_subscription_requested(self, code: str) -> None:
+        """체결가 구독 요청 시각을 기록한다."""
+        if code:
+            self._subscription_requested_ts[code] = time.time()
+
+    def clear_subscription_state(self, code: str) -> None:
+        """구독 해제 시 감시용 상태를 정리한다."""
+        self._subscription_requested_ts.pop(code, None)
+        self._last_tick_ts.pop(code, None)
+        self._latest_prices.pop(code, None)
+
+    def get_last_tick_ts(self, code: str) -> float:
+        """종목별 마지막 틱 수신 시각(epoch)을 반환한다."""
+        return self._last_tick_ts.get(code, 0.0)
+
+    def get_last_any_tick_ts(self) -> float:
+        """전체 체결가 스트림의 마지막 틱 수신 시각(epoch)을 반환한다."""
+        return self._last_any_tick_ts
+
+    def get_subscription_age(self, code: str) -> float:
+        """종목 구독 요청 이후 경과 시간(초)을 반환한다."""
+        requested_ts = self._subscription_requested_ts.get(code, 0.0)
+        if requested_ts <= 0:
+            return 0.0
+        return max(0.0, time.time() - requested_ts)
+
+    def get_stale_codes(self, threshold_sec: float, codes: Optional[List[str]] = None) -> List[str]:
+        """임계값 이상 틱이 없던 종목 목록을 반환한다."""
+        now_ts = time.time()
+        target_codes = codes or list(self._last_tick_ts.keys())
+        stale_codes: List[str] = []
+
+        for code in target_codes:
+            last_tick_ts = self._last_tick_ts.get(code, 0.0)
+            if last_tick_ts > 0:
+                if (now_ts - last_tick_ts) > threshold_sec:
+                    stale_codes.append(code)
+                continue
+
+            requested_ts = self._subscription_requested_ts.get(code, 0.0)
+            if requested_ts > 0 and (now_ts - requested_ts) > threshold_sec:
+                stale_codes.append(code)
+
+        return sorted(stale_codes)
 
     def create_subscriber_queue(self, code: str) -> asyncio.Queue:
         """SSE 클라이언트용 큐를 생성하고 등록한다."""

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -18,7 +18,8 @@ class StockQueryService:
     def __init__(self, market_data_service: MarketDataService, logger, market_clock, indicator_service=None,
                  ranking_task=None, performance_profiler: Optional[PerformanceProfiler] = None,
                  notification_service: Optional[NotificationService] = None,
-                 broker_api_wrapper=None):
+                 broker_api_wrapper=None,
+                 streaming_logger=None):
         self.broker = broker_api_wrapper
         self.market_data_service = market_data_service
         self.logger = logger
@@ -27,6 +28,7 @@ class StockQueryService:
         self.ranking_task = ranking_task
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._notification_service = notification_service
+        self._streaming_logger = streaming_logger
 
     def _get_sign_from_code(self, sign_code):
         """API 응답의 부호 코드(1,2,3,4,5)를 실제 부호 문자열로 변환합니다."""
@@ -73,6 +75,8 @@ class StockQueryService:
         if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
             msg = resp.msg1 if resp else "응답 없음"
             self.logger.error(f"{stock_code} 현재가 및 상세 정보 조회 실패: {msg}")
+            if self._streaming_logger:
+                self._streaming_logger.log_missing_reason(stock_code, "rest_failed")
             if self._notification_service:
                 await self._notification_service.emit(NotificationCategory.SYSTEM, NotificationLevel.WARNING, "현재가 조회 실패",
                                     f"{stock_code} - {msg}",

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from services.market_data_service import MarketDataService
     from services.price_stream_service import PriceStreamService
     from core.logger import StreamingEventLogger
+    from repositories.streaming_stock_repo import StreamingStockRepo
 
 
 class StreamingService:
@@ -45,6 +46,7 @@ class StreamingService:
         market_data_service: Optional["MarketDataService"] = None,
         streaming_logger: Optional["StreamingEventLogger"] = None,
         price_stream_service: Optional["PriceStreamService"] = None,
+        streaming_stock_repo: Optional["StreamingStockRepo"] = None,
     ):
         self.broker = broker_api_wrapper
         self.logger = logger
@@ -52,6 +54,7 @@ class StreamingService:
         self.market_data_service = market_data_service
         self._streaming_logger = streaming_logger
         self._price_stream_service: Optional["PriceStreamService"] = None
+        self._streaming_stock_repo: Optional["StreamingStockRepo"] = streaming_stock_repo
         self._last_console_print_time: float = 0.0
         self._PRINT_THROTTLE_SEC: float = 0.5
         self._callback = None  # 재연결 시 콜백 유실 방지용 저장
@@ -92,6 +95,10 @@ class StreamingService:
         self._price_stream_service = svc
         self.register_handler('realtime_price', svc.on_price_tick)
 
+    def set_streaming_stock_repo(self, repo: "StreamingStockRepo") -> None:
+        """StreamingStockRepo를 사후 주입한다."""
+        self._streaming_stock_repo = repo
+
     # ── 연결 수명주기 ──────────────────────────────────────────────
 
     async def connect_websocket(self, callback=None):
@@ -126,19 +133,31 @@ class StreamingService:
 
     async def subscribe_realtime_price(self, code: str):
         """실시간 체결가 구독 (BrokerAPIWrapper 위임)."""
-        return await self.broker.subscribe_realtime_price(code)
+        result = await self.broker.subscribe_realtime_price(code)
+        if result and self._price_stream_service:
+            self._price_stream_service.mark_subscription_requested(code)
+        return result
 
     async def unsubscribe_realtime_price(self, code: str):
         """실시간 체결가 구독 해지 (BrokerAPIWrapper 위임)."""
-        return await self.broker.unsubscribe_realtime_price(code)
+        result = await self.broker.unsubscribe_realtime_price(code)
+        if result and self._price_stream_service:
+            self._price_stream_service.clear_subscription_state(code)
+        return result
 
     async def subscribe_unified_price(self, code: str) -> bool:
         """실시간 통합 체결가(H0UNCNT0) 구독 — PriceSubscriptionService 전용."""
-        return await self.broker.subscribe_unified_price(code)
+        result = await self.broker.subscribe_unified_price(code)
+        if result and self._price_stream_service:
+            self._price_stream_service.mark_subscription_requested(code)
+        return result
 
     async def unsubscribe_unified_price(self, code: str) -> bool:
         """실시간 통합 체결가(H0UNCNT0) 구독 해지 — PriceSubscriptionService 전용."""
-        return await self.broker.unsubscribe_unified_price(code)
+        result = await self.broker.unsubscribe_unified_price(code)
+        if result and self._price_stream_service:
+            self._price_stream_service.clear_subscription_state(code)
+        return result
 
     # ── 고수준 스트림 핸들러 ──────────────────────────────────────
 
@@ -318,6 +337,13 @@ class StreamingService:
         if self._price_stream_service:
             return self._price_stream_service.get_cached_price(code)
         return None
+
+    def is_subscribed_realtime_price(self, code: str) -> bool:
+        """종목이 현재 통합 체결가 desired 구독 상태인지 반환한다."""
+        if not self._streaming_stock_repo:
+            return False
+        from repositories.streaming_stock_repo import StreamingType
+        return code in self._streaming_stock_repo.get_desired(StreamingType.UNIFIED_PRICE)
 
     # ── REST 조회 ─────────────────────────────────────────────────
 

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from services.program_trading_stream_service import ProgramTradingStreamService
     from services.market_calendar_service import MarketCalendarService
     from services.price_subscription_service import PriceSubscriptionService
+    from services.price_stream_service import PriceStreamService
     from repositories.streaming_stock_repo import StreamingStockRepo, StreamingType
     from core.logger import StreamingEventLogger
 
@@ -26,6 +27,10 @@ class WebSocketWatchdogTask(SchedulableTask):
 
     # 재구독 시 패킷 간 딜레이 (초) — 증권사 Rate Limit 방지
     SUBSCRIBE_DELAY_SEC = 0.2
+    WATCHDOG_INTERVAL_SEC = 60
+    PT_DATA_GAP_THRESHOLD_SEC = 300
+    PRICE_DATA_GAP_THRESHOLD_SEC = 180
+    PRICE_SUBSCRIPTION_GRACE_SEC = 30
 
     def __init__(
         self,
@@ -38,6 +43,7 @@ class WebSocketWatchdogTask(SchedulableTask):
         streaming_logger: Optional["StreamingEventLogger"] = None,
         streaming_stock_repo: Optional["StreamingStockRepo"] = None,
         price_subscription_service: Optional["PriceSubscriptionService"] = None,
+        price_stream_service: Optional["PriceStreamService"] = None,
     ):
         self._streaming_service = streaming_service
         self._program_trading_stream_service = program_trading_stream_service
@@ -48,6 +54,7 @@ class WebSocketWatchdogTask(SchedulableTask):
         self._streaming_logger = streaming_logger
         self._streaming_stock_repo = streaming_stock_repo
         self._price_subscription_service = price_subscription_service
+        self._price_stream_service = price_stream_service
 
         # SchedulableTask 상태
         self._state: TaskState = TaskState.IDLE
@@ -136,12 +143,9 @@ class WebSocketWatchdogTask(SchedulableTask):
         PT와 실시간 체결가(H0UNCNT0) 구독 여부를 모두 확인하여,
         둘 중 하나라도 활성 구독이 있으면 감시를 수행한다.
         """
-        WATCHDOG_INTERVAL = 60   # 감시 주기 (초)
-        DATA_GAP_THRESHOLD = 300  # PT 데이터 미수신 허용 최대 시간 (초)
-
         while True:
             try:
-                await asyncio.sleep(WATCHDOG_INTERVAL)
+                await asyncio.sleep(self.WATCHDOG_INTERVAL_SEC)
 
                 # suspend 상태이면 감시 스킵
                 if self._state == TaskState.SUSPENDED:
@@ -151,11 +155,11 @@ class WebSocketWatchdogTask(SchedulableTask):
                 from repositories.streaming_stock_repo import StreamingType
                 pt_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)) \
                     if self._streaming_stock_repo else []
+                price_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.UNIFIED_PRICE)) \
+                    if self._streaming_stock_repo else []
 
                 # 실시간 체결가(H0UNCNT0) 구독 여부 확인
-                has_price_subs = bool(
-                    self._price_subscription_service and self._price_subscription_service._refs
-                )
+                has_price_subs = bool(price_codes)
 
                 # PT 구독도 없고 실시간 체결가 구독도 없으면 감시 불필요
                 if not pt_codes and not has_price_subs:
@@ -191,13 +195,27 @@ class WebSocketWatchdogTask(SchedulableTask):
                     last_ts = self._program_trading_stream_service.last_data_ts
                     data_gap = (time.time() - last_ts) if last_ts > 0 else 0.0
 
+                price_gap = None
+                stale_price_codes = []
+                if has_price_subs and self._price_stream_service:
+                    last_any_tick_ts = self._price_stream_service.get_last_any_tick_ts()
+                    if last_any_tick_ts > 0:
+                        price_gap = time.time() - last_any_tick_ts
+                    stale_price_codes = self._price_stream_service.get_stale_codes(
+                        self.PRICE_DATA_GAP_THRESHOLD_SEC,
+                        codes=price_codes,
+                    )
+
                 if self._streaming_logger:
                     self._streaming_logger.log_watchdog_check(
                         receive_alive=receive_alive,
                         data_gap_sec=data_gap,
+                        price_data_gap_sec=price_gap,
                         market_open=market_is_open,
-                        subscribed_count=len(pt_codes),
+                        subscribed_count=len(pt_codes) + len(price_codes),
                     )
+                    if stale_price_codes:
+                        self._streaming_logger.log_stale_price_codes(stale_price_codes)
 
                 reconnect_trigger = None
                 if not receive_alive:
@@ -210,11 +228,15 @@ class WebSocketWatchdogTask(SchedulableTask):
                         if self._streaming_logger:
                             self._streaming_logger.log_receive_task_dead()
                         reconnect_trigger = "receive_task_dead"
-                elif pt_codes and data_gap > DATA_GAP_THRESHOLD:
+                elif pt_codes and data_gap > self.PT_DATA_GAP_THRESHOLD_SEC:
                     # 수신 태스크는 살아있지만 PT 데이터가 임계값 이상 안 오는 경우
                     if self._streaming_logger:
-                        self._streaming_logger.log_pt_data_gap(data_gap, DATA_GAP_THRESHOLD)
-                    reconnect_trigger = f"data_gap_{data_gap:.0f}s"
+                        self._streaming_logger.log_pt_data_gap(data_gap, self.PT_DATA_GAP_THRESHOLD_SEC)
+                    reconnect_trigger = f"pt_data_gap_{data_gap:.0f}s"
+                elif has_price_subs and price_gap is not None and price_gap > self.PRICE_DATA_GAP_THRESHOLD_SEC:
+                    if self._streaming_logger:
+                        self._streaming_logger.log_price_data_gap(price_gap, self.PRICE_DATA_GAP_THRESHOLD_SEC)
+                    reconnect_trigger = f"price_data_gap_{price_gap:.0f}s"
 
                 if reconnect_trigger:
                     self._intentionally_disconnected = False
@@ -240,10 +262,16 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         last_ts = 0.0
         data_gap = None
+        price_gap = None
         if self._program_trading_stream_service:
             last_ts = getattr(self._program_trading_stream_service, "last_data_ts", 0.0)
             if last_ts > 0:
                 data_gap = round(time.time() - last_ts, 1)
+
+        if self._price_stream_service:
+            last_price_ts = self._price_stream_service.get_last_any_tick_ts()
+            if last_price_ts > 0:
+                price_gap = round(time.time() - last_price_ts, 1)
 
         return {
             "running": self._state == TaskState.RUNNING,
@@ -251,6 +279,7 @@ class WebSocketWatchdogTask(SchedulableTask):
             "subscribed_pt_codes": subscribed_pt,
             "subscribed_price_codes": subscribed_price,
             "data_gap_sec": data_gap,
+            "price_data_gap_sec": price_gap,
             "market_open": self._market_open,
         }
 

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -26,6 +26,8 @@ def test_init(mock_stock_repo, mock_logger):
     assert service._stock_repo == mock_stock_repo
     assert service._logger == mock_logger
     assert service._latest_prices == {}
+    assert service._last_tick_ts == {}
+    assert service._last_any_tick_ts == 0.0
 
 
 def test_on_price_tick_missing_code_or_price(price_stream_service, mock_stock_repo):
@@ -63,6 +65,8 @@ def test_on_price_tick_success(price_stream_service, mock_stock_repo):
     assert cached['sign'] == '2'
     assert 'received_at' in cached
     assert isinstance(cached['received_at'], float)
+    assert price_stream_service.get_last_tick_ts('005930') == cached['received_at']
+    assert price_stream_service.get_last_any_tick_ts() == cached['received_at']
 
     # 2. StockRepository.update_realtime_data 호출 확인
     mock_stock_repo.update_realtime_data.assert_called_once_with('005930', 75000.0, 1500000)
@@ -203,3 +207,51 @@ def test_on_price_tick_broadcasts_even_if_repo_fails(price_stream_service, mock_
     tick = q.get_nowait()
     assert tick["price"] == 75000.0
     assert tick["volume"] == 1000
+
+
+def test_mark_subscription_requested_and_get_subscription_age(price_stream_service):
+    """구독 요청 시각이 기록되고 age 조회에 반영된다."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("services.price_stream_service.time.time", lambda: 1000.0)
+        price_stream_service.mark_subscription_requested("005930")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("services.price_stream_service.time.time", lambda: 1015.0)
+        assert price_stream_service.get_subscription_age("005930") == 15.0
+
+
+def test_get_stale_codes_with_last_tick(price_stream_service):
+    """마지막 틱 시각이 임계값을 넘은 종목만 stale로 판단한다."""
+    price_stream_service._last_tick_ts["005930"] = 100.0
+    price_stream_service._last_tick_ts["000660"] = 250.0
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("services.price_stream_service.time.time", lambda: 400.0)
+        stale_codes = price_stream_service.get_stale_codes(180.0, codes=["005930", "000660"])
+
+    assert stale_codes == ["005930"]
+
+
+def test_get_stale_codes_with_no_tick_after_grace(price_stream_service):
+    """아직 틱이 없더라도 구독 후 충분히 오래되면 stale로 판단한다."""
+    price_stream_service._subscription_requested_ts["005930"] = 100.0
+    price_stream_service._subscription_requested_ts["000660"] = 350.0
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("services.price_stream_service.time.time", lambda: 400.0)
+        stale_codes = price_stream_service.get_stale_codes(180.0, codes=["005930", "000660"])
+
+    assert stale_codes == ["005930"]
+
+
+def test_clear_subscription_state_removes_cached_tracking(price_stream_service):
+    """구독 해제 시 캐시/추적 상태가 정리된다."""
+    price_stream_service._latest_prices["005930"] = {"price": "70000"}
+    price_stream_service._last_tick_ts["005930"] = 100.0
+    price_stream_service._subscription_requested_ts["005930"] = 50.0
+
+    price_stream_service.clear_subscription_state("005930")
+
+    assert price_stream_service.get_cached_price("005930") is None
+    assert price_stream_service.get_last_tick_ts("005930") == 0.0
+    assert price_stream_service.get_subscription_age("005930") == 0.0

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -24,12 +24,14 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         self.mock_broker = AsyncMock()
         self.mock_market_data_service = AsyncMock()
         self.mock_market_data_service._env = AsyncMock()
+        self.mock_streaming_logger = MagicMock()
         self._original_stdout = sys.stdout
 
         self.stockQueryService = StockQueryService(
             market_data_service=self.mock_market_data_service, 
             logger=self.mock_logger, market_clock=self.mock_market_clock, indicator_service=self.mock_indicator_service,
-            broker_api_wrapper=self.mock_broker
+            broker_api_wrapper=self.mock_broker,
+            streaming_logger=self.mock_streaming_logger,
         )
 
     def _create_dummy_stock_info(self, overrides=None):
@@ -94,6 +96,7 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         await self.stockQueryService.handle_get_current_stock_price("005930")
         self.mock_logger.error.assert_called()
+        self.mock_streaming_logger.log_missing_reason.assert_called_once_with("005930", "rest_failed")
         self.assertIn("현재가 및 상세 정보 조회 실패", self.mock_logger.error.call_args[0][0])
 
     async def test_handle_get_current_stock_price_none_response(self):

--- a/tests/unit_test/services/test_streaming_service.py
+++ b/tests/unit_test/services/test_streaming_service.py
@@ -378,6 +378,40 @@ def test_get_cached_realtime_price_returns_none_without_service(streaming_servic
     assert result is None
 
 
+def test_is_subscribed_realtime_price_uses_streaming_stock_repo(streaming_service):
+    """통합 체결가 desired 상태를 기준으로 구독 여부를 판단한다."""
+    repo = MagicMock()
+    repo.get_desired.return_value = {"005930"}
+    streaming_service.set_streaming_stock_repo(repo)
+
+    assert streaming_service.is_subscribed_realtime_price("005930") is True
+    assert streaming_service.is_subscribed_realtime_price("000660") is False
+
+
+@pytest.mark.asyncio
+async def test_subscribe_realtime_price_marks_subscription_requested(streaming_service, mock_broker):
+    """실시간 가격 구독 전 price stream service에 구독 요청 시각을 기록한다."""
+    mock_price_stream = MagicMock()
+    streaming_service.set_price_stream_service(mock_price_stream)
+
+    await streaming_service.subscribe_realtime_price("005930")
+
+    mock_price_stream.mark_subscription_requested.assert_called_once_with("005930")
+    mock_broker.subscribe_realtime_price.assert_awaited_once_with("005930")
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_unified_price_clears_subscription_state(streaming_service, mock_broker):
+    """통합 체결가 해지 시 price stream service의 추적 상태를 정리한다."""
+    mock_price_stream = MagicMock()
+    streaming_service.set_price_stream_service(mock_price_stream)
+
+    await streaming_service.unsubscribe_unified_price("005930")
+
+    mock_price_stream.clear_subscription_state.assert_called_once_with("005930")
+    mock_broker.unsubscribe_unified_price.assert_awaited_once_with("005930")
+
+
 def test_dispatch_realtime_message_realtime_price_console_log(streaming_service):
     """dispatch_realtime_message: realtime_price 수신 시 콘솔 디버그 로그 출력"""
     # 스로틀 우회를 위해 마지막 출력 시각을 과거로 설정

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -62,12 +62,16 @@ def mock_deps():
 
     streaming_stock_repo = _make_streaming_stock_repo()
 
-    return streaming_service, program_trading_stream_service, market_calendar_service, logger, streaming_stock_repo
+    price_stream_service = MagicMock()
+    price_stream_service.get_last_any_tick_ts = MagicMock(return_value=0.0)
+    price_stream_service.get_stale_codes = MagicMock(return_value=[])
+
+    return streaming_service, program_trading_stream_service, market_calendar_service, logger, streaming_stock_repo, price_stream_service
 
 
 @pytest.fixture
 def watchdog_task(mock_deps, mock_streaming_logger):
-    streaming_service, program_trading_stream_service, market_calendar_service, logger, streaming_stock_repo = mock_deps
+    streaming_service, program_trading_stream_service, market_calendar_service, logger, streaming_stock_repo, price_stream_service = mock_deps
     return WebSocketWatchdogTask(
         streaming_service=streaming_service,
         program_trading_stream_service=program_trading_stream_service,
@@ -75,6 +79,7 @@ def watchdog_task(mock_deps, mock_streaming_logger):
         logger=logger,
         streaming_stock_repo=streaming_stock_repo,
         streaming_logger=mock_streaming_logger,
+        price_stream_service=price_stream_service,
     )
 
 
@@ -101,6 +106,8 @@ def mock_streaming_logger():
     logger.log_subscription_recovery_done = MagicMock()
     logger.log_restore = MagicMock()
     logger.log_reconnect = MagicMock()
+    logger.log_price_data_gap = MagicMock()
+    logger.log_stale_price_codes = MagicMock()
     return logger
 
 
@@ -209,6 +216,52 @@ async def test_streaming_watchdog_data_gap(watchdog_task, mock_deps):
     svc._streaming_logger.log_pt_data_gap.assert_called_once()
     data_gap_arg = svc._streaming_logger.log_pt_data_gap.call_args[0][0]
     assert data_gap_arg > 300
+
+
+@pytest.mark.asyncio
+async def test_streaming_watchdog_price_data_gap_triggers_reconnect(watchdog_task):
+    """체결가 전역 수신 갭이 임계값을 넘으면 price_data_gap trigger로 재연결한다."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now.return_value = True
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.UNIFIED_PRICE else set()
+    )
+    svc._price_stream_service.get_last_any_tick_ts.return_value = time.time() - 190
+    svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+    svc.force_reconnect = AsyncMock()
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(1)):
+        try:
+            await svc._streaming_watchdog()
+        except asyncio.CancelledError:
+            pass
+
+    svc._streaming_logger.log_price_data_gap.assert_called_once()
+    svc.force_reconnect.assert_called_once()
+    assert svc.force_reconnect.call_args.kwargs["trigger"].startswith("price_data_gap_")
+
+
+@pytest.mark.asyncio
+async def test_streaming_watchdog_logs_stale_price_codes_without_reconnect(watchdog_task):
+    """개별 stale 종목은 로그로 남기되 전역 gap이 없으면 즉시 재연결하지 않는다."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now.return_value = True
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930", "000660"} if stream_type == StreamingType.UNIFIED_PRICE else set()
+    )
+    svc._price_stream_service.get_last_any_tick_ts.return_value = time.time() - 30
+    svc._price_stream_service.get_stale_codes.return_value = ["005930"]
+    svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+    svc.force_reconnect = AsyncMock()
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(1)):
+        try:
+            await svc._streaming_watchdog()
+        except asyncio.CancelledError:
+            pass
+
+    svc._streaming_logger.log_stale_price_codes.assert_called_once_with(["005930"])
+    svc.force_reconnect.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -426,6 +479,7 @@ def test_get_progress_initial_state(watchdog_task):
     assert p["subscribed_pt_codes"] == 0
     assert p["subscribed_price_codes"] == 0
     assert p["data_gap_sec"] is None
+    assert p["price_data_gap_sec"] is None
     assert p["market_open"] is None
 
 
@@ -455,6 +509,16 @@ def test_get_progress_data_gap_calculated(watchdog_task):
 
     assert p["data_gap_sec"] is not None
     assert 28.0 <= p["data_gap_sec"] <= 33.0  # 30초 ± 여유
+
+
+def test_get_progress_price_data_gap_calculated(watchdog_task):
+    """price stream last tick이 설정되면 price_data_gap_sec을 계산한다."""
+    watchdog_task._price_stream_service.get_last_any_tick_ts.return_value = time.time() - 25.0
+
+    p = watchdog_task.get_progress()
+
+    assert p["price_data_gap_sec"] is not None
+    assert 23.0 <= p["price_data_gap_sec"] <= 28.0
 
 
 def test_get_progress_no_data_ts_returns_none_gap(watchdog_task):
@@ -701,7 +765,9 @@ async def test_streaming_watchdog_no_desired_codes(watchdog_task):
 async def test_streaming_watchdog_price_only_subscription_proceeds(watchdog_task, mock_price_subscription_service):
     """PT 구독이 없어도 실시간 체결가 구독이 있으면 워치독이 receive_alive를 감시한다."""
     svc = watchdog_task
-    svc._streaming_stock_repo.get_desired.return_value = set()  # PT 없음
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.UNIFIED_PRICE else set()
+    )
     svc._price_subscription_service = mock_price_subscription_service  # 체결가 구독 있음
     svc.mcs.is_market_open_now.return_value = True
     svc._streaming_service.broker.is_websocket_receive_alive.return_value = False

--- a/todo_list.md
+++ b/todo_list.md
@@ -31,6 +31,14 @@
     - `services/price_subscription_service.py`
     - `brokers/korea_investment/korea_invest_websocket_api.py`
     - `task/background/intraday/websocket_watchdog_task.py`
+  - 장중 실검증 체크리스트:
+    - 실제 장중에 `python main.py --web` 실행 후 종목 2~3개를 구독한다.
+    - 체결가가 정상 수신될 때 `PriceStreamService` 캐시와 관련 스트리밍 로그가 갱신되는지 확인한다.
+    - WebSocket 수신 중단을 유도한 뒤 `price_data_gap_*` trigger로 재연결이 발생하는지 확인한다.
+    - 재연결 이후 동일 종목의 체결가 수신이 다시 살아나는지 확인한다.
+    - PT 데이터는 오는데 체결가가 없을 때 `not_subscribed` 또는 `subscribed_no_tick` 로그가 기대대로 남는지 확인한다.
+    - 현재가 REST 조회 실패 상황에서 `rest_failed` 로그가 남는지 확인한다.
+    - 장 마감 후 조용한 상태를 장애로 오탐하지 않는지 로그를 함께 점검한다.
 
 - [ ] `NewHighTask` DB 경합 및 실패 경로 점검
   - 목표: 신고가 후처리 중 DB 락, 중복 실행, 후속 서비스 실패가 있는지 정리하고 수정한다.

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -3,6 +3,7 @@
 TradingApp의 초기화 로직을 참고하여 서비스 레이어만 초기화한다.
 """
 import asyncio
+import time
 from config.config_loader import load_configs
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
 import os
@@ -114,6 +115,7 @@ class WebAppContext:
         self.price_subscription_service: PriceSubscriptionService = None
         self.price_stream_service: PriceStreamService = None
         self.streaming_stock_repo: StreamingStockRepo = None
+        self._last_missing_reason_log_ts: dict[tuple[str, str], float] = {}
 
         # 실시간 스트리밍 전용 이벤트 로거 (logs/streaming/)
         self.streaming_event_logger = get_streaming_logger()
@@ -276,6 +278,7 @@ class WebAppContext:
             performance_profiler=self.pm,
             notification_service=self.notification_service,
             broker_api_wrapper=self.broker,
+            streaming_logger=self.streaming_event_logger,
         )
         # IndicatorService에 StockQueryService 주입
         self.indicator_service.stock_query_service = self.stock_query_service
@@ -342,6 +345,7 @@ class WebAppContext:
         # StreamingStockRepo 초기화 (구독 상태 중앙 저장소)
         self.streaming_stock_repo = StreamingStockRepo(logger=self.logger)
         self.streaming_stock_repo.load_pt_desired_from_db("data/program_subscribe/program_trading.db")
+        self.streaming_service.set_streaming_stock_repo(self.streaming_stock_repo)
 
         # PriceSubscriptionService 초기화 (StreamingService 생성 이후)
         self.price_subscription_service = PriceSubscriptionService(
@@ -364,6 +368,7 @@ class WebAppContext:
             streaming_logger=self.streaming_event_logger,
             streaming_stock_repo=self.streaming_stock_repo,
             price_subscription_service=self.price_subscription_service,
+            price_stream_service=self.price_stream_service,
         )
 
         self.daily_price_collector_task = DailyPriceCollectorTask(
@@ -789,9 +794,34 @@ class WebAppContext:
                         item['sign'] = price_data.get('sign')
                     else:
                         item['price'] = price_data
+                elif code:
+                    self._log_streaming_missing_reason(code)
 
         if self.streaming_service:
             self.streaming_service.dispatch_realtime_message(data)
+
+    def _log_streaming_missing_reason(self, code: str) -> None:
+        """PT 이벤트에 비해 체결가가 없는 상황의 원인을 저빈도로 기록한다."""
+        if not self.streaming_event_logger or not self.streaming_service:
+            return
+
+        if not self.streaming_service.is_subscribed_realtime_price(code):
+            reason = "not_subscribed"
+        elif self.price_stream_service:
+            subscription_age = self.price_stream_service.get_subscription_age(code)
+            if subscription_age < WebSocketWatchdogTask.PRICE_SUBSCRIPTION_GRACE_SEC:
+                return
+            reason = "subscribed_no_tick"
+        else:
+            reason = "subscribed_no_tick"
+
+        now_ts = time.monotonic()
+        last_logged_ts = self._last_missing_reason_log_ts.get((code, reason), 0.0)
+        if (now_ts - last_logged_ts) < 60.0:
+            return
+
+        self._last_missing_reason_log_ts[(code, reason)] = now_ts
+        self.streaming_event_logger.log_missing_reason(code, reason)
 
     async def start_program_trading(self, code: str) -> bool:
         """프로그램매매 구독 시작 (웹소켓 연결 + 구독). 이미 구독 중이면 스킵."""


### PR DESCRIPTION
services/price_stream_service.py, task/background/intraday/websocket_watchdog_task.py, core/loggers/streaming_event_logger.py 쪽에 체결가 last_tick 추적, 전역/종목별 stale 감지, price_data_gap_* 재연결 trigger, price_data_gap_sec progress 확장을 넣었습니다. services/streaming_service.py에는 통합 체결가 desired 기준 is_subscribed_realtime_price()와 구독 성공 시각 추적을 추가했고, brokers/korea_investment/korea_invest_websocket_api.py에서는 구독 요청 전송 성공과 서버 ACK 성공/실패를 분리해 로깅하도록 보강했습니다.

원인 분리도 넣어뒀습니다. services/stock_query_service.py에서는 REST 현재가 실패 시 rest_failed를 남기고, view/web/web_app_initializer.py PT 콜백에서는 체결가가 비어 있을 때 not_subscribed / subscribed_no_tick를 저빈도로 기록합니다. 워치독 주입 지점은 현재 확인된 생성 경로가 웹 초기화 한 곳뿐이라 그 경로에 price_stream_service와 repo 연결을 반영했습니다.