### PR TITLE
StockQueryService가 stale/no-tick을 감지하면 하위 캐시를 우회하도록 force_fresh=True로…

### DIFF
--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -158,6 +158,16 @@ class StockQueryService:
                         volume=str(output.acml_vol or "0"),
                         acml_tr_pbmn=str(output.acml_tr_pbmn or "0"),
                     )
+                elif isinstance(output, dict):
+                    self.price_stream_service.cache_price_snapshot(
+                        stock_code,
+                        price=str(output.get("stck_prpr", "") or ""),
+                        change=str(output.get("prdy_vrss", "0") or "0"),
+                        rate=str(output.get("prdy_ctrt", "0.00") or "0.00"),
+                        sign=str(output.get("prdy_vrss_sign", "3") or "3"),
+                        volume=str(output.get("acml_vol", "0") or "0"),
+                        acml_tr_pbmn=str(output.get("acml_tr_pbmn", "0") or "0"),
+                    )
             except Exception as e:
                 self.logger.debug({"event": "snapshot_backfill_skipped", "code": stock_code, "error": str(e)})
 

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -22,6 +22,7 @@ class StockQueryService:
                  broker_api_wrapper=None,
                  streaming_logger=None,
                  price_stream_service=None,
+                 price_subscription_service=None,
                  snapshot_max_age_sec: float = 5.0):
         self.broker = broker_api_wrapper
         self.market_data_service = market_data_service
@@ -33,6 +34,7 @@ class StockQueryService:
         self._notification_service = notification_service
         self._streaming_logger = streaming_logger
         self.price_stream_service = price_stream_service
+        self.price_subscription_service = price_subscription_service
         self._snapshot_max_age_sec = snapshot_max_age_sec
         self._price_lookup_stats: Dict[str, int] = {
             "snapshot_hit": 0,
@@ -84,12 +86,25 @@ class StockQueryService:
 
         per/pbr/eps 같이 snapshot에 없는 REST 전용 필드가 필요하면 force_fresh=True를 지정한다.
         """
+        fallback_force_fresh = force_fresh
+        unhealthy_stream_reason: Optional[str] = None
+
         if not force_fresh and self.price_stream_service is not None:
             snap = self.price_stream_service.get_cached_price(stock_code)
             if snap is None:
                 # 구독 중이나 tick 미수신 → REST fallback
                 self._price_lookup_stats["no_tick_fallback"] += 1
                 self.logger.debug({"event": "price_lookup_no_tick", "code": stock_code, "caller": caller})
+                fallback_force_fresh = True
+                subscription_age = 0.0
+                get_subscription_age = getattr(self.price_stream_service, "get_subscription_age", None)
+                if callable(get_subscription_age):
+                    try:
+                        subscription_age = float(get_subscription_age(stock_code) or 0.0)
+                    except (TypeError, ValueError):
+                        subscription_age = 0.0
+                if subscription_age >= self._snapshot_max_age_sec:
+                    unhealthy_stream_reason = "no_tick"
             else:
                 received_at = snap.get("received_at", 0.0) or 0.0
                 age = time.time() - received_at
@@ -100,11 +115,32 @@ class StockQueryService:
                     self._price_lookup_stats["stale_fallback"] += 1
                     self.logger.debug({"event": "price_lookup_stale", "code": stock_code,
                                        "age_sec": round(age, 2), "caller": caller})
+                    fallback_force_fresh = True
+                    unhealthy_stream_reason = "stale_snapshot"
 
         self._price_lookup_stats["rest_fallback"] += 1
         resp = await self.market_data_service.get_current_price(
-            stock_code, exchange=exchange, count_stats=count_stats, caller=caller, force_fresh=force_fresh
+            stock_code, exchange=exchange, count_stats=count_stats, caller=caller, force_fresh=fallback_force_fresh
         )
+
+        if unhealthy_stream_reason and self.price_subscription_service is not None:
+            drop_subscription = getattr(
+                self.price_subscription_service,
+                "drop_unhealthy_price_subscription",
+                None,
+            )
+            if callable(drop_subscription):
+                try:
+                    await drop_subscription(stock_code, reason=unhealthy_stream_reason)
+                except Exception as e:
+                    self.logger.warning(
+                        {
+                            "event": "price_subscription_drop_failed",
+                            "code": stock_code,
+                            "reason": unhealthy_stream_reason,
+                            "error": str(e),
+                        }
+                    )
 
         # REST 성공 응답을 snapshot 캐시에 backfill (다음 동일 종목 조회 hit 유도)
         if (self.price_stream_service is not None

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -145,6 +145,52 @@ class SubscriptionPolicy:
                     await self._streaming_stock_repo.unmark_desired(code, StreamingType.UNIFIED_PRICE)
         await self._rebalance()
 
+    async def drop_unhealthy_price_subscription(self, code: str, reason: str = "unhealthy_stream") -> bool:
+        """비정상 체결가 스트리밍 종목을 가격 구독 목록에서 제거한다.
+
+        REST fallback이 필요한 수준이면 해당 가격 구독은 신뢰하지 않고,
+        다음 조회부터 StockRepository의 streaming TTL 우회를 타지 않도록 정리한다.
+        """
+        if not code:
+            return False
+
+        removed = False
+        if code in self._refs:
+            price_categories = [
+                category_key
+                for category_key, request in self._refs[code].items()
+                if request.get("type") == StreamingType.UNIFIED_PRICE
+            ]
+            for category_key in price_categories:
+                self._refs[code].pop(category_key, None)
+                removed = True
+            if not self._refs.get(code):
+                self._refs.pop(code, None)
+
+        if self._streaming_stock_repo:
+            await self._streaming_stock_repo.unmark_desired(code, StreamingType.UNIFIED_PRICE)
+
+        unsubscribed = False
+        if code in self._active_codes_price:
+            await self._do_unsubscribe(code, StreamingType.UNIFIED_PRICE)
+            unsubscribed = True
+            removed = True
+        else:
+            self._stock_repo.unmark_streaming(code)
+            if self._streaming_stock_repo:
+                await self._streaming_stock_repo.mark_inactive(code, StreamingType.UNIFIED_PRICE)
+
+        if self._streaming_logger and not unsubscribed:
+            self._streaming_logger.log_unsubscribe(
+                code=code,
+                active_count=len(self._active_codes_price) + len(self._active_codes_pt),
+            )
+        self._logger.warning(
+            f"SubscriptionPolicy: unhealthy price subscription dropped "
+            f"code={code} reason={reason}"
+        )
+        return removed
+
     async def sync_subscriptions(
         self,
         codes: List[str],

--- a/tests/integration_test/strategies/test_it_api_high_tight_flag_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_high_tight_flag_strategy.py
@@ -153,4 +153,5 @@ async def test_htf_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     assert mock_get_price.call_count == 0, "캐시 적중 시 현재가 API는 호출되지 않아야 함"
     assert mock_get_ohlcv.call_count == 0, "캐시 적중 시 OHLCV API는 호출되지 않아야 함"
     assert mock_get_conclusion.call_count == calls_conclusion_on_miss, "체결강도 API는 항상 호출되어야 함"
-    assert stock_repo.get_cache_stats()["hits"] > 0
+    assert deep_paper_ctx.stock_query_service.price_stream_service.get_cached_price(code_a) is not None, \
+        "브로커 응답이 price_stream_service에 backfill 되어야 함"

--- a/tests/integration_test/strategies/test_it_api_oneil_pocket_pivot_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_oneil_pocket_pivot_strategy.py
@@ -174,6 +174,6 @@ async def test_pocket_pivot_scan_cache_behavior_reduces_api_calls(deep_paper_ctx
     # [검증 3] 실시간 API(체결강도)는 항상 호출되어야 함
     assert mock_get_conclusion.call_count == calls_conclusion_on_miss, "캐시 대상이 아닌 체결강도 API는 항상 호출되어야 합니다."
 
-    # 저장소 내부 통계값 검증
-    stats = stock_repo.get_cache_stats()
-    assert stats["hits"] > 0, "캐시 히트 카운트가 정상적으로 누적되어야 합니다."
+    # price_stream_service backfill 검증 (broker 응답이 스냅샷 캐시에 저장되어야 함)
+    assert deep_paper_ctx.stock_query_service.price_stream_service.get_cached_price(code_a) is not None, \
+        "브로커 응답이 price_stream_service에 backfill 되어야 합니다."

--- a/tests/integration_test/strategies/test_it_api_oneil_squeeze_breakout_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_oneil_squeeze_breakout_strategy.py
@@ -124,4 +124,5 @@ async def test_osb_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     
     assert mock_get_price.call_count == 0, "캐시 적중 시 현재가 외부 API는 호출되지 않아야 함"
     assert mock_get_conclusion.call_count == calls_conclusion_on_miss, "체결강도 실시간 API는 항상 호출되어야 함"
-    assert stock_repo.get_cache_stats()["hits"] > 0
+    assert deep_paper_ctx.stock_query_service.price_stream_service.get_cached_price(code_a) is not None, \
+        "브로커 응답이 price_stream_service에 backfill 되어야 함"

--- a/tests/integration_test/strategies/test_it_strategy_scan.py
+++ b/tests/integration_test/strategies/test_it_strategy_scan.py
@@ -1245,6 +1245,10 @@ class TestLarryWilliamsCBScan:
             "inquire-price": {"rt_cd": "0", "msg_cd": "MCA00000", "msg1": "정상", "output": price_output},
         })
 
+        # price_stream_service가 연결되면 웹소켓 스냅샷 미존재 시 force_fresh=True가 발동해
+        # _fetch_today_ohlcv가 채운 _price_cache를 우회하므로, 이 테스트에서는 비활성화한다.
+        deep_paper_ctx.stock_query_service.price_stream_service = None
+
         strategy = self._build_strategy(deep_paper_ctx, mock_tm, tmp_path)
         signals = await strategy.scan()
 

--- a/tests/unit_test/services/test_price_subscription_service.py
+++ b/tests/unit_test/services/test_price_subscription_service.py
@@ -145,6 +145,22 @@ async def test_remove_category_removes_all_in_category(svc, mock_streaming):
     assert svc.is_streaming("000660")  # portfolio 카테고리는 유지
 
 
+async def test_drop_unhealthy_price_subscription_removes_all_price_refs(svc, mock_streaming, mock_stock_repo):
+    """비정상 체결가 스트리밍은 모든 가격 참조와 활성 구독을 제거한다."""
+    await svc.add_subscription("005930", SubscriptionPriority.HIGH, "portfolio", StreamingType.UNIFIED_PRICE)
+    await svc.add_subscription("005930", SubscriptionPriority.MEDIUM, "strategy_oneil", StreamingType.UNIFIED_PRICE)
+    mock_streaming.reset_mock()
+    mock_stock_repo.reset_mock()
+
+    removed = await svc.drop_unhealthy_price_subscription("005930", reason="stale_snapshot")
+
+    assert removed is True
+    assert "005930" not in svc._refs
+    assert not svc.is_streaming("005930")
+    mock_streaming.unsubscribe_unified_price.assert_called_once_with("005930")
+    mock_stock_repo.unmark_streaming.assert_called_once_with("005930")
+
+
 # ── sync_subscriptions ────────────────────────────────────────────────────
 
 async def test_sync_subscriptions_atomic_replace(svc, mock_streaming):

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -181,6 +181,7 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         from unittest.mock import MagicMock
         mock_pss = MagicMock()
         mock_pss.get_cached_price.return_value = snap
+        mock_pss.get_subscription_age.return_value = snapshot_max_age_sec + 1.0
         mock_pss.cache_price_snapshot = MagicMock()
         self.stockQueryService.price_stream_service = mock_pss
         self.stockQueryService._snapshot_max_age_sec = snapshot_max_age_sec
@@ -221,19 +222,40 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         result = await self.stockQueryService.get_current_price("005930")
 
-        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=True
+        )
         self.assertEqual(self.stockQueryService._price_lookup_stats["stale_fallback"], 1)
 
     async def test_get_current_price_no_tick_falls_back_to_rest(self):
         """snapshot None (구독 중이나 tick 미수신) → REST fallback."""
+        from common.types import Exchange
         mock_pss = self._setup_sqs_with_pss(snap=None)
         expected = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()})
         self.mock_market_data_service.get_current_price.return_value = expected
 
         await self.stockQueryService.get_current_price("005930")
 
-        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        self.mock_market_data_service.get_current_price.assert_awaited_once_with(
+            "005930", exchange=Exchange.KRX, count_stats=True, caller="unknown", force_fresh=True
+        )
         self.assertEqual(self.stockQueryService._price_lookup_stats["no_tick_fallback"], 1)
+
+    async def test_get_current_price_unhealthy_streaming_drops_price_subscription(self):
+        """stale/no-tick streaming은 REST 조회 후 가격 구독 목록에서 제거."""
+        snap = self._make_fresh_snap(age_sec=10.0)
+        self._setup_sqs_with_pss(snap=snap, snapshot_max_age_sec=5.0)
+        mock_subscription_service = AsyncMock()
+        self.stockQueryService.price_subscription_service = mock_subscription_service
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd="0", msg1="정상", data={"output": self._create_dummy_stock_info()}
+        )
+
+        await self.stockQueryService.get_current_price("005930")
+
+        mock_subscription_service.drop_unhealthy_price_subscription.assert_awaited_once_with(
+            "005930", reason="stale_snapshot"
+        )
 
     async def test_get_current_price_force_fresh_bypasses_snapshot(self):
         """force_fresh=True → 신선한 snapshot 있어도 REST 직접 호출."""

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -453,6 +453,8 @@ class WebAppContext:
                 streaming_stock_repo=self.streaming_stock_repo,
                 market_calendar=self._mcs,
             )
+            if self.stock_query_service:
+                self.stock_query_service.price_subscription_service = self.price_subscription_service
             self.websocket_watchdog_task = WebSocketWatchdogTask(
                 streaming_service=self.streaming_service,
                 program_trading_stream_service=self.program_trading_stream_service,


### PR DESCRIPTION
… REST를 호출하고, SubscriptionPolicy에는 해당 종목의 가격 구독 참조를 강제로 제거하는 메서드를 추가

stale/no-tick fallback은 하위 캐시를 우회하고, 구독 드롭은 실패해도 현재가 조회를 막지 않도록 방어적으로