### PR TITLE
투자주의 종목 sell 못하는 버그 수정.

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -102,6 +102,7 @@ class OrderPolicyConfig(BaseModel):
     block_investment_warning: bool = True
     block_investment_caution: bool = False
     blocked_stock_status_codes: List[str] = Field(default_factory=lambda: ["51", "52", "53", "58"])
+    blocked_sell_stock_status_codes: List[str] = Field(default_factory=lambda: ["58"])
     quote_fail_policy: str = "block"        # allow | block
 
     model_config = {"extra": "allow"}

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -102,6 +102,7 @@ class OrderPolicyConfig(BaseModel):
     block_investment_warning: bool = True
     block_investment_caution: bool = False
     blocked_stock_status_codes: List[str] = Field(default_factory=lambda: ["51", "52", "53", "58"])
+    blocked_market_warning_codes: List[str] = Field(default_factory=lambda: ["2", "3"])
     blocked_sell_stock_status_codes: List[str] = Field(default_factory=lambda: ["58"])
     quote_fail_policy: str = "block"        # allow | block
 

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -125,6 +125,7 @@ class StrategyScheduler:
         self.MAX_HISTORY = 200  # 최대 보관 이력 수
         self._signal_history: List[SignalRecord] = self._load_signal_history()
         self._subscriber_queues: List[asyncio.Queue] = []
+        self._strategy_failure_alert_keys: set[tuple[str, str, str, str, str, str]] = set()
 
     # ── 전략 등록 ──
 
@@ -454,6 +455,36 @@ class StrategyScheduler:
 
         return None
 
+    def _should_emit_strategy_signal_notification(
+        self,
+        signal: TradeSignal,
+        *,
+        api_success: bool,
+        failure_msg: str,
+        now: datetime,
+    ) -> bool:
+        if api_success:
+            return True
+
+        date_key = now.strftime("%Y%m%d")
+        key = (
+            date_key,
+            str(signal.strategy_name),
+            str(signal.code),
+            str(signal.action),
+            str(signal.reason),
+            str(failure_msg or ""),
+        )
+        if key in self._strategy_failure_alert_keys:
+            self._logger.info(
+                f"[Scheduler] 중복 전략 실패 알림 suppress: "
+                f"strategy={signal.strategy_name} code={signal.code} action={signal.action}"
+            )
+            return False
+
+        self._strategy_failure_alert_keys.add(key)
+        return True
+
     async def _execute_signal_inner(self, signal: TradeSignal, tid: str):
         self._logger.info(
             f"[Scheduler] 시그널 실행: [{signal.strategy_name}] {signal.action} {signal.name}({signal.code}) "
@@ -482,6 +513,7 @@ class StrategyScheduler:
         return_rate = None
         category_key = f"scheduler_{signal.strategy_name}"
         api_success = True
+        order_error_msg = ""
         resp = None
 
         if self._dry_run:
@@ -587,12 +619,14 @@ class StrategyScheduler:
                 else:
                     api_success = False
                     msg = resp.msg1 if resp else "응답 없음"
+                    order_error_msg = msg
                     self._logger.warning(
                         f"[Scheduler] API 주문 실패: {signal.action} {signal.code} - {msg} "
                         f"(CSV는 기록됨)"
                     )
             except Exception as e:
                 api_success = False
+                order_error_msg = str(e)
                 self._logger.error(
                     f"[Scheduler] API 주문 예외: {signal.action} {signal.code} - {e} "
                     f"(CSV는 기록됨)"
@@ -633,17 +667,26 @@ class StrategyScheduler:
                    f"사유: {signal.reason}")
             if not api_success:
                 title = f"[{signal.strategy_name}] {signal.name} {action_kr} 실패"
-            await self._notification_service.emit(NotificationCategory.STRATEGY, level, title, msg, metadata={
-                "strategy_name": signal.strategy_name,
-                "code": signal.code,
-                "action": signal.action,
-                "price": log_price,
-                "qty": signal.qty,
-                "reason": signal.reason,
-                "api_success": api_success,
-                "return_rate": return_rate,
-                "trace_id": tid,
-            })
+                if order_error_msg:
+                    msg = f"{msg}\n실패: {order_error_msg}"
+            if self._should_emit_strategy_signal_notification(
+                signal,
+                api_success=api_success,
+                failure_msg=order_error_msg,
+                now=now,
+            ):
+                await self._notification_service.emit(NotificationCategory.STRATEGY, level, title, msg, metadata={
+                    "strategy_name": signal.strategy_name,
+                    "code": signal.code,
+                    "action": signal.action,
+                    "price": log_price,
+                    "qty": signal.qty,
+                    "reason": signal.reason,
+                    "order_error": order_error_msg,
+                    "api_success": api_success,
+                    "return_rate": return_rate,
+                    "trace_id": tid,
+                })
 
     async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig):
         """전략 중지 시 보유 종목 강제 청산 (force_exit_on_close=True)."""

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -82,6 +82,11 @@ class OrderExecutionService:
         env = getattr(self.broker_api_wrapper, "env", None)
         return getattr(env, "is_paper_trading", True)
 
+    @staticmethod
+    def _is_strategy_source(source: str) -> bool:
+        text = str(source or "")
+        return text.startswith("strategy:") or text.startswith("strategy_force_exit:")
+
     def _log_real_order_preview(
         self,
         *,
@@ -1637,7 +1642,7 @@ class OrderExecutionService:
                     f"주식 매수 주문 실패: 종목={stock_code}, 결과={{'rt_cd': '{rt_cd}', 'msg1': '{msg1}'}}")
                 if self._virtual_trade_service:
                     await self._virtual_trade_service.log_order_failure_async("BUY", stock_code, price, qty, msg1)
-                if self._notification_service:
+                if self._notification_service and not self._is_strategy_source(source):
                     await self._notification_service.emit(NotificationCategory.SYSTEM, NotificationLevel.ERROR, "매수 주문 실패",
                                         f"{stock_code} - {msg1}",
                                         metadata={"code": stock_code, "error": msg1, "trace_id": current_trace})
@@ -1696,7 +1701,7 @@ class OrderExecutionService:
                     f"주식 매도 주문 실패: 종목={stock_code}, 결과={{'rt_cd': '{rt_cd}', 'msg1': '{msg1}'}}")
                 if self._virtual_trade_service:
                     await self._virtual_trade_service.log_order_failure_async("SELL", stock_code, price, qty, msg1)
-                if self._notification_service:
+                if self._notification_service and not self._is_strategy_source(source):
                     await self._notification_service.emit(NotificationCategory.SYSTEM, NotificationLevel.ERROR, "매도 주문 실패",
                                         f"{stock_code} - {msg1}",
                                         metadata={"code": stock_code, "error": msg1, "trace_id": current_trace})

--- a/services/order_policy_service.py
+++ b/services/order_policy_service.py
@@ -331,14 +331,23 @@ class OrderPolicyService:
                 **context,
             )
 
-        blocked_status_codes = {str(code).strip() for code in self._cfg.blocked_stock_status_codes}
+        blocked_status_codes = {
+            self._normalize_status_code(code)
+            for code in self._cfg.blocked_stock_status_codes
+        }
+        blocked_market_warning_codes = {
+            self._normalize_status_code(code)
+            for code in getattr(self._cfg, "blocked_market_warning_codes", ["2", "3"])
+        }
         if self._cfg.block_investment_warning and (
-            self._is_flagged_code(mrkt_warn_cls_code) or iscd_stat_cls_code in blocked_status_codes
+            self._normalize_status_code(mrkt_warn_cls_code) in blocked_market_warning_codes
+            or self._normalize_status_code(iscd_stat_cls_code) in blocked_status_codes
         ):
             return self._blocked(
                 "investment_warning_stock",
                 "투자경고/위험 또는 거래정지 상태 종목은 주문할 수 없습니다.",
                 blocked_stock_status_codes=sorted(blocked_status_codes),
+                blocked_market_warning_codes=sorted(blocked_market_warning_codes),
                 **context,
             )
 
@@ -672,6 +681,13 @@ class OrderPolicyService:
     def _is_flagged_code(value: str) -> bool:
         text = str(value or "").strip().upper()
         return text not in ("", "0", "00", "000", "N", "NONE", "NULL")
+
+    @staticmethod
+    def _normalize_status_code(value: str) -> str:
+        text = str(value or "").strip().upper()
+        if text.isdigit():
+            return str(int(text))
+        return text
 
     @staticmethod
     def _with_context(decision: OrderPolicyDecision, extra_context: dict[str, Any]) -> OrderPolicyDecision:

--- a/services/order_policy_service.py
+++ b/services/order_policy_service.py
@@ -96,7 +96,7 @@ class OrderPolicyService:
 
         security_context: dict[str, Any] = {}
         if self._cfg.security_status_checks_enabled:
-            security_decision = await self._check_security_status(stock_code, exchange)
+            security_decision = await self._check_security_status(stock_code, exchange, side)
             security_context = security_decision.context
             if security_decision.blocked:
                 return security_decision
@@ -264,6 +264,7 @@ class OrderPolicyService:
         self,
         stock_code: str,
         exchange: Exchange,
+        side: OrderSide,
     ) -> OrderPolicyDecision:
         if self._security_info_provider is None:
             return self._security_status_failure_decision(stock_code, "security_info_provider_missing")
@@ -301,6 +302,27 @@ class OrderPolicyService:
             "invt_caful_yn": invt_caful_yn,
             "market_cap_won": market_cap,
         }
+
+        sell_blocked_status_codes = {
+            str(code).strip()
+            for code in getattr(self._cfg, "blocked_sell_stock_status_codes", ["58"])
+        }
+        if side == OrderSide.SELL and iscd_stat_cls_code in sell_blocked_status_codes:
+            return self._blocked(
+                "trading_halted_stock",
+                "거래정지 상태 종목은 주문할 수 없습니다.",
+                blocked_sell_stock_status_codes=sorted(sell_blocked_status_codes),
+                **context,
+            )
+
+        if side == OrderSide.SELL:
+            return OrderPolicyDecision(
+                allowed=True,
+                rule="security_status",
+                reason="security_status_allowed_for_sell",
+                severity="pass",
+                context=context,
+            )
 
         if self._cfg.block_managed_issue and self._is_flagged_code(mang_issu_cls_code):
             return self._blocked(

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -10,16 +10,25 @@
 """
 
 import math
+import inspect
 import logging
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import Any, Optional, Protocol, Tuple, TYPE_CHECKING
 
-from common.types import TradeSignal
+from common.types import ErrorCode, Exchange, ResCommonResponse, TradeSignal
 from core.account_snapshot import AccountSnapshotCache
 
 if TYPE_CHECKING:
     from services.indicator_service import IndicatorService
-    from common.types import Exchange, ErrorCode
-    from config.config_loader import PositionSizingConfig, RiskGateConfig
+    from config.config_loader import OrderPolicyConfig, PositionSizingConfig, RiskGateConfig
+
+
+class QuoteProvider(Protocol):
+    async def get_asking_price(
+        self,
+        stock_code: str,
+        exchange: Exchange = Exchange.KRX,
+    ) -> ResCommonResponse:
+        ...
 
 
 class PositionSizingService:
@@ -32,12 +41,16 @@ class PositionSizingService:
         config: "PositionSizingConfig",
         logger: Optional[logging.Logger] = None,
         risk_gate_config: Optional["RiskGateConfig"] = None,
+        quote_provider: Optional[QuoteProvider] = None,
+        order_policy_config: Optional["OrderPolicyConfig"] = None,
     ):
         self._cache = account_snapshot_cache
         self._indicator = indicator_service
         self._cfg = config
         self._logger = logger or logging.getLogger(__name__)
         self._risk_gate_config = risk_gate_config
+        self._quote_provider = quote_provider
+        self._order_policy_config = order_policy_config
 
     # ── 공개 API ──────────────────────────────────────────────────
 
@@ -95,15 +108,27 @@ class PositionSizingService:
         # 6. alloc_qty (전략별 자본 할당 캡, None 이면 제약 없음)
         alloc_qty = self._calc_strategy_alloc_qty(signal, price, total_equity)
 
-        # 7. 후보 목록 구성 — signal.qty / alloc_qty 는 None 이면 제외 (제약 없음)
-        candidates = [risk_qty, cap_qty, cash_qty]
-        if alloc_qty is not None:
-            candidates.append(alloc_qty)
-        if signal.qty is not None:
-            candidates.append(signal.qty)
-        final_qty = max(0, min(candidates))
+        # 7. 주문 직전 hard-block 정책과 같은 한도도 미리 수량에 반영
+        max_order_amount_qty = self._calc_max_order_amount_qty(price)
+        top_of_book_qty = await self._calc_top_of_book_qty(signal, price, exchange)
 
-        # 8. 사유 결정
+        # 8. 후보 목록 구성 — signal.qty / alloc_qty 는 None 이면 제외 (제약 없음)
+        candidates = {
+            "risk_limited": risk_qty,
+            "cap_limited": cap_qty,
+            "cash_limited": cash_qty,
+        }
+        if alloc_qty is not None:
+            candidates["strategy_capital_cap"] = alloc_qty
+        if max_order_amount_qty is not None:
+            candidates["max_order_amount_limited"] = max_order_amount_qty
+        if top_of_book_qty is not None:
+            candidates["top_of_book_limited"] = top_of_book_qty
+        if signal.qty is not None:
+            candidates["signal_cap"] = signal.qty
+        final_qty = max(0, min(candidates.values()))
+
+        # 9. 사유 결정
         if final_qty == 0:
             if risk_qty == 0:
                 reason = "risk_zero"
@@ -111,26 +136,34 @@ class PositionSizingService:
                 reason = "cap_exhausted"
             elif alloc_qty is not None and alloc_qty == 0:
                 reason = "strategy_capital_cap"
+            elif max_order_amount_qty is not None and max_order_amount_qty == 0:
+                reason = "max_order_amount_limited"
+            elif top_of_book_qty is not None and top_of_book_qty == 0:
+                reason = "top_of_book_limited"
             else:
                 reason = "cash_short"
         elif signal.qty is not None and final_qty == signal.qty:
             reason = "ok"
         else:
             # signal.qty 상한보다 작게 됐거나, qty=None 에서 sizing 이 단독 결정
-            limiting = min(risk_qty, cap_qty, cash_qty, *([alloc_qty] if alloc_qty is not None else []))
-            if alloc_qty is not None and limiting == alloc_qty:
-                reason = "strategy_capital_cap"
-            elif limiting == cash_qty:
-                reason = "cash_limited"
-            elif limiting == cap_qty:
-                reason = "cap_limited"
-            else:
-                reason = "risk_limited"
+            reason_priority = (
+                "strategy_capital_cap",
+                "max_order_amount_limited",
+                "top_of_book_limited",
+                "cash_limited",
+                "cap_limited",
+                "risk_limited",
+            )
+            reason = next(
+                key for key in reason_priority
+                if candidates.get(key) == final_qty
+            )
 
         self._logger.info(
             f"[PositionSizing] {signal.code} price={price:,} "
             f"equity={total_equity:,} risk/share={per_share_risk:.0f} "
             f"risk_qty={risk_qty} cap_qty={cap_qty} cash_qty={cash_qty} alloc_qty={alloc_qty} "
+            f"max_order_amount_qty={max_order_amount_qty} top_of_book_qty={top_of_book_qty} "
             f"signal_qty={signal.qty} → final={final_qty} ({reason})"
         )
         return final_qty, reason
@@ -153,6 +186,65 @@ class PositionSizingService:
 
         alloc_budget = int(total_equity * cap_pct / 100)
         return math.floor(alloc_budget / price)
+
+    def _calc_max_order_amount_qty(self, price: int) -> Optional[int]:
+        if not self._risk_gate_config or price <= 0:
+            return None
+        max_amount = int(getattr(self._risk_gate_config, "max_order_amount_won", 0) or 0)
+        if max_amount <= 0:
+            return None
+        return math.floor(max_amount / price)
+
+    async def _calc_top_of_book_qty(
+        self,
+        signal: TradeSignal,
+        price: int,
+        exchange: "Exchange | None",
+    ) -> Optional[int]:
+        if self._quote_provider is None or price <= 0:
+            return None
+        if self._order_policy_config is not None and not getattr(
+            self._order_policy_config, "order_book_checks_enabled", True
+        ):
+            return None
+
+        try:
+            resp = self._quote_provider.get_asking_price(
+                signal.code,
+                exchange=exchange or Exchange.KRX,
+            )
+            if inspect.isawaitable(resp):
+                resp = await resp
+        except TypeError:
+            try:
+                resp = self._quote_provider.get_asking_price(signal.code)
+                if inspect.isawaitable(resp):
+                    resp = await resp
+            except Exception as exc:
+                self._logger.debug(f"[PositionSizing] 호가 조회 실패 ({signal.code}): {exc}")
+                return None
+        except Exception as exc:
+            self._logger.debug(f"[PositionSizing] 호가 조회 실패 ({signal.code}): {exc}")
+            return None
+
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return None
+
+        quote = self._extract_quote_data(resp.data)
+        ask_qty = self._to_int(self._pick(quote, "askp_rsqn1", "매도호가잔량1"))
+        if ask_qty <= 0:
+            return None
+
+        max_pct = 100.0
+        if self._order_policy_config is not None:
+            max_pct = float(getattr(
+                self._order_policy_config,
+                "max_top_of_book_participation_pct",
+                100.0,
+            ) or 0.0)
+        if max_pct > 0:
+            return math.floor(ask_qty * max_pct / 100)
+        return ask_qty
 
     async def _get_per_share_risk_krw(self, signal: TradeSignal, price: int) -> float:
         """1주당 리스크 금액(KRW) — ATR 기반 또는 stop_loss_pct 기반."""
@@ -182,3 +274,27 @@ class PositionSizingService:
         except Exception as e:
             self._logger.debug(f"[PositionSizing] ATR 조회 실패 ({signal.code}): {e}")
             return 0.0
+
+    @staticmethod
+    def _extract_quote_data(data: Any) -> dict:
+        if isinstance(data, dict):
+            if isinstance(data.get("output1"), dict):
+                return data["output1"]
+            if isinstance(data.get("output"), dict):
+                return data["output"]
+            return data
+        return {}
+
+    @staticmethod
+    def _pick(data: dict, *keys: str):
+        for key in keys:
+            if key in data:
+                return data.get(key)
+        return None
+
+    @staticmethod
+    def _to_int(value) -> int:
+        try:
+            return int(float(str(value or "0").replace(",", "")))
+        except (TypeError, ValueError):
+            return 0

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1661,6 +1661,33 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         args, _ = scheduler._logger.warning.call_args
         self.assertIn("응답 없음", args[0])
 
+    async def test_duplicate_strategy_failure_alert_is_suppressed_for_same_day(self):
+        scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
+        notification_service = AsyncMock()
+        notification_service.emit = AsyncMock()
+        scheduler._notification_service = notification_service
+        oes.handle_place_sell_order.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+            msg1="Order Policy 차단: 거래정지 상태 종목은 주문할 수 없습니다.",
+        )
+        signal = TradeSignal(
+            code="037030",
+            name="파워넷",
+            action="SELL",
+            price=9980,
+            qty=1,
+            reason="오버나이트방어: 매수일(20260506) ≠ 오늘(20260507)",
+            strategy_name="래리윌리엄스VBO",
+        )
+
+        await scheduler._execute_signal(signal)
+        await scheduler._execute_signal(signal)
+
+        notification_service.emit.assert_awaited_once()
+        args, _ = notification_service.emit.await_args
+        self.assertEqual(args[0], NotificationCategory.STRATEGY)
+        self.assertIn("Order Policy 차단", args[3])
+
     def test_load_signal_history_branches(self):
         """시그널 히스토리 로드 분기 테스트."""
         scheduler, _, _, _, _ = self._make_scheduler()

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -303,6 +303,29 @@ async def test_handle_place_sell_order_trading_service_failure(handler, mock_bro
     assert result.rt_cd == "1"
     assert result.msg1 == "수량 부족"
 
+
+@pytest.mark.asyncio
+async def test_strategy_sell_failure_does_not_emit_duplicate_system_notification(
+    handler,
+    mock_broker_api_wrapper,
+    mock_notification_service,
+):
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="거래정지",
+        data=None,
+    )
+
+    result = await handler.handle_place_sell_order(
+        "005930",
+        60000,
+        5,
+        source="strategy:래리윌리엄스VBO",
+    )
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    mock_notification_service.emit.assert_not_awaited()
+
 @pytest.mark.asyncio # This test is not directly related to the market open check, but it's good to ensure it still works.
 async def test_handle_realtime_price_quote_stream_success(handler, mock_broker_api_wrapper, mock_logger, mock_market_calendar_service):
     """실시간 스트림이 성공적으로 연결, 구독, 종료되는지 테스트합니다."""

--- a/tests/unit_test/services/test_order_policy_service.py
+++ b/tests/unit_test/services/test_order_policy_service.py
@@ -380,6 +380,49 @@ async def test_security_status_blocks_configured_stock_status_code():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", ["52", "53"])
+async def test_security_status_allows_sell_for_investment_risk_or_warning(status_code):
+    provider = AsyncMock()
+    provider.get_current_price.return_value = _stock_info(iscd_stat_cls_code=status_code)
+    svc = _service(
+        config=OrderPolicyConfig(order_book_checks_enabled=False),
+        security_info_provider=provider,
+    )
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_000,
+        qty=1,
+        side=OrderSide.SELL,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule == "limit_tick_size"
+
+
+@pytest.mark.asyncio
+async def test_security_status_blocks_sell_for_trading_halt():
+    provider = AsyncMock()
+    provider.get_current_price.return_value = _stock_info(iscd_stat_cls_code="58")
+    svc = _service(
+        config=OrderPolicyConfig(order_book_checks_enabled=False),
+        security_info_provider=provider,
+    )
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_000,
+        qty=1,
+        side=OrderSide.SELL,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.blocked is True
+    assert decision.rule == "trading_halted_stock"
+
+
+@pytest.mark.asyncio
 async def test_security_status_blocks_investment_caution_when_enabled():
     provider = AsyncMock()
     provider.get_current_price.return_value = _stock_info(invt_caful_yn="Y")

--- a/tests/unit_test/services/test_order_policy_service.py
+++ b/tests/unit_test/services/test_order_policy_service.py
@@ -380,6 +380,51 @@ async def test_security_status_blocks_configured_stock_status_code():
 
 
 @pytest.mark.asyncio
+async def test_security_status_allows_investment_caution_54_by_default():
+    provider = AsyncMock()
+    provider.get_current_price.return_value = _stock_info(
+        iscd_stat_cls_code="54",
+        invt_caful_yn="Y",
+    )
+    svc = _service(
+        config=OrderPolicyConfig(order_book_checks_enabled=False),
+        security_info_provider=provider,
+    )
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_000,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule == "limit_tick_size"
+
+
+@pytest.mark.asyncio
+async def test_security_status_allows_market_warning_caution_code_by_default():
+    provider = AsyncMock()
+    provider.get_current_price.return_value = _stock_info(mrkt_warn_cls_code="1")
+    svc = _service(
+        config=OrderPolicyConfig(order_book_checks_enabled=False),
+        security_info_provider=provider,
+    )
+
+    decision = await svc.validate_order(
+        stock_code="005930",
+        price=70_000,
+        qty=1,
+        side=OrderSide.BUY,
+        exchange=Exchange.KRX,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule == "limit_tick_size"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", ["52", "53"])
 async def test_security_status_allows_sell_for_investment_risk_or_warning(status_code):
     provider = AsyncMock()

--- a/tests/unit_test/services/test_position_sizing_service.py
+++ b/tests/unit_test/services/test_position_sizing_service.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from services.position_sizing_service import PositionSizingService
-from config.config_loader import PositionSizingConfig
+from config.config_loader import OrderPolicyConfig, PositionSizingConfig, RiskGateConfig
 from common.types import TradeSignal, ResCommonResponse, ErrorCode
 from core.account_snapshot import AccountSnapshot
 
@@ -30,7 +30,27 @@ def _make_snapshot(total_equity=10_000_000, available_cash=5_000_000, positions=
     )
 
 
-def _make_service(snapshot, atr_value=0.0, cfg=None):
+def _quote(ask_qty=100):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data={
+            "askp1": "10000",
+            "bidp1": "9990",
+            "askp_rsqn1": str(ask_qty),
+            "bidp_rsqn1": "100",
+        },
+    )
+
+
+def _make_service(
+    snapshot,
+    atr_value=0.0,
+    cfg=None,
+    risk_gate_config=None,
+    quote_provider=None,
+    order_policy_config=None,
+):
     cache = AsyncMock()
     cache.get.return_value = snapshot
 
@@ -47,6 +67,9 @@ def _make_service(snapshot, atr_value=0.0, cfg=None):
         account_snapshot_cache=cache,
         indicator_service=indicator,
         config=cfg or _make_config(),
+        risk_gate_config=risk_gate_config,
+        quote_provider=quote_provider,
+        order_policy_config=order_policy_config,
     )
     return svc, cache, indicator
 
@@ -291,3 +314,76 @@ async def test_qty_int_acts_as_voluntary_cap():
     qty, reason = await svc.adjust_buy_qty(_buy_signal(price=10_000, qty=50))
     assert qty == 50
     assert reason == "ok"
+
+
+@pytest.mark.asyncio
+async def test_max_order_amount_limits_qty_before_risk_gate():
+    """단일 주문 한도를 넘는 수량은 RiskGate에서 실패하기 전에 줄인다."""
+    snap = _make_snapshot(total_equity=1_000_000_000, available_cash=1_000_000_000)
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+    )
+    risk_cfg = RiskGateConfig(max_order_amount_won=50_000_000)
+    svc, _, _ = _make_service(snap, cfg=cfg, risk_gate_config=risk_cfg)
+
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=135_900, qty=375))
+
+    assert qty == 367
+    assert 135_900 * qty <= 50_000_000
+    assert reason == "max_order_amount_limited"
+
+
+@pytest.mark.asyncio
+async def test_top_of_book_qty_limits_buy_qty_before_order_policy():
+    """최우선 매도호가 잔량보다 큰 매수 수량은 주문 전 줄인다."""
+    snap = _make_snapshot(total_equity=1_000_000_000, available_cash=1_000_000_000)
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+    )
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = _quote(ask_qty=200)
+    svc, _, _ = _make_service(
+        snap,
+        cfg=cfg,
+        quote_provider=provider,
+        order_policy_config=OrderPolicyConfig(order_book_checks_enabled=True),
+    )
+
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=51_800, qty=921))
+
+    assert qty == 200
+    assert reason == "top_of_book_limited"
+
+
+@pytest.mark.asyncio
+async def test_top_of_book_participation_limits_buy_qty():
+    """호가 잔량 참여율 제한도 포지션 사이징 단계에서 반영한다."""
+    snap = _make_snapshot(total_equity=1_000_000_000, available_cash=1_000_000_000)
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+    )
+    provider = AsyncMock()
+    provider.get_asking_price.return_value = _quote(ask_qty=100)
+    svc, _, _ = _make_service(
+        snap,
+        cfg=cfg,
+        quote_provider=provider,
+        order_policy_config=OrderPolicyConfig(
+            order_book_checks_enabled=True,
+            max_top_of_book_participation_pct=50.0,
+        ),
+    )
+
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=10_000, qty=80))
+
+    assert qty == 50
+    assert reason == "top_of_book_limited"

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -467,6 +467,8 @@ class WebAppContext:
 
         try:
             _ps_cfg = getattr(self.full_config, "position_sizing", None) or PositionSizingConfig()
+            _rg_cfg = getattr(self.full_config, "risk_gate", None) or RiskGateConfig()
+            _op_cfg = getattr(self.full_config, "order_policy", None) or OrderPolicyConfig()
             self.account_snapshot_cache = AccountSnapshotCache(
                 broker_api_wrapper=self.broker,
                 logger=self.logger,
@@ -477,16 +479,18 @@ class WebAppContext:
                 indicator_service=self.indicator_service,
                 config=_ps_cfg,
                 logger=self.logger,
+                risk_gate_config=_rg_cfg,
+                quote_provider=self.broker,
+                order_policy_config=_op_cfg,
             )
             self.risk_gate_service = RiskGateService(
-                config=getattr(self.full_config, "risk_gate", None) or RiskGateConfig(),
+                config=_rg_cfg,
                 kill_switch_service=self.kill_switch_service,
                 account_snapshot_cache=self.account_snapshot_cache,
                 strategy_risk_provider=self.virtual_trade_service,
                 logger=self.logger,
                 env=getattr(self.broker, "env", None),
             )
-            _op_cfg = getattr(self.full_config, "order_policy", None) or OrderPolicyConfig()
             self.execution_flow_service = ExecutionFlowService(
                 data_provider=self.broker,
                 market_clock=self.market_clock,


### PR DESCRIPTION
원인 파악해서 수정했습니다.

투경/투자위험 매도 실패의 직접 원인은
order_policy_service.py (line 96)
에서 종목상태 차단을 매수/매도 구분 없이 적용한 것이었습니다. 이제 매도는 58 거래정지만 차단하고, 52 투자위험 / 53 투자경고는 매도 가능하도록 바꿨습니다. 설정에도 blocked_sell_stock_status_codes (line 105)
를 추가해서 기본값은 ["58"]입니다.

알람이 수십 번 반복된 건 VBO가 실패한 오버나이트 SELL을 다음 주기마다 다시 시도하고, 주문 서비스의 SYSTEM 알림과 스케줄러의 STRATEGY 알림이 같이 나갔기 때문입니다. 전략 주문 실패는 스케줄러 알림 하나로 모으고, 같은 날 같은 전략/종목/액션/사유/실패 메시지는 한 번만 알리도록 strategy_scheduler.py (line 458)
에 중복 억제를 넣었습니다. 실패 알림에는 이제 실제 주문 실패 사유도 포함됩니다.

검증:
4017 passed 단위 테스트 전체 통과
203 passed 통합 테스트 전체 통과