### PR TITLE
구현까지 완료했습니다. 수정된 plan은 “broker 잔고를 truth로 보고, 로컬에만 있는 HOLD row만 force…

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -169,10 +169,6 @@ class ExecutionQualityReportConfig(BaseModel):
 
 class OpeningPositionReconcileConfig(BaseModel):
     enabled: bool = True
-    detect_only: bool = True
-    auto_buy_missing_local: bool = False
-    auto_sell_extra_broker: bool = False
-    allow_sell_unknown_broker: bool = False
     check_interval_sec: int = 30
     open_delay_sec: int = 60
     run_window_min: int = 10

--- a/docs/opening_position_reconcile_policy.md
+++ b/docs/opening_position_reconcile_policy.md
@@ -1,0 +1,94 @@
+# Opening Position Reconcile Policy
+
+`OpeningPositionReconcileTask`는 장 시작 직후 broker 계좌 잔고와 로컬 가상 원장(`virtual_trade.db`)의 보유 상태를 대사한다.
+
+이 정책의 기준 truth는 broker 계좌 잔고다. 로컬 원장은 broker 잔고에 맞춰 보수적으로 정정하며, broker에 실제 주문을 발주하지 않는다.
+
+## 실행 시점
+
+- 장 시작 시각 + `open_delay_sec` 이후 실행한다.
+- 기본 실행 윈도우는 10분이다.
+- 정상 대사 결과를 받은 날에는 하루 1회만 실행한다.
+- broker 잔고 조회 실패처럼 `error`가 있는 결과는 날짜 stamp를 남기지 않아, 같은 윈도우 안에서 다음 tick에 재시도할 수 있다.
+
+## 정정 규칙
+
+| Case | Behavior |
+| --- | --- |
+| 로컬 `HOLD`, broker 수량 0 | 로컬 `HOLD` row를 강제 종결한다. |
+| broker 수량 > 0, 로컬 `HOLD` 없음 | 자동 insert/매도 없이 경고만 남긴다. |
+| 양쪽 모두 보유하지만 수량 불일치 | 자동 정정 없이 경고만 남긴다. |
+| 양쪽 수량 일치 | 아무 작업도 하지 않는다. |
+
+강제 종결은 `VirtualTradeService.reconcile_with_broker()`가 수행한다.
+로컬에만 있는 종목은 해당 code의 `HOLD` row 수만큼 `log_sell_async(code, 0, reason="reconciled_force_close")`를 호출한다.
+
+## Force Close
+
+강제 종결된 거래는 다음 값으로 기록된다.
+
+```text
+status = SOLD
+sell_price = 0
+reason = reconciled_force_close
+```
+
+`VirtualTradeRepository.get_summary()`는 `reason="reconciled_force_close"` 거래를 승률과 평균수익률 계산에서 제외하고, `force_closed_count`로 별도 집계한다.
+
+## 수량 불일치
+
+수량 불일치는 자동 정정하지 않는다.
+
+partial close가 필요한 경우 어떤 lot 또는 어떤 전략의 `HOLD`를 닫아야 하는지 결정해야 한다. 현재 repository의 일반 매도 경로는 같은 code의 최신 `HOLD` row를 닫는 LIFO 방식이므로, 수량 차이 자동 정정은 별도 설계가 필요하다.
+
+대신 결과에 아래 형태로 포함해 알림과 로그에서 확인할 수 있게 한다.
+
+```python
+{
+    "quantity_mismatches": [
+        {"code": "005930", "local_qty": 3, "broker_qty": 1},
+    ],
+}
+```
+
+## Result Shape
+
+`OpeningPositionReconcileService.reconcile_once()`는 task 호환을 위해 아래 형태를 반환한다.
+
+```python
+{
+    "force_closed": ["005930"],
+    "unknown_in_broker": ["035420"],
+    "quantity_mismatches": [
+        {"code": "000660", "local_qty": 3, "broker_qty": 1},
+    ],
+    "mismatch_count": 3,
+    "error": None,
+}
+```
+
+`mismatch_count`는 `force_closed`, `unknown_in_broker`, `quantity_mismatches`의 항목 수 합계다.
+
+## Deprecated Config
+
+아래 설정은 더 이상 사용하지 않는다.
+
+```yaml
+opening_position_reconcile:
+  detect_only: true
+  auto_buy_missing_local: false
+  auto_sell_extra_broker: false
+  allow_sell_unknown_broker: false
+```
+
+새 정책은 broker 주문을 내지 않고 로컬 원장만 보수적으로 정정한다. 따라서 기존 detect-only/auto-buy/auto-sell 플래그는 의미가 없으며, 설정 파일에 남아 있으면 시작 시 warning으로 알린 뒤 무시한다.
+
+계속 사용하는 설정은 실행 스케줄 관련 필드다.
+
+```yaml
+opening_position_reconcile:
+  enabled: true
+  check_interval_sec: 30
+  open_delay_sec: 60
+  run_window_min: 10
+```

--- a/services/opening_position_reconcile_service.py
+++ b/services/opening_position_reconcile_service.py
@@ -3,37 +3,23 @@ from __future__ import annotations
 
 import inspect
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from common.types import ErrorCode, Exchange, ResCommonResponse
 
 
 class OpeningPositionReconcileService:
-    """VirtualTradeRepository HOLD 수량을 목표 포지션으로 보고 실제 계좌 수량과 맞춘다."""
-
-    SOURCE = "reconcile:opening"
+    """실제 계좌 잔고를 기준으로 로컬 가상 원장을 대사한다."""
 
     def __init__(
         self,
         *,
         broker,
-        order_execution_service,
         virtual_trade_service,
-        detect_only: bool = True,
-        auto_buy_missing_local: bool = False,
-        auto_sell_extra_broker: bool = False,
-        allow_sell_unknown_broker: bool = False,
-        managed_codes: Optional[set[str]] = None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._broker = broker
-        self._oes = order_execution_service
         self._vts = virtual_trade_service
-        self._detect_only = detect_only
-        self._auto_buy_missing_local = auto_buy_missing_local
-        self._auto_sell_extra_broker = auto_sell_extra_broker
-        self._allow_sell_unknown_broker = allow_sell_unknown_broker
-        self._managed_codes = {str(code).strip() for code in managed_codes or set() if str(code).strip()}
         self._logger = logger or logging.getLogger(__name__)
 
     async def reconcile_once(self, *, exchange: Exchange = Exchange.KRX) -> dict:
@@ -44,156 +30,17 @@ class OpeningPositionReconcileService:
             return self._empty_result(error=msg)
 
         actual_holdings = ((response.data or {}).get("output1", []) if isinstance(response.data, dict) else [])
-        local_positions = self._normalize_local_positions(self._vts.get_holds())
-        broker_positions = self._normalize_broker_positions(actual_holdings)
-        plan = self._build_plan(local_positions, broker_positions)
-
-        result = {
-            "detect_only": self._detect_only,
-            **plan,
-            "executed": [],
-            "error": None,
-        }
+        result = await self._vts.reconcile_with_broker(actual_holdings, logger=self._logger)
+        result.setdefault("force_closed", [])
+        result.setdefault("unknown_in_broker", [])
+        result.setdefault("quantity_mismatches", [])
         result["mismatch_count"] = (
-            len(result["planned_buys"]) + len(result["planned_sells"]) + len(result["skipped"])
+            len(result["force_closed"])
+            + len(result["unknown_in_broker"])
+            + len(result["quantity_mismatches"])
         )
-
-        if self._detect_only:
-            self._logger.info(f"[OpeningPositionReconcile] detect_only plan={result}")
-            return result
-
-        await self._execute_plan(result, exchange)
+        result["error"] = None
         return result
-
-    async def _execute_plan(self, result: dict, exchange: Exchange) -> None:
-        for item in result["planned_buys"]:
-            if not self._auto_buy_missing_local:
-                result["skipped"].append({**item, "reason": "auto_buy_disabled"})
-                continue
-            response = await self._oes.handle_place_buy_order(
-                item["code"],
-                0,
-                item["qty"],
-                source=self.SOURCE,
-                finalize_immediately=False,
-            )
-            result["executed"].append(self._order_result("BUY", item, response))
-
-        for item in result["planned_sells"]:
-            if not self._auto_sell_extra_broker:
-                result["skipped"].append({**item, "reason": "auto_sell_disabled"})
-                continue
-            response = await self._oes.handle_place_sell_order(
-                item["code"],
-                0,
-                item["qty"],
-                source=self.SOURCE,
-                finalize_immediately=False,
-            )
-            result["executed"].append(self._order_result("SELL", item, response))
-
-    def _build_plan(self, local_positions: dict[str, dict], broker_positions: dict[str, int]) -> dict:
-        planned_buys: list[dict] = []
-        planned_sells: list[dict] = []
-        skipped: list[dict] = []
-        matched: list[dict] = []
-
-        all_codes = sorted(set(local_positions) | set(broker_positions))
-        managed_codes = set(local_positions) | self._managed_codes
-        for code in all_codes:
-            local_qty = int(local_positions.get(code, {}).get("qty", 0))
-            broker_qty = int(broker_positions.get(code, 0))
-            diff = local_qty - broker_qty
-            if diff == 0:
-                if local_qty > 0:
-                    matched.append({"code": code, "qty": local_qty})
-                continue
-
-            strategy = local_positions.get(code, {}).get("strategy", "")
-            if diff > 0:
-                planned_buys.append({
-                    "code": code,
-                    "qty": diff,
-                    "local_qty": local_qty,
-                    "broker_qty": broker_qty,
-                    "strategy": strategy,
-                })
-                continue
-
-            sell_qty = abs(diff)
-            if code not in managed_codes and not self._allow_sell_unknown_broker:
-                skipped.append({
-                    "code": code,
-                    "qty": sell_qty,
-                    "local_qty": local_qty,
-                    "broker_qty": broker_qty,
-                    "reason": "unknown_broker_holding",
-                })
-                continue
-
-            reason = "broker_extra_qty" if local_qty > 0 else "unknown_broker_holding"
-            planned_sells.append({
-                "code": code,
-                "qty": sell_qty,
-                "local_qty": local_qty,
-                "broker_qty": broker_qty,
-                "reason": reason,
-            })
-
-        return {
-            "planned_buys": planned_buys,
-            "planned_sells": planned_sells,
-            "skipped": skipped,
-            "matched": matched,
-        }
-
-    @staticmethod
-    def _normalize_local_positions(holds: list[dict]) -> dict[str, dict]:
-        positions: dict[str, dict] = {}
-        for hold in holds or []:
-            code = str(hold.get("code", "")).strip()
-            if not code:
-                continue
-            qty = OpeningPositionReconcileService._to_int(hold.get("qty"), default=1)
-            if qty <= 0:
-                continue
-            current = positions.setdefault(code, {"qty": 0, "strategies": []})
-            current["qty"] += qty
-            strategy = str(hold.get("strategy", "")).strip()
-            if strategy:
-                current["strategies"].append(strategy)
-                current.setdefault("strategy", strategy)
-        return positions
-
-    @staticmethod
-    def _normalize_broker_positions(holdings: list[dict]) -> dict[str, int]:
-        positions: dict[str, int] = {}
-        for holding in holdings or []:
-            code = str(
-                holding.get("pdno")
-                or holding.get("PDNO")
-                or holding.get("code")
-                or ""
-            ).strip()
-            if not code:
-                continue
-            qty = OpeningPositionReconcileService._to_int(
-                holding.get("hldg_qty")
-                or holding.get("HLDG_QTY")
-                or holding.get("qty")
-                or holding.get("quantity")
-            )
-            if qty > 0:
-                positions[code] = positions.get(code, 0) + qty
-        return positions
-
-    @staticmethod
-    def _to_int(value: Any, default: int = 0) -> int:
-        try:
-            text = str(value if value is not None else "").replace(",", "").strip()
-            return int(float(text)) if text else default
-        except (TypeError, ValueError):
-            return default
 
     @staticmethod
     def _is_success_response(response) -> bool:
@@ -212,24 +59,11 @@ class OpeningPositionReconcileService:
         return response
 
     @staticmethod
-    def _order_result(action: str, item: dict, response) -> dict:
-        return {
-            "action": action,
-            "code": item["code"],
-            "qty": item["qty"],
-            "success": OpeningPositionReconcileService._is_success_response(response),
-            "message": getattr(response, "msg1", "") if response is not None else "응답 없음",
-        }
-
-    @staticmethod
     def _empty_result(*, error: str | None = None) -> dict:
         return {
-            "detect_only": True,
-            "planned_buys": [],
-            "planned_sells": [],
-            "skipped": [],
-            "matched": [],
-            "executed": [],
+            "force_closed": [],
+            "unknown_in_broker": [],
+            "quantity_mismatches": [],
             "mismatch_count": 0,
             "error": error,
         }

--- a/services/virtual_trade_service.py
+++ b/services/virtual_trade_service.py
@@ -1,17 +1,57 @@
 # services/virtual_trade_service.py
 import logging
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional, Any
 import pandas as pd
 import bisect
 from functools import lru_cache
 from datetime import datetime, timedelta
 
-from repositories.virtual_trade_repository import VirtualTradeRepository
+from repositories.virtual_trade_repository import VirtualTradeRepository, _FORCE_CLOSE_REASON
 from core.market_clock import MarketClock
 from common.trade_journal_comparison import compare_trade_journals
 from utils.transaction_cost_utils import TransactionCostUtils
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_position_qty(value: Any) -> int:
+    try:
+        text = str(value if value is not None else "").replace(",", "").strip()
+        return int(float(text)) if text else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _first_non_empty(mapping: dict, keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        value = mapping.get(key)
+        if str(value if value is not None else "").strip():
+            return value
+    return None
+
+
+def _normalize_broker_holdings(holdings: list[dict]) -> dict[str, int]:
+    positions: dict[str, int] = {}
+    for holding in holdings or []:
+        code = str(_first_non_empty(holding, ("pdno", "PDNO", "code")) or "").strip()
+        if not code:
+            continue
+        qty = _parse_position_qty(_first_non_empty(holding, ("hldg_qty", "HLDG_QTY", "qty", "quantity")))
+        if qty > 0:
+            positions[code] = positions.get(code, 0) + qty
+    return positions
+
+
+def _normalize_local_holds(holds: list[dict]) -> dict[str, int]:
+    positions: dict[str, int] = {}
+    for hold in holds or []:
+        code = str(hold.get("code", "")).strip()
+        if not code:
+            continue
+        qty = _parse_position_qty(hold.get("qty")) or 1
+        if qty > 0:
+            positions[code] = positions.get(code, 0) + qty
+    return positions
 
 @lru_cache(maxsize=1024)
 def _is_weekday(date_str: str) -> bool:
@@ -180,42 +220,64 @@ class VirtualTradeService:
     async def reconcile_with_broker(self, actual_holdings: list, logger=None) -> dict:
         """실제 증권사 잔고와 로컬 DB를 비교하여 불일치를 처리한다.
 
-        - 로컬 HOLD인데 실제 잔고 없음 → log_sell_async(code, 0, reason="reconciled_force_close") 강제 종결 + 경고
+        - 로컬 HOLD인데 실제 잔고 없음 → 해당 code의 로컬 HOLD row를 강제 종결 + 경고
         - 실제 잔고 있는데 로컬 없음 → 경고 로그만 (전략명 불명확 → 자동 insert 불가)
+        - 양쪽에 있으나 수량만 다름 → 경고 로그만
+
+        수량 불일치는 partial close 시 어떤 lot/전략을 닫을지 모호하므로 자동 정정하지 않는다.
 
         Args:
             actual_holdings: broker get_account_balance() resp.data["output1"] 리스트
             logger: 선택적 logger
 
         Returns:
-            {"force_closed": [codes], "unknown_in_broker": [codes]}
+            {
+                "force_closed": [codes],
+                "unknown_in_broker": [codes],
+                "quantity_mismatches": [{"code": code, "local_qty": L, "broker_qty": B}],
+            }
         """
         _log = logger or __import__('logging').getLogger(__name__)
 
-        actual_codes = {
-            str(h.get("pdno", "")).strip()
-            for h in actual_holdings
-            if str(h.get("hldg_qty", "0") or "0").strip() not in ("0", "", "00")
-        }
-
         local_holds = self.get_holds()
-        local_codes = {str(h.get("code", "")).strip() for h in local_holds if h.get("code")}
+        broker_positions = _normalize_broker_holdings(actual_holdings)
+        local_positions = _normalize_local_holds(local_holds)
 
         force_closed = []
         for hold in local_holds:
             code = str(hold.get("code", "")).strip()
-            if code and code not in actual_codes:
+            if code and broker_positions.get(code, 0) <= 0:
                 _log.warning(
                     f"[Reconciliation] 로컬 HOLD이나 실제 잔고 없음 → 강제 종결: "
                     f"{code} (strategy={hold.get('strategy')})"
                 )
-                await self.log_sell_async(code, 0, reason="reconciled_force_close")
+                await self.log_sell_async(code, 0, reason=_FORCE_CLOSE_REASON)
                 force_closed.append(code)
 
-        unknown_in_broker = sorted(actual_codes - local_codes)
+        local_codes = set(local_positions)
+        broker_codes = set(broker_positions)
+        unknown_in_broker = sorted(broker_codes - local_codes)
         if unknown_in_broker:
             _log.warning(
                 f"[Reconciliation] 실제 보유 중이나 로컬 DB 없음 (수동 확인 필요): {unknown_in_broker}"
             )
 
-        return {"force_closed": force_closed, "unknown_in_broker": unknown_in_broker}
+        quantity_mismatches = [
+            {
+                "code": code,
+                "local_qty": local_positions[code],
+                "broker_qty": broker_positions[code],
+            }
+            for code in sorted(local_codes & broker_codes)
+            if local_positions[code] != broker_positions[code]
+        ]
+        if quantity_mismatches:
+            _log.warning(
+                f"[Reconciliation] 로컬/브로커 보유 수량 불일치 (수동 확인 필요): {quantity_mismatches}"
+            )
+
+        return {
+            "force_closed": force_closed,
+            "unknown_in_broker": unknown_in_broker,
+            "quantity_mismatches": quantity_mismatches,
+        }

--- a/task/background/intraday/opening_position_reconcile_task.py
+++ b/task/background/intraday/opening_position_reconcile_task.py
@@ -121,18 +121,23 @@ class OpeningPositionReconcileTask(SchedulableTask):
         try:
             result = await self._service.reconcile_once()
             self._last_result = result
-            if self._market_clock:
+            if not result.get("error") and self._market_clock:
                 self._last_checked_date = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
 
             mismatch_count = int(result.get("mismatch_count") or 0)
             if mismatch_count:
+                message = (
+                    f"force_closed={len(result.get('force_closed') or [])} "
+                    f"unknown={len(result.get('unknown_in_broker') or [])} "
+                    f"qty_mismatch={len(result.get('quantity_mismatches') or [])}"
+                )
                 self._logger.warning(f"[OpeningPositionReconcile] mismatch_count={mismatch_count} result={result}")
                 if self._ns:
                     await self._ns.emit(
                         NotificationCategory.TRADE,
                         NotificationLevel.WARNING,
                         "장 시작 원장/잔고 대사 불일치",
-                        f"{mismatch_count}건 확인",
+                        message,
                         metadata=result,
                     )
             else:

--- a/tests/unit_test/services/test_opening_position_reconcile_service.py
+++ b/tests/unit_test/services/test_opening_position_reconcile_service.py
@@ -7,55 +7,7 @@ from services.opening_position_reconcile_service import OpeningPositionReconcile
 
 
 @pytest.mark.asyncio
-async def test_opening_reconcile_detect_only_builds_quantity_plan_without_orders():
-    virtual_trade_service = MagicMock()
-    virtual_trade_service.get_holds.return_value = [
-        {"code": "005930", "strategy": "S1", "qty": 3},
-        {"code": "000660", "strategy": "S2", "qty": 1},
-    ]
-    broker = MagicMock()
-    broker.get_account_balance = AsyncMock(
-        return_value=ResCommonResponse(
-            rt_cd=ErrorCode.SUCCESS.value,
-            msg1="OK",
-            data={"output1": [{"pdno": "005930", "hldg_qty": "1"}, {"pdno": "035420", "hldg_qty": "2"}]},
-        )
-    )
-    order_execution_service = MagicMock()
-    order_execution_service.handle_place_buy_order = AsyncMock()
-    order_execution_service.handle_place_sell_order = AsyncMock()
-    service = OpeningPositionReconcileService(
-        broker=broker,
-        order_execution_service=order_execution_service,
-        virtual_trade_service=virtual_trade_service,
-        logger=MagicMock(),
-    )
-
-    result = await service.reconcile_once()
-
-    assert result["detect_only"] is True
-    assert result["planned_buys"] == [
-        {"code": "000660", "qty": 1, "local_qty": 1, "broker_qty": 0, "strategy": "S2"},
-        {"code": "005930", "qty": 2, "local_qty": 3, "broker_qty": 1, "strategy": "S1"}
-    ]
-    assert result["planned_sells"] == []
-    assert result["skipped"] == [
-        {
-            "code": "035420",
-            "qty": 2,
-            "local_qty": 0,
-            "broker_qty": 2,
-            "reason": "unknown_broker_holding",
-        }
-    ]
-    order_execution_service.handle_place_buy_order.assert_not_awaited()
-    order_execution_service.handle_place_sell_order.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_opening_reconcile_can_buy_missing_local_quantity_when_enabled():
-    virtual_trade_service = MagicMock()
-    virtual_trade_service.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 3}]
+async def test_opening_reconcile_delegates_to_virtual_trade_reconcile():
     broker = MagicMock()
     broker.get_account_balance = AsyncMock(
         return_value=ResCommonResponse(
@@ -64,143 +16,86 @@ async def test_opening_reconcile_can_buy_missing_local_quantity_when_enabled():
             data={"output1": [{"pdno": "005930", "hldg_qty": "1"}]},
         )
     )
-    order_execution_service = MagicMock()
-    order_execution_service.handle_place_buy_order = AsyncMock(
-        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.reconcile_with_broker = AsyncMock(
+        return_value={
+            "force_closed": ["000660"],
+            "unknown_in_broker": ["035420"],
+            "quantity_mismatches": [{"code": "005930", "local_qty": 3, "broker_qty": 1}],
+        }
     )
+    logger = MagicMock()
     service = OpeningPositionReconcileService(
         broker=broker,
-        order_execution_service=order_execution_service,
         virtual_trade_service=virtual_trade_service,
-        detect_only=False,
-        auto_buy_missing_local=True,
-        logger=MagicMock(),
+        logger=logger,
     )
 
     result = await service.reconcile_once()
 
-    order_execution_service.handle_place_buy_order.assert_awaited_once_with(
-        "005930",
-        0,
-        2,
-        source="reconcile:opening",
-        finalize_immediately=False,
+    virtual_trade_service.reconcile_with_broker.assert_awaited_once_with(
+        [{"pdno": "005930", "hldg_qty": "1"}],
+        logger=logger,
     )
-    assert result["executed"] == [
-        {"action": "BUY", "code": "005930", "qty": 2, "success": True, "message": "OK"}
-    ]
+    assert result == {
+        "force_closed": ["000660"],
+        "unknown_in_broker": ["035420"],
+        "quantity_mismatches": [{"code": "005930", "local_qty": 3, "broker_qty": 1}],
+        "mismatch_count": 3,
+        "error": None,
+    }
 
 
 @pytest.mark.asyncio
-async def test_opening_reconcile_sells_only_managed_excess_by_default():
-    virtual_trade_service = MagicMock()
-    virtual_trade_service.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 1}]
+async def test_opening_reconcile_reports_zero_mismatch_when_positions_match():
     broker = MagicMock()
     broker.get_account_balance = AsyncMock(
         return_value=ResCommonResponse(
             rt_cd=ErrorCode.SUCCESS.value,
             msg1="OK",
-            data={
-                "output1": [
-                    {"pdno": "005930", "hldg_qty": "3"},
-                    {"pdno": "035420", "hldg_qty": "2"},
-                ]
-            },
+            data={"output1": [{"pdno": "005930", "hldg_qty": "3"}]},
         )
     )
-    order_execution_service = MagicMock()
-    order_execution_service.handle_place_sell_order = AsyncMock(
-        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
-    )
-    service = OpeningPositionReconcileService(
-        broker=broker,
-        order_execution_service=order_execution_service,
-        virtual_trade_service=virtual_trade_service,
-        detect_only=False,
-        auto_sell_extra_broker=True,
-        logger=MagicMock(),
-    )
-
-    result = await service.reconcile_once()
-
-    order_execution_service.handle_place_sell_order.assert_awaited_once_with(
-        "005930",
-        0,
-        2,
-        source="reconcile:opening",
-        finalize_immediately=False,
-    )
-    assert result["skipped"] == [
-        {
-            "code": "035420",
-            "qty": 2,
-            "local_qty": 0,
-            "broker_qty": 2,
-            "reason": "unknown_broker_holding",
-        }
-    ]
-    assert result["executed"] == [
-        {"action": "SELL", "code": "005930", "qty": 2, "success": True, "message": "OK"}
-    ]
-
-
-@pytest.mark.asyncio
-async def test_opening_reconcile_allows_unknown_broker_sell_only_when_explicitly_enabled():
     virtual_trade_service = MagicMock()
-    virtual_trade_service.get_holds.return_value = []
-    broker = MagicMock()
-    broker.get_account_balance = AsyncMock(
-        return_value=ResCommonResponse(
-            rt_cd=ErrorCode.SUCCESS.value,
-            msg1="OK",
-            data={"output1": [{"pdno": "035420", "hldg_qty": "2"}]},
-        )
-    )
-    order_execution_service = MagicMock()
-    order_execution_service.handle_place_sell_order = AsyncMock(
-        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=None)
+    virtual_trade_service.reconcile_with_broker = AsyncMock(
+        return_value={"force_closed": [], "unknown_in_broker": [], "quantity_mismatches": []}
     )
     service = OpeningPositionReconcileService(
         broker=broker,
-        order_execution_service=order_execution_service,
         virtual_trade_service=virtual_trade_service,
-        detect_only=False,
-        auto_sell_extra_broker=True,
-        allow_sell_unknown_broker=True,
         logger=MagicMock(),
     )
 
     result = await service.reconcile_once()
 
-    order_execution_service.handle_place_sell_order.assert_awaited_once()
-    assert result["planned_sells"] == [
-        {
-            "code": "035420",
-            "qty": 2,
-            "local_qty": 0,
-            "broker_qty": 2,
-            "reason": "unknown_broker_holding",
-        }
-    ]
-    assert result["skipped"] == []
+    assert result["force_closed"] == []
+    assert result["unknown_in_broker"] == []
+    assert result["quantity_mismatches"] == []
+    assert result["mismatch_count"] == 0
+    assert result["error"] is None
 
 
 @pytest.mark.asyncio
-async def test_opening_reconcile_reports_balance_failure_without_orders():
+async def test_opening_reconcile_reports_balance_failure_without_delegation():
     broker = MagicMock()
     broker.get_account_balance = AsyncMock(
         return_value=ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="denied", data=None)
     )
-    order_execution_service = MagicMock()
-    order_execution_service.handle_place_buy_order = AsyncMock()
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.reconcile_with_broker = AsyncMock()
     service = OpeningPositionReconcileService(
         broker=broker,
-        order_execution_service=order_execution_service,
-        virtual_trade_service=MagicMock(),
+        virtual_trade_service=virtual_trade_service,
         logger=MagicMock(),
     )
 
     result = await service.reconcile_once()
 
-    assert result["error"] == "denied"
-    order_execution_service.handle_place_buy_order.assert_not_awaited()
+    assert result == {
+        "force_closed": [],
+        "unknown_in_broker": [],
+        "quantity_mismatches": [],
+        "mismatch_count": 0,
+        "error": "denied",
+    }
+    virtual_trade_service.reconcile_with_broker.assert_not_awaited()

--- a/tests/unit_test/services/test_virtual_trade_service.py
+++ b/tests/unit_test/services/test_virtual_trade_service.py
@@ -361,8 +361,8 @@ def test_sync_live_strategy_positions_delegates_to_repo(virtual_trade_service, m
 async def test_reconcile_with_broker_force_closes_missing_local_holds(virtual_trade_service, mock_repo):
     """로컬 HOLD인데 실제 잔고가 없으면 강제 종결한다."""
     mock_repo.get_holds.return_value = [
-        {"code": "005930", "strategy": "S1"},
-        {"code": "000660", "strategy": "S2"},
+        {"code": "005930", "strategy": "S1", "qty": 1},
+        {"code": "000660", "strategy": "S2", "qty": 3},
     ]
     mock_repo.log_sell_async = AsyncMock()
     test_logger = MagicMock()
@@ -373,14 +373,14 @@ async def test_reconcile_with_broker_force_closes_missing_local_holds(virtual_tr
     )
 
     mock_repo.log_sell_async.assert_awaited_once_with("005930", 0, reason="reconciled_force_close")
-    assert result == {"force_closed": ["005930"], "unknown_in_broker": []}
+    assert result == {"force_closed": ["005930"], "unknown_in_broker": [], "quantity_mismatches": []}
     test_logger.warning.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_with_broker_reports_unknown_broker_holdings(virtual_trade_service, mock_repo):
     """실제 보유인데 로컬 DB가 없으면 unknown_in_broker로 보고한다."""
-    mock_repo.get_holds.return_value = [{"code": "005930", "strategy": "S1"}]
+    mock_repo.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 2}]
     mock_repo.log_sell_async = AsyncMock()
     test_logger = MagicMock()
 
@@ -394,5 +394,73 @@ async def test_reconcile_with_broker_reports_unknown_broker_holdings(virtual_tra
     )
 
     mock_repo.log_sell_async.assert_not_awaited()
-    assert result == {"force_closed": [], "unknown_in_broker": ["035420"]}
+    assert result == {"force_closed": [], "unknown_in_broker": ["035420"], "quantity_mismatches": []}
     assert test_logger.warning.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_with_broker_reports_quantity_mismatches(virtual_trade_service, mock_repo):
+    """양쪽에 같은 종목이 있으나 수량이 다르면 자동 종결 없이 보고한다."""
+    mock_repo.get_holds.return_value = [
+        {"code": "005930", "strategy": "S1", "qty": 1},
+        {"code": "005930", "strategy": "S2", "qty": 2},
+    ]
+    mock_repo.log_sell_async = AsyncMock()
+    test_logger = MagicMock()
+
+    result = await virtual_trade_service.reconcile_with_broker(
+        actual_holdings=[{"pdno": "005930", "hldg_qty": "1"}],
+        logger=test_logger,
+    )
+
+    mock_repo.log_sell_async.assert_not_awaited()
+    assert result == {
+        "force_closed": [],
+        "unknown_in_broker": [],
+        "quantity_mismatches": [{"code": "005930", "local_qty": 3, "broker_qty": 1}],
+    }
+    test_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_with_broker_normalizes_broker_holding_variants(virtual_trade_service, mock_repo):
+    """브로커 잔고의 대문자 키, 콤마, float 문자열을 정규화한다."""
+    mock_repo.get_holds.return_value = [{"code": "005930", "strategy": "S1", "qty": 1000}]
+    mock_repo.log_sell_async = AsyncMock()
+    test_logger = MagicMock()
+
+    result = await virtual_trade_service.reconcile_with_broker(
+        actual_holdings=[
+            {"PDNO": "005930", "HLDG_QTY": "1,000"},
+            {"pdno": "000660", "hldg_qty": "0.0000"},
+        ],
+        logger=test_logger,
+    )
+
+    mock_repo.log_sell_async.assert_not_awaited()
+    assert result == {"force_closed": [], "unknown_in_broker": [], "quantity_mismatches": []}
+    test_logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_with_broker_force_closes_each_missing_hold_row(virtual_trade_service, mock_repo):
+    """브로커에 없는 종목의 로컬 HOLD는 같은 code라도 row 수만큼 종결한다."""
+    mock_repo.get_holds.return_value = [
+        {"code": "005930", "strategy": "S1", "qty": 1},
+        {"code": "005930", "strategy": "S2", "qty": 2},
+    ]
+    mock_repo.log_sell_async = AsyncMock()
+    test_logger = MagicMock()
+
+    result = await virtual_trade_service.reconcile_with_broker(
+        actual_holdings=[],
+        logger=test_logger,
+    )
+
+    assert mock_repo.log_sell_async.await_count == 2
+    mock_repo.log_sell_async.assert_any_await("005930", 0, reason="reconciled_force_close")
+    assert result == {
+        "force_closed": ["005930", "005930"],
+        "unknown_in_broker": [],
+        "quantity_mismatches": [],
+    }

--- a/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
+++ b/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
@@ -36,6 +36,31 @@ async def test_opening_position_reconcile_runs_once_in_opening_window():
 
 
 @pytest.mark.asyncio
+async def test_opening_position_reconcile_does_not_stamp_date_on_error_result():
+    clock = MagicMock()
+    open_time = datetime(2026, 4, 30, 9, 0)
+    clock.get_market_open_time.return_value = open_time
+    clock.get_current_kst_time.return_value = open_time + timedelta(seconds=61)
+    mcs = AsyncMock()
+    mcs.is_business_day.return_value = True
+    service = AsyncMock()
+    service.reconcile_once.return_value = {"mismatch_count": 0, "error": "denied"}
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service,
+        market_calendar_service=mcs,
+        market_clock=clock,
+        notification_service=AsyncMock(),
+        logger=MagicMock(),
+    )
+
+    result = await task.run_once()
+
+    assert result["error"] == "denied"
+    assert task._last_checked_date is None
+    assert await task._should_run_now() is True
+
+
+@pytest.mark.asyncio
 async def test_opening_position_reconcile_skips_before_delay_and_after_window():
     clock = MagicMock()
     open_time = datetime(2026, 4, 30, 9, 0)

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -662,14 +662,21 @@ class WebAppContext:
             reconcile_cfg = getattr(self.full_config, "opening_position_reconcile", None)
             self.opening_position_reconcile_task = None
             if reconcile_cfg is None or getattr(reconcile_cfg, "enabled", True):
+                deprecated_reconcile_keys = (
+                    "detect_only",
+                    "auto_buy_missing_local",
+                    "auto_sell_extra_broker",
+                    "allow_sell_unknown_broker",
+                )
+                reconcile_extra = getattr(reconcile_cfg, "model_extra", {}) or {}
+                for key in deprecated_reconcile_keys:
+                    if key in reconcile_extra:
+                        self.logger.warning(
+                            f"opening_position_reconcile.{key} is deprecated and ignored"
+                        )
                 opening_reconcile_service = OpeningPositionReconcileService(
                     broker=self.broker,
-                    order_execution_service=self.order_execution_service,
                     virtual_trade_service=self.virtual_trade_service,
-                    detect_only=getattr(reconcile_cfg, "detect_only", True),
-                    auto_buy_missing_local=getattr(reconcile_cfg, "auto_buy_missing_local", False),
-                    auto_sell_extra_broker=getattr(reconcile_cfg, "auto_sell_extra_broker", False),
-                    allow_sell_unknown_broker=getattr(reconcile_cfg, "allow_sell_unknown_broker", False),
                     logger=self.logger,
                 )
                 self.opening_position_reconcile_task = OpeningPositionReconcileTask(


### PR DESCRIPTION
…-close, broker-only/수량 불일치는 자동 주문 없이 경고”로 정리했고 그대로 반영했습니다.

변경 요약:

OpeningPositionReconcileService: 주문 발주 경로 제거, VirtualTradeService.reconcile_with_broker() 위임 구조로 축소. VirtualTradeService: broker holdings 정규화 강화, 다중 HOLD row force-close, quantity_mismatches 보고 추가. OpeningPositionReconcileTask: error 결과면 날짜 stamp를 남기지 않아 윈도우 내 retry 가능하게 수정, 알림 메시지 개선. config_loader.py / web_app_initializer.py: deprecated reconcile flags 제거/무시 warning 처리. 정책 문서 추가: opening_position_reconcile_policy.md
검증:

대상 테스트: 35 passed
compileall: 통과
git diff --check: 통과
통합 테스트: 208 passed
전체 단위 테스트: 4099 passed, 2 failed
실패 2개는 tests/unit_test/repositories/test_virtual_trade_repository.py의 기존 asyncio.get_event_loop() contract 테스트가 xdist 전체 실행에서 event loop 없음으로 실패한 케이스입니다. 같은 2개 테스트를 단독 직렬 실행하면 2 passed라 이번 변경 회귀는 아닌 것으로 확인했습니다.