### PR TITLE
수정 완료했습니다.

### DIFF
--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -19,34 +19,6 @@ from common.types import (
 )
 
 
-def _real_only(method):
-    """모의투자 모드에서 호출 시 PAPER_NOT_SUPPORTED 응답을 반환하는 데코레이터.
-
-    KIS Open API는 시가총액/랭킹/상한가 등 일부 시세 API를 실전 도메인에서만 제공한다.
-    paper 모드에서 호출되면 broker 호출 전에 즉시 차단한다.
-    """
-    async def wrapper(self, *args, **kwargs):
-        env = getattr(self, "_env", None)
-        # 명시적 True만 차단 (MagicMock의 자동 속성 회피)
-        is_paper = getattr(env, "is_paper_trading", None) if env is not None else None
-        if is_paper is True:
-            logger = getattr(self, "_logger", None) or getattr(self, "logger", None)
-            if logger is not None:
-                logger.warning(
-                    f"[PAPER_NOT_SUPPORTED] {method.__name__}는 실전 모드 전용 API입니다. "
-                    f"모의투자 모드에서 호출되어 차단되었습니다."
-                )
-            return ResCommonResponse(
-                rt_cd=ErrorCode.PAPER_NOT_SUPPORTED.value,
-                msg1=f"{method.__name__}는 실전 모드 전용 API입니다.",
-                data=None,
-            )
-        return await method(self, *args, **kwargs)
-    wrapper.__name__ = method.__name__
-    wrapper.__doc__ = method.__doc__
-    return wrapper
-
-
 def _exchange_to_market_code(exchange: Exchange) -> str:
     """Exchange enum을 API 마켓코드 문자열로 변환합니다."""
     if exchange == Exchange.NXT:
@@ -291,10 +263,10 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
                 data=0
             )
 
-    @_real_only
     async def get_top_market_cap_stocks_code(self, market_code: str, count: int = 30) -> ResCommonResponse:
         """
         시가총액 상위 종목 목록을 반환합니다. 최대 30개까지만 지원됩니다.
+        모의투자 모드에서도 조회 정보 통일성을 위해 실전 조회 엔드포인트로 호출합니다.
         ResCommonResponse 형태로 반환하며, data 필드에 List[ResTopMarketCapApiItem] 포함.
         """
         full_config = self._env.active_config
@@ -617,10 +589,10 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
 
         return response
 
-    @_real_only
     async def get_top_rise_fall_stocks(self, rise: bool = True) -> ResCommonResponse:
         """
-        상승률/하락률 상위 종목 조회 (실전 모드 전용)
+        상승률/하락률 상위 종목 조회
+        모의투자 모드에서도 조회 정보 통일성을 위해 실전 조회 엔드포인트로 호출합니다.
         """
         full_config = self._env.active_config
         tr_id = self._trid_provider.quotations(TrIdLeaf.RANKING_FLUCTUATION)
@@ -669,10 +641,10 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
                 data=None
             )
 
-    @_real_only
     async def get_top_volume_stocks(self) -> ResCommonResponse:
         """
-        거래량 상위 종목 조회 (실전 모드 전용)
+        거래량 상위 종목 조회
+        모의투자 모드에서도 조회 정보 통일성을 위해 실전 조회 엔드포인트로 호출합니다.
         """
         full_config = self._env.active_config
         tr_id = self._trid_provider.quotations(TrIdLeaf.RANKING_VOLUME)

--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -119,9 +119,6 @@ class MarketDataService:
             self._logger.warning(f"[경고] count 파라미터가 명시되지 않아 기본값 30을 사용합니다. market_code={market_code}")
 
         self._logger.info(f"MarketDataService - 시가총액 상위 종목 조회 요청 - 시장: {market_code}, 개수: {limit}")
-        if self._env.is_paper_trading:
-            self._logger.warning("MarketDataService - 시가총액 상위 종목 조회는 모의투자를 지원하지 않습니다.")
-            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1="모의투자 미지원 API입니다.", data=[])
 
         return await self._broker_api_wrapper.get_top_market_cap_stocks_code(market_code, limit)
 
@@ -561,7 +558,6 @@ class MarketDataService:
         URL: /quotations/inquire-time-dailychartprice
         TR : FHKST03010230 (실전만)
         """
-        if self._env.is_paper_trading: return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="모의투자 미지원", data=[])
         return await self._broker_api_wrapper.inquire_time_dailychartprice(stock_code=stock_code, input_date_1=input_date_1, input_hour_1=input_hour_1, pw_data_incu_yn="Y", fake_tick_incu_yn="")
 
     async def get_latest_trading_date(self) -> Optional[str]:

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -211,17 +211,8 @@ class StockQueryService:
         """
         self.logger.debug(f"상한가 스캔 요청 (시장={market_code}, limit={limit})")
 
-        # 모의투자 / 장시간 검증
-        if getattr(self.market_data_service._env, "is_paper_trading", False):
-            self.logger.warning("모의투자 환경에서는 상한가 조회 미지원")
-            return ResCommonResponse(
-                rt_cd=ErrorCode.API_ERROR.value,
-                msg1="모의투자 미지원 API입니다.",
-                data=None
-            )
 
         try:
-            # 상위 종목 조회
             top_res: ResCommonResponse = await self.market_data_service.get_top_market_cap_stocks_code(market_code, limit)
             if not top_res or top_res.rt_cd != ErrorCode.SUCCESS.value:
                 self.logger.error(f"상위 종목 목록 조회 실패: {top_res}")
@@ -780,7 +771,7 @@ class StockQueryService:
         # 배치 호출 함수 선택
         async def _fetch_batch(cursor_hhmmss: str):
             cursor_hhmmss = self.market_clock.to_hhmmss(cursor_hhmmss)
-            if self.market_data_service._env.is_paper_trading:
+            if not date_ymd:
                 # 오늘(모의/실전; 배치당 30개)
                 return await self.get_intraday_minutes_today(
                     stock_code, input_hour_1=cursor_hhmmss

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -1907,12 +1907,18 @@ async def test_get_program_trade_by_stock_daily_parsing_error(mock_quotations):
 
 
 @pytest.mark.asyncio
-async def test_real_only_blocks_in_paper_mode(mock_quotations):
-    """paper 모드에서 실전 전용 API 호출 시 PAPER_NOT_SUPPORTED 차단 검증."""
+async def test_read_only_ranking_apis_pass_through_in_paper_mode(mock_quotations):
+    """paper 모드에서도 조회성 랭킹 API는 KIS 조회 엔드포인트로 전달한다."""
     mock_quotations._env.is_paper_trading = True
-    mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
-        rt_cd="0", msg1="should not be called", data={}
-    ))
+    mock_quotations.call_api = AsyncMock(side_effect=[
+        ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": []}),
+        ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": []}),
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={"output": [{"mksc_shrn_iscd": "005930", "stck_avls": "100"}]},
+        ),
+    ])
 
     for coro in (
         mock_quotations.get_top_volume_stocks(),
@@ -1920,16 +1926,16 @@ async def test_real_only_blocks_in_paper_mode(mock_quotations):
         mock_quotations.get_top_market_cap_stocks_code("0000"),
     ):
         result = await coro
-        assert result.rt_cd == ErrorCode.PAPER_NOT_SUPPORTED.value
-        assert result.data is None
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert result.rt_cd != ErrorCode.PAPER_NOT_SUPPORTED.value
 
-    # 실제 broker 호출이 발생하지 않았는지 검증
-    mock_quotations.call_api.assert_not_called()
+    mock_quotations.call_api.assert_awaited()
+    assert mock_quotations.call_api.await_count == 3
 
 
 @pytest.mark.asyncio
-async def test_real_only_passes_through_in_real_mode(mock_quotations):
-    """real 모드(is_paper_trading=False)에서는 데코레이터가 통과시킨다."""
+async def test_read_only_ranking_apis_pass_through_in_real_mode(mock_quotations):
+    """real 모드에서도 조회성 랭킹 API는 KIS 조회 엔드포인트로 전달한다."""
     mock_quotations._env.is_paper_trading = False
     mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
         rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": []}

--- a/tests/unit_test/services/test_market_data_service.py
+++ b/tests/unit_test/services/test_market_data_service.py
@@ -1035,16 +1035,19 @@ async def test_get_intraday_minutes_by_date_real(trading_service_fixture, mock_d
 
 @pytest.mark.asyncio
 async def test_get_intraday_minutes_by_date_paper(trading_service_fixture, mock_deps):
-    """일별 분봉 조회 (모의투자) 테스트 - 미지원"""
+    """일별 분봉 조회는 모의투자에서도 조회 엔드포인트로 위임한다."""
     broker = mock_deps.broker
     env = mock_deps.env
     env.is_paper_trading = True
-    
+    expected = ResCommonResponse(rt_cd="0", msg1="OK", data={})
+    broker.inquire_time_dailychartprice = AsyncMock(return_value=expected)
+
     resp = await trading_service_fixture.get_intraday_minutes_by_date(stock_code="005930", input_date_1="20250101")
-    
-    assert resp.rt_cd == ErrorCode.API_ERROR.value
-    assert "모의투자 미지원" in resp.msg1
-    broker.inquire_time_dailychartprice.assert_not_called()
+
+    assert resp == expected
+    broker.inquire_time_dailychartprice.assert_awaited_once_with(
+        stock_code="005930", input_date_1="20250101", input_hour_1="", pw_data_incu_yn="Y", fake_tick_incu_yn=""
+    )
 
 @pytest.mark.asyncio
 async def test_get_top_rise_fall_stocks(trading_service_fixture, mock_deps):
@@ -1823,14 +1826,21 @@ async def test_get_intraday_minutes_today_delegates_to_broker(trading_service_fi
 
 
 @pytest.mark.asyncio
-async def test_get_intraday_minutes_by_date_returns_error_in_paper_mode(trading_service_fixture, mock_deps):
+async def test_get_intraday_minutes_by_date_delegates_in_paper_mode(trading_service_fixture, mock_deps):
     mock_deps.env.is_paper_trading = True
+    expected = ResCommonResponse(rt_cd="0", msg1="OK", data=[{"date": "20250102"}])
+    mock_deps.broker.inquire_time_dailychartprice = AsyncMock(return_value=expected)
 
     result = await trading_service_fixture.get_intraday_minutes_by_date(stock_code="005930", input_date_1="20250102")
 
-    assert result.rt_cd == ErrorCode.API_ERROR.value
-    assert result.data == []
-    mock_deps.broker.inquire_time_dailychartprice.assert_not_called()
+    assert result == expected
+    mock_deps.broker.inquire_time_dailychartprice.assert_awaited_once_with(
+        stock_code="005930",
+        input_date_1="20250102",
+        input_hour_1="",
+        pw_data_incu_yn="Y",
+        fake_tick_incu_yn="",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_market_data_service_top_stocks.py
+++ b/tests/unit_test/services/test_market_data_service_top_stocks.py
@@ -22,28 +22,26 @@ class TestMarketDataServiceTopStocks(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_market_closed_returns_none(self):
+        expected = ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=[])
+        self.mock_broker_api_wrapper.get_top_market_cap_stocks_code = AsyncMock(return_value=expected)
+
         result: ResCommonResponse = await self.trading_service.get_top_market_cap_stocks_code(market_code="0000",limit=10)
 
         # 수정된 기대값 검증
-        assert isinstance(result, ResCommonResponse)
-        assert result.rt_cd == ErrorCode.INVALID_INPUT.value
-        assert result.msg1 == "모의투자 미지원 API입니다."
-        assert isinstance(result.data, List)
-        assert result.data == []
+        assert result == expected
+        self.mock_broker_api_wrapper.get_top_market_cap_stocks_code.assert_awaited_once_with("0000", 10)
 
-        self.mock_logger.warning.assert_any_call("MarketDataService - 시가총액 상위 종목 조회는 모의투자를 지원하지 않습니다.")
 
     @pytest.mark.asyncio
     async def test_paper_trading_returns_error(self):
         self.mock_env.is_paper_trading = True
+        expected = ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=[])
+        self.mock_broker_api_wrapper.get_top_market_cap_stocks_code = AsyncMock(return_value=expected)
 
         result: ResCommonResponse = await self.trading_service.get_top_market_cap_stocks_code(market_code="0000",limit=10)
 
-        assert isinstance(result, ResCommonResponse)
-        assert result.rt_cd == ErrorCode.INVALID_INPUT.value
-        assert result.msg1 == "모의투자 미지원 API입니다."
-        assert isinstance(result.data, List)
-        assert result.data == []
+        assert result == expected
+        self.mock_broker_api_wrapper.get_top_market_cap_stocks_code.assert_awaited_once_with("0000", 10)
 
     async def test_get_top_stocks_failure(self):
         self.mock_env.is_paper_trading = False

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -1349,6 +1349,30 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         # 첫 호출 커서 확인
         self.mock_market_data_service.get_intraday_minutes_today.assert_any_call(stock_code="005930", input_hour_1="153000")
 
+    async def test_get_day_intraday_minutes_list_paper_with_date_uses_by_date_api(self):
+        """date_ymd가 있으면 모의투자에서도 특정일 분봉 조회 API를 사용한다."""
+        self.mock_market_data_service._env.is_paper_trading = True
+        self.mock_market_clock.to_hhmmss.side_effect = lambda x: x.ljust(6, "0")
+        self.mock_market_clock.dec_minute.return_value = "085900"
+
+        resp = ResCommonResponse(
+            rt_cd="0",
+            msg1="OK",
+            data={"output2": [{"stck_bsop_date": "20250101", "stck_cntg_hour": "090000"}]},
+        )
+        self.mock_market_data_service.get_intraday_minutes_by_date.side_effect = [
+            resp,
+            ResCommonResponse(rt_cd="0", msg1="OK", data=[]),
+        ]
+
+        result = await self.stockQueryService.get_day_intraday_minutes_list(
+            "005930", date_ymd="20250101", start_hhmmss="090000", end_hhmmss="090000"
+        )
+
+        self.assertEqual(len(result), 1)
+        self.mock_market_data_service.get_intraday_minutes_by_date.assert_called()
+        self.mock_market_data_service.get_intraday_minutes_today.assert_not_called()
+
     async def test_get_day_intraday_minutes_list_extract_rows_dict_unknown_key(self):
         """_extract_rows: dict 응답이지만 알려진 키가 없을 때 (Line 697 coverage)"""
         self.mock_market_data_service._env.is_paper_trading = False

--- a/tests/unit_test/services/test_stock_query_service_upper_limit_stocks.py
+++ b/tests/unit_test/services/test_stock_query_service_upper_limit_stocks.py
@@ -103,14 +103,18 @@ class TestUpperLimitStocks(unittest.IsolatedAsyncioTestCase):
     # --- handle_upper_limit_stocks 테스트 케이스들 ---
 
     async def test_handle_upper_limit_stocks_paper_trading(self):
-        """모의투자 환경에서 상한가 종목 조회 시도 (미지원)."""
+        """상한가 종목 조회는 모의투자에서도 조회 엔드포인트로 위임한다."""
         self.mock_env.is_paper_trading = True
+        self.market_data_service.get_top_market_cap_stocks_code = AsyncMock(return_value=ResCommonResponse(
+            rt_cd="0",
+            msg1="정상",
+            data=[]
+        ))
 
         result = await self.stock_query_service.handle_upper_limit_stocks(market_code="0000", limit=500)
 
-        self.assertEqual(result, ResCommonResponse(rt_cd='100', msg1='시가총액 상위 종목 조회 실패', data=None))
-        self.mock_broker_api_wrapper.client.quotations.get_top_market_cap_stocks_code.assert_not_called()
-        self.mock_logger.warning.assert_called_once_with("MarketDataService - 시가총액 상위 종목 조회는 모의투자를 지원하지 않습니다.")
+        self.assertEqual(result, ResCommonResponse(rt_cd="0", msg1="조회 성공", data=[]))
+        self.market_data_service.get_top_market_cap_stocks_code.assert_called_once_with("0000", 500)
 
     async def test_handle_upper_limit_stocks_no_top_stocks_found(self):
         """상위 종목 목록이 비어있을 때."""


### PR DESCRIPTION
모의투자 환경에서도 조회성 API가 차단되지 않도록 다음 경로를 열었습니다.

korea_invest_quotations_api.py: get_top_market_cap_stocks_code, get_top_rise_fall_stocks, get_top_volume_stocks의 paper 차단 제거 market_data_service.py: 시가총액 상위 조회, 특정일 분봉 조회의 모의투자 차단 제거 stock_query_service.py: 상한가 조회와 특정일 분봉 리스트 조회가 paper에서도 조회 API로 위임되도록 변경 테스트도 새 정책에 맞춰 갱신했습니다.

검증:

py_compile 관련 파일 통과
quotation paper/real pass-through 테스트 통과
test_market_data_service.py -k intraday_minutes_by_date 통과 test_stock_query_service.py -k day_intraday_minutes_list 통과 상한가 paper 조회 테스트 통과