### PR TITLE
구현 완료 요약

### DIFF
--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -89,11 +89,25 @@ class PriceStreamService:
         self._last_tick_ts[stock_code] = now_ts
         self._last_any_tick_ts = now_ts
 
+        cum_vol = realtime_data.get('누적거래량', '0')
+        try:
+            vol_int = int(cum_vol) if cum_vol and cum_vol != 'N/A' else 0
+        except (ValueError, TypeError):
+            vol_int = 0
+
+        cum_tr_pbmn = realtime_data.get('누적거래대금', '0')
+        try:
+            tr_pbmn_int = int(cum_tr_pbmn) if cum_tr_pbmn and cum_tr_pbmn != 'N/A' else 0
+        except (ValueError, TypeError):
+            tr_pbmn_int = 0
+
         self._latest_prices[stock_code] = {
             "price": current_price,
             "change": realtime_data.get('전일대비', '0'),
             "rate": realtime_data.get('전일대비율', '0.00'),
             "sign": realtime_data.get('전일대비부호', '3'),
+            "acml_vol": vol_int,
+            "acml_tr_pbmn": tr_pbmn_int,
             "received_at": now_ts,
             "latency_sec": latency_sec,
             "quality_status": quality_status,
@@ -101,8 +115,6 @@ class PriceStreamService:
         }
 
         try:
-            cum_vol = realtime_data.get('누적거래량', '0')
-            vol_int = int(cum_vol) if cum_vol and cum_vol != 'N/A' else 0
             self._stock_repo.update_realtime_data(stock_code, float(current_price), vol_int)
         except Exception as e:
             self._logger.warning(f"StockRepository 실시간 틱 캐시 갱신 실패: {e}")
@@ -143,10 +155,23 @@ class PriceStreamService:
         rate: str = '0.00',
         sign: str = '3',
         volume: str = '0',
+        acml_tr_pbmn: Optional[str] = None,
     ) -> None:
         """REST 스냅샷 현재가를 최신가 캐시에 반영한다."""
         if not code or not price:
             return
+
+        try:
+            vol_int = int(volume) if volume and volume != 'N/A' else 0
+        except (ValueError, TypeError):
+            vol_int = 0
+
+        try:
+            tr_pbmn_int = (
+                int(acml_tr_pbmn) if acml_tr_pbmn and acml_tr_pbmn != 'N/A' else 0
+            )
+        except (ValueError, TypeError):
+            tr_pbmn_int = 0
 
         now_ts = time.time()
         self._latest_prices[code] = {
@@ -154,6 +179,8 @@ class PriceStreamService:
             "change": change,
             "rate": rate,
             "sign": sign,
+            "acml_vol": vol_int,
+            "acml_tr_pbmn": tr_pbmn_int,
             "received_at": now_ts,
             "latency_sec": 0.0,
             "quality_status": "ok",
@@ -161,10 +188,26 @@ class PriceStreamService:
         }
 
         try:
-            vol_int = int(volume) if volume and volume != 'N/A' else 0
             self._stock_repo.update_realtime_data(code, float(price), vol_int)
         except Exception as e:
             self._logger.warning(f"StockRepository 현재가 스냅샷 캐시 갱신 실패: {e}")
+
+    def get_liquidity_snapshot(self, code: str) -> Optional[dict]:
+        """체결틱 스냅샷에서 거래량/거래대금/수신시각을 반환한다.
+
+        반환 dict: {'acml_vol': int, 'acml_tr_pbmn': int, 'received_at': float}
+        snapshot 이 없거나 acml 필드가 미저장(예: 옛 캐시) 인 경우 None.
+        """
+        cached = self._latest_prices.get(code)
+        if not cached:
+            return None
+        if 'acml_vol' not in cached or 'acml_tr_pbmn' not in cached:
+            return None
+        return {
+            'acml_vol': cached['acml_vol'],
+            'acml_tr_pbmn': cached['acml_tr_pbmn'],
+            'received_at': cached.get('received_at', 0.0),
+        }
 
     def mark_subscription_requested(self, code: str) -> None:
         """체결가 구독 요청 시각을 기록한다."""

--- a/strategies/strategy_executor.py
+++ b/strategies/strategy_executor.py
@@ -1,12 +1,14 @@
 # strategies/strategy_executor.py
 import asyncio
 import logging
+import time
 from interfaces.strategy import Strategy
-from typing import Awaitable, Callable, List, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Awaitable, Callable, List, Dict, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from common.types import ResStockFullInfoApiOutput
     from config.config_loader import RiskGateConfig
+    from services.price_stream_service import PriceStreamService
 
 
 class StrategyExecutor:
@@ -26,8 +28,11 @@ class StrategyExecutor:
         guard_timeout: float = 3.0,
         logger: Optional[logging.Logger] = None,
         max_stage_concurrency: int = 20,
+        max_liquidity_concurrency: int = 10,
         risk_gate_config: Optional["RiskGateConfig"] = None,
         get_current_price_fn: Optional[Callable[[str], Awaitable["ResStockFullInfoApiOutput"]]] = None,
+        price_stream_service: Optional["PriceStreamService"] = None,
+        snapshot_max_age_sec: float = 5.0,
     ):
         """
         Args:
@@ -49,8 +54,11 @@ class StrategyExecutor:
         self._guard_timeout = guard_timeout
         self._logger = logger or logging.getLogger(__name__)
         self._max_stage_concurrency = max_stage_concurrency
+        self._max_liquidity_concurrency = max_liquidity_concurrency
         self._risk_gate_config = risk_gate_config
         self._get_current_price_fn = get_current_price_fn
+        self._price_stream_service = price_stream_service
+        self._snapshot_max_age_sec = snapshot_max_age_sec
 
     async def execute(self, stock_codes: List[str]) -> Dict:
         filtered = await self._apply_stage_guard(stock_codes)
@@ -77,21 +85,19 @@ class StrategyExecutor:
         if min_value is None and min_volume is None:
             return stock_codes
 
+        sem = asyncio.Semaphore(self._max_liquidity_concurrency)
+
         async def _passes(code: str) -> bool:
             try:
-                info = await self._get_current_price_fn(code)
-                if min_value is not None:
-                    tr_pbmn = int(info.acml_tr_pbmn or "0")
-                    if tr_pbmn < min_value:
-                        self._logger.info({"event": "liquidity_blocked", "code": code,
-                                           "reason": "min_trading_value_won", "value": tr_pbmn})
-                        return False
-                if min_volume is not None:
-                    vol = int(info.acml_vol or "0")
-                    if vol < min_volume:
-                        self._logger.info({"event": "liquidity_blocked", "code": code,
-                                           "reason": "min_avg_volume", "value": vol})
-                        return False
+                tr_pbmn, vol = await self._lookup_liquidity(code, sem)
+                if min_value is not None and tr_pbmn < min_value:
+                    self._logger.info({"event": "liquidity_blocked", "code": code,
+                                       "reason": "min_trading_value_won", "value": tr_pbmn})
+                    return False
+                if min_volume is not None and vol < min_volume:
+                    self._logger.info({"event": "liquidity_blocked", "code": code,
+                                       "reason": "min_avg_volume", "value": vol})
+                    return False
                 return True
             except Exception as e:
                 self._logger.warning({"event": "liquidity_fetch_error", "code": code, "error": str(e)})
@@ -107,6 +113,50 @@ class StrategyExecutor:
                 f"(strategy={strategy_name}, min_value={min_value}, min_vol={min_volume})"
             )
         return allowed
+
+    async def _lookup_liquidity(
+        self, code: str, sem: asyncio.Semaphore
+    ) -> Tuple[int, int]:
+        """(acml_tr_pbmn, acml_vol) 을 반환한다.
+
+        조회 우선순위:
+          1) PriceStreamService snapshot (received_at 이 snapshot_max_age_sec 이내)
+          2) get_current_price_fn(REST). 응답을 받으면 snapshot 캐시에 보강.
+        """
+        snap = None
+        if self._price_stream_service is not None:
+            try:
+                snap = self._price_stream_service.get_liquidity_snapshot(code)
+            except Exception:
+                snap = None
+
+        if snap is not None:
+            received_at = snap.get('received_at', 0.0) or 0.0
+            if (time.time() - received_at) <= self._snapshot_max_age_sec:
+                return (
+                    int(snap.get('acml_tr_pbmn') or 0),
+                    int(snap.get('acml_vol') or 0),
+                )
+
+        async with sem:
+            info = await self._get_current_price_fn(code)
+        tr_pbmn = int(getattr(info, 'acml_tr_pbmn', None) or "0")
+        vol = int(getattr(info, 'acml_vol', None) or "0")
+
+        if self._price_stream_service is not None:
+            try:
+                self._price_stream_service.cache_price_snapshot(
+                    code,
+                    price=str(getattr(info, 'stck_prpr', '') or ''),
+                    volume=str(vol),
+                    acml_tr_pbmn=str(tr_pbmn),
+                )
+            except Exception as e:
+                self._logger.debug(
+                    {"event": "snapshot_backfill_skipped", "code": code, "error": str(e)}
+                )
+
+        return tr_pbmn, vol
 
     # ── Stage Guard ────────────────────────────────────────────────────────
 

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -114,6 +114,56 @@ def test_cache_price_snapshot_updates_cache_without_tick_tracking(price_stream_s
     mock_stock_repo.update_realtime_data.assert_called_once_with("005930", 71000.0, 3210)
 
 
+def test_on_price_tick_stores_liquidity_fields(price_stream_service):
+    """체결틱의 누적거래량/누적거래대금이 snapshot 에 보관된다."""
+    data = {
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '75000',
+        '누적거래량': '1500000',
+        '누적거래대금': '112500000000',
+    }
+
+    price_stream_service.on_price_tick(data)
+
+    snap = price_stream_service.get_liquidity_snapshot('005930')
+    assert snap is not None
+    assert snap['acml_vol'] == 1500000
+    assert snap['acml_tr_pbmn'] == 112500000000
+    assert isinstance(snap['received_at'], float)
+
+
+def test_on_price_tick_handles_missing_trading_value(price_stream_service):
+    """누적거래대금 키가 없거나 N/A 인 경우 0 으로 보관된다."""
+    data = {
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '75000',
+        '누적거래량': '1500000',
+        # 누적거래대금 누락
+    }
+    price_stream_service.on_price_tick(data)
+    snap = price_stream_service.get_liquidity_snapshot('005930')
+    assert snap is not None
+    assert snap['acml_tr_pbmn'] == 0
+
+
+def test_cache_price_snapshot_stores_acml_tr_pbmn(price_stream_service):
+    """REST 스냅샷의 acml_tr_pbmn 값이 snapshot 에 반영된다."""
+    price_stream_service.cache_price_snapshot(
+        "005930",
+        price="71000",
+        volume="3210",
+        acml_tr_pbmn="22791000",
+    )
+    snap = price_stream_service.get_liquidity_snapshot("005930")
+    assert snap is not None
+    assert snap['acml_vol'] == 3210
+    assert snap['acml_tr_pbmn'] == 22791000
+
+
+def test_get_liquidity_snapshot_returns_none_when_unknown(price_stream_service):
+    assert price_stream_service.get_liquidity_snapshot("999999") is None
+
+
 def test_on_price_tick_repo_exception(price_stream_service, mock_stock_repo, mock_logger):
     """레포지토리 업데이트 중 예외 발생 시 로거로 경고를 남기고 앱이 중단되지 않는지 검증"""
     data = {'유가증권단축종목코드': '005930', '주식현재가': '75000'}

--- a/tests/unit_test/test_strategy_executor.py
+++ b/tests/unit_test/test_strategy_executor.py
@@ -151,6 +151,142 @@ async def test_price_fetch_error_blocks_code():
     assert "GOOD01" in strategy.last_run_codes
 
 
+class _StubPriceStream:
+    """PriceStreamService 스텁 — get_liquidity_snapshot / cache_price_snapshot 만 노출."""
+
+    def __init__(self, snapshots=None):
+        self._snapshots = dict(snapshots or {})
+        self.cache_calls = []
+
+    def get_liquidity_snapshot(self, code):
+        return self._snapshots.get(code)
+
+    def cache_price_snapshot(self, code, price, volume='0', acml_tr_pbmn=None, **kwargs):
+        self.cache_calls.append({
+            "code": code, "price": price, "volume": volume,
+            "acml_tr_pbmn": acml_tr_pbmn,
+        })
+
+
+async def test_snapshot_hit_skips_rest_call():
+    """fresh snapshot 이 있으면 get_current_price_fn 을 호출하지 않는다."""
+    import time as _time
+
+    strategy = _MockLiveStrategy("test_strategy")
+
+    rest_calls = []
+
+    async def _get_price(code):
+        rest_calls.append(code)
+        return _make_price_info(acml_tr_pbmn="20000000000")
+
+    stub = _StubPriceStream(snapshots={
+        "000001": {"acml_vol": 500_000, "acml_tr_pbmn": 20_000_000_000,
+                   "received_at": _time.time()},
+    })
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test_strategy": RiskGateStrategyLimitConfig(min_trading_value_won=10_000_000_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+        price_stream_service=stub,
+        snapshot_max_age_sec=5.0,
+    )
+
+    await executor.execute(["000001"])
+
+    assert rest_calls == [], "snapshot hit 인 경우 REST 가 호출되어선 안 된다"
+    assert "000001" in strategy.last_run_codes
+
+
+async def test_stale_snapshot_falls_back_to_rest_and_caches():
+    """오래된 snapshot 은 REST fallback + cache_price_snapshot 으로 보강된다."""
+    import time as _time
+
+    strategy = _MockLiveStrategy("test_strategy")
+
+    rest_calls = []
+
+    async def _get_price(code):
+        rest_calls.append(code)
+        return _make_price_info(acml_tr_pbmn="20000000000", acml_vol="500000")
+
+    # 100초 전 — snapshot_max_age_sec=5 보다 훨씬 오래됨
+    stale_ts = _time.time() - 100.0
+    stub = _StubPriceStream(snapshots={
+        "000001": {"acml_vol": 1, "acml_tr_pbmn": 1, "received_at": stale_ts},
+    })
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test_strategy": RiskGateStrategyLimitConfig(min_trading_value_won=10_000_000_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+        price_stream_service=stub,
+        snapshot_max_age_sec=5.0,
+    )
+
+    await executor.execute(["000001"])
+
+    assert rest_calls == ["000001"], "stale snapshot 은 REST fallback 을 트리거해야 한다"
+    assert len(stub.cache_calls) == 1
+    assert stub.cache_calls[0]["code"] == "000001"
+    assert "000001" in strategy.last_run_codes
+
+
+async def test_liquidity_filter_respects_concurrency_limit():
+    """max_liquidity_concurrency 가 동시 실행되는 _get_price 호출 수의 상한이다."""
+    import asyncio
+
+    strategy = _MockLiveStrategy("test_strategy")
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def _get_price(code: str) -> ResStockFullInfoApiOutput:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        try:
+            await asyncio.sleep(0.02)  # 동시 실행 윈도우 확보
+            return _make_price_info(acml_tr_pbmn="20000000000")
+        finally:
+            async with lock:
+                in_flight -= 1
+
+    risk_cfg = RiskGateConfig(
+        strategy_limits={
+            "test_strategy": RiskGateStrategyLimitConfig(min_trading_value_won=10_000_000_000)
+        }
+    )
+
+    executor = StrategyExecutor(
+        strategy=strategy,
+        risk_gate_config=risk_cfg,
+        get_current_price_fn=_get_price,
+        max_liquidity_concurrency=2,
+    )
+
+    codes = [f"{i:06d}" for i in range(1, 11)]  # 10 종목
+    await executor.execute(codes)
+
+    assert peak <= 2, f"동시 실행 피크 {peak} 가 한도 2 를 초과했다"
+    assert strategy.last_run_codes == codes  # 모두 통과해야 한다
+
+
 async def test_both_trading_value_and_volume_must_pass():
     """min_trading_value_won과 min_avg_volume 둘 다 설정된 경우 모두 충족해야 통과."""
     strategy = _MockLiveStrategy("strict_strategy")


### PR DESCRIPTION
변경 파일

strategies/strategy_executor.py — Liquidity Filter 에 max_liquidity_concurrency=10 semaphore 추가, price_stream_service + snapshot_max_age_sec=5.0 주입 가능, _lookup_liquidity() 헬퍼로 snapshot-first → REST fallback → cache backfill 흐름 구현. services/price_stream_service.py — _latest_prices 에 acml_vol/acml_tr_pbmn 추가 보관, cache_price_snapshot() 에 acml_tr_pbmn 인자, get_liquidity_snapshot(code) 신규 메서드. tests/unit_test/test_strategy_executor.py — 동시성 제한 / snapshot hit / stale snapshot fallback 3개 테스트 추가. tests/unit_test/services/test_price_stream_service.py — 거래량/거래대금 보관 / cache_price_snapshot acml_tr_pbmn / get_liquidity_snapshot 4개 테스트 추가. 테스트 결과

Unit: 3986 passed (140s)
Integration: 203 passed (57s)
Plan 대비 적용 범위

§1 Liquidity Filter 동시성 제한 — ✅ 완료
§2 Snapshot 에 거래량/거래대금 보관 — ✅ 완료
§3 StrategyExecutor snapshot-first + REST fallback + 캐시 보강 — ✅ 완료 §4 (당초) MomentumStrategy 중복 호출 제거 — 검증 결과 의도된 follow-through 호출이라 무효화 (plan 에 명시) §5 Request-scoped cache (scheduler 주입) — deferred. StrategyExecutor 가 본 코드베이스에서 활성 경로에 인스턴스화되지 않아 침습적 변경 대비 효과가 작음. PriceStreamService 가 이미 프로세스 수준 공유 캐시 역할을 하므로 후속 PR 로 분리 (plan-adaptive-patterson.md §5 참조). todo_list.md 의 2-2 4개 항목 중 처음 3개(동시성 제한 / snapshot 우선 / REST 보정용 제한)는 적용 완료, 4번째(전략 간 중복 조회 제거)는 부분적(executor 경로에서만) — strategy 본체 cache 통합은 별도 작업 필요.