### PR TITLE
services/strategy_log_report_service.py에 리뷰 반영했습니다. 스캔만 있고 신호가 없는 전략은…

### DIFF
--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -68,6 +68,29 @@ _REASON_KR: Dict[str, str] = {
 # 각 섹션에서 보여줄 최대 종목 수
 _MAX_REJECTED_SHOWN = 5
 _MAX_NEAR_MISS_SHOWN = 3
+_MA_PROXIMITY_LOWER_PCT = -2.0
+_MA_PROXIMITY_UPPER_PCT = 4.0
+_MA_NEAR_MISS_MAX_EXCESS_PCT = 4.0
+
+
+def _ma_proximity_excess_pct(pct: Optional[float]) -> Optional[float]:
+    """MA 허용 범위에서 벗어난 정도를 percentage point 단위로 반환한다."""
+    if pct is None:
+        return None
+    if pct < _MA_PROXIMITY_LOWER_PCT:
+        return _MA_PROXIMITY_LOWER_PCT - pct
+    if pct > _MA_PROXIMITY_UPPER_PCT:
+        return pct - _MA_PROXIMITY_UPPER_PCT
+    return 0.0
+
+
+def _near_miss_sort_metric(event: str, reason: str, data: dict) -> Optional[float]:
+    if reason == "no_ma_proximity":
+        excess = _ma_proximity_excess_pct(data.get('closest_ma_pct'))
+        if excess is None or excess > _MA_NEAR_MISS_MAX_EXCESS_PCT:
+            return None
+        return excess
+    return 0.0
 
 
 def _build_metric_str(event: str, reason: str, data: dict) -> str:
@@ -201,7 +224,7 @@ class StrategyLogReportService:
 
         active_sections: List[str] = []
         inactive_names: List[str] = []
-        market_timing: Dict[str, bool] = {}
+        market_timing: Dict[str, Tuple[str, bool]] = {}
         idx = 0
 
         for name, files in sorted(strategy_files.items()):
@@ -210,6 +233,7 @@ class StrategyLogReportService:
             scan_count: int = 0
             near_miss: Dict[str, dict] = {}
             name_map: Dict[str, str] = {}
+            early_guard_skipped: set[str] = set()
 
             for fpath in sorted(files):
                 for _level, ts, data in self._iter_events(fpath, date_prefix):
@@ -224,8 +248,8 @@ class StrategyLogReportService:
 
                     elif event == 'market_timing_updated':
                         mkt = data.get('market', '')
-                        if mkt and mkt not in market_timing:
-                            market_timing[mkt] = data.get('ok', False)
+                        if mkt and ts >= market_timing.get(mkt, ('', False))[0]:
+                            market_timing[mkt] = (ts, data.get('ok', False))
 
                     elif event == 'buy_signal_generated' and code:
                         metrics = data.get('metrics', {})
@@ -251,16 +275,32 @@ class StrategyLogReportService:
                                 'count': prev['count'] + 1,
                             }
 
+                    if event == 'breakout_skipped' and data.get('reason') == 'early_morning_guard' and code:
+                        early_guard_skipped.add(code)
+                        if code in near_miss:
+                            near_miss[code]['note'] = "장 초반 진입 제한으로 스킵"
+
                     if event in _NEAR_MISS_EVENTS and code and code not in bought:
                         reason = data.get('reason', '')
                         gate = _GATE_PRIORITY.get((event, reason), 0)
-                        if gate > 0 and gate > near_miss.get(code, {}).get('gate', -1):
+                        sort_metric = _near_miss_sort_metric(event, reason, data)
+                        prev = near_miss.get(code)
+                        should_replace = (
+                            gate > 0 and sort_metric is not None and (
+                                not prev
+                                or gate > prev.get('gate', -1)
+                                or (gate == prev.get('gate') and sort_metric < prev.get('sort_metric', float('inf')))
+                            )
+                        )
+                        if should_replace:
                             near_miss[code] = {
                                 'name': name_map.get(code, data.get('name', code)),
                                 'gate': gate,
+                                'sort_metric': sort_metric,
                                 'reason_kr': _REASON_KR.get(reason, "HTF 패턴 감지" if event == "htf_pattern_detected" else reason),
                                 'metric_str': _build_metric_str(event, reason, data),
                                 'time': ts[11:16] if len(ts) >= 16 else '',
+                                'note': "장 초반 진입 제한으로 스킵" if code in early_guard_skipped else "",
                             }
 
             # StockCodeRepository로 미해결 종목명 보완
@@ -273,6 +313,10 @@ class StrategyLogReportService:
                     info['name'] = self._db_resolve(code, info['name'])
 
             if not bought and not rejected and not near_miss:
+                if scan_count:
+                    idx += 1
+                    active_sections.append(f"<b>{idx}. {name}</b> — {scan_count}종목 스캔 (시그널 없음)")
+                    continue
                 inactive_names.append(name)
                 continue
 
@@ -305,13 +349,17 @@ class StrategyLogReportService:
             else:
                 lines.append("\n❌ 매수 실패: 없음")
 
-            top3 = sorted(near_miss.values(), key=lambda x: -x['gate'])[:_MAX_NEAR_MISS_SHOWN]
+            top3 = sorted(
+                near_miss.values(),
+                key=lambda x: (-x['gate'], x.get('sort_metric', float('inf')))
+            )[:_MAX_NEAR_MISS_SHOWN]
             if top3:
                 lines.append("\n🎯 매수 근접")
                 for c in top3:
                     metric = f" ({c['metric_str']})" if c['metric_str'] else ""
                     time_str = f" ({c['time']})" if c.get('time') else ""
-                    lines.append(f"• {c['name']}: {c['reason_kr']}{metric}{time_str}")
+                    note_str = f" - {c['note']}" if c.get('note') else ""
+                    lines.append(f"• {c['name']}: {c['reason_kr']}{metric}{time_str}{note_str}")
 
             active_sections.append("\n".join(lines))
 
@@ -319,7 +367,7 @@ class StrategyLogReportService:
 
         if market_timing:
             mt_parts = [
-                f"{mkt} {'🟢' if market_timing[mkt] else '🔴'}"
+                f"{mkt} {'🟢' if market_timing[mkt][1] else '🔴'}"
                 for mkt in ["KOSPI", "KOSDAQ"] if mkt in market_timing
             ]
             header = (

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -210,6 +210,7 @@ async def test_report_gzip_market_timing_and_db_name_resolution(log_dir):
         log_path,
         [
             _make_info_entry("market_timing_updated", "", "", market="KOSPI", ok=True),
+            _make_info_entry("market_timing_updated", "", "", market="KOSPI", ok=False),
             _make_info_entry("market_timing_updated", "", "", market="KOSDAQ", ok=False),
             _make_entry("buy_signal_generated", "005930", "005930", reason="오닐돌파", price=75000),
         ],
@@ -219,7 +220,7 @@ async def test_report_gzip_market_timing_and_db_name_resolution(log_dir):
     svc = StrategyLogReportService(log_dir=log_dir, stock_code_repo=DummyRepo())
     report = await svc.generate_report("20260418")
 
-    assert "시장: KOSPI 🟢 | KOSDAQ 🔴" in report
+    assert "시장: KOSPI 🔴 | KOSDAQ 🔴" in report
     assert "삼성전자(005930)" in report
 
 
@@ -237,6 +238,11 @@ async def test_report_inactive_summary_and_old_file_ignored(log_dir):
             _make_entry("scan_with_watchlist", "", "", date="2026-04-17"),
         ])
 
+    scanned_path = os.path.join(log_dir, "20260418_093000_ScannedStrategy.log.json")
+    scanned_entry = _make_entry("scan_with_watchlist", "", "")
+    scanned_entry["data"]["count"] = 17
+    _write_log(scanned_path, [scanned_entry])
+
     stale_path = os.path.join(log_dir, "20260418_093000_StaleStrategy.log.json")
     _write_log(stale_path, [
         _make_entry("buy_signal_generated", "000660", "SK하이닉스", reason="오래된로그"),
@@ -247,7 +253,9 @@ async def test_report_inactive_summary_and_old_file_ignored(log_dir):
     svc = StrategyLogReportService(log_dir=log_dir)
     report = await svc.generate_report("20260418")
 
+    assert "ScannedStrategy</b> — 17종목 스캔 (시그널 없음)" in report
     assert "💤 <i>활동 없음: DormantA, DormantB, DormantC 외 1개" in report
+    assert "활동 없음: ScannedStrategy" not in report
     assert "StaleStrategy" not in report
 
 
@@ -375,6 +383,24 @@ async def test_htf_pattern_detected_in_near_miss(log_dir):
 
 
 @pytest.mark.asyncio
+async def test_htf_near_miss_shows_early_morning_guard_note(log_dir):
+    """HTF 패턴 감지 후 장 초반 가드로 스킵되면 근접 사유에 방어 로직을 표시한다."""
+    log_path = os.path.join(log_dir, "20260418_093000_TestStrategy.log.json")
+    _write_log(log_path, [
+        _make_info_entry("htf_pattern_detected", "035420", "NAVER",
+                         surge_ratio=2.1, flag_days=8),
+        _make_info_entry("breakout_skipped", "035420", "NAVER",
+                         reason="early_morning_guard"),
+    ])
+
+    svc = StrategyLogReportService(log_dir=log_dir)
+    report = await svc.generate_report("20260418")
+
+    assert "HTF 패턴 감지" in report
+    assert "장 초반 진입 제한으로 스킵" in report
+
+
+@pytest.mark.asyncio
 async def test_bought_excluded_from_near_miss(log_dir):
     """매수 완료된 종목은 near-miss 섹션에 표시되지 않는다."""
     log_path = os.path.join(log_dir, "20260418_093000_TestStrategy.log.json")
@@ -419,3 +445,26 @@ async def test_near_miss_top3_limit(log_dir):
     near_miss_section = report.split("🎯 매수 근접")[1] if "🎯 매수 근접" in report else ""
     assert "종목D" not in near_miss_section  # gate=4 → near-miss 제외
     assert "종목E" not in near_miss_section  # gate=2 → near-miss 제외
+
+
+@pytest.mark.asyncio
+async def test_near_miss_ma_proximity_filters_far_distance_and_sorts_closest(log_dir):
+    """MA 거리 초과 near-miss는 허용 범위에 가까운 종목만 가까운 순으로 표시한다."""
+    log_path = os.path.join(log_dir, "20260418_093000_TestStrategy.log.json")
+    _write_log(log_path, [
+        _make_info_entry("pp_rejected", "A00001", "먼종목",
+                         reason="no_ma_proximity", closest_ma_pct=19.61),
+        _make_info_entry("pp_rejected", "A00002", "덜가까운종목",
+                         reason="no_ma_proximity", closest_ma_pct=7.54),
+        _make_info_entry("pp_rejected", "A00003", "가까운종목",
+                         reason="no_ma_proximity", closest_ma_pct=4.04),
+    ])
+
+    svc = StrategyLogReportService(log_dir=log_dir)
+    report = await svc.generate_report("20260418")
+    near_miss_section = report.split("🎯 매수 근접")[1] if "🎯 매수 근접" in report else ""
+
+    assert "가까운종목" in near_miss_section
+    assert "덜가까운종목" in near_miss_section
+    assert "먼종목" not in near_miss_section
+    assert near_miss_section.index("가까운종목") < near_miss_section.index("덜가까운종목")


### PR DESCRIPTION
… 이제 활동 없음이 아니라 N종목 스캔 (시그널 없음)으로 표시되고, MA 거리 초과 near-miss는 기본 허용 범위 -2%~+4%에서 너무 멀리 벗어난 종목을 제외한 뒤 가까운 순으로 정렬합니다. 시장 추세도 첫 값이 아니라 타임스탬프 기준 최신 market_timing_updated를 사용하도록 바꿨습니다.