### PR TITLE
fix strategy_log_report_service.py

### DIFF
--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -59,6 +59,37 @@ _DATA_ERROR_REASON_PATTERNS = (
     "invalid price data",
     "open or current is zero",
 )
+_HTF_EARLY_GUARD_NOTE = "장 초반 진입 제한, 이후 스캔 계속"
+
+_STRATEGY_ALIAS_TO_CANONICAL = {
+    "오닐스퀴즈돌파": "OneilSqueezeBreakout",
+    "오닐PP/BGU": "OneilPocketPivot",
+    "하이타이트플래그": "HighTightFlag",
+    "첫눌림목": "FirstPullback",
+    "래리윌리엄스VBO": "LarryWilliamsVBO",
+    "RSI2눌림목": "RSI2Pullback",
+    "래리윌리엄스CB": "LarryWilliamsCB",
+    "거래량돌파": "VolumeBreakoutLive",
+    "프로그램매수추종": "ProgramBuyFollow",
+    "거래량돌파(전통)": "TraditionalVolumeBreakout",
+}
+
+
+def _strategy_alias_key(value: Any) -> str:
+    return re.sub(r"\s+", "", str(value or "").strip()).casefold()
+
+
+_STRATEGY_CANONICAL_BY_KEY: Dict[str, str] = {}
+for _alias, _canonical in _STRATEGY_ALIAS_TO_CANONICAL.items():
+    _STRATEGY_CANONICAL_BY_KEY[_strategy_alias_key(_alias)] = _canonical
+    _STRATEGY_CANONICAL_BY_KEY[_strategy_alias_key(_canonical)] = _canonical
+
+
+def _strategy_report_key(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    return _STRATEGY_CANONICAL_BY_KEY.get(_strategy_alias_key(raw), raw)
 
 
 def _is_data_error_reason(reason: str) -> bool:
@@ -257,12 +288,14 @@ class StrategyLogReportService:
         virtual_trade_service: Optional[Any] = None,
         execution_quality_config: Optional[Any] = None,
         backtest_journal_provider: Optional[Callable[[str], List[dict]]] = None,
+        enabled_strategy_provider: Optional[Callable[[], Optional[List[str]]]] = None,
     ):
         self._log_dir = log_dir
         self._stock_code_repo = stock_code_repo
         self._virtual_trade_service = virtual_trade_service
         self._execution_quality_config = execution_quality_config
         self._backtest_journal_provider = backtest_journal_provider
+        self._enabled_strategy_provider = enabled_strategy_provider
         self._last_execution_quality_candidates: List[dict] = []
 
     def get_last_execution_quality_candidates(self) -> List[dict]:
@@ -380,7 +413,7 @@ class StrategyLogReportService:
             except (TypeError, ValueError):
                 price = 0
 
-            result.setdefault(strategy, {})[code] = {
+            result.setdefault(_strategy_report_key(strategy), {})[code] = {
                 'name': str(trade.get('name') or code),
                 'price': price,
                 'reason': str(trade.get('reason') or '체결 원장 기록'),
@@ -388,6 +421,26 @@ class StrategyLogReportService:
             }
 
         return (not saw_target_date_trade) or saw_strategy_tag, result
+
+    def _get_enabled_strategy_keys(self) -> Optional[set[str]]:
+        if not self._enabled_strategy_provider:
+            return None
+        try:
+            names = self._enabled_strategy_provider()
+        except Exception:
+            return None
+        if names is None:
+            return None
+        return {
+            key for key in (_strategy_report_key(name) for name in names)
+            if key
+        }
+
+    @staticmethod
+    def _is_strategy_enabled_for_report(name: str, enabled_strategy_keys: Optional[set[str]]) -> bool:
+        if enabled_strategy_keys is None:
+            return True
+        return _strategy_report_key(name) in enabled_strategy_keys
 
     def _build_portfolio_summary(
         self,
@@ -864,6 +917,7 @@ class StrategyLogReportService:
         inactive_names: List[str] = []
         market_timing: Dict[str, Tuple[str, bool]] = {}
         has_executed_buy_source, executed_buys_by_strategy = self._executed_buys_by_strategy(target_date)
+        enabled_strategy_keys = self._get_enabled_strategy_keys()
 
         # 전략 로직과 무관한 데이터 수신/파싱 오류를 따로 집계
         data_errors_by_strategy: Dict[str, int] = {}
@@ -908,10 +962,13 @@ class StrategyLogReportService:
 
                     elif event == 'execution_quality' and code:
                         name_value = name_map.get(code) or data.get('name') or code
+                        strategy_name = _strategy_name_from_source(data.get("source") or data.get("strategy_name"))
+                        if not self._is_strategy_enabled_for_report(strategy_name, enabled_strategy_keys):
+                            continue
                         execution_quality_records.append({
                             "timestamp": ts,
                             "order_key": data.get("order_key") or f"{ts}:{code}:{len(execution_quality_records)}",
-                            "strategy": _strategy_name_from_source(data.get("source") or data.get("strategy_name")),
+                            "strategy": strategy_name,
                             "code": str(code).strip(),
                             "name": self._db_resolve(str(code).strip(), str(name_value)),
                             "side": data.get("side", ""),
@@ -949,7 +1006,7 @@ class StrategyLogReportService:
                     if event == 'breakout_skipped' and data.get('reason') == 'early_morning_guard' and code:
                         early_guard_skipped.add(code)
                         if code in near_miss:
-                            near_miss[code]['note'] = "장 초반 진입 제한으로 스킵"
+                            near_miss[code]['note'] = _HTF_EARLY_GUARD_NOTE
 
                     if event in _NEAR_MISS_EVENTS and code and code not in bought:
                         reason = data.get('reason', '')
@@ -971,12 +1028,12 @@ class StrategyLogReportService:
                                 'reason_kr': _reason_to_korean("HTF 패턴 감지" if event == "htf_pattern_detected" else reason),
                                 'metric_str': _build_metric_str(event, reason, data),
                                 'time': ts[11:16] if len(ts) >= 16 else '',
-                                'note': "장 초반 진입 제한으로 스킵" if code in early_guard_skipped else "",
+                                'note': _HTF_EARLY_GUARD_NOTE if code in early_guard_skipped else "",
                             }
 
             # StockCodeRepository로 미해결 종목명 보완
             if has_executed_buy_source:
-                bought = executed_buys_by_strategy.get(name, {})
+                bought = executed_buys_by_strategy.get(_strategy_report_key(name), {})
 
             if self._stock_code_repo:
                 for code, info in bought.items():
@@ -985,6 +1042,9 @@ class StrategyLogReportService:
                     info['name'] = self._db_resolve(code, info['name'])
                 for code, info in near_miss.items():
                     info['name'] = self._db_resolve(code, info['name'])
+
+            if not self._is_strategy_enabled_for_report(name, enabled_strategy_keys):
+                continue
 
             if data_error_count > 0:
                 data_errors_by_strategy[name] = data_error_count

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -231,7 +231,13 @@ class HighTightFlagStrategy(LiveStrategy):
 
         # 장 초반 15분 이내: proj_vol 뻥튀기로 인한 가짜 돌파 시그널 방지
         if progress * 390 < 15:
-            self._logger.debug({"event": "breakout_skipped", "code": code, "reason": "early_morning_guard"})
+            self._logger.debug({
+                "event": "breakout_skipped",
+                "code": code,
+                "name": item.name,
+                "reason": "early_morning_guard",
+                "retry_after_guard": True,
+            })
             return None
 
         # 2. 가격 돌파: pole_high 기준 진입 밴드 확인 (옵션 A + 과확장 방어)

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -690,6 +690,98 @@ async def test_report_uses_virtual_trade_records_for_completed_buys_when_availab
 
 
 @pytest.mark.asyncio
+async def test_report_matches_virtual_trade_strategy_alias_to_log_section(log_dir):
+    """원장 전략명이 한글이어도 대응하는 영문 로그 섹션의 매수 완료 detail에 표시한다."""
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return [
+                {
+                    "strategy": "첫눌림목",
+                    "code": "005930",
+                    "name": "삼성전자",
+                    "buy_date": "2026-04-18 09:10:00",
+                    "buy_price": 75000,
+                    "status": "HOLD",
+                    "reason": "원장 체결",
+                },
+            ]
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+    _write_log(os.path.join(log_dir, "20260418_093000_FirstPullback.log.json"), [
+        _make_entry("buy_signal_generated", "005930", "삼성전자", reason="로그 시그널", price=75000),
+    ])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+    )
+    report = await svc.generate_report("20260418")
+
+    assert "<b>1. FirstPullback</b>" in report
+    assert "매수 완료 (1건)" in report
+    assert "삼성전자(005930): 원장 체결 @ ₩75,000 (09:10)" in report
+
+
+@pytest.mark.asyncio
+async def test_report_filters_disabled_strategy_sections_and_execution_quality(log_dir):
+    """스케줄러에서 제외된 전략은 실행 섹션과 체결 품질 요약에서 제외한다."""
+    scan_entry = _make_entry("scan_with_watchlist", "", "", reason="")
+    scan_entry["data"]["count"] = 3
+    _write_log(os.path.join(log_dir, "20260418_093000_FirstPullback.log.json"), [scan_entry])
+    _write_log(os.path.join(log_dir, "20260418_093000_TraditionalVolumeBreakout.log.json"), [
+        _make_entry("buy_signal_generated", "005930", "삼성전자", reason="전통돌파", price=75000),
+    ])
+    _write_log(os.path.join(log_dir, "20260418_093000_ExecutionQuality.log.json"), [
+        {
+            "timestamp": "2026-04-18 10:00:00,000",
+            "level": "INFO",
+            "name": "strategy.ExecutionQuality",
+            "data": {
+                "event": "execution_quality",
+                "code": "005930",
+                "name": "삼성전자",
+                "source": "strategy:거래량돌파(전통)",
+                "side": "BUY",
+                "order_type": "limit",
+                "filled_qty": 1,
+                "slippage_pct": 2.0,
+            },
+        },
+        {
+            "timestamp": "2026-04-18 10:01:00,000",
+            "level": "INFO",
+            "name": "strategy.ExecutionQuality",
+            "data": {
+                "event": "execution_quality",
+                "code": "000660",
+                "name": "SK하이닉스",
+                "source": "strategy:첫눌림목",
+                "side": "BUY",
+                "order_type": "limit",
+                "filled_qty": 1,
+                "slippage_pct": 0.2,
+            },
+        },
+    ])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        enabled_strategy_provider=lambda: ["첫눌림목"],
+    )
+    report = await svc.generate_report("20260418")
+
+    assert "FirstPullback" in report
+    assert "TraditionalVolumeBreakout" not in report
+    assert "거래량돌파(전통)" not in report
+    assert "첫눌림목: 1건" in report
+
+
+@pytest.mark.asyncio
 async def test_report_includes_execution_quality_summary(log_dir):
     """execution_quality 로그를 전략별/종목별 체결 품질로 집계한다."""
     log_path = os.path.join(log_dir, "20260418_093000_Execution.log.json")
@@ -992,7 +1084,7 @@ async def test_htf_near_miss_shows_early_morning_guard_note(log_dir):
     report = await svc.generate_report("20260418")
 
     assert "HTF 패턴 감지" in report
-    assert "장 초반 진입 제한으로 스킵" in report
+    assert "장 초반 진입 제한, 이후 스캔 계속" in report
 
 
 @pytest.mark.asyncio

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -587,6 +587,7 @@ class WebAppContext:
                     virtual_trade_service=self.virtual_trade_service,
                     backtest_journal_provider=self.backtest_journal_repository.load_records_for_date,
                     execution_quality_config=getattr(self.full_config, "execution_quality_report", None),
+                    enabled_strategy_provider=self._get_enabled_strategy_names_for_report,
                 ),
                 notification_service=self.notification_service,
                 telegram_reporter=getattr(self, 'telegram_reporter', None),
@@ -730,6 +731,17 @@ class WebAppContext:
         return {}
 
     # --- 전략 스케줄러 ---
+
+    def _get_enabled_strategy_names_for_report(self):
+        scheduler = getattr(self, "scheduler", None)
+        if not scheduler:
+            return None
+        strategies = getattr(scheduler, "_strategies", [])
+        return [
+            cfg.strategy.name
+            for cfg in strategies
+            if getattr(cfg, "enabled", False)
+        ]
 
     def initialize_scheduler(self):
         """전략 스케줄러 생성 및 전략 등록 (자동 시작하지 않음, 웹 UI에서 수동 시작)."""


### PR DESCRIPTION
수정 완료했습니다.

핵심 변경:

strategy_log_report_service.py (line 64): 원장 전략명(예: 첫눌림목)과 로그 파일 전략명(예: FirstPullback)을 alias로 매칭하도록 수정했습니다. 이제 요약에는 매수가 있는데 개별 전략 detail에는 안 나오는 문제가 해결됩니다.

strategy_log_report_service.py (line 425): 리포트 생성 시 현재 활성화된 전략만 실행 섹션과 체결 품질 요약에 포함하도록 필터링했습니다. 따라서 제외한 거래량돌파(전통)/TraditionalVolumeBreakout은 리포트와 체결품질 후보에서 빠집니다.

high_tight_flag_strategy.py (line 238): HTF 장초반 가드는 해당 scan만 skip하고 이후 scan은 계속됩니다. 로그/리포트 문구도 장 초반 진입 제한, 이후 스캔 계속으로 명확히 보이게 바꿨습니다.

web_app_initializer.py (line 590): 리포트 서비스가 스케줄러의 활성 전략 목록을 참조하도록 연결했습니다.

검증:

pytest tests/unit_test -v → 3999 passed

pytest tests/integration_test -v → 203 passed