### PR TITLE
좋아, 재발 방지까지 반영했습니다.

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -347,64 +347,11 @@ class VirtualTradeRepository:
         if not positions:
             return []
 
-        target_pairs = {(p["strategy"], p["code"]) for p in positions}
-        open_signal_map = self._load_scheduler_open_signal_map(target_pairs)
-        inserted: list[dict] = []
-
-        with self._lock:
-            for position in positions:
-                strategy_name = position["strategy"]
-                code = position["code"]
-                row = self._db.execute(
-                    "SELECT 1 FROM trades WHERE strategy=? AND code=? AND status='HOLD' LIMIT 1",
-                    (strategy_name, code)
-                ).fetchone()
-                if row is not None:
-                    continue
-
-                signal_meta = open_signal_map.get((strategy_name, code), {})
-                if not signal_meta:
-                    logger.warning(
-                        f"[가상매매] sync SKIP strategy={strategy_name} code={code} "
-                        "reason=no_open_scheduler_buy_signal"
-                    )
-                    continue
-
-                buy_price = float(signal_meta.get("buy_price") or position["buy_price"])
-                buy_date = str(signal_meta.get("buy_date") or position["buy_date"])
-                qty = int(signal_meta.get("qty") or 1)
-                source = "scheduler_signal"
-
-                # 행 단위 추적 로그 — 향후 의심 데이터(자정 buy_date 등) 발생 시 즉시 추적 가능.
-                # 자정(00:00:00)은 strategy state 파일이 YYYYMMDD 만 기록해 _normalize_entry_date 가
-                # 자정으로 정규화한 흔적이며, 정상 매매 흐름에서는 나오지 않는 패턴이다.
-                is_midnight = buy_date.endswith("00:00:00")
-                log_fn = logger.warning if is_midnight else logger.info
-                log_fn(
-                    f"[가상매매] sync INSERT strategy={strategy_name} code={code} "
-                    f"buy_date={buy_date} buy_price={buy_price} qty={qty} source={source}"
-                    + (" [의심: 자정 buy_date — state 파일 entry_date 가 시간 없는 형식]" if is_midnight else "")
-                )
-
-                with self._db:
-                    self._db.execute(
-                        _INSERT_TRADE,
-                        (strategy_name, code, buy_date, buy_price, qty, None, None, 0.0, "HOLD", "")
-                    )
-
-                inserted.append({
-                    "strategy": strategy_name,
-                    "code": code,
-                    "buy_date": buy_date,
-                    "buy_price": buy_price,
-                    "qty": qty,
-                    "source": source,
-                })
-
-        if inserted:
-            logger.info(f"[가상매매] live 전략 포지션 동기화: {inserted}")
-
-        return inserted
+        logger.warning(
+            "[가상매매] live 전략 상태파일 기반 HOLD 자동 복구 비활성화: "
+            f"{[(p['strategy'], p['code']) for p in positions]}"
+        )
+        return []
 
     # ---- 매수/매도 ----
 

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -1026,7 +1026,7 @@ class StrategyScheduler:
         repo_holdings: Optional[List[dict]] = None,
         allow_signal_history: bool = True,
     ) -> bool:
-        """가상매매 DB 또는 시그널 이력에 현재 포지션 근거가 남아 있는지 확인한다."""
+        """가상매매 원장 DB에 현재 포지션 근거가 남아 있는지 확인한다."""
         target_code = str(code).strip()
         holdings = repo_holdings
         if holdings is None:
@@ -1036,13 +1036,7 @@ class StrategyScheduler:
             if str(hold.get("code", "")).strip() == target_code:
                 return True
 
-        if not allow_signal_history:
-            return False
-
-        return (
-            self._get_signal_net_qty(strategy_name, target_code, only_success=True) > 0
-            or self._get_signal_net_qty(strategy_name, target_code, only_success=False) > 0
-        )
+        return False
 
     def _prune_disabled_force_exit_state(
         self,
@@ -1190,7 +1184,7 @@ class StrategyScheduler:
         return holding
 
     def _get_strategy_holdings(self, cfg: StrategySchedulerConfig) -> List[dict]:
-        """가상매매 DB와 전략 내부 position_state를 병합한 보유 목록."""
+        """가상매매 DB를 기준으로 한 보유 목록."""
         strategy_name = cfg.strategy.name
         merged: Dict[str, dict] = {}
 
@@ -1198,41 +1192,13 @@ class StrategyScheduler:
         for hold in repo_holdings:
             code = str(hold.get("code", "")).strip()
             if code:
-                merged[code] = dict(hold)
+                normalized_hold = dict(hold)
+                if not normalized_hold.get("name"):
+                    normalized_hold["name"] = self.stock_code_repository.get_name_by_code(code) or code
+                merged[code] = normalized_hold
 
         self._prune_disabled_force_exit_state(cfg, repo_holdings=repo_holdings)
         self._prune_stale_position_state(cfg, repo_holdings=repo_holdings)
-
-        for code, state in list(self._get_strategy_position_state(cfg.strategy).items()):
-            norm_code = str(code).strip()
-            if not norm_code:
-                continue
-            if not self._is_valid_strategy_code(norm_code):
-                self._logger.warning(
-                    f"[Scheduler] invalid position_state code ignored: strategy={strategy_name}, code={norm_code}"
-                )
-                continue
-            merged[norm_code] = self._build_strategy_state_holding(
-                strategy_name,
-                norm_code,
-                state,
-                existing=merged.get(norm_code),
-            )
-
-        if cfg.enabled or not cfg.force_exit_on_close:
-            for record in reversed(self._signal_history):
-                if record.strategy_name != strategy_name or record.action != "BUY":
-                    continue
-                code = str(record.code).strip()
-                if not code or code in merged or not self._is_valid_strategy_code(code):
-                    continue
-                if self._get_signal_net_qty(strategy_name, code, only_success=True) <= 0:
-                    continue
-                merged[code] = self._build_strategy_state_holding(
-                    strategy_name,
-                    code,
-                    object(),
-                )
 
         return list(merged.values())
 

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -969,8 +969,8 @@ def test_migrate_legacy_data_handles_failures(tmp_path):
     assert mock_logger.warning.call_count >= 2
 
 
-def test_sync_live_strategy_positions_backfills_missing_strategy_holds(virutal_trade_repository, tmp_path):
-    """전략 상태 파일 + scheduler signal_history를 기준으로 누락 HOLD를 복구한다."""
+def test_sync_live_strategy_positions_does_not_backfill_from_strategy_state(virutal_trade_repository, tmp_path):
+    """전략 state/scheduler 이력은 virtual_trade.db의 HOLD를 새로 만들 수 없다."""
     data_root = tmp_path / "data"
     scheduler_dir = data_root / "StrategyScheduler"
     scheduler_dir.mkdir(parents=True, exist_ok=True)
@@ -1015,20 +1015,13 @@ def test_sync_live_strategy_positions_backfills_missing_strategy_holds(virutal_t
             ],
         )
 
-    inserted = virutal_trade_repository.sync_live_strategy_positions()
+    with patch("repositories.virtual_trade_repository.logger") as mock_logger:
+        inserted = virutal_trade_repository.sync_live_strategy_positions()
     holds = virutal_trade_repository.get_holds_by_strategy("오닐PP/BGU")
 
-    assert len(inserted) == 1
-    assert {row["code"] for row in inserted} == {"489790"}
-    assert len(holds) == 1
-
-    by_code = {row["code"]: row for row in holds}
-    assert by_code["489790"]["buy_price"] == 82000
-    assert by_code["489790"]["qty"] == 6
-    assert by_code["489790"]["buy_date"] == "2026-04-24 13:14:18"
-
-    inserted_again = virutal_trade_repository.sync_live_strategy_positions()
-    assert inserted_again == []
+    assert inserted == []
+    assert holds == []
+    mock_logger.warning.assert_called()
 
 
 def test_sync_live_strategy_positions_skips_state_only_holds(virutal_trade_repository, tmp_path):

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -207,13 +207,14 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strat_status["max_positions"], 5)
         self.assertEqual(strat_status["interval_minutes"], 10)
 
-    def test_get_status_uses_strategy_position_state_when_virtual_trade_is_empty(self):
-        """가상매매 DB가 비어 있어도 전략 position_state 기준 보유를 반환한다."""
+    def test_get_status_prunes_strategy_position_state_when_virtual_trade_is_empty(self):
+        """가상매매 DB에 HOLD가 없으면 전략 position_state만으로 보유를 되살리지 않는다."""
         scheduler, vm, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="오닐PP/BGU")
         strategy._position_state = {
             "489790": SimpleNamespace(entry_price=82000, entry_date="20260424")
         }
+        strategy._save_state = MagicMock()
         scheduler._signal_history = [
             SignalRecord(
                 strategy_name="오닐PP/BGU",
@@ -232,13 +233,13 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         status = scheduler.get_status()
 
-        self.assertEqual(status["strategies"][0]["current_holds"], 1)
-        self.assertEqual(status["strategies"][0]["holdings"][0]["code"], "489790")
-        self.assertEqual(status["strategies"][0]["holdings"][0]["buy_price"], 82000)
-        self.assertEqual(status["strategies"][0]["holdings"][0]["qty"], 6)
+        self.assertEqual(status["strategies"][0]["current_holds"], 0)
+        self.assertEqual(status["strategies"][0]["holdings"], [])
+        self.assertEqual(strategy._position_state, {})
+        strategy._save_state.assert_called_once()
 
-    def test_get_status_uses_successful_buy_signal_history_when_virtual_trade_is_empty(self):
-        """체결 원장 반영 전에도 성공 BUY 이력은 포지션 슬롯 계산에 포함한다."""
+    def test_get_status_ignores_successful_buy_signal_history_when_virtual_trade_is_empty(self):
+        """성공 BUY 이력만으로는 보유 포지션을 복원하지 않는다."""
         scheduler, vm, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="래리윌리엄스VBO")
         scheduler._signal_history = [
@@ -270,20 +271,18 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         status = scheduler.get_status()
 
-        self.assertEqual(status["strategies"][0]["current_holds"], 1)
-        holding = status["strategies"][0]["holdings"][0]
-        self.assertEqual(holding["code"], "425420")
-        self.assertEqual(holding["buy_price"], 63500)
-        self.assertEqual(holding["qty"], 3)
+        self.assertEqual(status["strategies"][0]["current_holds"], 0)
+        self.assertEqual(status["strategies"][0]["holdings"], [])
 
-    def test_get_status_skips_invalid_strategy_code_and_recovers_buy_price_from_signal_history(self):
-        """잘못된 position_state 코드는 제외하고 신호 이력으로 진입가를 복원한다."""
+    def test_get_status_uses_virtual_trade_holdings_as_current_position_source(self):
+        """현재 보유 목록은 signal_history/position_state가 아니라 virtual trade 원장을 기준으로 한다."""
         scheduler, vm, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="거래량돌파(전통)")
         strategy._position_state = {
             "B": SimpleNamespace(breakout_level=1000, peak_price=1100),
             "010060": SimpleNamespace(breakout_level=326500, peak_price=377500),
         }
+        strategy._save_state = MagicMock()
         scheduler._signal_history = [
             SignalRecord(
                 strategy_name="거래량돌파(전통)",
@@ -298,15 +297,25 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             )
         ]
         scheduler.register(StrategySchedulerConfig(strategy=strategy, interval_minutes=1, max_positions=5))
-        vm.get_holds_by_strategy.return_value = []
+        vm.get_holds_by_strategy.return_value = [{
+            "strategy": "거래량돌파(전통)",
+            "code": "010060",
+            "name": "OCI홀딩스",
+            "buy_price": 326500,
+            "qty": 2,
+            "buy_date": "2026-04-24 12:39:00",
+            "status": "HOLD",
+        }]
 
         status = scheduler.get_status()
 
         self.assertEqual(status["strategies"][0]["current_holds"], 1)
         holding = status["strategies"][0]["holdings"][0]
         self.assertEqual(holding["code"], "010060")
-        self.assertEqual(holding["buy_price"], 377500)
-        self.assertEqual(holding["buy_date"], "2026-04-24 12:38:34")
+        self.assertEqual(holding["buy_price"], 326500)
+        self.assertEqual(holding["qty"], 2)
+        self.assertEqual(holding["buy_date"], "2026-04-24 12:39:00")
+        self.assertNotIn("B", strategy._position_state)
 
     def test_get_status_prunes_disabled_force_exit_strategy_state_without_position_evidence(self):
         """비활성 당일청산 전략에 DB/신호 근거 없는 state만 남으면 stale로 정리한다."""
@@ -523,8 +532,8 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(rejection_logs[0]["code"], "035420")
         self.assertEqual(rejection_logs[0]["reason"], "max_positions_reached")
 
-    async def test_run_strategy_uses_strategy_position_state_for_exit_and_capacity(self):
-        """전략 position_state도 현재 보유로 간주해 exit/max_positions에 반영한다."""
+    async def test_run_strategy_uses_virtual_trade_holdings_for_exit_and_capacity(self):
+        """exit/max_positions 판단은 virtual trade 원장의 HOLD만 사용한다."""
         scheduler, vm, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="오닐PP/BGU")
         strategy._position_state = {
@@ -552,7 +561,15 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         ]
         config = StrategySchedulerConfig(strategy=strategy, max_positions=1)
         scheduler.register(config)
-        vm.get_holds_by_strategy.return_value = []
+        vm.get_holds_by_strategy.return_value = [{
+            "strategy": "오닐PP/BGU",
+            "code": "489790",
+            "name": "한화비전",
+            "buy_price": 82000,
+            "qty": 6,
+            "buy_date": "2026-04-24 13:14:18",
+            "status": "HOLD",
+        }]
 
         await scheduler._run_strategy(config)
 
@@ -560,13 +577,14 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strategy.check_exits.await_args.args[0][0]["code"], "489790")
         strategy.scan.assert_not_awaited()
 
-    async def test_run_strategy_recovers_buy_price_from_signal_history_for_state_only_holding(self):
-        """state-only 보유도 신호 이력으로 buy_price를 복원해 check_exits에 전달한다."""
+    async def test_run_strategy_ignores_state_only_holding_and_continues_scan(self):
+        """원장 HOLD가 없으면 state-only 보유는 청산 대상/포지션 슬롯으로 취급하지 않는다."""
         scheduler, vm, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="거래량돌파(전통)")
         strategy._position_state = {
             "010060": SimpleNamespace(breakout_level=326500, peak_price=377500)
         }
+        strategy._save_state = MagicMock()
         strategy.check_exits = AsyncMock(return_value=[])
         strategy.scan = AsyncMock(return_value=[])
         scheduler._signal_history = [
@@ -588,11 +606,9 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         await scheduler._run_strategy(config)
 
-        strategy.check_exits.assert_awaited_once()
-        holding = strategy.check_exits.await_args.args[0][0]
-        self.assertEqual(holding["code"], "010060")
-        self.assertEqual(holding["buy_price"], 377500)
-        self.assertEqual(holding["qty"], 1)
+        strategy.check_exits.assert_not_awaited()
+        strategy.scan.assert_awaited_once()
+        self.assertEqual(strategy._position_state, {})
 
     async def test_run_strategy_scan_respects_max_positions_growing_holdings(self):
         """remaining 슬라이싱으로 max_positions 초과 매수를 방지하는지 테스트.
@@ -2821,12 +2837,22 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
     def test_position_evidence_uses_repo_holdings_and_persist_noop_without_save_hook(self):
         scheduler, _, _, _, _ = self._make_scheduler()
         strategy = MockStrategy(name="NoSaveHook")
+        scheduler._signal_history = [
+            SignalRecord("S", "005930", "Samsung", "BUY", 70000, 1, api_success=True)
+        ]
 
         self.assertTrue(
             scheduler._has_open_position_evidence(
                 "S",
                 "005930",
                 repo_holdings=[{"code": " 005930 "}],
+            )
+        )
+        self.assertFalse(
+            scheduler._has_open_position_evidence(
+                "S",
+                "005930",
+                repo_holdings=[],
             )
         )
 
@@ -2878,6 +2904,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             "": SimpleNamespace(entry_price=1000),
             "005930": SimpleNamespace(entry_price=70000),
         }
+        strategy._save_state = MagicMock()
         scheduler._signal_history = [
             SignalRecord(
                 strategy_name="BlankState",
@@ -2896,7 +2923,9 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         holdings = scheduler._get_strategy_holdings(config)
 
-        self.assertEqual([h["code"] for h in holdings], ["005930"])
+        self.assertEqual(holdings, [])
+        self.assertEqual(strategy._position_state, {})
+        strategy._save_state.assert_called_once()
 
     def test_get_strategy_holdings_prunes_state_without_open_evidence(self):
         scheduler, vm, _, _, _ = self._make_scheduler()


### PR DESCRIPTION
이번 변경의 핵심은 현재 보유 판단의 단일 원천을 data/VirtualTradeRepository/virtual_trade.db로 고정한 것입니다. scheduler.db.signal_history나 *_position_state.json에 과거 BUY/state가 남아 있어도 더 이상 스케줄러 UI 보유 종목으로 되살아나지 않습니다.

변경한 곳:

scheduler/strategy_scheduler.py

_get_strategy_holdings()가 이제 virtual trade 원장의 HOLD만 보유로 반환

signal_history의 성공 BUY fallback 제거

원장에 없는 position_state는 stale로 정리

repositories/virtual_trade_repository.py

sync_live_strategy_positions()가 JSON state + scheduler history로 HOLD를 자동 생성하지 않도록 차단

관련 테스트 갱신

test_strategy_scheduler.py

test_virtual_trade_repository.py

검증도 끝냈습니다.

pytest tests/unit_test -v 통과

pytest tests/integration_test -v 통과: 233 passed

웹 서버 재시작 완료: PID 12240

/api/scheduler/status 확인 결과 대상 종목 테스/금호석유화학/텔레칩스/티엠씨 없음, PP/BGU current_holds=0

정리하면, 앞으로 scheduler.db는 “신호 이력”으로만 남고, 보유 여부는 virtual trade 원장 DB만 믿게 바뀌었습니다.