### PR TITLE
P2-3 완료됐습니다. 사용자 질문에 답하겠습니다.

### DIFF
--- a/common/market_snapshot.py
+++ b/common/market_snapshot.py
@@ -1,0 +1,105 @@
+"""Market snapshot dataclass contracts.
+
+WebSocket / REST / backtest replay 세 경로에서 동일 타입으로 정규화.
+- MarketSnapshot: 현재가·거래량·거래대금·고가·저가·시가·데이터 시각
+- ConclusionSnapshot: 체결강도 (별도 API 경로)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MarketSnapshot:
+    """시세 snapshot contract.
+
+    source 필드:
+      "websocket"       — WebSocket 체결가 틱 수신
+      "rest"            — REST 응답을 backfill
+      "backtest_replay" — 백테스트 재현 replay
+    high/low/open 은 WebSocket 틱에서만 채워진다. REST backfill 경로에서는 None.
+    """
+
+    code: str
+    price: float
+    change: float
+    rate: float
+    sign: str  # "1"~"5" (상한/상승/보합/하락/하한)
+    acml_vol: int
+    acml_tr_pbmn: int
+    high: Optional[float]
+    low: Optional[float]
+    open: Optional[float]
+    received_at: float  # epoch seconds
+    latency_sec: float
+    quality_status: str  # "ok" | severity
+    quality_reason: str  # "websocket" | "rest_snapshot" | etc.
+    source: str
+
+    def to_legacy_dict(self) -> dict:
+        """기존 PriceStreamService._latest_prices dict 포맷으로 변환."""
+        return {
+            "price": str(self.price),
+            "change": str(self.change),
+            "rate": str(self.rate),
+            "sign": self.sign,
+            "acml_vol": self.acml_vol,
+            "acml_tr_pbmn": self.acml_tr_pbmn,
+            "high": self.high,
+            "low": self.low,
+            "open": self.open,
+            "received_at": self.received_at,
+            "latency_sec": self.latency_sec,
+            "quality_status": self.quality_status,
+            "quality_reason": self.quality_reason,
+        }
+
+    @classmethod
+    def from_legacy_dict(cls, code: str, d: dict, source: str = "websocket") -> "MarketSnapshot":
+        """PriceStreamService._latest_prices dict → MarketSnapshot."""
+
+        def _float(v, default: float = 0.0) -> float:
+            try:
+                return float(v) if v is not None and v != "N/A" else default
+            except (ValueError, TypeError):
+                return default
+
+        def _int(v, default: int = 0) -> int:
+            try:
+                return int(v) if v is not None and v != "N/A" else default
+            except (ValueError, TypeError):
+                return default
+
+        return cls(
+            code=code,
+            price=_float(d.get("price")),
+            change=_float(d.get("change")),
+            rate=_float(d.get("rate")),
+            sign=str(d.get("sign") or "3"),
+            acml_vol=_int(d.get("acml_vol")),
+            acml_tr_pbmn=_int(d.get("acml_tr_pbmn")),
+            high=_float(d["high"]) if d.get("high") is not None else None,
+            low=_float(d["low"]) if d.get("low") is not None else None,
+            open=_float(d["open"]) if d.get("open") is not None else None,
+            received_at=_float(d.get("received_at")),
+            latency_sec=_float(d.get("latency_sec")),
+            quality_status=str(d.get("quality_status") or "ok"),
+            quality_reason=str(d.get("quality_reason") or ""),
+            source=source,
+        )
+
+
+@dataclass(frozen=True)
+class ConclusionSnapshot:
+    """체결강도 snapshot contract.
+
+    source 필드:
+      "rest"            — REST get_stock_conclusion API 결과
+      "backtest_replay" — 백테스트 재현 replay
+    """
+
+    code: str
+    execution_strength_pct: float  # cgld / tday_rltv
+    received_at: float
+    source: str

--- a/services/backtest_replay_adapter.py
+++ b/services/backtest_replay_adapter.py
@@ -1,10 +1,13 @@
 """Replay adapters for period backtests."""
 from __future__ import annotations
 
-from typing import Any, Sequence
+import time
+from typing import Any, Optional, Sequence, Tuple
 
+from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
 from common.types import ErrorCode, ResCommonResponse, TradeSignal
 from services.backtest_execution_simulator import BacktestBar
+from services.data_quality_service import DataQualityService
 
 
 class StockQueryBacktestReplayService:
@@ -92,6 +95,104 @@ class StockQueryBacktestReplayService:
         if "session" not in kwargs:
             kwargs["session"] = self._session
         return await self._stock_query_service.get_day_intraday_minutes_list(stock_code, **kwargs)
+
+    def get_market_snapshot(
+        self,
+        code: str,
+        max_age_sec: Optional[float] = None,
+        force_fresh: bool = False,
+    ) -> Tuple[Optional[MarketSnapshot], Optional[str]]:
+        """Replay row cache → MarketSnapshot (sync, cache-only).
+
+        live PriceStreamService 캐시 대신 이미 조회된 row_cache 에서 빌드.
+        캐시 미스 시 REASON_SNAPSHOT_MISSING 반환.
+        """
+        if force_fresh or not self._backtest_date:
+            return None, DataQualityService.REASON_SNAPSHOT_MISSING
+
+        key = (code, self._backtest_date, self._session)
+        rows = self._row_cache.get(key)
+        if not rows:
+            return None, DataQualityService.REASON_SNAPSHOT_MISSING
+
+        latest = rows[-1]
+        closes = [value for value in (self._to_int(self._first(row, "stck_prpr", "prpr", "close", "price")) for row in rows) if value is not None]
+        latest_close = closes[-1] if closes else 0
+        highs = [value for value in (self._to_int(self._first(row, "stck_hgpr", "hgpr", "high")) for row in rows) if value is not None]
+        lows = [value for value in (self._to_int(self._first(row, "stck_lwpr", "lwpr", "low")) for row in rows) if value is not None]
+        volume = self._to_int(self._first(latest, "acml_vol")) or sum(
+            self._to_int(self._first(row, "cntg_vol", "volume")) or 0 for row in rows
+        )
+        trade_value = self._to_int(self._first(latest, "acml_tr_pbmn")) or 0
+
+        snap = MarketSnapshot(
+            code=code,
+            price=float(latest_close),
+            change=0.0,
+            rate=0.0,
+            sign="3",
+            acml_vol=volume or 0,
+            acml_tr_pbmn=trade_value or 0,
+            high=float(max(highs)) if highs else None,
+            low=float(min(lows)) if lows else None,
+            open=None,
+            received_at=time.time(),
+            latency_sec=0.0,
+            quality_status="ok",
+            quality_reason="backtest_replay",
+            source="backtest_replay",
+        )
+        return snap, None
+
+    async def get_conclusion_snapshot(
+        self,
+        code: str,
+        max_age_sec: float = 10.0,
+        force_fresh: bool = False,
+    ) -> Tuple[Optional[ConclusionSnapshot], Optional[str]]:
+        """Replay row cache → ConclusionSnapshot (async, uses get_stock_conclusion)."""
+        if not self._backtest_date:
+            return None, DataQualityService.REASON_CONCLUSION_MISSING
+
+        key = (code, self._backtest_date, self._session)
+        rows = self._row_cache.get(key)
+        if rows:
+            latest = rows[-1]
+            strength_raw = self._first(latest, "tday_rltv", "execution_strength", "cnqn", "체결강도")
+            if strength_raw is not None:
+                try:
+                    strength = float(strength_raw)
+                except (ValueError, TypeError):
+                    strength = 0.0
+                return ConclusionSnapshot(
+                    code=code,
+                    execution_strength_pct=strength,
+                    received_at=time.time(),
+                    source="backtest_replay",
+                ), None
+
+        resp = await self.get_stock_conclusion(code)
+        if resp is None or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return None, DataQualityService.REASON_CONCLUSION_MISSING
+
+        try:
+            output = (resp.data or {}).get("output")
+            if isinstance(output, list) and output:
+                output = output[0]
+            if isinstance(output, dict):
+                strength_raw = output.get("tday_rltv") or "0"
+            else:
+                strength_raw = "0"
+            strength = float(strength_raw)
+        except (ValueError, TypeError, AttributeError):
+            strength = 0.0
+
+        return ConclusionSnapshot(
+            code=code,
+            execution_strength_pct=strength,
+            received_at=time.time(),
+            source="backtest_replay",
+        ), None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._stock_query_service, name)

--- a/services/data_quality_service.py
+++ b/services/data_quality_service.py
@@ -34,6 +34,10 @@ class DataQualityService:
     REASON_STALE_PRICE = "stale_price"
     REASON_INVALID_TICK = "invalid_tick"
     REASON_LATENCY_EXCEEDED = "latency_exceeded"
+    REASON_SNAPSHOT_MISSING = "snapshot_missing"
+    REASON_SNAPSHOT_STALE = "snapshot_stale"
+    REASON_CONCLUSION_MISSING = "conclusion_missing"
+    REASON_CONCLUSION_STALE = "conclusion_stale"
 
     def __init__(
         self,

--- a/services/execution_flow_service.py
+++ b/services/execution_flow_service.py
@@ -63,6 +63,8 @@ class ExecutionFlowService:
         logger: Optional[logging.Logger] = None,
         cache_ttl_sec: float = 3.0,
         sample_window_sec: int = 60,
+        stock_query_service=None,
+        conclusion_max_age_sec: float = 10.0,
     ):
         self._data_provider = data_provider
         self._market_clock = market_clock
@@ -70,6 +72,8 @@ class ExecutionFlowService:
         self._cache_ttl_sec = max(0.0, float(cache_ttl_sec))
         self._sample_window_sec = max(1, int(sample_window_sec))
         self._cache: dict[tuple[str, str], tuple[float, ExecutionFlowSnapshot]] = {}
+        self._stock_query_service = stock_query_service
+        self._conclusion_max_age_sec = conclusion_max_age_sec
 
     async def get_snapshot(
         self,
@@ -85,25 +89,42 @@ class ExecutionFlowService:
             return cached[1]
 
         measured_at = self._now()
-        conclusion_resp = await self._safe_call("get_stock_conclusion", stock_code, exchange)
-        time_resp = await self._safe_call("get_time_concluded_prices", stock_code, exchange)
-
         quality_flags: list[str] = []
-        if not self._is_success(conclusion_resp):
-            quality_flags.append("conclusion_unavailable")
+
+        # 체결강도: ConclusionSnapshot 캐시 우선, 없으면 REST fallback
+        execution_strength: Optional[float] = None
+        conclusion_row: dict = {}
+        if self._stock_query_service is not None and not force_refresh:
+            try:
+                cs, cs_reason = await self._stock_query_service.get_conclusion_snapshot(
+                    stock_code, max_age_sec=self._conclusion_max_age_sec
+                )
+                if cs is not None:
+                    execution_strength = cs.execution_strength_pct
+                    quality_flags.append("conclusion_from_cache")
+                elif cs_reason:
+                    quality_flags.append(f"conclusion_snapshot:{cs_reason}")
+            except Exception as e:
+                self._logger.debug({"event": "conclusion_snapshot_error", "code": stock_code, "error": str(e)})
+
+        if execution_strength is None:
+            conclusion_resp = await self._safe_call("get_stock_conclusion", stock_code, exchange)
+            if not self._is_success(conclusion_resp):
+                quality_flags.append("conclusion_unavailable")
+            conclusion_row = self._first_row(conclusion_resp.data if self._is_success(conclusion_resp) else None)
+            execution_strength = self._to_float(self._pick(
+                conclusion_row,
+                "tday_rltv",
+                "cgld",
+                "execution_strength",
+                "체결강도",
+            ))
+
+        time_resp = await self._safe_call("get_time_concluded_prices", stock_code, exchange)
         if not self._is_success(time_resp):
             quality_flags.append("time_concluded_unavailable")
 
-        conclusion_row = self._first_row(conclusion_resp.data if self._is_success(conclusion_resp) else None)
         time_rows = self._rows(time_resp.data if self._is_success(time_resp) else None)
-
-        execution_strength = self._to_float(self._pick(
-            conclusion_row,
-            "tday_rltv",
-            "cgld",
-            "execution_strength",
-            "체결강도",
-        ))
 
         recent_rows = self._recent_rows(time_rows, measured_at)
         recent_trade_count = len(recent_rows) if time_rows else None

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -21,6 +21,7 @@ import logging
 import time
 from typing import Dict, List, Optional
 
+from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
 from repositories.stock_repository import StockRepository
 from services.notification_service import NotificationCategory, NotificationLevel
 
@@ -40,6 +41,7 @@ class PriceStreamService:
         self._data_quality_service = data_quality_service
         self._notification_service = notification_service
         self._latest_prices: Dict[str, dict] = {}
+        self._latest_conclusions: Dict[str, dict] = {}  # code → conclusion snapshot dict
         self._sse_queues: Dict[str, List[asyncio.Queue]] = {}  # code → SSE 구독 큐 목록
         self._last_tick_ts: Dict[str, float] = {}
         self._last_any_tick_ts: float = 0.0
@@ -101,6 +103,12 @@ class PriceStreamService:
         except (ValueError, TypeError):
             tr_pbmn_int = 0
 
+        def _sf(val: str, default: float = 0.0) -> Optional[float]:
+            try:
+                return float(val) if val and val != 'N/A' else None
+            except (ValueError, TypeError):
+                return None
+
         self._latest_prices[stock_code] = {
             "price": current_price,
             "change": realtime_data.get('전일대비', '0'),
@@ -108,10 +116,13 @@ class PriceStreamService:
             "sign": realtime_data.get('전일대비부호', '3'),
             "acml_vol": vol_int,
             "acml_tr_pbmn": tr_pbmn_int,
+            "high": _sf(realtime_data.get('주식최고가', '')),
+            "low": _sf(realtime_data.get('주식최저가', '')),
+            "open": _sf(realtime_data.get('주식시가', '')),
             "received_at": now_ts,
             "latency_sec": latency_sec,
             "quality_status": quality_status,
-            "quality_reason": quality_reason,
+            "quality_reason": "websocket",
         }
 
         try:
@@ -120,12 +131,6 @@ class PriceStreamService:
             self._logger.warning(f"StockRepository 실시간 틱 캐시 갱신 실패: {e}")
 
         if stock_code in self._sse_queues:
-            def _sf(val: str, default: float = 0.0) -> float:
-                try:
-                    return float(val) if val and val != 'N/A' else default
-                except (ValueError, TypeError):
-                    return default
-
             tick = {
                 "code": stock_code,
                 "price": float(current_price),
@@ -133,15 +138,47 @@ class PriceStreamService:
                 "change": realtime_data.get('전일대비', '0'),
                 "rate": realtime_data.get('전일대비율', '0.00'),
                 "sign": realtime_data.get('전일대비부호', '3'),
-                "open": _sf(realtime_data.get('주식시가')),
-                "high": _sf(realtime_data.get('주식최고가')),
-                "low": _sf(realtime_data.get('주식최저가')),
+                "open": _sf(realtime_data.get('주식시가', '')) or 0.0,
+                "high": _sf(realtime_data.get('주식최고가', '')) or 0.0,
+                "low": _sf(realtime_data.get('주식최저가', '')) or 0.0,
             }
             for q in self._sse_queues[stock_code]:
                 try:
                     q.put_nowait(tick)
                 except asyncio.QueueFull:
                     pass
+
+    def get_market_snapshot(self, code: str) -> Optional[MarketSnapshot]:
+        """메모리 캐시에서 MarketSnapshot 을 반환한다.
+
+        snapshot 이 없으면 None. 타입 정보가 필요 없는 기존 경로는 get_cached_price() 사용.
+        """
+        cached = self._latest_prices.get(code)
+        if cached is None:
+            return None
+        source = "websocket" if cached.get("quality_reason") == "websocket" else "rest"
+        return MarketSnapshot.from_legacy_dict(code, cached, source=source)
+
+    def cache_conclusion_snapshot(self, code: str, execution_strength_pct: float) -> None:
+        """체결강도 REST 응답을 캐시에 저장한다."""
+        if not code:
+            return
+        self._latest_conclusions[code] = {
+            "execution_strength_pct": execution_strength_pct,
+            "received_at": time.time(),
+        }
+
+    def get_conclusion_snapshot(self, code: str) -> Optional[ConclusionSnapshot]:
+        """캐시에서 ConclusionSnapshot 을 반환한다. 없으면 None."""
+        cached = self._latest_conclusions.get(code)
+        if cached is None:
+            return None
+        return ConclusionSnapshot(
+            code=code,
+            execution_strength_pct=cached["execution_strength_pct"],
+            received_at=cached["received_at"],
+            source="rest",
+        )
 
     def get_cached_price(self, code: str) -> Optional[dict]:
         """메모리 캐시에서 최신가 정보를 반환한다."""
@@ -156,6 +193,9 @@ class PriceStreamService:
         sign: str = '3',
         volume: str = '0',
         acml_tr_pbmn: Optional[str] = None,
+        high: Optional[str] = None,
+        low: Optional[str] = None,
+        open_price: Optional[str] = None,
     ) -> None:
         """REST 스냅샷 현재가를 최신가 캐시에 반영한다."""
         if not code or not price:
@@ -173,6 +213,14 @@ class PriceStreamService:
         except (ValueError, TypeError):
             tr_pbmn_int = 0
 
+        def _parse_opt(v: Optional[str]) -> Optional[float]:
+            if not v or v == 'N/A':
+                return None
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return None
+
         now_ts = time.time()
         self._latest_prices[code] = {
             "price": price,
@@ -181,6 +229,9 @@ class PriceStreamService:
             "sign": sign,
             "acml_vol": vol_int,
             "acml_tr_pbmn": tr_pbmn_int,
+            "high": _parse_opt(high),
+            "low": _parse_opt(low),
+            "open": _parse_opt(open_price),
             "received_at": now_ts,
             "latency_sec": 0.0,
             "quality_status": "ok",
@@ -219,6 +270,7 @@ class PriceStreamService:
         self._subscription_requested_ts.pop(code, None)
         self._last_tick_ts.pop(code, None)
         self._latest_prices.pop(code, None)
+        self._latest_conclusions.pop(code, None)
 
     def get_last_tick_ts(self, code: str) -> float:
         """종목별 마지막 틱 수신 시각(epoch)을 반환한다."""

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1,11 +1,13 @@
 # app/stock_query_service.py
 from __future__ import annotations
 import time
+from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
 from common.types import ErrorCode, ResCommonResponse, ResTopMarketCapApiItem, ResBasicStockInfo, \
     ResStockFullInfoApiOutput, Exchange
 from config.DynamicConfig import DynamicConfig
-from typing import List, Dict, Optional, Literal
+from typing import List, Dict, Optional, Tuple, Literal
 from core.performance_profiler import PerformanceProfiler
+from services.data_quality_service import DataQualityService
 from services.notification_service import NotificationService, NotificationCategory, NotificationLevel
 from services.market_data_service import MarketDataService
 
@@ -41,6 +43,9 @@ class StockQueryService:
             "no_tick_fallback": 0,
             "stale_fallback": 0,
             "rest_fallback": 0,
+            "conclusion_hit": 0,
+            "conclusion_stale_fallback": 0,
+            "conclusion_missing_fallback": 0,
         }
 
     def _get_sign_from_code(self, sign_code):
@@ -148,6 +153,11 @@ class StockQueryService:
                 and resp.rt_cd == ErrorCode.SUCCESS.value):
             try:
                 output = (resp.data or {}).get("output")
+
+                def _opt(v) -> Optional[str]:
+                    s = str(v) if v is not None else ""
+                    return s if s and s not in ("0", "N/A") else None
+
                 if isinstance(output, ResStockFullInfoApiOutput):
                     self.price_stream_service.cache_price_snapshot(
                         stock_code,
@@ -157,6 +167,9 @@ class StockQueryService:
                         sign=str(output.prdy_vrss_sign or "3"),
                         volume=str(output.acml_vol or "0"),
                         acml_tr_pbmn=str(output.acml_tr_pbmn or "0"),
+                        high=_opt(output.stck_hgpr),
+                        low=_opt(output.stck_lwpr),
+                        open_price=_opt(output.stck_oprc),
                     )
                 elif isinstance(output, dict):
                     self.price_stream_service.cache_price_snapshot(
@@ -167,6 +180,9 @@ class StockQueryService:
                         sign=str(output.get("prdy_vrss_sign", "3") or "3"),
                         volume=str(output.get("acml_vol", "0") or "0"),
                         acml_tr_pbmn=str(output.get("acml_tr_pbmn", "0") or "0"),
+                        high=_opt(output.get("stck_hgpr")),
+                        low=_opt(output.get("stck_lwpr")),
+                        open_price=_opt(output.get("stck_oprc")),
                     )
             except Exception as e:
                 self.logger.debug({"event": "snapshot_backfill_skipped", "code": stock_code, "error": str(e)})
@@ -196,6 +212,83 @@ class StockQueryService:
     async def get_stock_conclusion(self, stock_code: str) -> ResCommonResponse:
         """체결 정보 조회 (MarketDataService 래퍼)."""
         return await self.market_data_service.get_stock_conclusion(stock_code)
+
+    def get_market_snapshot(
+        self,
+        code: str,
+        max_age_sec: Optional[float] = None,
+        force_fresh: bool = False,
+    ) -> Tuple[Optional[MarketSnapshot], Optional[str]]:
+        """PriceStreamService 캐시에서 MarketSnapshot 을 반환한다.
+
+        반환값: (snapshot, reason)
+          - snapshot: MarketSnapshot 또는 None
+          - reason: None(신선) / REASON_SNAPSHOT_MISSING / REASON_SNAPSHOT_STALE
+        stale 인 경우에도 snapshot 자체는 반환한다(호출자가 fallback 여부 판단).
+        force_fresh=True 이면 항상 (None, REASON_SNAPSHOT_STALE) 반환.
+        """
+        if self.price_stream_service is None:
+            return None, DataQualityService.REASON_SNAPSHOT_MISSING
+
+        if force_fresh:
+            return None, DataQualityService.REASON_SNAPSHOT_STALE
+
+        snap = self.price_stream_service.get_market_snapshot(code)
+        if snap is None:
+            return None, DataQualityService.REASON_SNAPSHOT_MISSING
+
+        effective_max_age = max_age_sec if max_age_sec is not None else self._snapshot_max_age_sec
+        age = time.time() - snap.received_at
+        if age > effective_max_age:
+            return snap, DataQualityService.REASON_SNAPSHOT_STALE
+
+        return snap, None
+
+    async def get_conclusion_snapshot(
+        self,
+        code: str,
+        max_age_sec: float = 10.0,
+        force_fresh: bool = False,
+    ) -> Tuple[Optional[ConclusionSnapshot], Optional[str]]:
+        """체결강도 snapshot 을 캐시 우선으로 반환한다. cache miss/stale 시 REST fallback 후 backfill.
+
+        반환값: (snapshot, reason)
+          - reason: None(신선) / REASON_CONCLUSION_MISSING / REASON_CONCLUSION_STALE
+        """
+        if self.price_stream_service is None:
+            self._price_lookup_stats["conclusion_missing_fallback"] += 1
+            return None, DataQualityService.REASON_CONCLUSION_MISSING
+
+        if not force_fresh:
+            cached = self.price_stream_service.get_conclusion_snapshot(code)
+            if cached is not None:
+                age = time.time() - cached.received_at
+                if age <= max_age_sec:
+                    self._price_lookup_stats["conclusion_hit"] += 1
+                    return cached, None
+                self._price_lookup_stats["conclusion_stale_fallback"] += 1
+            else:
+                self._price_lookup_stats["conclusion_missing_fallback"] += 1
+
+        resp = await self.market_data_service.get_stock_conclusion(code)
+        if resp is None or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return None, DataQualityService.REASON_CONCLUSION_MISSING
+
+        try:
+            output = (resp.data or {}).get("output")
+            if isinstance(output, list) and output:
+                output = output[0]
+            if isinstance(output, dict):
+                strength_raw = output.get("tday_rltv") or output.get("cgld") or "0"
+            else:
+                strength_raw = getattr(output, "tday_rltv", None) or getattr(output, "cgld", None) or "0"
+            strength = float(strength_raw) if strength_raw and strength_raw != "N/A" else 0.0
+        except (ValueError, TypeError, AttributeError):
+            strength = 0.0
+
+        self.price_stream_service.cache_conclusion_snapshot(code, strength)
+        snap = self.price_stream_service.get_conclusion_snapshot(code)
+        return snap, None
 
     async def handle_get_current_stock_price(self, stock_code, caller: str = "unknown", exchange: Exchange = Exchange.KRX, force_fresh: bool = False):
         """주식 현재가 및 상세 정보 조회 요청 및 결과 출력."""

--- a/strategies/strategy_executor.py
+++ b/strategies/strategy_executor.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from config.config_loader import RiskGateConfig
     from services.price_stream_service import PriceStreamService
 
+from services.data_quality_service import DataQualityService
+
 
 class StrategyExecutor:
     """Strategy 실행기.
@@ -123,20 +125,28 @@ class StrategyExecutor:
           1) PriceStreamService snapshot (received_at 이 snapshot_max_age_sec 이내)
           2) get_current_price_fn(REST). 응답을 받으면 snapshot 캐시에 보강.
         """
-        snap = None
         if self._price_stream_service is not None:
             try:
-                snap = self._price_stream_service.get_liquidity_snapshot(code)
+                snap = self._price_stream_service.get_market_snapshot(code)
             except Exception:
                 snap = None
 
-        if snap is not None:
-            received_at = snap.get('received_at', 0.0) or 0.0
-            if (time.time() - received_at) <= self._snapshot_max_age_sec:
-                return (
-                    int(snap.get('acml_tr_pbmn') or 0),
-                    int(snap.get('acml_vol') or 0),
-                )
+            if snap is not None:
+                age = time.time() - snap.received_at
+                if age <= self._snapshot_max_age_sec:
+                    return snap.acml_tr_pbmn, snap.acml_vol
+                self._logger.debug({
+                    "event": "liquidity_snapshot_stale",
+                    "code": code,
+                    "reason": DataQualityService.REASON_SNAPSHOT_STALE,
+                    "age_sec": round(age, 2),
+                })
+            else:
+                self._logger.debug({
+                    "event": "liquidity_snapshot_missing",
+                    "code": code,
+                    "reason": DataQualityService.REASON_SNAPSHOT_MISSING,
+                })
 
         async with sem:
             info = await self._get_current_price_fn(code)

--- a/tests/unit_test/common/test_market_snapshot.py
+++ b/tests/unit_test/common/test_market_snapshot.py
@@ -1,0 +1,114 @@
+"""MarketSnapshot / ConclusionSnapshot dataclass invariant 테스트."""
+import pytest
+from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
+
+
+def _ws_dict() -> dict:
+    return {
+        "price": "75000",
+        "change": "500",
+        "rate": "0.67",
+        "sign": "2",
+        "acml_vol": 120000,
+        "acml_tr_pbmn": 9000000000,
+        "high": 75500.0,
+        "low": 74200.0,
+        "open": 74500.0,
+        "received_at": 1700000000.0,
+        "latency_sec": 0.05,
+        "quality_status": "ok",
+        "quality_reason": "websocket",
+    }
+
+
+def _rest_dict() -> dict:
+    d = _ws_dict()
+    d["high"] = None
+    d["low"] = None
+    d["open"] = None
+    d["quality_reason"] = "rest_snapshot"
+    return d
+
+
+class TestMarketSnapshotFromLegacyDict:
+    def test_websocket_dict_populates_high_low_open(self):
+        snap = MarketSnapshot.from_legacy_dict("005930", _ws_dict(), source="websocket")
+        assert snap.code == "005930"
+        assert snap.price == 75000.0
+        assert snap.high == 75500.0
+        assert snap.low == 74200.0
+        assert snap.open == 74500.0
+        assert snap.acml_vol == 120000
+        assert snap.acml_tr_pbmn == 9000000000
+        assert snap.source == "websocket"
+
+    def test_rest_dict_high_low_open_are_none(self):
+        snap = MarketSnapshot.from_legacy_dict("005930", _rest_dict(), source="rest")
+        assert snap.high is None
+        assert snap.low is None
+        assert snap.open is None
+        assert snap.source == "rest"
+
+    def test_invalid_numeric_values_default_to_zero(self):
+        d = _ws_dict()
+        d["price"] = "N/A"
+        d["acml_vol"] = "bad"
+        snap = MarketSnapshot.from_legacy_dict("005930", d)
+        assert snap.price == 0.0
+        assert snap.acml_vol == 0
+
+    def test_missing_keys_default_gracefully(self):
+        snap = MarketSnapshot.from_legacy_dict("005930", {})
+        assert snap.price == 0.0
+        assert snap.high is None
+        assert snap.sign == "3"
+        assert snap.quality_status == "ok"
+
+
+class TestMarketSnapshotToLegacyDict:
+    def test_roundtrip_websocket(self):
+        original = _ws_dict()
+        snap = MarketSnapshot.from_legacy_dict("005930", original, source="websocket")
+        result = snap.to_legacy_dict()
+        assert result["price"] == "75000.0"
+        assert result["acml_vol"] == 120000
+        assert result["high"] == 75500.0
+        assert result["low"] == 74200.0
+        assert result["quality_reason"] == "websocket"
+
+    def test_roundtrip_rest_none_fields(self):
+        snap = MarketSnapshot.from_legacy_dict("005930", _rest_dict(), source="rest")
+        result = snap.to_legacy_dict()
+        assert result["high"] is None
+        assert result["low"] is None
+        assert result["open"] is None
+
+
+class TestMarketSnapshotFrozen:
+    def test_is_frozen(self):
+        snap = MarketSnapshot.from_legacy_dict("005930", _ws_dict())
+        with pytest.raises((AttributeError, TypeError)):
+            snap.price = 99999.0  # type: ignore[misc]
+
+
+class TestConclusionSnapshot:
+    def test_basic_fields(self):
+        cs = ConclusionSnapshot(
+            code="005930",
+            execution_strength_pct=123.4,
+            received_at=1700000000.0,
+            source="rest",
+        )
+        assert cs.code == "005930"
+        assert cs.execution_strength_pct == 123.4
+        assert cs.source == "rest"
+
+    def test_is_frozen(self):
+        cs = ConclusionSnapshot(
+            code="005930",
+            execution_strength_pct=100.0,
+            received_at=1700000000.0,
+            source="rest",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            cs.execution_strength_pct = 200.0  # type: ignore[misc]

--- a/tests/unit_test/services/test_market_snapshot_contract.py
+++ b/tests/unit_test/services/test_market_snapshot_contract.py
@@ -1,0 +1,213 @@
+"""PriceStreamService / StockQueryService snapshot contract 회귀 테스트."""
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
+from common.types import ErrorCode, ResCommonResponse
+from services.data_quality_service import DataQualityService
+from services.price_stream_service import PriceStreamService
+from services.stock_query_service import StockQueryService
+
+
+# ─── PriceStreamService 신규 메서드 ───────────────────────────────────────────
+
+class TestPriceStreamServiceMarketSnapshot:
+    def _make_svc(self) -> PriceStreamService:
+        return PriceStreamService(stock_repo=MagicMock(), logger=MagicMock())
+
+    def test_get_market_snapshot_none_when_no_cache(self):
+        svc = self._make_svc()
+        assert svc.get_market_snapshot("005930") is None
+
+    def test_get_market_snapshot_websocket_source(self):
+        svc = self._make_svc()
+        svc.on_price_tick({
+            "유가증권단축종목코드": "005930",
+            "주식현재가": "75000",
+            "전일대비": "500",
+            "전일대비율": "0.67",
+            "전일대비부호": "2",
+            "누적거래량": "120000",
+            "누적거래대금": "9000000000",
+            "주식최고가": "75500",
+            "주식최저가": "74200",
+            "주식시가": "74500",
+        })
+        snap = svc.get_market_snapshot("005930")
+        assert isinstance(snap, MarketSnapshot)
+        assert snap.code == "005930"
+        assert snap.price == 75000.0
+        assert snap.high == 75500.0
+        assert snap.low == 74200.0
+        assert snap.open == 74500.0
+        assert snap.source == "websocket"
+
+    def test_get_market_snapshot_rest_source(self):
+        svc = self._make_svc()
+        svc.cache_price_snapshot("005930", price="75000", volume="100000")
+        snap = svc.get_market_snapshot("005930")
+        assert snap is not None
+        assert snap.source == "rest"
+        assert snap.high is None  # REST backfill 시 high 없음
+
+    def test_cache_and_get_conclusion_snapshot(self):
+        svc = self._make_svc()
+        assert svc.get_conclusion_snapshot("005930") is None
+
+        svc.cache_conclusion_snapshot("005930", 123.4)
+        cs = svc.get_conclusion_snapshot("005930")
+        assert isinstance(cs, ConclusionSnapshot)
+        assert cs.code == "005930"
+        assert cs.execution_strength_pct == 123.4
+        assert cs.source == "rest"
+
+    def test_clear_subscription_state_removes_conclusion(self):
+        svc = self._make_svc()
+        svc.cache_conclusion_snapshot("005930", 100.0)
+        svc.clear_subscription_state("005930")
+        assert svc.get_conclusion_snapshot("005930") is None
+
+
+# ─── StockQueryService.get_market_snapshot ────────────────────────────────────
+
+class TestStockQueryServiceGetMarketSnapshot:
+    def _make_sqs(self, snap_dict=None):
+        pss = MagicMock()
+        if snap_dict is None:
+            pss.get_market_snapshot.return_value = None
+        else:
+            code = snap_dict.get("code", "005930")
+            pss.get_market_snapshot.return_value = MarketSnapshot.from_legacy_dict(code, snap_dict)
+        mds = MagicMock()
+        sqs = StockQueryService(
+            market_data_service=mds,
+            logger=MagicMock(),
+            market_clock=MagicMock(),
+            price_stream_service=pss,
+            snapshot_max_age_sec=5.0,
+        )
+        return sqs, pss
+
+    def _fresh_dict(self, age=1.0):
+        return {
+            "price": "75000", "change": "0", "rate": "0.00", "sign": "3",
+            "acml_vol": 100000, "acml_tr_pbmn": 5000000000,
+            "received_at": time.time() - age,
+            "latency_sec": 0.0, "quality_status": "ok", "quality_reason": "websocket",
+        }
+
+    def test_returns_snapshot_and_none_reason_when_fresh(self):
+        sqs, _ = self._make_sqs(self._fresh_dict(age=1.0))
+        snap, reason = sqs.get_market_snapshot("005930")
+        assert isinstance(snap, MarketSnapshot)
+        assert reason is None
+
+    def test_returns_snapshot_and_stale_reason_when_old(self):
+        sqs, _ = self._make_sqs(self._fresh_dict(age=10.0))
+        snap, reason = sqs.get_market_snapshot("005930")
+        assert snap is not None
+        assert reason == DataQualityService.REASON_SNAPSHOT_STALE
+
+    def test_returns_none_and_missing_reason_when_no_cache(self):
+        sqs, _ = self._make_sqs(snap_dict=None)
+        snap, reason = sqs.get_market_snapshot("005930")
+        assert snap is None
+        assert reason == DataQualityService.REASON_SNAPSHOT_MISSING
+
+    def test_force_fresh_returns_none_and_stale_reason(self):
+        sqs, _ = self._make_sqs(self._fresh_dict(age=0.0))
+        snap, reason = sqs.get_market_snapshot("005930", force_fresh=True)
+        assert snap is None
+        assert reason == DataQualityService.REASON_SNAPSHOT_STALE
+
+    def test_no_price_stream_service_returns_missing(self):
+        mds = MagicMock()
+        sqs = StockQueryService(
+            market_data_service=mds, logger=MagicMock(), market_clock=MagicMock(),
+            price_stream_service=None,
+        )
+        snap, reason = sqs.get_market_snapshot("005930")
+        assert snap is None
+        assert reason == DataQualityService.REASON_SNAPSHOT_MISSING
+
+
+# ─── StockQueryService.get_conclusion_snapshot ────────────────────────────────
+
+class TestStockQueryServiceGetConclusionSnapshot:
+    def _make_sqs_with_pss(self, cs=None):
+        pss = MagicMock()
+        pss.get_conclusion_snapshot.return_value = cs
+        mds = AsyncMock()
+        sqs = StockQueryService(
+            market_data_service=mds,
+            logger=MagicMock(),
+            market_clock=MagicMock(),
+            price_stream_service=pss,
+        )
+        return sqs, pss, mds
+
+    def _make_cs(self, age=1.0) -> ConclusionSnapshot:
+        return ConclusionSnapshot(
+            code="005930",
+            execution_strength_pct=115.0,
+            received_at=time.time() - age,
+            source="rest",
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_when_fresh(self):
+        cs = self._make_cs(age=1.0)
+        sqs, pss, _ = self._make_sqs_with_pss(cs=cs)
+        result, reason = await sqs.get_conclusion_snapshot("005930", max_age_sec=10.0)
+        assert result is cs
+        assert reason is None
+        assert sqs._price_lookup_stats["conclusion_hit"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rest_fallback_when_stale(self):
+        cs = self._make_cs(age=20.0)
+        sqs, pss, mds = self._make_sqs_with_pss(cs=cs)
+        output = {"tday_rltv": "123.4"}
+        mds.get_stock_conclusion.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+            data={"output": [output]},
+        )
+        fresh_cs = ConclusionSnapshot(code="005930", execution_strength_pct=123.4,
+                                      received_at=time.time(), source="rest")
+        pss.get_conclusion_snapshot.side_effect = [cs, fresh_cs]
+
+        result, reason = await sqs.get_conclusion_snapshot("005930", max_age_sec=10.0)
+        assert result is fresh_cs
+        assert reason is None
+        pss.cache_conclusion_snapshot.assert_called_once_with("005930", 123.4)
+        assert sqs._price_lookup_stats["conclusion_stale_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rest_fallback_when_missing(self):
+        sqs, pss, mds = self._make_sqs_with_pss(cs=None)
+        output = {"tday_rltv": "99.5"}
+        mds.get_stock_conclusion.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+            data={"output": [output]},
+        )
+        fresh_cs = ConclusionSnapshot(code="005930", execution_strength_pct=99.5,
+                                      received_at=time.time(), source="rest")
+        pss.get_conclusion_snapshot.side_effect = [None, fresh_cs]
+
+        result, reason = await sqs.get_conclusion_snapshot("005930")
+        assert result is fresh_cs
+        assert sqs._price_lookup_stats["conclusion_missing_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_rest_fails(self):
+        sqs, _, mds = self._make_sqs_with_pss(cs=None)
+        mds.get_stock_conclusion.return_value = ResCommonResponse(
+            rt_cd="1", msg1="error", data={}
+        )
+        result, reason = await sqs.get_conclusion_snapshot("005930")
+        assert result is None
+        assert reason == DataQualityService.REASON_CONCLUSION_MISSING

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -339,7 +339,7 @@ def test_on_price_tick_quality_metadata_saved(mock_stock_repo, mock_logger):
 
     cached = svc.get_cached_price("005930")
     assert cached["quality_status"] == "ok"
-    assert cached["quality_reason"] == "ok"
+    assert cached["quality_reason"] == "websocket"
     assert cached["latency_sec"] == 0.25
 
 

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -305,6 +305,9 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
             sign="2",
             volume="300000",
             acml_tr_pbmn="24000000000",
+            high=None,
+            low=None,
+            open_price=None,
         )
 
     async def test_get_current_price_force_fresh_passed_through(self):

--- a/tests/unit_test/test_strategy_executor.py
+++ b/tests/unit_test/test_strategy_executor.py
@@ -152,14 +152,18 @@ async def test_price_fetch_error_blocks_code():
 
 
 class _StubPriceStream:
-    """PriceStreamService 스텁 — get_liquidity_snapshot / cache_price_snapshot 만 노출."""
+    """PriceStreamService 스텁 — get_market_snapshot / cache_price_snapshot 만 노출."""
 
     def __init__(self, snapshots=None):
         self._snapshots = dict(snapshots or {})
         self.cache_calls = []
 
-    def get_liquidity_snapshot(self, code):
-        return self._snapshots.get(code)
+    def get_market_snapshot(self, code):
+        from common.market_snapshot import MarketSnapshot
+        d = self._snapshots.get(code)
+        if d is None:
+            return None
+        return MarketSnapshot.from_legacy_dict(code, d)
 
     def cache_price_snapshot(self, code, price, volume='0', acml_tr_pbmn=None, **kwargs):
         self.cache_calls.append({

--- a/todo_list.md
+++ b/todo_list.md
@@ -273,9 +273,9 @@
 
 ### 2-3. Market snapshot 표준화
 
-- [ ] 기존 `PriceStreamService`의 `get_cached_price()` / `cache_price_snapshot()` 구조를 중복 구현하지 않고, 전략 공통 snapshot contract로 승격할 방법을 설계한다.
-- [ ] WebSocket / REST / DB snapshot 입력을 한곳에서 표준화해 현재가, 거래량, 거래대금, 고가, 저가, 체결강도, 데이터 시각을 같은 형태로 제공한다.
-- [ ] 전략은 REST 직접 조회보다 snapshot provider를 우선 참조하고, stale/missing reason을 rejected reason으로 남긴다.
+- [x] 기존 `PriceStreamService`의 `get_cached_price()` / `cache_price_snapshot()` 구조를 중복 구현하지 않고, 전략 공통 snapshot contract로 승격할 방법을 설계한다.
+- [x] WebSocket / REST / DB snapshot 입력을 한곳에서 표준화해 현재가, 거래량, 거래대금, 고가, 저가, 체결강도, 데이터 시각을 같은 형태로 제공한다.
+- [x] 전략은 REST 직접 조회보다 snapshot provider를 우선 참조하고, stale/missing reason을 rejected reason으로 남긴다.
 
 주요 파일:
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -540,6 +540,7 @@ class WebAppContext:
                 logger=self.logger,
                 cache_ttl_sec=_op_cfg.trade_flow_cache_ttl_sec,
                 sample_window_sec=_op_cfg.trade_flow_sample_window_sec,
+                stock_query_service=self.stock_query_service,
             )
             self.order_policy_service = OrderPolicyService(
                 config=_op_cfg,


### PR DESCRIPTION
P2-3 Market Snapshot 표준화 작업을 진행 중이었고, 방금 막 완료했습니다.

작업 내용 요약:

MarketSnapshot / ConclusionSnapshot frozen dataclass 신설 (common/market_snapshot.py) PriceStreamService에 체결강도 캐시(_latest_conclusions) 추가 StockQueryService에 get_market_snapshot() / get_conclusion_snapshot() 추가 (캐시 우선, REST fallback) ExecutionFlowService가 REST 직접 호출 전에 stock_query_service.get_conclusion_snapshot() 캐시를 먼저 참조 StrategyExecutor 유동성 필터를 MarketSnapshot dataclass 기반으로 교체 백테스트 replay 어댑터 동일 contract 반환
방금 해결한 버그: conclusion_row = None으로 초기화된 상태에서 체결강도를 캐시에서 가져오면 _ratio_from_fields(None, …) → _pick(None, key) → TypeError 발생해 통합 테스트가 ORDER_POLICY_BLOCKED로 실패. conclusion_row: dict = {} 로 수정하여 해결.

최종 결과: 단위 테스트 4281개 + 통합 테스트 224개 전부 통과.