### PR TITLE
확인 결과, 의심하신 게 맞습니다. OneilSqueezeBreakout의 005930, 000001, 000002, 000…

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -22,6 +22,12 @@ from core.loggers.async_handler import DictPreservingQueueHandler
 
 _active_listeners = []
 
+def _resolve_log_dir(log_dir: str) -> str:
+    """테스트 실행 시 기본 로그 경로를 격리된 임시 경로로 우회한다."""
+    if log_dir == "logs":
+        return os.getenv("INVESTMENT_LOG_DIR", log_dir)
+    return log_dir
+
 def setup_async_logger(logger: logging.Logger, file_handler: logging.Handler):
     """파일 I/O를 백그라운드 스레드로 위임하는 비동기 큐 세팅"""
     log_queue = queue.Queue(-1)
@@ -56,6 +62,7 @@ def get_streaming_logger(log_dir: str = "logs") -> "StreamingEventLogger":
                 "price_subscribe" | "price_unsubscribe" (현재 체결가 H0STCNT0)
       + action별 세부 필드 (code, categories, reason, trigger, ...)
     """
+    log_dir = _resolve_log_dir(log_dir)
     streaming_log_dir = os.path.join(log_dir, "streaming")
     os.makedirs(streaming_log_dir, exist_ok=True)
 
@@ -89,6 +96,7 @@ def get_cache_event_logger(log_dir: str = "logs") -> "CacheEventLogger":
       - action: 아래 CacheEventLogger 참조
       + action별 세부 필드 (code, caller, before_price, after_price, ohlcv_count, ...)
     """
+    log_dir = _resolve_log_dir(log_dir)
     cache_log_dir = os.path.join(log_dir, "cache")
     os.makedirs(cache_log_dir, exist_ok=True)
 
@@ -122,6 +130,7 @@ def get_strategy_logger(strategy_name: str, log_dir="logs", sub_dir: str = None)
       (핸들러 중복 생성으로 인한 신규 _N 파일 누적 방지).
     - 활성 파일이 maxBytes 를 넘으면 SizeTimeRotatingFileHandler 가 자동으로 _N+1 로 롤오버한다.
     """
+    log_dir = _resolve_log_dir(log_dir)
     logger_key = f"strategy.{strategy_name}"
     if sub_dir:
         logger_key = f"{logger_key}.{sub_dir}"
@@ -168,6 +177,7 @@ def get_performance_logger(log_dir="logs"):
     성능 측정 전용 로거를 생성하고 반환합니다.
     경로: logs/performance/{timestamp}_perf.log
     """
+    log_dir = _resolve_log_dir(log_dir)
     logger = logging.getLogger("performance")
     
     if logger.handlers:

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -393,12 +393,9 @@ class StrategyLogReportService:
         except Exception:
             return False, result
 
-        saw_target_date_trade = False
-        saw_strategy_tag = False
         for trade in all_trades:
             if not str(trade.get('buy_date', '')).startswith(date_prefix):
                 continue
-            saw_target_date_trade = True
             if trade.get('status') not in {"HOLD", "SOLD"}:
                 continue
 
@@ -406,7 +403,6 @@ class StrategyLogReportService:
             code = str(trade.get('code') or '').strip()
             if not strategy or not code:
                 continue
-            saw_strategy_tag = True
 
             try:
                 price = int(float(trade.get('buy_price') or 0))
@@ -420,7 +416,9 @@ class StrategyLogReportService:
                 'time': str(trade.get('buy_date', ''))[11:16],
             }
 
-        return (not saw_target_date_trade) or saw_strategy_tag, result
+        # 원장을 읽을 수 있으면 buy_signal_generated 로그보다 원장을 신뢰한다.
+        # 전략 태그가 없는 당일 거래가 있어도 테스트/드라이런 로그를 실매수로 오인하지 않는다.
+        return True, result
 
     def _get_enabled_strategy_keys(self) -> Optional[set[str]]:
         if not self._enabled_strategy_provider:
@@ -1172,8 +1170,11 @@ class StrategyLogReportService:
         divergence_section = self._build_backtest_live_divergence_section(target_date)
 
         if not active_sections:
+            portfolio_summary = self._build_portfolio_summary(target_date, fallback_buys)
             extra_sections = [
-                section for section in (warnings_section, divergence_section, execution_quality_section) if section
+                section
+                for section in (warnings_section, portfolio_summary, divergence_section, execution_quality_section)
+                if section
             ]
             extra_body = "\n\n".join(extra_sections)
             extra = f"\n\n{extra_body}" if extra_body else ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,15 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def isolate_live_strategy_state_files(monkeypatch, tmp_path):
+def isolate_live_strategy_files(monkeypatch, tmp_path):
     from strategies.first_pullback_strategy import FirstPullbackStrategy
     from strategies.high_tight_flag_strategy import HighTightFlagStrategy
     from strategies.oneil_pocket_pivot_strategy import OneilPocketPivotStrategy
     from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
     from strategies.rsi2_pullback_strategy import RSI2PullbackStrategy
     from strategies.traditional_volume_breakout_strategy import TraditionalVolumeBreakoutStrategy
+
+    monkeypatch.setenv("INVESTMENT_LOG_DIR", str(tmp_path / "logs"))
 
     state_dir = tmp_path / "strategy_state"
     state_dir.mkdir()

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -690,6 +690,45 @@ async def test_report_uses_virtual_trade_records_for_completed_buys_when_availab
 
 
 @pytest.mark.asyncio
+async def test_report_does_not_treat_log_buy_as_completed_when_journal_has_untagged_trade(log_dir):
+    """원장에 당일 거래가 있으면 전략 태그가 없어도 로그 시그널을 실매수로 보지 않는다."""
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return [
+                {
+                    "code": "000660",
+                    "name": "SK하이닉스",
+                    "buy_date": "2026-04-18 09:10:00",
+                    "buy_price": 120000,
+                    "status": "HOLD",
+                },
+            ]
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return [{"code": "000660"}]
+
+    _write_log(os.path.join(log_dir, "20260418_093000_OneilSqueezeBreakout.log.json"), [
+        {**_make_entry("scan_with_watchlist", "", ""), "data": {"event": "scan_with_watchlist", "count": 1}},
+        _make_entry("buy_signal_generated", "000001", "종목000001", reason="테스트 로그", price=75000),
+    ])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+    )
+    report = await svc.generate_report("20260418")
+
+    osb_section = report.split("<b>1. OneilSqueezeBreakout</b>", 1)[1].split("<b>💰 오늘의 포트폴리오 요약</b>", 1)[0]
+    assert "시그널 없음" in osb_section
+    assert "매수 완료" not in osb_section
+    assert "종목000001" not in osb_section
+    assert "신규 매수: 1건 (SK하이닉스)" in report
+
+
+@pytest.mark.asyncio
 async def test_report_matches_virtual_trade_strategy_alias_to_log_section(log_dir):
     """원장 전략명이 한글이어도 대응하는 영문 로그 섹션의 매수 완료 detail에 표시한다."""
     class DummyVirtualTradeService:

--- a/tests/unit_test/strategies/test_strategies_logger.py
+++ b/tests/unit_test/strategies/test_strategies_logger.py
@@ -1,6 +1,8 @@
 import pytest
 import importlib
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+import core.logger
 
 # 테스트할 전략 클래스와 예상되는 로거 이름 매핑
 STRATEGIES = [
@@ -58,3 +60,16 @@ def test_strategies_init_logger(module_path, class_name, expected_logger_name):
         # 전략 인스턴스에 로거가 할당되었는지 확인
         logger_attr = getattr(strategy, '_logger', getattr(strategy, 'logger', None))
         assert logger_attr == mock_get_logger.return_value
+
+
+def test_default_strategy_logger_uses_test_log_dir_env(monkeypatch, tmp_path):
+    """테스트 환경에서는 기본 전략 로그가 실제 logs/strategies에 쓰이지 않는다."""
+    redirected_log_dir = tmp_path / "isolated_logs"
+    monkeypatch.setenv("INVESTMENT_LOG_DIR", str(redirected_log_dir))
+
+    logger = core.logger.get_strategy_logger("EnvIsolationCheck")
+    logger.info({"event": "test_log_isolation"})
+    core.logger.shutdown_logging()
+
+    assert list((redirected_log_dir / "strategies").glob("*EnvIsolationCheck*.log.json*"))
+    assert not list(Path("logs/strategies").glob("*EnvIsolationCheck*.log.json*"))


### PR DESCRIPTION
…003은 실매수라기보다 테스트 로그가 실제 logs/strategies에 섞인 케이스입니다.

실제 오염 로그가 20260512_OneilSqueezeBreakout_1.log.json (line 22)에 있고, 000001~000003 패턴은 test_it_strategy_scan.py (line 1061)의 테스트 데이터와 일치합니다.

수정한 내용:

core/logger.py (line 25): 기본 logs 경로를 INVESTMENT_LOG_DIR로 우회 가능하게 했습니다.

tests/conftest.py (line 13): pytest 실행 중 로그가 테스트별 임시 폴더로 가도록 격리했습니다.

strategy_log_report_service.py (line 419): 원장을 읽을 수 있으면 buy_signal_generated 로그보다 원장을 신뢰하게 바꿔, 테스트/드라이런 로그가 “매수 완료”로 승격되지 않게 했습니다.

활성 전략 섹션이 없어도 원장 기반 포트폴리오 요약은 유지되도록 보강했습니다.

검증:

pytest tests/unit_test -v → 4290 passed

pytest tests/integration_test -v → 224 passed

기존에 이미 섞여 들어간 logs/strategies/20260512_OneilSqueezeBreakout_1.log.json 내용은 삭제하지 않았습니다. 운영 로그 원본이라 자동 정리보다는 확인 후 별도 정리하는 쪽이 안전합니다.