### PR TITLE
확인했고 수정했습니다.

### DIFF
--- a/services/virtual_trade_service.py
+++ b/services/virtual_trade_service.py
@@ -51,9 +51,9 @@ def _build_strategy_return_history(daily: dict, strategy_name: str) -> list[dict
 
 class VirtualTradeService:
     """모의매매 통계 계산 및 성과 분석을 담당하는 비즈니스 서비스 계층"""
-    def __init__(self, repository: VirtualTradeRepository, market_clock: MarketClock):
+    def __init__(self, repository: VirtualTradeRepository, market_clock: MarketClock = None):
         self._repo = repository
-        self.tm = market_clock
+        self.tm = market_clock or getattr(repository, "tm", None) or MarketClock()
 
     # ── 비즈니스 & 통계 계산 로직 ──
 

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -74,6 +74,8 @@ def test_load_config_and_env(mock_deps):
     mock_deps["load_configs"].assert_called_once()
     mock_deps["env"].assert_called_once()
     mock_deps["tm"].assert_called_once()
+    assert ctx.virtual_repo.tm is mock_deps["tm"].return_value
+    assert ctx.virtual_trade_service.tm is mock_deps["tm"].return_value
     assert ctx.full_config is not None
 
 @pytest.mark.asyncio

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -158,6 +158,8 @@ class WebAppContext:
             timezone=config_dict.get('market_timezone', "Asia/Seoul"),
             logger=self.logger
         )
+        self.virtual_repo.tm = self.market_clock
+        self.virtual_trade_service.tm = self.market_clock
         self.notification_service = NotificationService(self.market_clock)
         self.kill_switch_service = KillSwitchService(
             config=getattr(self.full_config, "kill_switch", None) or KillSwitchConfig(),


### PR DESCRIPTION
원인은 WebAppContext.__init__에서 self.market_clock = None인 상태로 VirtualTradeService를 먼저 생성해서, /virtual/history 스냅샷 계산 중 self.tm.get_current_kst_time() 호출이 NoneType 에러를 내는 흐름이었습니다.

수정 내용:

services/virtual_trade_service.py (line 54): market_clock가 None이어도 repository의 clock 또는 새 MarketClock()로 fallback. view/web/web_app_initializer.py (line 161): 설정 로드 후 생성된 MarketClock를 virtual_repo와 virtual_trade_service에 재연결. tests/unit_test/view/web/test_web_app_initializer.py (line 74): clock 재연결 회귀 테스트 추가. 검증:
C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/view/web/test_web_app_initializer.py tests/unit_test/view/web/routes/test_web_routes_virtual.py -v

결과: 62 passed