### PR TITLE
적용 완료했습니다.

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -768,28 +768,70 @@ class OneilUniverseService:
         ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(etf_code, limit=period + days + 5)
         ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
 
-        if not ohlcv or len(ohlcv) < period + days: # This check should be based on the actual 'closes' list length
-            return False, "데이터 부족", []
-        
-        closes = [r.get("close", 0) for r in ohlcv] # Changed: Do not filter out 0 values
+        if not ohlcv or len(ohlcv) < period + days:
+            return False, "insufficient data", []
+
+        closes = [r.get("close", 0) for r in ohlcv]
+        if len(closes) < period + days:
+            return False, "insufficient close data", []
+
         ma_values = []
         for i in range(days + 1):
             end = len(closes) - days + i
             ma_values.append(sum(closes[end-period:end]) / period)
-            
+
+        daily_changes_pct = []
+        for j in range(1, len(ma_values)):
+            prev = ma_values[j - 1]
+            curr = ma_values[j]
+            daily_changes_pct.append(((curr - prev) / prev * 100) if prev else 0.0)
+
+        first_ma = ma_values[0]
+        last_ma = ma_values[-1]
+        net_change_pct = ((last_ma - first_ma) / first_ma * 100) if first_ma else 0.0
+        max_daily_drop_pct = min(daily_changes_pct) if daily_changes_pct else 0.0
+        worst_drop_idx = daily_changes_pct.index(max_daily_drop_pct) + 1 if daily_changes_pct else 0
+
+        min_net_change_pct = getattr(self._cfg, "market_ma_min_net_change_pct", -0.10)
+        daily_dip_tolerance_pct = getattr(self._cfg, "market_ma_daily_dip_tolerance_pct", -0.20)
+        hard_decline_pct = getattr(self._cfg, "market_ma_hard_decline_pct", -0.50)
+
         is_rising = True
         fail_detail = ""
-        for j in range(1, len(ma_values)):
-            if ma_values[j] <= ma_values[j-1]:
-                is_rising = False
-                fail_detail = f"MA decline: {ma_values[j-1]:.2f} -> {ma_values[j]:.2f} (idx {j})"
-                break
+        trend_status = "rising"
+        if max_daily_drop_pct < hard_decline_pct:
+            is_rising = False
+            fail_detail = (
+                f"MA hard decline: {max_daily_drop_pct:.2f}% < {hard_decline_pct:.2f}% "
+                f"(idx {worst_drop_idx}, {ma_values[worst_drop_idx-1]:.2f} -> {ma_values[worst_drop_idx]:.2f})"
+            )
+            trend_status = "hard_decline"
+        elif net_change_pct < min_net_change_pct:
+            is_rising = False
+            fail_detail = (
+                f"MA trend weak: net {net_change_pct:.2f}% < {min_net_change_pct:.2f}% "
+                f"({first_ma:.2f} -> {last_ma:.2f})"
+            )
+            trend_status = "weak_trend"
+        elif max_daily_drop_pct < daily_dip_tolerance_pct:
+            trend_status = "uptrend_under_pressure"
 
         log_data = {
             "event": "market_timing_check",
             "etf_code": etf_code,
             "is_rising": is_rising,
-            "ma_values": [round(v, 2) for v in ma_values]
+            "trend_status": trend_status,
+            "ma_period": period,
+            "lookback_days": days,
+            "ma_values": [round(v, 2) for v in ma_values],
+            "daily_changes_pct": [round(v, 3) for v in daily_changes_pct],
+            "net_change_pct": round(net_change_pct, 3),
+            "max_daily_drop_pct": round(max_daily_drop_pct, 3),
+            "thresholds": {
+                "min_net_change_pct": min_net_change_pct,
+                "daily_dip_tolerance_pct": daily_dip_tolerance_pct,
+                "hard_decline_pct": hard_decline_pct,
+            },
         }
         if not is_rising:
             log_data["fail_detail"] = fail_detail

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -23,6 +23,9 @@ class OneilUniverseConfig(BaseStrategyConfig):
     kospi_etf_code: str = "069500"    # KODEX 200
     market_ma_period: int = 20
     market_ma_rising_days: int = 3
+    market_ma_min_net_change_pct: float = -0.10
+    market_ma_daily_dip_tolerance_pct: float = -0.20
+    market_ma_hard_decline_pct: float = -0.50
 
     # V2 스코어링
     rs_period_days: int = 63

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -672,7 +672,7 @@ async def test_check_etf_ma_rising_exact_calculation(mock_deps):
     assert log_call["event"] == "market_timing_check"
     assert log_call["is_rising"] is False
     assert "fail_detail" in log_call
-    assert "MA decline: 40.00 -> 36.00" in log_call["fail_detail"]
+    assert "MA hard decline" in log_call["fail_detail"]
 
     # Case 3: 중간에 MA 하락 (실패)
     logger.debug.reset_mock()
@@ -687,7 +687,32 @@ async def test_check_etf_ma_rising_exact_calculation(mock_deps):
     assert log_call["event"] == "market_timing_check"
     assert log_call["is_rising"] is False
     assert "fail_detail" in log_call
-    assert "MA decline: 30.00 -> 28.00" in log_call["fail_detail"]
+    assert "MA hard decline" in log_call["fail_detail"]
+
+
+async def test_check_etf_ma_rising_tolerates_small_ma_noise(mock_deps):
+    """_check_etf_ma_rising: small MA dips are tolerated when the net trend is intact."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+    service._cfg.market_ma_period = 1
+    service._cfg.market_ma_rising_days = 3
+
+    closes = [18928.25, 18952.75, 18941.25, 18939.50]
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data=[{"close": c} for c in closes]
+    )
+
+    is_rising, fail_detail, ma_values = await service._check_etf_ma_rising("229200")
+
+    assert is_rising is True
+    assert fail_detail == ""
+    assert ma_values == closes
+
+    log_call = logger.debug.call_args[0][0]
+    assert log_call["event"] == "market_timing_check"
+    assert log_call["trend_status"] == "rising"
+    assert log_call["net_change_pct"] > 0
+    assert log_call["max_daily_drop_pct"] > service._cfg.market_ma_daily_dip_tolerance_pct
 
 
 async def test_build_daily_surge_pool_logic(mock_deps):

--- a/tests/unit_test/services/test_oneil_universe_service_logs.py
+++ b/tests/unit_test/services/test_oneil_universe_service_logs.py
@@ -57,6 +57,11 @@ async def test_check_etf_ma_rising_logs(service, mock_components):
             assert arg["etf_code"] == "TEST_ETF"
             assert arg["is_rising"] is True
             assert "ma_values" in arg
+            assert arg["trend_status"] == "rising"
+            assert "daily_changes_pct" in arg
+            assert "net_change_pct" in arg
+            assert "max_daily_drop_pct" in arg
+            assert arg["thresholds"]["min_net_change_pct"] == service._cfg.market_ma_min_net_change_pct
             found_log = True
             break
     assert found_log, "market_timing_check 이벤트 로그가 기록되지 않았습니다."

--- a/todo_list.md
+++ b/todo_list.md
@@ -2,6 +2,12 @@
 
 최종 업데이트: 2026-04-29
 
+## 2026-04-29 Update - O'Neil Market Timing
+
+- [x] `_check_etf_ma_rising()` strict consecutive MA(20) rise filter was relaxed to a net-trend check with small daily MA dip tolerance.
+- [x] Market timing debug logs now include `trend_status`, `daily_changes_pct`, `net_change_pct`, `max_daily_drop_pct`, and the active threshold values.
+- [x] Unit tests were updated for small KOSDAQ-style MA noise, hard MA declines, and enriched market timing logs.
+
 현재 main 확인: `main...origin/main` 동기화 상태. 최근 반영 커밋 기준으로 주문 안전장치, Web 모드 보호, WebAppContext 분리, 전략 로그 정리, 일부 운영 복구/스트리밍 성능 개선이 반영되어 있다.
 
 이 문서는 `AGENTS.md`, `SKILL.md`, `CODEBASE_SUMMARY.md`, `CODEX_WORKFLOW.md`와 repo review 내용을 기준으로 정리한 실행형 To-Do입니다.


### PR DESCRIPTION
_check_etf_ma_rising()을 연속 상승 강제에서 순 추세 + 작은 일간 노이즈 허용 방식으로 바꿨습니다. 이제 예시처럼 18952.75 -> 18941.25 정도의 미세한 MA 하락은 바로 “추세 꺾임”으로 보지 않고, 전체 MA 변화율과 큰 하락 여부를 함께 봅니다.

변경 파일:

services/oneil_universe_service.py (line 764)
strategies/oneil_common_types.py (line 24)
tests/unit_test/services/test_oneil_universe_service.py (line 615) tests/unit_test/services/test_oneil_universe_service_logs.py (line 35) todo_list.md (line 4)
로깅도 보강해서 trend_status, daily_changes_pct, net_change_pct, max_daily_drop_pct, 적용된 threshold들이 남도록 했습니다.

검증:
test_oneil_universe_service.py + test_oneil_universe_service_logs.py 전체 실행 결과 70 passed입니다.