### PR TITLE
fix newhigh

### DIFF
--- a/task/background/after_market/daily_price_collector_task.py
+++ b/task/background/after_market/daily_price_collector_task.py
@@ -91,6 +91,35 @@ class DailyPriceCollectorTask(AfterMarketTask):
         }
         self._all_stocks_cache = None
 
+    @staticmethod
+    def _normalize_price_record(record: Dict) -> Dict:
+        """OHLC와 전일대비 필드가 섞인 응답을 DB 저장 전 일관되게 보정한다."""
+        current = int(record.get("current_price") or 0)
+        open_price = int(record.get("open_price") or 0)
+        high = int(record.get("high_price") or 0)
+        low = int(record.get("low_price") or 0)
+        prev_close = int(record.get("prev_close") or 0)
+        change_price = int(record.get("change_price") or 0)
+
+        if current > 0:
+            candidates = [p for p in (open_price, high, low, current) if p > 0]
+            if candidates:
+                record["high_price"] = max(candidates)
+                record["low_price"] = min(candidates)
+
+        expected_change = current - prev_close if current > 0 and prev_close > 0 else change_price
+        if current > 0 and prev_close > 0 and expected_change != change_price:
+            record["change_price"] = expected_change
+            if expected_change > 0:
+                record["change_sign"] = "2"
+            elif expected_change < 0:
+                record["change_sign"] = "5"
+            else:
+                record["change_sign"] = "3"
+            record["change_rate"] = str(round(expected_change / prev_close * 100, 2))
+
+        return record
+
     # ── SchedulableTask 인터페이스 구현 ────────────────────────
 
     @property
@@ -460,7 +489,7 @@ class DailyPriceCollectorTask(AfterMarketTask):
                 else (lambda k, d=None: output.get(k, d))
             )
 
-            return {
+            record = {
                 "code": code,
                 "name": name,
                 "current_price": _safe_int(_get("stck_prpr")),
@@ -485,6 +514,7 @@ class DailyPriceCollectorTask(AfterMarketTask):
                 "mrkt_warn_cls_code": _get("mrkt_warn_cls_code"),
                 "invt_caful_yn": _get("invt_caful_yn"),
             }
+            return DailyPriceCollectorTask._normalize_price_record(record)
         except Exception:
             return None
 

--- a/task/background/after_market/newhigh_task.py
+++ b/task/background/after_market/newhigh_task.py
@@ -274,10 +274,40 @@ class NewHighTask(AfterMarketTask):
         valid = sum(1 for s in snapshots if (s.get("w52_high") or 0) > 0)
         return valid / len(snapshots) >= 0.2
 
+    @staticmethod
+    def _normalize_snapshot_for_newhigh(snapshot: Dict) -> Dict:
+        """신고가 판정 전 OHLC/전일대비 모순을 보정한다."""
+        current = int(snapshot.get("current_price") or 0)
+        open_price = int(snapshot.get("open_price") or 0)
+        high = int(snapshot.get("high_price") or 0)
+        low = int(snapshot.get("low_price") or 0)
+        prev_close = int(snapshot.get("prev_close") or 0)
+        change_price = int(snapshot.get("change_price") or 0)
+
+        if current > 0:
+            candidates = [p for p in (open_price, high, low, current) if p > 0]
+            if candidates:
+                snapshot["high_price"] = max(candidates)
+                snapshot["low_price"] = min(candidates)
+
+        expected_change = current - prev_close if current > 0 and prev_close > 0 else change_price
+        if current > 0 and prev_close > 0 and expected_change != change_price:
+            snapshot["change_price"] = expected_change
+            if expected_change > 0:
+                snapshot["change_sign"] = "2"
+            elif expected_change < 0:
+                snapshot["change_sign"] = "5"
+            else:
+                snapshot["change_sign"] = "3"
+            snapshot["change_rate"] = str(round(expected_change / prev_close * 100, 2))
+
+        return snapshot
+
     def _filter_newhigh(self, snapshots: List[Dict]) -> List[Dict]:
         """current_price >= w52_high 인 종목 반환 (ETF/ETN 제외, 시가총액 내림차순)."""
         result = []
         for s in snapshots:
+            s = self._normalize_snapshot_for_newhigh(s)
             name = s.get("name") or ""
             if any(name.startswith(p) for p in _ETF_PREFIXES):
                 continue

--- a/tests/unit_test/task/background/after_market/test_daily_price_collector_task.py
+++ b/tests/unit_test/task/background/after_market/test_daily_price_collector_task.py
@@ -638,6 +638,38 @@ def test_extract_broker_api_record_object_output_and_failure_paths(task):
     assert task._extract_broker_api_record("005930", "삼성전자", "KOSPI", resp_broken) is None
 
 
+def test_extract_broker_api_record_normalizes_mixed_price_fields(task):
+    """현재가만 최신값으로 섞인 응답은 OHLC와 등락률을 현재가 기준으로 보정한다."""
+    resp = ResCommonResponse(
+        rt_cd="0",
+        msg1="",
+        data={"output": {
+            "stck_prpr": "84200",
+            "stck_oprc": "75500",
+            "stck_hgpr": "77600",
+            "stck_lwpr": "73200",
+            "stck_sdpr": "70300",
+            "prdy_vrss": "3900",
+            "prdy_vrss_sign": "2",
+            "prdy_ctrt": "5.55",
+            "acml_vol": "46101232",
+            "acml_tr_pbmn": "149586351500",
+            "hts_avls": "415199",
+            "w52_hgpr": "77600",
+            "w52_lwpr": "11800",
+        }},
+    )
+
+    record = task._extract_broker_api_record("006800", "미래에셋증권", "KOSPI", resp)
+
+    assert record["current_price"] == 84200
+    assert record["high_price"] == 84200
+    assert record["low_price"] == 73200
+    assert record["change_price"] == 13900
+    assert record["change_rate"] == "19.77"
+    assert record["change_sign"] == "2"
+
+
 def test_get_progress_and_zero_change_record(task):
     """진행률 복사본 반환 및 보합 종목 change_sign 계산 확인"""
     progress = task.get_progress()

--- a/tests/unit_test/task/background/after_market/test_newhigh_task.py
+++ b/tests/unit_test/task/background/after_market/test_newhigh_task.py
@@ -958,6 +958,36 @@ def test_filter_newhigh_rs_defaults_to_dash_when_no_rs_rating(task):
     assert result[0]["rs"] == "-"
 
 
+def test_filter_newhigh_normalizes_mixed_price_snapshot(task):
+    """현재가만 최신값으로 섞인 DB 스냅샷도 신고가 판정과 리포트 등락률을 보정한다."""
+    snap = _snap(
+        "006800",
+        "미래에셋증권",
+        84200,
+        77600,
+        market_cap=415_199,
+        change_rate="5.55",
+        high_price=77600,
+        volume=46_101_232,
+        trading_value=149_586_351_500,
+    )
+    snap.update({
+        "open_price": 75500,
+        "low_price": 73200,
+        "prev_close": 70300,
+        "change_price": 3900,
+        "change_sign": "2",
+    })
+
+    result = task._filter_newhigh([snap])
+
+    assert len(result) == 1
+    assert result[0]["high_price"] == 84200
+    assert result[0]["change_price"] == 13900
+    assert result[0]["change_rate"] == "19.77"
+    assert result[0]["is_newhigh"] is True
+
+
 @pytest.mark.asyncio
 async def test_get_newhigh_cache_triggers_refresh_when_empty(task):
     with patch.object(task, "trigger_refresh", return_value=True) as mock_trigger:


### PR DESCRIPTION
수정했습니다. 원인은 006800 스냅샷에서 current_price=84200인데 high_price=77600, change_rate=5.55처럼 가격 필드가 서로 섞인 상태였고, 신고가 리포트가 그 값을 그대로 사용한 점이었습니다.

변경 내용:

daily_price_collector_task.py (line 94): 수집 저장 전에 현재가를 OHLC 범위에 포함시키고, 현재가 - 전일종가 기준으로 대비/등락률을 보정

newhigh_task.py (line 277): 이미 DB에 남아 있는 모순 스냅샷도 신고가 필터/리포트 직전에 보정

006800 재현 테스트 추가: 현재 DB 기준 전일종가 70,300이면 84,200의 보정 등락률은 +19.77%로 계산됩니다.

검증:

python -m pytest tests/unit_test -v → 3997 passed

python -m pytest tests/integration_test -v → 203 passed

이미 생성된 오늘 리포트/DB 플래그는 기존 값이라, 신고가 강제 탐색을 다시 실행하면 미래에셋증권이 역사적 신고가로 찍히고 보정된 등락률로 나올 겁니다.