### PR TITLE
스트리밍 계열 슬로우 테스트를 정리했습니다. keepalive timeout 상수를 streaming.py (line 16)…

### DIFF
--- a/tests/unit_test/core/cache/test_cache_benchmark.py
+++ b/tests/unit_test/core/cache/test_cache_benchmark.py
@@ -1,13 +1,16 @@
 import time
+
 import pytest
-from core.cache.file_cache import FileCache
+
 from core.cache.db_cache import DBCache
+from core.cache.file_cache import FileCache
 from core.cache.memory_cache import MemoryCache
+
 
 @pytest.fixture
 def benchmark_data():
-    # 적당한 크기의 데이터 생성 (약 4KB 정도)
     return {"key": "value", "data": [i for i in range(1000)]}
+
 
 def run_benchmark(manager, operation, count, data=None):
     start_time = time.time()
@@ -19,7 +22,7 @@ def run_benchmark(manager, operation, count, data=None):
                 manager.set(f"key_{i}", data)
     elif operation == "get":
         for i in range(count):
-            if hasattr(manager, 'get_raw'):
+            if hasattr(manager, "get_raw"):
                 manager.get_raw(f"key_{i}")
             else:
                 manager.get(f"key_{i}")
@@ -29,56 +32,51 @@ def run_benchmark(manager, operation, count, data=None):
     end_time = time.time()
     return end_time - start_time
 
+
 @pytest.mark.slow
 def test_cache_performance_comparison(tmp_path, benchmark_data):
-    """FileCache vs DBCache vs MemoryCache 성능 비교 벤치마크"""
-    count = 500  # 테스트 항목 수
-    
-    # 1. FileCache 설정
+    """FileCache vs DBCache vs MemoryCache benchmark."""
+    count = 100
+
     file_cache_dir = tmp_path / "file_cache"
     file_config = {"cache": {"base_dir": str(file_cache_dir), "deserializable_classes": []}}
     file_manager = FileCache(config=file_config)
-    
-    # 2. DBCache 설정
+
     db_cache_dir = tmp_path / "db_cache"
     db_config = {"cache": {"base_dir": str(db_cache_dir), "deserializable_classes": []}}
     db_manager = DBCache(config=db_config)
 
-    # 3. MemoryCache 설정
     memory_manager = MemoryCache()
-    
+
     print(f"\n\n[Cache Benchmark (N={count})]")
-    
-    # --- SET (Write) ---
+
     file_set_time = run_benchmark(file_manager, "set", count, benchmark_data)
     db_set_time = run_benchmark(db_manager, "set", count, benchmark_data)
     mem_set_time = run_benchmark(memory_manager, "set", count, benchmark_data)
-    
-    print(f"SET (Write):")
+
+    print("SET (Write):")
     print(f"  FileCache: {file_set_time:.4f}s")
     print(f"  DBCache:   {db_set_time:.4f}s")
     print(f"  Memory:    {mem_set_time:.4f}s")
     if db_set_time > 0:
         print(f"  Speedup:   {file_set_time / db_set_time:.2f}x")
-    
-    # --- GET (Read) ---
+
     file_get_time = run_benchmark(file_manager, "get", count)
     db_get_time = run_benchmark(db_manager, "get", count)
     mem_get_time = run_benchmark(memory_manager, "get", count)
-    
-    print(f"GET (Read):")
+
+    print("GET (Read):")
     print(f"  FileCache: {file_get_time:.4f}s")
     print(f"  DBCache:   {db_get_time:.4f}s")
     print(f"  Memory:    {mem_get_time:.4f}s")
     if db_get_time > 0:
         print(f"  Speedup:   {file_get_time / db_get_time:.2f}x")
-    
-    # --- DELETE ---
+
     file_del_time = run_benchmark(file_manager, "delete", count)
     db_del_time = run_benchmark(db_manager, "delete", count)
     mem_del_time = run_benchmark(memory_manager, "delete", count)
-    
-    print(f"DELETE:")
+
+    print("DELETE:")
     print(f"  FileCache: {file_del_time:.4f}s")
     print(f"  DBCache:   {db_del_time:.4f}s")
     print(f"  Memory:    {mem_del_time:.4f}s")

--- a/tests/unit_test/view/web/routes/test_web_routes_program.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_program.py
@@ -122,7 +122,8 @@ async def test_stream_program_trading_logic(mock_web_ctx):
 
     # 4. 핸들러 호출 (StreamingResponse 반환)
     # _get_ctx()를 mock_web_ctx로 패치하여 테스트 컨텍스트를 사용하도록 함
-    with patch("view.web.web_api._get_ctx", return_value=mock_web_ctx):
+    with patch("view.web.web_api._get_ctx", return_value=mock_web_ctx), \
+         patch("view.web.routes.program.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_program_trading(mock_request)
 
     iterator = response.body_iterator
@@ -287,27 +288,26 @@ async def test_stream_program_trading_keepalive(mock_web_ctx):
     mock_rdm.get_history_data.return_value = {}
 
     # 핸들러 호출
-    with patch("view.web.web_api._get_ctx", return_value=mock_web_ctx):
+    with patch("view.web.web_api._get_ctx", return_value=mock_web_ctx), \
+         patch("view.web.routes.program.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_program_trading(mock_request)
+        iterator = response.body_iterator
 
-    iterator = response.body_iterator
+        # 1. 데이터 없이 대기 -> 타임아웃 발생 -> keepalive 메시지 수신 예상
+        chunk = await iterator.__anext__()
 
-    # 1. 데이터 없이 대기 -> 타임아웃 발생 -> keepalive 메시지 수신 예상
-    # stream_program_trading 내부 timeout은 0.1초
-    chunk = await iterator.__anext__()
-    
-    # Keepalive 메시지 포맷 검증 (SSE comment 형식)
-    assert chunk == ": keepalive\n\n"
+        # Keepalive 메시지 포맷 검증 (SSE comment 형식)
+        assert chunk == ": keepalive\n\n"
 
-    # 2. 종료 유도
-    mock_request.is_disconnected.return_value = True
-    
-    try:
-        # 타임아웃 후 루프 돌면서 종료 체크
-        await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
-    except (StopAsyncIteration, asyncio.TimeoutError):
-        pass
-        
+        # 2. 종료 유도
+        mock_request.is_disconnected.return_value = True
+
+        try:
+            # 타임아웃 후 루프 돌면서 종료 체크
+            await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+        except (StopAsyncIteration, asyncio.TimeoutError):
+            pass
+
     mock_rdm.remove_subscriber_queue.assert_called_with(test_queue)
 
 @pytest.mark.asyncio
@@ -357,7 +357,8 @@ async def test_stream_program_trading_cancellation(mock_web_ctx):
     mock_rdm.get_history_data.return_value = {}
 
     # 핸들러 호출 (program.py의 _get_ctx 패치)
-    with patch("view.web.routes.program._get_ctx", return_value=mock_web_ctx):
+    with patch("view.web.routes.program._get_ctx", return_value=mock_web_ctx), \
+         patch("view.web.routes.program.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_program_trading(mock_request)
 
     iterator = response.body_iterator
@@ -397,16 +398,16 @@ async def test_stream_program_trading_replays_history_and_disconnects(mock_web_c
         }]
     }
 
-    with patch("view.web.routes.program._get_ctx", return_value=mock_web_ctx):
+    with patch("view.web.routes.program._get_ctx", return_value=mock_web_ctx), \
+         patch("view.web.routes.program.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_program_trading(mock_request)
+        iterator = response.body_iterator
+        first = await iterator.__anext__()
+        assert first.startswith("data: [")
+        assert "005930" in first
 
-    iterator = response.body_iterator
-    first = await iterator.__anext__()
-    assert first.startswith("data: [")
-    assert "005930" in first
-
-    with pytest.raises(StopAsyncIteration):
-        await iterator.__anext__()
+        with pytest.raises(StopAsyncIteration):
+            await iterator.__anext__()
 
     mock_rdm.remove_subscriber_queue.assert_called_with(test_queue)
 

--- a/tests/unit_test/view/web/routes/test_web_routes_streaming.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_streaming.py
@@ -150,6 +150,7 @@ async def test_stream_price_yields_tick_and_cleanup():
     mock_request.is_disconnected = AsyncMock(return_value=True)
 
     with patch("view.web.routes.streaming._get_ctx", return_value=ctx), \
+         patch("view.web.routes.streaming.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01), \
          patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
         mock_wait_for.side_effect = [tick_data, asyncio.TimeoutError()]
 
@@ -180,6 +181,7 @@ async def test_stream_price_subscribes_and_unsubscribes():
     mock_request.is_disconnected = AsyncMock(return_value=True)
 
     with patch("view.web.routes.streaming._get_ctx", return_value=ctx), \
+         patch("view.web.routes.streaming.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01), \
          patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
         mock_wait_for.side_effect = asyncio.TimeoutError()
 
@@ -210,6 +212,7 @@ async def test_stream_price_works_without_sub_svc():
     mock_request.is_disconnected = AsyncMock(return_value=True)
 
     with patch("view.web.routes.streaming._get_ctx", return_value=ctx), \
+         patch("view.web.routes.streaming.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01), \
          patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
         mock_wait_for.side_effect = asyncio.TimeoutError()
 

--- a/tests/unit_test/view/web/test_web_notification.py
+++ b/tests/unit_test/view/web/test_web_notification.py
@@ -98,7 +98,8 @@ async def test_stream_notifications_timeout_keepalive(mock_get_ctx, mock_ctx):
         raise asyncio.TimeoutError
 
     # asyncio.wait_for가 TimeoutError를 발생시키도록 패치
-    with patch("asyncio.wait_for", side_effect=raise_timeout):
+    with patch("asyncio.wait_for", side_effect=raise_timeout), \
+         patch("view.web.routes.notification.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_notifications(mock_request)
         iterator = response.body_iterator
         
@@ -125,13 +126,14 @@ async def test_stream_notifications_disconnect(mock_get_ctx, mock_ctx):
     # 바로 연결 끊김 상태
     mock_request.is_disconnected = AsyncMock(return_value=True)
     
-    response = await stream_notifications(mock_request)
-    iterator = response.body_iterator
-    
-    # 데이터 없이 바로 종료되어야 함
-    with pytest.raises(StopAsyncIteration):
-        await iterator.__anext__()
-        
+    with patch("view.web.routes.notification.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
+        response = await stream_notifications(mock_request)
+        iterator = response.body_iterator
+
+        # 데이터 없이 바로 종료되어야 함
+        with pytest.raises(StopAsyncIteration):
+            await iterator.__anext__()
+
     mock_ctx.notification_service.remove_subscriber_queue.assert_called_once()
 
 @pytest.mark.asyncio
@@ -152,7 +154,8 @@ async def test_stream_notifications_cancelled(mock_get_ctx, mock_ctx):
         raise asyncio.CancelledError
 
     # wait_for에서 CancelledError 발생 시뮬레이션
-    with patch("asyncio.wait_for", side_effect=raise_cancelled):
+    with patch("asyncio.wait_for", side_effect=raise_cancelled), \
+         patch("view.web.routes.notification.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_notifications(mock_request)
         iterator = response.body_iterator
         
@@ -181,7 +184,8 @@ async def test_stream_notifications_timeout_disconnect_check(mock_get_ctx, mock_
         raise asyncio.TimeoutError
 
     # asyncio.wait_for가 TimeoutError를 발생시키도록 패치
-    with patch("asyncio.wait_for", side_effect=raise_timeout):
+    with patch("asyncio.wait_for", side_effect=raise_timeout), \
+         patch("view.web.routes.notification.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01):
         response = await stream_notifications(mock_request)
         iterator = response.body_iterator
         

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,94 +1,24 @@
 # Investment Trading App - Refined To-Do List
 
-## 2026-04-23 Summary - Order FSM Phase 1-2
+## 2026-04-24 Summary - Remaining Order Work
 
-### Phase 1 Completed - Core FSM / Execution Notice / Polling
-- [x] Added explicit order state models: `OrderState`, `OrderSide`, `OrderContext`.
-- [x] Added active-order protection using symbol-level locks and `has_active_order()` checks.
-- [x] Added retry-aware FSM transitions for `PENDING_SUBMIT`, `SUBMITTED`, `FILLED`, `PARTIAL_FILLED`, `CANCELED`, and `REJECTED`.
-- [x] Added broker order-number extraction and order-number indexing for matching broker events back to local FSM contexts.
-- [x] Added helper transition methods: partial fill, cancel, reject, and submitted-order resolution.
-- [x] Added `OrderExecutionReport` as a shared event model for WebSocket execution notices and order-query polling.
-- [x] Added domestic stock execution notice parsing for `H0STCNI0` (real) and `H0STCNI9` (paper).
-- [x] Added `htsid` based execution-notice subscribe/unsubscribe delegation through WebSocket API, KIS client, broker wrapper, and streaming service.
-- [x] Registered `signing_notice` handling in `WebAppContext` so execution notices update `OrderExecutionService`.
-- [x] Added idempotent FSM event application with duplicate event prevention and partial-fill accumulation.
-- [x] Added KIS `inquire-daily-ccld` endpoint, TR IDs, params, account API method, client delegation, and broker wrapper delegation.
-- [x] Added `OrderExecutionService.poll_active_orders_once()` to reconcile active orders via order-query polling.
-- [x] Removed scheduler-side forced `FILLED` transition after API order success so execution notice/polling can finalize state.
-- [x] Added unit tests for FSM transitions, execution notice parsing/subscription, polling reconciliation, and KIS delegation paths.
-- [x] Verified Phase1 direct impact scope: `375 passed`.
-- [x] Verified Phase1 syntax/import health with `compileall`.
-
-### Phase 2 Completed - Operational Hardening
-- [x] Added bounded lifecycle management for `_processed_execution_events` with LRU-style retention.
-- [x] Kept duplicate `event_key` behavior idempotent after the retention refactor.
-- [x] Hardened out-of-order handling: partial fill followed by late acceptance/SUBMITTED notice remains a no-op.
-- [x] Made cumulative fill handling monotonic so older polling rows cannot reduce filled quantity.
-- [x] Wired `poll_active_orders_once()` into the strategy scheduler loop as a lightweight periodic reconciliation caller.
-- [x] Avoided adding a separate long-lived polling task to reduce pytest/background-task hang risk.
-- [x] Hardened signing-notice parsing for short/drifted payloads and kept unknown/parse-error payloads observable.
-- [x] Escalated missing `htsid` in real trading mode with critical logging and startup-facing exception.
-- [x] Hardened `from_order_query()` rejected/canceled edge cases for missing `ord_qty`, cancel quantity, reject quantity, and missing remaining quantity.
-- [x] Added regression tests for Phase2 hardening paths.
-- [x] Verified Phase2 impact scope: `286 passed`.
-- [x] Verified Phase2 syntax/import health with `compileall`.
-
-### Phase 3 Completed - Execution-Confirmed Virtual Trade Persistence
-- [x] Moved live scheduler virtual-trade persistence away from API order acceptance.
-- [x] Kept dry-run virtual-trade persistence unchanged, because dry-run has no broker execution event.
-- [x] Added execution-confirmed virtual trade persistence in `OrderExecutionService`.
-- [x] Persisted BUY fills through `log_buy_async()` using confirmed fill price/qty.
-- [x] Persisted strategy SELL fills through `log_sell_by_strategy_async()`.
-- [x] Persisted manual/default SELL fills through `log_sell_async()`.
-- [x] Added idempotent virtual-trade recording with `OrderContext.virtual_recorded_qty`.
-- [x] Deferred partial-fill virtual persistence until terminal `FILLED` or partial-then-`CANCELED`.
-- [x] Stopped web manual orders from writing virtual trades immediately after API acceptance.
-- [x] Added regression tests for confirmed BUY/SELL persistence, duplicate execution notices, and partial-fill-then-cancel persistence.
-- [x] Updated scheduler and web route tests so live/API-accepted paths do not write virtual trades prematurely.
-- [x] Verified Phase3 impact scope: `242 passed`.
-- [x] Verified Phase3 syntax/import health with `compileall`.
-
-### Phase 4 Completed - Cancel Request Integration
-- [x] Added KIS domestic stock `order-rvsecncl` endpoint and real/paper TR IDs.
-- [x] Added revise/cancel request body params for cancel requests using `RVSE_CNCL_DVSN_CD="02"`.
-- [x] Added cancel delegation through KIS trading API, client, and broker wrapper.
-- [x] Added `OrderExecutionService.cancel_order()` using local FSM context plus `broker_order_no`.
-- [x] Sent cancel requests with remaining quantity and preserved terminal-state confirmation for execution notice/polling.
-- [x] Kept cancel API success from forcing immediate `OrderState.CANCELED`.
-- [x] Added regression tests for TR ID/provider selection, trading/client/wrapper delegation, and cancel service edge cases.
-- [x] Verified Phase4 impact scope: `133 passed`.
-- [x] Verified Phase4 syntax/import health with `compileall`.
-
-### Phase 5 Completed - Post-Submit Polling Fallback
-- [x] Added post-submit fast-poll window tracking in `OrderExecutionService`.
-- [x] Exposed active-order polling interval hints so the scheduler can choose between fast and default polling cadence.
-- [x] Kept the existing single scheduler loop and avoided adding a separate polling background task.
-- [x] Applied fast polling only for a short post-submit window, then automatically fell back to the default active-order polling interval.
-- [x] Ensured terminal orders stop affecting polling cadence without extra lifecycle management.
-- [x] Added regression tests for fast-poll registration, expiry, terminal-order pruning, and scheduler interval override behavior.
-- [x] Verified Phase5 impact scope: `145 passed`.
-- [x] Verified Phase5 syntax/import health with `compileall`.
-
-### Remaining Order FSM Work
-- [ ] Validate real KIS `inquire-daily-ccld` response fields in both paper and real environments.
-  - Fixture/schema prep: sanitized synthetic `output1` rows and parser contract tests added for submitted, partial-filled, filled, canceled, and rejected rows.
-  - Confirm order number, stock code, side, order qty, cumulative fill qty, remaining qty, average fill price, cancel/reject fields.
-  - Save sanitized captured examples for regression fixtures if possible.
-  - Still required: validate against captured paper and real KIS responses.
-- [ ] Add notification/logging for orders stuck in `SUBMITTED` or `PARTIAL_FILLED` beyond a threshold.
-  - Include order key, broker order number, side, qty, filled qty, remaining qty, source, and age.
-  - Decide warning vs critical thresholds for real trading.
-- [ ] Investigate full `tests/unit_test` timeout separately.
-  - Direct impact tests pass, but full suite previously hit the 5-minute command timeout.
-  - Check retry queue plain-dict mocks, background `asyncio.create_task()` loops not stopped, and websocket pending task warnings.
+### Remaining Order Follow-up
+- [ ] Validate real KIS `inquire-daily-ccld` response fields with captured real-account responses.
+  - Done already:
+    - synthetic fixture/schema prep and parser contract tests
+    - sanitized paper captured fixture and regression coverage
+    - stuck-order notification/logging
+    - `tests/unit_test` timeout investigation and runtime reduction
+  - Still required:
+    - capture real-account rows for dates/order numbers that actually have executions
+    - confirm real response mapping for order number, stock code, side, order qty, cumulative fill qty, remaining qty, average fill price, cancel/reject fields
+    - save sanitized real captured examples as regression fixtures
 
 ### Recommended Next Order
-1. Validate KIS polling fields with captured paper-trading responses.
-2. Add stuck-order notification/logging for long-lived `SUBMITTED` / `PARTIAL_FILLED`.
-3. Investigate full `tests/unit_test` timeout separately.
+1. Capture real-account `inquire-daily-ccld` responses that include actual order rows.
+2. Add sanitized real fixture(s) and extend regression verification if field shape differs from paper.
 
-최종 업데이트: 2026-04-23
+최종 업데이트: 2026-04-24
 
 이 문서는 현재 코드베이스와 `CODEX_WORKFLOW.md`, `CODEBASE_SUMMARY.md` 기준으로 다시 정리한 실행용 To-Do다.
 
@@ -128,15 +58,6 @@
     - 현재가 REST 조회 실패 상황에서 `rest_failed` 로그가 남는지 확인한다.
     - 장 마감 후 조용한 상태를 장애로 오탐하지 않는지 로그를 함께 점검한다.
 
-
-- [x] 주문 상태 기계(FSM) 도입
-  - 상태: Phase1/2에서 기본 FSM, 체결통보, 주문조회 polling, scheduler polling caller까지 적용됨.
-  - 후속 목표: 실체결 기준 가상매매 기록, 취소 API, post-submit fallback polling, stuck-order 알림으로 운영 안전성을 높인다.
-  - 대상:
-    - `common/types.py`
-    - `services/order_execution_service.py`
-    - `scheduler/strategy_scheduler.py`
-    - `brokers/korea_investment/*`
 
 - [ ] 계좌 보호용 킬 스위치 추가
   - 목표: 일손실 한도, 연속 손실, 비정상 응답 반복, 체결 이상 시 자동으로 주문/전략 실행을 막는다.
@@ -343,10 +264,8 @@
 
 ## 지금 바로 착수 추천 순서
 
-1. FSM 실체결 기준 가상매매 기록 전환
-2. KIS `inquire-daily-ccld` 실응답 필드 검증 및 fixture화
-3. missed WebSocket notice 대비 post-submit polling fallback 정책
-4. stuck-order notification/logging 추가
-5. full `tests/unit_test` timeout 원인 조사
-
-이 5개가 Phase1/2 이후 주문 실행 안정성을 완성하는 데 가장 투자 대비 효과가 크다.
+1. real 계좌 `inquire-daily-ccld` 실응답 캡처 및 fixture화
+2. 계좌 보호용 킬 스위치 추가
+3. 구독 종목 복구 지연 개선
+4. 스트리밍 데이터 수신 누락 원인 정리 및 수정
+5. `WebAppContext` 비대화 해소

--- a/view/web/routes/notification.py
+++ b/view/web/routes/notification.py
@@ -11,6 +11,7 @@ from view.web.api_common import _get_ctx
 from services.notification_service import NotificationCategory
 
 router = APIRouter()
+SSE_KEEPALIVE_TIMEOUT_SEC = 15
 
 
 @router.get("/notifications/recent")
@@ -34,7 +35,7 @@ async def stream_notifications(request: Request):
         try:
             while True:
                 try:
-                    data = await asyncio.wait_for(queue.get(), timeout=15)
+                    data = await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_TIMEOUT_SEC)
                     if data is None:
                         break
                     yield f"data: {data}\n\n"

--- a/view/web/routes/program.py
+++ b/view/web/routes/program.py
@@ -12,6 +12,7 @@ from view.web.api_common import (
 from repositories.streaming_stock_repo import StreamingType
 
 router = APIRouter()
+SSE_KEEPALIVE_TIMEOUT_SEC = 15.0
 
 
 @router.post("/program-trading/subscribe")
@@ -106,7 +107,7 @@ async def stream_program_trading(request: Request):
             # 2. 실시간 데이터 전송 (program_trading_stream_service에서 JSON 직렬화 후 큐에 삽입됨)
             while True:
                 try:
-                    data = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    data = await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_TIMEOUT_SEC)
                     if data is None:  # 테스트 종료 신호 (Poison Pill)
                         break
                     yield f"data: {data}\n\n"

--- a/view/web/routes/streaming.py
+++ b/view/web/routes/streaming.py
@@ -13,6 +13,7 @@ from view.web.api_common import _get_ctx
 from services.price_subscription_service import SubscriptionPriority
 
 router = APIRouter()
+SSE_KEEPALIVE_TIMEOUT_SEC = 15
 
 
 class SubscribeRequest(BaseModel):
@@ -76,7 +77,7 @@ async def stream_stock_price(code: str, request: Request):
         try:
             while True:
                 get_task = asyncio.ensure_future(queue.get())
-                _, pending = await asyncio.wait({get_task}, timeout=15)
+                _, pending = await asyncio.wait({get_task}, timeout=SSE_KEEPALIVE_TIMEOUT_SEC)
                 if pending:
                     get_task.cancel()
                     if await request.is_disconnected():


### PR DESCRIPTION
…, program.py (line 15), notification.py (line 14)에 분리했고, generator가 실제로 도는 시점까지 patch가 유지되도록 test_web_routes_program.py (line 270), test_web_notification.py (line 118)를 고쳤습니다. cache benchmark도 test_cache_benchmark.py (line 37)에서 샘플 수를 100으로 낮춰서 과도한 런타임을 줄였습니다.

검증 결과는 좋습니다. 타깃 35개 테스트는 35 passed in 8.52s였고, 이전 같은 묶음 54.22s 대비 크게 줄었습니다. 전체 유닛 테스트도 3221 passed in 346.34s (5:46)로 내려왔고, xdist는 3221 passed in 187.06s (3:07)였습니다. 이전 기준과 비교하면 직렬은 7:52 -> 5:46, 병렬은 3:28 -> 3:07입니다. 다만 직렬은 아직 5분 아래로는 못 내려왔습니다.