### PR TITLE
신고가 0종목으로 튀는 경로를 막는 패치 완료했습니다.

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -52,6 +52,7 @@ class StockOhlcvRepository:
             with sqlite3.connect(self._db_path) as conn:
                 conn.execute("PRAGMA journal_mode=WAL")
                 conn.execute("PRAGMA synchronous=NORMAL")
+                conn.execute("PRAGMA busy_timeout=10000")
                 conn.execute("""
                     CREATE TABLE IF NOT EXISTS ohlcv (
                         code TEXT NOT NULL,
@@ -123,6 +124,7 @@ class StockOhlcvRepository:
             if self._write_conn is None:
                 self._write_conn = await aiosqlite.connect(self._db_path)
                 await self._write_conn.execute("PRAGMA synchronous=NORMAL")
+                await self._write_conn.execute("PRAGMA busy_timeout=10000")
             try:
                 yield self._write_conn
                 await self._write_conn.commit()
@@ -138,6 +140,7 @@ class StockOhlcvRepository:
                 if self._read_conn is None:
                     conn = await aiosqlite.connect(self._db_path)
                     conn.row_factory = aiosqlite.Row
+                    await conn.execute("PRAGMA busy_timeout=10000")
                     self._read_conn = conn
         yield self._read_conn
 
@@ -415,28 +418,36 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository minervini fields update 실패: {e}")
 
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
-        """daily_prices의 is_newhigh / is_historical_newhigh 컬럼만 UPDATE."""
-        if not records:
-            return
+        """daily_prices의 is_newhigh / is_historical_newhigh 컬럼을 해당 날짜 기준으로 재작성."""
         try:
             async with self._get_write_connection() as conn:
-                await conn.executemany(
+                await conn.execute(
                     """
                     UPDATE daily_prices
-                    SET is_newhigh = :is_newhigh,
-                        is_historical_newhigh = :is_historical_newhigh
-                    WHERE code = :code AND trade_date = :trade_date
+                    SET is_newhigh = 0,
+                        is_historical_newhigh = 0
+                    WHERE trade_date = ?
                     """,
-                    [
-                        {
-                            "code": r.get("code"),
-                            "trade_date": trade_date,
-                            "is_newhigh": 1 if r.get("is_newhigh") else 0,
-                            "is_historical_newhigh": 1 if r.get("is_historical_new_high") else 0,
-                        }
-                        for r in records
-                    ],
+                    (trade_date,),
                 )
+                if records:
+                    await conn.executemany(
+                        """
+                        UPDATE daily_prices
+                        SET is_newhigh = :is_newhigh,
+                            is_historical_newhigh = :is_historical_newhigh
+                        WHERE code = :code AND trade_date = :trade_date
+                        """,
+                        [
+                            {
+                                "code": r.get("code"),
+                                "trade_date": trade_date,
+                                "is_newhigh": 1 if r.get("is_newhigh") else 0,
+                                "is_historical_newhigh": 1 if r.get("is_historical_new_high") else 0,
+                            }
+                            for r in records
+                        ],
+                    )
             self._logger.debug(
                 f"StockOhlcvRepository: newhigh fields {len(records)}건 update 완료 (date={trade_date})"
             )

--- a/services/newhigh_service.py
+++ b/services/newhigh_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import logging
-import asyncio
 from typing import Optional, TYPE_CHECKING
 from common.types import ResCommonResponse
 
@@ -27,7 +26,8 @@ class NewHighService:
 
     async def get_newhigh_list(self) -> ResCommonResponse:
         """신고가 종목 목록을 조회한다 (DB -> Task Cache -> Task Trigger)."""
-        
+        latest_date = None
+
         # 1차: DB 조회
         if self._stock_repository:
             try:
@@ -35,53 +35,71 @@ class NewHighService:
                 if latest_date:
                     db_items = await self._stock_repository.get_newhigh_stocks(latest_date)
                     if db_items:
-                        # 데이터 포매팅
-                        data = [
-                            {
-                                "code": it.get("code", ""),
-                                "name": it.get("name", ""),
-                                "stck_prpr": str(it.get("current_price") or 0),
-                                "prdy_ctrt": str(it.get("change_rate") or 0),
-                                "rs_rating": it.get("rs_rating") or 0,
-                                "market_cap": it.get("market_cap") or 0,
-                                "trading_value": it.get("trading_value") or 0,
-                                "w52_high": it.get("w52_high") or 0,
-                                "is_historical_new_high": bool(it.get("is_historical_newhigh")),
-                                "minervini_stage": it.get("minervini_stage") or 0,
-                            }
-                            for it in db_items
-                        ]
-                        return ResCommonResponse(rt_cd="0", msg1="성공", data=data)
+                        return ResCommonResponse(
+                            rt_cd="0",
+                            msg1="성공",
+                            data=[self._format_db_item(it) for it in db_items],
+                        )
             except Exception as e:
                 self._logger.warning(f"NewHighService DB 조회 오류: {e}")
 
-        # 2차: In-Memory 캐시
         task = self._newhigh_task
         if not task:
             return ResCommonResponse(rt_cd="1", msg1="NewHighTask 미설정", data=None)
 
+        progress = task.get_progress()
+        if (
+            latest_date
+            and progress.get("last_date") == latest_date
+            and not progress.get("running")
+            and int(progress.get("newhigh_count") or 0) == 0
+        ):
+            return ResCommonResponse(rt_cd="0", msg1="성공", data=[])
+
+        # 2차: In-Memory 캐시
         cache = await task.get_newhigh_cache()
         if cache:
-            data = [
-                {
-                    "code": it.get("code", ""),
-                    "name": it.get("name", ""),
-                    "stck_prpr": str(it.get("current_price") or 0),
-                    "prdy_ctrt": str(it.get("change_rate") or 0),
-                    "rs_rating": it.get("rs_rating") or 0,
-                    "market_cap": it.get("market_cap") or 0,
-                    "trading_value": it.get("trading_value") or 0,
-                    "w52_high": it.get("w52_high") or 0,
-                    "is_historical_new_high": it.get("is_historical_new_high", False),
-                    "minervini_stage": it.get("minervini_stage") or 0,
-                }
-                for it in cache
-            ]
-            return ResCommonResponse(rt_cd="0", msg1="성공", data=data)
+            return ResCommonResponse(
+                rt_cd="0",
+                msg1="성공",
+                data=[self._format_cache_item(it) for it in cache],
+            )
 
         # 3차: 갱신 트리거 후 수집 대기
         progress = task.get_progress()
         if not progress.get("running"):
-            asyncio.create_task(task.force_run())
-            
+            trigger_refresh = getattr(task, "trigger_refresh", None)
+            if callable(trigger_refresh):
+                trigger_refresh()
+
         return ResCommonResponse(rt_cd="0", msg1="수집 중", data=[])
+
+    @staticmethod
+    def _format_db_item(item: dict) -> dict:
+        return {
+            "code": item.get("code", ""),
+            "name": item.get("name", ""),
+            "stck_prpr": str(item.get("current_price") or 0),
+            "prdy_ctrt": str(item.get("change_rate") or 0),
+            "rs_rating": item.get("rs_rating") or 0,
+            "market_cap": item.get("market_cap") or 0,
+            "trading_value": item.get("trading_value") or 0,
+            "w52_high": item.get("w52_high") or 0,
+            "is_historical_new_high": bool(item.get("is_historical_newhigh")),
+            "minervini_stage": item.get("minervini_stage") or 0,
+        }
+
+    @staticmethod
+    def _format_cache_item(item: dict) -> dict:
+        return {
+            "code": item.get("code", ""),
+            "name": item.get("name", ""),
+            "stck_prpr": str(item.get("current_price") or 0),
+            "prdy_ctrt": str(item.get("change_rate") or 0),
+            "rs_rating": item.get("rs_rating") or 0,
+            "market_cap": item.get("market_cap") or 0,
+            "trading_value": item.get("trading_value") or 0,
+            "w52_high": item.get("w52_high") or 0,
+            "is_historical_new_high": item.get("is_historical_new_high", False),
+            "minervini_stage": item.get("minervini_stage") or 0,
+        }

--- a/task/background/after_market/newhigh_task.py
+++ b/task/background/after_market/newhigh_task.py
@@ -62,7 +62,19 @@ class NewHighTask(AfterMarketTask):
         self._rs_rating_min = rs_rating_min  # 0이면 RS Rating 필터 비활성
         self._newhigh_cache: List[Dict] = []
         self._last_collected_date: Optional[str] = None
-        self._progress: Dict = {"running": False, "last_date": None, "newhigh_count": 0, "status": None}
+        self._run_lock = asyncio.Lock()
+        self._refresh_task: Optional[asyncio.Task] = None
+        self._progress: Dict = {
+            "running": False,
+            "last_date": None,
+            "newhigh_count": 0,
+            "status": None,
+            "processed": 0,
+            "total": 0,
+            "collected": 0,
+            "elapsed": 0.0,
+            "last_error": None,
+        }
 
     # ── SchedulableTask 인터페이스 구현 ────────────────────────────
 
@@ -80,12 +92,39 @@ class NewHighTask(AfterMarketTask):
     async def get_newhigh_cache(self, limit: int = 200):
         """현재 메모리에 캐시된 신고가 종목 목록을 반환한다 (웹 UI 등에서 호출)."""
         if not self._newhigh_cache and not self._progress.get("running"):
-            try:
-                asyncio.get_running_loop()
-                asyncio.create_task(self.force_run())
-            except RuntimeError:
-                self._logger.warning("이벤트 루프 없음 — NewHigh 즉시 갱신 스킵")
+            self.trigger_refresh()
         return self._newhigh_cache[:limit]
+
+    def trigger_refresh(self) -> bool:
+        """캐시가 비었을 때 신고가 갱신을 한 번만 백그라운드로 예약한다."""
+        if self._refresh_task and not self._refresh_task.done():
+            return False
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._logger.warning("이벤트 루프 없음 — NewHigh 즉시 갱신 스킵")
+            return False
+
+        self._progress["running"] = True
+        self._progress["status"] = "신고가 갱신 대기 중..."
+        self._refresh_task = asyncio.create_task(self.force_run())
+        self._refresh_task.add_done_callback(self._clear_refresh_task)
+        return True
+
+    def _clear_refresh_task(self, task: asyncio.Task) -> None:
+        if self._refresh_task is task:
+            self._refresh_task = None
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self._logger.error(f"NewHighTask 백그라운드 갱신 오류: {e}", exc_info=True)
+        if self._progress.get("status") == "신고가 갱신 대기 중...":
+            self._progress["status"] = None
+        if self._progress.get("running") and not self._run_lock.locked():
+            self._progress["running"] = False
 
     # ── 장마감 후 콜백 ──────────────────────────────────────────────
 
@@ -97,79 +136,120 @@ class NewHighTask(AfterMarketTask):
         await self._run_newhigh(latest_trading_date)
 
     async def _run_newhigh(self, latest_trading_date: str) -> None:
-        self._progress["running"] = True
+        async with self._run_lock:
+            await self._run_newhigh_locked(latest_trading_date)
+
+    async def _run_newhigh_locked(self, latest_trading_date: str) -> None:
+        if self._last_collected_date == latest_trading_date:
+            self._logger.info(f"NewHighTask: {latest_trading_date} 이미 처리됨, 건너뜀")
+            return
+
+        self._progress.update({
+            "running": True,
+            "status": "신고가 탐색 중...",
+            "processed": 0,
+            "total": 0,
+            "collected": 0,
+            "elapsed": 0.0,
+            "last_error": None,
+        })
         start_time = time.time()
         try:
-            self._logger.info(f"NewHighTask: {latest_trading_date} 신고가 탐색 시작")
-            snapshots = await self._stock_repo.get_all_daily_snapshots(latest_trading_date)
-
+            snapshots = await self._load_snapshots_for_newhigh(latest_trading_date)
             if not snapshots:
-                self._logger.warning(f"NewHighTask: daily_prices 데이터 없음 (date={latest_trading_date})")
                 return
 
-            # w52_high 데이터 부재 시 DailyPriceCollectorTask로 강제 최신화 후 재조회
-            if self._daily_price_collector_task and not self._has_sufficient_w52_data(snapshots):
-                self._logger.warning(
-                    f"NewHighTask: w52_high 데이터 부재 — DailyPriceCollectorTask.force_run() 실행 후 재조회"
-                )
-                self._progress["status"] = "DailyPriceCollector 데이터 수집 중..."
-                await self._daily_price_collector_task.force_run()
-                self._progress["status"] = None
-                snapshots = await self._stock_repo.get_all_daily_snapshots(latest_trading_date)
-
             newhigh_stocks = self._filter_newhigh(snapshots)
-
-            # 600일치 데이터를 바탕으로 역사적 신고가 판별
             if self._stock_query_service and newhigh_stocks:
                 newhigh_stocks = await self._enrich_historical_high(newhigh_stocks)
-
-            # RS Rating 주입 및 필터링 (rs_rating_min > 0 이고 서비스가 있을 때만 활성)
             if self._rs_rating_service and newhigh_stocks:
                 newhigh_stocks = await self._enrich_and_filter_rs_rating(
                     newhigh_stocks, latest_trading_date
                 )
 
             self._newhigh_cache = newhigh_stocks
-            
-            # DB에 신고가 여부 기록 (best-effort)
-            try:
-                if self._stock_repo:
-                    trade_date = latest_trading_date
-                    records = []
-                    for s in newhigh_stocks:
-                        records.append({
-                            "code": s.get("code"),
-                            "is_newhigh": True,
-                            "is_historical_new_high": s.get("is_historical_new_high", False)
-                        })
-                    if records:
-                        await self._stock_repo.update_newhigh_fields(trade_date, records)
-            except Exception as e:
-                self._logger.warning(f"NewHighTask DB에 쓰기 실패: {e}")
+            await self._write_newhigh_fields(latest_trading_date, newhigh_stocks)
 
             elapsed = time.time() - start_time
             self._logger.info(
-                f"NewHighTask: 신고가 {len(newhigh_stocks)}개 감지 / 전체 {len(snapshots)}개 (date={latest_trading_date}) / 소요: {elapsed:.1f}s"
+                f"NewHighTask: 신고가 {len(newhigh_stocks)}개 감지 / 전체 {len(snapshots)}개 "
+                f"(date={latest_trading_date}) / 소요: {elapsed:.1f}s"
             )
-    
-            if self._telegram_reporter:
-                await self._telegram_reporter.send_newhigh_report(newhigh_stocks, latest_trading_date)
-    
-            if self._notification_service:
-                await self._notification_service.emit(
-                    NotificationCategory.BACKGROUND,
-                    NotificationLevel.INFO,
-                    "52주 신고가 리포트",
-                    f"{len(newhigh_stocks)}개 종목 감지 (date={latest_trading_date}) / 소요: {elapsed:.1f}초",
-                )
-    
+
             self._last_collected_date = latest_trading_date
-            self._progress.update({"last_date": latest_trading_date, "newhigh_count": len(newhigh_stocks)})
+            self._progress.update({
+                "last_date": latest_trading_date,
+                "newhigh_count": len(newhigh_stocks),
+                "collected": len(newhigh_stocks),
+                "elapsed": elapsed,
+            })
+            await self._send_reports(newhigh_stocks, latest_trading_date, elapsed)
         except Exception as e:
+            self._progress["last_error"] = str(e)
             self._logger.error(f"NewHighTask 신고가 탐색 중 오류 발생: {e}", exc_info=True)
         finally:
             self._progress["running"] = False
             self._progress["status"] = None
+
+    async def _load_snapshots_for_newhigh(self, latest_trading_date: str) -> List[Dict]:
+        self._logger.info(f"NewHighTask: {latest_trading_date} 신고가 탐색 시작")
+        snapshots = await self._stock_repo.get_all_daily_snapshots(latest_trading_date)
+        if not snapshots:
+            message = f"daily_prices 데이터 없음 (date={latest_trading_date})"
+            self._logger.warning(f"NewHighTask: {message}")
+            self._progress["last_error"] = message
+            return []
+
+        self._progress.update({"total": len(snapshots), "processed": len(snapshots)})
+        if self._daily_price_collector_task and not self._has_sufficient_w52_data(snapshots):
+            self._logger.warning(
+                "NewHighTask: w52_high 데이터 부재 — DailyPriceCollectorTask.force_run() 실행 후 재조회"
+            )
+            self._progress["status"] = "DailyPriceCollector 데이터 수집 중..."
+            await self._daily_price_collector_task.force_run()
+            self._progress["status"] = "신고가 탐색 중..."
+            snapshots = await self._stock_repo.get_all_daily_snapshots(latest_trading_date)
+            self._progress.update({"total": len(snapshots), "processed": len(snapshots)})
+
+        if not snapshots:
+            message = f"DailyPriceCollector 재수집 후에도 daily_prices 데이터 없음 (date={latest_trading_date})"
+            self._logger.warning(f"NewHighTask: {message}")
+            self._progress["last_error"] = message
+            return []
+        return snapshots
+
+    async def _write_newhigh_fields(self, trade_date: str, stocks: List[Dict]) -> None:
+        try:
+            records = [
+                {
+                    "code": s.get("code"),
+                    "is_newhigh": True,
+                    "is_historical_new_high": s.get("is_historical_new_high", False),
+                }
+                for s in stocks
+                if s.get("code")
+            ]
+            await self._stock_repo.update_newhigh_fields(trade_date, records)
+        except Exception as e:
+            self._logger.warning(f"NewHighTask DB에 쓰기 실패: {e}")
+
+    async def _send_reports(self, stocks: List[Dict], latest_trading_date: str, elapsed: float) -> None:
+        if self._telegram_reporter:
+            try:
+                await self._telegram_reporter.send_newhigh_report(stocks, latest_trading_date)
+            except Exception as e:
+                self._logger.warning(f"NewHighTask 텔레그램 리포트 전송 실패: {e}")
+
+        if self._notification_service:
+            try:
+                await self._notification_service.emit(
+                    NotificationCategory.BACKGROUND,
+                    NotificationLevel.INFO,
+                    "52주 신고가 리포트",
+                    f"{len(stocks)}개 종목 감지 (date={latest_trading_date}) / 소요: {elapsed:.1f}초",
+                )
+            except Exception as e:
+                self._logger.warning(f"NewHighTask 알림 발행 실패: {e}")
 
     async def force_run(self) -> None:
         """skip 조건을 무시하고 즉시 52주 신고가 탐색을 실행한다."""
@@ -180,6 +260,7 @@ class NewHighTask(AfterMarketTask):
                 target_date = await self._mcs.get_latest_trading_date()
             if not target_date:
                 self._logger.error("최근 거래일을 확인할 수 없어 강제 실행을 중단합니다.")
+                self._progress.update({"running": False, "status": None, "last_error": "최근 거래일 확인 실패"})
                 return
             await self._run_newhigh(target_date)
 
@@ -243,6 +324,16 @@ class NewHighTask(AfterMarketTask):
             rating_map: Dict[str, int] = resp.data
         except Exception as e:
             self._logger.warning(f"NewHighTask: RS Rating 조회 실패 ({e}) — 필터 건너뜀")
+            for s in stocks:
+                s.setdefault("rs_rating", 0)
+            return stocks
+
+        matched_count = sum(1 for s in stocks if s.get("code", "") in rating_map)
+        coverage = matched_count / len(stocks) if stocks else 1.0
+        if self._rs_rating_min > 0 and coverage < 0.2:
+            self._logger.warning(
+                f"NewHighTask: RS Rating 매칭률 낮음 ({matched_count}/{len(stocks)}) — 필터 건너뜀"
+            )
             for s in stocks:
                 s.setdefault("rs_rating", 0)
             return stocks

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -307,9 +307,33 @@ class TestUpdateNewhighFields:
         assert newhighs == []
 
     @pytest.mark.asyncio
-    async def test_empty_records_is_noop(self, repo):
-        """빈 records 전달 시 아무 동작도 하지 않는다."""
+    async def test_empty_records_clears_existing_flags(self, repo):
+        """빈 records는 해당 날짜의 기존 신고가 플래그를 모두 내린다."""
+        await repo.upsert_daily_snapshot("20260414", [
+            _make_snapshot("A001", stage=2),
+        ])
+        await repo.update_newhigh_fields("20260414", [
+            {"code": "A001", "is_newhigh": True, "is_historical_new_high": True},
+        ])
         await repo.update_newhigh_fields("20260414", [])
+        assert await repo.get_newhigh_stocks("20260414") == []
+
+    @pytest.mark.asyncio
+    async def test_rewrite_clears_stale_newhigh_flags(self, repo):
+        """새 결과를 쓸 때 이전 신고가 종목이 결과에서 빠지면 플래그가 내려간다."""
+        await repo.upsert_daily_snapshot("20260414", [
+            _make_snapshot("A001", stage=2),
+            _make_snapshot("A002", stage=2),
+        ])
+        await repo.update_newhigh_fields("20260414", [
+            {"code": "A001", "is_newhigh": True, "is_historical_new_high": False},
+        ])
+        await repo.update_newhigh_fields("20260414", [
+            {"code": "A002", "is_newhigh": True, "is_historical_new_high": False},
+        ])
+
+        result = await repo.get_newhigh_stocks("20260414")
+        assert [r["code"] for r in result] == ["A002"]
 
     @pytest.mark.asyncio
     async def test_exception_is_handled(self, repo, monkeypatch):

--- a/tests/unit_test/services/test_newhigh_service.py
+++ b/tests/unit_test/services/test_newhigh_service.py
@@ -1,6 +1,5 @@
 import pytest
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from services.newhigh_service import NewHighService
 from common.types import ResCommonResponse
@@ -49,6 +48,7 @@ def mock_task():
     # get_progress는 동기 메서드이므로 MagicMock으로 별도 설정
     task.get_progress = MagicMock(return_value={"running": False})
     task.force_run = AsyncMock()
+    task.trigger_refresh = MagicMock(return_value=True)
     return task
 
 
@@ -136,6 +136,26 @@ async def test_get_newhigh_list_db_empty_items_falls_to_cache(mock_repo, mock_ta
     assert result.data[0]["code"] == "000660"
 
 
+async def test_get_newhigh_list_db_empty_completed_zero_returns_success(mock_repo, mock_task):
+    """이미 해당 날짜 계산이 끝난 0건은 재수집으로 오인하지 않는다."""
+    mock_repo.get_newhigh_stocks.return_value = []
+    mock_task.get_progress.return_value = {
+        "running": False,
+        "last_date": "20260414",
+        "newhigh_count": 0,
+    }
+    mock_task.get_newhigh_cache.return_value = []
+
+    service = make_service(repo=mock_repo, task=mock_task)
+    result = await service.get_newhigh_list()
+
+    assert result.rt_cd == "0"
+    assert result.msg1 == "성공"
+    assert result.data == []
+    mock_task.get_newhigh_cache.assert_not_awaited()
+    mock_task.trigger_refresh.assert_not_called()
+
+
 async def test_get_newhigh_list_db_exception_falls_to_cache(mock_repo, mock_task):
     """DB 조회 중 예외 발생 시 캐시로 폴백한다."""
     mock_repo.get_latest_trade_date.side_effect = Exception("DB 연결 실패")
@@ -199,18 +219,17 @@ async def test_get_newhigh_list_cache_null_fields(mock_task):
 # ── force_run 트리거 ──────────────────────────────────────────────────────
 
 async def test_get_newhigh_list_no_cache_triggers_collect(mock_task):
-    """캐시가 없고 task가 실행 중이 아닐 때 force_run을 트리거하고 빈 목록을 반환한다."""
+    """캐시가 없고 task가 실행 중이 아닐 때 갱신을 트리거하고 빈 목록을 반환한다."""
     mock_task.get_newhigh_cache.return_value = []
     mock_task.get_progress.return_value = {"running": False}
 
     service = make_service(task=mock_task)
-    with patch("asyncio.create_task") as mock_create_task:
-        result = await service.get_newhigh_list()
+    result = await service.get_newhigh_list()
 
     assert result.rt_cd == "0"
     assert result.msg1 == "수집 중"
     assert result.data == []
-    mock_create_task.assert_called_once()
+    mock_task.trigger_refresh.assert_called_once()
 
 
 async def test_get_newhigh_list_no_cache_already_running_no_duplicate_trigger(mock_task):
@@ -219,12 +238,11 @@ async def test_get_newhigh_list_no_cache_already_running_no_duplicate_trigger(mo
     mock_task.get_progress.return_value = {"running": True}
 
     service = make_service(task=mock_task)
-    with patch("asyncio.create_task") as mock_create_task:
-        result = await service.get_newhigh_list()
+    result = await service.get_newhigh_list()
 
     assert result.rt_cd == "0"
     assert result.msg1 == "수집 중"
-    mock_create_task.assert_not_called()
+    mock_task.trigger_refresh.assert_not_called()
 
 
 # ── task 미설정 ───────────────────────────────────────────────────────────────

--- a/tests/unit_test/task/background/after_market/test_newhigh_task.py
+++ b/tests/unit_test/task/background/after_market/test_newhigh_task.py
@@ -2,6 +2,7 @@
 NewHighTask 단위 테스트.
 daily_prices 스냅샷 → w52_high 기준 신고가 필터링 및 텔레그램 리포트 전송 로직 검증.
 """
+import asyncio
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -245,6 +246,36 @@ async def test_on_market_closed_emits_notification(task, mock_stock_repo, mock_n
     ]
     await task._on_market_closed("20260412")
     mock_notification_service.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_run_same_date_executes_once(task, mock_stock_repo, mock_telegram_reporter):
+    """같은 거래일 동시 실행 요청은 한 번만 실제 계산한다."""
+    mock_stock_repo.get_all_daily_snapshots.return_value = [
+        _snap("005930", "삼성전자", 80000, 80000),
+    ]
+
+    await asyncio.gather(
+        task._run_newhigh("20260412"),
+        task._run_newhigh("20260412"),
+    )
+
+    assert mock_stock_repo.get_all_daily_snapshots.await_count == 1
+    assert mock_telegram_reporter.send_newhigh_report.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_telegram_failure_still_marks_completed(task, mock_stock_repo, mock_telegram_reporter):
+    """후속 리포트 실패가 신고가 계산 완료 상태를 되돌리지 않는다."""
+    mock_stock_repo.get_all_daily_snapshots.return_value = [
+        _snap("005930", "삼성전자", 80000, 80000),
+    ]
+    mock_telegram_reporter.send_newhigh_report.side_effect = Exception("telegram down")
+
+    await task._on_market_closed("20260412")
+
+    assert task._last_collected_date == "20260412"
+    assert task.get_progress()["newhigh_count"] == 1
 
 
 # ── _has_sufficient_w52_data ────────────────────────────────────────────
@@ -800,6 +831,16 @@ async def test_force_run_no_target_date(task):
 
 
 @pytest.mark.asyncio
+async def test_trigger_refresh_deduplicates_background_task(task):
+    """백그라운드 갱신 예약이 이미 있으면 중복 create_task 하지 않는다."""
+    assert task.trigger_refresh() is True
+    assert task.trigger_refresh() is False
+
+    if task._refresh_task:
+        await asyncio.gather(task._refresh_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_run_newhigh_empty_snapshots(task, mock_stock_repo):
     """조회된 snapshot 데이터가 없을 경우 early return 동작 검증"""
     mock_stock_repo.get_all_daily_snapshots.return_value = []
@@ -875,6 +916,26 @@ async def test_enrich_and_filter_rs_rating_exception(task, mock_rs_rating_servic
     result = await task._enrich_and_filter_rs_rating(stocks, "20260413")
     assert len(result) == 1
     assert result[0]["rs_rating"] == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_and_filter_rs_rating_low_coverage_skips_filter(task, mock_rs_rating_service):
+    """RS Rating 부분 데이터가 신고가 후보를 전부 0건으로 만들지 않도록 필터를 건너뛴다."""
+    task._rs_rating_service = mock_rs_rating_service
+    task._rs_rating_min = 80
+    mock_rs_rating_service.get_ratings_by_date.return_value = MagicMock(
+        rt_cd="0",
+        data={"999999": 99},
+    )
+    stocks = [
+        {"code": "005930", "name": "삼성전자"},
+        {"code": "000660", "name": "SK하이닉스"},
+    ]
+
+    result = await task._enrich_and_filter_rs_rating(stocks, "20260413")
+
+    assert len(result) == 2
+    assert all(s["rs_rating"] == 0 for s in result)
 
 
 # ── _filter_newhigh: rs 필드 전달 버그 수정 검증 ─────────────────────────

--- a/todo_list.md
+++ b/todo_list.md
@@ -96,11 +96,6 @@
     - 현재가 REST 조회 실패 상황에서 `rest_failed` 로그가 남는지 확인한다.
     - 장 마감 후 조용한 상태를 장애로 오탐하지 않는지 로그를 함께 점검한다.
 
-- [ ] `NewHighTask` DB 경합 및 실패 경로 점검
-  - 목표: 신고가 후처리 중 DB 락, 중복 실행, 후속 서비스 실패가 있는지 정리하고 수정한다.
-  - 대상:
-    - `task/background/after_market/newhigh_task.py`
-    - `services/newhigh_service.py`
 
 - [ ] 주문 상태 기계(FSM) 도입
   - 목표: `PENDING_SUBMIT -> SUBMITTED -> PARTIAL_FILLED -> FILLED/CANCELED` 같은 명시적 상태 전이로 중복 주문과 race condition을 줄인다.


### PR DESCRIPTION
주요 변경:

newhigh_task.py: 동일 거래일 중복 실행 방지용 lock과 백그라운드 갱신 dedupe 추가, 텔레그램/알림 실패가 계산 완료 상태를 깨지 않도록 분리. newhigh_task.py: RS Rating 매칭률이 너무 낮은 부분 데이터일 때 필터를 건너뛰어 후보 전체가 0건으로 탈락하지 않게 보강. newhigh_service.py: DB 0건이 “계산 완료된 0건”인지 “아직 수집 전/수집 중”인지 구분하고, 갱신 트리거 중복을 줄임. stock_ohlcv_repository.py: 신고가 플래그를 날짜 단위로 먼저 초기화한 뒤 새 결과를 쓰도록 변경, SQLite busy_timeout 추가. 검증:

python -m pytest tests/unit_test/...newhigh... test_newhigh_service.py test_stock_ohlcv_repository.py -v → 129 passed python -m pytest tests/unit_test -v → 3167 passed, 기존 scheduler 쪽 unraisable warning 1건 표시