### PR TITLE
signal_history DB 정리:

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -632,6 +632,20 @@ class StrategyScheduler:
                     f"(CSV는 기록됨)"
                 )
 
+        # BUY 실패 시 전략 내부 position_state에서 즉시 제거 (stale holding 방지)
+        if not api_success and signal.action == "BUY":
+            for _cfg in self._strategies:
+                if _cfg.strategy.name == signal.strategy_name:
+                    _ps = self._get_strategy_position_state(_cfg.strategy)
+                    if signal.code in _ps:
+                        _ps.pop(signal.code, None)
+                        self._persist_strategy_position_state(_cfg.strategy)
+                        self._logger.warning(
+                            f"[Scheduler] 매수 실패 position_state 정리: "
+                            f"strategy={signal.strategy_name}, code={signal.code}"
+                        )
+                    break
+
         if signal.action == "SELL" and return_rate is None and api_success:
             return_rate = self._estimate_return_rate_from_hold(
                 signal.strategy_name, signal.code, log_price
@@ -1117,6 +1131,7 @@ class StrategyScheduler:
                 "interval_minutes": cfg.interval_minutes,
                 "max_positions": cfg.max_positions,
                 "enabled": cfg.enabled,
+                "force_exit_on_close": cfg.force_exit_on_close,
                 "current_holds": len(holdings),
                 "holdings": holdings,  # 상세 보유 내역 추가
                 "last_run": last.strftime("%H:%M:%S") if last else None,

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1842,6 +1842,39 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertIn("루프 오류", args[0])
         self.assertIn("Time Error", args[0])
 
+    def test_get_status_includes_force_exit_on_close(self):
+        """get_status()가 force_exit_on_close 필드를 올바르게 노출하는지 테스트."""
+        scheduler, _, _, _, _ = self._make_scheduler()
+        strategy_on = MockStrategy(name="당일청산전략")
+        strategy_off = MockStrategy(name="일반전략")
+        scheduler.register(StrategySchedulerConfig(strategy=strategy_on, force_exit_on_close=True))
+        scheduler.register(StrategySchedulerConfig(strategy=strategy_off, force_exit_on_close=False))
+
+        status = scheduler.get_status()
+        by_name = {s["name"]: s for s in status["strategies"]}
+        self.assertTrue(by_name["당일청산전략"]["force_exit_on_close"])
+        self.assertFalse(by_name["일반전략"]["force_exit_on_close"])
+
+    async def test_execute_signal_buy_failure_cleans_position_state(self):
+        """BUY API 실패 시 strategy._position_state에서 해당 종목이 제거되는지 테스트."""
+        scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
+        strategy = MockStrategy(name="테스트전략")
+        strategy._position_state = {"028050": {}}
+        strategy._save_state = MagicMock()
+        scheduler.register(StrategySchedulerConfig(strategy=strategy))
+
+        oes.handle_place_buy_order.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.API_ERROR.value, msg1="매수 거부"
+        )
+        signal = TradeSignal(
+            code="028050", name="보락", action="BUY",
+            price=5000, qty=1, reason="테스트", strategy_name="테스트전략"
+        )
+        await scheduler._execute_signal(signal)
+
+        self.assertNotIn("028050", strategy._position_state)
+        strategy._save_state.assert_called_once()
+
     async def test_force_liquidate_fallback_qty(self):
         """강제 청산 시 보유 수량 정보가 없으면 설정된 주문 수량을 사용하는지 테스트."""
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)

--- a/view/web/static/js/scheduler.js
+++ b/view/web/static/js/scheduler.js
@@ -92,6 +92,9 @@ function renderSchedulerStatus(data) {
         const enabledBadge = s.enabled
             ? '<span class="badge open">활성</span>'
             : '<span class="badge closed">비활성</span>';
+        const dayTradeBadge = s.force_exit_on_close
+            ? '<span class="badge" style="background:#f59e0b;color:#fff;font-size:0.8em;">당일청산</span>'
+            : '';
         const positionBadge = `<span class="badge ${s.current_holds >= s.max_positions ? 'closed' : 'paper'}" style="cursor:pointer;" onclick="updateMaxPositions('${s.name}', ${s.max_positions})" title="클릭하여 최대 포지션 수 변경">포지션 ${s.current_holds}/${s.max_positions} ✏️</span>`;
         const toggleBtn = s.enabled
             ? `<button class="btn btn-sell" style="padding:4px 12px;font-size:0.85em;" onclick="stopStrategy('${s.name}')">정지</button>`
@@ -115,6 +118,7 @@ function renderSchedulerStatus(data) {
                 <div style="display:flex;align-items:center;gap:8px;">
                     <h3 style="margin:0;color:var(--text-primary);">${s.name}</h3>
                     ${enabledBadge}
+                    ${dayTradeBadge}
                 </div>
                 <div style="display:flex;align-items:center;gap:8px;">
                     ${positionBadge}


### PR DESCRIPTION
VBO 래리윌리엄스VBO의 037030 (파워넷) 82건 삭제 (BUY 1건 + failed SELL 스팸 81건) HTF/LWCB 관련 failed BUY 3건 삭제 (HTF 080580, LWCB 028050/007810 — 이미 position_state는 이전에 정리) 037030 잔류 (정상):

오닐PP/BGU BUY (qty=58, api_success=1) + SELL 시도 1건 → 오닐PP/BGU는 파워넷을 실제 보유 중이므로 유지 TC 추가 요약 (이전 작업):

test_get_status_includes_force_exit_on_close: get_status() 응답에 force_exit_on_close 필드가 True/False 모두 올바르게 노출되는지 검증 test_execute_signal_buy_failure_cleans_position_state: BUY API 실패 시 _position_state에서 해당 종목이 제거되고 _save_state가 호출되는지 검증 둘 다 PASSED