### PR TITLE
수정 완료했습니다.

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -572,7 +572,7 @@ class StrategyScheduler:
                         signal.price,
                         signal.qty,
                         exchange=signal_exchange,
-                        source=f"strategy:{signal.strategy_name}",
+                        source=self._source_for_signal(signal),
                         finalize_immediately=False,
                         trace_id=tid,
                     )
@@ -674,7 +674,7 @@ class StrategyScheduler:
             try:
                 resp = await self._oes.broker_api_wrapper.get_asking_price(code)
                 if resp and resp.rt_cd == ErrorCode.SUCCESS.value:
-                    best_bid = int(resp.data.get("bidp1", 0) or 0)
+                    best_bid = self._extract_best_bid(resp.data)
                     if best_bid > 0:
                         sell_price = best_bid
                         reason = f"전략 종료 강제 청산 (지정가 {best_bid:,}원)"
@@ -711,6 +711,7 @@ class StrategyScheduler:
             result = await self._virtual_trade_service.reconcile_with_broker(
                 holdings, logger=self._logger
             )
+            self._clear_reconciled_position_state(result.get("force_closed") or [])
             if result["force_closed"] or result["unknown_in_broker"]:
                 msg = (
                     f"강제종결: {result['force_closed']}, "
@@ -723,6 +724,49 @@ class StrategyScheduler:
                     )
         except Exception as e:
             self._logger.error(f"[Reconciliation] 대사 실패: {e}", exc_info=True)
+
+    @staticmethod
+    def _source_for_signal(signal: TradeSignal) -> str:
+        if signal.action == "SELL" and str(signal.reason or "").startswith("전략 종료 강제 청산"):
+            return f"strategy_force_exit:{signal.strategy_name}"
+        return f"strategy:{signal.strategy_name}"
+
+    @staticmethod
+    def _extract_best_bid(data) -> int:
+        if not isinstance(data, dict):
+            return 0
+        candidates = [
+            data,
+            data.get("output1"),
+            data.get("output"),
+        ]
+        for item in candidates:
+            if not isinstance(item, dict):
+                continue
+            try:
+                bid = int(item.get("bidp1", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if bid > 0:
+                return bid
+        return 0
+
+    def _clear_reconciled_position_state(self, force_closed_codes: list) -> None:
+        codes = {str(code).strip() for code in force_closed_codes if str(code).strip()}
+        if not codes:
+            return
+        for cfg in self._strategies:
+            position_state = self._get_strategy_position_state(cfg.strategy)
+            removed = [raw_code for raw_code in position_state if str(raw_code).strip() in codes]
+            if not removed:
+                continue
+            for code in removed:
+                position_state.pop(code, None)
+            self._persist_strategy_position_state(cfg.strategy)
+            self._logger.warning(
+                f"[Scheduler] reconciled position_state cleared: "
+                f"strategy={cfg.strategy.name}, codes={removed}"
+            )
 
     # ── 개별 전략 제어 ──
 

--- a/services/kill_switch_service.py
+++ b/services/kill_switch_service.py
@@ -171,16 +171,32 @@ class KillSwitchService:
         fill_price: float,
         code: str,
         qty: int,
+        side: str | None = None,
     ) -> None:
-        """체결가와 주문가 편차 확인. 임계 초과 시 트립."""
+        """체결가와 주문가의 불리한 편차 확인. 임계 초과 시 트립."""
         if not self._cfg.enabled or order_price <= 0:
             return
-        deviation_pct = abs(fill_price - order_price) / order_price * 100
+
+        side_value = getattr(side, "value", side)
+        side_value = str(side_value or "").upper()
+        if side_value == "BUY":
+            deviation_pct = (fill_price - order_price) / order_price * 100
+        elif side_value == "SELL":
+            deviation_pct = (order_price - fill_price) / order_price * 100
+        else:
+            deviation_pct = abs(fill_price - order_price) / order_price * 100
+
         if deviation_pct >= self._cfg.abnormal_fill_deviation_pct:
             async with self._lock:
                 await self._trip(
                     f"비정상 체결: 편차 {deviation_pct:.2f}% (한도: {self._cfg.abnormal_fill_deviation_pct}%)",
-                    {"code": code, "qty": qty, "order_price": order_price, "fill_price": fill_price},
+                    {
+                        "code": code,
+                        "qty": qty,
+                        "side": side_value or None,
+                        "order_price": order_price,
+                        "fill_price": fill_price,
+                    },
                 )
 
     # ── 전략별 Kill Switch ────────────────────────────────────────────

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -480,6 +480,8 @@ class OrderExecutionService:
         source = source or ""
         if source.startswith("strategy:"):
             return source.split(":", 1)[1] or "default", True
+        if source.startswith("strategy_force_exit:"):
+            return source.split(":", 1)[1] or "default", True
         if source.startswith("manual:"):
             return source.split(":", 1)[1] or "수동매매", False
         if source in ("", "default", "manual", "web"):
@@ -503,7 +505,11 @@ class OrderExecutionService:
         record_price = report.fill_price or context.price
         if self._kill_switch and report.fill_price and context.price > 0:
             await self._kill_switch.record_fill_event(
-                context.price, report.fill_price, context.stock_code, record_qty
+                context.price,
+                report.fill_price,
+                context.stock_code,
+                record_qty,
+                side=context.side.value,
             )
         try:
             if context.side == OrderSide.BUY:

--- a/services/order_policy_service.py
+++ b/services/order_policy_service.py
@@ -211,6 +211,7 @@ class OrderPolicyService:
             self._cfg.min_recent_trade_count > 0
             and snapshot.recent_trade_count is not None
             and snapshot.recent_trade_count < self._cfg.min_recent_trade_count
+            and not self._has_strong_execution_strength(snapshot)
         ):
             return self._blocked(
                 "trade_flow_velocity_too_low",
@@ -251,6 +252,13 @@ class OrderPolicyService:
             severity="pass",
             context=context,
         )
+
+    def _has_strong_execution_strength(self, snapshot: ExecutionFlowSnapshot) -> bool:
+        strength = snapshot.execution_strength_pct
+        if strength is None:
+            return False
+        threshold = self._cfg.min_execution_strength_pct if self._cfg.min_execution_strength_pct > 0 else 120.0
+        return strength >= threshold
 
     async def _check_security_status(
         self,

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -87,11 +87,13 @@ class RiskGateService:
         if env_blocked is not None:
             return env_blocked
 
-        blocked = await self._check_kill_switch()
+        is_force_exit_sell = self._is_force_exit_sell(side=side, source=source)
+
+        blocked = await self._check_kill_switch(skip=is_force_exit_sell)
         if blocked is not None:
             return blocked
 
-        if strategy_name:
+        if strategy_name and not is_force_exit_sell:
             strategy_ks_blocked = self._check_strategy_kill_switch(strategy_name)
             if strategy_ks_blocked is not None:
                 return strategy_ks_blocked
@@ -252,8 +254,8 @@ class RiskGateService:
             trip_reason=reason,
         )
 
-    async def _check_kill_switch(self) -> Optional[ResCommonResponse]:
-        if self._kill_switch is None:
+    async def _check_kill_switch(self, *, skip: bool = False) -> Optional[ResCommonResponse]:
+        if skip or self._kill_switch is None:
             return None
 
         try:
@@ -546,7 +548,13 @@ class RiskGateService:
         source = source or ""
         if source.startswith("strategy:"):
             return source.split(":", 1)[1] or None
+        if source.startswith("strategy_force_exit:"):
+            return source.split(":", 1)[1] or None
         return None
+
+    @staticmethod
+    def _is_force_exit_sell(*, side: OrderSide, source: str) -> bool:
+        return side == OrderSide.SELL and (source or "").startswith("strategy_force_exit:")
 
     def _blocked(
         self,

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -563,7 +563,7 @@ def _build_deep_mock_config():
 
 
 @pytest.fixture
-async def deep_paper_ctx(test_logger, web_app, mocker):
+async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
     """
     중간 깊이 IT용 픽스처.
     실제 WebAppContext를 생성하여 모든 서비스를 초기화하되,
@@ -574,6 +574,9 @@ async def deep_paper_ctx(test_logger, web_app, mocker):
     from view.web.web_app_initializer import WebAppContext
 
     mock_config = _build_deep_mock_config()
+    mock_config.kill_switch = mock_config.kill_switch.model_copy(
+        update={"state_file_path": str(tmp_path / "kill_switch_state.json")}
+    )
 
     class SimpleContext:
         env = None

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1244,7 +1244,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             0,
             5,
             exchange=Exchange.KRX,
-            source="strategy:TestStrategy",
+            source="strategy_force_exit:TestStrategy",
             finalize_immediately=False,
             trace_id=ANY,
         )
@@ -1279,7 +1279,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             0,
             3,
             exchange=Exchange.KRX,
-            source="strategy:TestStrategy",
+            source="strategy_force_exit:TestStrategy",
             finalize_immediately=False,
             trace_id=ANY,
         )
@@ -1835,7 +1835,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             0,
             10,
             exchange=Exchange.KRX,
-            source="strategy:S",
+            source="strategy_force_exit:S",
             finalize_immediately=False,
             trace_id=ANY,
         )
@@ -2338,6 +2338,65 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         signal = mock_exec.await_args.args[0]
         self.assertEqual(signal.price, 12345)
         self.assertEqual(signal.qty, 2)
+
+    async def test_force_liquidate_reads_nested_output1_best_bid(self):
+        scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
+        oes.broker_api_wrapper.get_asking_price = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="OK",
+                data={"output1": {"bidp1": "8560"}},
+            )
+        )
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "037030", "name": "Powernet", "qty": 1}
+        ]
+        config = StrategySchedulerConfig(strategy=MockStrategy(name="NestedBidExit"))
+
+        with patch.object(scheduler, "_execute_signal", new_callable=AsyncMock) as mock_exec:
+            await scheduler._force_liquidate_strategy(config)
+
+        signal = mock_exec.await_args.args[0]
+        self.assertEqual(signal.price, 8560)
+        self.assertIn("지정가", signal.reason)
+
+    async def test_execute_force_liquidation_signal_marks_force_exit_source(self):
+        scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
+
+        signal = TradeSignal(
+            code="037030", name="Powernet", action="SELL",
+            price=8560, qty=1,
+            reason="전략 종료 강제 청산 (지정가 8,560원)",
+            strategy_name="래리윌리엄스VBO",
+        )
+        await scheduler._execute_signal(signal)
+
+        self.assertEqual(
+            oes.handle_place_sell_order.await_args.kwargs["source"],
+            "strategy_force_exit:래리윌리엄스VBO",
+        )
+
+    async def test_run_reconciliation_clears_strategy_state_for_force_closed_codes(self):
+        scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
+        strategy = MockStrategy(name="오닐PP/BGU")
+        strategy._position_state = {"064350": SimpleNamespace(entry_price=265500)}
+        strategy._save_state = MagicMock()
+        scheduler.register(StrategySchedulerConfig(strategy=strategy))
+        oes.broker_api_wrapper.get_account_balance = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="OK",
+                data={"output1": []},
+            )
+        )
+        vm.reconcile_with_broker = AsyncMock(
+            return_value={"force_closed": ["064350"], "unknown_in_broker": []}
+        )
+
+        await scheduler._run_reconciliation()
+
+        self.assertEqual(strategy._position_state, {})
+        strategy._save_state.assert_called_once()
 
     async def test_run_reconciliation_emits_warning_on_mismatch(self):
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)

--- a/tests/unit_test/services/test_kill_switch_service.py
+++ b/tests/unit_test/services/test_kill_switch_service.py
@@ -174,6 +174,35 @@ async def test_fill_deviation_trips(cfg, mock_notif, logger):
     assert "비정상 체결" in ks._trip_reason
 
 
+async def test_favorable_buy_fill_deviation_does_not_trip(cfg, mock_notif, logger):
+    ks = _make_ks(cfg, mock_notif, logger)
+    # 매수 주문가보다 낮은 체결은 유리한 체결이므로 계좌 Kill Switch를 트립하지 않는다.
+    await ks.record_fill_event(
+        order_price=10_000,
+        fill_price=9_500,
+        code="005930",
+        qty=10,
+        side="BUY",
+    )
+
+    assert ks._is_tripped is False
+    mock_notif.emit.assert_not_awaited()
+
+
+async def test_adverse_sell_fill_deviation_trips(cfg, mock_notif, logger):
+    ks = _make_ks(cfg, mock_notif, logger)
+    await ks.record_fill_event(
+        order_price=10_000,
+        fill_price=9_500,
+        code="005930",
+        qty=10,
+        side="SELL",
+    )
+
+    assert ks._is_tripped is True
+    assert "비정상 체결" in ks._trip_reason
+
+
 async def test_fill_within_tolerance_does_not_trip(cfg, mock_notif, logger):
     ks = _make_ks(cfg, mock_notif, logger)
     # 10,000원 주문 → 10,200원 체결 (2% 이탈, 한도 3%)

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -1860,7 +1860,9 @@ async def test_manual_sell_terminal_report_uses_plain_virtual_sell_and_records_k
 
     assert filled.virtual_recorded_qty == 3
     virtual_trade_service.log_sell_async.assert_awaited_once_with("005930", 69900, 3)
-    kill_switch.record_fill_event.assert_awaited_once_with(70000, 69900, "005930", 3)
+    kill_switch.record_fill_event.assert_awaited_once_with(
+        70000, 69900, "005930", 3, side=OrderSide.SELL.value
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_order_policy_service.py
+++ b/tests/unit_test/services/test_order_policy_service.py
@@ -550,6 +550,35 @@ async def test_trade_flow_blocks_low_recent_trade_count():
 
 
 @pytest.mark.asyncio
+async def test_trade_flow_allows_low_recent_count_when_execution_strength_is_available():
+    provider = AsyncMock()
+    provider.get_snapshot.return_value = _flow_snapshot(
+        recent_trade_count=0,
+        execution_strength_pct=141.6,
+    )
+    svc = _service(
+        config=OrderPolicyConfig(
+            order_book_checks_enabled=False,
+            min_recent_trade_count=1,
+            min_execution_strength_pct=100.0,
+        ),
+        trade_flow_provider=provider,
+    )
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_000,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.context["recent_trade_count"] == 0
+    assert decision.context["execution_strength_pct"] == 141.6
+
+
+@pytest.mark.asyncio
 async def test_trade_flow_blocks_when_time_concluded_unavailable_for_velocity_check():
     provider = AsyncMock()
     provider.get_snapshot.return_value = _flow_snapshot(

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -65,6 +65,25 @@ async def test_kill_switch_blocks_with_compatible_error_code():
 
 
 @pytest.mark.asyncio
+async def test_kill_switch_allows_force_exit_sell():
+    kill_switch = AsyncMock()
+    kill_switch.check_orders_allowed = AsyncMock(return_value=(False, "abnormal fill"))
+    svc, _, _ = _service(kill_switch=kill_switch)
+
+    result = await svc.validate_order(
+        "005930",
+        70_000,
+        10,
+        OrderSide.SELL,
+        Exchange.KRX,
+        0,
+        source="strategy_force_exit:래리윌리엄스VBO",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_kill_switch_check_exception_fails_closed():
     kill_switch = AsyncMock()
     kill_switch.check_orders_allowed = AsyncMock(side_effect=RuntimeError("ks down"))


### PR DESCRIPTION
핵심 변경은 네 가지입니다.

services/kill_switch_service.py: 체결 편차를 abs()로 보던 로직을 매수/매도 방향별 “불리한 체결” 기준으로 변경했습니다. 오늘처럼 매수 주문가보다 낮게 체결된 유리한 체결은 Kill Switch를 트립하지 않습니다.

services/risk_gate_service.py, scheduler/strategy_scheduler.py: 강제청산 SELL은 strategy_force_exit:* 소스로 내려가며, Kill Switch 활성 중에도 청산 주문은 통과하도록 했습니다.

scheduler/strategy_scheduler.py: 강제청산 호가 조회가 bidp1 직접 필드뿐 아니라 output1.bidp1, output.bidp1도 읽도록 보강했습니다.

services/order_policy_service.py: 최근 체결 건수만 낮아도 체결강도가 충분히 강하면 단독 차단하지 않도록 완화했습니다.

추가로 reconciliation에서 실제 잔고가 없어 강제종결된 종목은 전략 내부 position_state에서도 제거되게 했습니다. 그래서 064350처럼 이미 실잔고가 없는 종목에 대해 전략이 뒤늦게 다시 SELL을 내는 케이스를 줄입니다.

검증도 끝났습니다.

pytest tests/unit_test -v → 3988 passed

pytest tests/integration_test -v → 203 passed

참고로 통합 테스트 픽스처가 실제 운영 Kill Switch 상태 파일을 읽고 있어서, 테스트 전용 임시 상태 파일을 쓰도록 tests/integration_test/conftest.py도 격리했습니다. 운영 data/kill_switch_state.json은 건드리지 않았습니다.