### PR TITLE
2-2 구현 완료했습니다.

### DIFF
--- a/common/types.py
+++ b/common/types.py
@@ -28,6 +28,7 @@ class ErrorCode(Enum):
     MARKET_CLOSED = "108"  # 장 마감
     KILL_SWITCH_BLOCKED = "109"  # Kill Switch 활성 상태로 주문 차단
     RISK_GATE_BLOCKED = "110"  # Risk Gate 정책으로 주문 차단
+    ORDER_POLICY_BLOCKED = "111"  # Order Policy 정책으로 주문 차단
     UNKNOWN_ERROR = "999"  # 기타 오류
 
     @property

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -45,11 +45,22 @@ class PositionSizingConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class RiskGateStrategyLimitConfig(BaseModel):
+    max_exposure_pct: Optional[float] = None
+    max_loss_pct: Optional[float] = None
+    block_duplicate_position: bool = True
+
+    model_config = {"extra": "allow"}
+
+
 class RiskGateConfig(BaseModel):
     enabled: bool = True
     max_order_amount_won: int = 10_000_000
     max_pending_orders: int = 10
     max_total_exposure_pct: float = 95.0
+    block_duplicate_strategy_position: bool = True
+    default_strategy_limit: RiskGateStrategyLimitConfig = Field(default_factory=RiskGateStrategyLimitConfig)
+    strategy_limits: Dict[str, RiskGateStrategyLimitConfig] = Field(default_factory=dict)
 
     model_config = {"extra": "allow"}
 

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -65,6 +65,21 @@ class RiskGateConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class OrderPolicyConfig(BaseModel):
+    enabled: bool = True
+    allow_market_buy: bool = True
+    allow_market_sell: bool = True
+    allow_nxt_market_order: bool = False
+    tick_size_policy: str = "adjust"        # adjust | block | ignore
+    order_book_checks_enabled: bool = False
+    max_market_slippage_pct: float = 1.0
+    max_spread_pct: float = 1.0
+    block_empty_order_book: bool = True
+    quote_fail_policy: str = "allow"        # allow | block
+
+    model_config = {"extra": "allow"}
+
+
 class AppConfig(BaseModel):
     # Core API keys
     api_key: Optional[str] = None
@@ -85,6 +100,7 @@ class AppConfig(BaseModel):
     cache: CacheConfig = Field(default_factory=CacheConfig)
     kill_switch: KillSwitchConfig = Field(default_factory=KillSwitchConfig)
     risk_gate: RiskGateConfig = Field(default_factory=RiskGateConfig)
+    order_policy: OrderPolicyConfig = Field(default_factory=OrderPolicyConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     
     # Dynamic/Merged configs

--- a/docs/order_policy.md
+++ b/docs/order_policy.md
@@ -1,0 +1,94 @@
+# Order Policy
+
+`OrderPolicyService`는 broker 주문 제출 직전에 주문 형태와 가격 정책을 검증한다.
+포트폴리오/전략 리스크는 `RiskGateService`가 담당하고, 시장가/지정가/NXT/호가단위/호가 공백/스프레드/슬리피지는 이 계층이 담당한다.
+
+## Decision Response
+
+차단 응답은 `ResCommonResponse`로 반환한다.
+
+```python
+ResCommonResponse(
+    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+    msg1="Order Policy 차단: 스프레드가 허용 범위를 초과했습니다.",
+    data={
+        "gate": "order_policy",
+        "rule": "spread_too_wide",
+        "severity": "block",
+        "reason": "스프레드가 허용 범위를 초과했습니다.",
+        "stock_code": "005930",
+        "ask": 71000,
+        "bid": 70000,
+        "spread_pct": 1.418,
+        "max_spread_pct": 1.0,
+    },
+)
+```
+
+## Logs
+
+차단은 `WARNING` 레벨로 남긴다.
+
+```text
+[OrderPolicy][BLOCK] rule=market_slippage_too_high reason=시장가 예상 슬리피지가 허용 범위를 초과했습니다. context={...}
+```
+
+호가단위 보정은 `INFO` 레벨로 남긴다.
+
+```text
+[OrderPolicy][ADJUST] rule=tick_size stock_code=005930 requested_price=70051 adjusted_price=70000 tick_size=100
+```
+
+## Rules
+
+| Rule | Scope | Behavior |
+| --- | --- | --- |
+| `non_positive_qty` | order | 주문 수량이 0 이하이면 차단 |
+| `negative_price` | order | 주문 가격이 음수이면 차단 |
+| `nxt_market_order_not_supported` | exchange | NXT 시장가 주문 차단 |
+| `market_buy_disabled` | order type | 시장가 매수 비활성화 시 차단 |
+| `market_sell_disabled` | order type | 시장가 매도 비활성화 시 차단 |
+| `invalid_tick_size` | limit price | 지정가가 호가단위에 맞지 않고 block 정책이면 차단 |
+| `tick_size_adjusted` | limit price | 지정가를 호가단위에 맞게 사전 보정 |
+| `empty_order_book` | market order | 최우선 매도/매수 호가가 비어 있으면 차단 |
+| `spread_too_wide` | market order | 최우선 매도-매수 스프레드가 설정 한도 초과 |
+| `market_slippage_too_high` | market order | 예상 체결가와 기준가의 괴리가 설정 한도 초과 |
+| `top_of_book_qty_short` | market order | 최우선 호가 잔량보다 주문 수량이 큼 |
+| `quote_unavailable` | market order | 호가 조회 실패. 설정에 따라 fail-open 또는 block |
+
+## Config Example
+
+```yaml
+order_policy:
+  enabled: true
+  allow_market_buy: true
+  allow_market_sell: true
+  allow_nxt_market_order: false
+  tick_size_policy: adjust      # adjust | block | ignore
+  order_book_checks_enabled: true
+  max_market_slippage_pct: 1.0
+  max_spread_pct: 1.0
+  block_empty_order_book: true
+  quote_fail_policy: block      # allow | block
+```
+
+## Market Order Notes
+
+`price == 0`은 시장가 주문으로 해석한다.
+
+- KRX 시장가 주문은 설정이 허용하면 가능하다.
+- NXT 시장가 주문은 기본적으로 차단한다.
+- 호가 검증을 켜면 `get_asking_price()`를 통해 최우선 매도/매수 호가와 잔량을 확인한다.
+- 호가 조회 실패 시 기본값은 fail-open이지만, 실전 주문에서는 `quote_fail_policy: block`을 권장한다.
+
+## Limit Order Notes
+
+`price > 0`은 지정가 주문으로 해석한다.
+
+`tick_size_policy`:
+
+- `adjust`: 호가단위에 맞게 내림 보정 후 보정 가격으로 주문 제출
+- `block`: 호가단위 불일치 시 broker 제출 전 차단
+- `ignore`: 사전 검증을 건너뛰고 broker 안전망에 위임
+
+broker 계층의 호가단위 보정은 마지막 안전망으로 유지한다.

--- a/docs/risk_gate.md
+++ b/docs/risk_gate.md
@@ -1,0 +1,98 @@
+# Risk Gate
+
+`RiskGateService`는 broker 주문 제출 직전에 실행되는 공통 hard-block 계층이다.
+주문 실행 서비스는 주문 상태 관리와 제출만 담당하고, 계좌/전략/포트폴리오 리스크 판단은 이 서비스가 담당한다.
+
+## Decision Response
+
+차단 응답은 `ResCommonResponse`로 반환한다.
+
+```python
+ResCommonResponse(
+    rt_cd=ErrorCode.RISK_GATE_BLOCKED.value,
+    msg1="Risk Gate 차단: 전략 자본 할당 한도 초과",
+    data={
+        "gate": "risk_gate",
+        "rule": "strategy_exposure_limit",
+        "severity": "block",
+        "reason": "전략 자본 할당 한도 초과",
+        "strategy_name": "모멘텀",
+        "stock_code": "005930",
+        "next_exposure_pct": 12.5,
+        "max_exposure_pct": 10.0,
+    },
+)
+```
+
+## Logs
+
+모든 차단은 `WARNING` 레벨로 남긴다.
+
+```text
+[RiskGate][BLOCK] rule=duplicate_strategy_position reason=동일 전략에서 이미 보유 중인 종목입니다. context={'strategy_name': '모멘텀', 'stock_code': '005930'}
+```
+
+선택 데이터 조회 실패는 fail-open으로 처리하되 진단 로그를 남긴다.
+
+```text
+[RiskGate][CHECK_ERROR] rule=strategy_loss_limit strategy=모멘텀 error=...
+```
+
+## Rules
+
+| Rule | Scope | Block Condition |
+| --- | --- | --- |
+| `kill_switch_active` | account | Kill switch가 주문 불가 상태를 반환 |
+| `kill_switch_check_failed` | account | Kill switch 상태 확인 실패 |
+| `buy_non_positive_price` | order | BUY 주문 가격이 0 이하 |
+| `max_pending_orders` | account | 진행 중 주문 수가 설정 한도 이상 |
+| `max_order_amount` | order | 주문 금액이 단일 주문 한도 초과 |
+| `duplicate_strategy_position` | strategy+stock | 같은 전략이 같은 종목을 이미 HOLD |
+| `strategy_loss_limit` | strategy | 전략 최근 수익률이 손실 한도 이하 |
+| `strategy_exposure_limit` | strategy | 전략 보유금액+신규주문금액이 전략 자본 한도 초과 |
+| `max_total_exposure` | account | 계좌 전체 노출이 총자산 대비 한도 초과 |
+
+## Duplicate Entry Policy
+
+중복 진입 제한은 `(strategy_name, stock_code)` 단위로 적용한다.
+
+- `모멘텀 / 005930` HOLD 상태에서 `모멘텀 / 005930` BUY: 차단
+- `모멘텀 / 005930` HOLD 상태에서 `눌림목 / 005930` BUY: 허용
+- 단, 다른 전략의 동일 종목 BUY도 총 노출, 전략별 노출, 섹터 집중도 같은 포트폴리오 한도는 그대로 적용받는다.
+
+## Config Example
+
+```yaml
+risk_gate:
+  enabled: true
+  max_order_amount_won: 10000000
+  max_pending_orders: 10
+  max_total_exposure_pct: 70.0
+  block_duplicate_strategy_position: true
+  default_strategy_limit:
+    max_exposure_pct: 20.0
+    max_loss_pct: 5.0
+    block_duplicate_position: true
+  strategy_limits:
+    모멘텀:
+      max_exposure_pct: 15.0
+      max_loss_pct: 4.0
+    눌림목:
+      max_exposure_pct: 10.0
+```
+
+`max_loss_pct`는 양수로 설정한다. 예를 들어 `5.0`은 최근 전략 수익률이 `-5.0%` 이하일 때 신규 BUY를 차단한다.
+
+## Fail-open Data
+
+아래 선택 데이터가 없거나 조회 실패하면 주문을 즉시 차단하지 않고 로그만 남긴다.
+
+- 전략별 HOLD 조회
+- 전략별 수익률 이력
+- 전략별 노출 계산용 계좌 스냅샷
+
+계좌 스냅샷의 `total_equity`가 0 이하일 때도 현재는 fail-open이다. 실전 운영에서 더 보수적으로 막고 싶다면 별도 설정으로 fail-close 정책을 추가한다.
+
+## Out Of Scope
+
+시장가/지정가, 호가단위, 슬리피지, 스프레드/호가 공백 검증은 2-3의 `OrderPolicy` 계층에서 다룬다.

--- a/docs/risk_gate.md
+++ b/docs/risk_gate.md
@@ -95,4 +95,4 @@ risk_gate:
 
 ## Out Of Scope
 
-시장가/지정가, 호가단위, 슬리피지, 스프레드/호가 공백 검증은 2-3의 `OrderPolicy` 계층에서 다룬다.
+시장가/지정가, 호가단위, 슬리피지, 스프레드/호가 공백 검증은 `OrderPolicyService` 계층에서 다룬다.

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -15,6 +15,7 @@ from services.market_calendar_service import MarketCalendarService
 from services.price_subscription_service import SubscriptionPriority
 from services.kill_switch_service import KillSwitchService
 from services.risk_gate_service import RiskGateService
+from services.order_policy_service import OrderPolicyService
 from core.account_snapshot import AccountSnapshotCache
 
 
@@ -42,7 +43,8 @@ class OrderExecutionService:
                  virtual_trade_service=None,
                  kill_switch_service: Optional[KillSwitchService] = None,
                  account_snapshot_cache: Optional[AccountSnapshotCache] = None,
-                 risk_gate_service: Optional[RiskGateService] = None):
+                 risk_gate_service: Optional[RiskGateService] = None,
+                 order_policy_service: Optional[OrderPolicyService] = None):
         self.broker_api_wrapper = broker_api_wrapper
         self.logger = logger
         self.market_clock = market_clock
@@ -54,6 +56,7 @@ class OrderExecutionService:
         self._kill_switch = kill_switch_service
         self._account_snapshot_cache = account_snapshot_cache
         self._risk_gate = risk_gate_service
+        self._order_policy = order_policy_service
         self._order_states: Dict[str, OrderContext] = {}
         self._order_locks: Dict[str, asyncio.Lock] = {}
         self._order_no_index: Dict[str, str] = {}
@@ -1126,6 +1129,27 @@ class OrderExecutionService:
                         msg1=f"진행 중인 주문이 있어 {action_kr} 주문을 차단했습니다. 상태={existing.state.value}",
                         data=existing.to_dict(),
                     )
+
+            if self._order_policy is not None:
+                policy_decision = await self._order_policy.validate_order(
+                    stock_code=stock_code,
+                    price=price,
+                    qty=qty,
+                    side=side,
+                    exchange=exchange,
+                )
+                if policy_decision.blocked:
+                    return policy_decision.to_response()
+                if (
+                    policy_decision.adjusted_price is not None
+                    and policy_decision.adjusted_price != price
+                ):
+                    self.logger.info(
+                        f"OrderPolicy 가격 조정: 종목={stock_code}, "
+                        f"{price} -> {policy_decision.adjusted_price}, "
+                        f"rule={policy_decision.rule}"
+                    )
+                    price = policy_decision.adjusted_price
 
             if self._risk_gate is not None:
                 strategy_name, is_strategy_source = self._strategy_name_from_source(source)

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -1128,6 +1128,7 @@ class OrderExecutionService:
                     )
 
             if self._risk_gate is not None:
+                strategy_name, is_strategy_source = self._strategy_name_from_source(source)
                 blocked = await self._risk_gate.validate_order(
                     stock_code=stock_code,
                     price=price,
@@ -1135,6 +1136,8 @@ class OrderExecutionService:
                     side=side,
                     exchange=exchange,
                     active_order_count=len(self._active_order_contexts()),
+                    source=source,
+                    strategy_name=strategy_name if is_strategy_source else None,
                 )
                 if blocked is not None:
                     return blocked

--- a/services/order_policy_service.py
+++ b/services/order_policy_service.py
@@ -1,0 +1,306 @@
+import inspect
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol
+
+from common.types import ErrorCode, Exchange, OrderSide, ResCommonResponse
+from config.config_loader import OrderPolicyConfig
+from utils.korea_invest_price_utils import adjust_price, get_tick_size
+
+
+class QuoteProvider(Protocol):
+    async def get_asking_price(self, stock_code: str, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        ...
+
+
+@dataclass
+class OrderPolicyDecision:
+    allowed: bool
+    rule: str = "ok"
+    reason: str = "ok"
+    adjusted_price: Optional[int] = None
+    severity: str = "block"
+    context: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allowed
+
+    def to_response(self) -> ResCommonResponse:
+        data = {
+            "gate": "order_policy",
+            "rule": self.rule,
+            "severity": self.severity,
+            "reason": self.reason,
+        }
+        if self.adjusted_price is not None:
+            data["adjusted_price"] = self.adjusted_price
+        data.update(self.context)
+        return ResCommonResponse(
+            rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+            msg1=f"Order Policy 차단: {self.reason}",
+            data=data,
+        )
+
+
+class OrderPolicyService:
+    """Validate order type, exchange, tick size, and order-book safety before broker submit."""
+
+    def __init__(
+        self,
+        config: OrderPolicyConfig,
+        quote_provider: Optional[QuoteProvider] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self._cfg = config
+        self._quote_provider = quote_provider
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def validate_order(
+        self,
+        *,
+        stock_code: str,
+        price: int,
+        qty: int,
+        side: OrderSide,
+        exchange: Exchange,
+    ) -> OrderPolicyDecision:
+        if not self._cfg.enabled:
+            return OrderPolicyDecision(allowed=True, adjusted_price=price)
+
+        if qty <= 0:
+            return self._blocked("non_positive_qty", "주문 수량은 0보다 커야 합니다.", qty=qty)
+        if price < 0:
+            return self._blocked("negative_price", "주문 가격은 음수일 수 없습니다.", price=price)
+
+        is_market = price == 0
+        if is_market:
+            order_type_blocked = self._check_market_order_type(side, exchange)
+            if order_type_blocked is not None:
+                return order_type_blocked
+            if self._cfg.order_book_checks_enabled:
+                quote_decision = await self._check_market_order_book(stock_code, qty, side, exchange)
+                if quote_decision.blocked:
+                    return quote_decision
+                return quote_decision
+            return OrderPolicyDecision(
+                allowed=True,
+                rule="market_order",
+                reason="market_order_allowed",
+                adjusted_price=price,
+                severity="pass",
+                context={"order_type": "market"},
+            )
+
+        tick_decision = self._check_limit_tick_size(stock_code, price)
+        if tick_decision.blocked:
+            return tick_decision
+        return tick_decision
+
+    def _check_market_order_type(
+        self,
+        side: OrderSide,
+        exchange: Exchange,
+    ) -> Optional[OrderPolicyDecision]:
+        if exchange == Exchange.NXT and not self._cfg.allow_nxt_market_order:
+            return self._blocked(
+                "nxt_market_order_not_supported",
+                "NXT 거래소에서는 시장가 주문을 허용하지 않습니다.",
+                exchange=exchange.value,
+            )
+        if side == OrderSide.BUY and not self._cfg.allow_market_buy:
+            return self._blocked("market_buy_disabled", "시장가 매수 주문이 비활성화되어 있습니다.")
+        if side == OrderSide.SELL and not self._cfg.allow_market_sell:
+            return self._blocked("market_sell_disabled", "시장가 매도 주문이 비활성화되어 있습니다.")
+        return None
+
+    def _check_limit_tick_size(self, stock_code: str, price: int) -> OrderPolicyDecision:
+        tick_size = get_tick_size(price)
+        adjusted = adjust_price(price)
+        context = {
+            "order_type": "limit",
+            "stock_code": stock_code,
+            "requested_price": price,
+            "tick_size": tick_size,
+            "adjusted_price": adjusted,
+        }
+        if adjusted == price or self._cfg.tick_size_policy == "ignore":
+            return OrderPolicyDecision(
+                allowed=True,
+                rule="limit_tick_size",
+                reason="limit_order_allowed",
+                adjusted_price=price,
+                severity="pass",
+                context=context,
+            )
+        if self._cfg.tick_size_policy == "block":
+            return self._blocked(
+                "invalid_tick_size",
+                "지정가가 호가단위에 맞지 않습니다.",
+                **context,
+            )
+
+        self._logger.info(
+            f"[OrderPolicy][ADJUST] rule=tick_size stock_code={stock_code} "
+            f"requested_price={price} adjusted_price={adjusted} tick_size={tick_size}"
+        )
+        return OrderPolicyDecision(
+            allowed=True,
+            rule="tick_size_adjusted",
+            reason="호가단위 보정",
+            adjusted_price=adjusted,
+            severity="adjust",
+            context=context,
+        )
+
+    async def _check_market_order_book(
+        self,
+        stock_code: str,
+        qty: int,
+        side: OrderSide,
+        exchange: Exchange,
+    ) -> OrderPolicyDecision:
+        if self._quote_provider is None:
+            return self._quote_failure_decision(stock_code, "quote_provider_missing")
+
+        try:
+            quote_resp = self._quote_provider.get_asking_price(stock_code, exchange=exchange)
+            if inspect.isawaitable(quote_resp):
+                quote_resp = await quote_resp
+        except Exception as exc:
+            return self._quote_failure_decision(stock_code, str(exc))
+
+        if not quote_resp or quote_resp.rt_cd != ErrorCode.SUCCESS.value:
+            reason = quote_resp.msg1 if quote_resp else "응답 없음"
+            return self._quote_failure_decision(stock_code, reason)
+
+        quote = self._extract_quote_data(quote_resp.data)
+        ask = self._to_int(self._pick(quote, "askp1", "매도호가1"))
+        bid = self._to_int(self._pick(quote, "bidp1", "매수호가1"))
+        ask_qty = self._to_int(self._pick(quote, "askp_rsqn1", "매도호가잔량1"))
+        bid_qty = self._to_int(self._pick(quote, "bidp_rsqn1", "매수호가잔량1"))
+        current_price = self._to_int(self._pick(quote, "stck_prpr", "주식현재가", "prpr"))
+
+        if self._cfg.block_empty_order_book and (ask <= 0 or bid <= 0):
+            return self._blocked(
+                "empty_order_book",
+                "최우선 매수/매도 호가가 비어 있습니다.",
+                stock_code=stock_code,
+                ask=ask,
+                bid=bid,
+            )
+
+        mid = (ask + bid) / 2 if ask > 0 and bid > 0 else current_price
+        spread_pct = ((ask - bid) / mid * 100) if mid and ask > 0 and bid > 0 else 0.0
+        if spread_pct > self._cfg.max_spread_pct:
+            return self._blocked(
+                "spread_too_wide",
+                "스프레드가 허용 범위를 초과했습니다.",
+                stock_code=stock_code,
+                ask=ask,
+                bid=bid,
+                spread_pct=round(spread_pct, 3),
+                max_spread_pct=self._cfg.max_spread_pct,
+            )
+
+        executable_price = ask if side == OrderSide.BUY else bid
+        reference_price = current_price or mid
+        slippage_pct = (
+            abs(executable_price - reference_price) / reference_price * 100
+            if reference_price and executable_price
+            else 0.0
+        )
+        if slippage_pct > self._cfg.max_market_slippage_pct:
+            return self._blocked(
+                "market_slippage_too_high",
+                "시장가 예상 슬리피지가 허용 범위를 초과했습니다.",
+                stock_code=stock_code,
+                side=side.value,
+                executable_price=executable_price,
+                reference_price=reference_price,
+                slippage_pct=round(slippage_pct, 3),
+                max_market_slippage_pct=self._cfg.max_market_slippage_pct,
+            )
+
+        book_qty = ask_qty if side == OrderSide.BUY else bid_qty
+        if book_qty > 0 and qty > book_qty:
+            return self._blocked(
+                "top_of_book_qty_short",
+                "최우선 호가 잔량보다 주문 수량이 큽니다.",
+                stock_code=stock_code,
+                side=side.value,
+                qty=qty,
+                top_of_book_qty=book_qty,
+            )
+
+        return OrderPolicyDecision(
+            allowed=True,
+            rule="market_order_book",
+            reason="market_order_book_allowed",
+            adjusted_price=0,
+            severity="pass",
+            context={
+                "order_type": "market",
+                "stock_code": stock_code,
+                "ask": ask,
+                "bid": bid,
+                "spread_pct": round(spread_pct, 3),
+                "slippage_pct": round(slippage_pct, 3),
+            },
+        )
+
+    def _quote_failure_decision(self, stock_code: str, reason: str) -> OrderPolicyDecision:
+        if self._cfg.quote_fail_policy == "block":
+            return self._blocked(
+                "quote_unavailable",
+                "호가 조회 실패로 시장가 주문을 검증할 수 없습니다.",
+                stock_code=stock_code,
+                quote_error=reason,
+            )
+        self._logger.warning(
+            f"[OrderPolicy][CHECK_ERROR] rule=quote_unavailable "
+            f"stock_code={stock_code} reason={reason}"
+        )
+        return OrderPolicyDecision(
+            allowed=True,
+            rule="quote_unavailable",
+            reason="quote_check_fail_open",
+            adjusted_price=0,
+            severity="pass",
+            context={"stock_code": stock_code, "quote_error": reason},
+        )
+
+    @staticmethod
+    def _extract_quote_data(data) -> dict:
+        if isinstance(data, dict):
+            if isinstance(data.get("output1"), dict):
+                return data["output1"]
+            if isinstance(data.get("output"), dict):
+                return data["output"]
+            return data
+        return {}
+
+    @staticmethod
+    def _pick(data: dict, *keys: str):
+        for key in keys:
+            if key in data:
+                return data.get(key)
+        return None
+
+    @staticmethod
+    def _to_int(value) -> int:
+        try:
+            return int(float(str(value or "0").replace(",", "")))
+        except (TypeError, ValueError):
+            return 0
+
+    def _blocked(self, rule: str, reason: str, **context) -> OrderPolicyDecision:
+        self._logger.warning(
+            f"[OrderPolicy][BLOCK] rule={rule} reason={reason} context={context}"
+        )
+        return OrderPolicyDecision(
+            allowed=False,
+            rule=rule,
+            reason=reason,
+            context=context,
+        )

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -82,10 +82,10 @@ class RiskGateService:
         if blocked is not None:
             return blocked
 
-        if side == OrderSide.BUY and price <= 0:
+        if price < 0:
             return self._blocked(
-                "buy_non_positive_price",
-                "BUY 주문은 0 이하 가격을 허용하지 않습니다.",
+                "negative_price",
+                "주문 가격은 음수일 수 없습니다.",
                 stock_code=stock_code,
                 price=price,
                 side=side.value,

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -1,10 +1,47 @@
+import inspect
 import logging
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol
 
 from common.types import ErrorCode, Exchange, OrderSide, ResCommonResponse
 from config.config_loader import RiskGateConfig
 from core.account_snapshot import AccountSnapshotCache
 from services.kill_switch_service import KillSwitchService
+
+
+class StrategyRiskDataProvider(Protocol):
+    def is_holding(self, strategy_name: str, code: str) -> bool:
+        ...
+
+    def get_holds_by_strategy(self, strategy_name: str) -> list[dict]:
+        ...
+
+    def get_strategy_return_history(self, strategy_name: str) -> list[dict]:
+        ...
+
+
+@dataclass
+class RiskGateDecision:
+    rule: str
+    reason: str
+    severity: str = "block"
+    gate: str = "risk_gate"
+    error_code: ErrorCode = ErrorCode.RISK_GATE_BLOCKED
+    context: dict[str, Any] = field(default_factory=dict)
+
+    def to_response(self) -> ResCommonResponse:
+        data = {
+            "gate": self.gate,
+            "rule": self.rule,
+            "severity": self.severity,
+            "reason": self.reason,
+        }
+        data.update(self.context)
+        return ResCommonResponse(
+            rt_cd=self.error_code.value,
+            msg1=f"Risk Gate 차단: {self.reason}",
+            data=data,
+        )
 
 
 class RiskGateService:
@@ -15,11 +52,13 @@ class RiskGateService:
         config: RiskGateConfig,
         kill_switch_service: Optional[KillSwitchService],
         account_snapshot_cache: Optional[AccountSnapshotCache],
+        strategy_risk_provider: Optional[StrategyRiskDataProvider] = None,
         logger: Optional[logging.Logger] = None,
     ):
         self._cfg = config
         self._kill_switch = kill_switch_service
         self._account_snapshot_cache = account_snapshot_cache
+        self._strategy_risk_provider = strategy_risk_provider
         self._logger = logger or logging.getLogger(__name__)
 
     async def validate_order(
@@ -30,10 +69,14 @@ class RiskGateService:
         side: OrderSide,
         exchange: Exchange,
         active_order_count: int,
+        source: str = "",
+        strategy_name: Optional[str] = None,
     ) -> Optional[ResCommonResponse]:
         """Return None when allowed, otherwise a blocking response."""
         if not self._cfg.enabled:
             return None
+
+        strategy_name = strategy_name or self._strategy_name_from_source(source)
 
         blocked = await self._check_kill_switch()
         if blocked is not None:
@@ -41,24 +84,43 @@ class RiskGateService:
 
         if side == OrderSide.BUY and price <= 0:
             return self._blocked(
-                f"Risk Gate 차단: BUY 주문은 0 이하 가격을 허용하지 않습니다. 종목={stock_code}, 가격={price}"
+                "buy_non_positive_price",
+                "BUY 주문은 0 이하 가격을 허용하지 않습니다.",
+                stock_code=stock_code,
+                price=price,
+                side=side.value,
             )
 
         if active_order_count >= self._cfg.max_pending_orders:
             return self._blocked(
-                f"Risk Gate 차단: 진행 중 주문 수 초과 "
-                f"({active_order_count}/{self._cfg.max_pending_orders})"
+                "max_pending_orders",
+                "진행 중 주문 수 초과",
+                active_order_count=active_order_count,
+                max_pending_orders=self._cfg.max_pending_orders,
             )
 
         if price > 0:
             order_amount = price * qty
             if order_amount > self._cfg.max_order_amount_won:
                 return self._blocked(
-                    f"Risk Gate 차단: 주문 금액 초과 "
-                    f"({order_amount:,}원 > {self._cfg.max_order_amount_won:,}원)"
+                    "max_order_amount",
+                    "주문 금액 초과",
+                    stock_code=stock_code,
+                    order_amount=order_amount,
+                    max_order_amount_won=self._cfg.max_order_amount_won,
                 )
 
             if side == OrderSide.BUY:
+                strategy_blocked = await self._check_strategy_risk(
+                    stock_code=stock_code,
+                    order_amount=order_amount,
+                    strategy_name=strategy_name,
+                    source=source,
+                    exchange=exchange,
+                )
+                if strategy_blocked is not None:
+                    return strategy_blocked
+
                 exposure_blocked = await self._check_buy_exposure(stock_code, order_amount, exchange)
                 if exposure_blocked is not None:
                     return exposure_blocked
@@ -72,23 +134,19 @@ class RiskGateService:
         try:
             allowed, reason = await self._kill_switch.check_orders_allowed()
         except Exception as exc:
-            msg = f"Risk Gate 차단: Kill Switch 확인 실패 ({exc})"
-            self._logger.warning(msg)
-            return ResCommonResponse(
-                rt_cd=ErrorCode.RISK_GATE_BLOCKED.value,
-                msg1=msg,
-                data=None,
+            return self._blocked(
+                "kill_switch_check_failed",
+                f"Kill Switch 확인 실패 ({exc})",
             )
 
         if allowed:
             return None
 
-        msg = f"Kill Switch 활성: {reason}"
-        self._logger.warning(msg)
-        return ResCommonResponse(
-            rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value,
-            msg1=msg,
-            data={"reason": reason},
+        return self._blocked(
+            "kill_switch_active",
+            f"Kill Switch 활성: {reason}",
+            error_code=ErrorCode.KILL_SWITCH_BLOCKED,
+            kill_switch_reason=reason,
         )
 
     async def _check_buy_exposure(
@@ -113,16 +171,213 @@ class RiskGateService:
         next_exposure_pct = (current_exposure + order_amount) / snapshot.total_equity * 100
         if next_exposure_pct > self._cfg.max_total_exposure_pct:
             return self._blocked(
-                f"Risk Gate 차단: 계좌 노출 한도 초과 "
-                f"({next_exposure_pct:.2f}% > {self._cfg.max_total_exposure_pct:.2f}%)"
+                "max_total_exposure",
+                "계좌 노출 한도 초과",
+                stock_code=stock_code,
+                current_exposure=current_exposure,
+                order_amount=order_amount,
+                total_equity=snapshot.total_equity,
+                next_exposure_pct=round(next_exposure_pct, 2),
+                max_total_exposure_pct=self._cfg.max_total_exposure_pct,
             )
 
         return None
 
-    def _blocked(self, msg: str) -> ResCommonResponse:
-        self._logger.warning(msg)
-        return ResCommonResponse(
-            rt_cd=ErrorCode.RISK_GATE_BLOCKED.value,
-            msg1=msg,
-            data=None,
+    async def _check_strategy_risk(
+        self,
+        stock_code: str,
+        order_amount: int,
+        strategy_name: Optional[str],
+        source: str,
+        exchange: Exchange,
+    ) -> Optional[ResCommonResponse]:
+        if not strategy_name:
+            return None
+
+        duplicate_blocked = await self._check_duplicate_strategy_position(
+            strategy_name, stock_code, source
         )
+        if duplicate_blocked is not None:
+            return duplicate_blocked
+
+        limit = self._get_strategy_limit(strategy_name)
+        if limit is None:
+            return None
+
+        loss_blocked = await self._check_strategy_loss_limit(strategy_name, limit)
+        if loss_blocked is not None:
+            return loss_blocked
+
+        return await self._check_strategy_exposure_limit(
+            strategy_name=strategy_name,
+            stock_code=stock_code,
+            order_amount=order_amount,
+            limit=limit,
+            exchange=exchange,
+        )
+
+    async def _check_duplicate_strategy_position(
+        self,
+        strategy_name: str,
+        stock_code: str,
+        source: str,
+    ) -> Optional[ResCommonResponse]:
+        limit = self._get_strategy_limit(strategy_name)
+        block_duplicate = self._cfg.block_duplicate_strategy_position
+        if limit is not None:
+            block_duplicate = block_duplicate and limit.block_duplicate_position
+        if not block_duplicate or self._strategy_risk_provider is None:
+            return None
+
+        try:
+            holding = self._strategy_risk_provider.is_holding(strategy_name, stock_code)
+            if inspect.isawaitable(holding):
+                holding = await holding
+        except Exception as exc:
+            self._logger.warning(
+                f"[RiskGate][CHECK_ERROR] rule=duplicate_strategy_position "
+                f"strategy={strategy_name} code={stock_code} error={exc}"
+            )
+            return None
+
+        if not holding:
+            return None
+
+        return self._blocked(
+            "duplicate_strategy_position",
+            "동일 전략에서 이미 보유 중인 종목입니다.",
+            strategy_name=strategy_name,
+            stock_code=stock_code,
+            source=source,
+        )
+
+    def _get_strategy_limit(self, strategy_name: str):
+        specific = self._cfg.strategy_limits.get(strategy_name)
+        return specific or self._cfg.default_strategy_limit
+
+    async def _check_strategy_loss_limit(
+        self,
+        strategy_name: str,
+        limit,
+    ) -> Optional[ResCommonResponse]:
+        if limit.max_loss_pct is None or self._strategy_risk_provider is None:
+            return None
+
+        try:
+            history = self._strategy_risk_provider.get_strategy_return_history(strategy_name)
+            if inspect.isawaitable(history):
+                history = await history
+        except Exception as exc:
+            self._logger.warning(
+                f"[RiskGate][CHECK_ERROR] rule=strategy_loss_limit "
+                f"strategy={strategy_name} error={exc}"
+            )
+            return None
+
+        if not history:
+            self._logger.debug(
+                f"[RiskGate][SKIP] rule=strategy_loss_limit strategy={strategy_name} reason=no_history"
+            )
+            return None
+
+        latest = history[-1] or {}
+        latest_return = float(latest.get("return_rate", 0) or 0)
+        max_loss_pct = abs(float(limit.max_loss_pct))
+        if latest_return <= -max_loss_pct:
+            return self._blocked(
+                "strategy_loss_limit",
+                "전략 손실 한도 초과",
+                strategy_name=strategy_name,
+                latest_return_pct=latest_return,
+                max_loss_pct=max_loss_pct,
+                reference_date=latest.get("date"),
+            )
+
+        return None
+
+    async def _check_strategy_exposure_limit(
+        self,
+        strategy_name: str,
+        stock_code: str,
+        order_amount: int,
+        limit,
+        exchange: Exchange,
+    ) -> Optional[ResCommonResponse]:
+        if limit.max_exposure_pct is None or self._strategy_risk_provider is None:
+            return None
+        if self._account_snapshot_cache is None:
+            self._logger.warning("[RiskGate] account snapshot cache 없음: 전략 노출 검증 skip")
+            return None
+
+        snapshot = await self._account_snapshot_cache.get(exchange)
+        if snapshot.total_equity <= 0:
+            self._logger.warning(
+                f"[RiskGate] total_equity<=0: 전략 노출 검증 fail-open. "
+                f"strategy={strategy_name} code={stock_code} equity={snapshot.total_equity}"
+            )
+            return None
+
+        try:
+            holds = self._strategy_risk_provider.get_holds_by_strategy(strategy_name) or []
+            if inspect.isawaitable(holds):
+                holds = await holds
+        except Exception as exc:
+            self._logger.warning(
+                f"[RiskGate][CHECK_ERROR] rule=strategy_exposure_limit "
+                f"strategy={strategy_name} error={exc}"
+            )
+            return None
+
+        current_strategy_exposure = sum(self._position_value(hold) for hold in holds)
+        next_exposure_pct = (
+            (current_strategy_exposure + order_amount) / snapshot.total_equity * 100
+        )
+        if next_exposure_pct > limit.max_exposure_pct:
+            return self._blocked(
+                "strategy_exposure_limit",
+                "전략 자본 할당 한도 초과",
+                strategy_name=strategy_name,
+                stock_code=stock_code,
+                current_strategy_exposure=current_strategy_exposure,
+                order_amount=order_amount,
+                total_equity=snapshot.total_equity,
+                next_exposure_pct=round(next_exposure_pct, 2),
+                max_exposure_pct=limit.max_exposure_pct,
+            )
+
+        return None
+
+    @staticmethod
+    def _position_value(hold: dict) -> int:
+        for key in ("current_value", "eval_amount", "evlu_amt", "market_value"):
+            if key in hold and hold.get(key) not in (None, ""):
+                return int(float(str(hold.get(key)).replace(",", "")))
+        price = float(str(hold.get("buy_price") or 0).replace(",", ""))
+        qty = int(float(str(hold.get("qty") or 0).replace(",", "")))
+        return int(price * qty)
+
+    @staticmethod
+    def _strategy_name_from_source(source: str) -> Optional[str]:
+        source = source or ""
+        if source.startswith("strategy:"):
+            return source.split(":", 1)[1] or None
+        return None
+
+    def _blocked(
+        self,
+        rule: str,
+        reason: str,
+        *,
+        error_code: ErrorCode = ErrorCode.RISK_GATE_BLOCKED,
+        **context,
+    ) -> ResCommonResponse:
+        decision = RiskGateDecision(
+            rule=rule,
+            reason=reason,
+            error_code=error_code,
+            context=context,
+        )
+        self._logger.warning(
+            f"[RiskGate][BLOCK] rule={rule} reason={reason} context={context}"
+        )
+        return decision.to_response()

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -1893,7 +1893,35 @@ async def test_risk_gate_uses_active_context_count_not_all_order_states(
 
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert risk_gate.validate_order.await_args.kwargs["active_order_count"] == 0
+    assert risk_gate.validate_order.await_args.kwargs["source"] == "default"
+    assert risk_gate.validate_order.await_args.kwargs["strategy_name"] is None
     assert handler.get_order_context("005930", True).state == OrderState.SUBMITTED
+
+
+@pytest.mark.asyncio
+async def test_risk_gate_receives_strategy_context(
+    mock_broker_api_wrapper,
+    mock_logger,
+    mock_market_clock,
+    mock_market_calendar_service,
+):
+    risk_gate = AsyncMock()
+    risk_gate.validate_order.return_value = None
+    handler = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        risk_gate_service=risk_gate,
+    )
+
+    result = await handler.handle_place_buy_order(
+        "005930", 70_000, 10, source="strategy:모멘텀"
+    )
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert risk_gate.validate_order.await_args.kwargs["source"] == "strategy:모멘텀"
+    assert risk_gate.validate_order.await_args.kwargs["strategy_name"] == "모멘텀"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -11,6 +11,7 @@ from core.account_snapshot import AccountSnapshot
 from services.notification_service import NotificationCategory, NotificationLevel
 from services.order_execution_service import OrderExecutionService
 from services.risk_gate_service import RiskGateService
+from services.order_policy_service import OrderPolicyDecision
 
 # 테스트를 위한 MockLogger
 class MockLogger:
@@ -1922,6 +1923,66 @@ async def test_risk_gate_receives_strategy_context(
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert risk_gate.validate_order.await_args.kwargs["source"] == "strategy:모멘텀"
     assert risk_gate.validate_order.await_args.kwargs["strategy_name"] == "모멘텀"
+
+
+@pytest.mark.asyncio
+async def test_order_policy_blocks_before_broker_submit(
+    mock_broker_api_wrapper,
+    mock_logger,
+    mock_market_clock,
+    mock_market_calendar_service,
+):
+    order_policy = AsyncMock()
+    order_policy.validate_order.return_value = OrderPolicyDecision(
+        allowed=False,
+        rule="nxt_market_order_not_supported",
+        reason="NXT 거래소에서는 시장가 주문을 허용하지 않습니다.",
+    )
+    handler = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        order_policy_service=order_policy,
+    )
+
+    result = await handler.handle_place_buy_order("005930", 0, 10, exchange=Exchange.NXT)
+
+    assert result.rt_cd == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert result.data["rule"] == "nxt_market_order_not_supported"
+    mock_broker_api_wrapper.place_stock_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_order_policy_adjusted_price_is_submitted(
+    mock_broker_api_wrapper,
+    mock_logger,
+    mock_market_clock,
+    mock_market_calendar_service,
+):
+    order_policy = AsyncMock()
+    order_policy.validate_order.return_value = OrderPolicyDecision(
+        allowed=True,
+        rule="tick_size_adjusted",
+        reason="호가단위 보정",
+        adjusted_price=70_000,
+    )
+    handler = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        order_policy_service=order_policy,
+    )
+
+    result = await handler.handle_place_buy_order("005930", 70_051, 10)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    mock_broker_api_wrapper.place_stock_order.assert_awaited_once_with(
+        "005930", 70_000, 10, is_buy=True, exchange=Exchange.KRX
+    )
+    context = handler.get_order_context("005930", True)
+    assert context.price == 70_000
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_order_policy_service.py
+++ b/tests/unit_test/services/test_order_policy_service.py
@@ -1,0 +1,158 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, Exchange, OrderSide, ResCommonResponse
+from config.config_loader import OrderPolicyConfig
+from services.order_policy_service import OrderPolicyService
+
+
+def _service(*, config=None, quote_provider=None, logger=None):
+    return OrderPolicyService(
+        config=config or OrderPolicyConfig(),
+        quote_provider=quote_provider,
+        logger=logger or MagicMock(),
+    )
+
+
+def _quote(ask=70_100, bid=70_000, ask_qty=100, bid_qty=100, current=70_000):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data={
+            "askp1": str(ask),
+            "bidp1": str(bid),
+            "askp_rsqn1": str(ask_qty),
+            "bidp_rsqn1": str(bid_qty),
+            "stck_prpr": str(current),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_limit_tick_size_adjusts_by_default():
+    logger = MagicMock()
+    svc = _service(logger=logger)
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_051,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule == "tick_size_adjusted"
+    assert decision.adjusted_price == 70_000
+    logger.info.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_limit_tick_size_block_mode_blocks():
+    svc = _service(config=OrderPolicyConfig(tick_size_policy="block"))
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_051,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.blocked is True
+    response = decision.to_response()
+    assert response.rt_cd == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert response.data["rule"] == "invalid_tick_size"
+
+
+@pytest.mark.asyncio
+async def test_nxt_market_order_blocks_by_default():
+    svc = _service()
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=0,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.NXT,
+    )
+
+    assert decision.blocked is True
+    assert decision.rule == "nxt_market_order_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_market_order_spread_blocks_when_order_book_enabled():
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = _quote(ask=71_000, bid=70_000, current=70_500)
+    svc = _service(config=OrderPolicyConfig(order_book_checks_enabled=True, max_spread_pct=1.0),
+                   quote_provider=provider)
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=0,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.blocked is True
+    assert decision.rule == "spread_too_wide"
+
+
+@pytest.mark.asyncio
+async def test_market_order_slippage_blocks_when_order_book_enabled():
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = _quote(ask=71_000, bid=70_900, current=70_000)
+    svc = _service(config=OrderPolicyConfig(order_book_checks_enabled=True, max_market_slippage_pct=1.0),
+                   quote_provider=provider)
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=0,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.blocked is True
+    assert decision.rule == "market_slippage_too_high"
+
+
+@pytest.mark.asyncio
+async def test_market_order_empty_book_blocks_when_enabled():
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = _quote(ask=0, bid=70_000)
+    svc = _service(config=OrderPolicyConfig(order_book_checks_enabled=True),
+                   quote_provider=provider)
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=0,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.blocked is True
+    assert decision.rule == "empty_order_book"
+
+
+@pytest.mark.asyncio
+async def test_market_order_quote_failure_can_fail_open():
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = ResCommonResponse(rt_cd="1", msg1="API error")
+    svc = _service(config=OrderPolicyConfig(order_book_checks_enabled=True, quote_fail_policy="allow"),
+                   quote_provider=provider)
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=0,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule == "quote_unavailable"

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -85,13 +85,13 @@ async def test_order_amount_over_limit_blocks_buy():
 
 
 @pytest.mark.asyncio
-async def test_buy_with_non_positive_price_blocks():
+async def test_negative_price_blocks():
     svc, _, _ = _service()
 
-    result = await svc.validate_order("005930", 0, 10, OrderSide.BUY, Exchange.KRX, 0)
+    result = await svc.validate_order("005930", -1, 10, OrderSide.BUY, Exchange.KRX, 0)
 
     assert result.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
-    assert "0 이하 가격" in result.msg1
+    assert result.data["rule"] == "negative_price"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from common.types import ErrorCode, Exchange, OrderSide
-from config.config_loader import RiskGateConfig
+from config.config_loader import RiskGateConfig, RiskGateStrategyLimitConfig
 from core.account_snapshot import AccountSnapshot
 from services.risk_gate_service import RiskGateService
 
@@ -13,6 +13,7 @@ def _service(
     config: RiskGateConfig | None = None,
     kill_switch=None,
     snapshot: AccountSnapshot | None = None,
+    strategy_provider=None,
     logger=None,
 ):
     if kill_switch is None:
@@ -28,6 +29,7 @@ def _service(
         config=config or RiskGateConfig(),
         kill_switch_service=kill_switch,
         account_snapshot_cache=cache,
+        strategy_risk_provider=strategy_provider,
         logger=logger or MagicMock(),
     ), kill_switch, cache
 
@@ -129,7 +131,94 @@ async def test_buy_exposure_over_limit_blocks_but_sell_passes():
 
     assert buy_result.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
     assert "계좌 노출 한도 초과" in buy_result.msg1
+    assert buy_result.data["rule"] == "max_total_exposure"
     assert sell_result is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_strategy_position_blocks_same_strategy_only():
+    provider = MagicMock()
+    provider.is_holding.side_effect = lambda strategy, code: strategy == "모멘텀"
+    svc, _, _ = _service(strategy_provider=provider)
+
+    blocked = await svc.validate_order(
+        "005930", 70_000, 10, OrderSide.BUY, Exchange.KRX, 0,
+        source="strategy:모멘텀",
+    )
+    allowed = await svc.validate_order(
+        "005930", 70_000, 10, OrderSide.BUY, Exchange.KRX, 0,
+        source="strategy:눌림목",
+    )
+
+    assert blocked.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
+    assert blocked.data["rule"] == "duplicate_strategy_position"
+    assert blocked.data["strategy_name"] == "모멘텀"
+    assert allowed is None
+
+
+@pytest.mark.asyncio
+async def test_strategy_exposure_limit_blocks():
+    provider = MagicMock()
+    provider.is_holding.return_value = False
+    provider.get_strategy_return_history.return_value = []
+    provider.get_holds_by_strategy.return_value = [
+        {"code": "000660", "buy_price": 10_000, "qty": 50},
+    ]
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "모멘텀": RiskGateStrategyLimitConfig(max_exposure_pct=1.0),
+        },
+    )
+    svc, _, _ = _service(config=cfg, strategy_provider=provider)
+
+    result = await svc.validate_order(
+        "005930", 70_000, 10, OrderSide.BUY, Exchange.KRX, 0,
+        source="strategy:모멘텀",
+    )
+
+    assert result.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
+    assert result.data["rule"] == "strategy_exposure_limit"
+    assert result.data["next_exposure_pct"] == 1.2
+
+
+@pytest.mark.asyncio
+async def test_strategy_loss_limit_blocks():
+    provider = MagicMock()
+    provider.is_holding.return_value = False
+    provider.get_strategy_return_history.return_value = [
+        {"date": "2026-04-24", "return_rate": -6.1},
+    ]
+    provider.get_holds_by_strategy.return_value = []
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "모멘텀": RiskGateStrategyLimitConfig(max_loss_pct=5.0),
+        },
+    )
+    svc, _, _ = _service(config=cfg, strategy_provider=provider)
+
+    result = await svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, 0,
+        source="strategy:모멘텀",
+    )
+
+    assert result.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
+    assert result.data["rule"] == "strategy_loss_limit"
+    assert result.data["latest_return_pct"] == -6.1
+
+
+@pytest.mark.asyncio
+async def test_block_logs_structured_context():
+    logger = MagicMock()
+    svc, _, _ = _service(
+        config=RiskGateConfig(max_order_amount_won=100_000),
+        logger=logger,
+    )
+
+    result = await svc.validate_order("005930", 70_000, 2, OrderSide.BUY, Exchange.KRX, 0)
+
+    assert result.data["rule"] == "max_order_amount"
+    logger.warning.assert_called()
+    assert "[RiskGate][BLOCK]" in logger.warning.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -16,6 +16,7 @@ def mock_deps():
         ("sqs", patch("view.web.web_app_initializer.StockQueryService", autospec=True)),
         ("oes", patch("view.web.web_app_initializer.OrderExecutionService", autospec=True)),
         ("risk_gate", patch("view.web.web_app_initializer.RiskGateService", autospec=True)),
+        ("order_policy", patch("view.web.web_app_initializer.OrderPolicyService", autospec=True)),
         ("vtm", patch("view.web.web_app_initializer.VirtualTradeRepository", autospec=True)),
         ("scm", patch("view.web.web_app_initializer.StockCodeRepository", autospec=True)),
         ("sched", patch("view.web.web_app_initializer.StrategyScheduler", autospec=True)),
@@ -105,6 +106,8 @@ async def test_initialize_services_success(mock_deps):
     assert oes_kwargs.get("virtual_trade_service") is ctx.virtual_trade_service
     mock_deps["risk_gate"].assert_called_once()
     assert oes_kwargs.get("risk_gate_service") is mock_deps["risk_gate"].return_value
+    mock_deps["order_policy"].assert_called_once()
+    assert oes_kwargs.get("order_policy_service") is mock_deps["order_policy"].return_value
     mock_deps["ous"].assert_called()
     _, report_kwargs = mock_deps["strategy_log_report_service"].call_args
     assert report_kwargs.get("stock_code_repo") is mock_deps["scm"].return_value

--- a/todo_list.md
+++ b/todo_list.md
@@ -41,66 +41,6 @@
 
 ---
 
-
-## P2. 공통 Risk Gate와 주문 정책 분리
-
-목표는 주문 실행 서비스가 모든 리스크 판단을 직접 떠안지 않게 하고, 주문 직전 검증을 공통 서비스로 강제하는 것입니다.
-
-### 2-1. `RiskGateService` 신규 생성
-
-- [X] `services/risk_gate_service.py`를 생성한다.
-- [X] `KillSwitchService`, `PositionSizingService`, 계좌/잔고/미체결 조회를 통합한다.
-- [X] 모든 주문은 broker 호출 직전 Risk Gate를 통과하도록 연결한다.
-- [X] 실패 시 broker API를 호출하지 않고 명확한 reason을 반환한다.
-
-주요 파일:
-
-- `services/risk_gate_service.py`
-- `services/order_execution_service.py`
-- `services/kill_switch_service.py`
-- `services/position_sizing_service.py`
-- `brokers/broker_api_wrapper.py`
-
-검증:
-
-- kill switch 발동 시 주문 차단
-- 주문 금액 초과 시 주문 차단
-- 미체결 주문 과다 시 주문 차단
-- 계좌 노출 한도 초과 시 주문 차단
-
-### 2-2. 포트폴리오 레벨 리스크 관리
-
-- [ ] 총 투자금 대비 최대 노출 비율을 제한한다. 예: 70%
-- [ ] 전략별 자본 할당과 손실 한도를 둔다.
-- [ ] 동일 종목/동일 전략 중복 진입을 제한한다.
-- [ ] 섹터/테마 집중도 제한을 위한 데이터 소스와 모델을 정한다.
-- [ ] 상관관계 기반 포지션 축소는 후순위 실험 과제로 분리한다.
-
-주요 파일:
-
-- `services/risk_gate_service.py`
-- `services/position_sizing_service.py`
-- `services/account_snapshot_service.py`
-- `strategies/strategy_executor.py`
-- `repositories/*`
-
-### 2-3. 시장가, 지정가, 호가단위 정책 분리
-
-- [ ] 주문 타입 정책을 `OrderPolicy` 또는 설정 객체로 분리한다.
-- [ ] 시장가/지정가/NXT 제한 조건을 서비스 레벨에서 검증한다.
-- [ ] 호가단위 보정은 broker API 계층에서만 암묵 처리하지 말고 사전 검증 결과로 노출한다.
-- [ ] 시장가 주문 시 허용 슬리피지 제한을 추가한다.
-- [ ] 스프레드 급증 또는 호가 공백 감지 시 주문을 차단한다.
-
-주요 파일:
-
-- `services/order_execution_service.py`
-- `brokers/broker_api_wrapper.py`
-- `brokers/korea_investment/korea_invest_trading_api.py`
-- `brokers/korea_investment/*provider.py`
-
----
-
 ## P3. 실전/모의 모드 안전장치 강화
 
 실전 계좌로 잘못 주문하는 사고를 막기 위한 보호막입니다. 기본값은 항상 안전한 쪽이어야 합니다.
@@ -425,12 +365,6 @@ C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_te
 ---
 
 ## 바로 착수 추천 순서
-
-2. `services/risk_gate_service.py`
-   - 신규 생성
-   - kill switch, position sizing, 계좌 노출, 미체결 상태를 공통 검증
-   - 모든 주문 직전 호출
-
 3. `brokers/broker_api_wrapper.py`
    - 미체결 주문 조회
    - 체결 내역 조회

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -437,6 +437,7 @@ class WebAppContext:
             config=getattr(self.full_config, "risk_gate", None) or RiskGateConfig(),
             kill_switch_service=self.kill_switch_service,
             account_snapshot_cache=self.account_snapshot_cache,
+            strategy_risk_provider=self.virtual_trade_service,
             logger=self.logger,
         )
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -62,7 +62,8 @@ from services.kill_switch_service import KillSwitchService
 from core.account_snapshot import AccountSnapshotCache
 from services.position_sizing_service import PositionSizingService
 from services.risk_gate_service import RiskGateService
-from config.config_loader import PositionSizingConfig
+from services.order_policy_service import OrderPolicyService
+from config.config_loader import PositionSizingConfig, OrderPolicyConfig
 from services.price_subscription_service import PriceSubscriptionService
 from services.price_stream_service import PriceStreamService
 from repositories.streaming_stock_repo import StreamingStockRepo, StreamingType
@@ -101,6 +102,7 @@ class WebAppContext:
         )
         self.account_snapshot_cache: AccountSnapshotCache = None
         self.risk_gate_service: RiskGateService = None
+        self.order_policy_service: OrderPolicyService = None
         self.position_sizing_service: PositionSizingService = None
         self.scheduler: StrategyScheduler = None
         self.oneil_universe_service: OneilUniverseService = None
@@ -440,6 +442,11 @@ class WebAppContext:
             strategy_risk_provider=self.virtual_trade_service,
             logger=self.logger,
         )
+        self.order_policy_service = OrderPolicyService(
+            config=getattr(self.full_config, "order_policy", None) or OrderPolicyConfig(),
+            quote_provider=self.broker,
+            logger=self.logger,
+        )
 
         self.order_execution_service = OrderExecutionService(
             broker_api_wrapper=self.broker,
@@ -452,6 +459,7 @@ class WebAppContext:
             kill_switch_service=self.kill_switch_service,
             account_snapshot_cache=self.account_snapshot_cache,
             risk_gate_service=self.risk_gate_service,
+            order_policy_service=self.order_policy_service,
         )
         self.streaming_service.register_handler(
             "signing_notice",


### PR DESCRIPTION
핵심 변경은 services/risk_gate_service.py (line 24)에 RiskGateDecision을 추가해서 차단 사유를 rule/context로 구조화했고, 모든 차단 로그가 [RiskGate][BLOCK] rule=... 형태로 남게 한 점입니다. 또한 (strategy_name, stock_code) 기준 중복 진입 차단, 전략별 노출 한도, 전략별 손실 한도 검증을 추가했습니다.

전략 문맥은 services/order_execution_service.py (line 1131)에서 source="strategy:..."를 해석해 RiskGate로 넘기고, 웹 초기화에서는 view/web/web_app_initializer.py (line 440)가 virtual_trade_service를 전략 리스크 조회 포트로 주입합니다. 다른 전략의 동일 종목 매수는 허용되고, 같은 전략+같은 종목 HOLD만 차단합니다.

문서도 docs/risk_gate.md (line 1)에 추가했습니다. rule id, 로그 예시, config 예시, fail-open 정책, 2-3 OrderPolicy와의 경계를 정리해뒀습니다.

검증:

test_risk_gate_service.py: 14 passed
RiskGate 관련 test_order_execution_service.py 3개: passed
test_web_app_initializer.py: 31 passed
py_compile: 통과