### PR TITLE
원장 불일치 해결 task 추가

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -165,6 +165,19 @@ class ExecutionQualityReportConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class OpeningPositionReconcileConfig(BaseModel):
+    enabled: bool = True
+    detect_only: bool = True
+    auto_buy_missing_local: bool = False
+    auto_sell_extra_broker: bool = False
+    allow_sell_unknown_broker: bool = False
+    check_interval_sec: int = 30
+    open_delay_sec: int = 60
+    run_window_min: int = 10
+
+    model_config = {"extra": "allow"}
+
+
 class AppConfig(BaseModel):
     # Core API keys
     api_key: Optional[str] = None
@@ -190,6 +203,7 @@ class AppConfig(BaseModel):
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)
+    opening_position_reconcile: OpeningPositionReconcileConfig = Field(default_factory=OpeningPositionReconcileConfig)
     
     # Dynamic/Merged configs
     tr_ids: Dict[str, Any] = Field(default_factory=dict)

--- a/services/opening_position_reconcile_service.py
+++ b/services/opening_position_reconcile_service.py
@@ -1,0 +1,235 @@
+"""장 시작 직후 로컬 가상 원장과 실제 계좌 잔고를 대사한다."""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Optional
+
+from common.types import ErrorCode, Exchange, ResCommonResponse
+
+
+class OpeningPositionReconcileService:
+    """VirtualTradeRepository HOLD 수량을 목표 포지션으로 보고 실제 계좌 수량과 맞춘다."""
+
+    SOURCE = "reconcile:opening"
+
+    def __init__(
+        self,
+        *,
+        broker,
+        order_execution_service,
+        virtual_trade_service,
+        detect_only: bool = True,
+        auto_buy_missing_local: bool = False,
+        auto_sell_extra_broker: bool = False,
+        allow_sell_unknown_broker: bool = False,
+        managed_codes: Optional[set[str]] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._broker = broker
+        self._oes = order_execution_service
+        self._vts = virtual_trade_service
+        self._detect_only = detect_only
+        self._auto_buy_missing_local = auto_buy_missing_local
+        self._auto_sell_extra_broker = auto_sell_extra_broker
+        self._allow_sell_unknown_broker = allow_sell_unknown_broker
+        self._managed_codes = {str(code).strip() for code in managed_codes or set() if str(code).strip()}
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def reconcile_once(self, *, exchange: Exchange = Exchange.KRX) -> dict:
+        response = await self._call(self._broker.get_account_balance, exchange=exchange)
+        if not self._is_success_response(response):
+            msg = getattr(response, "msg1", None) or "잔고 조회 실패"
+            self._logger.error(f"[OpeningPositionReconcile] broker balance failed: {msg}")
+            return self._empty_result(error=msg)
+
+        actual_holdings = ((response.data or {}).get("output1", []) if isinstance(response.data, dict) else [])
+        local_positions = self._normalize_local_positions(self._vts.get_holds())
+        broker_positions = self._normalize_broker_positions(actual_holdings)
+        plan = self._build_plan(local_positions, broker_positions)
+
+        result = {
+            "detect_only": self._detect_only,
+            **plan,
+            "executed": [],
+            "error": None,
+        }
+        result["mismatch_count"] = (
+            len(result["planned_buys"]) + len(result["planned_sells"]) + len(result["skipped"])
+        )
+
+        if self._detect_only:
+            self._logger.info(f"[OpeningPositionReconcile] detect_only plan={result}")
+            return result
+
+        await self._execute_plan(result, exchange)
+        return result
+
+    async def _execute_plan(self, result: dict, exchange: Exchange) -> None:
+        for item in result["planned_buys"]:
+            if not self._auto_buy_missing_local:
+                result["skipped"].append({**item, "reason": "auto_buy_disabled"})
+                continue
+            response = await self._oes.handle_place_buy_order(
+                item["code"],
+                0,
+                item["qty"],
+                source=self.SOURCE,
+                finalize_immediately=False,
+            )
+            result["executed"].append(self._order_result("BUY", item, response))
+
+        for item in result["planned_sells"]:
+            if not self._auto_sell_extra_broker:
+                result["skipped"].append({**item, "reason": "auto_sell_disabled"})
+                continue
+            response = await self._oes.handle_place_sell_order(
+                item["code"],
+                0,
+                item["qty"],
+                source=self.SOURCE,
+                finalize_immediately=False,
+            )
+            result["executed"].append(self._order_result("SELL", item, response))
+
+    def _build_plan(self, local_positions: dict[str, dict], broker_positions: dict[str, int]) -> dict:
+        planned_buys: list[dict] = []
+        planned_sells: list[dict] = []
+        skipped: list[dict] = []
+        matched: list[dict] = []
+
+        all_codes = sorted(set(local_positions) | set(broker_positions))
+        managed_codes = set(local_positions) | self._managed_codes
+        for code in all_codes:
+            local_qty = int(local_positions.get(code, {}).get("qty", 0))
+            broker_qty = int(broker_positions.get(code, 0))
+            diff = local_qty - broker_qty
+            if diff == 0:
+                if local_qty > 0:
+                    matched.append({"code": code, "qty": local_qty})
+                continue
+
+            strategy = local_positions.get(code, {}).get("strategy", "")
+            if diff > 0:
+                planned_buys.append({
+                    "code": code,
+                    "qty": diff,
+                    "local_qty": local_qty,
+                    "broker_qty": broker_qty,
+                    "strategy": strategy,
+                })
+                continue
+
+            sell_qty = abs(diff)
+            if code not in managed_codes and not self._allow_sell_unknown_broker:
+                skipped.append({
+                    "code": code,
+                    "qty": sell_qty,
+                    "local_qty": local_qty,
+                    "broker_qty": broker_qty,
+                    "reason": "unknown_broker_holding",
+                })
+                continue
+
+            reason = "broker_extra_qty" if local_qty > 0 else "unknown_broker_holding"
+            planned_sells.append({
+                "code": code,
+                "qty": sell_qty,
+                "local_qty": local_qty,
+                "broker_qty": broker_qty,
+                "reason": reason,
+            })
+
+        return {
+            "planned_buys": planned_buys,
+            "planned_sells": planned_sells,
+            "skipped": skipped,
+            "matched": matched,
+        }
+
+    @staticmethod
+    def _normalize_local_positions(holds: list[dict]) -> dict[str, dict]:
+        positions: dict[str, dict] = {}
+        for hold in holds or []:
+            code = str(hold.get("code", "")).strip()
+            if not code:
+                continue
+            qty = OpeningPositionReconcileService._to_int(hold.get("qty"), default=1)
+            if qty <= 0:
+                continue
+            current = positions.setdefault(code, {"qty": 0, "strategies": []})
+            current["qty"] += qty
+            strategy = str(hold.get("strategy", "")).strip()
+            if strategy:
+                current["strategies"].append(strategy)
+                current.setdefault("strategy", strategy)
+        return positions
+
+    @staticmethod
+    def _normalize_broker_positions(holdings: list[dict]) -> dict[str, int]:
+        positions: dict[str, int] = {}
+        for holding in holdings or []:
+            code = str(
+                holding.get("pdno")
+                or holding.get("PDNO")
+                or holding.get("code")
+                or ""
+            ).strip()
+            if not code:
+                continue
+            qty = OpeningPositionReconcileService._to_int(
+                holding.get("hldg_qty")
+                or holding.get("HLDG_QTY")
+                or holding.get("qty")
+                or holding.get("quantity")
+            )
+            if qty > 0:
+                positions[code] = positions.get(code, 0) + qty
+        return positions
+
+    @staticmethod
+    def _to_int(value: Any, default: int = 0) -> int:
+        try:
+            text = str(value if value is not None else "").replace(",", "").strip()
+            return int(float(text)) if text else default
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _is_success_response(response) -> bool:
+        if isinstance(response, ResCommonResponse):
+            return response.rt_cd == ErrorCode.SUCCESS.value
+        return getattr(response, "rt_cd", None) == ErrorCode.SUCCESS.value
+
+    @staticmethod
+    async def _call(method, *args, **kwargs):
+        try:
+            response = method(*args, **kwargs)
+        except TypeError:
+            response = method(*args)
+        if inspect.isawaitable(response):
+            return await response
+        return response
+
+    @staticmethod
+    def _order_result(action: str, item: dict, response) -> dict:
+        return {
+            "action": action,
+            "code": item["code"],
+            "qty": item["qty"],
+            "success": OpeningPositionReconcileService._is_success_response(response),
+            "message": getattr(response, "msg1", "") if response is not None else "응답 없음",
+        }
+
+    @staticmethod
+    def _empty_result(*, error: str | None = None) -> dict:
+        return {
+            "detect_only": True,
+            "planned_buys": [],
+            "planned_sells": [],
+            "skipped": [],
+            "matched": [],
+            "executed": [],
+            "mismatch_count": 0,
+            "error": error,
+        }

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -488,6 +488,10 @@ class OrderExecutionService:
             return "수동매매", False
         return source, False
 
+    @staticmethod
+    def _is_reconcile_source(source: str) -> bool:
+        return (source or "").startswith("reconcile:")
+
     async def _persist_virtual_trade_for_terminal_report(
         self,
         context: OrderContext,
@@ -499,6 +503,8 @@ class OrderExecutionService:
             return context
         if context.virtual_recorded_qty >= context.filled_qty:
             return context
+        if self._is_reconcile_source(context.source):
+            return self._mark_virtual_trade_recorded(context, context.filled_qty)
 
         strategy_name, is_strategy_source = self._strategy_name_from_source(context.source)
         record_qty = context.filled_qty

--- a/task/background/intraday/opening_position_reconcile_task.py
+++ b/task/background/intraday/opening_position_reconcile_task.py
@@ -1,0 +1,152 @@
+"""장 시작 직후 원장/브로커 잔고 대사 task."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from typing import Dict, List, Optional
+
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+from services.notification_service import NotificationCategory, NotificationLevel
+
+
+class OpeningPositionReconcileTask(SchedulableTask):
+    CHECK_INTERVAL_SEC = 30
+    OPEN_DELAY_SEC = 60
+    RUN_WINDOW_MIN = 10
+
+    def __init__(
+        self,
+        *,
+        reconcile_service,
+        market_calendar_service=None,
+        market_clock=None,
+        notification_service=None,
+        logger: Optional[logging.Logger] = None,
+        check_interval_sec: Optional[int] = None,
+        open_delay_sec: Optional[int] = None,
+        run_window_min: Optional[int] = None,
+    ) -> None:
+        self._service = reconcile_service
+        self._mcs = market_calendar_service
+        self._market_clock = market_clock
+        self._ns = notification_service
+        self._logger = logger or logging.getLogger(__name__)
+        self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
+        self._open_delay_sec = open_delay_sec if open_delay_sec is not None else self.OPEN_DELAY_SEC
+        self._run_window_min = run_window_min if run_window_min is not None else self.RUN_WINDOW_MIN
+        self._state = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._last_checked_date: Optional[str] = None
+        self._last_result: Dict = {"mismatch_count": None, "error": None}
+
+    @property
+    def task_name(self) -> str:
+        return "opening_position_reconcile"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.HIGH
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    def get_progress(self) -> Dict:
+        return {
+            "running": self._state == TaskState.RUNNING,
+            "last_checked_date": self._last_checked_date,
+            "last_result": self._last_result,
+        }
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._check_interval_sec)
+                if self._state == TaskState.SUSPENDED:
+                    continue
+                if await self._should_run_now():
+                    self._state = TaskState.RUNNING
+                    try:
+                        await self.run_once()
+                    finally:
+                        if self._state == TaskState.RUNNING:
+                            self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error(f"[OpeningPositionReconcile] loop error: {exc}", exc_info=True)
+
+    async def _should_run_now(self) -> bool:
+        if not self._market_clock or not self._mcs:
+            return False
+        now = self._market_clock.get_current_kst_time()
+        date_key = now.strftime("%Y%m%d")
+        if self._last_checked_date == date_key:
+            return False
+        try:
+            if not await self._mcs.is_business_day(date_key):
+                return False
+        except Exception:
+            return False
+        start_at = self._market_clock.get_market_open_time() + timedelta(seconds=self._open_delay_sec)
+        end_at = start_at + timedelta(minutes=self._run_window_min)
+        return start_at <= now < end_at
+
+    async def run_once(self) -> Dict:
+        try:
+            result = await self._service.reconcile_once()
+            self._last_result = result
+            if self._market_clock:
+                self._last_checked_date = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
+
+            mismatch_count = int(result.get("mismatch_count") or 0)
+            if mismatch_count:
+                self._logger.warning(f"[OpeningPositionReconcile] mismatch_count={mismatch_count} result={result}")
+                if self._ns:
+                    await self._ns.emit(
+                        NotificationCategory.TRADE,
+                        NotificationLevel.WARNING,
+                        "장 시작 원장/잔고 대사 불일치",
+                        f"{mismatch_count}건 확인",
+                        metadata=result,
+                    )
+            else:
+                self._logger.info("[OpeningPositionReconcile] OK")
+            return result
+        except Exception as exc:
+            self._last_result = {"mismatch_count": None, "error": str(exc)}
+            self._logger.error(f"[OpeningPositionReconcile] 실패: {exc}", exc_info=True)
+            if self._ns:
+                await self._ns.emit(
+                    NotificationCategory.TRADE,
+                    NotificationLevel.ERROR,
+                    "장 시작 원장/잔고 대사 실패",
+                    str(exc),
+                    metadata=self._last_result,
+                )
+            return self._last_result

--- a/tests/unit_test/services/test_opening_position_reconcile_service.py
+++ b/tests/unit_test/services/test_opening_position_reconcile_service.py
@@ -1,0 +1,206 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from services.opening_position_reconcile_service import OpeningPositionReconcileService
+
+
+@pytest.mark.asyncio
+async def test_opening_reconcile_detect_only_builds_quantity_plan_without_orders():
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.get_holds.return_value = [
+        {"code": "005930", "strategy": "S1", "qty": 3},
+        {"code": "000660", "strategy": "S2", "qty": 1},
+    ]
+    broker = MagicMock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={"output1": [{"pdno": "005930", "hldg_qty": "1"}, {"pdno": "035420", "hldg_qty": "2"}]},
+        )
+    )
+    order_execution_service = MagicMock()
+    order_execution_service.handle_place_buy_order = AsyncMock()
+    order_execution_service.handle_place_sell_order = AsyncMock()
+    service = OpeningPositionReconcileService(
+        broker=broker,
+        order_execution_service=order_execution_service,
+        virtual_trade_service=virtual_trade_service,
+        logger=MagicMock(),
+    )
+
+    result = await service.reconcile_once()
+
+    assert result["detect_only"] is True
+    assert result["planned_buys"] == [
+        {"code": "000660", "qty": 1, "local_qty": 1, "broker_qty": 0, "strategy": "S2"},
+        {"code": "005930", "qty": 2, "local_qty": 3, "broker_qty": 1, "strategy": "S1"}
+    ]
+    assert result["planned_sells"] == []
+    assert result["skipped"] == [
+        {
+            "code": "035420",
+            "qty": 2,
+            "local_qty": 0,
+            "broker_qty": 2,
+            "reason": "unknown_broker_holding",
+        }
+    ]
+    order_execution_service.handle_place_buy_order.assert_not_awaited()
+    order_execution_service.handle_place_sell_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_opening_reconcile_can_buy_missing_local_quantity_when_enabled():
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 3}]
+    broker = MagicMock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={"output1": [{"pdno": "005930", "hldg_qty": "1"}]},
+        )
+    )
+    order_execution_service = MagicMock()
+    order_execution_service.handle_place_buy_order = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
+    )
+    service = OpeningPositionReconcileService(
+        broker=broker,
+        order_execution_service=order_execution_service,
+        virtual_trade_service=virtual_trade_service,
+        detect_only=False,
+        auto_buy_missing_local=True,
+        logger=MagicMock(),
+    )
+
+    result = await service.reconcile_once()
+
+    order_execution_service.handle_place_buy_order.assert_awaited_once_with(
+        "005930",
+        0,
+        2,
+        source="reconcile:opening",
+        finalize_immediately=False,
+    )
+    assert result["executed"] == [
+        {"action": "BUY", "code": "005930", "qty": 2, "success": True, "message": "OK"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_opening_reconcile_sells_only_managed_excess_by_default():
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 1}]
+    broker = MagicMock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={
+                "output1": [
+                    {"pdno": "005930", "hldg_qty": "3"},
+                    {"pdno": "035420", "hldg_qty": "2"},
+                ]
+            },
+        )
+    )
+    order_execution_service = MagicMock()
+    order_execution_service.handle_place_sell_order = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
+    )
+    service = OpeningPositionReconcileService(
+        broker=broker,
+        order_execution_service=order_execution_service,
+        virtual_trade_service=virtual_trade_service,
+        detect_only=False,
+        auto_sell_extra_broker=True,
+        logger=MagicMock(),
+    )
+
+    result = await service.reconcile_once()
+
+    order_execution_service.handle_place_sell_order.assert_awaited_once_with(
+        "005930",
+        0,
+        2,
+        source="reconcile:opening",
+        finalize_immediately=False,
+    )
+    assert result["skipped"] == [
+        {
+            "code": "035420",
+            "qty": 2,
+            "local_qty": 0,
+            "broker_qty": 2,
+            "reason": "unknown_broker_holding",
+        }
+    ]
+    assert result["executed"] == [
+        {"action": "SELL", "code": "005930", "qty": 2, "success": True, "message": "OK"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_opening_reconcile_allows_unknown_broker_sell_only_when_explicitly_enabled():
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.get_holds.return_value = []
+    broker = MagicMock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={"output1": [{"pdno": "035420", "hldg_qty": "2"}]},
+        )
+    )
+    order_execution_service = MagicMock()
+    order_execution_service.handle_place_sell_order = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
+    )
+    service = OpeningPositionReconcileService(
+        broker=broker,
+        order_execution_service=order_execution_service,
+        virtual_trade_service=virtual_trade_service,
+        detect_only=False,
+        auto_sell_extra_broker=True,
+        allow_sell_unknown_broker=True,
+        logger=MagicMock(),
+    )
+
+    result = await service.reconcile_once()
+
+    order_execution_service.handle_place_sell_order.assert_awaited_once()
+    assert result["planned_sells"] == [
+        {
+            "code": "035420",
+            "qty": 2,
+            "local_qty": 0,
+            "broker_qty": 2,
+            "reason": "unknown_broker_holding",
+        }
+    ]
+    assert result["skipped"] == []
+
+
+@pytest.mark.asyncio
+async def test_opening_reconcile_reports_balance_failure_without_orders():
+    broker = MagicMock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="denied", data=None)
+    )
+    order_execution_service = MagicMock()
+    order_execution_service.handle_place_buy_order = AsyncMock()
+    service = OpeningPositionReconcileService(
+        broker=broker,
+        order_execution_service=order_execution_service,
+        virtual_trade_service=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    result = await service.reconcile_once()
+
+    assert result["error"] == "denied"
+    order_execution_service.handle_place_buy_order.assert_not_awaited()

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -1041,6 +1041,45 @@ async def test_execution_confirmed_buy_persists_virtual_trade(mock_broker_api_wr
 
 
 @pytest.mark.asyncio
+async def test_reconcile_source_does_not_persist_virtual_trade(mock_broker_api_wrapper, mock_logger, mock_market_clock, mock_market_calendar_service):
+    virtual_trade_service = AsyncMock()
+    handler = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        virtual_trade_service=virtual_trade_service,
+    )
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="주문 성공",
+        data={"ordno": "A0001"},
+    )
+    await handler.handle_place_buy_order(
+        "005930", 0, 2, source="reconcile:opening", finalize_immediately=False
+    )
+
+    filled = await handler.handle_signing_notice({
+        "ODER_NO": "A0001",
+        "STCK_SHRN_ISCD": "005930",
+        "SELN_BYOV_CLS": "02",
+        "CNTG_QTY": "2",
+        "CNTG_UNPR": "70100",
+        "STCK_CNTG_HOUR": "101500",
+        "RFUS_YN": "N",
+        "CNTG_YN": "2",
+        "ACPT_YN": "Y",
+        "ODER_QTY": "2",
+    }, tr_id="H0STCNI0")
+
+    assert filled.state == OrderState.FILLED
+    assert filled.virtual_recorded_qty == 2
+    virtual_trade_service.log_buy_async.assert_not_awaited()
+    virtual_trade_service.log_sell_async.assert_not_awaited()
+    virtual_trade_service.log_sell_by_strategy_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_duplicate_execution_notice_does_not_duplicate_virtual_trade(mock_broker_api_wrapper, mock_logger, mock_market_clock, mock_market_calendar_service):
     virtual_trade_service = AsyncMock()
     handler = OrderExecutionService(

--- a/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
+++ b/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
@@ -1,0 +1,110 @@
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from interfaces.schedulable_task import TaskState
+from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
+
+
+@pytest.mark.asyncio
+async def test_opening_position_reconcile_runs_once_in_opening_window():
+    clock = MagicMock()
+    open_time = datetime(2026, 4, 30, 9, 0)
+    clock.get_market_open_time.return_value = open_time
+    clock.get_current_kst_time.return_value = open_time + timedelta(seconds=61)
+    mcs = AsyncMock()
+    mcs.is_business_day.return_value = True
+    service = AsyncMock()
+    service.reconcile_once.return_value = {"mismatch_count": 1, "executed": [], "skipped": []}
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service,
+        market_calendar_service=mcs,
+        market_clock=clock,
+        notification_service=AsyncMock(),
+        logger=MagicMock(),
+    )
+
+    assert await task._should_run_now() is True
+    result = await task.run_once()
+
+    service.reconcile_once.assert_awaited_once()
+    assert result["mismatch_count"] == 1
+    assert task._last_checked_date == "20260430"
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_opening_position_reconcile_skips_before_delay_and_after_window():
+    clock = MagicMock()
+    open_time = datetime(2026, 4, 30, 9, 0)
+    clock.get_market_open_time.return_value = open_time
+    mcs = AsyncMock()
+    mcs.is_business_day.return_value = True
+    task = OpeningPositionReconcileTask(
+        reconcile_service=AsyncMock(),
+        market_calendar_service=mcs,
+        market_clock=clock,
+        open_delay_sec=60,
+        run_window_min=10,
+    )
+
+    clock.get_current_kst_time.return_value = open_time + timedelta(seconds=30)
+    assert await task._should_run_now() is False
+
+    clock.get_current_kst_time.return_value = open_time + timedelta(minutes=12)
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_opening_position_reconcile_notifies_mismatch_and_failure():
+    ns = AsyncMock()
+    service = AsyncMock()
+    service.reconcile_once.return_value = {"mismatch_count": 2, "executed": [], "skipped": []}
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service,
+        notification_service=ns,
+        logger=MagicMock(),
+    )
+
+    result = await task.run_once()
+
+    assert result["mismatch_count"] == 2
+    ns.emit.assert_awaited_once()
+
+    ns.reset_mock()
+    service.reconcile_once.side_effect = RuntimeError("boom")
+    result = await task.run_once()
+
+    assert result["error"] == "boom"
+    ns.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_opening_position_reconcile_lifecycle_stops_background_loop():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+
+    try:
+        await task.start()
+        assert task.state == TaskState.IDLE
+        await task.start()
+        assert len(task._tasks) == 1
+    finally:
+        await task.stop()
+
+    assert task.state == TaskState.STOPPED
+    assert task._tasks == []
+
+
+@pytest.mark.asyncio
+async def test_opening_position_reconcile_loop_runs_once_and_recovers_errors():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+    task._should_run_now = AsyncMock(side_effect=[True, RuntimeError("loop boom"), asyncio.CancelledError()])
+    task.run_once = AsyncMock()
+
+    with patch("task.background.intraday.opening_position_reconcile_task.asyncio.sleep", new_callable=AsyncMock):
+        await task._loop()
+
+    task.run_once.assert_awaited_once()
+    task._logger.error.assert_called_once()

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -34,6 +34,7 @@ from interfaces.schedulable_task import TaskPriority
 from task.background.intraday.strategy_scheduler_task_adapter import StrategySchedulerTaskAdapter
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
+from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.minervini_update_task import MinerviniUpdateTask
 from task.background.after_market.daily_price_collector_task import DailyPriceCollectorTask
@@ -72,6 +73,7 @@ from services.price_stream_service import PriceStreamService
 from repositories.streaming_stock_repo import StreamingStockRepo, StreamingType
 from services.telegram_notifier import TelegramNotifier, TelegramReporter
 from services.data_quality_service import DataQualityService
+from services.opening_position_reconcile_service import OpeningPositionReconcileService
 
 from core.cache.cache_store import CacheStore
 from services.rs_rating_service import RSRatingService
@@ -117,6 +119,7 @@ class WebAppContext:
         self.minervini_update_task: MinerviniUpdateTask = None
         self.websocket_watchdog_task: WebSocketWatchdogTask = None
         self.pre_market_health_check_task: PreMarketHealthCheckTask = None
+        self.opening_position_reconcile_task: OpeningPositionReconcileTask = None
         self.after_market_reconcile_task: AfterMarketReconcileTask = None
         self.daily_price_collector_task: DailyPriceCollectorTask = None
         self.ohlcv_update_task: OhlcvUpdateTask = None
@@ -610,6 +613,29 @@ class WebAppContext:
                 logger=self.logger,
                 worker_pool=self.worker_pool,
             )
+            reconcile_cfg = getattr(self.full_config, "opening_position_reconcile", None)
+            self.opening_position_reconcile_task = None
+            if reconcile_cfg is None or getattr(reconcile_cfg, "enabled", True):
+                opening_reconcile_service = OpeningPositionReconcileService(
+                    broker=self.broker,
+                    order_execution_service=self.order_execution_service,
+                    virtual_trade_service=self.virtual_trade_service,
+                    detect_only=getattr(reconcile_cfg, "detect_only", True),
+                    auto_buy_missing_local=getattr(reconcile_cfg, "auto_buy_missing_local", False),
+                    auto_sell_extra_broker=getattr(reconcile_cfg, "auto_sell_extra_broker", False),
+                    allow_sell_unknown_broker=getattr(reconcile_cfg, "allow_sell_unknown_broker", False),
+                    logger=self.logger,
+                )
+                self.opening_position_reconcile_task = OpeningPositionReconcileTask(
+                    reconcile_service=opening_reconcile_service,
+                    market_calendar_service=self._mcs,
+                    market_clock=self.market_clock,
+                    notification_service=self.notification_service,
+                    logger=self.logger,
+                    check_interval_sec=getattr(reconcile_cfg, "check_interval_sec", 30),
+                    open_delay_sec=getattr(reconcile_cfg, "open_delay_sec", 60),
+                    run_window_min=getattr(reconcile_cfg, "run_window_min", 10),
+                )
         except Exception as e:
             self.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
@@ -627,6 +653,7 @@ class WebAppContext:
                 (self.newhigh_task,                      TaskPriority.LOW),
                 (self.log_cleanup_task,                  TaskPriority.MAINTENANCE),
                 (self.strategy_log_report_task,          TaskPriority.LOW),
+                (self.opening_position_reconcile_task,   TaskPriority.HIGH),
                 (self.after_market_reconcile_task,       TaskPriority.LOW),
             ]:
                 if task:
@@ -653,6 +680,7 @@ class WebAppContext:
                 self.newhigh_task,
                 self.notification_queue_task,
                 self.strategy_log_report_task,
+                self.opening_position_reconcile_task,
                 self.after_market_reconcile_task,
             ]:
                 if task:


### PR DESCRIPTION
기본은 안전하게 장 시작 후 60초부터 10분 window 안에서 하루 1회 detect_only 대사만 수행하고, 자동 매수/매도는 config로 명시적으로 켜야 실행됩니다.

변경 핵심:

opening_position_reconcile_service.py: 로컬 HOLD 수량과 실제 계좌 수량을 비교해 매수/매도/skip 계획 생성 및 선택적 시장가 주문 실행

opening_position_reconcile_task.py: 장 시작 후 대사 task 추가

order_execution_service.py: reconcile:* 주문은 체결 후 가상 원장에 중복 기록하지 않도록 방어

config_loader.py: opening_position_reconcile 설정 추가

web_app_initializer.py: task 생성 및 scheduler 등록

기본 설정값은: