### PR TITLE
우선순위대로 수정 완료했습니다.

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -5,6 +5,7 @@ from repositories.stock_code_repository import StockCodeRepository
 from typing import Any, List, Optional, TYPE_CHECKING
 from common.types import ResCommonResponse, Exchange, ErrorCode
 from core.cache.cache_wrapper import cache_wrap_client
+from core.retry_queue.retry_classifier import is_non_retriable_business_error
 from core.retry_queue.api_request_queue import ApiRequestQueue
 from core.retry_queue.client_with_retry_queue import retry_queue_wrap_client
 from datetime import datetime, timedelta
@@ -289,6 +290,11 @@ class BrokerAPIWrapper:
         rt_cd = getattr(resp, 'rt_cd', None) if resp else None
         if rt_cd == ErrorCode.SUCCESS.value:
             self._cb_record_success()
+        elif is_non_retriable_business_error(resp):
+            if self._logger:
+                self._logger.warning(
+                    f"[CircuitBreaker] 비즈니스 거부는 실패 카운트 제외: {stock_code}"
+                )
         else:
             self._cb_record_failure()
         return resp

--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -114,6 +114,8 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
 
         try:
             response_data_dict = response.data['output']
+            if isinstance(response_data_dict, list):
+                response_data_dict = response_data_dict[0] if response_data_dict else {}
             # Pydantic 모델 필수 필드 누락 방지 (API 응답에 없을 경우 기본값 설정)
             if "new_hgpr_lwpr_cls_code" not in response_data_dict:
                 response_data_dict["new_hgpr_lwpr_cls_code"] = "-"

--- a/core/loggers/app_logger.py
+++ b/core/loggers/app_logger.py
@@ -112,24 +112,24 @@ class Logger:
 
         return logger
 
-    def info(self, message):
-        self.operational_logger.info(message, stacklevel=2)
-        self.debug_logger.info(message, stacklevel=2)
+    def info(self, message, *args):
+        self.operational_logger.info(message, *args, stacklevel=2)
+        self.debug_logger.info(message, *args, stacklevel=2)
 
-    def debug(self, message):
-        self.debug_logger.debug(message, stacklevel=2)
+    def debug(self, message, *args):
+        self.debug_logger.debug(message, *args, stacklevel=2)
 
-    def warning(self, message, exc_info=False):
-        self.operational_logger.warning(message, exc_info=exc_info, stacklevel=2)
-        self.debug_logger.warning(message, exc_info=exc_info, stacklevel=2)
+    def warning(self, message, *args, exc_info=False):
+        self.operational_logger.warning(message, *args, exc_info=exc_info, stacklevel=2)
+        self.debug_logger.warning(message, *args, exc_info=exc_info, stacklevel=2)
 
-    def error(self, message, exc_info=False):
-        self.operational_logger.error(message, exc_info=exc_info, stacklevel=2)
-        self.debug_logger.error(message, exc_info=exc_info, stacklevel=2)
+    def error(self, message, *args, exc_info=False):
+        self.operational_logger.error(message, *args, exc_info=exc_info, stacklevel=2)
+        self.debug_logger.error(message, *args, exc_info=exc_info, stacklevel=2)
 
-    def critical(self, message, exc_info=False):
-        self.operational_logger.critical(message, exc_info=exc_info, stacklevel=2)
-        self.debug_logger.critical(message, exc_info=exc_info, stacklevel=2)
+    def critical(self, message, *args, exc_info=False):
+        self.operational_logger.critical(message, *args, exc_info=exc_info, stacklevel=2)
+        self.debug_logger.critical(message, *args, exc_info=exc_info, stacklevel=2)
 
     def exception(self, message):
         """

--- a/core/retry_queue/retry_classifier.py
+++ b/core/retry_queue/retry_classifier.py
@@ -13,7 +13,7 @@ class RequestOutcome(Enum):
 _NON_RETRIABLE_MSG_PATTERNS = [
     "잔고부족", "주문가능금액", "거래정지", "주문불가", "상장폐지",
     "매도가능수량", "이미처리", "접수불가", "매매불가능종목",
-    "종목코드 오류", "유효하지 않은", "입력값 오류",
+    "종목코드 오류", "유효하지 않은", "입력값 오류", "주문이 불가",
 ]
 
 # KIS API msg1에 포함될 경우 일시적 과부하로 재시도 가능한 키워드
@@ -75,3 +75,21 @@ def _classify_by_msg(msg: str | None) -> RequestOutcome:
 
     # 알 수 없는 오류 → 안전하게 FAIL (재시도해도 같은 결과일 가능성 높음)
     return RequestOutcome.FAIL
+
+
+def is_non_retriable_business_error(result: ResCommonResponse | None) -> bool:
+    """계좌/잔고/종목 상태처럼 재시도해도 성공 가능성이 낮은 주문 거부인지 판정."""
+    if result is None or result.rt_cd == ErrorCode.SUCCESS.value:
+        return False
+
+    msg = result.msg1 or ""
+    if "Business Error" in msg:
+        return True
+    if any(kw in msg for kw in _NON_RETRIABLE_MSG_PATTERNS):
+        return True
+
+    try:
+        code = ErrorCode(result.rt_cd)
+    except ValueError:
+        return False
+    return code in _NON_RETRIABLE_CODES

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Dict, Optional
 from common.types import ErrorCode, ResCommonResponse, Exchange, OrderContext, OrderSide, OrderState, OrderExecutionReport
-from core.retry_queue.retry_classifier import classify, RequestOutcome
+from core.retry_queue.retry_classifier import classify, is_non_retriable_business_error, RequestOutcome
 from core.loggers.trace_context import trace_scope, get_trace_id, new_trace_id
 from core.performance_profiler import PerformanceProfiler
 from core.market_clock import MarketClock
@@ -1445,6 +1445,10 @@ class OrderExecutionService:
             if self._kill_switch:
                 if result and result.rt_cd == ErrorCode.SUCCESS.value:
                     await self._kill_switch.record_api_success()
+                elif result and is_non_retriable_business_error(result):
+                    self.logger.warning(
+                        f"KillSwitch API 오류 카운트 제외: {action_str} 비즈니스 거부 - {result.msg1}"
+                    )
                 else:
                     rt = result.rt_cd if result else "no_response"
                     await self._kill_switch.record_api_failure(rt)

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -166,6 +166,27 @@ async def test_get_price_summary(mock_quotations):
 
 
 @pytest.mark.asyncio
+async def test_get_current_price_accepts_single_item_output_list(mock_quotations):
+    output = _BASE_DUMMY_DATA.copy()
+    output.update({
+        "stck_prpr": "432000",
+        "stck_oprc": "467500",
+        "prdy_ctrt": "-7.50",
+    })
+    mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상 처리",
+        data={"output": [output]},
+    ))
+
+    result = await mock_quotations.get_current_price("357780")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert isinstance(result.data["output"], ResStockFullInfoApiOutput)
+    assert result.data["output"].stck_prpr == "432000"
+
+
+@pytest.mark.asyncio
 async def test_get_price_summary_open_price_zero(mock_quotations):
     # Mock 반환 값을 ResCommonResponse 형식으로 변경
     mock_output = _create_dummy_output({

--- a/tests/unit_test/brokers/test_broker_api_wrapper.py
+++ b/tests/unit_test/brokers/test_broker_api_wrapper.py
@@ -836,6 +836,51 @@ async def test_place_stock_order_failure_increments_cb(broker_wrapper_instance):
     await wrapper.place_stock_order("005930", 70000, 10, is_buy=True)
 
     assert wrapper._cb_consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_place_stock_order_business_reject_does_not_increment_cb(broker_wrapper_instance):
+    """재시도 불가 비즈니스 거부는 API 장애 서킷 브레이커 카운트에서 제외합니다."""
+    wrapper, mock_client, _, _ = broker_wrapper_instance
+    wrapper._cb_open_until = None
+    wrapper._cb_consecutive_failures = 0
+
+    from common.types import ErrorCode, ResCommonResponse
+    mock_client.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="API 오류: Business Error: 모의투자 주문이 불가한 계좌입니다.",
+        data=None,
+    )
+
+    result = await wrapper.place_stock_order("139130", 18370, 108, is_buy=True)
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    assert wrapper._cb_consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_place_stock_order_paper_account_reject_does_not_open_circuit_breaker(broker_wrapper_instance):
+    """'모의투자 주문이 불가한 계좌입니다.' 응답은 서킷 브레이커를 열지 않습니다."""
+    wrapper, mock_client, _, mock_logger = broker_wrapper_instance
+    wrapper._cb_open_until = None
+    wrapper._cb_consecutive_failures = wrapper._cb_threshold - 1
+
+    from common.types import ErrorCode, ResCommonResponse
+    mock_client.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="API 오류: Business Error: 모의투자 주문이 불가한 계좌입니다.",
+        data=None,
+    )
+
+    result = await wrapper.place_stock_order("139130", 18370, 108, is_buy=True)
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    assert wrapper._cb_consecutive_failures == wrapper._cb_threshold - 1
+    assert wrapper._cb_open_until is None
+    assert any(
+        "비즈니스 거부는 실패 카운트 제외" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
 @pytest.mark.asyncio
 async def test_cancel_stock_order_delegation(mock_env, mock_logger, mock_market_clock):
     with patch(f"{wrapper_module.__name__}.StockCodeRepository"), \

--- a/tests/unit_test/core/loggers/test_app_logger.py
+++ b/tests/unit_test/core/loggers/test_app_logger.py
@@ -98,6 +98,21 @@ def test_logger_critical_with_exc_info(clean_logger_instance):
         assert "RuntimeError: Critical error occurred" in content
         assert "Traceback" in content
 
+
+def test_logger_critical_accepts_logging_format_args(clean_logger_instance):
+    logger, common_log_dir = clean_logger_instance
+
+    logger.critical("[KillSwitch] 트립! 사유: %s | 메타: %s", "연속 API 오류", {"last_reason": "HTTP 500"})
+    logger.flush()
+
+    log_files = list(common_log_dir.glob("*.log"))
+    assert len(log_files) == 2
+
+    for f in log_files:
+        content = f.read_text(encoding='utf-8')
+        assert "[KillSwitch] 트립! 사유: 연속 API 오류 | 메타: {'last_reason': 'HTTP 500'}" in content
+
+
 def test_logger_creates_log_dir_if_not_exists(tmp_path):
     non_existent_log_dir = tmp_path / "non_existent_logs_dir"
 

--- a/tests/unit_test/core/retry_queue/test_retry_classifier.py
+++ b/tests/unit_test/core/retry_queue/test_retry_classifier.py
@@ -2,7 +2,12 @@
 
 import pytest
 from common.types import ResCommonResponse, ErrorCode
-from core.retry_queue.retry_classifier import classify, RequestOutcome, _classify_by_msg
+from core.retry_queue.retry_classifier import (
+    classify,
+    is_non_retriable_business_error,
+    RequestOutcome,
+    _classify_by_msg,
+)
 
 
 def resp(rt_cd: str, msg1: str = "") -> ResCommonResponse:
@@ -86,6 +91,16 @@ class TestClassifyByMsgKeyword:
     def test_unknown_msg_defaults_to_fail(self):
         """어떤 키워드에도 매칭되지 않으면 안전하게 FAIL (재시도해도 같은 결과 가능성 높음)"""
         assert classify(resp(ErrorCode.API_ERROR.value, "알 수 없는 오류 발생")) == RequestOutcome.FAIL
+
+    def test_paper_account_reject_returns_fail(self):
+        """KIS 모의투자 계좌 주문 불가 응답은 재시도 불가 비즈니스 거부로 고정합니다."""
+        result = resp(
+            ErrorCode.API_ERROR.value,
+            "API 오류: Business Error: 모의투자 주문이 불가한 계좌입니다.",
+        )
+
+        assert classify(result) == RequestOutcome.FAIL
+        assert is_non_retriable_business_error(result) is True
 
 
 class TestClassifyUnknownErrorCode:

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -3065,6 +3065,52 @@ async def test_business_reject_no_retry_marks_rejected(
 
 
 @pytest.mark.asyncio
+async def test_business_reject_does_not_record_kill_switch_api_failure(
+    handler, mock_broker_api_wrapper
+):
+    """계좌/잔고 등 재시도 불가 주문 거부는 KillSwitch API 장애 카운터에서 제외합니다."""
+    kill_switch = AsyncMock()
+    handler._kill_switch = kill_switch
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="API 오류: Business Error: 모의투자 주문이 불가한 계좌입니다.",
+        data=None,
+    )
+
+    result = await handler.handle_place_buy_order("139130", 18370, 108)
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    kill_switch.record_api_failure.assert_not_awaited()
+    kill_switch.record_api_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_paper_account_reject_no_retry_no_kill_switch_failure_marks_rejected(
+    handler, mock_broker_api_wrapper, mock_market_clock
+):
+    """'모의투자 주문이 불가한 계좌입니다.' 응답은 재시도/KillSwitch 장애 카운트 없이 REJECTED 처리합니다."""
+    kill_switch = AsyncMock()
+    handler._kill_switch = kill_switch
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="API 오류: Business Error: 모의투자 주문이 불가한 계좌입니다.",
+        data=None,
+    )
+
+    result = await handler.handle_place_buy_order("139130", 18370, 108)
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    mock_broker_api_wrapper.place_stock_order.assert_awaited_once()
+    mock_market_clock.async_sleep.assert_not_awaited()
+    kill_switch.record_api_failure.assert_not_awaited()
+    kill_switch.record_api_success.assert_not_awaited()
+    order_key = handler._make_order_key("139130", OrderSide.BUY, Exchange.KRX)
+    ctx = handler._order_states.get(order_key)
+    assert ctx is not None
+    assert ctx.state == OrderState.REJECTED
+
+
+@pytest.mark.asyncio
 async def test_transient_api_retried_max_3(
     handler, mock_broker_api_wrapper, mock_market_clock, mock_market_calendar_service
 ):


### PR DESCRIPTION
핵심 원인은 확인 결과 코드가 실전 계좌를 잘못 보낸 게 아니라, 실제로 모의투자 서버 + 모의 TR ID + paper_stock_account_number 계좌로 주문을 냈는데 KIS가 모의투자 주문이 불가한 계좌입니다를 반환한 상황이었습니다. 즉 이 건은 계좌/모의투자 권한 쪽 문제라서 KIS 계좌 설정 갱신 또는 모의투자 가능 계좌 재확인이 필요합니다.

코드 쪽에서 같이 터진 연쇄 문제는 수정했습니다.

Logger.critical()이 포맷 인자를 못 받아 원래 주문 실패 원인을 가리던 문제 수정 현재가 조회 응답의 output이 list로 오는 경우 파싱 실패하던 문제 수정
모의투자 주문이 불가한 계좌입니다, 잔고 부족 같은 비즈니스 거부는 Circuit Breaker 실패 카운트에서 제외 같은 비즈니스 거부는 KillSwitch API 장애 카운트에서도 제외해서 후속 주문이 “서킷 브레이커 개방”으로 연쇄 차단되지 않게 조정 관련 단위 테스트 추가
검증도 끝냈습니다.

pytest tests/unit_test -v → 4285 passed
pytest tests/integration_test -v → 224 passed
단위 테스트 중 기존 test_minervini_stage_service.py 쪽 PytestUnraisableExceptionWarning이 1건 보였는데, 이번 변경과는 무관한 기존 경고로 보입니다.

추가했습니다. "모의투자 주문이 불가한 계좌입니다." 문구를 그대로 넣은 회귀 TC를 3곳에 고정했습니다.

test_retry_classifier.py (line 95): 해당 응답을 재시도 불가 비즈니스 거부로 분류 test_broker_api_wrapper.py (line 862): 해당 응답이 와도 Circuit Breaker가 열리지 않음 test_order_execution_service.py (line 3088): 재시도 없음, KillSwitch API 장애 카운트 없음, 주문 상태는 REJECTED 검증도 완료했습니다.

pytest tests/unit_test/core/retry_queue/test_retry_classifier.py tests/unit_test/brokers/test_broker_api_wrapper.py tests/unit_test/services/test_order_execution_service.py -v -n0 결과: 206 passed

참고로 KIS가 실제로 “모의투자 주문 불가 계좌”라고 거부하는 것 자체는 외부 계좌 권한/설정 문제라 TC로 막을 수는 없습니다. 대신 같은 응답이 다시 와도 시스템이 재시도 폭주, KillSwitch 장애 누적, 서킷 브레이커 개방으로 번지지 않도록 테스트로 고정했습니다.