### PR TITLE
완료했습니다. todo_list.md를 먼저 4-1 보완안 기준으로 업데이트했고, 그 우선순위대로 AlertSource.ST…

### DIFF
--- a/common/operator_alert_types.py
+++ b/common/operator_alert_types.py
@@ -25,6 +25,7 @@ class AlertSource(str, Enum):
     RECONCILE = "RECONCILE"
     WEBSOCKET_WATCHDOG = "WEBSOCKET_WATCHDOG"
     DATA_QUALITY = "DATA_QUALITY"
+    STRATEGY_PERF = "STRATEGY_PERF"
 
 
 # severity 순서 (낮을수록 심각)

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -119,6 +119,18 @@ execution_quality_report:
   candidate_avg_order_age_sec: 300.0
   auto_disable_enabled: false
 
+# 전략별 최근 거래 성과 저하 감지 (사후 평가용, 1차는 soft alert만)
+strategy_performance_degradation:
+  window_size: 20
+  min_live_trades: 10
+  min_baseline_trades: 10
+  capital_base_won: null          # live/backtest가 같은 분모 정의를 쓸 때만 설정
+  warn_win_rate_drop_pctp: 15.0
+  warn_avg_return_drop_pctp: 1.0
+  warn_profit_factor_below: 1.0
+  critical_consecutive_losses: 5
+  critical_mdd_ratio_multiplier: 2.0
+
 # 포지션 사이징 (Fixed Fractional / Penbold 식)
 position_sizing:
   enabled: true

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -167,6 +167,20 @@ class ExecutionQualityReportConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class StrategyPerformanceDegradationConfig(BaseModel):
+    window_size: int = 20
+    min_live_trades: int = 10
+    min_baseline_trades: int = 10
+    capital_base_won: Optional[float] = None
+    warn_win_rate_drop_pctp: float = 15.0
+    warn_avg_return_drop_pctp: float = 1.0
+    warn_profit_factor_below: Optional[float] = 1.0
+    critical_consecutive_losses: Optional[int] = 5
+    critical_mdd_ratio_multiplier: Optional[float] = 2.0
+
+    model_config = {"extra": "allow"}
+
+
 class OpeningPositionReconcileConfig(BaseModel):
     enabled: bool = True
     check_interval_sec: int = 30
@@ -201,6 +215,9 @@ class AppConfig(BaseModel):
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)
+    strategy_performance_degradation: StrategyPerformanceDegradationConfig = Field(
+        default_factory=StrategyPerformanceDegradationConfig
+    )
     opening_position_reconcile: OpeningPositionReconcileConfig = Field(default_factory=OpeningPositionReconcileConfig)
     
     # Dynamic/Merged configs

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -12,6 +12,10 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from common.trade_journal_comparison import compare_trade_journals
+from services.strategy_performance_degradation_service import (
+    StrategyPerformanceDegradationConfig,
+    analyze_strategy_performance_degradation,
+)
 
 
 def _esc(value: Any) -> str:
@@ -297,6 +301,7 @@ class StrategyLogReportService:
         execution_quality_config: Optional[Any] = None,
         backtest_journal_provider: Optional[Callable[[str], List[dict]]] = None,
         enabled_strategy_provider: Optional[Callable[[], Optional[List[str]]]] = None,
+        strategy_degradation_config: Optional[Any] = None,
     ):
         self._log_dir = log_dir
         self._stock_code_repo = stock_code_repo
@@ -304,11 +309,17 @@ class StrategyLogReportService:
         self._execution_quality_config = execution_quality_config
         self._backtest_journal_provider = backtest_journal_provider
         self._enabled_strategy_provider = enabled_strategy_provider
+        self._strategy_degradation_config = strategy_degradation_config
         self._last_execution_quality_candidates: List[dict] = []
+        self._last_strategy_degradation_candidates: List[dict] = []
 
     def get_last_execution_quality_candidates(self) -> List[dict]:
         """최근 generate_report 실행에서 산출된 체결 품질 비활성화 후보 목록."""
         return list(self._last_execution_quality_candidates)
+
+    def get_last_strategy_degradation_candidates(self) -> List[dict]:
+        """최근 generate_report 실행에서 산출된 전략 성과 저하 후보 목록."""
+        return list(self._last_strategy_degradation_candidates)
 
     # ── 파일 탐색 ────────────────────────────────────────────────
 
@@ -600,6 +611,67 @@ class StrategyLogReportService:
                 pnl_part = f", 순손익 {int(round(float(row.get('net_pnl_diff')))):+,}원"
             lines.append(f"  - {strategy}/{code}: {net_part}{fill_part}{pnl_part}")
 
+        return "\n".join(lines)
+
+    def _strategy_degradation_cfg(self) -> StrategyPerformanceDegradationConfig:
+        cfg = self._strategy_degradation_config
+        if isinstance(cfg, StrategyPerformanceDegradationConfig):
+            return cfg
+        values = {}
+        if cfg is not None:
+            for field in StrategyPerformanceDegradationConfig.__dataclass_fields__:
+                if hasattr(cfg, field):
+                    values[field] = getattr(cfg, field)
+        return StrategyPerformanceDegradationConfig(**values)
+
+    def _build_strategy_degradation_section(self, target_date: str) -> Optional[str]:
+        self._last_strategy_degradation_candidates = []
+        if not self._virtual_trade_service or not self._backtest_journal_provider:
+            return None
+
+        try:
+            live_records = self._virtual_trade_service.get_standard_journal_records() or []
+            backtest_records = self._backtest_journal_provider(target_date) or []
+        except Exception:
+            return None
+
+        try:
+            result = analyze_strategy_performance_degradation(
+                live_records,
+                backtest_records,
+                self._strategy_degradation_cfg(),
+            )
+        except Exception:
+            return None
+
+        candidates = result.get("candidates") or []
+        self._last_strategy_degradation_candidates = [dict(item) for item in candidates]
+        if not candidates:
+            return None
+
+        lines = ["<b>📉 전략별 성과 저하 후보</b>"]
+        for item in candidates[:5]:
+            strategy = _esc(item.get("strategy") or "")
+            status = _esc(item.get("status") or "")
+            live = item.get("live_metrics") or {}
+            reasons = ", ".join(str(reason) for reason in item.get("reasons") or [])
+            actions = ", ".join(str(action) for action in item.get("recommended_actions") or [])
+            pf = live.get("profit_factor")
+            pf_text = f", PF {float(pf):.2f}" if pf is not None else ""
+            lines.append(
+                f"• {strategy}: {status} — 최근 {int(live.get('trade_count') or 0)}거래, "
+                f"승률 {float(live.get('win_rate') or 0) * 100:.1f}%, "
+                f"평균 {float(live.get('avg_net_return') or 0):+.2f}%{pf_text}, "
+                f"MDD {int(round(float(live.get('mdd_amount') or 0))):,}원, "
+                f"연속손실 {int(live.get('max_consecutive_losses') or 0)}"
+            )
+            if reasons:
+                lines.append(f"  - 사유: {_esc(reasons)}")
+            if actions:
+                lines.append(f"  - 권고: {_esc(actions)}")
+        rest_count = len(candidates) - 5
+        if rest_count > 0:
+            lines.append(f"  …외 {rest_count}개 전략")
         return "\n".join(lines)
 
     def _build_execution_quality_section(self, records: List[dict]) -> Optional[str]:
@@ -911,6 +983,7 @@ class StrategyLogReportService:
         """
         date_prefix = f"{target_date[:4]}-{target_date[4:6]}-{target_date[6:8]}"
         self._last_execution_quality_candidates = []
+        self._last_strategy_degradation_candidates = []
         strategy_files = self._find_strategy_files()
 
         if not strategy_files:
@@ -1176,12 +1249,19 @@ class StrategyLogReportService:
             warnings_section = "<b>⚠️ 시스템 경고</b>\n" + "\n".join(system_warnings)
         execution_quality_section = self._build_execution_quality_section(execution_quality_records)
         divergence_section = self._build_backtest_live_divergence_section(target_date)
+        degradation_section = self._build_strategy_degradation_section(target_date)
 
         if not active_sections:
             portfolio_summary = self._build_portfolio_summary(target_date, fallback_buys)
             extra_sections = [
                 section
-                for section in (warnings_section, portfolio_summary, divergence_section, execution_quality_section)
+                for section in (
+                    warnings_section,
+                    portfolio_summary,
+                    divergence_section,
+                    degradation_section,
+                    execution_quality_section,
+                )
                 if section
             ]
             extra_body = "\n\n".join(extra_sections)
@@ -1198,6 +1278,8 @@ class StrategyLogReportService:
             body += f"\n\n{portfolio_summary}"
         if divergence_section:
             body += f"\n\n{divergence_section}"
+        if degradation_section:
+            body += f"\n\n{degradation_section}"
         if execution_quality_section:
             body += f"\n\n{execution_quality_section}"
 

--- a/services/strategy_performance_degradation_service.py
+++ b/services/strategy_performance_degradation_service.py
@@ -1,0 +1,343 @@
+"""Strategy performance degradation analysis from standard journal records.
+
+The module is intentionally pure: callers provide live/backtest journal records
+and receive metrics/candidates without any service or filesystem dependency.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class StrategyPerformanceDegradationConfig:
+    window_size: int = 20
+    min_live_trades: int = 10
+    min_baseline_trades: int = 10
+    capital_base_won: Optional[float] = None
+    warn_win_rate_drop_pctp: float = 15.0
+    warn_avg_return_drop_pctp: float = 1.0
+    warn_profit_factor_below: Optional[float] = 1.0
+    critical_consecutive_losses: Optional[int] = 5
+    critical_mdd_ratio_multiplier: Optional[float] = 2.0
+
+
+def compute_strategy_window_metrics(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    window_size: int = 20,
+    capital_base_won: Optional[float] = None,
+) -> dict[str, dict[str, Any]]:
+    """Compute recent-window metrics per strategy from SOLD journal records."""
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for record in records:
+        if str(record.get("status") or "").upper() != "SOLD":
+            continue
+        strategy = str(record.get("strategy") or "").strip()
+        if not strategy:
+            continue
+        grouped.setdefault(strategy, []).append(record)
+
+    result: dict[str, dict[str, Any]] = {}
+    for strategy, items in grouped.items():
+        ordered = sorted(items, key=_closed_time_key)
+        window = ordered[-max(int(window_size or 0), 1):]
+        result[strategy] = _compute_window_metrics(window, capital_base_won=capital_base_won)
+    return result
+
+
+def analyze_strategy_performance_degradation(
+    live_records: Iterable[Mapping[str, Any]],
+    baseline_records: Iterable[Mapping[str, Any]],
+    config: StrategyPerformanceDegradationConfig | None = None,
+) -> dict[str, Any]:
+    """Compare live recent-window metrics with baseline and return soft candidates."""
+    cfg = config or StrategyPerformanceDegradationConfig()
+    live_metrics = compute_strategy_window_metrics(
+        live_records,
+        window_size=cfg.window_size,
+        capital_base_won=cfg.capital_base_won,
+    )
+    baseline_metrics = compute_strategy_window_metrics(
+        baseline_records,
+        window_size=cfg.window_size,
+        capital_base_won=cfg.capital_base_won,
+    )
+
+    strategies = sorted(set(live_metrics) | set(baseline_metrics))
+    by_strategy: dict[str, dict[str, Any]] = {}
+    candidates: list[dict[str, Any]] = []
+
+    for strategy in strategies:
+        live = live_metrics.get(strategy, _empty_metrics())
+        baseline = baseline_metrics.get(strategy, _empty_metrics())
+
+        if live["trade_count"] < cfg.min_live_trades:
+            status = "insufficient_live"
+            reasons = ["insufficient_live"]
+        elif baseline["trade_count"] < cfg.min_baseline_trades:
+            status = "insufficient_baseline"
+            reasons = ["insufficient_baseline"]
+        else:
+            status, reasons = _classify_degradation(live, baseline, cfg)
+
+        recommended_actions = _recommended_actions(status)
+        item = {
+            "strategy": strategy,
+            "status": status,
+            "reasons": reasons,
+            "live_metrics": live,
+            "baseline_metrics": baseline,
+            "divergence": _build_divergence(live, baseline, cfg),
+            "recommended_actions": recommended_actions,
+        }
+        by_strategy[strategy] = item
+        if status in {"degraded", "critical_candidate"}:
+            candidates.append(item)
+
+    candidates.sort(key=lambda item: (0 if item["status"] == "critical_candidate" else 1, item["strategy"]))
+    return {
+        "window_size": cfg.window_size,
+        "strategies": by_strategy,
+        "candidates": candidates,
+    }
+
+
+def _compute_window_metrics(
+    records: list[Mapping[str, Any]],
+    *,
+    capital_base_won: Optional[float],
+) -> dict[str, Any]:
+    net_pnls = [_to_float(record.get("net_pnl")) or 0.0 for record in records]
+    net_returns = [_to_float(record.get("net_return")) for record in records]
+    valid_returns = [value for value in net_returns if value is not None]
+    wins_pnl = [value for value in net_pnls if value > 0]
+    losses_pnl = [value for value in net_pnls if value < 0]
+    win_returns = [value for value in valid_returns if value > 0]
+    loss_returns = [value for value in valid_returns if value < 0]
+    mfe_values = [_to_float(record.get("mfe")) for record in records]
+    mae_values = [_to_float(record.get("mae")) for record in records]
+    valid_mfe = [value for value in mfe_values if value is not None]
+    valid_mae = [value for value in mae_values if value is not None]
+    mdd_amount = _mdd_amount(net_pnls)
+    capital_base = _resolve_capital_base(records, capital_base_won)
+
+    return {
+        "trade_count": len(records),
+        "win_count": len(wins_pnl),
+        "loss_count": len(losses_pnl),
+        "win_rate": _safe_div(len(wins_pnl), len(records), default=0.0),
+        "avg_net_return": _avg(valid_returns, default=0.0),
+        "total_net_pnl": sum(net_pnls),
+        "payoff_ratio": _payoff_ratio(win_returns, loss_returns),
+        "profit_factor": _profit_factor(wins_pnl, losses_pnl),
+        "mdd_amount": mdd_amount,
+        "mdd_ratio": _safe_div(mdd_amount, capital_base) if capital_base else None,
+        "max_consecutive_losses": _max_consecutive_losses(net_pnls),
+        "avg_mfe": _avg(valid_mfe) if valid_mfe else None,
+        "avg_mae": _avg(valid_mae) if valid_mae else None,
+        "missing_mfe_count": sum(1 for value in mfe_values if value is None),
+        "missing_mae_count": sum(1 for value in mae_values if value is None),
+    }
+
+
+def _classify_degradation(
+    live: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    cfg: StrategyPerformanceDegradationConfig,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    critical = False
+
+    win_rate_drop_pctp = (float(baseline["win_rate"]) - float(live["win_rate"])) * 100
+    if win_rate_drop_pctp >= cfg.warn_win_rate_drop_pctp:
+        reasons.append("win_rate_drop")
+
+    avg_return_drop = float(baseline["avg_net_return"]) - float(live["avg_net_return"])
+    if avg_return_drop >= cfg.warn_avg_return_drop_pctp:
+        reasons.append("avg_return_drop")
+
+    live_profit_factor = live.get("profit_factor")
+    if (
+        cfg.warn_profit_factor_below is not None
+        and live_profit_factor is not None
+        and float(live_profit_factor) < cfg.warn_profit_factor_below
+    ):
+        reasons.append("profit_factor_low")
+
+    if (
+        cfg.critical_consecutive_losses is not None
+        and int(live.get("max_consecutive_losses") or 0) >= cfg.critical_consecutive_losses
+    ):
+        reasons.append("consecutive_losses")
+        critical = True
+
+    live_mdd_ratio = live.get("mdd_ratio")
+    baseline_mdd_ratio = baseline.get("mdd_ratio")
+    if (
+        cfg.critical_mdd_ratio_multiplier is not None
+        and live_mdd_ratio is not None
+        and baseline_mdd_ratio not in (None, 0)
+        and float(live_mdd_ratio) >= float(baseline_mdd_ratio) * cfg.critical_mdd_ratio_multiplier
+    ):
+        reasons.append("mdd_ratio_worse")
+        critical = True
+
+    if critical:
+        return "critical_candidate", reasons
+    if reasons:
+        return "degraded", reasons
+    return "healthy", []
+
+
+def _build_divergence(
+    live: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    cfg: StrategyPerformanceDegradationConfig,
+) -> dict[str, Any]:
+    live_mdd_ratio = live.get("mdd_ratio")
+    baseline_mdd_ratio = baseline.get("mdd_ratio")
+    return {
+        "win_rate_diff_pctp": (float(live["win_rate"]) - float(baseline["win_rate"])) * 100,
+        "avg_net_return_diff_pctp": float(live["avg_net_return"]) - float(baseline["avg_net_return"]),
+        "profit_factor_diff": _optional_diff(live.get("profit_factor"), baseline.get("profit_factor")),
+        "mdd_amount_diff": float(live["mdd_amount"]) - float(baseline["mdd_amount"]),
+        "mdd_ratio_diff": (
+            _optional_diff(live_mdd_ratio, baseline_mdd_ratio)
+            if cfg.capital_base_won is not None
+            else None
+        ),
+    }
+
+
+def _recommended_actions(status: str) -> list[str]:
+    if status == "critical_candidate":
+        return [
+            "pause_new_entries_candidate",
+            "reduce_position_size_candidate",
+            "paper_mode_candidate",
+        ]
+    if status == "degraded":
+        return [
+            "pause_new_entries_candidate",
+            "reduce_position_size_candidate",
+        ]
+    return []
+
+
+def _closed_time_key(record: Mapping[str, Any]) -> str:
+    metadata = record.get("metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("sell_date", "exit_time", "closed_at"):
+            value = metadata.get(key)
+            if value not in (None, ""):
+                return str(value)
+    for key in ("sell_date", "exit_time", "closed_at", "signal_time"):
+        value = record.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def _mdd_amount(net_pnls: list[float]) -> float:
+    peak = 0.0
+    cumulative = 0.0
+    mdd = 0.0
+    for pnl in net_pnls:
+        cumulative += pnl
+        if cumulative > peak:
+            peak = cumulative
+        drawdown = peak - cumulative
+        if drawdown > mdd:
+            mdd = drawdown
+    return mdd
+
+
+def _max_consecutive_losses(net_pnls: list[float]) -> int:
+    current = 0
+    best = 0
+    for pnl in net_pnls:
+        if pnl < 0:
+            current += 1
+            best = max(best, current)
+        else:
+            current = 0
+    return best
+
+
+def _payoff_ratio(win_returns: list[float], loss_returns: list[float]) -> Optional[float]:
+    if not win_returns or not loss_returns:
+        return None
+    avg_loss = abs(_avg(loss_returns))
+    return _safe_div(_avg(win_returns), avg_loss) if avg_loss else None
+
+
+def _profit_factor(wins_pnl: list[float], losses_pnl: list[float]) -> Optional[float]:
+    total_loss = abs(sum(losses_pnl))
+    if not wins_pnl or total_loss == 0:
+        return None
+    return sum(wins_pnl) / total_loss
+
+
+def _resolve_capital_base(
+    records: list[Mapping[str, Any]],
+    capital_base_won: Optional[float],
+) -> Optional[float]:
+    explicit = _to_float(capital_base_won)
+    if explicit and explicit > 0:
+        return explicit
+    for record in records:
+        metadata = record.get("metadata")
+        if isinstance(metadata, Mapping):
+            for key in ("capital_base_won", "equity", "total_equity"):
+                value = _to_float(metadata.get(key))
+                if value and value > 0:
+                    return value
+    return None
+
+
+def _empty_metrics() -> dict[str, Any]:
+    return {
+        "trade_count": 0,
+        "win_count": 0,
+        "loss_count": 0,
+        "win_rate": 0.0,
+        "avg_net_return": 0.0,
+        "total_net_pnl": 0.0,
+        "payoff_ratio": None,
+        "profit_factor": None,
+        "mdd_amount": 0.0,
+        "mdd_ratio": None,
+        "max_consecutive_losses": 0,
+        "avg_mfe": None,
+        "avg_mae": None,
+        "missing_mfe_count": 0,
+        "missing_mae_count": 0,
+    }
+
+
+def _avg(values: list[float], default: Optional[float] = None) -> Optional[float]:
+    if not values:
+        return default
+    return sum(values) / len(values)
+
+
+def _safe_div(numerator: float, denominator: float, default: Optional[float] = None) -> Optional[float]:
+    return default if denominator == 0 else numerator / denominator
+
+
+def _optional_diff(left: Any, right: Any) -> Optional[float]:
+    left_value = _to_float(left)
+    right_value = _to_float(right)
+    if left_value is None or right_value is None:
+        return None
+    return left_value - right_value
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/task/background/after_market/strategy_log_report_task.py
+++ b/task/background/after_market/strategy_log_report_task.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
+from common.operator_alert_types import AlertSource
 from task.background.after_market.after_market_task_base import AfterMarketTask
 from services.notification_service import NotificationCategory, NotificationLevel, NotificationService
 
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from core.market_clock import MarketClock
     from services.market_calendar_service import MarketCalendarService
     from scheduler.worker.worker_pool import WorkerPool
+    from services.kill_switch_service import KillSwitchService
+    from services.operator_alert_service import OperatorAlertService
 
 
 class StrategyLogReportTask(AfterMarketTask):
@@ -29,6 +32,8 @@ class StrategyLogReportTask(AfterMarketTask):
         logger=None,
         worker_pool: Optional["WorkerPool"] = None,
         rejection_distribution_service: Optional["RejectionDistributionService"] = None,
+        operator_alert_service: Optional["OperatorAlertService"] = None,
+        kill_switch_service: Optional["KillSwitchService"] = None,
     ) -> None:
         super().__init__(
             mcs=mcs,
@@ -40,6 +45,8 @@ class StrategyLogReportTask(AfterMarketTask):
         self._notification_service = notification_service
         self._telegram_reporter = telegram_reporter
         self._rejection_distribution_service = rejection_distribution_service
+        self._operator_alert_service = operator_alert_service
+        self._kill_switch_service = kill_switch_service
 
     @property
     def task_name(self) -> str:
@@ -58,6 +65,7 @@ class StrategyLogReportTask(AfterMarketTask):
             return
 
         await self._emit_execution_quality_candidate_alert(latest_trading_date)
+        await self._emit_strategy_degradation_candidate_alert(latest_trading_date)
 
         if self._rejection_distribution_service:
             try:
@@ -98,6 +106,65 @@ class StrategyLogReportTask(AfterMarketTask):
             f"{report_date}: {', '.join(shown)}{extra}",
             metadata={
                 "alert_type": "execution_quality_candidate",
+                "report_date": report_date,
+                "candidates": candidates,
+            },
+        )
+
+    async def _emit_strategy_degradation_candidate_alert(self, report_date: str) -> None:
+        getter = getattr(self._report_service, "get_last_strategy_degradation_candidates", None)
+        if not callable(getter):
+            return
+        candidates = getter() or []
+        if not candidates:
+            return
+
+        if self._operator_alert_service:
+            for item in candidates:
+                strategy = str(item.get("strategy") or "미분류")
+                status = str(item.get("status") or "degraded")
+                severity = "critical" if status == "critical_candidate" else "warning"
+                ks_trip = None
+                if self._kill_switch_service and strategy:
+                    try:
+                        ks_trip = self._kill_switch_service.is_strategy_tripped(strategy)
+                    except Exception:
+                        ks_trip = None
+                reasons = ", ".join(str(reason) for reason in item.get("reasons") or [])
+                metadata = {
+                    "alert_type": "strategy_degradation_candidate",
+                    "report_date": report_date,
+                    "strategy": strategy,
+                    "candidate": item,
+                    "already_blocked_by_kill_switch": bool(ks_trip),
+                    "kill_switch_trip": ks_trip,
+                }
+                await self._operator_alert_service.report(
+                    AlertSource.STRATEGY_PERF,
+                    f"strategy_perf:{strategy}",
+                    severity,
+                    f"전략 성과 저하 후보: {strategy}",
+                    f"{report_date}: {status}" + (f" ({reasons})" if reasons else ""),
+                    metadata=metadata,
+                )
+            return
+
+        if not self._notification_service:
+            return
+
+        shown = []
+        for item in candidates[:3]:
+            strategy = item.get("strategy", "미분류")
+            status = item.get("status", "")
+            shown.append(f"{strategy}({status})" if status else str(strategy))
+        extra = f" 외 {len(candidates) - 3}개" if len(candidates) > 3 else ""
+        await self._notification_service.emit(
+            NotificationCategory.STRATEGY,
+            NotificationLevel.WARNING,
+            "전략 성과 저하 후보",
+            f"{report_date}: {', '.join(shown)}{extra}",
+            metadata={
+                "alert_type": "strategy_degradation_candidate",
                 "report_date": report_date,
                 "candidates": candidates,
             },

--- a/tests/fixtures/strategy_degradation/expected_metrics.json
+++ b/tests/fixtures/strategy_degradation/expected_metrics.json
@@ -1,0 +1,16 @@
+{
+  "S1_window_5": {
+    "trade_count": 5,
+    "win_rate": 0.4,
+    "avg_net_return": -0.2,
+    "total_net_pnl": -1000.0,
+    "payoff_ratio": 1.0,
+    "profit_factor": 0.6667,
+    "mdd_amount": 3000.0,
+    "max_consecutive_losses": 3,
+    "avg_mfe": 1.25,
+    "avg_mae": -1.25,
+    "missing_mfe_count": 1,
+    "missing_mae_count": 1
+  }
+}

--- a/tests/fixtures/strategy_degradation/recent_trades_backtest.json
+++ b/tests/fixtures/strategy_degradation/recent_trades_backtest.json
@@ -1,0 +1,57 @@
+[
+  {
+    "strategy": "S1",
+    "code": "100001",
+    "status": "SOLD",
+    "signal_time": "2026-04-01 09:00:00",
+    "net_pnl": 2000,
+    "net_return": 2.0,
+    "mfe": 3.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-04-01 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "100002",
+    "status": "SOLD",
+    "signal_time": "2026-04-02 09:00:00",
+    "net_pnl": 2000,
+    "net_return": 2.0,
+    "mfe": 3.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-04-02 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "100003",
+    "status": "SOLD",
+    "signal_time": "2026-04-03 09:00:00",
+    "net_pnl": 2000,
+    "net_return": 2.0,
+    "mfe": 3.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-04-03 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "100004",
+    "status": "SOLD",
+    "signal_time": "2026-04-04 09:00:00",
+    "net_pnl": 2000,
+    "net_return": 2.0,
+    "mfe": 3.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-04-04 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "100005",
+    "status": "SOLD",
+    "signal_time": "2026-04-05 09:00:00",
+    "net_pnl": -1000,
+    "net_return": -1.0,
+    "mfe": 1.0,
+    "mae": -1.5,
+    "metadata": {"sell_date": "2026-04-05 14:50:00"}
+  }
+]

--- a/tests/fixtures/strategy_degradation/recent_trades_live.json
+++ b/tests/fixtures/strategy_degradation/recent_trades_live.json
@@ -1,0 +1,84 @@
+[
+  {
+    "strategy": "S1",
+    "code": "000001",
+    "status": "SOLD",
+    "signal_time": "2026-05-01 09:00:00",
+    "net_pnl": 1000,
+    "net_return": 1.0,
+    "mfe": 2.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-05-01 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "000002",
+    "status": "SOLD",
+    "signal_time": "2026-05-02 09:00:00",
+    "net_pnl": 1000,
+    "net_return": 1.0,
+    "mfe": 2.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-05-02 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "000003",
+    "status": "SOLD",
+    "signal_time": "2026-05-03 09:00:00",
+    "net_pnl": 1000,
+    "net_return": 1.0,
+    "mfe": 2.0,
+    "mae": -0.5,
+    "metadata": {"sell_date": "2026-05-03 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "000004",
+    "status": "SOLD",
+    "signal_time": "2026-05-04 09:00:00",
+    "net_pnl": -1000,
+    "net_return": -1.0,
+    "mfe": 0.5,
+    "mae": -2.0,
+    "metadata": {"sell_date": "2026-05-04 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "000005",
+    "status": "SOLD",
+    "signal_time": "2026-05-05 09:00:00",
+    "net_pnl": -1000,
+    "net_return": -1.0,
+    "mfe": 0.5,
+    "mae": -2.0,
+    "metadata": {"exit_time": "2026-05-05 14:50:00"}
+  },
+  {
+    "strategy": "S1",
+    "code": "000006",
+    "status": "SOLD",
+    "signal_time": "2026-05-06 09:00:00",
+    "net_pnl": -1000,
+    "net_return": -1.0,
+    "metadata": {"closed_at": "2026-05-06 14:50:00"}
+  },
+  {
+    "strategy": "S2",
+    "code": "000101",
+    "status": "SOLD",
+    "signal_time": "2026-05-01 09:00:00",
+    "net_pnl": 500,
+    "net_return": 0.5,
+    "metadata": {"sell_date": "2026-05-01 14:50:00"}
+  },
+  {
+    "strategy": "S2",
+    "code": "000102",
+    "status": "HOLD",
+    "signal_time": "2026-05-02 09:00:00",
+    "net_pnl": 9999,
+    "net_return": 9.9,
+    "metadata": {"sell_date": "2026-05-02 14:50:00"}
+  }
+]

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -99,6 +99,8 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     )
 
     assert config.is_paper_trading is True
+    assert config.strategy_performance_degradation.window_size == 20
+    assert config.strategy_performance_degradation.warn_profit_factor_below == 1.0
 
 def test_app_config_validation_invalid_url():
     """AppConfig base_url 유효성 검사 실패 테스트"""

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -4,6 +4,7 @@ StockOhlcvRepository 단위 테스트.
 import pytest
 import pytest_asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 from repositories.stock_ohlcv_repository import StockOhlcvRepository
@@ -536,11 +537,12 @@ class TestCleanupOldData:
     @pytest.mark.asyncio
     async def test_deletes_old_records_keeps_recent(self, repo):
         """keep_days보다 오래된 데이터는 삭제되고 최근 데이터는 보존된다."""
+        recent_date = datetime.now().strftime("%Y%m%d")
         await repo.upsert_daily_snapshot("20200101", [_make_snapshot("A001")])
-        await repo.upsert_daily_snapshot("20260414", [_make_snapshot("A002")])
+        await repo.upsert_daily_snapshot(recent_date, [_make_snapshot("A002")])
         await repo.cleanup_old_data(keep_days=30)
         assert await repo.get_count_by_date("20200101") == 0
-        assert await repo.get_count_by_date("20260414") == 1
+        assert await repo.get_count_by_date(recent_date) == 1
 
     @pytest.mark.asyncio
     async def test_no_error_when_nothing_to_delete(self, repo):

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -18,6 +18,7 @@ from services.strategy_log_report_service import (
     _strategy_name_from_source,
     _to_float,
 )
+from services.strategy_performance_degradation_service import StrategyPerformanceDegradationConfig
 
 
 # ── 헬퍼 ─────────────────────────────────────────────────────────
@@ -259,6 +260,54 @@ def test_backtest_live_divergence_section_from_provider():
     assert "평균 순수익률 괴리: -1.50%p" in section
     assert "총 순손익 괴리: -1,500원" in section
     assert "S1/005930: 순수익률 -1.50%p, 체결가 -1.9048%, 순손익 -1,500원" in section
+
+
+@pytest.mark.asyncio
+async def test_report_includes_strategy_degradation_candidates(log_dir):
+    """표준 journal 기반 성과 저하 후보를 리포트에 포함하고 getter로 노출한다."""
+    fixture_dir = os.path.join("tests", "fixtures", "strategy_degradation")
+    with open(os.path.join(fixture_dir, "recent_trades_live.json"), encoding="utf-8") as f:
+        live_records = json.load(f)
+    with open(os.path.join(fixture_dir, "recent_trades_backtest.json"), encoding="utf-8") as f:
+        backtest_records = json.load(f)
+
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return []
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+        def get_standard_journal_records(self):
+            return live_records
+
+    _write_log(os.path.join(log_dir, "20260418_093000_S1.log.json"), [
+        _make_entry("scan_with_watchlist", "", "", reason=""),
+    ])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+        backtest_journal_provider=lambda _target_date: backtest_records,
+        strategy_degradation_config=StrategyPerformanceDegradationConfig(
+            window_size=5,
+            min_live_trades=5,
+            min_baseline_trades=5,
+            capital_base_won=100_000,
+            critical_consecutive_losses=3,
+        ),
+    )
+
+    report = await svc.generate_report("20260418")
+    candidates = svc.get_last_strategy_degradation_candidates()
+
+    assert "전략별 성과 저하 후보" in report
+    assert "S1: critical_candidate" in report
+    assert "연속손실 3" in report
+    assert candidates[0]["strategy"] == "S1"
 
 
 # ── _extract_strategy_name ────────────────────────────────────────

--- a/tests/unit_test/services/test_strategy_performance_degradation_service.py
+++ b/tests/unit_test/services/test_strategy_performance_degradation_service.py
@@ -1,0 +1,88 @@
+"""전략별 최근 거래 성과 저하 분석 테스트."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.strategy_performance_degradation_service import (
+    StrategyPerformanceDegradationConfig,
+    analyze_strategy_performance_degradation,
+    compute_strategy_window_metrics,
+)
+
+
+FIXTURE_DIR = Path("tests/fixtures/strategy_degradation")
+
+
+def _load(name: str):
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_compute_strategy_window_metrics_uses_recent_closed_trades_only():
+    """SOLD 거래만 청산 시각 우선으로 정렬한 뒤 최근 window를 집계한다."""
+    records = _load("recent_trades_live.json")
+    expected = _load("expected_metrics.json")["S1_window_5"]
+
+    metrics = compute_strategy_window_metrics(records, window_size=5, capital_base_won=100_000)
+    s1 = metrics["S1"]
+
+    assert s1["trade_count"] == expected["trade_count"]
+    assert s1["win_rate"] == pytest.approx(expected["win_rate"])
+    assert s1["avg_net_return"] == pytest.approx(expected["avg_net_return"])
+    assert s1["total_net_pnl"] == pytest.approx(expected["total_net_pnl"])
+    assert s1["payoff_ratio"] == pytest.approx(expected["payoff_ratio"])
+    assert s1["profit_factor"] == pytest.approx(expected["profit_factor"], rel=1e-4)
+    assert s1["mdd_amount"] == pytest.approx(expected["mdd_amount"])
+    assert s1["mdd_ratio"] == pytest.approx(0.03)
+    assert s1["max_consecutive_losses"] == expected["max_consecutive_losses"]
+    assert s1["avg_mfe"] == pytest.approx(expected["avg_mfe"])
+    assert s1["avg_mae"] == pytest.approx(expected["avg_mae"])
+    assert s1["missing_mfe_count"] == expected["missing_mfe_count"]
+    assert s1["missing_mae_count"] == expected["missing_mae_count"]
+
+    assert metrics["S2"]["trade_count"] == 1
+
+
+def test_analyze_marks_degraded_candidate_against_baseline():
+    live = _load("recent_trades_live.json")
+    backtest = _load("recent_trades_backtest.json")
+    cfg = StrategyPerformanceDegradationConfig(
+        window_size=5,
+        min_live_trades=5,
+        min_baseline_trades=5,
+        capital_base_won=100_000,
+        warn_win_rate_drop_pctp=30.0,
+        warn_avg_return_drop_pctp=1.0,
+        warn_profit_factor_below=1.0,
+        critical_consecutive_losses=3,
+    )
+
+    result = analyze_strategy_performance_degradation(live, backtest, cfg)
+
+    s1 = result["strategies"]["S1"]
+    assert s1["status"] == "critical_candidate"
+    assert "win_rate_drop" in s1["reasons"]
+    assert "avg_return_drop" in s1["reasons"]
+    assert "profit_factor_low" in s1["reasons"]
+    assert "consecutive_losses" in s1["reasons"]
+    assert "pause_new_entries_candidate" in s1["recommended_actions"]
+    assert "paper_mode_candidate" in s1["recommended_actions"]
+    assert result["candidates"][0]["strategy"] == "S1"
+
+
+def test_analyze_separates_insufficient_live_and_baseline_samples():
+    live = _load("recent_trades_live.json")
+    backtest = _load("recent_trades_backtest.json")[:1]
+    cfg = StrategyPerformanceDegradationConfig(
+        window_size=5,
+        min_live_trades=5,
+        min_baseline_trades=5,
+    )
+
+    result = analyze_strategy_performance_degradation(live, backtest, cfg)
+
+    assert result["strategies"]["S2"]["status"] == "insufficient_live"
+    assert result["strategies"]["S1"]["status"] == "insufficient_baseline"
+    assert result["candidates"] == []

--- a/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
@@ -15,6 +15,7 @@ def mock_report_service():
     svc = MagicMock()
     svc.generate_report = AsyncMock(return_value="<html>report</html>")
     svc.get_last_execution_quality_candidates.return_value = []
+    svc.get_last_strategy_degradation_candidates.return_value = []
     return svc
 
 
@@ -22,6 +23,13 @@ def mock_report_service():
 def mock_notification_service():
     svc = MagicMock()
     svc.emit = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def mock_operator_alert_service():
+    svc = MagicMock()
+    svc.report = AsyncMock()
     return svc
 
 
@@ -108,6 +116,63 @@ class TestOnMarketClosed:
         assert args[2] == "체결 품질 비활성화 후보"
         assert "잔량전략" in args[3]
         assert kwargs["metadata"]["alert_type"] == "execution_quality_candidate"
+
+    async def test_strategy_degradation_candidates_use_operator_alert_only(
+        self, mock_report_service, mock_notification_service, mock_operator_alert_service
+    ):
+        mock_report_service.get_last_strategy_degradation_candidates.return_value = [{
+            "strategy": "S1",
+            "status": "critical_candidate",
+            "reasons": ["consecutive_losses"],
+            "recommended_actions": ["pause_new_entries_candidate"],
+        }]
+        kill_switch = MagicMock()
+        kill_switch.is_strategy_tripped.return_value = {
+            "trip_reason": "연속 손실 5회",
+            "trip_timestamp": "2026-05-15T15:10:00+09:00",
+        }
+        task = StrategyLogReportTask(
+            report_service=mock_report_service,
+            notification_service=mock_notification_service,
+            operator_alert_service=mock_operator_alert_service,
+            kill_switch_service=kill_switch,
+            logger=MagicMock(),
+        )
+
+        await task._on_market_closed("20260419")
+
+        mock_operator_alert_service.report.assert_awaited_once()
+        mock_notification_service.emit.assert_not_awaited()
+        args, kwargs = mock_operator_alert_service.report.await_args
+        assert args[0].value == "STRATEGY_PERF"
+        assert args[1] == "strategy_perf:S1"
+        assert args[2] == "critical"
+        assert kwargs["metadata"]["already_blocked_by_kill_switch"] is True
+        assert kwargs["metadata"]["kill_switch_trip"]["trip_reason"] == "연속 손실 5회"
+
+    async def test_strategy_degradation_candidates_fallback_to_notification(
+        self, mock_report_service, mock_notification_service
+    ):
+        mock_report_service.get_last_strategy_degradation_candidates.return_value = [{
+            "strategy": "S1",
+            "status": "degraded",
+            "reasons": ["profit_factor_low"],
+            "recommended_actions": ["reduce_position_size_candidate"],
+        }]
+        task = StrategyLogReportTask(
+            report_service=mock_report_service,
+            notification_service=mock_notification_service,
+            logger=MagicMock(),
+        )
+
+        await task._on_market_closed("20260419")
+
+        mock_notification_service.emit.assert_awaited_once()
+        args, kwargs = mock_notification_service.emit.await_args
+        assert args[0].value == "STRATEGY"
+        assert args[1].value == "warning"
+        assert args[2] == "전략 성과 저하 후보"
+        assert kwargs["metadata"]["alert_type"] == "strategy_degradation_candidate"
 
     async def test_telegram_send_called(self, task, mock_telegram):
         await task._on_market_closed("20260419")

--- a/tests/unit_test/test_operator_alert_service.py
+++ b/tests/unit_test/test_operator_alert_service.py
@@ -226,3 +226,8 @@ async def test_emit_metadata_contains_transition_and_key(svc, notification_servi
     assert meta["dedup_key"] == "kill_switch:global"
     assert meta["source"] == AlertSource.KILL_SWITCH.value
     assert meta["foo"] == "bar"
+
+
+def test_strategy_perf_alert_source_value_is_stable():
+    """전략 성과 저하 알림의 dedup source 값은 대문자 enum 컨벤션을 따른다."""
+    assert AlertSource.STRATEGY_PERF.value == "STRATEGY_PERF"

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-15 (1-4 시장 국면 분해 구현)
+최종 업데이트: 2026-05-15 (4-1 전략별 성과 저하 감지 계획 보강)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -306,17 +306,47 @@
 
 ### 4-1. 전략별 성과 저하 감지
 
-- [ ] 전략별 최근 20거래 손익, 최근 20거래 승률, 평균 손익비, MDD, 연속 손실, MFE/MAE를 집계한다.
-- [ ] 백테스트 기대값 대비 실거래 괴리를 전략별로 계산한다.
-- [ ] 성과 악화 시 신규 진입 중단, 수량 축소, paper mode 전환, 관리자 알림 후보로 표시한다.
-- [ ] 자동 차단 기준은 KillSwitch/RiskGate와 충돌하지 않도록 정책 우선순위를 정의한다.
+- [x] `services/regime_performance_service.py` 와 같은 pure function 패턴으로 standard journal record 기반 분석 모듈을 추가한다.
+  - 입력은 `get_standard_journal_records()` 와 동일한 record shape를 사용한다.
+  - SOLD 거래만 대상으로 하며, 최근 N거래 기본값은 20건이다.
+- [x] "최근 N거래" 정렬 기준을 확정한다.
+  - 청산 시각 우선: `metadata.sell_date` → `metadata.exit_time` → `metadata.closed_at` → fallback `signal_time`.
+  - 성과 저하는 결과 확정 시점 기준이므로 진입 시각보다 청산 시각을 우선한다.
+- [x] 전략별 최근 20거래 손익, 승률, payoff ratio, profit factor, MDD, 연속 손실, MFE/MAE를 집계한다.
+  - `payoff_ratio = avg_win_return / abs(avg_loss_return)`.
+  - `profit_factor = sum_win_pnl / abs(sum_loss_pnl)` 이며 판정 기준은 profit factor를 우선한다.
+  - MDD는 `mdd_amount`(누적 net_pnl peak-to-trough)와 `mdd_ratio`를 함께 산출한다.
+  - `mdd_ratio`는 live/backtest가 같은 `capital_base_won` 분모 정의를 공유할 때만 baseline 비교에 사용한다.
+- [x] 백테스트 기대값 대비 실거래 괴리를 전략별로 계산한다.
+  - live sample 부족은 `insufficient_live`, baseline sample 부족은 `insufficient_baseline`으로 분리한다.
+  - 표본 부족 시 hard 후보 판정은 하지 않고 리포트/metadata에만 표시한다.
+- [~] 성과 악화 시 신규 진입 중단, 수량 축소, paper mode 전환, 관리자 알림 후보로 표시한다.
+  - 1차 구현은 soft signal만 산출하며 실제 자동 차단, 수량 변경, paper 전환은 실행하지 않는다.
+  - 후보 metadata에 recommended_actions를 포함한다.
+- [x] 운영자 알림은 `OperatorAlertService.report(AlertSource.STRATEGY_PERF, ...)` 경로를 우선 사용한다.
+  - `AlertSource.STRATEGY_PERF = "STRATEGY_PERF"` 를 추가한다.
+  - `operator_alert_service is not None` 이면 OperatorAlertService만 사용한다.
+  - `operator_alert_service is None` 이고 `notification_service is not None` 일 때만 NotificationService fallback을 사용한다.
+  - 둘을 동시에 호출하지 않는다.
+- [x] 자동 차단 기준은 KillSwitch/RiskGate와 충돌하지 않도록 정책 우선순위를 정의한다.
+  - 우선순위: `KillSwitch` hard stop > `RiskGate` 주문 직전 hard block > `StrategyPerf` soft alert.
+  - `KillSwitchService.is_strategy_tripped(strategy_name)` 가 truthy이면 추가 차단 없이 `already_blocked_by_kill_switch=True`, `kill_switch_trip=<trip meta>` metadata로 알림만 보낸다.
+- [x] 테스트 fixture를 `tests/fixtures/strategy_degradation/` 아래에 추가한다.
+  - `recent_trades_live.json`
+  - `recent_trades_backtest.json`
+  - 필요 시 `expected_metrics.json`
 
 주요 파일:
 
+- `common/operator_alert_types.py`
+- `services/strategy_performance_degradation_service.py`
 - `services/strategy_log_report_service.py`
 - `task/background/after_market/strategy_log_report_task.py`
 - `services/kill_switch_service.py`
 - `services/risk_gate_service.py`
+- `tests/fixtures/strategy_degradation/`
+- `tests/unit_test/services/test_strategy_performance_degradation_service.py`
+- `tests/unit_test/task/background/after_market/test_strategy_log_report_task.py`
 
 ### 4-2. Rejected reason 리포트
 
@@ -379,8 +409,8 @@
    - event-driven 전략 평가 목표 아키텍처 문서화
 
 5. P3/P4 유지보수와 운영 품질
-   - rejected reason 표준화 및 전략별/일자별 분포 리포트
    - 전략별 성과 저하 감지 지표 집계
+   - `AlertSource.STRATEGY_PERF` 기반 운영자 알림 연결
    - `WebAppContext` 분리
    - ServiceContainer / Factory 도입
    - `OrderExecutionService` 역할 분리

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -656,9 +656,14 @@ class WebAppContext:
                     virtual_trade_service=self.virtual_trade_service,
                     backtest_journal_provider=self.backtest_journal_repository.load_records_for_date,
                     execution_quality_config=getattr(self.full_config, "execution_quality_report", None),
+                    strategy_degradation_config=getattr(
+                        self.full_config, "strategy_performance_degradation", None
+                    ),
                     enabled_strategy_provider=self._get_enabled_strategy_names_for_report,
                 ),
                 notification_service=self.notification_service,
+                operator_alert_service=self.operator_alert_service,
+                kill_switch_service=self.kill_switch_service,
                 telegram_reporter=getattr(self, 'telegram_reporter', None),
                 mcs=self._mcs,
                 market_clock=self.market_clock,


### PR DESCRIPTION
…RATEGY_PERF부터 성과 저하 분석, 리포트, OperatorAlert 연동까지 구현했습니다.

주요 변경:

todo_list.md (line 307): 4-1 계획을 리뷰 반영 버전으로 갱신

strategy_performance_degradation_service.py (line 13): 최근 N거래 성과 지표, baseline 괴리, 후보 판정 pure function 추가

operator_alert_types.py (line 28): STRATEGY_PERF 추가

strategy_log_report_service.py (line 627): 전략 성과 저하 후보 섹션과 getter 추가

strategy_log_report_task.py (line 114): OperatorAlertService.report(AlertSource.STRATEGY_PERF, ...) 우선, 없을 때만 Notification fallback

web_app_initializer.py (line 660): config, OperatorAlert, KillSwitch 주입 연결

tests/fixtures/strategy_degradation/: live/backtest/expected fixture 추가

추가로 전체 단위 테스트 중 날짜 민감 테스트가 현재 날짜 기준으로 깨져서, test_stock_ohlcv_repository.py (line 542)의 “최근 데이터” fixture를 고정 날짜 대신 현재 날짜로 보정했습니다.

검증:

pytest tests/unit_test -q --tb=short: 4422 passed

pytest tests/integration_test -q --tb=short: 233 passed

통합 테스트 끝에 기존 리소스 정리 경고(StockOhlcvRepository was not closed explicitly)가 2줄 출력됐지만, 테스트 실패는 없습니다.