### PR TITLE
확인 결과, 처음에는 StrategyScheduler가 떠 있긴 했지만 실제 전략 실행 경로에는 못 들어가고 있었습니다. 0…

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -212,7 +212,9 @@ class StrategyScheduler:
 
                     self._logger.info("현재는 휴장일이거나 장 운영 시간이 아닙니다.")
                     self._force_exit_done.clear()
-                    await self._mcs.wait_until_next_open()
+                    await self._mcs.wait_until_next_open(
+                        max_sleep_seconds=self.MARKET_CLOSED_SLEEP_SEC
+                    )
                     continue
 
                 # 장중: 시간 계산

--- a/services/market_calendar_service.py
+++ b/services/market_calendar_service.py
@@ -158,7 +158,23 @@ class MarketCalendarService:
         # 장 운영 시간이 아니면 달력(API/캐시)을 확인할 필요도 없이 바로 False 반환 (성능 최적화)
         if not self._market_clock.is_market_operating_hours():
             return False
-        return await self.is_business_day()
+
+        if await self.is_business_day():
+            return True
+
+        if not self._broker:
+            return False
+
+        today_str = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
+        latest_trading_date = await self.get_latest_trading_date()
+        if latest_trading_date == today_str:
+            self._logger.warning(
+                "휴장일 API는 오늘을 비영업일로 판단했지만 최신 거래일이 오늘이므로 장중으로 처리합니다. "
+                f"(date={today_str})"
+            )
+            return True
+
+        return False
 
     async def get_next_open_day(self, current_date_str: str = None) -> str:
         """기준일의 '다음 영업일(YYYYMMDD)'을 반환합니다 (연휴 완벽 스킵)."""
@@ -204,15 +220,21 @@ class MarketCalendarService:
             datetime(next_open_date.year, next_open_date.month, next_open_date.day, open_hour, open_minute)
         )
 
-    async def wait_until_next_open(self):
+    async def wait_until_next_open(self, max_sleep_seconds: Optional[float] = None):
         """다음 개장 시간까지 스케줄러를 비동기적으로 대기시킵니다."""
         now = self._market_clock.get_current_kst_time()
         next_open = await self.get_next_open_time()
         
         seconds_left = max(0.0, (next_open - now).total_seconds())
         if seconds_left > 0:
-            self._logger.info(f"다음 개장시간({next_open.strftime('%Y-%m-%d %H:%M:%S')})까지 {seconds_left:.1f}초 대기합니다. 💤")
-            await asyncio.sleep(seconds_left)
+            sleep_seconds = seconds_left
+            if max_sleep_seconds is not None:
+                sleep_seconds = min(seconds_left, max(0.0, max_sleep_seconds))
+            self._logger.info(
+                f"다음 개장시간({next_open.strftime('%Y-%m-%d %H:%M:%S')})까지 "
+                f"{seconds_left:.1f}초 남았습니다. {sleep_seconds:.1f}초 후 재확인합니다. 💤"
+            )
+            await asyncio.sleep(sleep_seconds)
 
     async def get_latest_market_close_time(self) -> Optional[datetime]:
         """

--- a/tests/unit_test/services/test_market_calendar_service.py
+++ b/tests/unit_test/services/test_market_calendar_service.py
@@ -243,6 +243,37 @@ async def test_is_market_open_now(manager, mock_deps):
     tm.is_market_operating_hours = MagicMock(return_value=True) # 시계는 장중이라고 판단
     assert await manager.is_market_open_now() is False # 달력이 컷트!
 
+@pytest.mark.asyncio
+async def test_is_market_open_now_falls_back_to_latest_trading_date(manager, mock_deps, mock_broker):
+    """휴장일 캐시가 False여도 최신 거래일이 오늘이면 장중으로 복구한다."""
+    tm, logger = mock_deps
+    broker, _ = mock_broker
+    manager.set_broker(broker)
+
+    tm.get_current_kst_time.return_value = tm.market_timezone.localize(datetime(2026, 5, 14, 9, 5, 0))
+    tm.is_market_operating_hours = MagicMock(return_value=True)
+    manager.is_business_day = AsyncMock(return_value=False)
+    manager.get_latest_trading_date = AsyncMock(return_value="20260514")
+
+    assert await manager.is_market_open_now() is True
+    manager.get_latest_trading_date.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_is_market_open_now_keeps_holiday_closed_when_latest_trading_date_is_previous_day(manager, mock_deps, mock_broker):
+    """실제 휴장일이면 최신 거래일 fallback으로도 장중 처리하지 않는다."""
+    tm, logger = mock_deps
+    broker, _ = mock_broker
+    manager.set_broker(broker)
+
+    tm.get_current_kst_time.return_value = tm.market_timezone.localize(datetime(2026, 5, 14, 9, 5, 0))
+    tm.is_market_operating_hours = MagicMock(return_value=True)
+    manager.is_business_day = AsyncMock(return_value=False)
+    manager.get_latest_trading_date = AsyncMock(return_value="20260513")
+
+    assert await manager.is_market_open_now() is False
+    manager.get_latest_trading_date.assert_awaited_once()
+
 # ── get_next_open_time Tests ──────────────────────────────────────────
 
 def _is_weekday_side_effect(date_str):
@@ -534,3 +565,18 @@ async def test_wait_until_next_open_no_sleep(mock_sleep, manager, mock_deps):
     manager.get_next_open_time = AsyncMock(return_value=tm.get_current_kst_time.return_value)
     await manager.wait_until_next_open()
     mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("asyncio.sleep", new_callable=AsyncMock)
+async def test_wait_until_next_open_caps_sleep_for_recheck(mock_sleep, manager, mock_deps):
+    """긴 대기 시간이 계산되어도 호출자가 지정한 주기로 재확인할 수 있게 sleep을 제한한다."""
+    tm, logger = mock_deps
+    now = tm.market_timezone.localize(datetime(2026, 5, 14, 9, 0, 0))
+    next_open = tm.market_timezone.localize(datetime(2026, 5, 15, 9, 0, 0))
+    tm.get_current_kst_time.return_value = now
+    manager.get_next_open_time = AsyncMock(return_value=next_open)
+
+    await manager.wait_until_next_open(max_sleep_seconds=60)
+
+    mock_sleep.assert_awaited_once_with(60)


### PR DESCRIPTION
…9:00에 MarketCalendarService가 오늘 2026-05-14를 휴장/장외로 잘못 판단해서 다음 개장시간을 2026-05-15 09:00으로 잡았고, 그래서 last_run이 갱신되지 않았습니다.

지금은 수정 후 상태가 정상입니다. /api/scheduler/status에서 running: true이고, 로그상 전략들이 09:11부터 순차 실행되었습니다. 예: 오닐스퀴즈돌파 09:11, 오닐PP/BGU 09:12, 하이타이트플래그 09:13, 첫눌림목 09:14, 래리윌리엄스VBO 09:15. VBO는 006110 BUY 주문 성공 로그도 확인됐습니다.

수정한 내용:

market_calendar_service.py (line 156): 휴장일 API가 False를 줘도 최신 거래일이 오늘이면 장중으로 복구

market_calendar_service.py (line 220): 다음 개장까지 하루 종일 sleep하지 않도록 최대 대기시간 옵션 추가

strategy_scheduler.py (line 212): 장외 판정 시 60초마다 재확인하도록 연결

test_market_calendar_service.py (line 243): 재현/회귀 테스트 추가

검증:

pytest tests/unit_test -v 통과

pytest tests/integration_test -v 통과

통합 테스트 종료 시 기존 백그라운드 pending task 경고 2건은 출력됐지만, 테스트 결과는 233 passed였습니다.