### PR TITLE
가능하다고 보고 바로 반영했습니다. cache_warmup은 이제 장마감 TimeDispatcher 티켓 대상에서 빠지고, …

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -1,5 +1,5 @@
 # config/task_config.yaml
-# 장 마감 후 백그라운드 태스크 설정
+# 백그라운드 태스크 설정
 #
 # after_market_delay_min
 #   장 마감 감지 후 해당 태스크를 실제로 실행하기까지의 Padding 시간(분).
@@ -20,5 +20,4 @@ after_market_tasks:
     newhigh: 21                  # NewHighTask — daily_price_collector 완료(21분) + 여유
     minervini_update: 21        # MinerviniUpdateTask — 장 마감 21분 후
     전일기준주도주_생성: 50        # PremiumWatchlistGeneratorTask — 장 마감 50분 후
-    cache_warmup: 60             # CacheWarmupTask — 장 마감 60분 후 (우량주 생성 완료 후)
     log_cleanup: 300              # LogCleanupTask — 장 마감 300분(5시간) 후

--- a/task/background/after_market/cache_warmup_task.py
+++ b/task/background/after_market/cache_warmup_task.py
@@ -1,27 +1,25 @@
 # task/background/after_market/cache_warmup_task.py
 """
-Watchlist / 보유종목 / 관심종목(우량주) 위주로 캐시를 사전 구성하는 백그라운드 태스크.
+Watchlist / 보유종목 위주로 캐시를 사전 구성하는 백그라운드 태스크.
 
-장 마감 후 전략 실행에 자주 쓰이는 종목들의 가격 요약 데이터를 미리 캐시에 적재하여
-다음날 장 시작 전·후 전략이 빠르게 데이터에 접근할 수 있도록 한다.
+장전 또는 장중 기동 직후 전략 실행에 자주 쓰이는 종목들의 가격 요약 데이터를
+미리 캐시에 적재하여 장중 전략이 빠르게 데이터에 접근할 수 있도록 한다.
 
 대상 종목 (우선순위 순):
   1. OneilUniverseService watchlist — 전략이 직접 참조하는 핵심 관심 풀
   2. 보유종목(계좌 잔고 output2.pdno) — 리스크 관리 최우선
-  3. 우량주 풀(data/premium_stocks.json) — 전일기준 주도주
 """
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import os
 import time
+from contextlib import asynccontextmanager
+from datetime import timedelta
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from common.types import ErrorCode
-from task.background.after_market.after_market_task_base import AfterMarketTask
-from interfaces.schedulable_task import TaskState
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
 from services.notification_service import NotificationService, NotificationCategory, NotificationLevel
 
 if TYPE_CHECKING:
@@ -30,11 +28,6 @@ if TYPE_CHECKING:
     from services.oneil_universe_service import OneilUniverseService
     from services.market_calendar_service import MarketCalendarService
     from core.market_clock import MarketClock
-
-_PREMIUM_STOCKS_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    "..", "..", "..", "data", "premium_stocks.json",
-)
 
 # 청크당 병렬 호출 수 — 가격 조회는 가벼우므로 다소 넉넉하게 설정
 _API_CHUNK_SIZE = 10
@@ -46,8 +39,11 @@ def _chunked(lst: list, size: int):
         yield lst[i:i + size]
 
 
-class CacheWarmupTask(AfterMarketTask):
-    """장 마감 후 주요 관심 종목의 가격 데이터를 캐시에 사전 적재하는 태스크."""
+class CacheWarmupTask(SchedulableTask):
+    """장 시작 전/장중 주요 관심 종목의 가격 데이터를 캐시에 사전 적재하는 태스크."""
+
+    CHECK_INTERVAL_SEC = 60
+    PRE_OPEN_WINDOW_MIN = 30
 
     def __init__(
         self,
@@ -60,16 +56,17 @@ class CacheWarmupTask(AfterMarketTask):
         logger=None,
         worker_pool=None,
     ) -> None:
-        super().__init__(
-            mcs=market_calendar_service,
-            market_clock=market_clock,
-            logger=logger or logging.getLogger(__name__),
-            worker_pool=worker_pool,
-        )
+        self._mcs = market_calendar_service
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
         self._mds = market_data_service
         self._sqs = stock_query_service
         self._universe_service = universe_service
         self._ns = notification_service
+        self._worker_pool = worker_pool
+        self._state: TaskState = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._running_depth: int = 0
 
         self._suspend_event: asyncio.Event = asyncio.Event()
         self._suspend_event.set()
@@ -93,8 +90,33 @@ class CacheWarmupTask(AfterMarketTask):
         return "cache_warmup"
 
     @property
-    def _scheduler_label(self) -> str:
-        return "CacheWarmup"
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    async def start(self) -> None:
+        self._tasks = [task for task in self._tasks if not task.done()]
+        if self._tasks:
+            return
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
+        await self._on_start_hook()
+        self._tasks.append(asyncio.create_task(self._loop()))
+        self._logger.info("CacheWarmupTask 장전/장중 웜업 루프 시작")
+
+    async def stop(self) -> None:
+        self._logger.info(f"cache_warmup 종료 시작: {len(self._tasks)}개 태스크")
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+        self._logger.info("cache_warmup 종료 완료")
 
     async def _on_start_hook(self) -> None:
         self._suspend_event.set()
@@ -108,22 +130,62 @@ class CacheWarmupTask(AfterMarketTask):
     async def resume(self) -> None:
         if self._state == TaskState.SUSPENDED:
             self._suspend_event.set()
-            self._state = TaskState.RUNNING
+            self._state = TaskState.IDLE
             self._logger.info("CacheWarmupTask 재개")
 
     def get_progress(self) -> Dict:
         return dict(self._progress)
 
-    # ── 장 마감 콜백 ─────────────────────────────────────────────
+    @asynccontextmanager
+    async def _running_state(self):
+        entered = self._state not in (TaskState.SUSPENDED, TaskState.STOPPED)
+        if entered:
+            self._running_depth += 1
+            self._state = TaskState.RUNNING
+        try:
+            yield
+        finally:
+            if entered:
+                self._running_depth -= 1
+                if self._running_depth == 0 and self._state == TaskState.RUNNING:
+                    self._state = TaskState.IDLE
 
-    async def _on_market_closed(self, latest_trading_date: str) -> None:
-        """장 마감 후 콜백: 해당 거래일 캐시 웜업이 필요하면 실행."""
-        if self._last_warmed_date == latest_trading_date:
-            self._logger.info(
-                f"CacheWarmupTask: {latest_trading_date} 이미 웜업 완료 — 스킵"
-            )
-            return
-        await self._run_warmup(latest_trading_date)
+    # ── 장전/장중 스케줄 ─────────────────────────────────────────
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                if self._state != TaskState.SUSPENDED:
+                    should_run, trading_date = await self._should_run_now()
+                    if should_run and trading_date:
+                        async with self._running_state():
+                            await self._run_warmup(trading_date)
+                await asyncio.sleep(self.CHECK_INTERVAL_SEC)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error(f"CacheWarmupTask 루프 오류: {exc}", exc_info=True)
+                await asyncio.sleep(self.CHECK_INTERVAL_SEC)
+
+    async def _should_run_now(self) -> tuple[bool, Optional[str]]:
+        if not self._market_clock or not self._mcs:
+            return False, None
+        now = self._market_clock.get_current_kst_time()
+        date_key = now.strftime("%Y%m%d")
+        if self._last_warmed_date == date_key:
+            return False, date_key
+        try:
+            if not await self._mcs.is_business_day(date_key):
+                return False, date_key
+        except Exception:
+            return False, date_key
+
+        if self._market_clock.is_market_operating_hours():
+            return True, date_key
+
+        open_time = self._market_clock.get_market_open_time()
+        should_run = open_time - timedelta(minutes=self.PRE_OPEN_WINDOW_MIN) <= now < open_time
+        return should_run, date_key
 
     # ── 강제 실행 ─────────────────────────────────────────────────
 

--- a/tests/unit_test/task/background/after_market/test_cache_warmup_task.py
+++ b/tests/unit_test/task/background/after_market/test_cache_warmup_task.py
@@ -1,10 +1,11 @@
 """
 CacheWarmupTask 단위 테스트.
-장 마감 후 watchlist/보유종목/우량주 캐시 웜업 태스크 검증.
+장전/장중 watchlist/보유종목 캐시 웜업 태스크 검증.
 """
-import json
+import asyncio
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch, mock_open
+from datetime import datetime
+from unittest.mock import MagicMock, AsyncMock, patch
 
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
 from common.types import ResCommonResponse, ErrorCode
@@ -106,10 +107,10 @@ class TestTaskProperties:
 
 class TestStartStop:
 
-    async def test_start_sets_running_state(self, task):
+    async def test_start_schedules_premarket_loop_and_stays_idle_until_run(self, task):
         try:
             await task.start()
-            assert task.state == TaskState.RUNNING
+            assert task.state == TaskState.IDLE
             assert len(task._tasks) == 1
         finally:
             await task.stop()
@@ -148,7 +149,7 @@ class TestSuspendResume:
     async def test_resume_from_suspended(self, task):
         task._state = TaskState.SUSPENDED
         await task.resume()
-        assert task.state == TaskState.RUNNING
+        assert task.state == TaskState.IDLE
 
     async def test_suspend_when_not_running_is_noop(self, task):
         assert task.state == TaskState.IDLE
@@ -165,25 +166,67 @@ class TestSuspendResume:
 # _on_market_closed
 # ---------------------------------------------------------------------------
 
-class TestOnMarketClosed:
+class TestShouldRunNow:
 
-    async def test_runs_warmup_for_new_date(self, task, mock_mds):
-        task._last_warmed_date = None
-        with patch.object(task, "_run_warmup", new_callable=AsyncMock) as mock_run:
-            await task._on_market_closed("20260320")
-            mock_run.assert_awaited_once_with("20260320")
+    async def test_should_run_in_pre_open_window(self, task, mock_mcs, mock_market_clock):
+        mock_market_clock.get_current_kst_time.return_value = datetime(2026, 3, 20, 8, 45)
+        mock_market_clock.get_market_open_time.return_value = datetime(2026, 3, 20, 9, 0)
+        mock_market_clock.is_market_operating_hours.return_value = False
+        mock_mcs.is_business_day = AsyncMock(return_value=True)
 
-    async def test_skips_warmup_for_same_date(self, task):
+        should_run, date_key = await task._should_run_now()
+
+        assert should_run is True
+        assert date_key == "20260320"
+
+    async def test_should_run_during_market_hours_for_late_start(self, task, mock_mcs, mock_market_clock):
+        mock_market_clock.get_current_kst_time.return_value = datetime(2026, 3, 20, 10, 0)
+        mock_market_clock.get_market_open_time.return_value = datetime(2026, 3, 20, 9, 0)
+        mock_market_clock.is_market_operating_hours.return_value = True
+        mock_mcs.is_business_day = AsyncMock(return_value=True)
+
+        should_run, date_key = await task._should_run_now()
+
+        assert should_run is True
+        assert date_key == "20260320"
+
+    async def test_should_not_run_twice_same_day(self, task, mock_mcs, mock_market_clock):
         task._last_warmed_date = "20260320"
-        with patch.object(task, "_run_warmup", new_callable=AsyncMock) as mock_run:
-            await task._on_market_closed("20260320")
-            mock_run.assert_not_awaited()
+        mock_market_clock.get_current_kst_time.return_value = datetime(2026, 3, 20, 10, 0)
+        mock_market_clock.is_market_operating_hours.return_value = True
+        mock_mcs.is_business_day = AsyncMock(return_value=True)
 
-    async def test_runs_warmup_for_next_trading_date(self, task):
-        task._last_warmed_date = "20260319"
-        with patch.object(task, "_run_warmup", new_callable=AsyncMock) as mock_run:
-            await task._on_market_closed("20260320")
-            mock_run.assert_awaited_once_with("20260320")
+        should_run, date_key = await task._should_run_now()
+
+        assert should_run is False
+        assert date_key == "20260320"
+
+    async def test_should_not_run_on_closed_day_or_without_dependencies(self, task, mock_mcs, mock_market_clock):
+        empty_task = CacheWarmupTask(
+            market_data_service=MagicMock(),
+            stock_query_service=MagicMock(),
+            market_calendar_service=None,
+            market_clock=None,
+            logger=MagicMock(),
+        )
+        assert await empty_task._should_run_now() == (False, None)
+
+        mock_market_clock.get_current_kst_time.return_value = datetime(2026, 3, 21, 8, 45)
+        mock_mcs.is_business_day = AsyncMock(return_value=False)
+        assert await task._should_run_now() == (False, "20260321")
+
+
+class TestLoop:
+
+    async def test_loop_runs_immediately_when_market_is_open(self, task):
+        task._should_run_now = AsyncMock(side_effect=[(True, "20260320"), asyncio.CancelledError()])
+        task._run_warmup = AsyncMock()
+
+        with patch("task.background.after_market.cache_warmup_task.asyncio.sleep", new_callable=AsyncMock):
+            await task._loop()
+
+        task._run_warmup.assert_awaited_once_with("20260320")
+        assert task.state == TaskState.IDLE
 
 
 # ---------------------------------------------------------------------------
@@ -353,16 +396,14 @@ class TestGetHoldingsCodes:
 class TestCollectTargetCodes:
 
     async def test_deduplicates_across_sources(self, task, mock_universe_service, mock_sqs):
-        """watchlist·보유·우량주에 중복 종목이 있어도 Set으로 중복 제거된다."""
-        # watchlist: 035720, 035420
-        # holdings: 005930, 000660
-        # premium: 035720 (중복), 005930 (중복)
-        fake_data = json.dumps({"kospi": ["035720", "005930"], "kosdaq": []})
-        with patch("builtins.open", mock_open(read_data=fake_data)), \
-             patch("os.path.exists", return_value=True):
-            codes = await task._collect_target_codes()
+        """watchlist·보유 종목에 중복 종목이 있어도 Set으로 중복 제거된다."""
+        mock_universe_service.get_watchlist.return_value = {
+            "035720": MagicMock(),
+            "005930": MagicMock(),
+        }
+        codes = await task._collect_target_codes()
 
-        assert codes == {"035720", "035420", "005930", "000660"}
+        assert codes == {"035720", "005930", "000660"}
 
     async def test_empty_when_all_sources_fail(self, task, mock_universe_service, mock_sqs):
         mock_universe_service.get_watchlist.side_effect = RuntimeError()

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -483,6 +483,30 @@ def test_get_background_status_pre_market_health_check_schedule_type(web_client,
     assert data[0]["progress"] == {"running": False, "status": "Waiting to start"}
 
 
+def test_get_background_status_cache_warmup_schedule_type(web_client, mock_web_ctx):
+    """cache_warmup은 장마감 티켓 배치가 아니라 장전/장중 웜업으로 분류한다."""
+    class CacheWarmupTask:
+        pass
+
+    CacheWarmupTask.__module__ = "task.background.after_market.cache_warmup_task"
+    mock_task = CacheWarmupTask()
+    mock_task._progress = {"running": False}
+    mock_task.get_progress = MagicMock(return_value={"running": False, "last_warmed_date": None})
+
+    mock_web_ctx.background_scheduler = MagicMock()
+    mock_web_ctx.background_scheduler.get_all_status.return_value = [
+        {"name": "cache_warmup", "state": "idle", "priority": 100},
+    ]
+    mock_web_ctx.background_scheduler.get_task.return_value = mock_task
+
+    response = web_client.get("/api/background/status")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data[0]["name"] == "cache_warmup"
+    assert data[0]["schedule_type"] == "pre_market"
+
+
 def test_get_background_status_idle_with_internal_flag(web_client, mock_web_ctx):
     """태스크가 IDLE 상태지만 내부 플래그(_is_refreshing)가 있는 경우 get_progress() 호출 확인"""
     mock_task = MagicMock()

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -19,6 +19,7 @@ router = APIRouter()
 _SCHEDULE_TYPES = {
     "pre_market_health_check": "pre_market",
     "websocket_watchdog":  "intraday",
+    "cache_warmup":       "pre_market",
     "strategy_scheduler":  "intraday",
     "ranking_refresh":     "after_market",
     "daily_price_collector": "after_market",

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -623,7 +623,6 @@ class WebAppContext:
                 (self.daily_price_collector_task,        TaskPriority.LOW),
                 (self.ohlcv_update_task,                 TaskPriority.LOW),
                 (self.premium_watchlist_generator_task,  TaskPriority.LOW),
-                (self.cache_warmup_task,                 TaskPriority.LOW),
                 (self.newhigh_task,                      TaskPriority.LOW),
                 (self.log_cleanup_task,                  TaskPriority.MAINTENANCE),
                 (self.strategy_log_report_task,          TaskPriority.LOW),


### PR DESCRIPTION
…자체 루프에서 장전 30분 윈도우 또는 장중 실행 상태를 감지해 하루 1회 웜업합니다. 장중에 프로그램을 켜면 첫 루프에서 바로 실행되고, 이후 같은 날짜는 중복 실행하지 않습니다.

주요 변경:

cache_warmup_task.py (line 100): AfterMarketTask 기반에서 독립 SchedulableTask 루프로 전환 cache_warmup_task.py (line 155): 장전/장중 즉시 실행 조건 추가 web_app_initializer.py (line 620): cache_warmup을 장마감 티켓 등록에서 제외 system.py (line 19): UI 스케줄 타입을 pre_market으로 표시
task_config.yaml (line 13): cache_warmup: 60 제거
검증:
173 passed

test_cache_warmup_task.py
test_pre_market_health_check_task.py
test_web_routes_system.py
test_web_app_initializer.py
test_time_dispatcher.py
파일 위치는 기존 import 영향 줄이려고 그대로 after_market/cache_warmup_task.py에 뒀습니다. 동작과 UI 분류는 이제 장전/장중 웜업 쪽입니다.