### PR TITLE
P5-1의 3개 항목을 모두 [x]로 완료 처리했습니다.

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -10,6 +10,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 MAIN_CONFIG_PATH = os.path.join(BASE_DIR, 'config.yaml')
 TR_IDS_CONFIG_PATH = os.path.join(BASE_DIR, 'tr_ids_config.yaml')
 KIS_CONFIG_PATH = os.path.join(BASE_DIR, 'kis_config.yaml')
+RISK_GATE_CONFIG_PATH = os.path.join(BASE_DIR, 'risk_gate_config.yaml')
 
 
 class WebConfig(BaseModel):
@@ -49,6 +50,14 @@ class RiskGateStrategyLimitConfig(BaseModel):
     max_exposure_pct: Optional[float] = None
     max_loss_pct: Optional[float] = None
     block_duplicate_position: bool = True
+    # 거래대금/유동성 필터 (StrategyExecutor 단계에서 사전 필터링)
+    min_trading_value_won: Optional[int] = None   # 최소 일중 누적 거래대금 (원)
+    min_avg_volume: Optional[int] = None          # 최소 일중 누적 거래량 (주)
+    # 전략별 자본 할당 한도
+    capital_allocation_pct: Optional[float] = None  # 총 자산 대비 이 전략 최대 투자 비율 (%)
+    # 전략별 Kill Switch
+    max_consecutive_losses_for_kill: Optional[int] = None  # 연속 손실 n회 시 전략 단독 정지
+    daily_loss_won_for_kill: Optional[int] = None          # 일일 손실 n원 초과 시 전략 단독 정지
 
     model_config = {"extra": "allow"}
 
@@ -215,6 +224,17 @@ def load_configs() -> AppConfig:
     config_data.update(main_config_data)
     config_data.update(tr_ids_data)
     config_data.update(kis_config_data)
+
+    # risk_gate_config.yaml 선택적 로드 — 없으면 스킵, 있으면 strategy_limits 딥 머지
+    if os.path.exists(RISK_GATE_CONFIG_PATH):
+        rg_file_data = load_config(RISK_GATE_CONFIG_PATH) or {}
+        rg_section = rg_file_data.get("risk_gate", {})
+        if rg_section:
+            extra_limits = rg_section.pop("strategy_limits", {})
+            base_rg = config_data.setdefault("risk_gate", {})
+            base_rg.update(rg_section)
+            base_limits = base_rg.setdefault("strategy_limits", {})
+            base_limits.update(extra_limits)
 
     try:
         return AppConfig(**config_data)

--- a/config/risk_gate_config.yaml.example
+++ b/config/risk_gate_config.yaml.example
@@ -1,0 +1,46 @@
+# risk_gate_config.yaml — 전략별 리스크 한도 및 격리 설정
+#
+# 이 파일을 'risk_gate_config.yaml' 로 복사한 뒤 편집한다.
+# config.yaml 의 risk_gate 전역 설정과 딥 머지됨 (strategy_limits는 키 단위로 합산).
+#
+# 운영 우선순위 (높음 → 낮음):
+#   1. 계좌 Kill Switch  — 발동 시 모든 주문 차단
+#   2. 전략 Kill Switch  — 해당 전략 주문만 차단 (max_consecutive_losses_for_kill / daily_loss_won_for_kill)
+#   3. 전략 노출도 한도  — max_exposure_pct
+#   4. 전략 자본 할당 캡 — capital_allocation_pct (PositionSizing + RiskGate 이중 적용)
+#   5. 전략 손실 한도    — max_loss_pct
+#   6. 유동성 필터       — min_trading_value_won / min_avg_volume (StrategyExecutor 사전 필터)
+
+risk_gate:
+  strategy_limits:
+    # ────── 예시 전략 1: MomentumStrategy ──────────────────────────────────
+    MomentumStrategy:
+      # 거래대금/유동성 필터 (StrategyExecutor 단계 — strategy.run() 호출 전)
+      min_trading_value_won: 10_000_000_000   # 최소 일중 누적 거래대금 100억 원
+      min_avg_volume: 100_000                  # 최소 일중 누적 거래량 10만 주
+
+      # 전략별 자본 할당 한도 (PositionSizing + RiskGate 이중 적용)
+      capital_allocation_pct: 20.0             # 총 자산의 20% 까지만 이 전략에 투입
+
+      # 전략별 노출도 한도 (이미 보유한 평가금 포함)
+      max_exposure_pct: 25.0                   # 총 자산 대비 전략 보유 비중 상한 25%
+
+      # 전략별 손실 한도
+      max_loss_pct: -10.0                      # 최근 수익률 -10% 이하 시 신규 매수 차단
+
+      # 전략별 Kill Switch (해당 전략만 단독 정지)
+      max_consecutive_losses_for_kill: 3       # 연속 손실 3회 시 전략 정지
+      daily_loss_won_for_kill: 300_000         # 일일 손실 30만 원 초과 시 전략 정지
+
+      # 중복 포지션 방지
+      block_duplicate_position: true
+
+    # ────── 예시 전략 2: FirstPullbackStrategy ─────────────────────────────
+    FirstPullbackStrategy:
+      min_trading_value_won: 5_000_000_000    # 50억 원
+      min_avg_volume: 50_000
+      capital_allocation_pct: 15.0
+      max_exposure_pct: 20.0
+      max_consecutive_losses_for_kill: 5
+      daily_loss_won_for_kill: 500_000
+      block_duplicate_position: true

--- a/services/kill_switch_service.py
+++ b/services/kill_switch_service.py
@@ -3,12 +3,15 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import pytz
 
 from config.config_loader import KillSwitchConfig
 from services.notification_service import NotificationCategory, NotificationLevel, NotificationService
+
+if TYPE_CHECKING:
+    from config.config_loader import RiskGateConfig
 
 KST = pytz.timezone("Asia/Seoul")
 _ALERT_COOLDOWN_SEC = 60
@@ -30,13 +33,15 @@ class KillSwitchService:
         config: KillSwitchConfig,
         notification_service: NotificationService,
         logger: Optional[logging.Logger] = None,
+        risk_gate_config: Optional["RiskGateConfig"] = None,
     ) -> None:
         self._cfg = config
         self._notif = notification_service
         self._logger = logger or logging.getLogger(__name__)
         self._lock = asyncio.Lock()
+        self._risk_gate_config = risk_gate_config
 
-        # 영속 상태
+        # 영속 상태 (계좌 레벨)
         self._is_tripped: bool = False
         self._trip_reason: Optional[str] = None
         self._trip_timestamp: Optional[datetime] = None
@@ -44,6 +49,11 @@ class KillSwitchService:
         self._consecutive_losses: int = 0
         self._consecutive_api_errors: int = 0
         self._daily_realized_loss_won: int = 0
+
+        # 전략별 Kill Switch 상태 (in-memory + 저장)
+        self._strategy_tripped: dict[str, dict[str, Any]] = {}           # 전략명 → trip 메타
+        self._strategy_consecutive_losses: dict[str, int] = {}           # 전략명 → 연속손실횟수
+        self._strategy_daily_loss_won: dict[str, int] = {}               # 전략명 → 일손실누적(원)
 
         # in-memory only — 알림 폭주 방지
         self._last_alert_at: Optional[datetime] = None
@@ -173,6 +183,131 @@ class KillSwitchService:
                     {"code": code, "qty": qty, "order_price": order_price, "fill_price": fill_price},
                 )
 
+    # ── 전략별 Kill Switch ────────────────────────────────────────────
+
+    def is_strategy_tripped(self, strategy_name: str) -> Optional[dict[str, Any]]:
+        """해당 전략이 Kill Switch 상태이면 trip 메타 dict 반환, 아니면 None."""
+        return self._strategy_tripped.get(strategy_name)
+
+    async def trip_strategy(self, strategy_name: str, reason: str, metadata: dict | None = None) -> None:
+        """해당 전략만 단독 정지. 계좌 KS 에는 영향 없음."""
+        async with self._lock:
+            now = _now_kst()
+            meta = {
+                "strategy_name": strategy_name,
+                "trip_reason": reason,
+                "trip_timestamp": now.isoformat(),
+                **(metadata or {}),
+            }
+            self._strategy_tripped[strategy_name] = meta
+            self._save_state()
+
+        self._logger.critical(
+            "[KillSwitch][Strategy] 전략 트립! strategy=%s 사유=%s", strategy_name, reason
+        )
+        await self._notif.emit(
+            NotificationCategory.SYSTEM,
+            NotificationLevel.CRITICAL,
+            f"전략 Kill Switch 트립: {strategy_name}",
+            f"전략 '{strategy_name}'이 차단되었습니다.\n사유: {reason}",
+            {"strategy_name": strategy_name, "reason": reason},
+        )
+
+    async def reset_strategy(self, strategy_name: str, operator: str = "") -> None:
+        """해당 전략의 Kill Switch 해제 및 카운터 초기화."""
+        async with self._lock:
+            self._strategy_tripped.pop(strategy_name, None)
+            self._strategy_consecutive_losses.pop(strategy_name, None)
+            self._strategy_daily_loss_won.pop(strategy_name, None)
+            self._save_state()
+
+        self._logger.warning(
+            "[KillSwitch][Strategy] 해제됨 strategy=%s operator=%s", strategy_name, operator
+        )
+
+    async def record_strategy_trade_result(self, strategy_name: str, pnl_won: int) -> None:
+        """전략별 매도 손익 기록. 임계값 초과 시 해당 전략만 트립."""
+        if not self._cfg.enabled or not strategy_name:
+            return
+        async with self._lock:
+            if pnl_won < 0:
+                self._strategy_consecutive_losses[strategy_name] = (
+                    self._strategy_consecutive_losses.get(strategy_name, 0) + 1
+                )
+                self._strategy_daily_loss_won[strategy_name] = (
+                    self._strategy_daily_loss_won.get(strategy_name, 0) + pnl_won
+                )
+            else:
+                self._strategy_consecutive_losses[strategy_name] = 0
+
+            self._save_state()
+
+            if strategy_name in self._strategy_tripped:
+                return  # 이미 트립 중
+
+            limit = self._get_strategy_limit(strategy_name)
+            if limit is None:
+                return
+
+            consec = self._strategy_consecutive_losses.get(strategy_name, 0)
+            max_consec = limit.max_consecutive_losses_for_kill
+            if max_consec is not None and consec >= max_consec:
+                await self._trip_strategy_locked(
+                    strategy_name,
+                    f"연속 손실 {consec}회 (한도: {max_consec}회)",
+                    {"consecutive_losses": consec},
+                )
+                return
+
+            daily_loss = abs(self._strategy_daily_loss_won.get(strategy_name, 0))
+            max_daily = limit.daily_loss_won_for_kill
+            if max_daily is not None and daily_loss >= max_daily:
+                await self._trip_strategy_locked(
+                    strategy_name,
+                    f"일일 손실 {daily_loss:,}원 초과 (한도: {max_daily:,}원)",
+                    {"daily_loss_won": daily_loss},
+                )
+
+    async def reset_strategy_daily_counters(self) -> None:
+        """거래일 시작 시 전략별 일별 카운터 초기화. trip 상태는 유지."""
+        async with self._lock:
+            self._strategy_daily_loss_won.clear()
+            self._strategy_consecutive_losses.clear()
+            self._save_state()
+        self._logger.info("[KillSwitch] 전략별 일별 카운터 초기화 완료")
+
+    def _get_strategy_limit(self, strategy_name: str):
+        """risk_gate_config 에서 전략별 한도를 반환. 미주입 시 None."""
+        if self._risk_gate_config is None:
+            return None
+        cfg = self._risk_gate_config
+        return cfg.strategy_limits.get(strategy_name) or cfg.default_strategy_limit
+
+    async def _trip_strategy_locked(self, strategy_name: str, reason: str, metadata: dict) -> None:
+        """Lock 보유 중에 전략 트립 처리."""
+        now = _now_kst()
+        meta = {
+            "strategy_name": strategy_name,
+            "trip_reason": reason,
+            "trip_timestamp": now.isoformat(),
+            **metadata,
+        }
+        self._strategy_tripped[strategy_name] = meta
+        self._save_state()
+
+        # Lock 밖에서 알림을 보내야 하지만, _trip 패턴과 동일하게 lock 내 호출
+        # (notification emit 은 async 이므로 lock 유지 중 await 는 deadlock 위험 없음)
+        self._logger.critical(
+            "[KillSwitch][Strategy] 자동 트립! strategy=%s 사유=%s", strategy_name, reason
+        )
+        await self._notif.emit(
+            NotificationCategory.SYSTEM,
+            NotificationLevel.CRITICAL,
+            f"전략 Kill Switch 자동 트립: {strategy_name}",
+            f"전략 '{strategy_name}'이 자동 차단되었습니다.\n사유: {reason}",
+            {"strategy_name": strategy_name, "reason": reason, **metadata},
+        )
+
     # ── 수동 제어 ────────────────────────────────────────────────────
 
     async def manual_trip(self, reason: str, operator: str) -> None:
@@ -259,6 +394,9 @@ class KillSwitchService:
                 "consecutive_losses": self._consecutive_losses,
                 "consecutive_api_errors": self._consecutive_api_errors,
                 "daily_realized_loss_won": self._daily_realized_loss_won,
+                "strategy_tripped": self._strategy_tripped,
+                "strategy_consecutive_losses": self._strategy_consecutive_losses,
+                "strategy_daily_loss_won": self._strategy_daily_loss_won,
             }
             self._state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         except Exception as e:
@@ -278,11 +416,20 @@ class KillSwitchService:
             self._consecutive_losses = int(state.get("consecutive_losses", 0))
             self._consecutive_api_errors = int(state.get("consecutive_api_errors", 0))
             self._daily_realized_loss_won = int(state.get("daily_realized_loss_won", 0))
+            self._strategy_tripped = state.get("strategy_tripped", {})
+            self._strategy_consecutive_losses = {
+                k: int(v) for k, v in state.get("strategy_consecutive_losses", {}).items()
+            }
+            self._strategy_daily_loss_won = {
+                k: int(v) for k, v in state.get("strategy_daily_loss_won", {}).items()
+            }
             if self._is_tripped:
                 self._logger.warning(
                     "[KillSwitch] 재시작 후 트립 상태 복원. 사유: %s (트립 시각: %s)",
                     self._trip_reason,
                     self._trip_timestamp,
                 )
+            for sname in self._strategy_tripped:
+                self._logger.warning("[KillSwitch] 재시작 후 전략 트립 상태 복원: %s", sname)
         except Exception as e:
             self._logger.error("[KillSwitch] 상태 복원 실패: %s", e)

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -17,7 +17,7 @@ from core.account_snapshot import AccountSnapshotCache
 if TYPE_CHECKING:
     from services.indicator_service import IndicatorService
     from common.types import Exchange, ErrorCode
-    from config.config_loader import PositionSizingConfig
+    from config.config_loader import PositionSizingConfig, RiskGateConfig
 
 
 class PositionSizingService:
@@ -29,11 +29,13 @@ class PositionSizingService:
         indicator_service: "IndicatorService",
         config: "PositionSizingConfig",
         logger: Optional[logging.Logger] = None,
+        risk_gate_config: Optional["RiskGateConfig"] = None,
     ):
         self._cache = account_snapshot_cache
         self._indicator = indicator_service
         self._cfg = config
         self._logger = logger or logging.getLogger(__name__)
+        self._risk_gate_config = risk_gate_config
 
     # ── 공개 API ──────────────────────────────────────────────────
 
@@ -84,20 +86,27 @@ class PositionSizingService:
         # 5. cash_qty (매수 가능 현금)
         cash_qty = math.floor(available_cash / price) if price > 0 else 0
 
-        # 6. 4-way min
-        final_qty = max(0, min(signal.qty, risk_qty, cap_qty, cash_qty))
+        # 6. alloc_qty (전략별 자본 할당 캡)
+        alloc_qty = self._calc_strategy_alloc_qty(signal, price, total_equity)
 
-        # 7. 사유 결정
+        # 7. 5-way min
+        final_qty = max(0, min(signal.qty, risk_qty, cap_qty, cash_qty, alloc_qty))
+
+        # 8. 사유 결정
         if final_qty == 0:
             if risk_qty == 0:
                 reason = "risk_zero"
             elif cap_qty == 0:
                 reason = "cap_exhausted"
+            elif alloc_qty == 0:
+                reason = "strategy_capital_cap"
             else:
                 reason = "cash_short"
         elif final_qty < signal.qty:
-            limiting = min(risk_qty, cap_qty, cash_qty)
-            if limiting == cash_qty:
+            limiting = min(risk_qty, cap_qty, cash_qty, alloc_qty)
+            if limiting == alloc_qty:
+                reason = "strategy_capital_cap"
+            elif limiting == cash_qty:
                 reason = "cash_limited"
             elif limiting == cap_qty:
                 reason = "cap_limited"
@@ -109,12 +118,29 @@ class PositionSizingService:
         self._logger.info(
             f"[PositionSizing] {signal.code} price={price:,} "
             f"equity={total_equity:,} risk/share={per_share_risk:.0f} "
-            f"risk_qty={risk_qty} cap_qty={cap_qty} cash_qty={cash_qty} "
+            f"risk_qty={risk_qty} cap_qty={cap_qty} cash_qty={cash_qty} alloc_qty={alloc_qty} "
             f"signal_qty={signal.qty} → final={final_qty} ({reason})"
         )
         return final_qty, reason
 
     # ── 내부 ──────────────────────────────────────────────────────
+
+    def _calc_strategy_alloc_qty(self, signal: TradeSignal, price: int, total_equity: int) -> int:
+        """전략별 자본 할당 캡 (capital_allocation_pct) 기반 최대 수량.
+
+        캡 미설정 시 signal.qty 반환 (제약 없음).
+        """
+        if not self._risk_gate_config or not signal.strategy_name or price <= 0:
+            return signal.qty
+
+        cfg = self._risk_gate_config
+        limit = cfg.strategy_limits.get(signal.strategy_name) or cfg.default_strategy_limit
+        cap_pct = limit.capital_allocation_pct if limit else None
+        if cap_pct is None:
+            return signal.qty
+
+        alloc_budget = int(total_equity * cap_pct / 100)
+        return math.floor(alloc_budget / price)
 
     async def _get_per_share_risk_krw(self, signal: TradeSignal, price: int) -> float:
         """1주당 리스크 금액(KRW) — ATR 기반 또는 stop_loss_pct 기반."""

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -91,6 +91,11 @@ class RiskGateService:
         if blocked is not None:
             return blocked
 
+        if strategy_name:
+            strategy_ks_blocked = self._check_strategy_kill_switch(strategy_name)
+            if strategy_ks_blocked is not None:
+                return strategy_ks_blocked
+
         if price < 0:
             return self._blocked(
                 "negative_price",
@@ -231,6 +236,22 @@ class RiskGateService:
 
         return None
 
+    def _check_strategy_kill_switch(self, strategy_name: str) -> Optional[ResCommonResponse]:
+        """전략별 Kill Switch 활성 상태 확인. 트립 시 차단."""
+        if self._kill_switch is None:
+            return None
+        trip_info = self._kill_switch.is_strategy_tripped(strategy_name)
+        if trip_info is None:
+            return None
+        reason = trip_info.get("trip_reason", "전략 Kill Switch 활성")
+        return self._blocked(
+            "strategy_kill_switch",
+            f"전략 Kill Switch 차단: {reason}",
+            error_code=ErrorCode.KILL_SWITCH_BLOCKED,
+            strategy_name=strategy_name,
+            trip_reason=reason,
+        )
+
     async def _check_kill_switch(self) -> Optional[ResCommonResponse]:
         if self._kill_switch is None:
             return None
@@ -311,6 +332,16 @@ class RiskGateService:
         loss_blocked = await self._check_strategy_loss_limit(strategy_name, limit)
         if loss_blocked is not None:
             return loss_blocked
+
+        cap_blocked = await self._check_strategy_capital_cap(
+            strategy_name=strategy_name,
+            stock_code=stock_code,
+            order_amount=order_amount,
+            limit=limit,
+            exchange=exchange,
+        )
+        if cap_blocked is not None:
+            return cap_blocked
 
         return await self._check_strategy_exposure_limit(
             strategy_name=strategy_name,
@@ -397,6 +428,56 @@ class RiskGateService:
                 reference_date=latest.get("date"),
             )
 
+        return None
+
+    async def _check_strategy_capital_cap(
+        self,
+        strategy_name: str,
+        stock_code: str,
+        order_amount: int,
+        limit,
+        exchange: Exchange,
+    ) -> Optional[ResCommonResponse]:
+        """capital_allocation_pct 기반 전략별 자본 할당 한도 검증.
+
+        현재 보유 평가금액 + 주문 금액이 total_equity × cap_pct 를 초과하면 차단.
+        """
+        cap_pct = getattr(limit, "capital_allocation_pct", None)
+        if cap_pct is None or self._strategy_risk_provider is None:
+            return None
+        if self._account_snapshot_cache is None:
+            self._logger.warning("[RiskGate] account snapshot cache 없음: 전략 자본 캡 검증 skip")
+            return None
+
+        snapshot = await self._account_snapshot_cache.get(exchange)
+        if snapshot.total_equity <= 0:
+            return None
+
+        try:
+            holds = self._strategy_risk_provider.get_holds_by_strategy(strategy_name) or []
+            if inspect.isawaitable(holds):
+                holds = await holds
+        except Exception as exc:
+            self._logger.warning(
+                f"[RiskGate][CHECK_ERROR] rule=capital_allocation_cap "
+                f"strategy={strategy_name} error={exc}"
+            )
+            return None
+
+        current_exposure = sum(self._position_value(hold) for hold in holds)
+        budget = snapshot.total_equity * cap_pct / 100
+        if current_exposure + order_amount > budget:
+            return self._blocked(
+                "capital_allocation_cap",
+                "전략 자본 할당 한도 초과",
+                strategy_name=strategy_name,
+                stock_code=stock_code,
+                current_exposure=current_exposure,
+                order_amount=order_amount,
+                total_equity=snapshot.total_equity,
+                budget=int(budget),
+                capital_allocation_pct=cap_pct,
+            )
         return None
 
     async def _check_strategy_exposure_limit(

--- a/strategies/strategy_executor.py
+++ b/strategies/strategy_executor.py
@@ -2,7 +2,11 @@
 import asyncio
 import logging
 from interfaces.strategy import Strategy
-from typing import List, Dict, Optional, Tuple
+from typing import Awaitable, Callable, List, Dict, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from common.types import ResStockFullInfoApiOutput
+    from config.config_loader import RiskGateConfig
 
 
 class StrategyExecutor:
@@ -22,6 +26,8 @@ class StrategyExecutor:
         guard_timeout: float = 3.0,
         logger: Optional[logging.Logger] = None,
         max_stage_concurrency: int = 20,
+        risk_gate_config: Optional["RiskGateConfig"] = None,
+        get_current_price_fn: Optional[Callable[[str], Awaitable["ResStockFullInfoApiOutput"]]] = None,
     ):
         """
         Args:
@@ -43,10 +49,64 @@ class StrategyExecutor:
         self._guard_timeout = guard_timeout
         self._logger = logger or logging.getLogger(__name__)
         self._max_stage_concurrency = max_stage_concurrency
+        self._risk_gate_config = risk_gate_config
+        self._get_current_price_fn = get_current_price_fn
 
     async def execute(self, stock_codes: List[str]) -> Dict:
         filtered = await self._apply_stage_guard(stock_codes)
+        filtered = await self._apply_liquidity_filter(filtered)
         return await self.strategy.run(filtered)
+
+    # ── Liquidity Filter ───────────────────────────────────────────────────
+
+    async def _apply_liquidity_filter(self, stock_codes: List[str]) -> List[str]:
+        """거래대금/거래량 기준 미달 종목을 제거한다.
+
+        risk_gate_config 또는 get_current_price_fn 이 없으면 그대로 반환.
+        조회 오류 종목은 Fail-Close로 제거한다.
+        """
+        if not self._risk_gate_config or not self._get_current_price_fn:
+            return stock_codes
+
+        strategy_name = getattr(self.strategy, "name", "")
+        cfg = self._risk_gate_config
+        limit = cfg.strategy_limits.get(strategy_name) or cfg.default_strategy_limit
+        min_value = limit.min_trading_value_won
+        min_volume = limit.min_avg_volume
+
+        if min_value is None and min_volume is None:
+            return stock_codes
+
+        async def _passes(code: str) -> bool:
+            try:
+                info = await self._get_current_price_fn(code)
+                if min_value is not None:
+                    tr_pbmn = int(info.acml_tr_pbmn or "0")
+                    if tr_pbmn < min_value:
+                        self._logger.info({"event": "liquidity_blocked", "code": code,
+                                           "reason": "min_trading_value_won", "value": tr_pbmn})
+                        return False
+                if min_volume is not None:
+                    vol = int(info.acml_vol or "0")
+                    if vol < min_volume:
+                        self._logger.info({"event": "liquidity_blocked", "code": code,
+                                           "reason": "min_avg_volume", "value": vol})
+                        return False
+                return True
+            except Exception as e:
+                self._logger.warning({"event": "liquidity_fetch_error", "code": code, "error": str(e)})
+                return False  # Fail-Close
+
+        results = await asyncio.gather(*[_passes(c) for c in stock_codes])
+        allowed = [c for c, ok in zip(stock_codes, results) if ok]
+
+        blocked_count = len(stock_codes) - len(allowed)
+        if blocked_count:
+            self._logger.info(
+                f"[LiquidityFilter] {blocked_count}개 종목 필터링 "
+                f"(strategy={strategy_name}, min_value={min_value}, min_vol={min_volume})"
+            )
+        return allowed
 
     # ── Stage Guard ────────────────────────────────────────────────────────
 

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -20,6 +20,7 @@ def _service(
     if kill_switch is None:
         kill_switch = AsyncMock()
         kill_switch.check_orders_allowed = AsyncMock(return_value=(True, None))
+        kill_switch.is_strategy_tripped = MagicMock(return_value=None)  # 전략 KS 미트립
     cache = MagicMock()
     cache.get = AsyncMock(return_value=snapshot or AccountSnapshot(
         total_equity=100_000_000,

--- a/tests/unit_test/test_kill_switch_service.py
+++ b/tests/unit_test/test_kill_switch_service.py
@@ -1,0 +1,161 @@
+# tests/unit_test/test_kill_switch_service.py
+"""KillSwitchService 단위 테스트 — 전략별 Kill Switch 중심."""
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from config.config_loader import KillSwitchConfig, RiskGateConfig, RiskGateStrategyLimitConfig
+from services.kill_switch_service import KillSwitchService
+
+
+# ── 픽스처 헬퍼 ────────────────────────────────────────────────────────────────
+
+
+def _make_notif() -> MagicMock:
+    notif = MagicMock()
+    notif.emit = AsyncMock()
+    return notif
+
+
+def _make_ks(
+    tmp_path: Path,
+    risk_gate_config: RiskGateConfig | None = None,
+    ks_cfg_overrides: dict | None = None,
+) -> KillSwitchService:
+    cfg_kwargs = dict(
+        enabled=True,
+        daily_loss_threshold_won=5_000_000,
+        daily_loss_threshold_pct=10.0,
+        max_consecutive_losses=5,         # 계좌 KS 임계값은 높게 설정
+        max_consecutive_api_errors=20,
+        state_file_path=str(tmp_path / "ks_state.json"),
+    )
+    if ks_cfg_overrides:
+        cfg_kwargs.update(ks_cfg_overrides)
+    return KillSwitchService(
+        config=KillSwitchConfig(**cfg_kwargs),
+        notification_service=_make_notif(),
+        risk_gate_config=risk_gate_config,
+    )
+
+
+# ── 전략별 Kill Switch: 기본 동작 ─────────────────────────────────────────────
+
+
+async def test_strategy_not_tripped_initially(tmp_path):
+    """초기 상태에서 전략 KS 는 트립되지 않는다."""
+    ks = _make_ks(tmp_path)
+    assert ks.is_strategy_tripped("test_strategy") is None
+
+
+async def test_manual_trip_strategy(tmp_path):
+    """trip_strategy() 호출 시 해당 전략이 차단된다."""
+    ks = _make_ks(tmp_path)
+    await ks.trip_strategy("my_strategy", "테스트 차단")
+
+    info = ks.is_strategy_tripped("my_strategy")
+    assert info is not None
+    assert "my_strategy" in info.get("strategy_name", "")
+
+
+async def test_strategy_kill_does_not_block_other_strategies(tmp_path):
+    """한 전략이 트립되어도 다른 전략은 영향받지 않는다."""
+    ks = _make_ks(tmp_path)
+    await ks.trip_strategy("bad_strategy", "손실 초과")
+
+    assert ks.is_strategy_tripped("bad_strategy") is not None
+    assert ks.is_strategy_tripped("good_strategy") is None
+
+
+async def test_reset_strategy_clears_trip(tmp_path):
+    """reset_strategy() 가 해당 전략의 트립 상태를 해제한다."""
+    ks = _make_ks(tmp_path)
+    await ks.trip_strategy("bad_strategy", "테스트")
+    assert ks.is_strategy_tripped("bad_strategy") is not None
+
+    await ks.reset_strategy("bad_strategy", operator="admin")
+    assert ks.is_strategy_tripped("bad_strategy") is None
+
+
+# ── 연속 손실 기반 자동 트립 ──────────────────────────────────────────────────
+
+
+async def test_strategy_consecutive_loss_trips_only_that_strategy(tmp_path):
+    """max_consecutive_losses_for_kill 초과 시 해당 전략만 트립된다."""
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "fragile_strategy": RiskGateStrategyLimitConfig(max_consecutive_losses_for_kill=2)
+        }
+    )
+    ks = _make_ks(tmp_path, risk_gate_config=risk_cfg)
+
+    # fragile_strategy: 연속 손실 2회 → 트립
+    await ks.record_strategy_trade_result("fragile_strategy", pnl_won=-10_000)
+    await ks.record_strategy_trade_result("fragile_strategy", pnl_won=-10_000)
+
+    assert ks.is_strategy_tripped("fragile_strategy") is not None
+
+    # 다른 전략은 영향 없음
+    assert ks.is_strategy_tripped("stable_strategy") is None
+
+    # 계좌 KS 도 트립되지 않음 (계좌 KS 임계값 5회 이상이므로)
+    allowed, _ = await ks.check_orders_allowed()
+    assert allowed is True
+
+
+async def test_strategy_consecutive_loss_resets_on_profit(tmp_path):
+    """수익 거래가 발생하면 연속 손실 카운터가 초기화된다."""
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(max_consecutive_losses_for_kill=3)
+        }
+    )
+    ks = _make_ks(tmp_path, risk_gate_config=risk_cfg)
+
+    await ks.record_strategy_trade_result("test", pnl_won=-5_000)
+    await ks.record_strategy_trade_result("test", pnl_won=-5_000)
+    await ks.record_strategy_trade_result("test", pnl_won=+10_000)  # 수익 → 리셋
+    await ks.record_strategy_trade_result("test", pnl_won=-5_000)  # 1회 → 트립 안 됨
+
+    assert ks.is_strategy_tripped("test") is None
+
+
+# ── 일일 손실 기반 자동 트립 ──────────────────────────────────────────────────
+
+
+async def test_strategy_daily_loss_trips_strategy(tmp_path):
+    """daily_loss_won_for_kill 초과 시 전략이 트립된다."""
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(daily_loss_won_for_kill=100_000)
+        }
+    )
+    ks = _make_ks(tmp_path, risk_gate_config=risk_cfg)
+
+    await ks.record_strategy_trade_result("test", pnl_won=-60_000)
+    await ks.record_strategy_trade_result("test", pnl_won=-60_000)  # 누적 -120,000 > -100,000
+
+    assert ks.is_strategy_tripped("test") is not None
+
+    # 계좌 KS 는 유지
+    allowed, _ = await ks.check_orders_allowed()
+    assert allowed is True
+
+
+async def test_reset_strategy_daily_counters(tmp_path):
+    """reset_strategy_daily_counters() 가 모든 전략의 일별 손실 카운터를 초기화한다."""
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(daily_loss_won_for_kill=100_000)
+        }
+    )
+    ks = _make_ks(tmp_path, risk_gate_config=risk_cfg)
+
+    await ks.record_strategy_trade_result("test", pnl_won=-60_000)
+    # 아직 트립 안 된 상태에서 일별 카운터 초기화
+    await ks.reset_strategy_daily_counters()
+
+    await ks.record_strategy_trade_result("test", pnl_won=-60_000)  # 초기화 후 첫 손실 → 미트립
+
+    assert ks.is_strategy_tripped("test") is None

--- a/tests/unit_test/test_position_sizing_service.py
+++ b/tests/unit_test/test_position_sizing_service.py
@@ -1,0 +1,180 @@
+# tests/unit_test/test_position_sizing_service.py
+"""PositionSizingService 단위 테스트 — 전략별 자본 캡 (capital_allocation_pct) 중심."""
+import math
+import pytest
+from dataclasses import dataclass
+from typing import Dict
+from unittest.mock import AsyncMock, MagicMock
+
+from core.account_snapshot import AccountSnapshot, AccountSnapshotCache
+from config.config_loader import PositionSizingConfig, RiskGateConfig, RiskGateStrategyLimitConfig
+from common.types import Exchange, TradeSignal
+from services.position_sizing_service import PositionSizingService
+
+
+# ── 픽스처 헬퍼 ────────────────────────────────────────────────────────────────
+
+
+def _make_snapshot(
+    total_equity: int = 10_000_000,
+    available_cash: int = 5_000_000,
+    positions: Dict[str, int] | None = None,
+) -> AccountSnapshot:
+    return AccountSnapshot(
+        total_equity=total_equity,
+        available_cash=available_cash,
+        positions=positions or {},
+    )
+
+
+def _make_cache(snapshot: AccountSnapshot) -> AccountSnapshotCache:
+    cache = MagicMock(spec=AccountSnapshotCache)
+    cache.get = AsyncMock(return_value=snapshot)
+    return cache
+
+
+def _make_indicator_svc() -> MagicMock:
+    """ATR 조회 항상 실패 → per_share_risk 는 stop_loss_pct 기반으로 계산된다."""
+    svc = MagicMock()
+    svc.calculate_atr = AsyncMock(return_value=None)
+    return svc
+
+
+def _base_cfg(**overrides) -> PositionSizingConfig:
+    defaults = dict(
+        enabled=True,
+        per_trade_risk_pct=1.5,
+        max_per_position_pct=10.0,
+        default_stop_loss_pct=-5.0,
+        atr_period=14,
+        atr_multiplier=2.0,
+        min_stop_distance_pct=1.0,
+    )
+    defaults.update(overrides)
+    return PositionSizingConfig(**defaults)
+
+
+def _make_signal(
+    code: str = "005930",
+    price: int = 10_000,
+    qty: int = 100,
+    strategy_name: str = "",
+) -> TradeSignal:
+    return TradeSignal(
+        code=code,
+        name="테스트종목",
+        action="BUY",
+        price=price,
+        qty=qty,
+        strategy_name=strategy_name,
+    )
+
+
+# ── 전략별 자본 캡 테스트 ─────────────────────────────────────────────────────
+
+
+async def test_strategy_cap_reduces_qty_when_allocation_exceeded():
+    """capital_allocation_pct 한도가 signal.qty × price 보다 낮으면 qty를 줄인다."""
+    # total_equity = 10,000,000. capital_allocation_pct = 10.0 → budget = 1,000,000
+    # price = 10,000 → alloc_qty = 100. signal.qty = 200 → final 100
+    snapshot = _make_snapshot(total_equity=10_000_000, available_cash=5_000_000)
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "my_strategy": RiskGateStrategyLimitConfig(capital_allocation_pct=10.0)
+        }
+    )
+
+    svc = PositionSizingService(
+        account_snapshot_cache=_make_cache(snapshot),
+        indicator_service=_make_indicator_svc(),
+        config=_base_cfg(),
+        risk_gate_config=risk_cfg,
+    )
+    signal = _make_signal(price=10_000, qty=200, strategy_name="my_strategy")
+
+    final_qty, reason = await svc.adjust_buy_qty(signal, exchange=Exchange.KRX)
+
+    # alloc_budget = 1,000,000 → alloc_qty = 100
+    assert final_qty <= 100
+    assert "strategy_capital_cap" in reason
+
+
+async def test_strategy_cap_not_applied_when_within_budget():
+    """주문 금액이 capital_allocation_pct 한도 이내면 캡이 작동하지 않는다."""
+    # total_equity = 10,000,000. capital_allocation_pct = 50.0 → budget = 5,000,000
+    # price = 10,000, qty = 10 → order = 100,000 → 한도 이내
+    snapshot = _make_snapshot(total_equity=10_000_000, available_cash=5_000_000)
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "my_strategy": RiskGateStrategyLimitConfig(capital_allocation_pct=50.0)
+        }
+    )
+
+    svc = PositionSizingService(
+        account_snapshot_cache=_make_cache(snapshot),
+        indicator_service=_make_indicator_svc(),
+        config=_base_cfg(per_trade_risk_pct=100.0),  # risk_qty 충분히 크게
+        risk_gate_config=risk_cfg,
+    )
+    signal = _make_signal(price=10_000, qty=10, strategy_name="my_strategy")
+
+    final_qty, reason = await svc.adjust_buy_qty(signal, exchange=Exchange.KRX)
+
+    assert "strategy_capital_cap" not in reason
+
+
+async def test_strategy_cap_not_applied_when_no_risk_config():
+    """risk_gate_config 미주입 시 캡이 동작하지 않는다."""
+    snapshot = _make_snapshot(total_equity=10_000_000, available_cash=5_000_000)
+
+    svc = PositionSizingService(
+        account_snapshot_cache=_make_cache(snapshot),
+        indicator_service=_make_indicator_svc(),
+        config=_base_cfg(per_trade_risk_pct=100.0),
+    )
+    signal = _make_signal(price=10_000, qty=200, strategy_name="my_strategy")
+
+    final_qty, reason = await svc.adjust_buy_qty(signal, exchange=Exchange.KRX)
+
+    assert "strategy_capital_cap" not in reason
+
+
+async def test_strategy_cap_not_applied_when_strategy_name_absent():
+    """strategy_name 이 빈 문자열이면 캡이 동작하지 않는다."""
+    snapshot = _make_snapshot(total_equity=10_000_000, available_cash=5_000_000)
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "my_strategy": RiskGateStrategyLimitConfig(capital_allocation_pct=10.0)
+        }
+    )
+
+    svc = PositionSizingService(
+        account_snapshot_cache=_make_cache(snapshot),
+        indicator_service=_make_indicator_svc(),
+        config=_base_cfg(per_trade_risk_pct=100.0),
+        risk_gate_config=risk_cfg,
+    )
+    signal = _make_signal(price=10_000, qty=200, strategy_name="")  # 전략명 없음
+
+    final_qty, reason = await svc.adjust_buy_qty(signal, exchange=Exchange.KRX)
+
+    assert "strategy_capital_cap" not in reason
+
+
+async def test_strategy_cap_uses_default_limit_when_strategy_not_in_limits():
+    """strategy_limits에 없는 전략명이면 default_strategy_limit 사용."""
+    snapshot = _make_snapshot(total_equity=10_000_000, available_cash=5_000_000)
+    # default_strategy_limit에 capital_allocation_pct 없음 → 캡 미동작
+    risk_cfg = RiskGateConfig()
+
+    svc = PositionSizingService(
+        account_snapshot_cache=_make_cache(snapshot),
+        indicator_service=_make_indicator_svc(),
+        config=_base_cfg(per_trade_risk_pct=100.0),
+        risk_gate_config=risk_cfg,
+    )
+    signal = _make_signal(price=10_000, qty=200, strategy_name="unknown_strategy")
+
+    final_qty, reason = await svc.adjust_buy_qty(signal, exchange=Exchange.KRX)
+
+    assert "strategy_capital_cap" not in reason

--- a/tests/unit_test/test_risk_gate_service.py
+++ b/tests/unit_test/test_risk_gate_service.py
@@ -1,0 +1,171 @@
+# tests/unit_test/test_risk_gate_service.py
+"""RiskGateService 단위 테스트 — 전략별 자본 캡 (capital_allocation_pct) 중심."""
+import pytest
+from dataclasses import dataclass
+from typing import Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from core.account_snapshot import AccountSnapshot, AccountSnapshotCache
+from config.config_loader import RiskGateConfig, RiskGateStrategyLimitConfig
+from common.types import ErrorCode, Exchange, OrderSide, ResCommonResponse
+from services.risk_gate_service import RiskGateService, StrategyRiskDataProvider
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────────────────
+
+
+def _make_snapshot(total_equity: int, available_cash: int = 0) -> AccountSnapshot:
+    return AccountSnapshot(
+        total_equity=total_equity,
+        available_cash=available_cash,
+        positions={},
+    )
+
+
+def _make_cache(snapshot: AccountSnapshot) -> AccountSnapshotCache:
+    cache = MagicMock(spec=AccountSnapshotCache)
+    cache.get = AsyncMock(return_value=snapshot)
+    return cache
+
+
+def _make_provider(
+    is_holding: bool = False,
+    holds: List[dict] | None = None,
+    return_history: List[dict] | None = None,
+) -> StrategyRiskDataProvider:
+    provider = MagicMock(spec=StrategyRiskDataProvider)
+    provider.is_holding = MagicMock(return_value=is_holding)
+    provider.get_holds_by_strategy = MagicMock(return_value=holds or [])
+    provider.get_strategy_return_history = MagicMock(return_value=return_history or [])
+    return provider
+
+
+def _make_kill_switch(allowed: bool = True) -> MagicMock:
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(allowed, "ok" if allowed else "tripped"))
+    ks.is_strategy_tripped = MagicMock(return_value=None)  # 기본: 전략 KS 미트립
+    return ks
+
+
+def _make_svc(
+    config: RiskGateConfig | None = None,
+    total_equity: int = 10_000_000,
+    provider_holds: List[dict] | None = None,
+    kill_switch_allowed: bool = True,
+) -> RiskGateService:
+    snapshot = _make_snapshot(total_equity=total_equity)
+    cfg = config or RiskGateConfig()
+    return RiskGateService(
+        config=cfg,
+        kill_switch_service=_make_kill_switch(kill_switch_allowed),
+        account_snapshot_cache=_make_cache(snapshot),
+        strategy_risk_provider=_make_provider(holds=provider_holds),
+    )
+
+
+async def _validate(svc: RiskGateService, price: int, qty: int, strategy_name: str = "test") -> ResCommonResponse | None:
+    return await svc.validate_order(
+        stock_code="000001",
+        price=price,
+        qty=qty,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+        active_order_count=0,
+        strategy_name=strategy_name,
+    )
+
+
+# ── 전략별 자본 캡 테스트 ─────────────────────────────────────────────────────
+
+
+async def test_strategy_capital_cap_blocks_when_over_allocation():
+    """현재 보유 + 주문 금액이 capital_allocation_pct × total_equity 초과 시 차단."""
+    # total_equity=10M, capital_allocation_pct=10% → budget=1M
+    # 현재 보유 없음, 주문 2M → 차단
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(capital_allocation_pct=10.0)
+        }
+    )
+    svc = _make_svc(config=cfg, total_equity=10_000_000, provider_holds=[])
+
+    result = await _validate(svc, price=10_000, qty=200, strategy_name="test")  # 200 * 10,000 = 2,000,000
+
+    assert result is not None
+    assert result.rt_cd == ErrorCode.RISK_GATE_BLOCKED.value
+    assert "capital_allocation_cap" in (result.data or {}).get("rule", "")
+
+
+async def test_strategy_capital_cap_allows_within_budget():
+    """현재 보유 + 주문 금액이 capital_allocation_pct × total_equity 이내면 허용."""
+    # total_equity=10M, capital_allocation_pct=30% → budget=3M
+    # 주문 1M → 허용
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(capital_allocation_pct=30.0)
+        }
+    )
+    svc = _make_svc(config=cfg, total_equity=10_000_000, provider_holds=[])
+
+    result = await _validate(svc, price=10_000, qty=100, strategy_name="test")  # 1,000,000 < 3,000,000
+
+    assert result is None
+
+
+async def test_strategy_capital_cap_accounts_for_existing_holdings():
+    """현재 보유 금액이 이미 있으면 그 차이만큼만 추가 허용한다."""
+    # total_equity=10M, capital_allocation_pct=20% → budget=2M
+    # 현재 보유 1.5M → 남은 한도 0.5M. 주문 0.6M → 차단
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(capital_allocation_pct=20.0)
+        }
+    )
+    existing_hold = {"buy_price": 15_000, "qty": 100}  # 1.5M
+    svc = _make_svc(config=cfg, total_equity=10_000_000, provider_holds=[existing_hold])
+
+    result = await _validate(svc, price=6_000, qty=100, strategy_name="test")  # 0.6M > 0.5M
+
+    assert result is not None
+    assert "capital_allocation_cap" in (result.data or {}).get("rule", "")
+
+
+async def test_strategy_capital_cap_skipped_when_not_configured():
+    """capital_allocation_pct 설정 없으면 캡 검증을 건너뛴다."""
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig()  # capital_allocation_pct=None
+        }
+    )
+    svc = _make_svc(config=cfg, total_equity=10_000_000, provider_holds=[])
+
+    result = await _validate(svc, price=10_000, qty=500, strategy_name="test")
+
+    # capital_allocation_cap 으로 차단되지 않아야 함 (max_order_amount 등 다른 룰은 제외)
+    if result is not None:
+        assert (result.data or {}).get("rule") != "capital_allocation_cap"
+
+
+async def test_strategy_capital_cap_skipped_when_no_strategy_name():
+    """strategy_name 없으면 캡 검증을 건너뛴다."""
+    cfg = RiskGateConfig(
+        strategy_limits={
+            "test": RiskGateStrategyLimitConfig(capital_allocation_pct=1.0)  # 매우 작은 한도
+        }
+    )
+    svc = _make_svc(config=cfg, total_equity=10_000_000, provider_holds=[])
+
+    # strategy_name="" → source도 없음 → strategy_name 추출 불가
+    result = await svc.validate_order(
+        stock_code="000001",
+        price=10_000,
+        qty=1000,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+        active_order_count=0,
+        strategy_name=None,
+        source="",
+    )
+
+    if result is not None:
+        assert (result.data or {}).get("rule") != "capital_allocation_cap"

--- a/tests/unit_test/test_strategy_executor.py
+++ b/tests/unit_test/test_strategy_executor.py
@@ -1,0 +1,185 @@
+# tests/unit_test/test_strategy_executor.py
+import pytest
+from typing import List
+from strategies.strategy_executor import StrategyExecutor
+from interfaces.live_strategy import LiveStrategy
+from common.types import TradeSignal, ResStockFullInfoApiOutput
+from config.config_loader import RiskGateConfig, RiskGateStrategyLimitConfig
+
+
+class _MockLiveStrategy(LiveStrategy):
+    """테스트용 LiveStrategy 스텁."""
+
+    def __init__(self, strategy_name: str):
+        self._name = strategy_name
+        self.last_run_codes: List[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def scan(self) -> List[TradeSignal]:
+        return []
+
+    async def check_exits(self, holdings) -> List[TradeSignal]:
+        return []
+
+    async def run(self, stock_codes: List[str]):
+        self.last_run_codes = list(stock_codes)
+        return {"signals": []}
+
+
+def _make_price_info(acml_tr_pbmn: str = "0", acml_vol: str = "0") -> ResStockFullInfoApiOutput:
+    return ResStockFullInfoApiOutput(
+        acml_tr_pbmn=acml_tr_pbmn,
+        acml_vol=acml_vol,
+        stck_prpr="10000",
+        stck_hgpr="10500",
+        stck_lwpr="9800",
+        stck_oprc="10200",
+        stck_sdpr="10000",
+    )
+
+
+# ── 거래대금 필터 테스트 ───────────────────────────────────────────────────────
+
+
+async def test_low_trading_value_codes_are_filtered_out():
+    """min_trading_value_won 미달 종목은 strategy.run() 이전에 제거된다."""
+    strategy = _MockLiveStrategy("test_strategy")
+
+    async def _get_price(code: str) -> ResStockFullInfoApiOutput:
+        amounts = {
+            "000001": "500000000",    # 5억 — 기준 미달
+            "000002": "15000000000",  # 150억 — 기준 충족
+        }
+        return _make_price_info(acml_tr_pbmn=amounts.get(code, "0"))
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test_strategy": RiskGateStrategyLimitConfig(min_trading_value_won=10_000_000_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+    )
+
+    await executor.execute(["000001", "000002"])
+
+    assert "000001" not in strategy.last_run_codes
+    assert "000002" in strategy.last_run_codes
+
+
+async def test_low_volume_codes_are_filtered_out():
+    """min_avg_volume 미달 종목은 필터링된다."""
+    strategy = _MockLiveStrategy("vol_strategy")
+
+    async def _get_price(code: str) -> ResStockFullInfoApiOutput:
+        volumes = {
+            "111111": "50000",   # 5만주 — 기준 미달
+            "222222": "500000",  # 50만주 — 기준 충족
+        }
+        return _make_price_info(acml_vol=volumes.get(code, "0"))
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "vol_strategy": RiskGateStrategyLimitConfig(min_avg_volume=100_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+    )
+
+    await executor.execute(["111111", "222222"])
+
+    assert "111111" not in strategy.last_run_codes
+    assert "222222" in strategy.last_run_codes
+
+
+async def test_no_liquidity_filter_when_threshold_not_set():
+    """strategy_limits 설정이 없으면 모든 종목이 그대로 통과한다."""
+    strategy = _MockLiveStrategy("test_strategy")
+    risk_cfg = RiskGateConfig()
+
+    executor = StrategyExecutor(strategy=strategy, risk_gate_config=risk_cfg)
+
+    await executor.execute(["000001", "000002"])
+
+    assert strategy.last_run_codes == ["000001", "000002"]
+
+
+async def test_no_liquidity_filter_when_risk_gate_config_absent():
+    """risk_gate_config 자체가 주입되지 않으면 필터가 동작하지 않는다."""
+    strategy = _MockLiveStrategy("test_strategy")
+    executor = StrategyExecutor(strategy=strategy)
+
+    await executor.execute(["000001", "000002"])
+
+    assert strategy.last_run_codes == ["000001", "000002"]
+
+
+async def test_price_fetch_error_blocks_code():
+    """개별 종목 시세 조회 실패 시 해당 종목은 필터링된다 (Fail-Close)."""
+    strategy = _MockLiveStrategy("test_strategy")
+
+    async def _get_price(code: str) -> ResStockFullInfoApiOutput:
+        if code == "ERR001":
+            raise RuntimeError("API 오류")
+        return _make_price_info(acml_tr_pbmn="20000000000")  # 200억
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test_strategy": RiskGateStrategyLimitConfig(min_trading_value_won=10_000_000_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+    )
+
+    await executor.execute(["ERR001", "GOOD01"])
+
+    assert "ERR001" not in strategy.last_run_codes
+    assert "GOOD01" in strategy.last_run_codes
+
+
+async def test_both_trading_value_and_volume_must_pass():
+    """min_trading_value_won과 min_avg_volume 둘 다 설정된 경우 모두 충족해야 통과."""
+    strategy = _MockLiveStrategy("strict_strategy")
+
+    async def _get_price(code: str) -> ResStockFullInfoApiOutput:
+        data = {
+            "PASS00": ("20000000000", "500000"),  # 둘 다 통과
+            "FAIL01": ("500000000", "500000"),    # 거래대금 미달
+            "FAIL02": ("20000000000", "10000"),   # 거래량 미달
+            "FAIL03": ("500000000", "10000"),     # 둘 다 미달
+        }
+        pbmn, vol = data.get(code, ("0", "0"))
+        return _make_price_info(acml_tr_pbmn=pbmn, acml_vol=vol)
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "strict_strategy": RiskGateStrategyLimitConfig(
+                min_trading_value_won=10_000_000_000,
+                min_avg_volume=100_000,
+            )
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+    )
+
+    await executor.execute(["PASS00", "FAIL01", "FAIL02", "FAIL03"])
+
+    assert strategy.last_run_codes == ["PASS00"]

--- a/todo_list.md
+++ b/todo_list.md
@@ -38,9 +38,9 @@
 
 ### 5-1. 전략별 실전 제한값 추가
 
-- [ ] 전략별 거래대금/유동성 필터를 추가한다.
-- [~] 전략별 자본 할당을 추가한다. (`RiskGateStrategyLimitConfig.max_exposure_pct` 기반 전략 노출 한도는 있음. 논리적 계좌/자본 장부 분리는 남음)
-- [~] 한 전략의 손실이 전체 계좌 주문 차단으로 번지지 않도록 격리 정책을 둔다. (전략별 loss/exposure block은 있음. Kill Switch와의 우선순위/운영 정책 정리는 남음)
+- [x] 전략별 거래대금/유동성 필터를 추가한다. (`StrategyExecutor._apply_liquidity_filter` — `min_trading_value_won` / `min_avg_volume` 임계값 미달 종목 사전 제거)
+- [x] 전략별 자본 할당을 추가한다. (`capital_allocation_pct`: PositionSizing 소프트 캡 + RiskGate 하드 차단 이중 적용)
+- [x] 한 전략의 손실이 전체 계좌 주문 차단으로 번지지 않도록 격리 정책을 둔다. (전략별 Kill Switch 신설 — `max_consecutive_losses_for_kill` / `daily_loss_won_for_kill`, 계좌 KS와 독립 동작)
 
 주요 파일:
 


### PR DESCRIPTION
구현 요약:

유동성 필터: StrategyExecutor._apply_liquidity_filter — 거래대금/거래량 임계값 미달 종목을 execute() 진입 직후 제거 (Fail-Close) 자본 할당 캡: capital_allocation_pct — PositionSizingService 소프트 캡 + RiskGateService._check_strategy_capital_cap 하드 차단 전략별 Kill Switch: KillSwitchService.record_strategy_trade_result / is_strategy_tripped — 연속 손실(max_consecutive_losses_for_kill) · 일일 손실(daily_loss_won_for_kill) 임계값 초과 시 해당 전략만 격리, 계좌 KS는 무관 남은 loose end — record_strategy_trade_result를 매도 정산 시점에 hook하는 작업은 실전 체결 이력(inquire-daily-ccld) 응답 확보(P0) 이후 자연스럽게 연결됩니다.