### PR TITLE
처리했습니다.

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -12,6 +12,7 @@ always_on_tasks:
 
 after_market_tasks:
   after_market_delay_min:
+    after_market_reconcile: 0       # AfterMarketReconcileTask — 장 마감 직후 주문/브로커 상태 검증
     strategy_log_report: 3          # strategy_log_report — 장 마감 3분 후
     ranking_refresh: 5          # RankingTask — 장 마감 5분 후
     daily_price_collector: 10      # DailyPriceCollectorTask — 장 마감 10분 후

--- a/scheduler/background_scheduler.py
+++ b/scheduler/background_scheduler.py
@@ -154,7 +154,7 @@ class BackgroundScheduler:
 
         # 2. SchedulableTask 종료
         for name, task in self._tasks.items():
-            if task.state in (TaskState.RUNNING, TaskState.SUSPENDED):
+            if task.state in (TaskState.RUNNING, TaskState.SUSPENDED) or self._has_active_internal_tasks(task):
                 try:
                     await task.stop()
                     self._logger.info(f"[BackgroundScheduler] '{name}' 종료 완료")
@@ -167,6 +167,13 @@ class BackgroundScheduler:
             self._logger.info("[BackgroundScheduler] WorkerPool 종료 완료")
 
         self._pm.log_timer("BackgroundScheduler.shutdown", t_start)
+
+    @staticmethod
+    def _has_active_internal_tasks(task: SchedulableTask) -> bool:
+        internal_tasks = getattr(task, "_tasks", None)
+        if not internal_tasks:
+            return False
+        return any(not internal_task.done() for internal_task in internal_tasks)
 
     async def suspend_all(self) -> None:
         """실행 중인 모든 태스크를 일시 중지한다 (WorkerPool 포함)."""

--- a/task/background/intraday/pre_market_health_check_task.py
+++ b/task/background/intraday/pre_market_health_check_task.py
@@ -56,9 +56,10 @@ class PreMarketHealthCheckTask(SchedulableTask):
         return self._state
 
     async def start(self) -> None:
-        if self._state == TaskState.RUNNING:
+        if any(not task.done() for task in self._tasks):
             return
-        self._state = TaskState.RUNNING
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
         self._tasks.append(asyncio.create_task(self._loop()))
 
     async def stop(self) -> None:
@@ -76,7 +77,7 @@ class PreMarketHealthCheckTask(SchedulableTask):
 
     async def resume(self) -> None:
         if self._state == TaskState.SUSPENDED:
-            self._state = TaskState.RUNNING
+            self._state = TaskState.IDLE
 
     def get_progress(self) -> Dict:
         return {
@@ -92,7 +93,12 @@ class PreMarketHealthCheckTask(SchedulableTask):
                 if self._state == TaskState.SUSPENDED:
                     continue
                 if await self._should_run_now():
-                    await self.run_once()
+                    self._state = TaskState.RUNNING
+                    try:
+                        await self.run_once()
+                    finally:
+                        if self._state == TaskState.RUNNING:
+                            self._state = TaskState.IDLE
             except asyncio.CancelledError:
                 break
             except Exception as exc:

--- a/tests/unit_test/scheduler/test_background_scheduler.py
+++ b/tests/unit_test/scheduler/test_background_scheduler.py
@@ -85,6 +85,23 @@ async def test_shutdown(scheduler):
 
 
 @pytest.mark.asyncio
+async def test_shutdown_stops_idle_task_with_active_background_loop(scheduler):
+    """상태는 IDLE이어도 내부 백그라운드 루프가 살아 있으면 shutdown에서 stop한다."""
+    t1 = _make_mock_task("idle_loop", TaskState.IDLE)
+    pending = asyncio.create_task(asyncio.sleep(60))
+    t1._tasks = [pending]
+    scheduler.register(t1)
+
+    try:
+        await scheduler.shutdown()
+    finally:
+        pending.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+
+    t1.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_suspend_all(scheduler):
     t1 = _make_mock_task("t1", TaskState.RUNNING)
     t2 = _make_mock_task("t2", TaskState.IDLE)  # idle → 스킵

--- a/tests/unit_test/task/background/intraday/test_pre_market_health_check_task.py
+++ b/tests/unit_test/task/background/intraday/test_pre_market_health_check_task.py
@@ -162,16 +162,16 @@ async def test_pre_market_task_lifecycle_progress_suspend_resume_stop():
 
     try:
         await task.start()
-        assert task.state == TaskState.RUNNING
-        assert task.get_progress()["running"] is True
+        assert task.state == TaskState.IDLE
+        assert task.get_progress()["running"] is False
 
         await task.start()
         assert len(task._tasks) == 1
 
         await task.suspend()
-        assert task.state == TaskState.SUSPENDED
+        assert task.state == TaskState.IDLE
         await task.resume()
-        assert task.state == TaskState.RUNNING
+        assert task.state == TaskState.IDLE
     finally:
         await task.stop()
 
@@ -274,7 +274,7 @@ async def test_pre_market_check_broker_api_accepts_sync_response_and_plain_rt_cd
 @pytest.mark.asyncio
 async def test_pre_market_loop_runs_once_and_logs_errors():
     task = PreMarketHealthCheckTask(logger=MagicMock())
-    task._state = TaskState.RUNNING
+    task._state = TaskState.IDLE
     task._should_run_now = AsyncMock(side_effect=[True, RuntimeError("loop boom"), asyncio.CancelledError()])
     task.run_once = AsyncMock()
 
@@ -283,3 +283,24 @@ async def test_pre_market_loop_runs_once_and_logs_errors():
 
     task.run_once.assert_awaited_once()
     task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_market_loop_marks_running_only_while_checking():
+    task = PreMarketHealthCheckTask(logger=MagicMock())
+    task._state = TaskState.IDLE
+    task._should_run_now = AsyncMock(side_effect=[True, asyncio.CancelledError()])
+    seen_states = []
+
+    async def _run_once():
+        seen_states.append(task.state)
+        seen_states.append(task.get_progress()["running"])
+
+    task.run_once = AsyncMock(side_effect=_run_once)
+
+    with patch("task.background.intraday.pre_market_health_check_task.asyncio.sleep", new_callable=AsyncMock):
+        await task._loop()
+
+    assert seen_states == [TaskState.RUNNING, True]
+    assert task.state == TaskState.IDLE
+    assert task.get_progress()["running"] is False

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -459,6 +459,30 @@ def test_get_background_status_module_names(web_client, mock_web_ctx):
     assert all(v == 0 for v in delays.values())
 
 
+def test_get_background_status_pre_market_health_check_schedule_type(web_client, mock_web_ctx):
+    """pre_market_health_check는 일반 장중 태스크가 아니라 장전 점검으로 분류한다."""
+    class PreMarketTask:
+        pass
+
+    PreMarketTask.__module__ = "task.background.intraday.pre_market_health_check_task"
+    mock_task = PreMarketTask()
+    mock_task.get_progress = MagicMock(return_value={"running": False, "last_checked_date": None})
+
+    mock_web_ctx.background_scheduler = MagicMock()
+    mock_web_ctx.background_scheduler.get_all_status.return_value = [
+        {"name": "pre_market_health_check", "state": "idle", "priority": 50},
+    ]
+    mock_web_ctx.background_scheduler.get_task.return_value = mock_task
+
+    response = web_client.get("/api/background/status")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data[0]["name"] == "pre_market_health_check"
+    assert data[0]["schedule_type"] == "pre_market"
+    assert data[0]["progress"] == {"running": False, "status": "Waiting to start"}
+
+
 def test_get_background_status_idle_with_internal_flag(web_client, mock_web_ctx):
     """태스크가 IDLE 상태지만 내부 플래그(_is_refreshing)가 있는 경우 get_progress() 호출 확인"""
     mock_task = MagicMock()

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -772,6 +772,44 @@ async def test_force_minervini_update_not_init(web_client, mock_web_ctx):
     assert response.status_code == 503
 
 
+# ── POST /api/background/reconcile/force-update ───────────────────────
+
+@pytest.mark.asyncio
+async def test_force_after_market_reconcile_success(web_client, mock_web_ctx):
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": False}
+    mock_task.force_run = AsyncMock()
+    mock_web_ctx.after_market_reconcile_task = mock_task
+
+    response = web_client.post("/api/background/reconcile/force-update")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    await asyncio.sleep(0)
+    mock_task.force_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_force_after_market_reconcile_running(web_client, mock_web_ctx):
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": True}
+    mock_web_ctx.after_market_reconcile_task = mock_task
+
+    response = web_client.post("/api/background/reconcile/force-update")
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_force_after_market_reconcile_not_init(web_client, mock_web_ctx):
+    mock_web_ctx.after_market_reconcile_task = None
+
+    response = web_client.post("/api/background/reconcile/force-update")
+
+    assert response.status_code == 503
+
+
 # ── GET /api/background/status — time_dispatcher 티켓 발행 현황 ──────────────
 
 def _make_td_mock(last_dispatched_date, last_dispatched_at=None, market_is_open=False, registered_tasks=None):

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -13,9 +13,11 @@ router = APIRouter()
 
 # 태스크별 실행 스케줄 유형
 # intraday: 장 중에만 의미있는 태스크 (장 마감 후 비활성)
+# pre_market: 장 시작 전 준비/상태 점검 태스크
 # after_market: 장 마감 후 실행되는 배치 태스크 (장 중 비활성)
 # always_on: 항상 동작해야 하는 실시간 태스크
 _SCHEDULE_TYPES = {
+    "pre_market_health_check": "pre_market",
     "websocket_watchdog":  "intraday",
     "strategy_scheduler":  "intraday",
     "ranking_refresh":     "after_market",
@@ -29,8 +31,9 @@ _SCHEDULE_TYPES = {
 
 _SCHEDULE_ORDER = {
     "always_on": 0,
-    "intraday": 1,
-    "after_market": 2,
+    "pre_market": 1,
+    "intraday": 2,
+    "after_market": 3,
     "unknown": 99,
 }
 
@@ -377,7 +380,10 @@ async def get_background_status():
         schedule_type = "unknown"
         if task:
             module_name = task.__class__.__module__
-            if "strategy_scheduler" in module_name:
+            configured_type = _SCHEDULE_TYPES.get(name)
+            if configured_type:
+                schedule_type = configured_type
+            elif "strategy_scheduler" in module_name:
                 schedule_type = "intraday"
             elif "after_market" in module_name:
                 schedule_type = "after_market"

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -710,3 +710,19 @@ async def force_minervini_update():
 
     asyncio.create_task(task.force_run())
     return {"success": True, "message": "Minervini S2 강제 갱신이 시작되었습니다."}
+
+
+@router.post("/background/reconcile/force-update")
+async def force_after_market_reconcile():
+    """주문/브로커 상태 reconcile을 즉시 강제 실행한다."""
+    ctx = _get_ctx()
+    task = getattr(ctx, "after_market_reconcile_task", None)
+    if not task:
+        raise HTTPException(status_code=503, detail="AfterMarketReconcileTask가 초기화되지 않았습니다")
+
+    progress = task.get_progress()
+    if progress.get("running"):
+        raise HTTPException(status_code=409, detail="이미 주문/브로커 검증이 진행 중입니다")
+
+    asyncio.create_task(task.force_run())
+    return {"success": True, "message": "주문/브로커 상태 강제 검증이 시작되었습니다."}

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -447,6 +447,7 @@ function _renderProgressBody(progress, taskName) {
 
 // 태스크별 강제 수집 설정 (task_name → {endpoint, label})
 const FORCE_UPDATE_CONFIG = {
+    after_market_reconcile:{ endpoint: '/api/background/reconcile/force-update',     label: '강제 검증' },
     ohlcv_update:         { endpoint: '/api/ohlcv/force-update',                       label: '강제 수집' },
     ranking_refresh:      { endpoint: '/api/background/ranking/force-update',          label: '강제 수집' },
     daily_price_collector:{ endpoint: '/api/background/daily-price/force-update',      label: '강제 수집' },
@@ -535,8 +536,8 @@ async function updateBackgroundStatus() {
                 ? `<span style="background:${schBadge.color}; color:#fff; padding:1px 6px; border-radius:8px; font-size:0.75em; margin-left:6px; vertical-align:middle;">${schBadge.label}</span>`
                 : '';
             const delayMin = task.delay_sec ? Math.round(task.delay_sec / 60) : 0;
-            const delayHtml = delayMin > 0
-                ? `<span style="color:#aaa; font-size:0.75em; margin-left:5px; vertical-align:middle;">+${delayMin}m</span>`
+            const delayHtml = task.schedule_type === 'after_market'
+                ? `<span style="color:#aaa; font-size:0.75em; margin-left:5px; vertical-align:middle;">${delayMin > 0 ? `+${delayMin}m` : '즉시'}</span>`
                 : '';
             return `
                 <tr>

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -196,6 +196,7 @@ const STATE_BADGE = {
 
 const SCHEDULE_TYPE_BADGE = {
     always_on:     { label: '실시간',     color: '#E64A19' },
+    pre_market:    { label: '장전 점검',   color: '#00897B' },
     intraday:     { label: '장중 전용',   color: '#1976D2' },
     after_market: { label: '장마감 후',   color: '#6A1B9A' },
 };


### PR DESCRIPTION
pre_market_health_check는 이제 앱 시작 후 루프만 켜진 상태에서는 IDLE로 표시되고, 실제 장전 점검을 수행하는 순간에만 RUNNING으로 바뀝니다. 그래서 화면에서 평소에는 더 이상 “장전 점검인데 RUNNING”처럼 보이지 않습니다.

같이 반영한 내용:

pre_market_health_check_task.py: start()는 루프 중복 실행만 방지하고 상태는 IDLE 유지, run_once() 실행 구간만 RUNNING. system.py: pre_market_health_check를 intraday가 아니라 pre_market 타입으로 분류. system.js: 배지를 장전 점검으로 표시.
background_scheduler.py: 상태가 IDLE이어도 내부 백그라운드 루프가 살아 있으면 shutdown 때 stop() 하도록 보강했습니다. 검증:
40 passed for 관련 태스크/스케줄러 테스트, 그리고 62 passed for test_web_routes_system.py 전체.