### PR TITLE
reject reason 구현

### DIFF
--- a/services/rejection_distribution_service.py
+++ b/services/rejection_distribution_service.py
@@ -1,0 +1,126 @@
+"""전략별/일자별 거절 사유 분포를 수집하고 파일로 플러시하는 서비스."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, Optional
+
+
+class RejectionDistributionService:
+    """실전 거래 중 발생하는 거절 사유를 날짜/전략별로 누적하고 파일로 플러시.
+
+    사용법:
+      svc = RejectionDistributionService(reason_labels=_REASON_KR)
+      svc.attach_to_strategy_logger()   # 전략 logger에 자동 수집 핸들러 부착
+      ...
+      svc.flush_to_file("20260513")     # 장 마감 후 JSONL 저장
+    """
+
+    def __init__(self, reason_labels: Optional[Dict[str, str]] = None) -> None:
+        # {date: {strategy_name: {reason_code: count}}}
+        self._counts: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(int))
+        )
+        self._reason_labels: Dict[str, str] = reason_labels or {}
+
+    def record(
+        self,
+        strategy_name: str,
+        reason_code: str,
+        stock_code: str = "",
+        date: Optional[str] = None,
+    ) -> None:
+        """거절 사유 1건을 누적한다."""
+        if not strategy_name or not reason_code:
+            return
+        key = date or datetime.now().strftime("%Y%m%d")
+        self._counts[key][strategy_name][reason_code] += 1
+
+    def get_distribution(self, strategy_name: str, date: str) -> Dict[str, int]:
+        """{reason_code: count} 반환. 해당 날짜/전략 데이터 없으면 빈 dict."""
+        return dict(self._counts.get(date, {}).get(strategy_name, {}))
+
+    def get_all_strategies(self, date: str) -> Dict[str, Dict[str, int]]:
+        """{strategy_name: {reason_code: count}} 전략 전체 반환."""
+        return {
+            strategy: dict(reasons)
+            for strategy, reasons in self._counts.get(date, {}).items()
+        }
+
+    def flush_to_file(
+        self,
+        date: str,
+        log_dir: str = "logs/strategies/rejections",
+    ) -> None:
+        """누적 데이터를 logs/strategies/rejections/YYYYMMDD.jsonl 에 저장한다.
+
+        각 line 형식:
+          {"strategy": ..., "date": ..., "reason_code": ..., "count": ..., "label_kr": ...}
+        """
+        strategy_map = self._counts.get(date, {})
+        if not strategy_map:
+            return
+        os.makedirs(log_dir, exist_ok=True)
+        path = os.path.join(log_dir, f"{date}.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            for strategy_name, reason_map in sorted(strategy_map.items()):
+                for reason_code, count in sorted(reason_map.items()):
+                    row = {
+                        "strategy": strategy_name,
+                        "date": date,
+                        "reason_code": reason_code,
+                        "count": count,
+                        "label_kr": self._reason_labels.get(reason_code, reason_code),
+                    }
+                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    def attach_to_strategy_logger(self) -> None:
+        """strategy.* 네임스페이스 로거에 핸들러를 부착해 거절 이벤트를 자동 수집한다.
+
+        strategy.* 로거들은 propagate=True 이므로 부모 "strategy" 로거에 한 번만 부착하면 된다.
+        중복 호출해도 핸들러가 두 번 부착되지 않는다.
+        """
+        handler = _StrategyRejectionHandler(self)
+        logger = logging.getLogger("strategy")
+        if not any(
+            isinstance(h, _StrategyRejectionHandler) and h._service is self
+            for h in logger.handlers
+        ):
+            logger.addHandler(handler)
+
+
+# ── Internal handler ──────────────────────────────────────────────────────
+
+_REJECTION_EVENTS: frozenset[str] = frozenset({
+    "pp_rejected",
+    "bgu_rejected",
+    "entry_rejected",
+    "entry_rejected_by_smart_money",
+    "smart_money_rejected",
+    "stage_blocked",
+    "liquidity_blocked",
+})
+
+
+class _StrategyRejectionHandler(logging.Handler):
+    """strategy.* 로거의 거절 이벤트를 RejectionDistributionService로 라우팅."""
+
+    def __init__(self, service: RejectionDistributionService) -> None:
+        super().__init__(level=logging.DEBUG)
+        self._service = service
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = record.msg
+        if not isinstance(msg, dict):
+            return
+        event = msg.get("event", "")
+        if event not in _REJECTION_EVENTS:
+            return
+        reason = str(msg.get("reason", event))
+        # logger name: "strategy.OneilPocketPivot" → "OneilPocketPivot"
+        parts = record.name.split(".", 1)
+        strategy_name = parts[1] if len(parts) > 1 else record.name
+        self._service.record(strategy_name=strategy_name, reason_code=reason)

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -109,6 +109,14 @@ _REASON_KR: Dict[str, str] = {
     "poor_candle_quality":           "캔들 위치 미달",
     "low_pg_metrics":                "프로그램 수급 미달",
     "low_pg_ratio":                  "프로그램 비중 미달",
+    # ── 유동성 / 시장 타이밍 / RiskGate / 포트폴리오 ────────────
+    "insufficient_trading_value":    "거래대금 부족",
+    "rs_rating_low":                 "RS Rating 부족",
+    "market_timing_off":             "시장 타이밍 OFF",
+    "risk_gate_blocked":             "RiskGate 차단",
+    "insufficient_cash":             "현금 부족",
+    "duplicate_entry_blocked":       "동일 종목 재진입 차단",
+    "stage_blocked":                 "StageGuard 탈락",
     # ── OneilPocketPivot / FirstPullback ────────────────────────
     "no_ma_proximity":               "MA 거리 초과",
     "no_bullish_reversal":           "반등 미확인",

--- a/strategies/debug/rejection_collector.py
+++ b/strategies/debug/rejection_collector.py
@@ -30,6 +30,7 @@ class RejectionLogHandler(logging.Handler):
         "scan_skipped",
         "cgld_check_failed",
         "stage_blocked",
+        "liquidity_blocked",
     }
 
     def __init__(self) -> None:

--- a/strategies/debug/rejection_report.py
+++ b/strategies/debug/rejection_report.py
@@ -18,6 +18,7 @@ _STAGE_LABELS = {
     "scan_skipped": "스캔 스킵",
     "buy_signal_generated": "매수 신호 발생",
     "stage_blocked": "StageGuard",
+    "liquidity_blocked": "유동성 필터",
 }
 
 
@@ -25,6 +26,11 @@ def _event_label(event: RejectionEvent) -> str:
     label = _STAGE_LABELS.get(event.event, event.event)
     reason = event.details.get("reason", "")
     d = event.details
+
+    if event.event == "liquidity_blocked":
+        value = d.get("value")
+        value_str = f"{value:,}" if isinstance(value, (int, float)) else str(value or "?")
+        return f"{label} 탈락 — {reason} (value={value_str})"
 
     if event.event == "entry_rejected" and reason == "low_execution_strength":
         entry_type = d.get("entry_type", "?")

--- a/strategies/strategy_executor.py
+++ b/strategies/strategy_executor.py
@@ -94,11 +94,11 @@ class StrategyExecutor:
                 tr_pbmn, vol = await self._lookup_liquidity(code, sem)
                 if min_value is not None and tr_pbmn < min_value:
                     self._logger.info({"event": "liquidity_blocked", "code": code,
-                                       "reason": "min_trading_value_won", "value": tr_pbmn})
+                                       "reason": "insufficient_trading_value", "value": tr_pbmn})
                     return False
                 if min_volume is not None and vol < min_volume:
                     self._logger.info({"event": "liquidity_blocked", "code": code,
-                                       "reason": "min_avg_volume", "value": vol})
+                                       "reason": "insufficient_volume", "value": vol})
                     return False
                 return True
             except Exception as e:

--- a/task/background/after_market/strategy_log_report_task.py
+++ b/task/background/after_market/strategy_log_report_task.py
@@ -10,6 +10,7 @@ from services.notification_service import NotificationCategory, NotificationLeve
 
 if TYPE_CHECKING:
     from services.strategy_log_report_service import StrategyLogReportService
+    from services.rejection_distribution_service import RejectionDistributionService
     from core.market_clock import MarketClock
     from services.market_calendar_service import MarketCalendarService
     from scheduler.worker.worker_pool import WorkerPool
@@ -27,6 +28,7 @@ class StrategyLogReportTask(AfterMarketTask):
         market_clock: Optional["MarketClock"] = None,
         logger=None,
         worker_pool: Optional["WorkerPool"] = None,
+        rejection_distribution_service: Optional["RejectionDistributionService"] = None,
     ) -> None:
         super().__init__(
             mcs=mcs,
@@ -37,6 +39,7 @@ class StrategyLogReportTask(AfterMarketTask):
         self._report_service = report_service
         self._notification_service = notification_service
         self._telegram_reporter = telegram_reporter
+        self._rejection_distribution_service = rejection_distribution_service
 
     @property
     def task_name(self) -> str:
@@ -55,6 +58,12 @@ class StrategyLogReportTask(AfterMarketTask):
             return
 
         await self._emit_execution_quality_candidate_alert(latest_trading_date)
+
+        if self._rejection_distribution_service:
+            try:
+                self._rejection_distribution_service.flush_to_file(latest_trading_date)
+            except Exception as e:
+                self._logger.warning(f"거절 사유 분포 파일 저장 실패: {e}")
 
         if self._telegram_reporter:
             try:

--- a/tests/unit_test/services/test_rejection_distribution_service.py
+++ b/tests/unit_test/services/test_rejection_distribution_service.py
@@ -1,0 +1,180 @@
+"""RejectionDistributionService 단위 테스트."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+
+import pytest
+
+from services.rejection_distribution_service import RejectionDistributionService
+
+
+# ── record / get_distribution ─────────────────────────────────────────────
+
+
+def test_record_accumulates_counts():
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyA", "low_execution_strength", date="20260513")
+
+    dist = svc.get_distribution("StrategyA", "20260513")
+    assert dist["insufficient_volume"] == 2
+    assert dist["low_execution_strength"] == 1
+
+
+def test_record_different_strategies_are_isolated():
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyB", "insufficient_volume", date="20260513")
+
+    assert svc.get_distribution("StrategyA", "20260513") == {"insufficient_volume": 1}
+    assert svc.get_distribution("StrategyB", "20260513") == {"insufficient_volume": 1}
+
+
+def test_record_different_dates_are_isolated():
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyA", "insufficient_volume", date="20260514")
+
+    assert svc.get_distribution("StrategyA", "20260513") == {"insufficient_volume": 1}
+    assert svc.get_distribution("StrategyA", "20260514") == {"insufficient_volume": 1}
+
+
+def test_record_ignores_empty_strategy_name():
+    svc = RejectionDistributionService()
+    svc.record("", "insufficient_volume", date="20260513")
+    assert svc.get_distribution("", "20260513") == {}
+
+
+def test_record_ignores_empty_reason_code():
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "", date="20260513")
+    assert svc.get_distribution("StrategyA", "20260513") == {}
+
+
+def test_get_distribution_returns_empty_for_unknown():
+    svc = RejectionDistributionService()
+    assert svc.get_distribution("Unknown", "20260513") == {}
+
+
+def test_get_all_strategies_returns_all():
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyB", "low_execution_strength", date="20260513")
+
+    result = svc.get_all_strategies("20260513")
+    assert "StrategyA" in result
+    assert "StrategyB" in result
+    assert result["StrategyA"] == {"insufficient_volume": 1}
+
+
+# ── flush_to_file ─────────────────────────────────────────────────────────
+
+
+def test_flush_to_file_writes_jsonl(tmp_path):
+    labels = {"insufficient_volume": "거래량 미달", "low_execution_strength": "체결강도 미달"}
+    svc = RejectionDistributionService(reason_labels=labels)
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyB", "low_execution_strength", date="20260513")
+
+    svc.flush_to_file("20260513", log_dir=str(tmp_path))
+
+    path = os.path.join(str(tmp_path), "20260513.jsonl")
+    assert os.path.exists(path)
+    rows = [json.loads(line) for line in open(path, encoding="utf-8")]
+    assert len(rows) == 2
+
+    a_row = next(r for r in rows if r["strategy"] == "StrategyA")
+    assert a_row["reason_code"] == "insufficient_volume"
+    assert a_row["count"] == 2
+    assert a_row["label_kr"] == "거래량 미달"
+    assert a_row["date"] == "20260513"
+
+    b_row = next(r for r in rows if r["strategy"] == "StrategyB")
+    assert b_row["reason_code"] == "low_execution_strength"
+    assert b_row["count"] == 1
+    assert b_row["label_kr"] == "체결강도 미달"
+
+
+def test_flush_to_file_uses_reason_code_as_fallback_label(tmp_path):
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "unknown_reason", date="20260513")
+    svc.flush_to_file("20260513", log_dir=str(tmp_path))
+
+    rows = [json.loads(line) for line in open(os.path.join(str(tmp_path), "20260513.jsonl"), encoding="utf-8")]
+    assert rows[0]["label_kr"] == "unknown_reason"
+
+
+def test_flush_to_file_skips_empty_date(tmp_path):
+    svc = RejectionDistributionService()
+    svc.flush_to_file("20260513", log_dir=str(tmp_path))
+    assert not os.path.exists(os.path.join(str(tmp_path), "20260513.jsonl"))
+
+
+def test_flush_to_file_creates_directory(tmp_path):
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    nested = str(tmp_path / "nested" / "dir")
+    svc.flush_to_file("20260513", log_dir=nested)
+    assert os.path.exists(os.path.join(nested, "20260513.jsonl"))
+
+
+# ── attach_to_strategy_logger ─────────────────────────────────────────────
+
+
+def test_attach_captures_rejection_events():
+    svc = RejectionDistributionService()
+    svc.attach_to_strategy_logger()
+    today = datetime.now().strftime("%Y%m%d")
+
+    logger = logging.getLogger("strategy.TestRejectionSvc")
+    logger.setLevel(logging.DEBUG)
+    logger.info({"event": "entry_rejected", "code": "005930", "reason": "low_execution_strength"})
+
+    dist = svc.get_distribution("TestRejectionSvc", today)
+    assert dist.get("low_execution_strength", 0) >= 1
+
+    # 부착된 핸들러 정리
+    strategy_logger = logging.getLogger("strategy")
+    from services.rejection_distribution_service import _StrategyRejectionHandler
+    for h in list(strategy_logger.handlers):
+        if isinstance(h, _StrategyRejectionHandler) and h._service is svc:
+            strategy_logger.removeHandler(h)
+
+
+def test_attach_ignores_non_rejection_events():
+    svc = RejectionDistributionService()
+    svc.attach_to_strategy_logger()
+    today = datetime.now().strftime("%Y%m%d")
+
+    logger = logging.getLogger("strategy.TestNonRejection")
+    logger.setLevel(logging.DEBUG)
+    logger.info({"event": "buy_signal_generated", "code": "005930"})
+    logger.info({"event": "scan_started", "strategy_name": "test"})
+
+    dist = svc.get_distribution("TestNonRejection", today)
+    assert dist == {}
+
+    strategy_logger = logging.getLogger("strategy")
+    from services.rejection_distribution_service import _StrategyRejectionHandler
+    for h in list(strategy_logger.handlers):
+        if isinstance(h, _StrategyRejectionHandler) and h._service is svc:
+            strategy_logger.removeHandler(h)
+
+
+def test_attach_idempotent():
+    svc = RejectionDistributionService()
+    svc.attach_to_strategy_logger()
+    svc.attach_to_strategy_logger()
+
+    strategy_logger = logging.getLogger("strategy")
+    from services.rejection_distribution_service import _StrategyRejectionHandler
+    handlers = [h for h in strategy_logger.handlers if isinstance(h, _StrategyRejectionHandler) and h._service is svc]
+    assert len(handlers) == 1
+
+    for h in handlers:
+        strategy_logger.removeHandler(h)

--- a/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
@@ -1,0 +1,126 @@
+"""전략 rejected reason 리포트 API 테스트."""
+from __future__ import annotations
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock
+
+from services.rejection_distribution_service import RejectionDistributionService
+
+
+# ── 메모리 기반 응답 ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_from_memory(web_client, mock_web_ctx):
+    """rejection_distribution_service 메모리 데이터를 반환한다."""
+    svc = RejectionDistributionService(reason_labels={"insufficient_volume": "거래량 미달"})
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    mock_web_ctx.rejection_distribution_service = svc
+
+    resp = web_client.get("/api/strategies/rejected-reasons?strategy=StrategyA&date=20260513")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["date"] == "20260513"
+    assert data["strategy"] == "StrategyA"
+    rows = data["distribution"]
+    assert len(rows) == 1
+    assert rows[0]["reason_code"] == "insufficient_volume"
+    assert rows[0]["count"] == 2
+    assert rows[0]["label_kr"] == "거래량 미달"
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_all_strategies(web_client, mock_web_ctx):
+    """strategy 파라미터 없으면 전체 전략을 반환한다."""
+    svc = RejectionDistributionService()
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    svc.record("StrategyB", "low_execution_strength", date="20260513")
+    mock_web_ctx.rejection_distribution_service = svc
+
+    resp = web_client.get("/api/strategies/rejected-reasons?date=20260513")
+    assert resp.status_code == 200
+    data = resp.json()
+    strategies = {r["strategy"] for r in data["distribution"]}
+    assert "StrategyA" in strategies
+    assert "StrategyB" in strategies
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_returns_empty_when_no_service(web_client, mock_web_ctx):
+    """rejection_distribution_service가 None이면 빈 결과를 반환한다."""
+    mock_web_ctx.rejection_distribution_service = None
+
+    resp = web_client.get("/api/strategies/rejected-reasons?date=20260513")
+    assert resp.status_code == 200
+    assert resp.json()["distribution"] == []
+
+
+# ── 파일 기반 응답 ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_from_file(web_client, mock_web_ctx, tmp_path, monkeypatch):
+    """JSONL 파일 데이터를 읽어 반환한다."""
+    svc = RejectionDistributionService()
+    mock_web_ctx.rejection_distribution_service = svc
+
+    # JSONL 파일 생성
+    log_dir = str(tmp_path)
+    rows = [
+        {"strategy": "StrategyA", "date": "20260510", "reason_code": "insufficient_volume",
+         "count": 5, "label_kr": "거래량 미달"},
+        {"strategy": "StrategyA", "date": "20260510", "reason_code": "low_execution_strength",
+         "count": 3, "label_kr": "체결강도 미달"},
+    ]
+    path = os.path.join(log_dir, "20260510.jsonl")
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    # 라우트의 DEFAULT_LOG_DIR를 tmp_path로 패치
+    import view.web.routes.strategy_report as route_mod
+    monkeypatch.setattr(route_mod, "_DEFAULT_LOG_DIR", log_dir)
+
+    resp = web_client.get("/api/strategies/rejected-reasons?strategy=StrategyA&date=20260510")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["date"] == "20260510"
+    assert len(data["distribution"]) == 2
+    reason_codes = {r["reason_code"] for r in data["distribution"]}
+    assert "insufficient_volume" in reason_codes
+    assert "low_execution_strength" in reason_codes
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_file_not_found_returns_empty(web_client, mock_web_ctx, tmp_path, monkeypatch):
+    """파일이 없으면 빈 결과를 반환한다."""
+    mock_web_ctx.rejection_distribution_service = None
+
+    import view.web.routes.strategy_report as route_mod
+    monkeypatch.setattr(route_mod, "_DEFAULT_LOG_DIR", str(tmp_path))
+
+    resp = web_client.get("/api/strategies/rejected-reasons?date=19990101")
+    assert resp.status_code == 200
+    assert resp.json()["distribution"] == []
+
+
+# ── 필드명 일관성 ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rejected_reasons_field_names(web_client, mock_web_ctx):
+    """응답 필드명이 format_json()의 reason/event/code 규약과 일치한다."""
+    svc = RejectionDistributionService(reason_labels={"insufficient_volume": "거래량 미달"})
+    svc.record("StrategyA", "insufficient_volume", date="20260513")
+    mock_web_ctx.rejection_distribution_service = svc
+
+    resp = web_client.get("/api/strategies/rejected-reasons?strategy=StrategyA&date=20260513")
+    row = resp.json()["distribution"][0]
+    # 필수 필드명
+    assert "reason_code" in row   # format_json()의 events[].reason 에 대응
+    assert "count" in row
+    assert "label_kr" in row
+    assert "strategy" in row

--- a/todo_list.md
+++ b/todo_list.md
@@ -305,9 +305,19 @@
 
 ### 4-2. Rejected reason 리포트
 
-- [ ] 거래량 부족, 거래대금 부족, Stage Guard 탈락, RS Rating 부족, 시장 타이밍 OFF, RiskGate 차단, 현금 부족, 동일 종목 재진입 차단, 호가/체결강도 불량을 rejected reason으로 표준화한다.
-- [ ] 전략별/일자별 rejected reason 분포를 리포트한다.
-- [ ] `run_strategy_debug`와 운영 대시보드에서 rejected reason을 같은 필드명으로 표시한다.
+- [x] 거래량 부족, 거래대금 부족, Stage Guard 탈락, RS Rating 부족, 시장 타이밍 OFF, RiskGate 차단, 현금 부족, 동일 종목 재진입 차단, 호가/체결강도 불량을 rejected reason으로 표준화한다.
+  - `services/strategy_log_report_service.py` `_REASON_KR`에 `insufficient_trading_value`, `rs_rating_low`, `market_timing_off`, `risk_gate_blocked`, `insufficient_cash`, `duplicate_entry_blocked`, `stage_blocked` 추가
+  - `strategies/debug/rejection_collector.py` `CAPTURED_EVENTS`에 `liquidity_blocked` 추가
+  - `strategies/debug/rejection_report.py` `_STAGE_LABELS`·`_event_label()` 업데이트
+  - `strategies/strategy_executor.py` reason 문자열 → canonical code 교체 (`min_trading_value_won` → `insufficient_trading_value`, `min_avg_volume` → `insufficient_volume`)
+- [x] 전략별/일자별 rejected reason 분포를 리포트한다.
+  - `services/rejection_distribution_service.py` 신규: `record()` / `get_distribution()` / `flush_to_file()` / `attach_to_strategy_logger()`
+  - `task/background/after_market/strategy_log_report_task.py`: 장 마감 후 `flush_to_file()` 호출
+  - `view/web/web_app_initializer.py`: 서비스 초기화 및 `attach_to_strategy_logger()` 연결
+  - 저장 경로: `logs/strategies/rejections/YYYYMMDD.jsonl`
+- [x] `run_strategy_debug`와 운영 대시보드에서 rejected reason을 같은 필드명으로 표시한다.
+  - `view/web/routes/strategy_report.py` 신규: `GET /api/strategies/rejected-reasons?strategy=&date=YYYYMMDD`
+  - 필드명 `reason_code`, `count`, `label_kr`, `strategy`로 `format_json()` 규약과 통일
 
 ### 4-3. 운영 대시보드와 알림
 

--- a/view/web/routes/__init__.py
+++ b/view/web/routes/__init__.py
@@ -18,6 +18,7 @@ from view.web.routes.ohlcv import router as ohlcv_router
 from view.web.routes.streaming import router as streaming_router
 from view.web.routes.favorite import router as favorite_router
 from view.web.routes.kill_switch import router as kill_switch_router
+from view.web.routes.strategy_report import router as strategy_report_router
 
 router = APIRouter(prefix="/api")
 
@@ -35,3 +36,4 @@ router.include_router(ohlcv_router)
 router.include_router(streaming_router)
 router.include_router(favorite_router)
 router.include_router(kill_switch_router)
+router.include_router(strategy_report_router)

--- a/view/web/routes/strategy_report.py
+++ b/view/web/routes/strategy_report.py
@@ -1,0 +1,92 @@
+"""전략 거절 사유 분포 리포트 API."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter
+
+from view.web.api_common import _get_ctx
+
+router = APIRouter()
+
+_DEFAULT_LOG_DIR = os.path.join("logs", "strategies", "rejections")
+
+
+def _read_file_rows(date: str, log_dir: str) -> List[dict]:
+    """YYYYMMDD.jsonl 파일에서 행을 읽는다. 파일이 없으면 빈 리스트 반환."""
+    path = os.path.join(log_dir, f"{date}.jsonl")
+    if not os.path.exists(path):
+        return []
+    rows = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return rows
+
+
+@router.get("/strategies/rejected-reasons")
+async def get_rejected_reasons(strategy: str = "", date: str = ""):
+    """전략별/일자별 거절 사유 분포 조회.
+
+    Args:
+        strategy: 전략명 필터. 빈 문자열이면 전체 전략.
+        date:     YYYYMMDD. 빈 문자열이면 오늘.
+
+    Returns:
+        {
+          "strategy": <strategy or "">,
+          "date": <YYYYMMDD>,
+          "distribution": [
+            {"strategy": ..., "reason_code": ..., "count": ..., "label_kr": ...}
+          ]
+        }
+
+    필드명 규약: format_json()의 events[].reason → reason_code, count, label_kr.
+    """
+    target_date = date or datetime.now().strftime("%Y%m%d")
+    ctx = _get_ctx()
+    svc = getattr(ctx, "rejection_distribution_service", None)
+
+    # 1) 메모리 데이터 수집
+    distribution: List[dict] = []
+    if svc is not None:
+        all_strategies = svc.get_all_strategies(target_date)
+        reason_labels = getattr(svc, "_reason_labels", {})
+        for strat_name, reason_map in all_strategies.items():
+            if strategy and strat_name != strategy:
+                continue
+            for reason_code, count in reason_map.items():
+                distribution.append({
+                    "strategy": strat_name,
+                    "reason_code": reason_code,
+                    "count": count,
+                    "label_kr": reason_labels.get(reason_code, reason_code),
+                })
+
+    # 2) 파일 데이터 병합 (메모리에 없는 과거 날짜 or 재시작 후)
+    if not distribution:
+        for row in _read_file_rows(target_date, _DEFAULT_LOG_DIR):
+            strat_name = row.get("strategy", "")
+            if strategy and strat_name != strategy:
+                continue
+            distribution.append({
+                "strategy": strat_name,
+                "reason_code": row.get("reason_code", ""),
+                "count": row.get("count", 0),
+                "label_kr": row.get("label_kr", row.get("reason_code", "")),
+            })
+
+    return {
+        "strategy": strategy,
+        "date": target_date,
+        "distribution": distribution,
+    }

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -46,7 +46,8 @@ from task.background.after_market.log_cleanup_task import LogCleanupTask
 from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
-from services.strategy_log_report_service import StrategyLogReportService
+from services.strategy_log_report_service import StrategyLogReportService, _REASON_KR
+from services.rejection_distribution_service import RejectionDistributionService
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
@@ -97,6 +98,7 @@ class WebAppContext:
         self.streaming_service: StreamingService = None
         self.order_execution_service: OrderExecutionService = None
         self.kill_switch_service: KillSwitchService = None
+        self.rejection_distribution_service: RejectionDistributionService = None
         self.data_quality_service: DataQualityService = None
         self.indicator_service: IndicatorService = None
         self.virtual_repo = VirtualTradeRepository()
@@ -177,6 +179,10 @@ class WebAppContext:
             notification_service=self.notification_service,
             logger=self.logger,
         )
+        self.rejection_distribution_service = RejectionDistributionService(
+            reason_labels=_REASON_KR,
+        )
+        self.rejection_distribution_service.attach_to_strategy_logger()
         # ---------------------------------------------------------
         # [추가] Telegram Notifier 초기화 및 핸들러 등록
         telegram_backlog_bot_token = config_dict.get("telegram_backlog_bot_token")
@@ -648,6 +654,7 @@ class WebAppContext:
                 market_clock=self.market_clock,
                 logger=self.logger,
                 worker_pool=self.worker_pool,
+                rejection_distribution_service=self.rejection_distribution_service,
             )
             self.notification_queue_task = NotificationQueueTask(
                 notification_service=self.notification_service,


### PR DESCRIPTION
구현이 완료되었습니다. 변경 사항 요약:

Step 2 — canonical code 표준화

strategy_log_report_service.py:102-132: _REASON_KR에 7개 신규 코드 추가 (insufficient_trading_value, rs_rating_low, market_timing_off, risk_gate_blocked, insufficient_cash, duplicate_entry_blocked, stage_blocked) rejection_collector.py: liquidity_blocked 이벤트 캡처 추가 rejection_report.py: liquidity_blocked 레이블 및 포맷 추가 strategy_executor.py:96-101: 거절 사유 문자열 canonical code로 교체 Step 3 — RejectionDistributionService (14개 TDD 테스트 통과)

services/rejection_distribution_service.py: record() / flush_to_file() / attach_to_strategy_logger() 구현 strategy.* 로거에 자동 핸들러 부착 → 전략 내부 거절 이벤트 실전에서도 수집
Step 4 — 실전 연결

strategy_log_report_task.py: 장 마감 후 flush_to_file() 호출 web_app_initializer.py: 서비스 초기화 + _REASON_KR 레이블 주입 Step 5 — 웹 API (6개 TDD 테스트 통과)

view/web/routes/strategy_report.py: GET /api/strategies/rejected-reasons?strategy=&date=YYYYMMDD 메모리 우선 → 파일 폴백, 필드명 reason_code/count/label_kr으로 format_json() 규약 준수