### PR TITLE
진행 완료했습니다.

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -62,6 +62,7 @@ class StrategySchedulerConfig:
     enabled: bool = True            # 개별 전략 활성/비활성
     allow_pyramiding: bool = False  # 불타기(추가매수) 허용 여부
     force_exit_on_close: bool = False       # 당일 청산 여부
+    scan_when_position_full: bool = False   # 포지션 한도 도달 시에도 탐색/거절 로그 기록
 
 
 class StrategyScheduler:
@@ -361,7 +362,8 @@ class StrategyScheduler:
         current_holdings = self._get_strategy_holdings(cfg)
         current_holds_count = len(current_holdings)
 
-        if current_holds_count >= cfg.max_positions:
+        position_full = current_holds_count >= cfg.max_positions
+        if position_full and not cfg.scan_when_position_full:
             self._logger.info(
                 f"[Scheduler] {name}: 최대 포지션 도달 "
                 f"({current_holds_count}/{cfg.max_positions}), 스캔 스킵"
@@ -380,8 +382,12 @@ class StrategyScheduler:
             holding_codes = {str(h.get('code')) for h in current_holdings if h.get('code')}
             valid_signals = [s for s in buy_signals if str(s.code) not in holding_codes]
 
-        remaining = cfg.max_positions - current_holds_count
+        remaining = max(cfg.max_positions - current_holds_count, 0)
         target_signals = valid_signals[:remaining]
+        rejected_signals = valid_signals[remaining:]
+
+        if rejected_signals:
+            self._log_position_limit_rejections(cfg, rejected_signals, current_holds_count)
 
         if target_signals:
             for sig in target_signals:
@@ -396,6 +402,30 @@ class StrategyScheduler:
 
         self._pm.log_timer(f"{name}.run_strategy", t_run)
         self._logger.info(f"[Scheduler] {name} 실행 완료")
+
+    def _log_position_limit_rejections(
+        self,
+        cfg: StrategySchedulerConfig,
+        signals: List[TradeSignal],
+        current_holds_count: int,
+    ):
+        """포지션 한도로 실행하지 않은 매수 신호를 구조화 로그로 남긴다."""
+        for sig in signals:
+            if sig.action != "BUY":
+                continue
+            self._logger.info({
+                "event": "signal_rejected",
+                "reason": "max_positions_reached",
+                "strategy_name": sig.strategy_name or cfg.strategy.name,
+                "code": sig.code,
+                "name": sig.name,
+                "action": sig.action,
+                "price": sig.price,
+                "qty": sig.qty,
+                "current_holds": current_holds_count,
+                "max_positions": cfg.max_positions,
+                "message": "전략 최대 보유 포지션 수 도달로 매수 신호 거절",
+            })
 
     # ── 시그널 실행 ──
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -460,6 +460,69 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         # max_positions 도달 → log_buy 호출 안됨
         vm.log_buy_async.assert_not_called()
 
+    async def test_run_strategy_scans_and_logs_rejections_when_position_full_option_enabled(self):
+        """옵션이 켜져 있으면 max_positions 도달 후에도 스캔하고 매수 신호를 reject 로그로 남긴다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "buy_price": 70000},
+            {"code": "000660", "buy_price": 120000},
+            {"code": "035420", "buy_price": 300000},
+        ]
+
+        buy_signal = TradeSignal(
+            code="999999", name="테스트", action="BUY",
+            price=10000, qty=1, reason="스캔", strategy_name="테스트전략"
+        )
+        strategy = MockStrategy(scan_signals=[buy_signal])
+        strategy.scan = AsyncMock(return_value=[buy_signal])
+        config = StrategySchedulerConfig(
+            strategy=strategy,
+            max_positions=3,
+            scan_when_position_full=True,
+        )
+
+        await scheduler._run_strategy(config)
+
+        strategy.scan.assert_awaited_once()
+        vm.log_buy_async.assert_not_called()
+
+        rejection_logs = [
+            args[0]
+            for args, _ in scheduler._logger.info.call_args_list
+            if args and isinstance(args[0], dict) and args[0].get("event") == "signal_rejected"
+        ]
+        self.assertEqual(len(rejection_logs), 1)
+        self.assertEqual(rejection_logs[0]["reason"], "max_positions_reached")
+        self.assertEqual(rejection_logs[0]["current_holds"], 3)
+        self.assertEqual(rejection_logs[0]["max_positions"], 3)
+
+    async def test_run_strategy_logs_rejections_for_signals_beyond_remaining_slots(self):
+        """남은 슬롯을 초과한 매수 신호도 포지션 한도 reject 로그로 남긴다."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        vm.get_holds_by_strategy.return_value = [{"code": "005930", "buy_price": 70000}]
+
+        buy_signals = [
+            TradeSignal(code="000660", name="SK하이닉스", action="BUY",
+                        price=120000, qty=1, reason="테스트1", strategy_name="테스트전략"),
+            TradeSignal(code="035420", name="NAVER", action="BUY",
+                        price=300000, qty=1, reason="테스트2", strategy_name="테스트전략"),
+        ]
+        strategy = MockStrategy(scan_signals=buy_signals)
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=2)
+
+        await scheduler._run_strategy(config)
+
+        vm.log_buy_async.assert_awaited_once_with("테스트전략", "000660", 120000, 1)
+        rejection_logs = [
+            args[0]
+            for args, _ in scheduler._logger.info.call_args_list
+            if args and isinstance(args[0], dict) and args[0].get("event") == "signal_rejected"
+        ]
+        self.assertEqual(len(rejection_logs), 1)
+        self.assertEqual(rejection_logs[0]["code"], "035420")
+        self.assertEqual(rejection_logs[0]["reason"], "max_positions_reached")
+
     async def test_run_strategy_uses_strategy_position_state_for_exit_and_capacity(self):
         """전략 position_state도 현재 보유로 간주해 exit/max_positions에 반영한다."""
         scheduler, vm, _, _, _ = self._make_scheduler()

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -765,6 +765,7 @@ class WebAppContext:
             enabled=False,
             force_exit_on_close=False,  # 👈 오닐 전략은 오버나잇(홀딩) 허용!
             allow_pyramiding=True,     # 👈 오버나잇 전략이므로 불타기 허용
+            scan_when_position_full=True,
         ))
         
         self.osb_strategy = osb_strategy # (웹 API 하위 호환성 유지용)
@@ -785,6 +786,7 @@ class WebAppContext:
             enabled=False,
             force_exit_on_close=False,  # 7주 홀딩 허용
             allow_pyramiding=True,      # 👈 오버나잇 전략이므로 불타기 허용
+            scan_when_position_full=True,
         ))
 
         # 하이 타이트 플래그 전략 등록
@@ -801,6 +803,7 @@ class WebAppContext:
             order_qty=1,
             enabled=False,
             force_exit_on_close=False,  # HTF는 오버나잇 홀딩 허용
+            scan_when_position_full=True,
         ))
 
         # 첫 눌림목(Holy Grail) 전략 등록
@@ -818,6 +821,7 @@ class WebAppContext:
             enabled=False,
             force_exit_on_close=False,  # 스윙 전략: 오버나잇 허용
             allow_pyramiding=False,
+            scan_when_position_full=True,
         ))
         # 래리 윌리엄스 변동성 돌파 전략 등록
         vbo_strategy = LarryWilliamsVBOStrategy(
@@ -834,6 +838,7 @@ class WebAppContext:
             enabled=False,
             force_exit_on_close=True,   # 오버나이트 금지 — 당일 장 마감 전 강제 청산
             allow_pyramiding=False,
+            scan_when_position_full=True,
         ))
         # 래리 코너스 RSI(2) 눌림목 전략 등록
         rsi2_strategy = RSI2PullbackStrategy(
@@ -851,6 +856,7 @@ class WebAppContext:
             enabled=False,
             force_exit_on_close=False,  # 평균 보유 ~2.5일 — 오버나잇 허용
             allow_pyramiding=False,     # 1종목 1회 진입 invariant
+            scan_when_position_full=True,
         ))
         # 래리 윌리엄스 / 펜볼드 돈천 채널 돌파 전략 등록
         lwcb_strategy = LarryWilliamsChannelBreakoutStrategy(
@@ -868,6 +874,7 @@ class WebAppContext:
             enabled=False,              # 수동 활성화 대기
             force_exit_on_close=False,  # 스윙 포지션 — 오버나잇 허용
             allow_pyramiding=False,     # 1종목 1포지션 invariant
+            scan_when_position_full=True,
         ))
 
         self.logger.info("웹 앱: 전략 스케줄러 초기화 완료 (수동 시작 대기)")


### PR DESCRIPTION
StrategySchedulerConfig (line 56)에 scan_when_position_full 옵션을 추가했고, 기본값은 기존 호환성을 위해 False로 유지했습니다. 옵션이 켜진 전략은 보유 수가 max_positions 이상이어도 scan()을 실행하고, 매수 실행은 하지 않으며 event="signal_rejected", reason="max_positions_reached" 구조화 로그를 남깁니다. 남은 슬롯보다 scan 결과가 더 많은 경우에도 초과분은 같은 reject 로그로 남깁니다.

운영 웹 초기화 쪽의 등록 전략들은 모두 scan_when_position_full=True로 켰습니다: web_app_initializer.py (line 760). 관련 테스트도 추가했습니다: test_strategy_scheduler.py (line 463).

검증도 끝났습니다.

pytest tests/unit_test/scheduler/test_strategy_scheduler.py -v: 134 passed

pytest tests/unit_test -v: 3981 passed

pytest tests/integration_test -v: 203 passed