### PR TITLE
모든 파일 구문 검증 통과. 페이지네이션 구현 완료.

### DIFF
--- a/todo_list.md
+++ b/todo_list.md
@@ -170,6 +170,7 @@ main 반영 확인.
   - [X] 단위 테스트: `tests/unit_test/strategies/test_rsi2_pullback_strategy.py` (11건)
   - [X] 통합 테스트: `tests/integration_test/strategies/test_it_api_rsi2_pullback_strategy.py` + `test_it_strategy_scan.py::TestRSI2PullbackScan` (5건)
   - [X] WebAppContext 등록 및 StrategyScheduler 연결 (`view/web/web_app_initializer.py`, `enabled=False` 수동 활성화 대기)
+
 - [X] Larry Williams / 브렌트 펜볼드 돈천 채널 돌파 전략을 설계·구현한다. (L218 확장 3과 동일 전략으로 통합)
   - [X] RS Rating ≥ 80, ADX(14) ≥ 25 우상향, 거래대금 필터를 함께 적용한다.
   - [X] 20일 고가 돌파 진입, 10일 저가 trailing stop 청산.
@@ -180,7 +181,10 @@ main 반영 확인.
   - [X] ADX 인프라: `services/indicator_service.py` — `_compute_adx` + `calc_adx_sync` 추가
   - [X] 단위 테스트: `tests/unit_test/strategies/test_larry_williams_channel_breakout_strategy.py` (16건) + ADX 테스트 4건
   - [X] WebAppContext 등록 (`view/web/web_app_initializer.py`, `enabled=False` 수동 활성화 대기)
-
+  - 미적용 리뷰 항목
+      ADX 우상황 주석: 본 전략 파일이 아닌 IndicatorService.calc_adx_sync 내부 사항이라 별도 PR 권장.
+      _extract_* None 체크 명시화: 사소, 동작 동일하므로 보류.
+      check_exits OHLCV 재호출: 문서에 트레이드오프 명시됨. 운영 모니터링 후 결정.
 주요 파일:
 
 - `strategies/*`

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -635,3 +635,47 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     animation: skeleton-shimmer 1.4s ease-in-out infinite;
 }
 .skeleton-row td { padding: 10px 8px; }
+
+/* Pagination controls (shared by virtual / scheduler / ranking / system pages) */
+.pagination-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 0 4px;
+}
+.pagination-info {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+.pagination {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+}
+.pagination-btn {
+    min-width: 30px;
+    padding: 4px 9px;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.pagination-btn:hover:not(:disabled):not(.active) {
+    background: var(--bg-primary);
+    border-color: var(--accent);
+}
+.pagination-btn.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+    font-weight: 600;
+}
+.pagination-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}

--- a/view/web/static/js/pagination.js
+++ b/view/web/static/js/pagination.js
@@ -1,0 +1,91 @@
+// Generic client-side pagination utility shared by scheduler/virtual/system/ranking pages.
+// Stores per-table page state in memory and exposes a small global Paginator API.
+(function () {
+    const _state = {};
+
+    function _get(dataKey, pageSize) {
+        if (!_state[dataKey]) {
+            _state[dataKey] = { page: 1, pageSize: pageSize || 20 };
+        } else if (pageSize) {
+            _state[dataKey].pageSize = pageSize;
+        }
+        return _state[dataKey];
+    }
+
+    function _renderControls(containerId, dataKey, totalItems, pageSize, currentPage, onPageChange) {
+        const el = document.getElementById(containerId);
+        if (!el) return;
+        const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+        if (totalPages <= 1) {
+            el.innerHTML = '';
+            return;
+        }
+
+        const startIdx = (currentPage - 1) * pageSize + 1;
+        const endIdx = Math.min(totalItems, currentPage * pageSize);
+
+        // Build a window of up to 5 page numbers around current page.
+        const windowSize = 5;
+        let winStart = Math.max(1, currentPage - Math.floor(windowSize / 2));
+        let winEnd = Math.min(totalPages, winStart + windowSize - 1);
+        winStart = Math.max(1, winEnd - windowSize + 1);
+
+        const parts = [];
+        parts.push(`<span class="pagination-info">총 ${totalItems.toLocaleString()}건 중 ${startIdx}-${endIdx}</span>`);
+        parts.push(`<div class="pagination">`);
+
+        const disabledFirst = currentPage === 1 ? ' disabled' : '';
+        const disabledLast = currentPage === totalPages ? ' disabled' : '';
+
+        parts.push(`<button type="button" class="pagination-btn${disabledFirst}" data-page="1" title="처음">«</button>`);
+        parts.push(`<button type="button" class="pagination-btn${disabledFirst}" data-page="${currentPage - 1}" title="이전">‹</button>`);
+
+        for (let p = winStart; p <= winEnd; p++) {
+            const active = p === currentPage ? ' active' : '';
+            parts.push(`<button type="button" class="pagination-btn${active}" data-page="${p}">${p}</button>`);
+        }
+
+        parts.push(`<button type="button" class="pagination-btn${disabledLast}" data-page="${currentPage + 1}" title="다음">›</button>`);
+        parts.push(`<button type="button" class="pagination-btn${disabledLast}" data-page="${totalPages}" title="마지막">»</button>`);
+
+        parts.push(`</div>`);
+
+        el.innerHTML = parts.join('');
+
+        el.querySelectorAll('.pagination-btn').forEach(btn => {
+            btn.addEventListener('click', (ev) => {
+                const target = parseInt(ev.currentTarget.dataset.page, 10);
+                if (!Number.isFinite(target)) return;
+                const clamped = Math.min(totalPages, Math.max(1, target));
+                if (clamped === _state[dataKey].page) return;
+                _state[dataKey].page = clamped;
+                if (typeof onPageChange === 'function') onPageChange();
+            });
+        });
+    }
+
+    window.Paginator = {
+        paginate(dataKey, data, controlsContainerId, onPageChange, pageSize = 20) {
+            const items = Array.isArray(data) ? data : [];
+            const state = _get(dataKey, pageSize);
+            const total = items.length;
+            const totalPages = Math.max(1, Math.ceil(total / state.pageSize));
+            // Auto-clamp page if data shrank below current page.
+            if (state.page > totalPages) state.page = totalPages;
+            if (state.page < 1) state.page = 1;
+            const start = (state.page - 1) * state.pageSize;
+            const end = start + state.pageSize;
+            _renderControls(controlsContainerId, dataKey, total, state.pageSize, state.page, onPageChange);
+            return items.slice(start, end);
+        },
+
+        reset(dataKey) {
+            if (_state[dataKey]) _state[dataKey].page = 1;
+            else _state[dataKey] = { page: 1, pageSize: 20 };
+        },
+
+        getPage(dataKey) {
+            return _state[dataKey] ? _state[dataKey].page : 1;
+        },
+    };
+})();

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -48,6 +48,7 @@ async function loadRanking(category) {
         clearTimeout(_rankingPollTimer);
         _rankingPollTimer = null;
     }
+    if (window.Paginator) window.Paginator.reset('ranking');
     _rankingCurrentCategory = category;
     _rankingDirection = null;
 
@@ -153,6 +154,7 @@ async function loadInvestorRanking() {
     const dir = _rankingDirection;
     const investors = Array.from(_rankingSelectedInvestors);
 
+    if (window.Paginator) window.Paginator.reset('ranking');
     _rankingSortState = { key: null, dir: 'asc' };
     _rankingCurrentCategory = `investor_${dir}`;
 
@@ -380,6 +382,10 @@ function renderRankingTable() {
         else data = rankingSortCompare(data, _rankingSortState.key, _rankingSortState.dir);
     }
 
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('ranking', data, 'ranking-pagination', renderRankingTable)
+        : data;
+
     const formatMarketCap = (val) => {
         if (!val) return '-';
         let v = parseFloat(val);
@@ -394,7 +400,7 @@ function renderRankingTable() {
     };
 
     let rows = '';
-    data.forEach(item => {
+    pageData.forEach(item => {
         const rate = parseFloat(item.prdy_ctrt || 0);
         const color = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
         const code = item.stck_shrn_iscd || item.iscd || item.mksc_shrn_iscd || item.code || '';
@@ -453,6 +459,7 @@ function sortRanking(key) {
         _rankingSortState.key = key;
         _rankingSortState.dir = 'asc';
     }
+    if (window.Paginator) window.Paginator.reset('ranking');
     renderRankingTable();
 }
 

--- a/view/web/static/js/scheduler.js
+++ b/view/web/static/js/scheduler.js
@@ -212,6 +212,7 @@ function filterSchedulerHistory(strategyName, btnElement) {
     const filtered = strategyName === '전체'
         ? allSchedulerHistory
         : allSchedulerHistory.filter(h => h.strategy_name === strategyName);
+    if (window.Paginator) window.Paginator.reset('scheduler-history');
     renderSchedulerHistory(filtered);
 }
 
@@ -223,10 +224,16 @@ function renderSchedulerHistory(history) {
 
     if (!history || history.length === 0) {
         tbody.innerHTML = '<tr><td colspan="8" style="text-align:center;padding:15px;">실행 이력이 없습니다.</td></tr>';
+        const ctrl = document.getElementById('scheduler-history-pagination');
+        if (ctrl) ctrl.innerHTML = '';
         return;
     }
 
-    tbody.innerHTML = history.map(h => {
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('scheduler-history', history, 'scheduler-history-pagination',
+            () => renderSchedulerHistory(history))
+        : history;
+    tbody.innerHTML = pageData.map(h => {
         const isSizingSkip = h.action === 'BUY' && Number(h.qty || 0) <= 0 && String(h.reason || '').startsWith('sizing_skip:');
         const actionClass = isSizingSkip ? '' : (h.action === 'BUY' ? 'text-red' : 'text-blue');
         const actionLabel = isSizingSkip ? '스킵' : (h.action === 'BUY' ? '매수' : '매도');

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -101,7 +101,12 @@ function renderPriceCacheDetails(stats) {
     renderCallersSection('price-details-inner', stats.callers);
     const tbody = document.getElementById('price-items-body');
     if (!tbody || !stats.items) return;
-    tbody.innerHTML = stats.items.map(item => {
+    const _items = stats.items;
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('price-items', _items, 'price-items-pagination',
+            () => renderPriceCacheDetails(stats))
+        : _items;
+    tbody.innerHTML = pageData.map(item => {
         const displayName = item.name && item.name !== item.code ? `${item.name}(${item.code})` : (item.code || '-');
         const streamBadge = item.is_streaming
             ? `<span style="background:var(--success-color,#4CAF50);color:#fff;padding:1px 7px;border-radius:8px;font-size:0.82em;font-weight:bold;">실시간</span>`
@@ -128,7 +133,12 @@ function renderOhlcvCacheDetails(stats) {
     renderCallersSection('ohlcv-details-inner', stats.callers);
     const tbody = document.getElementById('ohlcv-items-body');
     if (!tbody || !stats.items) return;
-    tbody.innerHTML = stats.items.map(item => {
+    const _items = stats.items;
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('ohlcv-items', _items, 'ohlcv-items-pagination',
+            () => renderOhlcvCacheDetails(stats))
+        : _items;
+    tbody.innerHTML = pageData.map(item => {
         const displayName = item.name && item.name !== item.code ? `${item.name}(${item.code})` : (item.code || '-');
         const completeBadge = item.historical_complete
             ? `<span style="color:var(--success-color,#4CAF50);">완전</span>`
@@ -505,10 +515,16 @@ async function updateBackgroundStatus() {
 
         if (result.data.length === 0) {
             tbody.innerHTML = '<tr><td colspan="5" style="text-align:center; color:#888;">등록된 태스크 없음</td></tr>';
+            const ctrl = document.getElementById('background-tasks-pagination');
+            if (ctrl) ctrl.innerHTML = '';
             return;
         }
 
-        tbody.innerHTML = result.data.map(task => {
+        const _tasks = result.data;
+        const pageData = window.Paginator
+            ? window.Paginator.paginate('background-tasks', _tasks, 'background-tasks-pagination', updateBackgroundStatus)
+            : _tasks;
+        tbody.innerHTML = pageData.map(task => {
             const badge = STATE_BADGE[task.state] || { label: task.state.toUpperCase(), color: '#888' };
             const priorityLabel = PRIORITY_LABEL[task.priority] ?? task.priority;
             const progressHtml = renderProgressCell(task.progress, task.name);
@@ -590,6 +606,7 @@ function selectSubTab(btn, priority) {
     _subTab = priority;
     document.querySelectorAll('.sub-tab-btn').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
+    if (window.Paginator) window.Paginator.reset('sub-table');
     renderSubTable();
 }
 
@@ -600,10 +617,15 @@ function renderSubTable() {
     const rows = _subData.pending_by_priority ? _subData.pending_by_priority[_subTab] || [] : [];
     if (rows.length === 0) {
         tbody.innerHTML = `<tr><td colspan="4" style="text-align:center; color:#888;">구독 종목 없음</td></tr>`;
+        const ctrl = document.getElementById('sub-table-pagination');
+        if (ctrl) ctrl.innerHTML = '';
         return;
     }
 
-    tbody.innerHTML = rows.map(item => {
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('sub-table', rows, 'sub-table-pagination', renderSubTable)
+        : rows;
+    tbody.innerHTML = pageData.map(item => {
         const displayName = item.name && item.name !== item.code ? `${item.name}(${item.code})` : item.code;
         const activeBadge = item.active
             ? `<span style="background:var(--success-color,#4CAF50); color:#fff; padding:2px 8px; border-radius:10px; font-size:0.82em; font-weight:bold;">구독 중</span>`

--- a/view/web/static/js/virtual.js
+++ b/view/web/static/js/virtual.js
@@ -199,6 +199,10 @@ window.toggleVirtualStrategy = function(strategyName, btnElement) {
 };
 
 function applyVirtualFilter() {
+    if (window.Paginator) {
+        window.Paginator.reset('virtual-hold');
+        window.Paginator.reset('virtual-sold');
+    }
     const isAll = selectedVirtualStrategies.has('ALL');
     const selectedArray = isAll ? ['ALL'] : [...selectedVirtualStrategies];
     const displayLabel = isAll ? 'ALL' : selectedArray.join(', ');
@@ -520,9 +524,14 @@ function renderVirtualHoldTable() {
 
     if (data.length === 0) {
         holdBody.innerHTML = '<tr><td colspan="5" style="text-align:center; padding:15px;">보유 종목이 없습니다.</td></tr>';
+        const ctrl = document.getElementById('virtual-hold-pagination');
+        if (ctrl) ctrl.innerHTML = '';
         return;
     }
-    data.forEach(item => {
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('virtual-hold', data, 'virtual-hold-pagination', renderVirtualHoldTable)
+        : data;
+    pageData.forEach(item => {
         const ror = item.return_rate || 0;
         const rorClass = ror > 0 ? 'text-positive' : (ror < 0 ? 'text-negative' : '');
         const buyDate = item.buy_date ? item.buy_date.split(' ')[0] : '-';
@@ -581,9 +590,14 @@ function renderVirtualSoldTable() {
 
     if (data.length === 0) {
         soldBody.innerHTML = '<tr><td colspan="5" style="text-align:center; padding:15px;">매도 기록이 없습니다.</td></tr>';
+        const ctrl = document.getElementById('virtual-sold-pagination');
+        if (ctrl) ctrl.innerHTML = '';
         return;
     }
-    data.forEach(item => {
+    const pageData = window.Paginator
+        ? window.Paginator.paginate('virtual-sold', data, 'virtual-sold-pagination', renderVirtualSoldTable)
+        : data;
+    pageData.forEach(item => {
         const ror = item.return_rate || 0;
         const rorClass = ror > 0 ? 'text-positive' : (ror < 0 ? 'text-negative' : '');
         const buyDate = item.buy_date ? item.buy_date.split(' ')[0] : '-';
@@ -637,6 +651,9 @@ function sortVirtual(table, key) {
         state.dir = 'asc';
     }
 
+    if (window.Paginator) {
+        window.Paginator.reset(table === 'hold' ? 'virtual-hold' : 'virtual-sold');
+    }
     if (table === 'hold') renderVirtualHoldTable();
     else renderVirtualSoldTable();
 }

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=8">
+    <link rel="stylesheet" href="/static/css/style.css?v=9">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }
@@ -148,6 +148,7 @@
 <script src="/static/js/common.js?v=1"></script>
 <script src="/static/js/notifications.js?v=1"></script>
 <script src="/static/js/kill_switch.js?v=1"></script>
+<script src="/static/js/pagination.js?v=1"></script>
 
 <!-- ── 서버 요청 진단 패널 (hang 디버깅용) ─────────────────────────────
      - 모든 페이지에 항상 떠있음 (좌하단 고정)

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -33,11 +33,12 @@
             </div>
         </div>
         <div id="ranking-result"></div>
+        <div id="ranking-pagination" class="pagination-wrap"></div>
     </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=1"></script>
+<script src="/static/js/ranking.js?v=2"></script>
 <script>
     loadRanking('rise');
 </script>

--- a/view/web/templates/scheduler.html
+++ b/view/web/templates/scheduler.html
@@ -34,11 +34,12 @@
                 <tbody id="scheduler-history-body"></tbody>
             </table>
         </div>
+        <div id="scheduler-history-pagination" class="pagination-wrap"></div>
     </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/scheduler.js?v=4"></script>
+<script src="/static/js/scheduler.js?v=5"></script>
 <script>
     loadSchedulerStatus();
 </script>

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -31,6 +31,7 @@
                     </tbody>
                 </table>
             </div>
+            <div id="background-tasks-pagination" class="pagination-wrap"></div>
         </div>
 
         <!-- 실시간 구독 현황 -->
@@ -61,6 +62,7 @@
                     </tbody>
                 </table>
             </div>
+            <div id="sub-table-pagination" class="pagination-wrap"></div>
         </div>
 
         <!-- 현재가 캐시 모니터링 -->
@@ -91,6 +93,7 @@
                         <tbody id="price-items-body"></tbody>
                     </table>
                 </div>
+                <div id="price-items-pagination" class="pagination-wrap"></div>
             </div>
         </div>
 
@@ -122,6 +125,7 @@
                         <tbody id="ohlcv-items-body"></tbody>
                     </table>
                 </div>
+                <div id="ohlcv-items-pagination" class="pagination-wrap"></div>
             </div>
         </div>
     </div>
@@ -129,5 +133,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=15"></script>
+<script src="/static/js/system.js?v=16"></script>
 {% endblock %}

--- a/view/web/templates/virtual.html
+++ b/view/web/templates/virtual.html
@@ -46,6 +46,7 @@
                 <tbody id="virtual-hold-body"></tbody>
             </table>
         </div>
+        <div id="virtual-hold-pagination" class="pagination-wrap"></div>
 
         <h3 style="margin:24px 0 8px; color:var(--text-primary);">매도 완료</h3>
         <div class="table-container">
@@ -62,13 +63,14 @@
                 <tbody id="virtual-sold-body"></tbody>
             </table>
         </div>
+        <div id="virtual-sold-pagination" class="pagination-wrap"></div>
     </div>
 {% endblock %}
 
 {% block scripts %}
 <script src="/static/js/virtual_chart.js?v=8"></script>
 <script src="/static/js/stock.js?v=1"></script>
-<script src="/static/js/virtual.js?v=1"></script>
+<script src="/static/js/virtual.js?v=2"></script>
 <script>
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', () => loadVirtualHistory(), { once: true });


### PR DESCRIPTION
변경 요약
신규

view/web/static/js/pagination.js — 재사용 가능한 window.Paginator (paginate / reset / getPage), 페이지당 20개 기본, « ‹ 1..5 › » 컨트롤 + "총 N건 중 X-Y" 표기, 데이터 축소 시 자동 클램프 수정

view/web/static/css/style.css — .pagination, .pagination-btn(.active/:disabled), .pagination-info, .pagination-wrap 추가 view/web/templates/base.html — pagination.js 글로벌 인클루드, css ?v=8 → ?v=9 view/web/templates/virtual.html — hold/sold 컨트롤 div 2개 + js ?v=2 view/web/templates/scheduler.html — history 컨트롤 div + js ?v=5 view/web/templates/ranking.html — ranking 컨트롤 div + js ?v=2 view/web/templates/system.html — 4개 테이블 컨트롤 div + js ?v=16 view/web/static/js/virtual.js — renderVirtualHoldTable/renderVirtualSoldTable 슬라이스, sortVirtual/applyVirtualFilter 페이지 리셋 view/web/static/js/scheduler.js — renderSchedulerHistory 슬라이스, filterSchedulerHistory 리셋 view/web/static/js/ranking.js — renderRankingTable 슬라이스, loadRanking/loadInvestorRanking/sortRanking 리셋 view/web/static/js/system.js — 4개 렌더(price-items, ohlcv-items, background-tasks, sub-table) 슬라이스, selectSubTab 리셋 검증 방법

conda activate py310
python main.py --web
http://localhost:8000 에서 /virtual, /scheduler, /ranking, /system 페이지의 21개 이상 데이터 테이블에 페이지네이션 컨트롤이 노출되는지 확인. 시스템 페이지의 캐시 폴링(15초)·백그라운드 폴링(5초) 후에도 현재 페이지가 유지되는지 확인.

# Conflicts:
#	todo_list.md
#	view/web/templates/system.html