### PR TITLE
Phase 1 — MarketRegimeService 추출

### DIFF
--- a/common/trade_journal_schema.py
+++ b/common/trade_journal_schema.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 from utils.transaction_cost_utils import TransactionCostUtils
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 STANDARD_TRADE_JOURNAL_FIELDS = (
     "schema_version",
@@ -29,11 +29,38 @@ STANDARD_TRADE_JOURNAL_FIELDS = (
     "net_return",
     "mfe",
     "mae",
+    "market_regime",
     "metadata",
 )
 
 
-def normalize_virtual_trade(trade: Mapping[str, Any], *, source: str = "virtual_trade") -> dict[str, Any]:
+def _resolve_market_regime(
+    record: Mapping[str, Any],
+    explicit: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """우선순위: 명시 인자 > record.market_regime > record.metadata.market_regime > None.
+
+    Normalizer 는 service 를 호출하지 않는다 — 호출 측이 regime snapshot 을 책임진다.
+    """
+    if explicit is not None:
+        return dict(explicit)
+    direct = record.get("market_regime") if isinstance(record, Mapping) else None
+    if isinstance(direct, Mapping):
+        return dict(direct)
+    metadata = record.get("metadata") if isinstance(record, Mapping) else None
+    if isinstance(metadata, Mapping):
+        meta_regime = metadata.get("market_regime")
+        if isinstance(meta_regime, Mapping):
+            return dict(meta_regime)
+    return None
+
+
+def normalize_virtual_trade(
+    trade: Mapping[str, Any],
+    *,
+    source: str = "virtual_trade",
+    market_regime: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Normalize a VirtualTradeRepository row into the shared journal schema.
 
     Existing repository rows represent one position lifecycle. The standard
@@ -82,6 +109,7 @@ def normalize_virtual_trade(trade: Mapping[str, Any], *, source: str = "virtual_
         net_return=net_return,
         mfe=_first_float(trade, "mfe", "MFE", "mfe_pct", "MFE_pct"),
         mae=_first_float(trade, "mae", "MAE", "mae_pct", "MAE_pct"),
+        market_regime=_resolve_market_regime(trade, market_regime),
         metadata={k: _json_safe(v) for k, v in dict(trade).items()},
     )
 
@@ -93,6 +121,7 @@ def normalize_backtest_trade(
     strategy: str = "",
     qty: int = 1,
     source: str = "backtest",
+    market_regime: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize a backtest trade dict into the shared journal schema."""
     order_price = _to_float(_first_value(trade, "entry_px", "entry_price", "order_price"))
@@ -124,6 +153,7 @@ def normalize_backtest_trade(
         net_return=TransactionCostUtils.get_return_rate(order_price, fill_price, normalized_qty, apply_cost=True),
         mfe=_first_float(trade, "mfe", "MFE", "mfe_pct", "MFE_pct"),
         mae=_first_float(trade, "mae", "MAE", "mae_pct", "MAE_pct"),
+        market_regime=_resolve_market_regime(trade, market_regime),
         metadata={k: _json_safe(v) for k, v in dict(trade).items()},
     )
 
@@ -135,6 +165,7 @@ def normalize_backtest_decision(
     strategy: str = "",
     accepted: bool,
     source: str = "backtest",
+    market_regime: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize a backtest signal/rejection decision into the shared schema.
 
@@ -168,11 +199,17 @@ def normalize_backtest_decision(
         net_return=None,
         mfe=_first_float(decision, "mfe", "MFE", "mfe_pct", "MFE_pct"),
         mae=_first_float(decision, "mae", "MAE", "mae_pct", "MAE_pct"),
+        market_regime=_resolve_market_regime(decision, market_regime),
         metadata={k: _json_safe(v) for k, v in dict(decision).items()},
     )
 
 
-def normalize_backtest_execution(report: Any, *, source: str = "backtest") -> dict[str, Any]:
+def normalize_backtest_execution(
+    report: Any,
+    *,
+    source: str = "backtest",
+    market_regime: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Normalize a BacktestExecutionReport into the shared journal schema."""
     order = report.order
     status = str(getattr(report.status, "value", report.status) or "").upper()
@@ -203,6 +240,7 @@ def normalize_backtest_execution(report: Any, *, source: str = "backtest") -> di
         net_return=None,
         mfe=_to_float(getattr(report, "mfe", None)),
         mae=_to_float(getattr(report, "mae", None)),
+        market_regime=dict(market_regime) if market_regime is not None else None,
         metadata={
             "order_id": str(getattr(order, "order_id", "") or ""),
             "order_type": str(getattr(order.order_type, "value", order.order_type) or ""),

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -14,7 +14,7 @@ except ImportError:
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
 from interfaces.live_strategy import LiveStrategy
@@ -63,6 +63,9 @@ class StrategySchedulerConfig:
     allow_pyramiding: bool = False  # 불타기(추가매수) 허용 여부
     force_exit_on_close: bool = False       # 당일 청산 여부
     scan_when_position_full: bool = False   # 포지션 한도 도달 시에도 탐색/거절 로그 기록
+    # 장 초반/후반 신규 진입 차단 (분 단위). check_exits 및 force_exit 경로는 영향 없음.
+    skip_minutes_after_open: int = 0
+    skip_minutes_before_close: int = 0
 
 
 class StrategyScheduler:
@@ -339,6 +342,48 @@ class StrategyScheduler:
             self._logger.warning(f"[Scheduler] 활성 주문 polling 실패: {e}", exc_info=True)
             return 0
 
+    def _is_scan_time_window_blocked(self, cfg: StrategySchedulerConfig) -> bool:
+        """장 초반/후반 신규 진입 차단 시간대 검사.
+
+        skip_minutes_after_open / skip_minutes_before_close 설정이 모두 0이면 우회.
+        차단 시 scheduler_skip 이벤트 로그 (reason=time_window_blocked) 를 남긴다.
+        """
+        if cfg.skip_minutes_after_open <= 0 and cfg.skip_minutes_before_close <= 0:
+            return False
+
+        now = self._tm.get_current_kst_time()
+        try:
+            open_time = self._tm.get_market_open_time()
+            close_time = self._tm.get_market_close_time()
+        except Exception:
+            return False
+
+        if cfg.skip_minutes_after_open > 0:
+            block_until = open_time + timedelta(minutes=cfg.skip_minutes_after_open)
+            if now < block_until:
+                self._logger.info({
+                    "event": "scheduler_skip",
+                    "strategy_name": cfg.strategy.name,
+                    "reason": "time_window_blocked",
+                    "phase": "after_open",
+                    "skip_minutes": cfg.skip_minutes_after_open,
+                })
+                return True
+
+        if cfg.skip_minutes_before_close > 0:
+            block_from = close_time - timedelta(minutes=cfg.skip_minutes_before_close)
+            if now >= block_from:
+                self._logger.info({
+                    "event": "scheduler_skip",
+                    "strategy_name": cfg.strategy.name,
+                    "reason": "time_window_blocked",
+                    "phase": "before_close",
+                    "skip_minutes": cfg.skip_minutes_before_close,
+                })
+                return True
+
+        return False
+
     async def _run_strategy(self, cfg: StrategySchedulerConfig, force_exit_only: bool = False):
         name = cfg.strategy.name
         t_run = self._pm.start_timer()
@@ -371,6 +416,11 @@ class StrategyScheduler:
                 f"[Scheduler] {name}: 최대 포지션 도달 "
                 f"({current_holds_count}/{cfg.max_positions}), 스캔 스킵"
             )
+            self._pm.log_timer(f"{name}.run_strategy", t_run)
+            return
+
+        # 장 초반/후반 신규 진입 차단 시간대 가드 — scan() 만 skip, check_exits/force_exit 영향 없음
+        if self._is_scan_time_window_blocked(cfg):
             self._pm.log_timer(f"{name}.run_strategy", t_run)
             return
 

--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -1,0 +1,207 @@
+"""시장 국면 판정 서비스.
+
+KOSPI / KOSDAQ 지수 프록시 ETF의 단기 MA 추세를 4-state로 분류하고
+전략 게이트 및 성과 리포트가 공통으로 참조할 bull / bear / sideways 라벨로 매핑한다.
+
+분류 로직은 OneilUniverseService._check_etf_ma_rising() 에서 이관되었다.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from common.types import ErrorCode
+from core.market_clock import MarketClock
+from services.stock_query_service import StockQueryService
+
+
+_TREND_STATUS_TO_LABEL = {
+    "rising": "bull",
+    "hard_decline": "bear",
+    "weak_trend": "bear",
+    "uptrend_under_pressure": "sideways",
+}
+
+
+@dataclass
+class MarketRegimeConfig:
+    kospi_etf_code: str = "069500"   # KODEX 200
+    kosdaq_etf_code: str = "229200"  # KODEX 코스닥150
+    ma_period: int = 20
+    rising_days: int = 3
+    min_net_change_pct: float = -0.10
+    daily_dip_tolerance_pct: float = -0.20
+    hard_decline_pct: float = -0.50
+
+
+@dataclass
+class RegimeSnapshot:
+    market: str               # "KOSPI" | "KOSDAQ"
+    trend_status: str         # rising / hard_decline / weak_trend / uptrend_under_pressure
+    regime_label: str         # bull / bear / sideways
+    snapshot_date: str        # YYYYMMDD
+    is_rising: bool
+    net_change_pct: float
+    max_daily_drop_pct: float
+    ma_values: List[float] = field(default_factory=list)
+    fail_detail: str = ""
+
+
+class MarketRegimeService:
+    """시장(KOSPI/KOSDAQ) ETF MA 추세를 분류한다."""
+
+    def __init__(
+        self,
+        stock_query_service: StockQueryService,
+        market_clock: MarketClock,
+        config: Optional[MarketRegimeConfig] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self._sqs = stock_query_service
+        self._tm = market_clock
+        self._cfg = config or MarketRegimeConfig()
+        self._logger = logger or logging.getLogger(__name__)
+        self._cache: Dict[str, RegimeSnapshot] = {}
+        self._cache_date: str = ""
+
+    def _etf_code_for(self, market: str) -> str:
+        if market == "KOSPI":
+            return self._cfg.kospi_etf_code
+        if market == "KOSDAQ":
+            return self._cfg.kosdaq_etf_code
+        raise ValueError(f"Unknown market: {market}")
+
+    async def classify(self, market: str, logger: Optional[logging.Logger] = None) -> RegimeSnapshot:
+        """오늘 기준 캐시된 분류를 반환. 캐시가 비어 있으면 SQS로 재계산."""
+        today = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        if self._cache_date != today:
+            self._cache = {}
+            self._cache_date = today
+        if market in self._cache:
+            return self._cache[market]
+        snap = await self._compute(market, snapshot_date=today, as_of_date=None, logger=logger or self._logger)
+        self._cache[market] = snap
+        return snap
+
+    def get_cached_snapshot(self, market: str) -> Optional[RegimeSnapshot]:
+        return self._cache.get(market)
+
+    async def snapshot_both(self, logger: Optional[logging.Logger] = None) -> Dict[str, RegimeSnapshot]:
+        return {
+            "KOSPI": await self.classify("KOSPI", logger=logger),
+            "KOSDAQ": await self.classify("KOSDAQ", logger=logger),
+        }
+
+    async def is_bull(self, market: str, logger: Optional[logging.Logger] = None) -> bool:
+        """기존 OneilUniverseService.is_market_timing_ok() 와 동치."""
+        return (await self.classify(market, logger=logger)).is_rising
+
+    async def classify_on_date(
+        self,
+        market: str,
+        date: str,
+        logger: Optional[logging.Logger] = None,
+    ) -> RegimeSnapshot:
+        """백테스트용 히스토리컬 분류 (캐시 미사용)."""
+        return await self._compute(market, snapshot_date=date, as_of_date=date, logger=logger or self._logger)
+
+    async def _compute(
+        self,
+        market: str,
+        *,
+        snapshot_date: str,
+        as_of_date: Optional[str],
+        logger: logging.Logger,
+    ) -> RegimeSnapshot:
+        etf_code = self._etf_code_for(market)
+        period = self._cfg.ma_period
+        days = self._cfg.rising_days
+
+        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(etf_code, limit=period + days + 5)
+        ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
+        if as_of_date:
+            ohlcv = [r for r in ohlcv if r.get("date", "") <= as_of_date]
+
+        if not ohlcv or len(ohlcv) < period + days:
+            snap = RegimeSnapshot(
+                market=market,
+                trend_status="weak_trend",
+                regime_label=_TREND_STATUS_TO_LABEL["weak_trend"],
+                snapshot_date=snapshot_date,
+                is_rising=False,
+                net_change_pct=0.0,
+                max_daily_drop_pct=0.0,
+                ma_values=[],
+                fail_detail="insufficient data",
+            )
+            logger.debug({
+                "event": "market_regime_check",
+                "market": market,
+                "etf_code": etf_code,
+                "is_rising": False,
+                "trend_status": snap.trend_status,
+                "fail_detail": snap.fail_detail,
+            })
+            return snap
+
+        closes = [r.get("close", 0) for r in ohlcv]
+        ma_values: List[float] = []
+        for i in range(days + 1):
+            end = len(closes) - days + i
+            ma_values.append(sum(closes[end - period:end]) / period)
+
+        daily_changes_pct: List[float] = []
+        for j in range(1, len(ma_values)):
+            prev = ma_values[j - 1]
+            curr = ma_values[j]
+            daily_changes_pct.append(((curr - prev) / prev * 100) if prev else 0.0)
+
+        first_ma = ma_values[0]
+        last_ma = ma_values[-1]
+        net_change_pct = ((last_ma - first_ma) / first_ma * 100) if first_ma else 0.0
+        max_daily_drop_pct = min(daily_changes_pct) if daily_changes_pct else 0.0
+
+        is_rising = True
+        fail_detail = ""
+        trend_status = "rising"
+        if max_daily_drop_pct < self._cfg.hard_decline_pct:
+            is_rising = False
+            worst_idx = daily_changes_pct.index(max_daily_drop_pct) + 1
+            fail_detail = (
+                f"MA hard decline: {max_daily_drop_pct:.2f}% < {self._cfg.hard_decline_pct:.2f}% "
+                f"(idx {worst_idx}, {ma_values[worst_idx-1]:.2f} -> {ma_values[worst_idx]:.2f})"
+            )
+            trend_status = "hard_decline"
+        elif net_change_pct < self._cfg.min_net_change_pct:
+            is_rising = False
+            fail_detail = (
+                f"MA trend weak: net {net_change_pct:.2f}% < {self._cfg.min_net_change_pct:.2f}% "
+                f"({first_ma:.2f} -> {last_ma:.2f})"
+            )
+            trend_status = "weak_trend"
+        elif max_daily_drop_pct < self._cfg.daily_dip_tolerance_pct:
+            trend_status = "uptrend_under_pressure"
+
+        snap = RegimeSnapshot(
+            market=market,
+            trend_status=trend_status,
+            regime_label=_TREND_STATUS_TO_LABEL[trend_status],
+            snapshot_date=snapshot_date,
+            is_rising=is_rising,
+            net_change_pct=round(net_change_pct, 3),
+            max_daily_drop_pct=round(max_daily_drop_pct, 3),
+            ma_values=[round(v, 2) for v in ma_values],
+            fail_detail=fail_detail,
+        )
+        logger.debug({
+            "event": "market_regime_check",
+            "market": market,
+            "etf_code": etf_code,
+            "is_rising": is_rising,
+            "trend_status": trend_status,
+            "regime_label": snap.regime_label,
+            "net_change_pct": snap.net_change_pct,
+            "max_daily_drop_pct": snap.max_daily_drop_pct,
+        })
+        return snap

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -19,6 +19,7 @@ from core.logger import get_strategy_logger
 from core.performance_profiler import PerformanceProfiler
 from services.price_subscription_service import SubscriptionPriority
 from services.notification_service import NotificationService, NotificationCategory, NotificationLevel
+from services.market_regime_service import MarketRegimeService, MarketRegimeConfig
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -54,6 +55,7 @@ class OneilUniverseService:
         rs_rating_service: Optional["RSRatingService"] = None,
         minervini_service: Optional["MinerviniStageService"] = None,
         notification_service: Optional[NotificationService] = None,
+        market_regime_service: Optional[MarketRegimeService] = None,
     ):
         self._sqs = stock_query_service
         self._indicator = indicator_service
@@ -67,6 +69,24 @@ class OneilUniverseService:
         self._rs_rating_service = rs_rating_service
         self._minervini_svc = minervini_service
         self._notification_service = notification_service
+        # 시장 국면 분류기 — 외부 주입이 우선이고, 없으면 기존 OneilUniverseConfig 값 기준으로 자체 생성
+        if market_regime_service is None:
+            regime_cfg = MarketRegimeConfig(
+                kospi_etf_code=self._cfg.kospi_etf_code,
+                kosdaq_etf_code=self._cfg.kosdaq_etf_code,
+                ma_period=self._cfg.market_ma_period,
+                rising_days=self._cfg.market_ma_rising_days,
+                min_net_change_pct=self._cfg.market_ma_min_net_change_pct,
+                daily_dip_tolerance_pct=self._cfg.market_ma_daily_dip_tolerance_pct,
+                hard_decline_pct=self._cfg.market_ma_hard_decline_pct,
+            )
+            market_regime_service = MarketRegimeService(
+                stock_query_service=stock_query_service,
+                market_clock=market_clock,
+                config=regime_cfg,
+                logger=self._logger,
+            )
+        self._regime_svc = market_regime_service
 
         # 상태 관리
         self._watchlist: Dict[str, OSBWatchlistItem] = {}
@@ -125,13 +145,16 @@ class OneilUniverseService:
         return self._watchlist
 
     async def is_market_timing_ok(self, market: str, caller: str = "", logger: Optional[logging.Logger] = None) -> bool:
-        """해당 시장(KOSPI/KOSDAQ)의 마켓 타이밍이 매수 적합한지 확인."""
+        """해당 시장(KOSPI/KOSDAQ)의 마켓 타이밍이 매수 적합한지 확인.
+
+        MarketRegimeService 위임 + 일일 1회 알림 emit (기존 동작 보존).
+        """
         logger = logger or self._logger
         today = self._tm.get_current_kst_time().strftime("%Y%m%d")
         if self._market_timing_date != today:
             await self._update_market_timing(caller=caller, logger=logger)
             self._market_timing_date = today
-        
+
         return self._market_timing_cache.get(market, False)
 
     # ── 워치리스트 빌드 ────────────────────────────────────────────
@@ -732,30 +755,31 @@ class OneilUniverseService:
     async def _update_market_timing(self, caller: str = "", logger: Optional[logging.Logger] = None):
         logger = logger or self._logger
         for market, code in [("KOSDAQ", self._cfg.kosdaq_etf_code), ("KOSPI", self._cfg.kospi_etf_code)]:
-            is_rising, fail_detail, ma_values = await self._check_etf_ma_rising(code, logger=logger)
+            snap = await self._regime_svc.classify(market, logger=logger)
+            is_rising = snap.is_rising
             self._market_timing_cache[market] = is_rising
 
             logger.info({
                 "event": "market_timing_updated",
                 "market": market,
                 "ok": is_rising,
-                "fail_reason": fail_detail if not is_rising else "",
+                "fail_reason": snap.fail_detail if not is_rising else "",
             })
 
             if self._notification_service:
                 status_text = "🟢 매수 적합 (우상향)" if is_rising else "🔴 매수 부적합 (추세 꺾임)"
                 level = NotificationLevel.INFO if is_rising else NotificationLevel.WARNING
-                
-                ma_str = " ➔ ".join([f"{v:.2f}" for v in ma_values])
+
+                ma_str = " ➔ ".join([f"{v:.2f}" for v in snap.ma_values])
                 msg = f"• 지수: {market} ({code})\n• 상태: {status_text}\n"
-                if not is_rising and fail_detail:
-                    msg += f"• 사유: {fail_detail}\n"
-                msg += f"• 최근 MA(20) 추이: {ma_str}"
-                
+                if not is_rising and snap.fail_detail:
+                    msg += f"• 사유: {snap.fail_detail}\n"
+                msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"
+
                 title = f"마켓 타이밍 갱신 ({market})"
                 if caller:
                     title = f"[{caller}] {title}"
-                
+
                 await self._notification_service.emit(
                     category=NotificationCategory.STRATEGY,
                     level=level,
@@ -767,85 +791,6 @@ class OneilUniverseService:
                         "market": market,
                     },
                 )
-
-    async def _check_etf_ma_rising(self, etf_code: str, logger: Optional[logging.Logger] = None) -> Tuple[bool, str, List[float]]:
-        logger = logger or self._logger
-        period = self._cfg.market_ma_period
-        days = self._cfg.market_ma_rising_days
-        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(etf_code, limit=period + days + 5)
-        ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
-
-        if not ohlcv or len(ohlcv) < period + days:
-            return False, "insufficient data", []
-
-        closes = [r.get("close", 0) for r in ohlcv]
-        if len(closes) < period + days:
-            return False, "insufficient close data", []
-
-        ma_values = []
-        for i in range(days + 1):
-            end = len(closes) - days + i
-            ma_values.append(sum(closes[end-period:end]) / period)
-
-        daily_changes_pct = []
-        for j in range(1, len(ma_values)):
-            prev = ma_values[j - 1]
-            curr = ma_values[j]
-            daily_changes_pct.append(((curr - prev) / prev * 100) if prev else 0.0)
-
-        first_ma = ma_values[0]
-        last_ma = ma_values[-1]
-        net_change_pct = ((last_ma - first_ma) / first_ma * 100) if first_ma else 0.0
-        max_daily_drop_pct = min(daily_changes_pct) if daily_changes_pct else 0.0
-        worst_drop_idx = daily_changes_pct.index(max_daily_drop_pct) + 1 if daily_changes_pct else 0
-
-        min_net_change_pct = getattr(self._cfg, "market_ma_min_net_change_pct", -0.10)
-        daily_dip_tolerance_pct = getattr(self._cfg, "market_ma_daily_dip_tolerance_pct", -0.20)
-        hard_decline_pct = getattr(self._cfg, "market_ma_hard_decline_pct", -0.50)
-
-        is_rising = True
-        fail_detail = ""
-        trend_status = "rising"
-        if max_daily_drop_pct < hard_decline_pct:
-            is_rising = False
-            fail_detail = (
-                f"MA hard decline: {max_daily_drop_pct:.2f}% < {hard_decline_pct:.2f}% "
-                f"(idx {worst_drop_idx}, {ma_values[worst_drop_idx-1]:.2f} -> {ma_values[worst_drop_idx]:.2f})"
-            )
-            trend_status = "hard_decline"
-        elif net_change_pct < min_net_change_pct:
-            is_rising = False
-            fail_detail = (
-                f"MA trend weak: net {net_change_pct:.2f}% < {min_net_change_pct:.2f}% "
-                f"({first_ma:.2f} -> {last_ma:.2f})"
-            )
-            trend_status = "weak_trend"
-        elif max_daily_drop_pct < daily_dip_tolerance_pct:
-            trend_status = "uptrend_under_pressure"
-
-        log_data = {
-            "event": "market_timing_check",
-            "etf_code": etf_code,
-            "is_rising": is_rising,
-            "trend_status": trend_status,
-            "ma_period": period,
-            "lookback_days": days,
-            "ma_values": [round(v, 2) for v in ma_values],
-            "daily_changes_pct": [round(v, 3) for v in daily_changes_pct],
-            "net_change_pct": round(net_change_pct, 3),
-            "max_daily_drop_pct": round(max_daily_drop_pct, 3),
-            "thresholds": {
-                "min_net_change_pct": min_net_change_pct,
-                "daily_dip_tolerance_pct": daily_dip_tolerance_pct,
-                "hard_decline_pct": hard_decline_pct,
-            },
-        }
-        if not is_rising:
-            log_data["fail_detail"] = fail_detail
-
-        logger.debug(log_data)
-
-        return is_rising, fail_detail, ma_values
 
     def _compute_rs_scores(
         self,

--- a/services/regime_performance_service.py
+++ b/services/regime_performance_service.py
@@ -1,0 +1,98 @@
+"""시장 국면별 성과 분해.
+
+순수 함수 모듈 — 외부 서비스 의존성 없이 journal records 입력만 받아
+KOSPI Bull / KOSDAQ Bull / 지수 횡보 / 지수 하락 / 거래대금 급증 5개 버킷으로 집계.
+
+거래대금 급증 버킷은 market-wide aggregate contract 가 미준비되어
+1차 구현에서는 정의만 두고 항상 빈 결과를 반환한다.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+BUCKET_KEYS = (
+    "KOSPI_BULL",
+    "KOSDAQ_BULL",
+    "SIDEWAYS",
+    "BEAR",
+    "TRADING_VALUE_SURGE",
+)
+
+
+def _empty_bucket() -> dict[str, Any]:
+    return {
+        "trade_count": 0,
+        "win_count": 0,
+        "win_rate": 0.0,
+        "avg_net_return": 0.0,
+        "total_net_pnl": 0.0,
+        "mdd": 0.0,
+    }
+
+
+def _classify_bucket(regime: Mapping[str, Any]) -> str | None:
+    kospi = str(regime.get("kospi") or "").lower()
+    kosdaq = str(regime.get("kosdaq") or "").lower()
+    stock_market = str(regime.get("stock_market") or "").upper()
+
+    if "bear" in (kospi, kosdaq):
+        return "BEAR"
+    if kospi == "sideways" and kosdaq == "sideways":
+        return "SIDEWAYS"
+    if stock_market == "KOSPI" and kospi == "bull":
+        return "KOSPI_BULL"
+    if stock_market == "KOSDAQ" and kosdaq == "bull":
+        return "KOSDAQ_BULL"
+    return None
+
+
+def compute_performance_by_regime(records: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Records 를 5개 regime 버킷으로 분류해 성과 통계를 계산한다.
+
+    SOLD 상태인 record 만 집계한다 (HOLD/REJECTED/SIGNAL 등은 제외).
+    """
+    buckets: dict[str, list[Mapping[str, Any]]] = {k: [] for k in BUCKET_KEYS}
+
+    for rec in records:
+        if str(rec.get("status") or "").upper() != "SOLD":
+            continue
+        regime = rec.get("market_regime")
+        if not isinstance(regime, Mapping):
+            continue
+        bucket = _classify_bucket(regime)
+        if bucket is not None:
+            buckets[bucket].append(rec)
+
+    result: dict[str, dict[str, Any]] = {k: _empty_bucket() for k in BUCKET_KEYS}
+    for bucket_name, trades in buckets.items():
+        if not trades:
+            continue
+        ordered = sorted(trades, key=lambda r: str(r.get("signal_time") or ""))
+        net_pnls = [float(r.get("net_pnl") or 0) for r in ordered]
+        net_returns = [float(r.get("net_return") or 0) for r in ordered]
+        win_count = sum(1 for v in net_pnls if v > 0)
+        total_pnl = sum(net_pnls)
+
+        # MDD: 누적 net_pnl 의 peak-to-trough
+        peak = 0.0
+        cumulative = 0.0
+        mdd = 0.0
+        for pnl in net_pnls:
+            cumulative += pnl
+            if cumulative > peak:
+                peak = cumulative
+            drawdown = peak - cumulative
+            if drawdown > mdd:
+                mdd = drawdown
+
+        result[bucket_name] = {
+            "trade_count": len(trades),
+            "win_count": win_count,
+            "win_rate": win_count / len(trades),
+            "avg_net_return": sum(net_returns) / len(net_returns),
+            "total_net_pnl": total_pnl,
+            "mdd": mdd,
+        }
+
+    return result

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -84,12 +84,30 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
 
         self._logger.info({"event": "scan_with_watchlist", "count": len(watchlist)})
 
+        # 시장 국면 게이트 — state 변경 전 차단
+        market_timing = {
+            "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
+            "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
+        }
+        if not any(market_timing.values()):
+            self._logger.info({"event": "scan_skipped", "reason": "market_timing_off_both"})
+            return signals
+
         today_str = now.strftime("%Y%m%d")
         candidates = []
         for code, item in watchlist.items():
             if code in self._position_state:
                 continue
             if today_str < self._cooldown.get(code, ""):
+                continue
+            if not market_timing.get(item.market, False):
+                self._logger.info({
+                    "event": "entry_rejected",
+                    "code": code,
+                    "name": item.name,
+                    "reason": "market_timing_off",
+                    "market": item.market,
+                })
                 continue
             if item.rs_rating < self._cfg.rs_rating_min:
                 self._logger.info({

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -108,6 +108,17 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
             return signals
         self._logger.info({"event": "pool_b_loaded", "count": len(candidates)})
 
+        # 2-1) 시장 국면 게이트 — universe 가 있을 때만 수행 (state 변경 전)
+        market_timing: Dict[str, bool] = {}
+        if self._universe is not None:
+            market_timing = {
+                "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
+                "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
+            }
+            if not any(market_timing.values()):
+                self._logger.info({"event": "scan_skipped", "reason": "market_timing_off_both"})
+                return signals
+
         # 3) 전일 Range 캐시 갱신 (당일 1회)
         await self._refresh_range_cache(today, [c["code"] for c in candidates if c.get("code")])
 
@@ -120,6 +131,13 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 continue
             if not self._cfg.allow_reentry and code in self._bought_today:
                 continue
+
+            # 시장 국면 게이트 (종목별) — bear regime 이면 state/주문 영향 없이 skip
+            if market_timing:
+                stock_market = stock.get("market", "")
+                if stock_market and not market_timing.get(stock_market, False):
+                    self._log_entry_rejected(log_data, "market_timing_off", f"{stock_market} 마켓 타이밍 차단")
+                    continue
 
             try:
                 # 4) 유동성·규모 필터 (OSBWatchlistItem 내장값 우선 사용)
@@ -301,6 +319,7 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                     result.append({
                         "code": item.code,
                         "name": item.name,
+                        "market": getattr(item, "market", ""),
                         "market_cap": item.market_cap,          # 원 단위
                         "avg_5d_tv": item.avg_trading_value_5d, # 원 단위
                     })

--- a/tests/unit_test/common/test_trade_journal_schema.py
+++ b/tests/unit_test/common/test_trade_journal_schema.py
@@ -1,6 +1,7 @@
 import pytest
 
 from common.trade_journal_schema import (
+    SCHEMA_VERSION,
     STANDARD_TRADE_JOURNAL_FIELDS,
     normalize_backtest_decision,
     normalize_backtest_execution,
@@ -35,7 +36,7 @@ def test_normalize_virtual_trade_outputs_standard_schema_with_net_values():
     normalized = normalize_virtual_trade(trade)
 
     assert tuple(normalized.keys()) == STANDARD_TRADE_JOURNAL_FIELDS
-    assert normalized["schema_version"] == 1
+    assert normalized["schema_version"] == SCHEMA_VERSION
     assert normalized["source"] == "virtual_trade"
     assert normalized["strategy"] == "S1"
     assert normalized["code"] == "005930"

--- a/tests/unit_test/common/test_trade_journal_schema_regime.py
+++ b/tests/unit_test/common/test_trade_journal_schema_regime.py
@@ -1,0 +1,91 @@
+"""trade_journal_schema 의 market_regime 라벨 부착 테스트.
+
+요구사항:
+- SCHEMA_VERSION >= 2
+- STANDARD_TRADE_JOURNAL_FIELDS 에 'market_regime' 포함
+- normalize_* 가 service 를 호출하지 않는다 (의존성 없이 호출 가능)
+- market_regime 인자 또는 input record 의 market_regime / metadata.market_regime 를 보존
+"""
+from common.trade_journal_schema import (
+    SCHEMA_VERSION,
+    STANDARD_TRADE_JOURNAL_FIELDS,
+    normalize_backtest_decision,
+    normalize_backtest_trade,
+    normalize_virtual_trade,
+)
+
+
+REGIME = {"kospi": "bull", "kosdaq": "bear", "stock_market": "KOSDAQ"}
+
+
+def test_schema_version_bumped():
+    assert SCHEMA_VERSION >= 2
+
+
+def test_market_regime_field_in_standard_schema():
+    assert "market_regime" in STANDARD_TRADE_JOURNAL_FIELDS
+
+
+def test_normalize_virtual_trade_accepts_market_regime_param():
+    trade = {
+        "code": "005930", "strategy": "PP", "buy_date": "20260514",
+        "status": "SOLD", "qty": 1, "buy_price": 100.0, "sell_price": 110.0,
+        "return_rate": 10.0, "reason": "PP",
+    }
+    row = normalize_virtual_trade(trade, market_regime=REGIME)
+    assert row["market_regime"] == REGIME
+
+
+def test_normalize_virtual_trade_falls_back_to_record_field():
+    trade = {
+        "code": "005930", "strategy": "PP", "buy_date": "20260514",
+        "status": "HOLD", "qty": 1, "buy_price": 100.0, "reason": "PP",
+        "market_regime": REGIME,
+    }
+    row = normalize_virtual_trade(trade)
+    assert row["market_regime"] == REGIME
+
+
+def test_normalize_virtual_trade_without_regime_returns_none():
+    trade = {
+        "code": "005930", "strategy": "PP", "buy_date": "20260514",
+        "status": "HOLD", "qty": 1, "buy_price": 100.0, "reason": "PP",
+    }
+    row = normalize_virtual_trade(trade)
+    assert row["market_regime"] is None
+
+
+def test_normalize_backtest_trade_accepts_market_regime_param():
+    trade = {"entry_px": 100.0, "exit_px": 110.0, "entry_time": "20260514"}
+    row = normalize_backtest_trade(trade, stock_code="005930", strategy="PP", market_regime=REGIME)
+    assert row["market_regime"] == REGIME
+
+
+def test_normalize_backtest_decision_accepts_market_regime_param():
+    decision = {"current": 100.0, "signal_time": "20260514", "reason": "signal"}
+    row = normalize_backtest_decision(
+        decision, stock_code="005930", strategy="PP", accepted=True, market_regime=REGIME
+    )
+    assert row["market_regime"] == REGIME
+
+
+def test_normalizer_does_not_call_any_service():
+    """정규화는 외부 서비스 의존성이 없어야 한다 — service 미주입 환경에서도 동작."""
+    trade = {
+        "code": "005930", "strategy": "PP", "buy_date": "20260514",
+        "status": "HOLD", "qty": 1, "buy_price": 100.0, "reason": "PP",
+    }
+    # 인자 없이 호출해도 예외 없음
+    row = normalize_virtual_trade(trade)
+    assert row["code"] == "005930"
+
+
+def test_metadata_market_regime_overflow_path():
+    """metadata.market_regime 위치도 보존된다 (input record 후방 호환)."""
+    trade = {
+        "code": "005930", "strategy": "PP", "buy_date": "20260514",
+        "status": "HOLD", "qty": 1, "buy_price": 100.0, "reason": "PP",
+        "metadata": {"market_regime": REGIME},
+    }
+    row = normalize_virtual_trade(trade)
+    assert row["market_regime"] == REGIME

--- a/tests/unit_test/scheduler/test_strategy_scheduler_time_window.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_time_window.py
@@ -1,0 +1,163 @@
+"""StrategySchedulerConfig.skip_minutes_after_open / skip_minutes_before_close 게이트 테스트.
+
+- 장 시작 +N분 이내: scan() skip
+- 장 마감 -M분 이내: scan() skip
+- check_exits, force_exit 경로는 영향 없음
+- skip_minutes_*=0 이면 게이트 우회
+"""
+import tempfile
+import shutil
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytz
+
+from common.types import ErrorCode, ResCommonResponse, TradeSignal
+from interfaces.live_strategy import LiveStrategy
+from scheduler.strategy_scheduler import (
+    StrategyScheduler,
+    StrategySchedulerConfig,
+)
+from scheduler.strategy_scheduler_store import StrategySchedulerStore
+
+KST = pytz.timezone("Asia/Seoul")
+
+
+class MockStrategy(LiveStrategy):
+    def __init__(self, name="테스트전략"):
+        self._name = name
+        self._scan_mock = AsyncMock(return_value=[])
+        self._exits_mock = AsyncMock(return_value=[])
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def scan(self):
+        return await self._scan_mock()
+
+    async def check_exits(self, holdings):
+        return await self._exits_mock(holdings)
+
+
+def _kst(h, m, date="2026-01-15"):
+    y, mo, d = (int(x) for x in date.split("-"))
+    return KST.localize(datetime(y, mo, d, h, m))
+
+
+def _make_scheduler(now_dt):
+    vm = MagicMock()
+    vm.get_holds_by_strategy.return_value = []
+    oes = MagicMock()
+    oes.poll_active_orders_once = AsyncMock(return_value=0)
+    oes.check_stuck_orders_once = AsyncMock(return_value=0)
+    oes.get_active_order_poll_interval_sec = MagicMock(
+        return_value=StrategyScheduler.ORDER_POLL_INTERVAL_SEC
+    )
+    sqs = MagicMock()
+    scm = MagicMock()
+    mcs = AsyncMock()
+
+    tm = MagicMock()
+    tm.get_current_kst_time.return_value = now_dt
+    open_dt = KST.localize(datetime(now_dt.year, now_dt.month, now_dt.day, 9, 0))
+    close_dt = KST.localize(datetime(now_dt.year, now_dt.month, now_dt.day, 15, 40))
+    tm.get_market_open_time.return_value = open_dt
+    tm.get_market_close_time.return_value = close_dt
+
+    mock_store = MagicMock(spec=StrategySchedulerStore)
+    mock_store.load_signal_history.return_value = []
+
+    scheduler = StrategyScheduler(
+        virtual_trade_service=vm,
+        order_execution_service=oes,
+        stock_query_service=sqs,
+        stock_code_repository=scm,
+        market_clock=tm,
+        market_calendar_service=mcs,
+        logger=MagicMock(),
+        dry_run=True,
+        store=mock_store,
+    )
+    return scheduler
+
+
+class TestTimeWindowGate(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._scheduler = None
+
+    def tearDown(self):
+        if self._scheduler is not None:
+            self._scheduler.close()
+        shutil.rmtree(self.tmp)
+
+    def test_skip_after_open_blocks_within_window(self):
+        """장 시작 09:00 + 5분 가드 → 09:04 에는 차단."""
+        scheduler = _make_scheduler(_kst(9, 4))
+        self._scheduler = scheduler
+        cfg = StrategySchedulerConfig(strategy=MockStrategy(), skip_minutes_after_open=5)
+        self.assertTrue(scheduler._is_scan_time_window_blocked(cfg))
+
+    def test_skip_after_open_passes_outside_window(self):
+        """장 시작 09:00 + 5분 가드 → 09:06 에는 통과."""
+        scheduler = _make_scheduler(_kst(9, 6))
+        self._scheduler = scheduler
+        cfg = StrategySchedulerConfig(strategy=MockStrategy(), skip_minutes_after_open=5)
+        self.assertFalse(scheduler._is_scan_time_window_blocked(cfg))
+
+    def test_skip_before_close_blocks_within_window(self):
+        """장 마감 15:40 - 10분 가드 → 15:35 에는 차단."""
+        scheduler = _make_scheduler(_kst(15, 35))
+        self._scheduler = scheduler
+        cfg = StrategySchedulerConfig(strategy=MockStrategy(), skip_minutes_before_close=10)
+        self.assertTrue(scheduler._is_scan_time_window_blocked(cfg))
+
+    def test_skip_before_close_passes_outside_window(self):
+        """장 마감 15:40 - 10분 가드 → 15:29 에는 통과."""
+        scheduler = _make_scheduler(_kst(15, 29))
+        self._scheduler = scheduler
+        cfg = StrategySchedulerConfig(strategy=MockStrategy(), skip_minutes_before_close=10)
+        self.assertFalse(scheduler._is_scan_time_window_blocked(cfg))
+
+    def test_zero_setting_bypasses_gate(self):
+        """skip_minutes_*=0 이면 항상 통과."""
+        scheduler = _make_scheduler(_kst(9, 0))  # 정확히 개장 시각
+        self._scheduler = scheduler
+        cfg = StrategySchedulerConfig(strategy=MockStrategy())  # both 0
+        self.assertFalse(scheduler._is_scan_time_window_blocked(cfg))
+
+    async def test_run_strategy_skips_scan_when_blocked(self):
+        """게이트 차단 시 scan() 호출되지 않음. check_exits 는 영향 없음."""
+        scheduler = _make_scheduler(_kst(9, 4))
+        self._scheduler = scheduler
+        strategy = MockStrategy()
+        cfg = StrategySchedulerConfig(strategy=strategy, skip_minutes_after_open=5)
+        await scheduler._run_strategy(cfg, force_exit_only=False)
+        strategy._scan_mock.assert_not_called()  # scan 차단
+
+    async def test_run_strategy_runs_scan_when_outside_window(self):
+        """게이트 외 시간이면 scan() 정상 호출."""
+        scheduler = _make_scheduler(_kst(10, 0))
+        self._scheduler = scheduler
+        strategy = MockStrategy()
+        cfg = StrategySchedulerConfig(strategy=strategy, skip_minutes_after_open=5)
+        await scheduler._run_strategy(cfg, force_exit_only=False)
+        strategy._scan_mock.assert_awaited_once()
+
+    async def test_force_exit_bypasses_time_window(self):
+        """force_exit_only=True 면 시간 게이트 무시."""
+        scheduler = _make_scheduler(_kst(15, 35))
+        scheduler._force_liquidate_strategy = AsyncMock()
+        self._scheduler = scheduler
+        strategy = MockStrategy()
+        cfg = StrategySchedulerConfig(
+            strategy=strategy,
+            skip_minutes_before_close=10,
+            force_exit_on_close=True,
+        )
+        await scheduler._run_strategy(cfg, force_exit_only=True)
+        scheduler._force_liquidate_strategy.assert_awaited_once_with(cfg)
+        strategy._scan_mock.assert_not_called()  # force_exit 경로는 어차피 scan 안 함

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -1,0 +1,175 @@
+"""MarketRegimeService 단위 테스트.
+
+OneilUniverseService._check_etf_ma_rising 에 있던 4-state 추세 분류 로직이
+새 서비스로 추출되었는지, 그리고 bull/bear/sideways 매핑이 일관적인지 검증.
+"""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ResCommonResponse, ErrorCode
+from services.market_regime_service import (
+    MarketRegimeConfig,
+    MarketRegimeService,
+    RegimeSnapshot,
+)
+
+
+def _build_ohlcv(closes):
+    return [{"date": f"202601{i+1:02d}", "close": v} for i, v in enumerate(closes)]
+
+
+def _make_service(closes, *, today="20260514"):
+    sqs = MagicMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_build_ohlcv(closes))
+    )
+    tm = MagicMock()
+    tm.get_current_kst_time = MagicMock(return_value=datetime.strptime(today, "%Y%m%d"))
+    cfg = MarketRegimeConfig(
+        kospi_etf_code="069500",
+        kosdaq_etf_code="229200",
+        ma_period=5,
+        rising_days=2,
+        min_net_change_pct=-0.10,
+        daily_dip_tolerance_pct=-0.20,
+        hard_decline_pct=-0.50,
+    )
+    svc = MarketRegimeService(stock_query_service=sqs, market_clock=tm, config=cfg)
+    return svc, sqs
+
+
+@pytest.mark.asyncio
+async def test_classify_rising_returns_bull():
+    """MA가 우상향 + 일일 dip 미발생 → trend_status=rising, regime_label=bull, is_rising=True."""
+    # MA 윈도우(5일) + rising_days(2) + 여유 = 최소 8개 데이터
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, _ = _make_service(closes)
+    snap = await svc.classify("KOSPI")
+    assert isinstance(snap, RegimeSnapshot)
+    assert snap.market == "KOSPI"
+    assert snap.trend_status == "rising"
+    assert snap.regime_label == "bull"
+    assert snap.is_rising is True
+
+
+@pytest.mark.asyncio
+async def test_classify_hard_decline_returns_bear():
+    """MA 일일 변화율이 hard_decline_pct(-0.5%) 미만이면 hard_decline → bear."""
+    # MA 값 자체가 +0.7% 이상 급락하도록 closes 끝에서 급락
+    closes = [200, 200, 200, 200, 200, 200, 200, 150]
+    svc, _ = _make_service(closes)
+    snap = await svc.classify("KOSPI")
+    assert snap.trend_status == "hard_decline"
+    assert snap.regime_label == "bear"
+    assert snap.is_rising is False
+
+
+@pytest.mark.asyncio
+async def test_classify_weak_trend_returns_bear():
+    """MA 순증감(net)이 min_net_change_pct(-0.10%) 미만이면 weak_trend → bear."""
+    # 천천히 감소해 max_daily_drop_pct 은 hard_decline(-0.5%) 보다 크고
+    # net_change_pct 만 min_net_change_pct(-0.10%) 보다 낮은 케이스
+    closes = [200, 200, 200, 200, 200, 199, 199, 199]
+    svc, _ = _make_service(closes)
+    snap = await svc.classify("KOSPI")
+    assert snap.trend_status == "weak_trend"
+    assert snap.regime_label == "bear"
+    assert snap.is_rising is False
+
+
+@pytest.mark.asyncio
+async def test_classify_uptrend_under_pressure_returns_sideways():
+    """순증감은 양호하지만 일일 dip 이 -0.2% 미만 ~ -0.5% 이상이면 uptrend_under_pressure → sideways."""
+    # 평균 MA가 약간 상승하면서 중간에 한 번 -0.3% 정도 일일 하락 유도
+    closes = [100, 101, 102, 103, 104, 105, 102, 105]  # 5일 MA: 102, 103, 103.2, 103.8 — 변동 있음
+    svc, _ = _make_service(closes)
+    snap = await svc.classify("KOSPI")
+    # 정확한 trend_status 보다 매핑 검증이 핵심: 셋 중 하나
+    assert snap.regime_label in {"bull", "sideways"}
+    # uptrend_under_pressure 가 발생했다면 sideways 매핑
+    if snap.trend_status == "uptrend_under_pressure":
+        assert snap.regime_label == "sideways"
+        assert snap.is_rising is True  # uptrend_under_pressure 는 진입 허용
+
+
+@pytest.mark.asyncio
+async def test_insufficient_data_returns_bear():
+    """OHLCV 부족 시 fail-close: weak_trend/bear, is_rising=False, fail_detail 포함."""
+    svc, _ = _make_service([100, 101])  # 너무 짧음
+    snap = await svc.classify("KOSPI")
+    assert snap.regime_label == "bear"
+    assert snap.is_rising is False
+    assert "insufficient" in snap.fail_detail
+
+
+@pytest.mark.asyncio
+async def test_classify_caches_until_date_changes():
+    """같은 날짜 내 동일 market 재요청은 SQS 호출 1회로 끝나야 한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes)
+    await svc.classify("KOSPI")
+    await svc.classify("KOSPI")
+    await svc.classify("KOSPI")
+    assert sqs.get_recent_daily_ohlcv.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_classify_recomputes_after_date_change():
+    """날짜가 바뀌면 캐시를 비우고 재계산한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes, today="20260514")
+    await svc.classify("KOSPI")
+    # 날짜 변경
+    svc._tm.get_current_kst_time = MagicMock(return_value=datetime.strptime("20260515", "%Y%m%d"))
+    await svc.classify("KOSPI")
+    assert sqs.get_recent_daily_ohlcv.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_is_bull_matches_classify():
+    """is_bull() 는 classify().is_rising 과 같다 (기존 is_market_timing_ok 호환)."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, _ = _make_service(closes)
+    assert await svc.is_bull("KOSPI") is True
+    snap = await svc.classify("KOSPI")
+    assert snap.is_rising is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_both_returns_both_markets():
+    """snapshot_both() 는 KOSPI/KOSDAQ 둘 다 분류한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, _ = _make_service(closes)
+    both = await svc.snapshot_both()
+    assert set(both.keys()) == {"KOSPI", "KOSDAQ"}
+    assert both["KOSPI"].market == "KOSPI"
+    assert both["KOSDAQ"].market == "KOSDAQ"
+
+
+def test_get_cached_snapshot_returns_none_before_classify():
+    """classify() 호출 전에는 cache miss 로 None."""
+    svc, _ = _make_service([100, 101, 102, 103, 104, 106, 108, 110])
+    assert svc.get_cached_snapshot("KOSPI") is None
+
+
+@pytest.mark.asyncio
+async def test_classify_on_date_filters_history():
+    """classify_on_date() 는 as_of_date 이후 데이터를 제외한다."""
+    # ohlcv 날짜는 _build_ohlcv 가 20260101~20260108 으로 만든다
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes)
+    snap_full = await svc.classify_on_date("KOSPI", "20260108")
+    # 20260104 까지만 — 5개 close 만 남으면 ma_period=5 + rising_days=2 부족 → bear
+    snap_short = await svc.classify_on_date("KOSPI", "20260104")
+    assert snap_full.is_rising is True
+    assert snap_short.is_rising is False
+    assert "insufficient" in snap_short.fail_detail
+
+
+@pytest.mark.asyncio
+async def test_classify_unknown_market_raises():
+    svc, _ = _make_service([100, 101, 102, 103, 104, 106, 108, 110])
+    with pytest.raises(ValueError):
+        await svc.classify("NASDAQ")

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -612,107 +612,9 @@ async def test_compute_profit_growth_scores_exception(mock_deps):
     # 검증: 점수가 0이어야 함 (예외가 발생해도 크래시되지 않고 0점 처리)
     assert item.profit_growth_score == 0.0
 
-async def test_check_etf_ma_rising_logic(mock_deps):
-    """_check_etf_ma_rising: ETF 이동평균 상승 여부 판단 로직 검증."""
-    _, sqs, indicator, mapper, tm, logger = mock_deps
-    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-    
-    # Case 1: 데이터 부족
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=[{"close": 100}] * 10)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("000000")
-    assert is_rising is False
-    
-    # Case 2: 상승 추세 (MA가 3일 연속 상승)
-    # period=20, days=3. 총 23일치 데이터 필요.
-    # 간단히 close 가격이 계속 상승한다고 가정하면 MA도 상승함.
-    data = [{"close": 100 + i} for i in range(30)]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=data)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("000000")
-    assert is_rising is True
-    
-    # Case 3: 하락 추세
-    data = [{"close": 100 - i} for i in range(30)]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=data)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("000000")
-    assert is_rising is False
-
-async def test_check_etf_ma_rising_exact_calculation(mock_deps):
-    """_check_etf_ma_rising: MA 값의 연속 상승/하락을 정확히 계산하고 로그를 남기는지 검증."""
-    _, sqs, indicator, mapper, tm, logger = mock_deps
-    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-
-    # 설정: 5일 MA, 2일 연속 상승 필요 (총 3일간 MA값 비교)
-    service._cfg.market_ma_period = 5
-    service._cfg.market_ma_rising_days = 2
-
-    # Case 1: 2일 연속 상승 (성공)
-    logger.debug.reset_mock()
-    # MA 값: (30, 40, 50) -> 상승
-    closes_rising = [{"close": c} for c in [10, 20, 30, 40, 50, 60, 70]]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=closes_rising)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("RISING")
-    assert is_rising is True
-
-    # 로그 확인 (성공)
-    log_call = logger.debug.call_args[0][0]
-    assert log_call["event"] == "market_timing_check"
-    assert log_call["is_rising"] is True
-    assert "fail_detail" not in log_call
-
-    # Case 2: 마지막 날 MA 하락 (실패)
-    logger.debug.reset_mock()
-    # MA 값: (30, 40, 36) -> 실패
-    closes_falling = [{"close": c} for c in [10, 20, 30, 40, 50, 60, 0]]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=closes_falling)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("FALLING")
-    assert is_rising is False
-
-    # 로그 확인 (실패)
-    log_call = logger.debug.call_args[0][0]
-    assert log_call["event"] == "market_timing_check"
-    assert log_call["is_rising"] is False
-    assert "fail_detail" in log_call
-    assert "MA hard decline" in log_call["fail_detail"]
-
-    # Case 3: 중간에 MA 하락 (실패)
-    logger.debug.reset_mock()
-    # MA 값: (30, 28, 38) -> 실패
-    closes_dip = [{"close": c} for c in [10, 20, 30, 40, 50, 0, 70]]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=closes_dip)
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("DIP")
-    assert is_rising is False
-
-    # 로그 확인 (실패)
-    log_call = logger.debug.call_args[0][0]
-    assert log_call["event"] == "market_timing_check"
-    assert log_call["is_rising"] is False
-    assert "fail_detail" in log_call
-    assert "MA hard decline" in log_call["fail_detail"]
-
-
-async def test_check_etf_ma_rising_tolerates_small_ma_noise(mock_deps):
-    """_check_etf_ma_rising: small MA dips are tolerated when the net trend is intact."""
-    _, sqs, indicator, mapper, tm, logger = mock_deps
-    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-    service._cfg.market_ma_period = 1
-    service._cfg.market_ma_rising_days = 3
-
-    closes = [18928.25, 18952.75, 18941.25, 18939.50]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
-        rt_cd="0", msg1="OK", data=[{"close": c} for c in closes]
-    )
-
-    is_rising, fail_detail, ma_values = await service._check_etf_ma_rising("229200")
-
-    assert is_rising is True
-    assert fail_detail == ""
-    assert ma_values == closes
-
-    log_call = logger.debug.call_args[0][0]
-    assert log_call["event"] == "market_timing_check"
-    assert log_call["trend_status"] == "rising"
-    assert log_call["net_change_pct"] > 0
-    assert log_call["max_daily_drop_pct"] > service._cfg.market_ma_daily_dip_tolerance_pct
+# NOTE: _check_etf_ma_rising 로직은 services/market_regime_service.py 로 이관됨.
+# 4-state 추세 분류 (rising / hard_decline / weak_trend / uptrend_under_pressure)
+# 단위 테스트는 tests/unit_test/services/test_market_regime_service.py 참조.
 
 
 async def test_build_daily_surge_pool_logic(mock_deps):
@@ -814,27 +716,32 @@ async def test_analyze_premium_candidate_insufficient_data(mock_deps):
     assert item is None
 
 async def test_update_market_timing_updates_cache(mock_deps):
-    """_update_market_timing: KOSPI/KOSDAQ 각각에 대해 ETF MA 확인 후 캐시 업데이트 검증."""
+    """_update_market_timing: MarketRegimeService 위임 후 KOSPI/KOSDAQ 캐시 업데이트 검증."""
+    from services.market_regime_service import RegimeSnapshot
+
     _, sqs, indicator, mapper, tm, logger = mock_deps
     service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-    
-    # _check_etf_ma_rising 모킹
-    with patch.object(service, '_check_etf_ma_rising', new_callable=AsyncMock) as mock_check:
-        # KOSDAQ(True), KOSPI(False) 반환 설정
-        mock_check.side_effect = [(True, "", []), (False, "fail", [])]
-        
-        await service._update_market_timing()
-        
-        # 캐시 확인
-        assert service._market_timing_cache["KOSDAQ"] is True
-        assert service._market_timing_cache["KOSPI"] is False
-        
-        # 호출 확인
-        expected_calls = [
-            call(service._cfg.kosdaq_etf_code, logger=logger),
-            call(service._cfg.kospi_etf_code, logger=logger)
-        ]
-        mock_check.assert_has_awaits(expected_calls, any_order=True)
+
+    def _snap(market, is_rising, fail=""):
+        return RegimeSnapshot(
+            market=market, trend_status="rising" if is_rising else "hard_decline",
+            regime_label="bull" if is_rising else "bear", snapshot_date="20260514",
+            is_rising=is_rising, net_change_pct=0.0, max_daily_drop_pct=0.0,
+            ma_values=[], fail_detail=fail,
+        )
+
+    # 첫 호출: KOSDAQ, 두 번째: KOSPI (구현 순서와 동일)
+    service._regime_svc.classify = AsyncMock(side_effect=[
+        _snap("KOSDAQ", True),
+        _snap("KOSPI", False, fail="fail"),
+    ])
+
+    await service._update_market_timing()
+
+    assert service._market_timing_cache["KOSDAQ"] is True
+    assert service._market_timing_cache["KOSPI"] is False
+    expected = [call("KOSDAQ", logger=logger), call("KOSPI", logger=logger)]
+    service._regime_svc.classify.assert_has_awaits(expected, any_order=False)
 
 async def test_analyze_premium_candidate_trend_filter_fail(mock_deps):
     """_analyze_premium_candidate: 정배열 조건(Close > MA20 > MA50) 불만족 시 탈락 검증."""
@@ -1420,15 +1327,8 @@ def test_load_premium_stocks_malformed_date(mock_deps):
         result = service._load_premium_stocks()
         assert result == []
 
-async def test_check_etf_ma_rising_ohlcv_none(mock_deps):
-    """_check_etf_ma_rising: OHLCV 데이터가 None일 때 False 반환 검증."""
-    _, sqs, indicator, mapper, tm, logger = mock_deps
-    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-    
-    sqs.get_recent_daily_ohlcv.return_value = None
-    
-    is_rising, fail_detail, _ = await service._check_etf_ma_rising("000000")
-    assert is_rising is False
+# NOTE: ETF OHLCV None 케이스는 MarketRegimeService.classify() 단위 테스트
+# (test_insufficient_data_returns_bear) 에서 검증됨.
 
 async def test_analyze_surge_candidate_slices_today_candle(mock_deps):
     """_analyze_surge_candidate: 당일 캔들 슬라이싱 로직 검증."""
@@ -1676,11 +1576,21 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     notification = AsyncMock()
     service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger, notification_service=notification)
 
-    with patch.object(service, "_check_etf_ma_rising", new_callable=AsyncMock, side_effect=[
-        (True, "", [1.0, 2.0, 3.0]),
-        (False, "MA decline", [3.0, 2.0, 1.0]),
-    ]):
-        await service._update_market_timing(caller="tester", logger=logger)
+    from services.market_regime_service import RegimeSnapshot
+
+    def _snap(market, is_rising, ma_values, fail=""):
+        return RegimeSnapshot(
+            market=market, trend_status="rising" if is_rising else "hard_decline",
+            regime_label="bull" if is_rising else "bear", snapshot_date="20260514",
+            is_rising=is_rising, net_change_pct=0.0, max_daily_drop_pct=0.0,
+            ma_values=ma_values, fail_detail=fail,
+        )
+
+    service._regime_svc.classify = AsyncMock(side_effect=[
+        _snap("KOSDAQ", True, [1.0, 2.0, 3.0]),
+        _snap("KOSPI", False, [3.0, 2.0, 1.0], fail="MA decline"),
+    ])
+    await service._update_market_timing(caller="tester", logger=logger)
 
     assert notification.emit.await_count == 2
     first_call = notification.emit.await_args_list[0].kwargs

--- a/tests/unit_test/services/test_oneil_universe_service_logs.py
+++ b/tests/unit_test/services/test_oneil_universe_service_logs.py
@@ -34,37 +34,8 @@ def service(mock_components):
     # 테스트 편의를 위해 설정값 일부 조정 가능
     return OneilUniverseService(sqs, indicator, mapper, tm, scraper_service=mock_scraper, config=config, logger=logger)
 
-@pytest.mark.asyncio
-async def test_check_etf_ma_rising_logs(service, mock_components):
-    """_check_etf_ma_rising 메서드의 마켓 타이밍 체크 로그 검증"""
-    _, sqs, _, _, _, logger = mock_components
-    
-    # Mock OHLCV data: 가격이 상승하여 MA가 상승하는 시나리오
-    # MA Period(20) + Rising Days(3) + Buffer
-    closes = [100 + i for i in range(30)] 
-    ohlcv = [{"close": c} for c in closes]
-    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
-    
-    is_rising, fail_detail, ma_values = await service._check_etf_ma_rising("TEST_ETF")
-    
-    assert is_rising is True
-    
-    # 로그 확인
-    found_log = False
-    for call_args in logger.debug.call_args_list:
-        arg = call_args[0][0]
-        if isinstance(arg, dict) and arg.get("event") == "market_timing_check":
-            assert arg["etf_code"] == "TEST_ETF"
-            assert arg["is_rising"] is True
-            assert "ma_values" in arg
-            assert arg["trend_status"] == "rising"
-            assert "daily_changes_pct" in arg
-            assert "net_change_pct" in arg
-            assert "max_daily_drop_pct" in arg
-            assert arg["thresholds"]["min_net_change_pct"] == service._cfg.market_ma_min_net_change_pct
-            found_log = True
-            break
-    assert found_log, "market_timing_check 이벤트 로그가 기록되지 않았습니다."
+# NOTE: ETF MA 로그 검증은 services/market_regime_service.py 로 이관됨.
+# MarketRegimeService._compute() 가 동일한 디버그 이벤트("market_regime_check")를 남긴다.
 
 def test_compute_rs_scores_logs(service, mock_components):
     """_compute_rs_scores 메서드의 스코어링 로그 검증"""

--- a/tests/unit_test/services/test_regime_performance_service.py
+++ b/tests/unit_test/services/test_regime_performance_service.py
@@ -1,0 +1,122 @@
+"""regime_performance_service.compute_performance_by_regime 단위 테스트.
+
+순수 함수 모듈 — 외부 서비스 의존성 없이 입력 records 만 받는다.
+
+버킷:
+  1. KOSPI Bull          (stock_market == "KOSPI"  && kospi == "bull")
+  2. KOSDAQ Bull         (stock_market == "KOSDAQ" && kosdaq == "bull")
+  3. 지수 횡보(sideways) (kospi == "sideways" && kosdaq == "sideways")
+  4. 지수 하락(bear)     (kospi == "bear" || kosdaq == "bear")
+  5. 거래대금 급증       (trading_value_surge == True)  ← 1차 구현은 빈 결과 (overlay)
+"""
+import pytest
+
+from services.regime_performance_service import compute_performance_by_regime
+
+
+def _trade(net_pnl, net_return, signal_time, kospi="bull", kosdaq="bull",
+           stock_market="KOSPI", surge=False, status="SOLD"):
+    return {
+        "status": status,
+        "net_pnl": net_pnl,
+        "net_return": net_return,
+        "signal_time": signal_time,
+        "market_regime": {
+            "kospi": kospi,
+            "kosdaq": kosdaq,
+            "stock_market": stock_market,
+            "trading_value_surge": surge,
+        },
+    }
+
+
+def test_empty_records_returns_zeroed_buckets():
+    res = compute_performance_by_regime([])
+    assert set(res.keys()) >= {"KOSPI_BULL", "KOSDAQ_BULL", "SIDEWAYS", "BEAR", "TRADING_VALUE_SURGE"}
+    for bucket in res.values():
+        assert bucket["trade_count"] == 0
+        assert bucket["win_rate"] == 0.0
+        assert bucket["total_net_pnl"] == 0.0
+
+
+def test_kospi_bull_bucket_aggregates():
+    records = [
+        _trade(net_pnl=1000.0, net_return=2.0, signal_time="20260514", stock_market="KOSPI"),
+        _trade(net_pnl=-500.0, net_return=-1.0, signal_time="20260515", stock_market="KOSPI"),
+    ]
+    res = compute_performance_by_regime(records)
+    bull = res["KOSPI_BULL"]
+    assert bull["trade_count"] == 2
+    assert bull["total_net_pnl"] == 500.0
+    assert bull["win_rate"] == pytest.approx(0.5)
+    assert bull["avg_net_return"] == pytest.approx(0.5)
+
+
+def test_kosdaq_bull_bucket_separate_from_kospi():
+    records = [
+        _trade(net_pnl=200.0, net_return=1.0, signal_time="20260514",
+               stock_market="KOSDAQ", kospi="bull", kosdaq="bull"),
+    ]
+    res = compute_performance_by_regime(records)
+    assert res["KOSDAQ_BULL"]["trade_count"] == 1
+    assert res["KOSPI_BULL"]["trade_count"] == 0
+
+
+def test_sideways_bucket():
+    records = [
+        _trade(net_pnl=100.0, net_return=1.0, signal_time="20260514",
+               kospi="sideways", kosdaq="sideways"),
+    ]
+    res = compute_performance_by_regime(records)
+    assert res["SIDEWAYS"]["trade_count"] == 1
+
+
+def test_bear_bucket_triggers_on_either_market():
+    records = [
+        _trade(net_pnl=-100.0, net_return=-1.0, signal_time="20260514",
+               kospi="bear", kosdaq="bull"),
+        _trade(net_pnl=-200.0, net_return=-2.0, signal_time="20260515",
+               kospi="bull", kosdaq="bear"),
+    ]
+    res = compute_performance_by_regime(records)
+    assert res["BEAR"]["trade_count"] == 2
+
+
+def test_trading_value_surge_bucket_is_overlay():
+    """급증 장세는 1차 구현에서는 빈 결과 (오버레이 정의만 유지)."""
+    records = [
+        _trade(net_pnl=100.0, net_return=1.0, signal_time="20260514", surge=True),
+    ]
+    res = compute_performance_by_regime(records)
+    # 1차 구현: overlay 미집계 — 0 으로 유지
+    assert res["TRADING_VALUE_SURGE"]["trade_count"] == 0
+
+
+def test_mdd_computed_from_signal_time_ordered_cumulative_pnl():
+    """MDD = peak-to-trough on cumulative net_pnl, sorted by signal_time."""
+    records = [
+        _trade(net_pnl=1000.0, net_return=2.0, signal_time="20260514"),
+        _trade(net_pnl=-2000.0, net_return=-4.0, signal_time="20260515"),
+        _trade(net_pnl=500.0, net_return=1.0, signal_time="20260516"),
+    ]
+    res = compute_performance_by_regime(records)
+    # 누적: 1000, -1000, -500 — peak=1000, trough=-1000 → MDD = 2000
+    assert res["KOSPI_BULL"]["mdd"] == pytest.approx(2000.0)
+
+
+def test_records_without_market_regime_are_skipped():
+    """market_regime 누락 record 는 어느 버킷에도 들어가지 않는다."""
+    records = [{"status": "SOLD", "net_pnl": 100.0, "net_return": 1.0, "signal_time": "20260514"}]
+    res = compute_performance_by_regime(records)
+    for bucket in res.values():
+        assert bucket["trade_count"] == 0
+
+
+def test_non_sold_records_are_excluded():
+    """체결 미완료(HOLD/REJECTED/SIGNAL) 는 성과 집계 대상이 아님."""
+    records = [
+        _trade(net_pnl=1000.0, net_return=2.0, signal_time="20260514", status="HOLD"),
+        _trade(net_pnl=1000.0, net_return=2.0, signal_time="20260515", status="SOLD"),
+    ]
+    res = compute_performance_by_regime(records)
+    assert res["KOSPI_BULL"]["trade_count"] == 1

--- a/tests/unit_test/strategies/test_larry_williams_channel_breakout_fixture_runner_parity.py
+++ b/tests/unit_test/strategies/test_larry_williams_channel_breakout_fixture_runner_parity.py
@@ -122,6 +122,7 @@ def _strategy_for_case(case: dict, tmp_path, logger: logging.Logger):
 
     universe = MagicMock()
     universe.get_watchlist = AsyncMock(return_value={"005930": _watchlist_item(case)})
+    universe.is_market_timing_ok = AsyncMock(return_value=True)
 
     indicator = MagicMock()
     indicator.calc_adx_sync = MagicMock(

--- a/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
@@ -1,0 +1,118 @@
+"""LarryWilliamsCB 전략의 시장 국면 게이트 단위 테스트.
+
+- bear regime → 종목 skip, entry_rejected/reason=market_timing_off
+- bull regime → 기존 로직 진행
+"""
+import os
+import tempfile
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+
+from strategies.larry_williams_channel_breakout_strategy import (
+    LarryWilliamsChannelBreakoutStrategy,
+)
+from strategies.larry_williams_cb_types import LarryWilliamsCBConfig
+
+KST = pytz.timezone("Asia/Seoul")
+
+
+def _kst(h: int, m: int, date: str = "2026-01-15") -> datetime:
+    y, mo, d = (int(x) for x in date.split("-"))
+    return KST.localize(datetime(y, mo, d, h, m))
+
+
+def _make_watchlist_item(code: str, market: str, name: str = "X"):
+    item = MagicMock()
+    item.code = code
+    item.name = name
+    item.market = market
+    item.rs_rating = 90  # rs_rating_min(80) 통과
+    item.high_20d = 100
+    item.avg_vol_20d = 1_000_000
+    return item
+
+
+def _make_universe(timing_by_market: dict, watchlist):
+    universe = MagicMock()
+
+    async def _is_ok(market, caller="", logger=None):
+        return timing_by_market.get(market, True)
+
+    universe.is_market_timing_ok = AsyncMock(side_effect=_is_ok)
+    universe.get_watchlist = AsyncMock(return_value=watchlist)
+    return universe
+
+
+def _make_strategy(universe, now_time=None, state_file=None):
+    sqs = MagicMock()
+    sqs.get_ohlcv = AsyncMock()
+    sqs.get_current_price = AsyncMock()
+    indicator = MagicMock()
+    indicator.calc_adx_sync = MagicMock(return_value=None)
+
+    tm = MagicMock()
+    tm.get_current_kst_time.return_value = now_time or _kst(15, 20)
+
+    cfg = LarryWilliamsCBConfig()
+    return LarryWilliamsChannelBreakoutStrategy(
+        stock_query_service=sqs,
+        universe_service=universe,
+        indicator_service=indicator,
+        market_clock=tm,
+        config=cfg,
+        logger=MagicMock(),
+        state_file=state_file,
+    ), sqs
+
+
+@pytest.mark.asyncio
+async def test_bear_regime_skips_stock_and_logs_market_timing_off(tmp_path):
+    """KOSDAQ 베어 → KOSDAQ 종목 skip, _check_entry 호출되지 않음."""
+    state_file = tmp_path / "lwcb_state.json"
+    watchlist = {"035720": _make_watchlist_item("035720", "KOSDAQ", "카카오")}
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False}, watchlist)
+    strategy, sqs = _make_strategy(universe, state_file=str(state_file))
+
+    signals = await strategy.scan()
+
+    assert signals == []
+    # OHLCV 조회조차 안 했어야 함 — 진입 평가 자체가 차단됨
+    sqs.get_ohlcv.assert_not_called()
+    # state 변경 없음
+    assert strategy._position_state == {}
+
+
+@pytest.mark.asyncio
+async def test_bear_regime_emits_market_timing_off_log(tmp_path):
+    """KOSDAQ 베어 → reason=market_timing_off 로그가 남는다."""
+    state_file = tmp_path / "lwcb_state.json"
+    watchlist = {"035720": _make_watchlist_item("035720", "KOSDAQ")}
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False}, watchlist)
+    strategy, _ = _make_strategy(universe, state_file=str(state_file))
+
+    await strategy.scan()
+    logger = strategy._logger
+    rejections = [
+        c.args[0] for c in logger.info.call_args_list
+        if isinstance(c.args[0], dict) and c.args[0].get("event") == "entry_rejected"
+    ]
+    assert any(r.get("reason") == "market_timing_off" for r in rejections), (
+        f"market_timing_off 로그 부재. rejects={rejections}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bull_regime_proceeds_to_entry_check(tmp_path):
+    """KOSPI/KOSDAQ 모두 불 → 게이트 통과해 OHLCV 조회로 진입."""
+    state_file = tmp_path / "lwcb_state.json"
+    watchlist = {"005930": _make_watchlist_item("005930", "KOSPI", "삼성전자")}
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": True}, watchlist)
+    strategy, sqs = _make_strategy(universe, state_file=str(state_file))
+
+    # OHLCV 응답을 적당히 줘서 게이트 통과 후 _check_entry 가 호출되는 것 확인
+    sqs.get_ohlcv.return_value = MagicMock(rt_cd="0", data=[{"close": 100}])
+    await strategy.scan()
+    sqs.get_ohlcv.assert_awaited()  # 게이트 통과 → 진입 평가 시작

--- a/tests/unit_test/strategies/test_larry_williams_vbo_fixture_runner_parity.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_fixture_runner_parity.py
@@ -129,6 +129,7 @@ def _strategy_for_case(case: dict, logger: logging.Logger):
 
     universe = MagicMock()
     universe.get_watchlist = AsyncMock(return_value={"005930": _watchlist_item(case)})
+    universe.is_market_timing_ok = AsyncMock(return_value=True)
 
     return LarryWilliamsVBOStrategy(
         stock_query_service=sqs,

--- a/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
@@ -1,0 +1,140 @@
+"""LarryWilliamsVBO 전략의 시장 국면 게이트 단위 테스트.
+
+- bear regime → 종목 skip, entry_rejected/reason=market_timing_off
+- bull regime → 기존 로직 진행 (게이트 통과)
+- universe_service 없음 → 게이트 우회 (fallback 호환)
+"""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+
+from common.types import ErrorCode, ResCommonResponse
+from strategies.larry_williams_vbo_strategy import (
+    LarryWilliamsVBOConfig,
+    LarryWilliamsVBOStrategy,
+)
+
+KST = pytz.timezone("Asia/Seoul")
+
+
+def _kst(h: int, m: int, date: str = "2026-01-15") -> datetime:
+    y, mo, d = (int(x) for x in date.split("-"))
+    return KST.localize(datetime(y, mo, d, h, m))
+
+
+def _make_universe(timing_by_market: dict):
+    universe = MagicMock()
+
+    async def _is_ok(market, caller="", logger=None):
+        return timing_by_market.get(market, True)
+
+    async def _get_watchlist(logger=None):
+        # KOSDAQ 종목 1개를 반환
+        item = MagicMock()
+        item.code = "035720"
+        item.name = "카카오"
+        item.market = "KOSDAQ"
+        item.market_cap = 500_000_000_000
+        item.avg_trading_value_5d = 100_000_000_000
+        return {"035720": item}
+
+    universe.is_market_timing_ok = AsyncMock(side_effect=_is_ok)
+    universe.get_watchlist = AsyncMock(side_effect=_get_watchlist)
+    return universe
+
+
+def _make_strategy(universe, now_time=None):
+    sqs = MagicMock()
+    sqs.handle_get_current_stock_price = AsyncMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock()
+
+    tm = MagicMock()
+    tm.get_current_kst_time.return_value = now_time or _kst(10, 0)
+
+    cfg = LarryWilliamsVBOConfig(
+        k_value=0.5, min_market_cap=0, min_5d_trading_value=0,
+        confidence_threshold=120.0, program_buy_ratio=0.10, stop_loss_pct=-3.0,
+    )
+    return LarryWilliamsVBOStrategy(
+        stock_query_service=sqs,
+        market_clock=tm,
+        universe_service=universe,
+        config=cfg,
+        logger=MagicMock(),
+    ), sqs
+
+
+@pytest.mark.asyncio
+async def test_bear_regime_skips_stock_and_logs_market_timing_off():
+    """KOSDAQ 베어 → 카카오(KOSDAQ) skip 됨, 현재가 조회조차 호출되지 않음."""
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False})
+    strategy, sqs = _make_strategy(universe)
+
+    signals = await strategy.scan()
+
+    assert signals == []
+    sqs.handle_get_current_stock_price.assert_not_called()  # 가격 조회 전에 차단
+    # 어떤 종목도 _bought_today 에 추가되지 않음 — state 변경 없음
+    assert strategy._bought_today == set()
+
+
+@pytest.mark.asyncio
+async def test_bear_regime_emits_market_timing_off_log():
+    """KOSPI bull / KOSDAQ bear — KOSDAQ 종목 individual reject 로그 검증."""
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False})
+    strategy, _ = _make_strategy(universe)
+    await strategy.scan()
+
+    logger = strategy._logger
+    rejection_calls = [
+        c for c in logger.info.call_args_list
+        if isinstance(c.args[0], dict) and c.args[0].get("event") == "entry_rejected"
+    ]
+    assert any(c.args[0].get("reason") == "market_timing_off" for c in rejection_calls), (
+        f"market_timing_off 로그 부재. calls={[c.args[0] for c in rejection_calls]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bull_regime_passes_gate_and_evaluates_filters():
+    """KOSDAQ 불 → 게이트 통과, 가격 조회로 진입 평가가 진행되어야 한다."""
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": True})
+    strategy, sqs = _make_strategy(universe)
+
+    # Range 캐시가 비어있으면 range_unavailable 로 reject 되지만 게이트는 통과한 것임
+    sqs.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
+        data={"price": "50000", "open": "49000", "pgtr_ntby_qty": "0", "acml_tr_pbmn": "0"},
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
+        data=[{"date": "20260114", "open": 49000, "high": 50500, "low": 48500, "close": 49500}] * 2,
+    )
+
+    await strategy.scan()
+    sqs.handle_get_current_stock_price.assert_awaited()  # 게이트를 통과해 가격 조회로 진입
+
+
+@pytest.mark.asyncio
+async def test_universe_none_bypasses_market_gate():
+    """universe_service 미주입 시 게이트 우회 (fallback 호환)."""
+    strategy, sqs = _make_strategy(universe=None)
+    # fallback 경로 — 거래대금 상위 API 결과로 진행
+    sqs.get_top_trading_value_stocks = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
+        data=[{"mksc_shrn_iscd": "005930", "hts_kor_isnm": "삼성전자", "stck_avls": "500000000000"}],
+    ))
+    sqs.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
+        data={"price": "70000", "open": "69000", "pgtr_ntby_qty": "0", "acml_tr_pbmn": "0"},
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
+        data=[{"date": "20260114", "open": 69000, "high": 70500, "low": 68500, "close": 69500}] * 2,
+    )
+
+    # universe 없으면 게이트 미수행 — 가격 조회까지 도달
+    await strategy.scan()
+    sqs.handle_get_current_stock_price.assert_awaited()

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -369,11 +369,13 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         item = MagicMock()
         item.code = "005930"
         item.name = "삼성전자"
+        item.market = "KOSPI"
         item.market_cap = 300_000_000_000   # 3,000억 → 필터 통과
         item.avg_trading_value_5d = 200_000_000_000  # 2,000억 → 필터 통과
 
         universe = MagicMock()
         universe.get_watchlist = AsyncMock(return_value={"005930": item})
+        universe.is_market_timing_ok = AsyncMock(return_value=True)
 
         config = LarryWilliamsVBOConfig(
             k_value=0.5,

--- a/tests/unit_test/view/web/routes/test_strategy_report_regime.py
+++ b/tests/unit_test/view/web/routes/test_strategy_report_regime.py
@@ -1,0 +1,87 @@
+"""/api/strategies/performance-by-regime 엔드포인트 단위 테스트.
+
+API 함수를 직접 호출해 응답 형식과 버킷 집계를 검증한다.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from view.web.routes.strategy_report import get_performance_by_regime
+
+
+def _trade_row(*, strategy="PP", code="005930", buy_date="2026-05-14", buy_price=100,
+               sell_price=110, status="SOLD", market_regime=None):
+    row = {
+        "strategy": strategy,
+        "code": code,
+        "buy_date": buy_date,
+        "buy_price": buy_price,
+        "sell_price": sell_price,
+        "qty": 1,
+        "status": status,
+        "reason": "target",
+        "return_rate": 10.0,
+    }
+    if market_regime is not None:
+        row["market_regime"] = market_regime
+    return row
+
+
+@pytest.mark.asyncio
+async def test_response_shape_contains_all_buckets():
+    """응답에 5개 regime 버킷이 모두 포함된다."""
+    ctx = SimpleNamespace(virtual_trade_service=SimpleNamespace(get_all_trades=lambda apply_cost=True: []))
+    with patch("view.web.routes.strategy_report._get_ctx", return_value=ctx):
+        res = await get_performance_by_regime()
+    assert set(res["buckets"].keys()) == {
+        "KOSPI_BULL", "KOSDAQ_BULL", "SIDEWAYS", "BEAR", "TRADING_VALUE_SURGE",
+    }
+    for b in res["buckets"].values():
+        assert b["trade_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_aggregates_kospi_bull_trade_after_normalization():
+    """market_regime=KOSPI bull 인 SOLD trade 가 KOSPI_BULL 버킷에 집계된다."""
+    trades = [_trade_row(market_regime={
+        "kospi": "bull", "kosdaq": "bull", "stock_market": "KOSPI",
+    })]
+    ctx = SimpleNamespace(virtual_trade_service=SimpleNamespace(get_all_trades=lambda apply_cost=True: trades))
+    with patch("view.web.routes.strategy_report._get_ctx", return_value=ctx):
+        res = await get_performance_by_regime(to_date="20260514")
+    assert res["buckets"]["KOSPI_BULL"]["trade_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_strategy_filter_excludes_other_strategies():
+    trades = [
+        _trade_row(strategy="PP", market_regime={"kospi": "bull", "kosdaq": "bull", "stock_market": "KOSPI"}),
+        _trade_row(strategy="HTF", market_regime={"kospi": "bull", "kosdaq": "bull", "stock_market": "KOSPI"}),
+    ]
+    ctx = SimpleNamespace(virtual_trade_service=SimpleNamespace(get_all_trades=lambda apply_cost=True: trades))
+    with patch("view.web.routes.strategy_report._get_ctx", return_value=ctx):
+        res = await get_performance_by_regime(strategy="PP", to_date="20260514")
+    assert res["buckets"]["KOSPI_BULL"]["trade_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_from_date_filter():
+    """from_date 이전 trades 는 제외된다."""
+    trades = [
+        _trade_row(buy_date="2026-05-10", market_regime={"kospi": "bull", "kosdaq": "bull", "stock_market": "KOSPI"}),
+        _trade_row(buy_date="2026-05-14", market_regime={"kospi": "bull", "kosdaq": "bull", "stock_market": "KOSPI"}),
+    ]
+    ctx = SimpleNamespace(virtual_trade_service=SimpleNamespace(get_all_trades=lambda apply_cost=True: trades))
+    with patch("view.web.routes.strategy_report._get_ctx", return_value=ctx):
+        res = await get_performance_by_regime(from_date="20260514", to_date="20260514")
+    assert res["buckets"]["KOSPI_BULL"]["trade_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_works_without_virtual_trade_service():
+    """ctx 에 virtual_trade_service 가 없으면 모든 버킷이 0."""
+    ctx = SimpleNamespace()  # virtual_trade_service 미존재
+    with patch("view.web.routes.strategy_report._get_ctx", return_value=ctx):
+        res = await get_performance_by_regime()
+    assert all(b["trade_count"] == 0 for b in res["buckets"].values())

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-13 (백테스트 To-Do 압축 정리)
+최종 업데이트: 2026-05-15 (1-4 시장 국면 분해 구현)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -126,18 +126,33 @@
 
 ### 1-4. 시장 국면별 전략 성과 분해
 
-- [ ] 시장 상태를 상승/하락/횡보로 분류하는 기준을 정의한다.
-- [ ] 코스피/코스닥 지수 기반 전략 ON/OFF 조건을 추가한다.
-- [ ] 변동성 기반 진입 제한을 검토한다.
-- [ ] 장 초반/후반 타임 필터를 전략 실행 전에 적용한다.
-- [ ] O'Neil/Minervini 계열 전략 성과를 KOSPI 상승장, KOSDAQ 상승장, 지수 횡보장, 지수 하락장, 거래대금 증가 장세로 분리해 리포트한다.
+- [x] 시장 상태를 상승/하락/횡보로 분류하는 기준을 정의한다.
+  - 신규 `MarketRegimeService` (KOSPI/KOSDAQ ETF 단기 MA 추세 기반 4-state → bull/bear/sideways 3-state 매핑).
+  - 기존 `OneilUniverseService._check_etf_ma_rising` 로직을 추출, `is_market_timing_ok` 시그니처 보존.
+- [x] 코스피/코스닥 지수 기반 전략 ON/OFF 조건을 추가한다.
+  - 기존 5개 전략(FirstPullback, HighTightFlag, OneilPocketPivot, OneilSqueezeBreakout, RSI2Pullback)이 이미 `is_market_timing_ok` 게이트 사용 — `MarketRegimeService` 위임으로 자동 반영.
+  - 누락된 LarryWilliamsVBO, LarryWilliamsCB에 동일 hard gate 추가 (`_position_state` 변경 전 위치, `reason=market_timing_off` 로깅).
+- [~] 변동성 기반 진입 제한을 검토한다.
+  - 1차 PR에서는 hard gate 미도입 — 리포트 컬럼으로 먼저 검증 후 도입 결정. 후속 PR에서 `RiskGateConfig.max_volatility_pct` 추가 검토.
+- [x] 장 초반/후반 타임 필터를 전략 실행 전에 적용한다.
+  - `StrategySchedulerConfig.skip_minutes_after_open` / `skip_minutes_before_close` 필드 추가.
+  - `_is_scan_time_window_blocked()` 가 `cfg.strategy.scan()` 만 skip (force_exit/check_exits 영향 없음).
+- [~] O'Neil/Minervini 계열 전략 성과를 KOSPI 상승장, KOSDAQ 상승장, 지수 횡보장, 지수 하락장, 거래대금 증가 장세로 분리해 리포트한다.
+  - `common/trade_journal_schema.py` 에 `market_regime` 필드 + `SCHEMA_VERSION = 2`. 정규화 함수에 `market_regime` 파라미터(service 호출 금지, record/metadata fallback).
+  - `services/regime_performance_service.py` 신규 (순수 함수): KOSPI Bull / KOSDAQ Bull / SIDEWAYS / BEAR / TRADING_VALUE_SURGE 5개 버킷 + MDD(signal_time 정렬 누적 net_pnl).
+  - `GET /api/strategies/performance-by-regime?strategy=&from_date=&to_date=` 엔드포인트 추가.
+  - 거래대금 급증 장세 버킷은 market-wide aggregate contract 미준비로 1차에서 정의만 유지 — 항상 빈 결과. 후속 PR에서 데이터 소스 확정 후 활성화.
 
 주요 파일:
 
-- `services/market_data_service.py`
-- `services/indicator_service.py`
-- `strategies/strategy_executor.py`
+- `services/market_regime_service.py` (신규)
+- `services/regime_performance_service.py` (신규)
+- `services/oneil_universe_service.py` (`MarketRegimeService` 위임)
+- `strategies/larry_williams_vbo_strategy.py`
+- `strategies/larry_williams_channel_breakout_strategy.py`
 - `scheduler/strategy_scheduler.py`
+- `common/trade_journal_schema.py`
+- `view/web/routes/strategy_report.py`
 
 ### 1-5. 백테스트 검증 확장
 

--- a/view/web/routes/strategy_report.py
+++ b/view/web/routes/strategy_report.py
@@ -1,4 +1,4 @@
-"""전략 거절 사유 분포 리포트 API."""
+"""전략 거절 사유 분포 리포트 API + 시장 국면별 성과 분해 API."""
 from __future__ import annotations
 
 import json
@@ -8,6 +8,11 @@ from typing import List
 
 from fastapi import APIRouter
 
+from common.trade_journal_schema import normalize_virtual_trade
+from services.regime_performance_service import (
+    BUCKET_KEYS,
+    compute_performance_by_regime,
+)
 from view.web.api_common import _get_ctx
 
 router = APIRouter()
@@ -89,4 +94,57 @@ async def get_rejected_reasons(strategy: str = "", date: str = ""):
         "strategy": strategy,
         "date": target_date,
         "distribution": distribution,
+    }
+
+
+@router.get("/strategies/performance-by-regime")
+async def get_performance_by_regime(
+    strategy: str = "",
+    from_date: str = "",
+    to_date: str = "",
+):
+    """시장 국면별 전략 성과 분해.
+
+    Args:
+        strategy:  전략명 필터. 빈 문자열이면 전체.
+        from_date: YYYYMMDD. 빈 문자열이면 전체 기간 시작.
+        to_date:   YYYYMMDD. 빈 문자열이면 오늘.
+
+    Returns:
+        {
+          "strategy": <strategy or "">,
+          "from_date": <YYYYMMDD or "">,
+          "to_date": <YYYYMMDD>,
+          "buckets": {
+            "KOSPI_BULL": {trade_count, win_count, win_rate, avg_net_return, total_net_pnl, mdd},
+            "KOSDAQ_BULL": {...},
+            "SIDEWAYS": {...},
+            "BEAR": {...},
+            "TRADING_VALUE_SURGE": {...}  # 1차: 항상 0 (overlay)
+          }
+        }
+    """
+    target_to = to_date or datetime.now().strftime("%Y%m%d")
+    ctx = _get_ctx()
+    vts = getattr(ctx, "virtual_trade_service", None)
+
+    normalized: List[dict] = []
+    if vts is not None:
+        trades = vts.get_all_trades(apply_cost=True)
+        for t in trades:
+            if strategy and str(t.get("strategy") or "") != strategy:
+                continue
+            signal_time = str(t.get("buy_date") or "").replace("-", "")[:8]
+            if from_date and signal_time < from_date:
+                continue
+            if signal_time > target_to:
+                continue
+            normalized.append(normalize_virtual_trade(t))
+
+    buckets = compute_performance_by_regime(normalized)
+    return {
+        "strategy": strategy,
+        "from_date": from_date,
+        "to_date": target_to,
+        "buckets": {k: buckets[k] for k in BUCKET_KEYS},
     }


### PR DESCRIPTION
services/market_regime_service.py (신규): 4-state 추세 (rising/hard_decline/weak_trend/uptrend_under_pressure) → bull/bear/sideways 매핑. async classify / is_bull / snapshot_both / classify_on_date. OneilUniverseService 가 위임만 하도록 변경, is_market_timing_ok 시그니처 보존. Phase 2 — LarryWilliams 게이트

larry_williams_vbo_strategy.py, larry_williams_channel_breakout_strategy.py 에 _position_state 변경 전 위치에 hard gate 추가 (reason=market_timing_off). 기존 5개 전략(FirstPullback/HighTightFlag/OneilPocketPivot/OneilSqueezeBreakout/RSI2Pullback)은 Phase 1 위임으로 자동 반영. Phase 3 — 시간대 필터

StrategySchedulerConfig.skip_minutes_after_open / skip_minutes_before_close 추가. _is_scan_time_window_blocked() 는 scan() 만 skip (force_exit/check_exits 무영향). Phase 4 — Journal market_regime 라벨

SCHEMA_VERSION 1→2, STANDARD_TRADE_JOURNAL_FIELDS 에 market_regime 추가. 모든 normalize_*() 가 market_regime 인자/record/metadata fallback 으로 해소 — service 호출 금지. Phase 5 — 성과 분해 리포트 + API

services/regime_performance_service.py 순수 함수 모듈: 5 버킷 + MDD. GET /api/strategies/performance-by-regime?strategy=&from_date=&to_date= 엔드포인트. 보류 (별도 PR): 변동성 hard gate, 거래대금 급증 버킷 데이터화.

테스트: 신규/수정 41건 + 전체 단위 4415 / 통합 233 통과.