### PR TITLE
API 호출 최적화

### DIFF
--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1,5 +1,6 @@
 # app/stock_query_service.py
 from __future__ import annotations
+import time
 from common.types import ErrorCode, ResCommonResponse, ResTopMarketCapApiItem, ResBasicStockInfo, \
     ResStockFullInfoApiOutput, Exchange
 from config.DynamicConfig import DynamicConfig
@@ -19,7 +20,9 @@ class StockQueryService:
                  ranking_task=None, performance_profiler: Optional[PerformanceProfiler] = None,
                  notification_service: Optional[NotificationService] = None,
                  broker_api_wrapper=None,
-                 streaming_logger=None):
+                 streaming_logger=None,
+                 price_stream_service=None,
+                 snapshot_max_age_sec: float = 5.0):
         self.broker = broker_api_wrapper
         self.market_data_service = market_data_service
         self.logger = logger
@@ -29,6 +32,14 @@ class StockQueryService:
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._notification_service = notification_service
         self._streaming_logger = streaming_logger
+        self.price_stream_service = price_stream_service
+        self._snapshot_max_age_sec = snapshot_max_age_sec
+        self._price_lookup_stats: Dict[str, int] = {
+            "snapshot_hit": 0,
+            "no_tick_fallback": 0,
+            "stale_fallback": 0,
+            "rest_fallback": 0,
+        }
 
     def _get_sign_from_code(self, sign_code):
         """API 응답의 부호 코드(1,2,3,4,5)를 실제 부호 문자열로 변환합니다."""
@@ -39,9 +50,82 @@ class StockQueryService:
         else:  # 3:보합 (또는 기타)
             return ""
 
+    def _build_snapshot_response(self, snap: dict) -> ResCommonResponse:
+        """PriceStreamService 캐시 dict → ResCommonResponse(output=ResStockFullInfoApiOutput) 변환.
+
+        snapshot에 없는 필드는 ""로 채워진다. 호출자가 per/pbr 같은
+        REST 전용 필드가 필요하면 force_fresh=True를 사용한다.
+        """
+        fields = {name: "" for name in ResStockFullInfoApiOutput.model_fields}
+        fields.update({
+            "stck_prpr": str(snap.get("price") or "0"),
+            "prdy_vrss": str(snap.get("change") or "0"),
+            "prdy_ctrt": str(snap.get("rate") or "0.00"),
+            "prdy_vrss_sign": str(snap.get("sign") or "3"),
+            "acml_vol": str(snap.get("acml_vol") or "0"),
+            "acml_tr_pbmn": str(snap.get("acml_tr_pbmn") or "0"),
+        })
+        output = ResStockFullInfoApiOutput.model_validate(fields)
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="snapshot",
+            data={"output": output},
+        )
+
     async def get_current_price(self, stock_code: str, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
-        """현재가만 빠르게 조회 (MarketDataService 래퍼)."""
-        return await self.market_data_service.get_current_price(stock_code, exchange=exchange, count_stats=count_stats, caller=caller, force_fresh=force_fresh)
+        """현재가 조회. WebSocket snapshot이 신선하면 우선 사용하고 REST는 fallback으로 제한.
+
+        우선순위:
+          1) PriceStreamService snapshot (received_at이 snapshot_max_age_sec 이내)
+          2) REST (MarketDataService → StockRepository 캐시 → broker API)
+
+        force_fresh=True 또는 price_stream_service 미주입 시 항상 REST.
+        REST 성공 시 snapshot 캐시를 backfill해 다음 호출에서 hit 가능하게 한다.
+
+        per/pbr/eps 같이 snapshot에 없는 REST 전용 필드가 필요하면 force_fresh=True를 지정한다.
+        """
+        if not force_fresh and self.price_stream_service is not None:
+            snap = self.price_stream_service.get_cached_price(stock_code)
+            if snap is None:
+                # 구독 중이나 tick 미수신 → REST fallback
+                self._price_lookup_stats["no_tick_fallback"] += 1
+                self.logger.debug({"event": "price_lookup_no_tick", "code": stock_code, "caller": caller})
+            else:
+                received_at = snap.get("received_at", 0.0) or 0.0
+                age = time.time() - received_at
+                if age <= self._snapshot_max_age_sec:
+                    self._price_lookup_stats["snapshot_hit"] += 1
+                    return self._build_snapshot_response(snap)
+                else:
+                    self._price_lookup_stats["stale_fallback"] += 1
+                    self.logger.debug({"event": "price_lookup_stale", "code": stock_code,
+                                       "age_sec": round(age, 2), "caller": caller})
+
+        self._price_lookup_stats["rest_fallback"] += 1
+        resp = await self.market_data_service.get_current_price(
+            stock_code, exchange=exchange, count_stats=count_stats, caller=caller, force_fresh=force_fresh
+        )
+
+        # REST 성공 응답을 snapshot 캐시에 backfill (다음 동일 종목 조회 hit 유도)
+        if (self.price_stream_service is not None
+                and resp is not None
+                and resp.rt_cd == ErrorCode.SUCCESS.value):
+            try:
+                output = (resp.data or {}).get("output")
+                if isinstance(output, ResStockFullInfoApiOutput):
+                    self.price_stream_service.cache_price_snapshot(
+                        stock_code,
+                        price=str(output.stck_prpr or ""),
+                        change=str(output.prdy_vrss or "0"),
+                        rate=str(output.prdy_ctrt or "0.00"),
+                        sign=str(output.prdy_vrss_sign or "3"),
+                        volume=str(output.acml_vol or "0"),
+                        acml_tr_pbmn=str(output.acml_tr_pbmn or "0"),
+                    )
+            except Exception as e:
+                self.logger.debug({"event": "snapshot_backfill_skipped", "code": stock_code, "error": str(e)})
+
+        return resp
 
     async def get_multi_price(self, stock_codes: list[str]) -> ResCommonResponse:
         """복수종목 현재가 조회 (최대 30종목, MarketDataService 래퍼)."""

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -160,6 +160,131 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result, expected_response)
 
+    # --- get_current_price snapshot-first 테스트 ---
+
+    def _make_fresh_snap(self, price="75000", acml_vol=1000000, acml_tr_pbmn=5000000000, age_sec=0.0):
+        import time
+        return {
+            "price": price,
+            "change": "500",
+            "rate": "0.67",
+            "sign": "2",
+            "acml_vol": acml_vol,
+            "acml_tr_pbmn": acml_tr_pbmn,
+            "received_at": time.time() - age_sec,
+            "latency_sec": 0.01,
+            "quality_status": "ok",
+            "quality_reason": "ok",
+        }
+
+    def _setup_sqs_with_pss(self, snap=None, snapshot_max_age_sec=5.0):
+        from unittest.mock import MagicMock
+        mock_pss = MagicMock()
+        mock_pss.get_cached_price.return_value = snap
+        mock_pss.cache_price_snapshot = MagicMock()
+        self.stockQueryService.price_stream_service = mock_pss
+        self.stockQueryService._snapshot_max_age_sec = snapshot_max_age_sec
+        return mock_pss
+
+    async def test_get_current_price_snapshot_hit_skips_rest(self):
+        """신선한 snapshot → REST 호출 0회, snapshot 값 반환."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap(price="75000", acml_vol=500000, acml_tr_pbmn=3000000000)
+        mock_pss = self._setup_sqs_with_pss(snap=snap)
+
+        result = await self.stockQueryService.get_current_price("005930")
+
+        self.mock_market_data_service.get_current_price.assert_not_awaited()
+        self.assertEqual(result.rt_cd, ErrorCode.SUCCESS.value)
+        output = result.data["output"]
+        self.assertEqual(output.stck_prpr, "75000")
+        self.assertEqual(output.acml_vol, "500000")
+        self.assertEqual(output.acml_tr_pbmn, "3000000000")
+
+    async def test_get_current_price_snapshot_hit_increments_counter(self):
+        """snapshot hit 시 _price_lookup_stats['snapshot_hit'] 증가."""
+        snap = self._make_fresh_snap()
+        self._setup_sqs_with_pss(snap=snap)
+        before = self.stockQueryService._price_lookup_stats["snapshot_hit"]
+
+        await self.stockQueryService.get_current_price("005930")
+
+        self.assertEqual(self.stockQueryService._price_lookup_stats["snapshot_hit"], before + 1)
+
+    async def test_get_current_price_stale_snapshot_falls_back_to_rest(self):
+        """stale snapshot (age > threshold) → REST fallback."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap(age_sec=10.0)  # 10초 경과 → stale
+        mock_pss = self._setup_sqs_with_pss(snap=snap, snapshot_max_age_sec=5.0)
+        expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()})
+        self.mock_market_data_service.get_current_price.return_value = expected
+
+        result = await self.stockQueryService.get_current_price("005930")
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        self.assertEqual(self.stockQueryService._price_lookup_stats["stale_fallback"], 1)
+
+    async def test_get_current_price_no_tick_falls_back_to_rest(self):
+        """snapshot None (구독 중이나 tick 미수신) → REST fallback."""
+        mock_pss = self._setup_sqs_with_pss(snap=None)
+        expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()})
+        self.mock_market_data_service.get_current_price.return_value = expected
+
+        await self.stockQueryService.get_current_price("005930")
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        self.assertEqual(self.stockQueryService._price_lookup_stats["no_tick_fallback"], 1)
+
+    async def test_get_current_price_force_fresh_bypasses_snapshot(self):
+        """force_fresh=True → 신선한 snapshot 있어도 REST 직접 호출."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap()
+        mock_pss = self._setup_sqs_with_pss(snap=snap)
+        expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()})
+        self.mock_market_data_service.get_current_price.return_value = expected
+
+        await self.stockQueryService.get_current_price("005930", force_fresh=True)
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        mock_pss.get_cached_price.assert_not_called()
+
+    async def test_get_current_price_no_pss_uses_rest(self):
+        """price_stream_service=None → 기존 REST 경로 그대로 (backward compat)."""
+        from common.types import Exchange
+        self.stockQueryService.price_stream_service = None
+        expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()})
+        self.mock_market_data_service.get_current_price.return_value = expected
+
+        result = await self.stockQueryService.get_current_price("005930")
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=False
+        )
+
+    async def test_get_current_price_rest_backfills_snapshot(self):
+        """REST fallback 성공 시 cache_price_snapshot() 호출로 캐시 backfill."""
+        snap = self._make_fresh_snap(age_sec=10.0)  # stale → REST fallback
+        mock_pss = self._setup_sqs_with_pss(snap=snap)
+        output = self._create_dummy_stock_info({
+            "stck_prpr": "80000", "prdy_vrss": "1000", "prdy_ctrt": "1.27",
+            "prdy_vrss_sign": "2", "acml_vol": "300000", "acml_tr_pbmn": "24000000000",
+        })
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd="0", msg1="정상", data={"output": output}
+        )
+
+        await self.stockQueryService.get_current_price("005930")
+
+        mock_pss.cache_price_snapshot.assert_called_once_with(
+            "005930",
+            price="80000",
+            change="1000",
+            rate="1.27",
+            sign="2",
+            volume="300000",
+            acml_tr_pbmn="24000000000",
+        )
+
     async def test_get_current_price_force_fresh_passed_through(self):
         """force_fresh=True가 market_data_service.get_current_price에 그대로 전달되는지 검증"""
         from common.types import Exchange

--- a/todo_list.md
+++ b/todo_list.md
@@ -176,16 +176,27 @@
 
 ### 2-2. API 호출 최적화
 
-- [ ] `StrategyExecutor` Liquidity Filter의 `asyncio.gather()`에 semaphore 기반 동시성 제한을 추가한다.
-- [ ] 종목별 current price REST 호출을 최소화하고 WebSocket/stream snapshot을 우선 사용한다.
-- [ ] REST API는 snapshot 누락, 검증, 보정용으로 제한한다.
-- [ ] 전략별 중복 조회를 제거하고 동일 종목 데이터는 공통 snapshot에서 읽도록 정리한다.
+- [x] `StrategyExecutor` Liquidity Filter의 `asyncio.gather()`에 semaphore 기반 동시성 제한을 추가한다.
+  - 근거: `strategies/strategy_executor.py:88` `Semaphore(self._max_liquidity_concurrency)` 적용, `:106` gather, `:141` `async with sem:` 으로 REST 호출 보호.
+  - snapshot-first chain도 동일 파일 `:127-139`에 구현됨 (PriceStreamService 신선 snapshot 우선 사용 → 없거나 stale 시 REST fallback → REST 응답을 `cache_price_snapshot()`으로 backfill).
+- [x] 종목별 current price REST 호출을 최소화하고 WebSocket/stream snapshot을 우선 사용한다.
+  - 완료: `StockQueryService.get_current_price()`에 snapshot-first 로직 추가. `price_stream_service` 주입 시 `get_cached_price()` 우선 참조 → stale/없음 시 REST fallback. `web_app_initializer.py`에서 `price_stream_service` 주입.
+  - 구독 중이나 tick 미수신(snapshot=None) 케이스: `no_tick_fallback`으로 분류해 REST fallback. `_price_lookup_stats`에 `snapshot_hit/no_tick_fallback/stale_fallback/rest_fallback` 카운터 노출.
+  - REST 성공 시 `cache_price_snapshot()`으로 backfill → 다음 호출 snapshot hit 유도.
+  - 전략들은 호출 코드 변경 없이 자동으로 WebSocket 캐시 활용.
+- [x] REST API는 snapshot 누락, 검증, 보정용으로 제한한다.
+  - 완료: snapshot 없음/stale → REST fallback. `force_fresh=True` 시 snapshot 무시(주문/리스크/수동 조회 경로에서 사용).
+  - `_price_lookup_stats` dict를 `price_lookup_stats` 이벤트 로그로 노출 가능.
+- [x] 전략별 중복 조회를 제거하고 동일 종목 데이터는 공통 snapshot에서 읽도록 정리한다.
+  - 완료: 전략들이 `StockQueryService.get_current_price()` 한 통로를 거치므로 snapshot-first 기본화로 자연 해결. REST backfill로 첫 호출 이후 동일 종목 재조회 시 캐시 hit.
 
 주요 파일:
 
 - `strategies/strategy_executor.py`
 - `services/stock_query_service.py`
 - `services/price_stream_service.py`
+- `view/web/web_app_initializer.py` (price_stream_service 주입)
+- `services/order_execution_service.py`, `services/risk_gate_service.py` (`force_fresh=True` 명시)
 
 ### 2-3. Market snapshot 표준화
 

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -182,7 +182,8 @@ def get_operations_status():
             reconcile = None
 
     sqs = getattr(ctx, "stock_query_service", None)
-    price_lookup = dict(getattr(sqs, "_price_lookup_stats", {})) if sqs else None
+    _raw_stats = getattr(sqs, "_price_lookup_stats", None) if sqs else None
+    price_lookup = dict(_raw_stats) if isinstance(_raw_stats, dict) else None
 
     return {
         "success": True,

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -181,6 +181,9 @@ def get_operations_status():
         except Exception:
             reconcile = None
 
+    sqs = getattr(ctx, "stock_query_service", None)
+    price_lookup = dict(getattr(sqs, "_price_lookup_stats", {})) if sqs else None
+
     return {
         "success": True,
         "data": {
@@ -193,6 +196,7 @@ def get_operations_status():
             "notification_queue_depth": queue_depth,
             "kill_switch": kill_switch,
             "after_market_reconcile": reconcile,
+            "price_lookup": price_lookup,
         },
     }
 

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -643,6 +643,14 @@ async function updateOperationsStatus() {
         const day = pnl.day || {};
         const fmtWon = (value) => value == null ? '-' : `${Number(value).toLocaleString()}원`;
         const fmtPct = (value) => value == null ? '-' : `${Number(value).toFixed(2)}%`;
+        const pl = data.price_lookup || {};
+        const plHit  = pl.snapshot_hit    ?? 0;
+        const plRest = pl.rest_fallback   ?? 0;
+        const plNoTick = pl.no_tick_fallback ?? 0;
+        const plStale  = pl.stale_fallback   ?? 0;
+        const plTotal = plHit + plRest;
+        const plRate  = plTotal > 0 ? ((plHit / plTotal) * 100).toFixed(1) : null;
+        const plRateTone = plRate === null ? 'normal' : (parseFloat(plRate) >= 70 ? 'normal' : parseFloat(plRate) >= 30 ? 'warn' : 'bad');
         el.innerHTML = [
             renderOpsMetric('활성 전략', data.active_strategy_count ?? 0),
             renderOpsMetric('현재 포지션', data.position_count ?? 0),
@@ -654,7 +662,10 @@ async function updateOperationsStatus() {
             renderOpsMetric('Data Quality', dq.enabled ? (dqResult.reason || 'ok') : 'disabled', dqResult.ok === false ? 'bad' : 'normal'),
             renderOpsMetric('WebSocket', ws.receive_alive ? 'alive' : 'down', ws.receive_alive ? 'normal' : 'warn'),
             renderOpsMetric('알림 큐', data.notification_queue_depth ?? 0),
-            renderOpsMetric('Kill Switch', ks && ks.is_tripped ? 'TRIPPED' : 'normal', ks && ks.is_tripped ? 'bad' : 'normal')
+            renderOpsMetric('Kill Switch', ks && ks.is_tripped ? 'TRIPPED' : 'normal', ks && ks.is_tripped ? 'bad' : 'normal'),
+            plTotal > 0 ? renderOpsMetric('현가 Snap율', `${plRate}%`, plRateTone) : '',
+            plTotal > 0 ? renderOpsMetric('Snap Hit', plHit.toLocaleString()) : '',
+            plTotal > 0 ? renderOpsMetric('REST호출', `${plRest.toLocaleString()} (NoTick ${plNoTick} / Stale ${plStale})`, plRest > plHit && plTotal > 20 ? 'warn' : 'normal') : '',
         ].join('');
     } catch (e) {
         console.error('운영 요약 조회 오류:', e);

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -439,6 +439,8 @@ class WebAppContext:
             )
             self.data_quality_service.set_price_stream_service(self.price_stream_service)
             self.streaming_service.set_price_stream_service(self.price_stream_service)
+            if self.stock_query_service:
+                self.stock_query_service.price_stream_service = self.price_stream_service
             self.streaming_stock_repo = StreamingStockRepo(logger=self.logger)
             self.streaming_stock_repo.load_pt_desired_from_db("data/program_subscribe/program_trading.db")
             self.streaming_service.set_streaming_stock_repo(self.streaming_stock_repo)


### PR DESCRIPTION
완료. 요약:

변경 파일:

services/stock_query_service.py — get_current_price()에 snapshot-first 로직 + _build_snapshot_response() + backfill + _price_lookup_stats 카운터 view/web/web_app_initializer.py — price_stream_service 주입 (line 441 이후) tests/unit_test/services/test_stock_query_service.py — 7개 신규 테스트 (snapshot hit, stale, no_tick, force_fresh, backward compat, backfill 검증) todo_list.md — 2-2 나머지 3개 항목 [x] 완료 표기 + no_tick 처리 방식 명시 동작 흐름:

get_current_price() 호출 → PSS 신선 snapshot (≤5초) → 즉시 반환 (snapshot_hit) snapshot=None (구독 중, tick 미수신) → REST fallback (no_tick_fallback) snapshot stale (>5초) → REST fallback (stale_fallback) REST 성공 → cache_price_snapshot() backfill → 다음 동일 종목은 hit force_fresh=True → 항상 REST (주문/리스크 경로)