### PR TITLE
Bug fixes:

### DIFF
--- a/core/loggers/streaming_event_logger.py
+++ b/core/loggers/streaming_event_logger.py
@@ -509,15 +509,15 @@ class StreamingEventLogger:
             return
         self._logger.error({"action": "pt_restore_error", "code": code, "error": error})
 
-    def log_pt_restore_failed_removed(self, codes: list) -> None:
-        """복원 실패한 PT 종목들을 desired 상태에서 제거.
+    def log_pt_restore_failed_pending(self, codes: list) -> None:
+        """복원 실패한 PT 종목들을 재시도 대기 상태로 기록 (desired는 유지).
 
         Args:
-            codes: 제거 대상 종목코드 목록
+            codes: 재시도 대기 종목코드 목록
         """
         if not self._logger.isEnabledFor(logging.WARNING):
             return
-        self._logger.warning({"action": "pt_restore_failed_removed", "codes": sorted(codes)})
+        self._logger.warning({"action": "pt_restore_failed_pending", "codes": sorted(codes)})
 
     def log_price_restore_start(self, desired_count: int) -> None:
         """H0UNCNT0(실시간 체결가) 구독 복원 시작.

--- a/repositories/program_trading_repo.py
+++ b/repositories/program_trading_repo.py
@@ -44,7 +44,7 @@ class ProgramTradingRepo:
     FLUSH_INTERVAL_SEC = 1.0
     FLUSH_BATCH_SIZE = 100
 
-    def __init__(self, base_dir: str = "data/program_subscribe", logger=None):
+    def __init__(self, base_dir: str = "data/program_subscribe", logger=None, streaming_stock_repo=None):
         self._logger = logger or logging.getLogger(__name__)
         self._base_dir = base_dir
         self._db_path = os.path.join(base_dir, "program_trading.db")
@@ -56,6 +56,7 @@ class ProgramTradingRepo:
         self._buffer_lock = threading.Lock()
         self._flush_task: Optional[asyncio.Task] = None
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pt_db")
+        self._streaming_stock_repo = streaming_stock_repo
 
         os.makedirs(self._base_dir, exist_ok=True)
         self._init_db()
@@ -250,8 +251,12 @@ class ProgramTradingRepo:
             while True:
                 await asyncio.sleep(self.FLUSH_INTERVAL_SEC)
                 await self._flush_write_buffer()
+                if self._streaming_stock_repo is not None:
+                    self._streaming_stock_repo.flush_pt_desired_sync()
         except asyncio.CancelledError:
             await self._flush_write_buffer()
+            if self._streaming_stock_repo is not None:
+                self._streaming_stock_repo.flush_pt_desired_sync()
 
     # ── 스냅샷 저장/조회 ─────────────────────────────────────────────
 
@@ -381,6 +386,8 @@ class ProgramTradingRepo:
                 pass
 
         self.flush_write_buffer_sync()
+        if self._streaming_stock_repo is not None:
+            self._streaming_stock_repo.flush_pt_desired_sync()
         self._executor.shutdown(wait=False)
 
         if self._conn:

--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -53,6 +53,10 @@ class StreamingStockRepo:
         self._db_lock = threading.Lock()
         self._db_path: Optional[str] = None
 
+        # 배치 flush용 pending queue — 즉시 commit 대신 flush_pt_desired_sync()에서 일괄 처리
+        self._pending_desired_ops: list = []  # list of (code: str, add: bool)
+        self._pending_lock = threading.Lock()
+
     # ── 초기화 / 영속성 ──────────────────────────────────────────────
 
     def load_pt_desired_from_db(self, db_path: str) -> None:
@@ -71,22 +75,39 @@ class StreamingStockRepo:
             self._logger.warning(f"StreamingStockRepo: PT desired DB 복원 실패 (무시): {e}")
 
     def _persist_pt_desired(self, code: str, add: bool) -> None:
-        """PT desired 상태를 SQLite에 동기 저장. add=True이면 INSERT, False이면 DELETE."""
+        """PT desired 변경을 pending queue에 적재. flush_pt_desired_sync()에서 일괄 커밋."""
         if self._db_conn is None:
             return
+        with self._pending_lock:
+            self._pending_desired_ops.append((code, add))
+
+    def flush_pt_desired_sync(self) -> None:
+        """pending queue의 PT desired 변경을 1회 트랜잭션으로 일괄 커밋."""
+        if self._db_conn is None:
+            return
+        with self._pending_lock:
+            if not self._pending_desired_ops:
+                return
+            ops = list(self._pending_desired_ops)
+            self._pending_desired_ops.clear()
         try:
             with self._db_lock:
-                if add:
-                    self._db_conn.execute(
-                        "INSERT OR IGNORE INTO pt_subscriptions (code) VALUES (?)", (code,)
-                    )
-                else:
-                    self._db_conn.execute(
-                        "DELETE FROM pt_subscriptions WHERE code = ?", (code,)
-                    )
+                for code, add in ops:
+                    if add:
+                        self._db_conn.execute(
+                            "INSERT OR IGNORE INTO pt_subscriptions (code) VALUES (?)", (code,)
+                        )
+                    else:
+                        self._db_conn.execute(
+                            "DELETE FROM pt_subscriptions WHERE code = ?", (code,)
+                        )
                 self._db_conn.commit()
         except Exception as e:
-            self._logger.warning(f"StreamingStockRepo: PT desired DB 업데이트 실패 ({code}): {e}")
+            self._logger.warning(f"StreamingStockRepo: PT desired 배치 flush 실패: {e}")
+            try:
+                self._db_conn.rollback()
+            except Exception:
+                pass
 
     # ── 상태 변경 (asyncio.Lock 보호) ────────────────────────────────
 

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -215,6 +215,10 @@ class ProgramTradingStreamService:
             ).strftime("%Y-%m-%d %H:%M:%S")
         return status
 
+    def wire_streaming_stock_repo(self, streaming_stock_repo) -> None:
+        """StreamingStockRepo를 사후 주입하여 desired flush를 repo의 flush_loop에 통합한다."""
+        self._repo._streaming_stock_repo = streaming_stock_repo
+
     # ── 생명주기 관리 ────────────────────────────────────────────────
 
     def start_background_tasks(self):

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -320,38 +320,33 @@ class WebSocketWatchdogTask(SchedulableTask):
                     total=len(pt_codes),
                     codes=pt_codes,
                 )
-        for code in pt_codes:
-            try:
-                connected = await self._streaming_service.connect_websocket()
-                if not connected:
-                    if self._streaming_logger:
-                        self._streaming_logger.log_pt_restore_connect_failed(code)
-                    pt_failed.append(code)
-                    continue
-                await self._streaming_service.subscribe_program_trading(code)
+            connected = await self._streaming_service.connect_websocket()
+            if not connected:
                 if self._streaming_logger:
-                    self._streaming_logger.log_pt_subscribe(code, reason="restore")
-                await self._streaming_service.subscribe_realtime_price(code)
-                if self._streaming_logger:
-                    self._streaming_logger.log_price_subscribe(code, reason="restore")
-                if self._streaming_stock_repo:
-                    await self._streaming_stock_repo.mark_active(code, StreamingType.PROGRAM_TRADING)
-                pt_success += 1
-                await asyncio.sleep(self.SUBSCRIBE_DELAY_SEC)
-            except Exception as e:
-                if self._streaming_logger:
-                    self._streaming_logger.log_pt_restore_error(code, str(e))
-                pt_failed.append(code)
+                    self._streaming_logger.log_pt_restore_connect_failed(f"all({len(pt_codes)})")
+                pt_failed = list(pt_codes)
+            else:
+                for code in pt_codes:
+                    try:
+                        await self._streaming_service.subscribe_program_trading(code)
+                        if self._streaming_logger:
+                            self._streaming_logger.log_pt_subscribe(code, reason="restore")
+                        await self._streaming_service.subscribe_realtime_price(code)
+                        if self._streaming_logger:
+                            self._streaming_logger.log_price_subscribe(code, reason="restore")
+                        if self._streaming_stock_repo:
+                            await self._streaming_stock_repo.mark_active(code, StreamingType.PROGRAM_TRADING)
+                        pt_success += 1
+                        await asyncio.sleep(self.SUBSCRIBE_DELAY_SEC)
+                    except Exception as e:
+                        if self._streaming_logger:
+                            self._streaming_logger.log_pt_restore_error(code, str(e))
+                        pt_failed.append(code)
 
         if pt_failed:
+            # desired 유지 — 다음 watchdog tick(60초)에서 재시도
             if self._streaming_logger:
-                self._streaming_logger.log_pt_restore_failed_removed(pt_failed)
-            for code in pt_failed:
-                if self._streaming_stock_repo:
-                    await self._streaming_stock_repo.unmark_desired(code, StreamingType.PROGRAM_TRADING)
-                if self._streaming_logger:
-                    self._streaming_logger.log_pt_unsubscribe(code, reason="restore_failed")
-                    self._streaming_logger.log_price_unsubscribe(code, reason="restore_failed")
+                self._streaming_logger.log_pt_restore_failed_pending(pt_failed)
 
         if pt_codes:
             if self._streaming_logger:

--- a/tests/unit_test/core/loggers/test_streaming_event_logger.py
+++ b/tests/unit_test/core/loggers/test_streaming_event_logger.py
@@ -417,16 +417,16 @@ def test_log_pt_restore_error(streaming_logger_setup):
     assert lines[0]["level"] == "ERROR"
 
 
-def test_log_pt_restore_failed_removed(streaming_logger_setup):
+def test_log_pt_restore_failed_pending(streaming_logger_setup):
     streaming_logger, streaming_log_dir = streaming_logger_setup
 
-    streaming_logger.log_pt_restore_failed_removed(["000660", "005930"])
+    streaming_logger.log_pt_restore_failed_pending(["000660", "005930"])
 
     _flush_streaming_logger()
 
     lines = _read_json_lines(streaming_log_dir)
     d = lines[0]["data"]
-    assert d["action"] == "pt_restore_failed_removed"
+    assert d["action"] == "pt_restore_failed_pending"
     assert d["codes"] == ["000660", "005930"]
     assert lines[0]["level"] == "WARNING"
 
@@ -678,7 +678,7 @@ def test_log_ignored_when_level_is_high(streaming_logger_setup):
     streaming_logger.log_watchdog_error("msg")
     streaming_logger.log_pt_restore_connect_failed("005930")
     streaming_logger.log_pt_restore_error("005930", "err")
-    streaming_logger.log_pt_restore_failed_removed([])
+    streaming_logger.log_pt_restore_failed_pending([])
     streaming_logger.log_price_restore_start(1)
     streaming_logger.log_price_restore_done(1)
     streaming_logger.log_force_reconnect_start("trig", [])

--- a/tests/unit_test/repositories/test_program_trading_repo.py
+++ b/tests/unit_test/repositories/test_program_trading_repo.py
@@ -384,3 +384,46 @@ async def test_shutdown_skips_close_when_connection_missing(repo):
 
     mock_flush.assert_called_once()
     mock_shutdown.assert_called_once_with(wait=False)
+
+
+@pytest.mark.asyncio
+async def test_flush_loop_calls_streaming_stock_repo_flush(tmp_path):
+    """_flush_loop이 매 주기마다 streaming_stock_repo.flush_pt_desired_sync()를 호출한다."""
+    logger = MagicMock()
+    mock_ssr = MagicMock()
+    repo = ProgramTradingRepo(
+        base_dir=str(tmp_path / "pt_repo"),
+        logger=logger,
+        streaming_stock_repo=mock_ssr,
+    )
+    try:
+        with patch.object(repo, "_flush_write_buffer", new=AsyncMock()), \
+             patch(
+                 "repositories.program_trading_repo.asyncio.sleep",
+                 new=AsyncMock(side_effect=[None, asyncio.CancelledError()]),
+             ):
+            await repo._flush_loop()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        if repo._conn:
+            repo._conn.close()
+        repo._executor.shutdown(wait=False)
+
+    assert mock_ssr.flush_pt_desired_sync.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_flushes_streaming_stock_repo(tmp_path):
+    """shutdown 시 streaming_stock_repo.flush_pt_desired_sync()가 호출된다."""
+    logger = MagicMock()
+    mock_ssr = MagicMock()
+    repo = ProgramTradingRepo(
+        base_dir=str(tmp_path / "pt_repo"),
+        logger=logger,
+        streaming_stock_repo=mock_ssr,
+    )
+
+    await repo.shutdown()
+
+    mock_ssr.flush_pt_desired_sync.assert_called_once()

--- a/tests/unit_test/repositories/test_streaming_stock_repo.py
+++ b/tests/unit_test/repositories/test_streaming_stock_repo.py
@@ -96,17 +96,24 @@ async def test_pt_persistence_flow(tmp_path, mock_logger):
     repo1 = StreamingStockRepo(logger=mock_logger)
     repo1.load_pt_desired_from_db(db_path)
     
-    # 3. 구독 대상 추가
+    # 3. 구독 대상 추가 — flush 전에는 in-memory만 반영, DB는 미반영
     await repo1.mark_desired("005930", StreamingType.PROGRAM_TRADING)
     await repo1.mark_desired("000660", StreamingType.PROGRAM_TRADING)
-    
-    # DB에 저장되었는지 확인
+
+    assert "005930" in repo1.get_desired(StreamingType.PROGRAM_TRADING)
+
     conn = sqlite3.connect(db_path)
-    cursor = conn.execute("SELECT code FROM pt_subscriptions")
-    rows = {row[0] for row in cursor.fetchall()}
+    rows_before = {row[0] for row in conn.execute("SELECT code FROM pt_subscriptions").fetchall()}
+    conn.close()
+    assert len(rows_before) == 0
+
+    # flush 후 DB 반영 확인
+    repo1.flush_pt_desired_sync()
+    conn = sqlite3.connect(db_path)
+    rows = {row[0] for row in conn.execute("SELECT code FROM pt_subscriptions").fetchall()}
+    conn.close()
     assert "005930" in rows
     assert "000660" in rows
-    conn.close()
 
     # 4. 새로운 repo 객체로 DB에서 복원 검증
     repo2 = StreamingStockRepo(logger=mock_logger)
@@ -115,9 +122,10 @@ async def test_pt_persistence_flow(tmp_path, mock_logger):
     assert "005930" in desired2
     assert "000660" in desired2
 
-    # 5. 구독 대상 제거 검증
+    # 5. 구독 대상 제거 검증 — flush 후 DB 반영
     await repo1.unmark_desired("005930", StreamingType.PROGRAM_TRADING)
-    
+    repo1.flush_pt_desired_sync()
+
     repo3 = StreamingStockRepo(logger=mock_logger)
     repo3.load_pt_desired_from_db(db_path)
     desired3 = repo3.get_desired(StreamingType.PROGRAM_TRADING)
@@ -136,12 +144,18 @@ def test_load_pt_desired_from_db_failure(mock_logger):
 
 @pytest.mark.asyncio
 async def test_persist_pt_desired_execute_failure(tmp_path, mock_logger):
-    """DB INSERT/DELETE 쿼리 중 예외 발생 시 무시되고 로깅만 남는지 검증"""
+    """flush_pt_desired_sync() 중 DB 예외 발생 시 무시되고 warning 로깅만 남는지 검증"""
     repo = StreamingStockRepo(logger=mock_logger)
     repo._db_conn = MagicMock()
     repo._db_conn.execute.side_effect = Exception("Mock DB Execute Error")
-    
+
     await repo.mark_desired("005930", StreamingType.PROGRAM_TRADING)
-    
+
+    # mark_desired만으로는 DB 기록 없음 — pending queue에만 적재
+    mock_logger.warning.assert_not_called()
+
+    # flush 시 실제 DB 기록 시도 → 예외 발생 → warning 로그
+    repo.flush_pt_desired_sync()
+
     mock_logger.warning.assert_called_once()
     assert "Mock DB Execute Error" in mock_logger.warning.call_args[0][0]

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -474,3 +474,12 @@ def test_inspect_db_status_exception(manager):
     status = manager.inspect_db_status()
 
     assert "error" in status
+
+
+def test_wire_streaming_stock_repo(manager):
+    """wire_streaming_stock_repo가 _repo에 streaming_stock_repo를 주입한다."""
+    mock_ssr = MagicMock()
+
+    manager.wire_streaming_stock_repo(mock_ssr)
+
+    assert manager._repo._streaming_stock_repo is mock_ssr

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -139,7 +139,7 @@ async def test_restore_program_trading_success(watchdog_task, mock_deps):
     with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", new_callable=AsyncMock):
         await svc._restore_all_subscriptions()
 
-    assert svc._streaming_service.connect_websocket.call_count == 2
+    assert svc._streaming_service.connect_websocket.call_count == 1
     assert svc._streaming_service.subscribe_program_trading.call_count == 2
     assert svc._streaming_service.subscribe_realtime_price.call_count == 2
     svc._streaming_logger.log_subscription_recovery_done.assert_called_once()
@@ -147,31 +147,28 @@ async def test_restore_program_trading_success(watchdog_task, mock_deps):
 
 @pytest.mark.asyncio
 async def test_restore_program_trading_partial_failure(watchdog_task, mock_deps):
-    """_restore_all_subscriptions: 연결 실패 종목은 desired에서 제거, 성공 종목은 active로 등록."""
+    """_restore_all_subscriptions: 구독 예외 종목은 desired 유지(재시도 대기), 성공 종목은 active 등록."""
     svc = watchdog_task
     svc.mcs.is_market_open_now = AsyncMock(return_value=True)
-    # "000660"만 connect 실패, "005930"과 "035720"은 성공
-    connect_results = iter([True, False, True])
+    svc._streaming_service.connect_websocket = AsyncMock(return_value=True)
 
-    async def connect_side_effect(callback=None):
-        return next(connect_results)
+    # "000660"만 subscribe_program_trading에서 예외 발생
+    async def subscribe_side_effect(code):
+        if code == "000660":
+            raise RuntimeError("subscribe fail")
 
-    svc._streaming_service.connect_websocket = AsyncMock(side_effect=connect_side_effect)
-
-    # 구독 종목 2개 (성공하는 것 1개, 실패하는 것 1개)
-    svc._streaming_stock_repo.get_desired.return_value = {"005930", "000660", "035720"}
+    svc._streaming_service.subscribe_program_trading = AsyncMock(side_effect=subscribe_side_effect)
+    svc._streaming_stock_repo.get_desired.return_value = {"005930", "000660"}
 
     with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", new_callable=AsyncMock):
         await svc._restore_all_subscriptions()
 
-    assert svc._streaming_service.connect_websocket.await_count == 3
+    # connect는 루프 밖에서 1회만 호출
+    assert svc._streaming_service.connect_websocket.await_count == 1
 
-    # connect 실패한 종목은 streaming_logger + unmark_desired 호출 확인
-    from repositories.streaming_stock_repo import StreamingType
-    unmark_calls = {call.args[0] for call in svc._streaming_stock_repo.unmark_desired.call_args_list}
-    assert len(unmark_calls) == 1  # connect 실패 1종목
-    failed_code = next(iter(unmark_calls))
-    svc._streaming_logger.log_pt_restore_connect_failed.assert_called_once_with(failed_code)
+    # 실패 종목도 desired에 유지 — unmark_desired 호출 없음
+    svc._streaming_stock_repo.unmark_desired.assert_not_called()
+    svc._streaming_logger.log_pt_restore_failed_pending.assert_called_once()
 
 
 # ── _streaming_watchdog 테스트 ─────────────────────────────────────────
@@ -313,7 +310,7 @@ async def test_force_reconnect_program_trading(watchdog_task, mock_deps):
         await svc.force_reconnect_program_trading()
 
     svc._streaming_service.disconnect_websocket.assert_awaited_once()
-    assert svc._streaming_service.connect_websocket.call_count == 2
+    assert svc._streaming_service.connect_websocket.call_count == 1
     assert svc._streaming_service.subscribe_program_trading.call_count == 2
     assert svc._streaming_service.subscribe_realtime_price.call_count == 2
     svc._streaming_logger.log_force_reconnect_done.assert_called_once_with("manual")
@@ -461,10 +458,9 @@ async def test_force_reconnect_program_trading_errors(watchdog_task, mock_deps):
         await svc.force_reconnect_program_trading()
 
     svc._streaming_logger.log_force_reconnect_disconnect_error.assert_called_once_with("Disconnect Error")
-    svc._streaming_logger.log_pt_restore_connect_failed.assert_called_once_with("005930")
-    # 실패 종목이 unmark_desired 호출되어야 함
-    svc._streaming_stock_repo.unmark_desired.assert_called_once()
-    assert svc._streaming_stock_repo.unmark_desired.call_args.args[0] == "005930"
+    svc._streaming_logger.log_pt_restore_connect_failed.assert_called_once_with("all(1)")
+    # 실패 종목도 desired 유지 — unmark_desired 호출 없음
+    svc._streaming_stock_repo.unmark_desired.assert_not_called()
 
 
 # ── get_progress() 테스트 ────────────────────────────────────────────────────
@@ -1024,7 +1020,7 @@ async def test_restore_price_done_log_reflects_active_count(watchdog_task, mock_
 
 @pytest.mark.asyncio
 async def test_restore_program_trading_subscribe_exception_marks_failed(watchdog_task):
-    """PT 구독 중 예외가 나면 실패 목록으로 이동하고 desired에서 제거된다."""
+    """PT 구독 중 예외가 나면 실패 로그를 남기고 desired는 유지된다 (다음 watchdog tick 재시도)."""
     svc = watchdog_task
     svc.mcs.is_market_open_now = AsyncMock(return_value=True)
     svc._streaming_stock_repo.get_desired.return_value = {"005930"}
@@ -1034,7 +1030,7 @@ async def test_restore_program_trading_subscribe_exception_marks_failed(watchdog
     await svc._restore_all_subscriptions()
 
     svc._streaming_logger.log_pt_restore_error.assert_called_once()
-    svc._streaming_stock_repo.unmark_desired.assert_awaited_once_with("005930", StreamingType.PROGRAM_TRADING)
+    svc._streaming_stock_repo.unmark_desired.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -346,6 +346,7 @@ class WebAppContext:
         self.streaming_stock_repo = StreamingStockRepo(logger=self.logger)
         self.streaming_stock_repo.load_pt_desired_from_db("data/program_subscribe/program_trading.db")
         self.streaming_service.set_streaming_stock_repo(self.streaming_stock_repo)
+        self.program_trading_stream_service.wire_streaming_stock_repo(self.streaming_stock_repo)
 
         # PriceSubscriptionService 초기화 (StreamingService 생성 이후)
         self.price_subscription_service = PriceSubscriptionService(


### PR DESCRIPTION
websocket_watchdog_task.py — _restore_all_subscriptions: connect_websocket() moved outside the per-code loop (1 call instead of N), and all unmark_desired() calls on failure removed. Transient failures now keep desired intact and retry on the next watchdog tick (60s). Batch DB writes:

streaming_stock_repo.py — _persist_pt_desired() now enqueues to _pending_desired_ops (no immediate commit). flush_pt_desired_sync() drains the queue in a single transaction. program_trading_repo.py — _flush_loop and shutdown both call streaming_stock_repo.flush_pt_desired_sync() after the data flush. Wiring:

program_trading_stream_service.py — Added wire_streaming_stock_repo() for post-construction DI. web_app_initializer.py — Added program_trading_stream_service.wire_streaming_stock_repo(streaming_stock_repo) after StreamingStockRepo init. Logger rename:

streaming_event_logger.py — log_pt_restore_failed_removed → log_pt_restore_failed_pending (action key updated to reflect retry semantics). Tests updated:

test_streaming_stock_repo.py — test_pt_persistence_flow adds flush_pt_desired_sync() calls before DB assertions; test_persist_pt_desired_execute_failure verifies flush triggers the error, not mark_desired. test_websocket_watchdog_task.py — 5 tests updated: connect_websocket count 2→1, unmark_desired assertions changed to assert_not_called(), partial failure test rewritten to use subscribe exception instead of per-code connect fail. test_program_trading_repo.py — 2 new tests for streaming_stock_repo flush integration in loop and shutdown. test_program_trading_stream_service.py — 1 new test for wire_streaming_stock_repo. test_streaming_event_logger.py — renamed to test_log_pt_restore_failed_pending.