### PR TITLE
처리했습니다. 현재 브랜치는 feature/price_qulity_report입니다.

### DIFF
--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -238,6 +238,28 @@ class OrderExecutionService:
     def _log_execution_quality(self, context: OrderContext) -> None:
         if context.average_fill_price is None:
             return
+        event = {
+            "event": "execution_quality",
+            "order_key": context.order_key,
+            "code": context.stock_code,
+            "side": context.side.value,
+            "source": context.source,
+            "expected_fill_price": context.expected_fill_price,
+            "average_fill_price": context.average_fill_price,
+            "filled_qty": context.filled_qty,
+            "slippage_amount_won": context.slippage_amount_won,
+            "slippage_pct": context.slippage_pct,
+            "first_fill_latency_sec": context.first_fill_latency_sec,
+            "trace_id": context.trace_id,
+        }
+        self.logger.info(event)
+        log_dir = getattr(self.logger, "log_dir", None)
+        if isinstance(log_dir, str):
+            try:
+                from core.logger import get_strategy_logger
+                get_strategy_logger("ExecutionQuality", log_dir=log_dir).info(event)
+            except Exception as exc:
+                self.logger.warning(f"execution_quality 전략 로그 기록 실패: {exc}")
         self.logger.info(
             f"[EXECUTION QUALITY] order_key={context.order_key} code={context.stock_code} "
             f"side={context.side.value} expected_price={context.expected_fill_price} "

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -101,6 +101,7 @@ _MAX_SOLD_DETAILS_SHOWN = 5
 _MA_PROXIMITY_LOWER_PCT = -2.0
 _MA_PROXIMITY_UPPER_PCT = 4.0
 _MA_NEAR_MISS_MAX_EXCESS_PCT = 4.0
+_MAX_EXECUTION_QUALITY_ROWS = 5
 
 
 def _to_float(value: Any) -> Optional[float]:
@@ -119,6 +120,19 @@ def _first_number(data: dict, *keys: str) -> Optional[float]:
             if value is not None:
                 return value
     return None
+
+
+def _strategy_name_from_source(source: Any) -> str:
+    raw = str(source or "").strip()
+    if not raw:
+        return "미분류"
+    if raw.startswith("strategy:"):
+        value = raw.split(":", 1)[1].strip()
+        return value or "미분류"
+    if raw.startswith("manual:"):
+        value = raw.split(":", 1)[1].strip()
+        return value or "수동매매"
+    return raw
 
 
 def _normalize_reason(reason: str) -> str:
@@ -440,6 +454,76 @@ class StrategyLogReportService:
 
         return "\n".join(lines)
 
+    def _build_execution_quality_section(self, records: List[dict]) -> Optional[str]:
+        if not records:
+            return None
+
+        by_strategy: Dict[str, List[dict]] = {}
+        by_symbol: Dict[Tuple[str, str], List[dict]] = {}
+        for record in records:
+            strategy = record["strategy"]
+            by_strategy.setdefault(strategy, []).append(record)
+            by_symbol.setdefault((record["code"], record["name"]), []).append(record)
+
+        lines = ["<b>📈 체결 품질 요약</b>"]
+        strategy_rows = []
+        for strategy, items in by_strategy.items():
+            slip_values = [
+                abs(item["slippage_pct"])
+                for item in items
+                if item.get("slippage_pct") is not None
+            ]
+            latency_values = [
+                item["first_fill_latency_sec"]
+                for item in items
+                if item.get("first_fill_latency_sec") is not None
+            ]
+            avg_slip = sum(slip_values) / len(slip_values) if slip_values else None
+            max_slip = max(slip_values) if slip_values else None
+            avg_latency = sum(latency_values) / len(latency_values) if latency_values else None
+            strategy_rows.append({
+                "strategy": strategy,
+                "count": len(items),
+                "avg_slip": avg_slip,
+                "max_slip": max_slip,
+                "avg_latency": avg_latency,
+            })
+
+        strategy_rows.sort(key=lambda row: (row["avg_slip"] is None, -(row["avg_slip"] or 0), row["strategy"]))
+        for row in strategy_rows[:_MAX_EXECUTION_QUALITY_ROWS]:
+            slip_str = f"{row['avg_slip']:.3f}%" if row["avg_slip"] is not None else "N/A"
+            max_str = f"{row['max_slip']:.3f}%" if row["max_slip"] is not None else "N/A"
+            latency_str = f"{row['avg_latency']:.1f}s" if row["avg_latency"] is not None else "N/A"
+            lines.append(
+                f"• {_esc(row['strategy'])}: {row['count']}건, 평균 슬리피지 {slip_str}, "
+                f"최대 {max_str}, 평균 지연 {latency_str}"
+            )
+
+        symbol_rows = []
+        for (code, name), items in by_symbol.items():
+            slip_values = [
+                abs(item["slippage_pct"])
+                for item in items
+                if item.get("slippage_pct") is not None
+            ]
+            if not slip_values:
+                continue
+            symbol_rows.append({
+                "code": code,
+                "name": name,
+                "count": len(items),
+                "avg_slip": sum(slip_values) / len(slip_values),
+            })
+        symbol_rows.sort(key=lambda row: (-row["avg_slip"], row["name"], row["code"]))
+        if symbol_rows:
+            parts = [
+                f"{_esc(row['name'])}({row['code']}) {row['avg_slip']:.3f}%/{row['count']}건"
+                for row in symbol_rows[:3]
+            ]
+            lines.append("• 종목별 슬리피지 상위: " + ", ".join(parts))
+
+        return "\n".join(lines)
+
     # ── 리포트 생성 ──────────────────────────────────────────────
 
     async def generate_report(self, target_date: str) -> str:
@@ -463,6 +547,7 @@ class StrategyLogReportService:
 
         # 전략 로직과 무관한 데이터 수신/파싱 오류를 따로 집계
         data_errors_by_strategy: Dict[str, int] = {}
+        execution_quality_records: List[dict] = []
 
         for name, files in sorted(strategy_files.items()):
             bought: Dict[str, dict] = {}
@@ -500,6 +585,19 @@ class StrategyLogReportService:
                         }
                         rejected.pop(code, None)
                         near_miss.pop(code, None)
+
+                    elif event == 'execution_quality' and code:
+                        name_value = name_map.get(code) or data.get('name') or code
+                        execution_quality_records.append({
+                            "strategy": _strategy_name_from_source(data.get("source") or data.get("strategy_name")),
+                            "code": str(code).strip(),
+                            "name": self._db_resolve(str(code).strip(), str(name_value)),
+                            "side": data.get("side", ""),
+                            "filled_qty": int(_to_float(data.get("filled_qty")) or 0),
+                            "slippage_amount_won": _to_float(data.get("slippage_amount_won")),
+                            "slippage_pct": _to_float(data.get("slippage_pct")),
+                            "first_fill_latency_sec": _to_float(data.get("first_fill_latency_sec")),
+                        })
 
                     elif code and (event in self.REJECTED_EVENTS or event.endswith('_rejected')):
                         if code not in bought:
@@ -680,9 +778,14 @@ class StrategyLogReportService:
         warnings_section = ""
         if system_warnings:
             warnings_section = "<b>⚠️ 시스템 경고</b>\n" + "\n".join(system_warnings)
+        execution_quality_section = self._build_execution_quality_section(execution_quality_records)
 
         if not active_sections:
-            extra = f"\n\n{warnings_section}" if warnings_section else ""
+            extra_sections = [
+                section for section in (warnings_section, execution_quality_section) if section
+            ]
+            extra_body = "\n\n".join(extra_sections)
+            extra = f"\n\n{extra_body}" if extra_body else ""
             return header + extra + "\n\n당일 활동한 전략이 없습니다." + footer
 
         sections: List[str] = []
@@ -693,6 +796,8 @@ class StrategyLogReportService:
         portfolio_summary = self._build_portfolio_summary(target_date, fallback_buys)
         if portfolio_summary:
             body += f"\n\n{portfolio_summary}"
+        if execution_quality_section:
+            body += f"\n\n{execution_quality_section}"
 
         if inactive_names:
             inactive_summary = f"\n\n💤 <i>활동 없음: {_esc(', '.join(inactive_names[:3]))}"

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -427,6 +427,69 @@ async def test_report_uses_virtual_trade_records_for_completed_buys_when_availab
     assert "SK하이닉스" in other_section
 
 
+@pytest.mark.asyncio
+async def test_report_includes_execution_quality_summary(log_dir):
+    """execution_quality 로그를 전략별/종목별 체결 품질로 집계한다."""
+    log_path = os.path.join(log_dir, "20260418_093000_Execution.log.json")
+    _write_log(log_path, [
+        {
+            "timestamp": "2026-04-18 10:00:00,000",
+            "level": "INFO",
+            "name": "order.execution",
+            "data": {
+                "event": "execution_quality",
+                "code": "005930",
+                "name": "삼성전자",
+                "source": "strategy:전략A",
+                "side": "BUY",
+                "filled_qty": 10,
+                "slippage_pct": 0.2,
+                "slippage_amount_won": 140,
+                "first_fill_latency_sec": 4.0,
+            },
+        },
+        {
+            "timestamp": "2026-04-18 10:01:00,000",
+            "level": "INFO",
+            "name": "order.execution",
+            "data": {
+                "event": "execution_quality",
+                "code": "005930",
+                "name": "삼성전자",
+                "source": "strategy:전략A",
+                "side": "BUY",
+                "filled_qty": 5,
+                "slippage_pct": -0.1,
+                "slippage_amount_won": -70,
+                "first_fill_latency_sec": 2.0,
+            },
+        },
+        {
+            "timestamp": "2026-04-18 10:02:00,000",
+            "level": "INFO",
+            "name": "order.execution",
+            "data": {
+                "event": "execution_quality",
+                "code": "000660",
+                "name": "SK하이닉스",
+                "source": "manual:수동매매",
+                "side": "SELL",
+                "filled_qty": 1,
+                "slippage_pct": 0.5,
+                "first_fill_latency_sec": 9.0,
+            },
+        },
+    ])
+
+    svc = StrategyLogReportService(log_dir=log_dir)
+    report = await svc.generate_report("20260418")
+
+    assert "체결 품질 요약" in report
+    assert "전략A: 2건, 평균 슬리피지 0.150%, 최대 0.200%, 평균 지연 3.0s" in report
+    assert "수동매매: 1건, 평균 슬리피지 0.500%, 최대 0.500%, 평균 지연 9.0s" in report
+    assert "종목별 슬리피지 상위: SK하이닉스(000660) 0.500%/1건, 삼성전자(005930) 0.150%/2건" in report
+
+
 # ── _build_metric_str ─────────────────────────────────────────────
 
 def test_build_metric_str_low_execution_strength():

--- a/todo_list.md
+++ b/todo_list.md
@@ -19,10 +19,10 @@
 
 ### 0-1. 실전 KIS `inquire-daily-ccld` 응답 필드 검증
 
-- [ ] 실제 체결 이력이 있는 실전 계좌 응답을 캡처한다.
-- [ ] 민감정보를 제거한 fixture를 추가한다.
-- [ ] paper fixture와 real fixture의 필드 차이를 회귀 테스트에 반영한다.
-- [ ] 주문번호, 종목코드, 매수/매도 구분, 주문수량, 누적체결수량, 미체결수량, 평균체결가, 취소/거부 필드 매핑을 확정한다.
+- [blocked] 실제 체결 이력이 있는 실전 계좌 응답을 캡처한다. (현재 실전 계좌 체결 이력 부재)
+- [blocked] 민감정보를 제거한 fixture를 추가한다. (실전 응답 확보 후 진행)
+- [blocked] paper fixture와 real fixture의 필드 차이를 회귀 테스트에 반영한다. (실전 응답 확보 후 진행)
+- [blocked] 주문번호, 종목코드, 매수/매도 구분, 주문수량, 누적체결수량, 미체결수량, 평균체결가, 취소/거부 필드 매핑을 확정한다. (실전 응답 확보 후 진행)
 
 주요 파일:
 
@@ -114,7 +114,7 @@ main 반영 확인.
 - [x] 슬리피지 금액과 슬리피지 비율을 계산한다. (`slippage_amount_won`, `slippage_pct`)
 - [~] 주문 타입, 주문 시각, 체결 지연 시간을 함께 기록한다. (`created_at`, `first_fill_latency_sec`는 `OrderContext`에 기록됨. `order_type`은 `OrderPolicyDecision.context`에 남으며 `OrderContext` 영속 필드는 아님)
 - [~] 호가 스프레드는 시장가 주문 정책 판단 컨텍스트에 기록한다. 영속 리포트 반영은 후속 작업으로 남긴다.
-- [ ] 전략별/종목별 체결 품질 리포트를 추가한다.
+- [x] 전략별/종목별 체결 품질 리포트를 추가한다. (`execution_quality` JSON 로그 이벤트 + `StrategyLogReportService` 체결 품질 요약)
 - [ ] 체결 품질이 기준 이하인 전략은 경고 또는 자동 비활성화 후보로 표시한다.
 
 주요 파일:


### PR DESCRIPTION
P0는 todo_list.md에서 실전 체결 이력 부재로 [blocked] 처리했고, P4-1은 완료로 갱신했습니다.

구현 내용:

services/order_execution_service.py: 체결 품질을 execution_quality JSON 이벤트로 남기고, 운영 리포트가 읽는 logs/strategies/ExecutionQuality 로그에도 기록하도록 보강했습니다. services/strategy_log_report_service.py: execution_quality 이벤트를 전략별/종목별로 집계해 “체결 품질 요약” 섹션을 생성합니다. tests/unit_test/services/test_strategy_log_report_service.py: 전략별 평균/최대 슬리피지, 평균 지연, 종목별 슬리피지 상위 출력 테스트를 추가했습니다. 검증:

pytest tests\unit_test\services\test_strategy_log_report_service.py -v -o addopts= 통과, 33 passed pytest tests\unit_test\services\test_order_execution_service.py::test_execution_report_records_execution_quality_metrics -v -o addopts= 통과