### PR TITLE
구현 완료 요약:

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -404,6 +404,7 @@ class OneilUniverseService:
             w52_hgpr=w52_hgpr, avg_trading_value_5d=tv_5d, market_cap=stck_llam,
             rs_return_3m=rs_return,
             ma_150d=ma_150d, ma_200d=ma_200d, w52_lwpr=w52_lwpr, minervini_stage=minervini_stage,
+            source="pool_a",
         )
 
     async def _analyze_surge_candidate(self, code: str, name: str, logger: Optional[logging.Logger] = None) -> Optional[OSBWatchlistItem]:
@@ -553,7 +554,8 @@ class OneilUniverseService:
             high_20d=high_20d, ma_20d=ma_20d, ma_50d=ma_50d,
             avg_vol_20d=avg_vol_20d, bb_width_min_20d=bb_min, prev_bb_width=prev_width,
             w52_hgpr=w52_hgpr, avg_trading_value_5d=tv_5d, market_cap=stck_llam,
-            rs_return_3m=rs_return
+            rs_return_3m=rs_return,
+            source="pool_b",
         )
 
     # ── 전일 기준 우량주 생성 (배치) ─────────────────────────────────────────

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -81,20 +81,34 @@ class OneilBreakoutConfig(BaseStrategyConfig):
     min_qty: int = 1
 
     # [추가] 돌파 품질: 현재가가 당일 변동폭(고가-저가)의 상단 70% 위에 있어야 함
-    osb_min_candle_relative_pos: float = 0.7 
-    
+    osb_min_candle_relative_pos: float = 0.7
+
     # [추가] 스마트 머니 유연화 기준
     sm_flexible_pg_ratio: float = 7.0           # 프로그램 비중이 약간 낮아도(7%)
     sm_flexible_execution_strength: float = 140.0 # 체결강도가 압도적(140%)이면 인정
-    
+
     # [추가] 시가총액 대비 프로그램 매수 기본 허들 (중소형주 기준)
     program_to_market_cap_pct: float = 0.3
-    
+
     execution_strength_min: float = 120.0  # 체결강도 기본 하한선
     osb_max_extension_pct: float = 2.0     # 돌파 후 최대 추격 허용 범위 (2%)
     early_partial_profit_pct: float = 7.0  # 조기 부분익절 기준 (+7%)
     early_partial_sell_ratio: float = 0.3  # 조기 부분익절 비율 (30%)
     cooldown_days: int = 3                 # 손절 후 재진입 금지 기간 (일)
+
+    # [신규] 전천후 방어막 4종
+    # 1. 스퀴즈 런타임 게이트 (Pool A 전용)
+    osb_runtime_squeeze_tolerance: float = 1.2  # prev_bb_width <= bb_width_min_20d * 1.2
+    # 2. 다이내믹 거래량 필터 (매직넘버 config화 포함)
+    baseline_min_vol_ratio: float = 0.3         # 전 시간대 절대 하한 (기존 하드코딩 0.3 승격)
+    morning_cutoff_hour: int = 10               # 오전장 종료 기준 시 (미만 = 오전장)
+    morning_min_vol_ratio: float = 0.4          # 오전 추가 절대 하한 (baseline보다 빡빡)
+    afternoon_cutoff_hour: int = 13             # 오후장 시작 기준 시 (이상 = 오후장)
+    afternoon_volume_boost: float = 1.0         # 오후장 multiplier 가산 (1.5 → 2.5)
+    # 3. 안착 버퍼 (HTF의 breakout_min_buffer_pct 차용)
+    breakout_min_buffer_pct: float = 0.5        # high_20d 대비 최소 +0.5% 돌파 요구
+    # 4. 트레일링 스탑 수익 게이트
+    trailing_min_peak_profit_pct: float = 5.0   # peak_pnl >= 5% 도달 후에만 트레일링 발동
 
 @dataclass
 class OSBWatchlistItem:
@@ -125,6 +139,9 @@ class OSBWatchlistItem:
     ma_200d: float = 0.0            # 200일 이동평균 (Trend Template)
     w52_lwpr: int = 0               # 52주 최저가 (장중 저가 기준)
     minervini_stage: int = 0        # 1~4단계 (0=미계산)
+
+    # Pool 구분 (squeeze 게이트 선택적 적용용)
+    source: str = "pool_a"          # "pool_a" (전일기준 우량주) | "pool_b" (당일 급등주)
 
 
 @dataclass

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -142,13 +142,25 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         day_high = get_val("stck_hgpr", current)
         day_low = get_val("stck_lwpr", current)
 
-        # 장 시작 직후에는 예상 거래량이 튀기 쉬우므로, 최소한 평균 거래량의 30%는 달성해야 함
-        min_absolute_vol = item.avg_vol_20d * 0.3
-        if vol < min_absolute_vol:
+        # 전 시간대 절대 하한 (baseline_min_vol_ratio, 기존 0.3 하드코딩 config화)
+        if vol < item.avg_vol_20d * self._cfg.baseline_min_vol_ratio:
             return None
-            
-        # 🚨 [관문 1] 가격 돌파 (20일 신고가)
-        if current < item.high_20d: return None
+
+        # 🚨 [관문 0] Pool A 스퀴즈 런타임 검증 (Pool B 급등주는 변동성 확장 단계라 skip)
+        if item.source == "pool_a":
+            if item.prev_bb_width > item.bb_width_min_20d * self._cfg.osb_runtime_squeeze_tolerance:
+                self._logger.debug({
+                    "event": "breakout_rejected", "code": code, "reason": "not_in_squeeze",
+                    "prev_bb_width": item.prev_bb_width,
+                    "bb_min": item.bb_width_min_20d,
+                    "tolerance": self._cfg.osb_runtime_squeeze_tolerance,
+                })
+                return None
+
+        # 🚨 [관문 1] 가격 돌파 — 안착 버퍼 적용 (int 캐스팅으로 호가 단위 미스매치 방지)
+        breakout_threshold = int(item.high_20d * (1 + self._cfg.breakout_min_buffer_pct / 100))
+        if current < breakout_threshold:
+            return None
 
         # 장 초반 15분 이내: proj_vol 뻥튀기로 인한 가짜 돌파 시그널 방지
         if progress * 390 < 15:
@@ -173,10 +185,27 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                 self._logger.info({"event": "breakout_rejected", "code": code, "name": item.name, "reason": "poor_candle_quality", "pos": round(relative_pos, 2), "threshold": self._cfg.osb_min_candle_relative_pos})
                 return None
 
-        # 🚨 [관문 2] 거래량 돌파 (기존 동일)
+        # 🚨 [관문 2] 다이내믹 거래량 돌파 (시간대별 허들 차등 적용)
         effective_progress = max(progress, 0.05)
         proj_vol = vol / effective_progress
-        if proj_vol < item.avg_vol_20d * self._cfg.volume_breakout_multiplier:
+        current_hour = self._tm.get_current_kst_time().hour
+        if current_hour < self._cfg.morning_cutoff_hour:
+            # 오전장: 예상 거래량 뻥튀기 방지 — 실거래량 절대 하한 추가 적용
+            if vol < item.avg_vol_20d * self._cfg.morning_min_vol_ratio:
+                self._logger.debug({
+                    "event": "breakout_rejected", "code": code, "reason": "morning_low_vol",
+                    "vol": vol, "threshold": int(item.avg_vol_20d * self._cfg.morning_min_vol_ratio),
+                })
+                return None
+            vol_threshold = item.avg_vol_20d * self._cfg.volume_breakout_multiplier
+        elif current_hour >= self._cfg.afternoon_cutoff_hour:
+            # 오후장: 가짜 돌파 방지 — multiplier 가산
+            vol_threshold = item.avg_vol_20d * (
+                self._cfg.volume_breakout_multiplier + self._cfg.afternoon_volume_boost
+            )
+        else:
+            vol_threshold = item.avg_vol_20d * self._cfg.volume_breakout_multiplier
+        if proj_vol < vol_threshold:
             return None
 
         # 🚨 [선행 조회] 체결강도 스냅샷 (수급 판정의 재료로 사용)
@@ -439,11 +468,13 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         # 1. 손절
         if pnl <= self._cfg.stop_loss_pct:
             reason = f"손절({pnl:.1f}%)"
-        # 2. 트레일링 스탑
+        # 2. 트레일링 스탑 — 수익 게이트 적용 (peak_pnl >= trailing_min_peak_profit_pct 이후에만 발동)
         elif state.peak_price > 0:
-            drop = float((current - state.peak_price) / state.peak_price * 100)
-            if drop <= -self._cfg.trailing_stop_pct:
-                reason = f"트레일링스탑({drop:.1f}%)"
+            peak_pnl = float((state.peak_price - buy_price) / buy_price * 100)
+            if peak_pnl >= self._cfg.trailing_min_peak_profit_pct:
+                drop = float((current - state.peak_price) / state.peak_price * 100)
+                if drop <= -self._cfg.trailing_stop_pct:
+                    reason = f"트레일링스탑(고점수익 {peak_pnl:.1f}%, 낙폭 {drop:.1f}%)"
 
         # 2.5. 본절스탑: 부분익절 후 진입가 하회
         if not reason and state.breakeven_armed and current < buy_price:

--- a/tests/integration_test/strategies/test_it_api_oneil_squeeze_breakout_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_oneil_squeeze_breakout_strategy.py
@@ -86,7 +86,7 @@ async def test_osb_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     premium_item = OSBWatchlistItem(
         code=code_a, name="테스트종목A", market="KOSPI",
         high_20d=75000, ma_20d=70000.0, ma_50d=68000.0,  # current=75500, max_entry=75000*1.02=76500 (within 2%)
-        avg_vol_20d=600000.0, bb_width_min_20d=0.03, prev_bb_width=0.04,
+        avg_vol_20d=600000.0, bb_width_min_20d=0.03, prev_bb_width=0.035,  # squeeze gate: 0.035 <= 0.03*1.2
         w52_hgpr=77000, avg_trading_value_5d=50000000000, market_cap=400_000_000_000_000,
         rs_return_3m=10.0, profit_growth_score=0, smart_money_score=0, rs_score=0, total_score=0
     )

--- a/tests/integration_test/strategies/test_it_strategy_scan.py
+++ b/tests/integration_test/strategies/test_it_strategy_scan.py
@@ -561,7 +561,7 @@ class TestOneilSqueezeBreakoutScan:
             high_20d=74000,  # 현재가 75000 > 74000 → 돌파, max_entry=74000*1.02=75480 (within 2%)
             ma_20d=70000.0, ma_50d=68000.0,
             avg_vol_20d=1000000.0,  # 환산거래량 6M > 1M*1.5 → 통과
-            bb_width_min_20d=0.03, prev_bb_width=0.04,
+            bb_width_min_20d=0.03, prev_bb_width=0.035,  # squeeze gate: 0.035 <= 0.03*1.2
             w52_hgpr=77000, avg_trading_value_5d=500_000_000_000,
             market_cap=400_000_000_000,  # 4000억 (대형주 동적 허들 우회)
         )
@@ -967,7 +967,7 @@ class TestScanChunkParallelism:
         defaults = dict(
             name=f"종목{code}", market="KOSPI",
             high_20d=70000, ma_20d=68000.0, ma_50d=65000.0,
-            avg_vol_20d=1_000_000.0, bb_width_min_20d=0.03, prev_bb_width=0.04,
+            avg_vol_20d=1_000_000.0, bb_width_min_20d=0.03, prev_bb_width=0.035,  # squeeze gate: 0.035 <= 0.03*1.2
             w52_hgpr=77000, avg_trading_value_5d=500_000_000_000,
             market_cap=400_000_000_000,  # 4000억
         )

--- a/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
@@ -1184,3 +1184,170 @@ def test_check_time_stop_invalid_state_returns_false(mock_strategy_deps):
     strategy = OneilSqueezeBreakoutStrategy(sqs, universe, tm, logger=logger)
 
     assert strategy._check_time_stop(OSBPositionState(0, "", 0, 0), 10000, [{"date": "20250102"}]) is False
+
+
+# ── [신규] 전천후 방어막 4종 테스트 ─────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_scan_rejects_pool_a_when_not_squeezed(scan_setup):
+    """[관문 0] Pool A 종목의 prev_bb_width가 스퀴즈 허용 범위를 벗어나면 거부한다."""
+    strategy, sqs, universe, tm, logger = scan_setup
+    not_squeezed_item = OSBWatchlistItem(
+        code="005930", name="Samsung", market="KOSPI",
+        high_20d=70000, ma_20d=68000, ma_50d=65000,
+        avg_vol_20d=100000, bb_width_min_20d=1000,
+        prev_bb_width=1300,  # 1300 > 1000 * 1.2 → 스퀴즈 아님
+        w52_hgpr=80000, avg_trading_value_5d=50_000_000_000,
+        market_cap=100_000_000_000,
+        source="pool_a",
+    )
+    universe.get_watchlist.return_value = {"005930": not_squeezed_item}
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "70500", "stck_hgpr": "70600", "stck_lwpr": "70000",
+            "acml_vol": "200000", "pgtr_ntby_qty": "30000", "acml_tr_pbmn": "14200000000",
+        }}
+    )
+
+    signals = await strategy.scan()
+
+    assert signals == []
+    logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_allows_pool_b_without_squeeze_check(scan_setup):
+    """[관문 0] Pool B 종목은 squeeze 미충족이라도 다른 조건 만족 시 매수 시그널을 생성한다."""
+    strategy, sqs, universe, tm, logger = scan_setup
+    pool_b_item = OSBWatchlistItem(
+        code="005930", name="Samsung", market="KOSPI",
+        high_20d=70000, ma_20d=68000, ma_50d=65000,
+        avg_vol_20d=100000, bb_width_min_20d=1000,
+        prev_bb_width=1300,  # Pool A라면 스퀴즈 실패할 폭
+        w52_hgpr=80000, avg_trading_value_5d=50_000_000_000,
+        market_cap=100_000_000_000,
+        source="pool_b",  # Pool B → squeeze 게이트 건너뜀
+    )
+    universe.get_watchlist.return_value = {"005930": pool_b_item}
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "70500", "stck_hgpr": "70600", "stck_lwpr": "70000",
+            "acml_vol": "200000", "pgtr_ntby_qty": "30000", "acml_tr_pbmn": "14200000000",
+        }}
+    )
+    sqs.get_stock_conclusion.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": [{"tday_rltv": "150.0"}]}
+    )
+
+    signals = await strategy.scan()
+
+    assert len(signals) == 1
+    assert signals[0].code == "005930"
+    assert signals[0].action == "BUY"
+
+
+@pytest.mark.asyncio
+async def test_scan_rejects_when_within_buffer_zone(scan_setup):
+    """[관문 1] 현재가가 20일 고가(70000) 대비 +0.5% 버퍼(70350) 미만이면 거부한다."""
+    strategy, sqs, _, _, _ = scan_setup
+    # int(70000 * 1.005) = 70350이므로 70300은 버퍼 내 → 거부
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "70300", "stck_hgpr": "70400", "stck_lwpr": "70000",
+            "acml_vol": "200000", "pgtr_ntby_qty": "30000", "acml_tr_pbmn": "14200000000",
+        }}
+    )
+
+    signals = await strategy.scan()
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_rejects_morning_low_absolute_vol(scan_setup):
+    """[관문 2] 오전(10시 미만)에 실거래량이 20일 평균의 40% 미만이면 거부한다."""
+    strategy, sqs, _, tm, _ = scan_setup
+    # 오전 9:30 — early_morning_guard(15분) 이후지만 morning_min_vol_ratio(0.4) 미달
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 30, 0)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "70500", "stck_hgpr": "70600", "stck_lwpr": "70000",
+            "acml_vol": "35000",  # 35% < 40% → 오전 절대 하한 미달
+            "pgtr_ntby_qty": "10000", "acml_tr_pbmn": "2485000000",
+        }}
+    )
+
+    signals = await strategy.scan()
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_afternoon_requires_higher_volume(scan_setup):
+    """[관문 2] 오후(13시 이상)에는 예상거래량 허들이 1.5배→2.5배로 강화된다."""
+    strategy, sqs, _, tm, _ = scan_setup
+    # 오후 14:00 — 예상거래량이 일반(1.5x) 통과 수준이나 가산(2.5x) 미달
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 14, 0, 0)
+    # progress = (14:00-9:00) / 6.5h = 300/390 ≈ 0.769
+    # vol=180000 → proj_vol≈234000 > 150000(normal) but < 250000(afternoon) → 거부
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "70500", "stck_hgpr": "70600", "stck_lwpr": "70000",
+            "acml_vol": "180000",
+            "pgtr_ntby_qty": "30000", "acml_tr_pbmn": "12690000000",
+        }}
+    )
+
+    signals = await strategy.scan()
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_check_exits_skips_trailing_when_peak_below_5pct(mock_strategy_deps):
+    """[트레일링 게이트] 최고가 수익이 5% 미만이면 낙폭이 -8% 이상이어도 트레일링 미발동."""
+    sqs, universe, tm, logger = mock_strategy_deps
+    strategy = OneilSqueezeBreakoutStrategy(sqs, universe, tm, logger=logger)
+    # buy=10000, peak=10400(+4%), current=9568(10400*0.92, -8%에서 drop)
+    # pnl=(9568-10000)/10000=-4.32% → 손절(-5%) 미달
+    # trailing 조건 충족(-8%)이나 peak_pnl(4%) < 5% → 게이트 차단 → 시그널 없음
+    strategy._position_state["005930"] = OSBPositionState(
+        entry_price=10000, entry_date="20250101", peak_price=10400, breakout_level=9500
+    )
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 12, 0, 0)
+    tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
+    tm.get_market_close_time.return_value = datetime(2025, 1, 1, 15, 30, 0)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "9568", "acml_vol": "50000"}}
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=[])
+
+    signals = await strategy.check_exits([{"code": "005930", "buy_price": "10000"}])
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_check_exits_trailing_fires_when_peak_above_5pct(mock_strategy_deps):
+    """[트레일링 게이트] 최고가 수익이 5% 이상이면 -8% 낙폭 시 트레일링스탑 발동한다."""
+    sqs, universe, tm, logger = mock_strategy_deps
+    strategy = OneilSqueezeBreakoutStrategy(sqs, universe, tm, logger=logger)
+    # buy=10000, peak=11000(+10%), current=10120(11000*0.92, -8% drop)
+    # pnl=(10120-10000)/10000=+1.2% → 손절 없음, 부분익절 없음
+    # peak_pnl=10% >= 5% → 트레일링 발동
+    strategy._position_state["005930"] = OSBPositionState(
+        entry_price=10000, entry_date="20250101", peak_price=11000, breakout_level=9500
+    )
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 12, 0, 0)
+    tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
+    tm.get_market_close_time.return_value = datetime(2025, 1, 1, 15, 30, 0)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "10120", "acml_vol": "50000"}}
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=[])
+
+    signals = await strategy.check_exits([{"code": "005930", "buy_price": "10000"}])
+
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert "트레일링스탑" in signals[0].reason


### PR DESCRIPTION
파일	변경 내용
strategies/oneil_common_types.py	OSBWatchlistItem.source 필드 추가, OneilBreakoutConfig에 8개 신규 config 추가 (baseline_min_vol_ratio, osb_runtime_squeeze_tolerance, morning/afternoon 필터, breakout_min_buffer_pct, trailing_min_peak_profit_pct) services/oneil_universe_service.py	Pool A → source="pool_a", Pool B → source="pool_b" 명시 strategies/oneil_squeeze_breakout_strategy.py	_check_breakout: 관문0(squeeze) / 관문1(buffer+int캐스팅) / 관문2(dynamic volume) 추가, 하드코딩 0.3 config화. _check_single_exit: 트레일링 수익 게이트(peak_pnl≥5%) 추가 tests/.../test_oneil_squeeze_breakout_strategy.py	신규 테스트 7개 추가, 기존 57개 수정 불필요