### PR TITLE
원인은 백엔드 보유종목 소스 불일치가 아니라 프론트 동기화 누락이었습니다. StrategyScheduler.get_statu…

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -321,7 +321,7 @@ class StrategyScheduler:
             return
 
         # 1) 보유 종목 청산 조건 체크
-        holdings = self._virtual_trade_service.get_holds_by_strategy(name)
+        holdings = self._get_strategy_holdings(cfg)
         if holdings:
             t_exit = self._pm.start_timer()
             sell_signals = await cfg.strategy.check_exits(holdings)
@@ -332,7 +332,7 @@ class StrategyScheduler:
                     await f
 
         # 2) 새 매수 스캔
-        current_holdings = self._virtual_trade_service.get_holds_by_strategy(name)
+        current_holdings = self._get_strategy_holdings(cfg)
         current_holds_count = len(current_holdings)
 
         if current_holds_count >= cfg.max_positions:
@@ -504,7 +504,7 @@ class StrategyScheduler:
     async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig):
         """전략 중지 시 보유 종목 강제 청산 (force_exit_on_close=True)."""
         name = cfg.strategy.name
-        holdings = self._virtual_trade_service.get_holds_by_strategy(name)
+        holdings = self._get_strategy_holdings(cfg)
         if not holdings:
             return
 
@@ -615,6 +615,143 @@ class StrategyScheduler:
                 return True
         return False
 
+    def _get_signal_net_qty(self, strategy_name: str, code: str, *, only_success: bool = True) -> int:
+        """신호 이력 기준으로 전략별 순수량을 추정한다."""
+        net_qty = 0
+        target_code = str(code)
+        for record in self._signal_history:
+            if record.strategy_name != strategy_name or str(record.code) != target_code:
+                continue
+            if only_success and not record.api_success:
+                continue
+            qty = int(record.qty or 0)
+            if record.action == "BUY":
+                net_qty += qty
+            elif record.action == "SELL":
+                net_qty -= qty
+        return net_qty
+
+    def _get_latest_open_buy_record(
+        self,
+        strategy_name: str,
+        code: str,
+        *,
+        only_success: bool = True,
+    ) -> Optional[SignalRecord]:
+        """현재 미청산 포지션에 대응하는 가장 최근 BUY 신호를 찾는다."""
+        remaining_sell_qty = 0
+        target_code = str(code)
+        for record in reversed(self._signal_history):
+            if record.strategy_name != strategy_name or str(record.code) != target_code:
+                continue
+            if only_success and not record.api_success:
+                continue
+            qty = int(record.qty or 0)
+            if record.action == "SELL":
+                remaining_sell_qty += qty
+                continue
+            if record.action != "BUY":
+                continue
+            if remaining_sell_qty >= qty:
+                remaining_sell_qty -= qty
+                continue
+            return record
+        return None
+
+    @staticmethod
+    def _is_valid_strategy_code(code: str) -> bool:
+        """전략 state에 남은 비정상 코드값을 걸러낸다."""
+        return code.isdigit() and len(code) == 6
+
+    def _get_strategy_position_state(self, strategy: LiveStrategy) -> Dict[str, object]:
+        """전략이 자체 관리하는 position_state를 반환한다."""
+        state = getattr(strategy, "_position_state", None)
+        return state if isinstance(state, dict) else {}
+
+    def _build_strategy_state_holding(
+        self,
+        strategy_name: str,
+        code: str,
+        state: object,
+        existing: Optional[dict] = None,
+    ) -> dict:
+        """전략 position_state를 scheduler holding 포맷으로 맞춘다."""
+        holding = dict(existing or {})
+        holding["strategy"] = strategy_name
+        holding["code"] = code
+
+        if not holding.get("buy_price"):
+            entry_price = getattr(state, "entry_price", None)
+            if entry_price is not None:
+                holding["buy_price"] = entry_price
+
+        latest_buy = self._get_latest_open_buy_record(strategy_name, code, only_success=True)
+        if latest_buy is None:
+            latest_buy = self._get_latest_open_buy_record(strategy_name, code, only_success=False)
+
+        if latest_buy is not None:
+            if not holding.get("buy_price"):
+                holding["buy_price"] = latest_buy.price
+            if not holding.get("buy_date") and latest_buy.timestamp:
+                holding["buy_date"] = latest_buy.timestamp
+            if not holding.get("name") and latest_buy.name:
+                holding["name"] = latest_buy.name
+
+        if not holding.get("qty"):
+            qty = self._get_signal_net_qty(strategy_name, code, only_success=True)
+            if qty <= 0:
+                qty = self._get_signal_net_qty(strategy_name, code, only_success=False)
+            holding["qty"] = qty if qty > 0 else 1
+
+        if not holding.get("buy_date"):
+            entry_date = str(getattr(state, "entry_date", "") or "")
+            if len(entry_date) == 8 and entry_date.isdigit():
+                holding["buy_date"] = f"{entry_date[:4]}-{entry_date[4:6]}-{entry_date[6:8]} 00:00:00"
+            elif entry_date:
+                holding["buy_date"] = entry_date
+
+        holding["status"] = "HOLD"
+        if not holding.get("name"):
+            holding["name"] = self.stock_code_repository.get_name_by_code(code) or code
+
+        return holding
+
+    def _get_strategy_holdings(self, cfg: StrategySchedulerConfig) -> List[dict]:
+        """가상매매 DB와 전략 내부 position_state를 병합한 보유 목록."""
+        strategy_name = cfg.strategy.name
+        merged: Dict[str, dict] = {}
+
+        repo_holdings = self._virtual_trade_service.get_holds_by_strategy(strategy_name) or []
+        for hold in repo_holdings:
+            code = str(hold.get("code", "")).strip()
+            if code:
+                merged[code] = dict(hold)
+
+        for code, state in self._get_strategy_position_state(cfg.strategy).items():
+            norm_code = str(code).strip()
+            if not norm_code:
+                continue
+            if not self._is_valid_strategy_code(norm_code):
+                self._logger.warning(
+                    f"[Scheduler] invalid position_state code ignored: strategy={strategy_name}, code={norm_code}"
+                )
+                continue
+            merged[norm_code] = self._build_strategy_state_holding(
+                strategy_name,
+                norm_code,
+                state,
+                existing=merged.get(norm_code),
+            )
+
+        return list(merged.values())
+
+    def _get_all_current_positions(self) -> List[dict]:
+        """등록된 전략 전체 보유 목록을 합친다."""
+        positions: List[dict] = []
+        for cfg in self._strategies:
+            positions.extend(self._get_strategy_holdings(cfg))
+        return positions
+
     # ── 상태 조회 ──
 
     def get_status(self) -> dict:
@@ -622,7 +759,7 @@ class StrategyScheduler:
         for cfg in self._strategies:
             name = cfg.strategy.name
             last = self._last_run.get(name)
-            holdings = self._virtual_trade_service.get_holds_by_strategy(name)
+            holdings = self._get_strategy_holdings(cfg)
             strategies.append({
                 "name": name,
                 "interval_minutes": cfg.interval_minutes,
@@ -672,7 +809,7 @@ class StrategyScheduler:
     def _save_scheduler_state(self):
         """활성 전략 목록 및 설정을 DB에 저장."""
         enabled_names = [cfg.strategy.name for cfg in self._strategies if cfg.enabled]
-        current_positions = self._virtual_trade_service.get_holds()
+        current_positions = self._get_all_current_positions()
         state = {
             "running": self._running,
             "enabled_strategies": enabled_names,
@@ -739,7 +876,7 @@ class StrategyScheduler:
                     if cfg.strategy.name not in restored:
                         continue
                     name = cfg.strategy.name
-                    holdings = self._virtual_trade_service.get_holds_by_strategy(name)
+                    holdings = self._get_strategy_holdings(cfg)
                     for hold in holdings:
                         code = hold.get("code")
                         if code:

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -668,6 +668,78 @@ class StrategyScheduler:
         state = getattr(strategy, "_position_state", None)
         return state if isinstance(state, dict) else {}
 
+    def _persist_strategy_position_state(self, strategy: LiveStrategy):
+        """전략이 제공하는 state 저장 함수를 통해 position_state를 즉시 반영한다."""
+        save_state = getattr(strategy, "_save_state", None)
+        if not callable(save_state):
+            return
+        try:
+            save_state()
+        except Exception as e:
+            self._logger.warning(f"[Scheduler] 전략 state 저장 실패: {strategy.name} - {e}")
+
+    def _has_open_position_evidence(
+        self,
+        strategy_name: str,
+        code: str,
+        *,
+        repo_holdings: Optional[List[dict]] = None,
+    ) -> bool:
+        """가상매매 DB 또는 시그널 이력에 현재 포지션 근거가 남아 있는지 확인한다."""
+        target_code = str(code).strip()
+        holdings = repo_holdings
+        if holdings is None:
+            holdings = self._virtual_trade_service.get_holds_by_strategy(strategy_name) or []
+
+        for hold in holdings:
+            if str(hold.get("code", "")).strip() == target_code:
+                return True
+
+        return (
+            self._get_signal_net_qty(strategy_name, target_code, only_success=True) > 0
+            or self._get_signal_net_qty(strategy_name, target_code, only_success=False) > 0
+        )
+
+    def _prune_disabled_force_exit_state(
+        self,
+        cfg: StrategySchedulerConfig,
+        *,
+        repo_holdings: Optional[List[dict]] = None,
+    ) -> bool:
+        """비활성 force-exit 전략에 남은 stale position_state를 정리한다."""
+        if cfg.enabled or not cfg.force_exit_on_close:
+            return False
+
+        position_state = self._get_strategy_position_state(cfg.strategy)
+        if not position_state:
+            return False
+
+        stale_codes: List[str] = []
+        for raw_code in list(position_state.keys()):
+            norm_code = str(raw_code).strip()
+            if not norm_code or not self._is_valid_strategy_code(norm_code):
+                stale_codes.append(raw_code)
+                continue
+            if self._has_open_position_evidence(
+                cfg.strategy.name,
+                norm_code,
+                repo_holdings=repo_holdings,
+            ):
+                continue
+            stale_codes.append(raw_code)
+
+        if not stale_codes:
+            return False
+
+        for raw_code in stale_codes:
+            position_state.pop(raw_code, None)
+
+        self._persist_strategy_position_state(cfg.strategy)
+        self._logger.warning(
+            f"[Scheduler] stale position_state cleared: strategy={cfg.strategy.name}, codes={stale_codes}"
+        )
+        return True
+
     def _build_strategy_state_holding(
         self,
         strategy_name: str,
@@ -727,7 +799,9 @@ class StrategyScheduler:
             if code:
                 merged[code] = dict(hold)
 
-        for code, state in self._get_strategy_position_state(cfg.strategy).items():
+        self._prune_disabled_force_exit_state(cfg, repo_holdings=repo_holdings)
+
+        for code, state in list(self._get_strategy_position_state(cfg.strategy).items()):
             norm_code = str(code).strip()
             if not norm_code:
                 continue
@@ -849,6 +923,7 @@ class StrategyScheduler:
             enabled_names = state.get("enabled_strategies", [])
             saved_positions = state.get("current_positions", [])
             strategy_configs = state.get("strategy_configs", {})
+            stale_state_cleared = False
 
             if saved_positions:
                 self._logger.info(
@@ -864,11 +939,16 @@ class StrategyScheduler:
                 if cfg.strategy.name in enabled_names:
                     cfg.enabled = True
                     restored.append(cfg.strategy.name)
+                elif self._prune_disabled_force_exit_state(cfg):
+                    stale_state_cleared = True
 
             if restored:
                 self._running = True
                 self._task = asyncio.create_task(self._loop())
                 self._logger.info(f"[Scheduler] 이전 상태 복원 — 자동 시작: {restored}")
+
+            if stale_state_cleared:
+                self._save_scheduler_state()
 
             # 복원된 전략의 가상 보유 종목을 스트리밍 구독에 재등록
             if self._price_sub_svc and restored:

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import tempfile
 import shutil
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch, mock_open, call
 from common.types import TradeSignal, ErrorCode, ResCommonResponse, Exchange, OrderState
 from scheduler.strategy_scheduler import StrategyScheduler, StrategySchedulerConfig, SignalRecord
@@ -195,6 +196,68 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strat_status["max_positions"], 5)
         self.assertEqual(strat_status["interval_minutes"], 10)
 
+    def test_get_status_uses_strategy_position_state_when_virtual_trade_is_empty(self):
+        """가상매매 DB가 비어 있어도 전략 position_state 기준 보유를 반환한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="오닐PP/BGU")
+        strategy._position_state = {
+            "489790": SimpleNamespace(entry_price=82000, entry_date="20260424")
+        }
+        scheduler._signal_history = [
+            SignalRecord(
+                strategy_name="오닐PP/BGU",
+                code="489790",
+                name="한화비전",
+                action="BUY",
+                price=82000,
+                qty=6,
+                reason="test",
+                timestamp="2026-04-24 13:14:18",
+                api_success=True,
+            )
+        ]
+        scheduler.register(StrategySchedulerConfig(strategy=strategy, interval_minutes=3, max_positions=5))
+        vm.get_holds_by_strategy.return_value = []
+
+        status = scheduler.get_status()
+
+        self.assertEqual(status["strategies"][0]["current_holds"], 1)
+        self.assertEqual(status["strategies"][0]["holdings"][0]["code"], "489790")
+        self.assertEqual(status["strategies"][0]["holdings"][0]["buy_price"], 82000)
+        self.assertEqual(status["strategies"][0]["holdings"][0]["qty"], 6)
+
+    def test_get_status_skips_invalid_strategy_code_and_recovers_buy_price_from_signal_history(self):
+        """잘못된 position_state 코드는 제외하고 신호 이력으로 진입가를 복원한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="거래량돌파(전통)")
+        strategy._position_state = {
+            "B": SimpleNamespace(breakout_level=1000, peak_price=1100),
+            "010060": SimpleNamespace(breakout_level=326500, peak_price=377500),
+        }
+        scheduler._signal_history = [
+            SignalRecord(
+                strategy_name="거래량돌파(전통)",
+                code="010060",
+                name="OCI홀딩스",
+                action="BUY",
+                price=377500,
+                qty=1,
+                reason="test",
+                timestamp="2026-04-24 12:38:34",
+                api_success=True,
+            )
+        ]
+        scheduler.register(StrategySchedulerConfig(strategy=strategy, interval_minutes=1, max_positions=5))
+        vm.get_holds_by_strategy.return_value = []
+
+        status = scheduler.get_status()
+
+        self.assertEqual(status["strategies"][0]["current_holds"], 1)
+        holding = status["strategies"][0]["holdings"][0]
+        self.assertEqual(holding["code"], "010060")
+        self.assertEqual(holding["buy_price"], 377500)
+        self.assertEqual(holding["buy_date"], "2026-04-24 12:38:34")
+
     def test_get_status_empty(self):
         """전략 미등록 상태에서 get_status 테스트."""
         scheduler, _, _, _, _ = self._make_scheduler()
@@ -283,6 +346,77 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         # max_positions 도달 → log_buy 호출 안됨
         vm.log_buy_async.assert_not_called()
+
+    async def test_run_strategy_uses_strategy_position_state_for_exit_and_capacity(self):
+        """전략 position_state도 현재 보유로 간주해 exit/max_positions에 반영한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="오닐PP/BGU")
+        strategy._position_state = {
+            "489790": SimpleNamespace(entry_price=82000, entry_date="20260424")
+        }
+        strategy.check_exits = AsyncMock(return_value=[])
+        strategy.scan = AsyncMock(return_value=[
+            TradeSignal(
+                code="100840", name="SNT에너지", action="BUY",
+                price=57700, qty=8, reason="scan", strategy_name="오닐PP/BGU"
+            )
+        ])
+        scheduler._signal_history = [
+            SignalRecord(
+                strategy_name="오닐PP/BGU",
+                code="489790",
+                name="한화비전",
+                action="BUY",
+                price=82000,
+                qty=6,
+                reason="test",
+                timestamp="2026-04-24 13:14:18",
+                api_success=True,
+            )
+        ]
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=1)
+        scheduler.register(config)
+        vm.get_holds_by_strategy.return_value = []
+
+        await scheduler._run_strategy(config)
+
+        strategy.check_exits.assert_awaited_once()
+        self.assertEqual(strategy.check_exits.await_args.args[0][0]["code"], "489790")
+        strategy.scan.assert_not_awaited()
+
+    async def test_run_strategy_recovers_buy_price_from_signal_history_for_state_only_holding(self):
+        """state-only 보유도 신호 이력으로 buy_price를 복원해 check_exits에 전달한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="거래량돌파(전통)")
+        strategy._position_state = {
+            "010060": SimpleNamespace(breakout_level=326500, peak_price=377500)
+        }
+        strategy.check_exits = AsyncMock(return_value=[])
+        strategy.scan = AsyncMock(return_value=[])
+        scheduler._signal_history = [
+            SignalRecord(
+                strategy_name="거래량돌파(전통)",
+                code="010060",
+                name="OCI홀딩스",
+                action="BUY",
+                price=377500,
+                qty=1,
+                reason="test",
+                timestamp="2026-04-24 12:38:34",
+                api_success=True,
+            )
+        ]
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=5)
+        scheduler.register(config)
+        vm.get_holds_by_strategy.return_value = []
+
+        await scheduler._run_strategy(config)
+
+        strategy.check_exits.assert_awaited_once()
+        holding = strategy.check_exits.await_args.args[0][0]
+        self.assertEqual(holding["code"], "010060")
+        self.assertEqual(holding["buy_price"], 377500)
+        self.assertEqual(holding["qty"], 1)
 
     async def test_run_strategy_scan_respects_max_positions_growing_holdings(self):
         """remaining 슬라이싱으로 max_positions 초과 매수를 방지하는지 테스트.

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -870,7 +870,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         scheduler._running = True
         config.enabled = True
 
-        vm.get_holds.return_value = [{"code": "005930", "name": "삼성전자"}]
+        vm.get_holds_by_strategy.return_value = [{"code": "005930", "name": "삼성전자"}]
 
         # Save State
         scheduler._save_scheduler_state()

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -258,6 +258,67 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(holding["buy_price"], 377500)
         self.assertEqual(holding["buy_date"], "2026-04-24 12:38:34")
 
+    def test_get_status_prunes_disabled_force_exit_strategy_state_without_position_evidence(self):
+        """비활성 당일청산 전략에 DB/신호 근거 없는 state만 남으면 stale로 정리한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="거래량돌파(전통)")
+        strategy._position_state = {
+            "B": SimpleNamespace(breakout_level=1000, peak_price=1100),
+            "010060": SimpleNamespace(breakout_level=326500, peak_price=377500),
+        }
+        strategy._save_state = MagicMock()
+        scheduler.register(StrategySchedulerConfig(
+            strategy=strategy,
+            interval_minutes=1,
+            max_positions=5,
+            enabled=False,
+            force_exit_on_close=True,
+        ))
+        vm.get_holds_by_strategy.return_value = []
+
+        status = scheduler.get_status()
+
+        self.assertEqual(status["strategies"][0]["current_holds"], 0)
+        self.assertEqual(status["strategies"][0]["holdings"], [])
+        self.assertEqual(strategy._position_state, {})
+        strategy._save_state.assert_called_once()
+
+    def test_get_status_keeps_disabled_force_exit_strategy_state_when_signal_evidence_exists(self):
+        """비활성 당일청산 전략이라도 열린 포지션 근거가 있으면 state를 유지한다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="거래량돌파(전통)")
+        strategy._position_state = {
+            "010060": SimpleNamespace(breakout_level=326500, peak_price=377500),
+        }
+        strategy._save_state = MagicMock()
+        scheduler._signal_history = [
+            SignalRecord(
+                strategy_name="거래량돌파(전통)",
+                code="010060",
+                name="OCI홀딩스",
+                action="BUY",
+                price=377500,
+                qty=1,
+                reason="test",
+                timestamp="2026-04-24 12:38:34",
+                api_success=True,
+            )
+        ]
+        scheduler.register(StrategySchedulerConfig(
+            strategy=strategy,
+            interval_minutes=1,
+            max_positions=5,
+            enabled=False,
+            force_exit_on_close=True,
+        ))
+        vm.get_holds_by_strategy.return_value = []
+
+        status = scheduler.get_status()
+
+        self.assertEqual(status["strategies"][0]["current_holds"], 1)
+        self.assertEqual(status["strategies"][0]["holdings"][0]["code"], "010060")
+        strategy._save_state.assert_not_called()
+
     def test_get_status_empty(self):
         """전략 미등록 상태에서 get_status 테스트."""
         scheduler, _, _, _, _ = self._make_scheduler()

--- a/view/web/static/js/scheduler.js
+++ b/view/web/static/js/scheduler.js
@@ -5,6 +5,16 @@ let allSchedulerHistory = [];
 let currentSchedulerFilter = '전체';
 let schedulerEventSource = null;
 
+function syncSchedulerRealtimeState(data) {
+    if (data && data.running) {
+        if (!schedulerPollingId) {
+            startSchedulerPolling();
+        }
+        return;
+    }
+    stopSchedulerPolling();
+}
+
 async function loadSchedulerStatus() {
     try {
         // 두 요청을 동시에 시작 (병렬)
@@ -14,16 +24,13 @@ async function loadSchedulerStatus() {
         // status가 도착하는 즉시 렌더링 — history를 기다리지 않음
         const statusData = await statusPromise.then(r => r.json());
         renderSchedulerStatus(statusData);
+        syncSchedulerRealtimeState(statusData);
 
         // history가 도착하면 이력 테이블 렌더링
         const historyData = await historyPromise.then(r => r.json());
         allSchedulerHistory = historyData.history || [];
         buildSchedulerHistoryTabs(statusData.strategies || []);
         filterSchedulerHistory(currentSchedulerFilter);
-
-        if (statusData.running && !schedulerPollingId) {
-            startSchedulerPolling();
-        }
     } catch (e) {
         const info = document.getElementById('scheduler-info');
         if (info) info.innerHTML = '<span>스케줄러 상태 조회 실패</span>';
@@ -98,7 +105,7 @@ async function startScheduler() {
         const data = await res.json();
         if (data.success) {
             renderSchedulerStatus(data.status);
-            startSchedulerPolling();
+            syncSchedulerRealtimeState(data.status);
         }
     } catch (e) {
         alert('스케줄러 시작 실패');
@@ -111,7 +118,7 @@ async function stopScheduler() {
         const data = await res.json();
         if (data.success) {
             renderSchedulerStatus(data.status);
-            stopSchedulerPolling();
+            syncSchedulerRealtimeState(data.status);
         }
     } catch (e) {
         alert('스케줄러 정지 실패');
@@ -124,6 +131,7 @@ async function startStrategy(name) {
         const data = await res.json();
         if (data.success) {
             renderSchedulerStatus(data.status);
+            syncSchedulerRealtimeState(data.status);
         } else {
             alert(data.detail || '전략 시작 실패');
         }
@@ -138,6 +146,7 @@ async function stopStrategy(name) {
         const data = await res.json();
         if (data.success) {
             renderSchedulerStatus(data.status);
+            syncSchedulerRealtimeState(data.status);
         } else {
             alert(data.detail || '전략 정지 실패');
         }
@@ -165,6 +174,7 @@ async function updateMaxPositions(name, currentMax) {
         const data = await res.json();
         if (data.success) {
             renderSchedulerStatus(data.status);
+            syncSchedulerRealtimeState(data.status);
         } else {
             alert(data.detail || '포지션 수 변경 실패');
         }
@@ -269,7 +279,10 @@ function connectSchedulerSSE() {
 
             fetch('/api/scheduler/status')
                 .then(res => res.json())
-                .then(data => renderSchedulerStatus(data))
+                .then(data => {
+                    renderSchedulerStatus(data);
+                    syncSchedulerRealtimeState(data);
+                })
                 .catch(() => {});
         } catch (e) {
             console.error('[Scheduler SSE] parse error:', e);

--- a/view/web/templates/scheduler.html
+++ b/view/web/templates/scheduler.html
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/scheduler.js?v=1"></script>
+<script src="/static/js/scheduler.js?v=2"></script>
 <script>
     loadSchedulerStatus();
 </script>


### PR DESCRIPTION
…s()는 원래도 전략이 쓰는 VirtualTradeService.get_holds_by_strategy() 기준으로 상태를 만들고 있어서 서버 쪽 데이터 소스는 같았고, 문제는 개별 전략 시작 시 scheduler.js에서 polling/SSE를 켜지 않아 웹 보유종목 목록이 stale 상태로 남는 점이었습니다. 특히 startStrategy()와 stopStrategy() 경로가 전체 스케줄러 시작/정지와 다르게 렌더만 하고 실시간 동기화를 재설정하지 않았습니다.

그래서 scheduler.js에 syncSchedulerRealtimeState()를 추가해서 초기 로드, 전체 시작/정지, 개별 전략 시작/정지, 포지션 수 변경, SSE 후 상태 재조회까지 모두 같은 기준으로 polling/SSE를 맞추도록 정리했습니다. 브라우저 캐시 때문에 구버전 JS가 남지 않게 scheduler.html 스크립트 버전도 v=2로 올렸습니다. scheduler.py는 이번 이슈 기준으로 추가 수정이 필요하지 않았습니다.