### PR TITLE
원인 잡아서 수정했습니다.

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -760,7 +760,12 @@ class OneilUniverseService:
                     category=NotificationCategory.STRATEGY,
                     level=level,
                     title=title,
-                    message=msg
+                    message=msg,
+                    metadata={
+                        "force_external": True,
+                        "event": "market_timing_updated",
+                        "market": market,
+                    },
                 )
 
     async def _check_etf_ma_rising(self, etf_code: str, logger: Optional[logging.Logger] = None) -> Tuple[bool, str, List[float]]:

--- a/task/background/always_on/notification_queue_task.py
+++ b/task/background/always_on/notification_queue_task.py
@@ -143,6 +143,9 @@ class NotificationQueueTask(SchedulableTask):
             return True
         if not getattr(cfg, "enabled", True):
             return False
+        metadata = getattr(event, "metadata", {}) or {}
+        if isinstance(metadata, dict) and metadata.get("force_external"):
+            return True
         route_levels = getattr(cfg, "route_levels", None)
         if not route_levels:
             return True

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1687,6 +1687,8 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     second_call = notification.emit.await_args_list[1].kwargs
     assert first_call["level"] == service._notification_service.emit.await_args_list[0].kwargs["level"]
     assert "[tester] 마켓 타이밍 갱신 (KOSDAQ)" == first_call["title"]
+    assert first_call["metadata"] == {"force_external": True, "event": "market_timing_updated", "market": "KOSDAQ"}
+    assert second_call["metadata"] == {"force_external": True, "event": "market_timing_updated", "market": "KOSPI"}
     assert "MA decline" in second_call["message"]
 
 

--- a/tests/unit_test/task/background/always_on/test_notification_queue_task.py
+++ b/tests/unit_test/task/background/always_on/test_notification_queue_task.py
@@ -286,6 +286,36 @@ async def test_drain_loop_filters_telegram_by_category_level(ns):
 
 
 @pytest.mark.asyncio
+async def test_drain_loop_sends_force_external_event_even_when_level_filtered(ns):
+    """metadata.force_external=True 이벤트는 레벨 라우팅에서 제외돼도 외부 핸들러에 전달한다."""
+    handler = AsyncMock()
+    ns.register_external_handler(handler)
+    task = NotificationQueueTask(
+        ns,
+        poll_interval=0,
+        telegram_config=SimpleNamespace(
+            enabled=True,
+            route_levels={"STRATEGY": ["warning", "error", "critical"]},
+        ),
+        logger=MagicMock(),
+    )
+
+    event = await ns.emit(
+        NotificationCategory.STRATEGY,
+        NotificationLevel.INFO,
+        "market timing",
+        "telegram",
+        metadata={"force_external": True},
+    )
+
+    await task.start()
+    await asyncio.wait_for(ns.external_handler_queue.join(), timeout=2.0)
+    await task.stop()
+
+    handler.assert_awaited_once_with(event)
+
+
+@pytest.mark.asyncio
 async def test_drain_loop_skips_external_when_telegram_disabled(ns):
     handler = AsyncMock()
     ns.register_external_handler(handler)


### PR DESCRIPTION
market_timing 알림은 웹 notification에는 정상 발행되고 있었지만, Telegram 큐에서 STRATEGY + info 레벨이 필터링되고 있었습니다. 현재 설정은 STRATEGY Telegram 전송을 warning/error/critical만 허용하거든요. 그래서 초록색 “매수 적합” 알림처럼 info로 발행되는 마켓 타이밍 갱신은 Telegram까지 가지 않았습니다.

수정 내용:

oneil_universe_service.py (line 765): 마켓 타이밍 갱신 알림에 metadata.force_external=True 추가

notification_queue_task.py (line 147): Telegram이 활성화된 상태에서는 force_external 이벤트가 레벨 필터를 우회하도록 처리

전체 STRATEGY info를 열지는 않았습니다. 마켓 타이밍 같은 지정 이벤트만 Telegram으로 나가게 했습니다.

pre_market_health_check도 확인했습니다. 역할은 장 시작 30분 전, 영업일마다 1회 실행되는 운영 점검입니다:

env/API 설정 누락 확인

토큰 접근 가능 여부 확인

현재가 API와 잔고 API 가벼운 probe

data quality 서비스 활성 여부 확인

streaming desired 상태 조회 가능 여부 확인

문제가 있으면 SYSTEM + error로 “장 시작 전 상태 점검 실패” 알림 발행

정상일 때는 알림 없이 로그만 남김

검증:

관련 단위 테스트 통과

pytest tests/unit_test -v: 4069 passed

pytest tests/integration_test -v: 205 passed

실운영에서는 다음 마켓 타이밍 갱신부터 사진의 알림도 Telegram으로 같이 나가야 합니다.