### PR TITLE
다음 착수 가능 항목으로 P4 4-3의 데이터 품질 차단 알림을 연결했습니다. P0 실전 fixture 작업은 실제 계좌 응…

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -123,6 +123,8 @@ class DataQualityConfig(BaseModel):
     block_on_stale_price: bool = True
     block_on_invalid_api_response: bool = True
     alert_cooldown_sec: float = 60.0
+    violation_alert_threshold: int = 5
+    violation_alert_window_sec: float = 60.0
 
     model_config = {"extra": "allow"}
 

--- a/services/data_quality_service.py
+++ b/services/data_quality_service.py
@@ -1,12 +1,17 @@
 """Common data quality checks for realtime trading inputs."""
 from __future__ import annotations
 
+import asyncio
 import time
 from dataclasses import dataclass, field, asdict
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
+from common.operator_alert_types import AlertSource
 from common.types import ErrorCode, ResCommonResponse
 from config.config_loader import DataQualityConfig
+
+if TYPE_CHECKING:
+    from services.operator_alert_service import OperatorAlertService
 
 
 @dataclass
@@ -46,15 +51,18 @@ class DataQualityService:
         price_stream_service=None,
         market_clock=None,
         logger=None,
+        operator_alert_service: Optional["OperatorAlertService"] = None,
     ) -> None:
         self._cfg = config or DataQualityConfig()
         self._price_stream_service = price_stream_service
         self._market_clock = market_clock
         self._logger = logger
+        self._operator_alert_service = operator_alert_service
         self._last_good_price: dict[str, float] = {}
         self._last_result: DataQualityResult = DataQualityResult(ok=True, reason="not_checked")
         self._profile = "base"
         self._violation_history: list[dict[str, Any]] = []
+        self._last_operator_alert_ts: dict[str, float] = {}
 
     @property
     def config(self) -> DataQualityConfig:
@@ -99,13 +107,78 @@ class DataQualityService:
         result = DataQualityResult(ok=ok, reason=reason, severity=severity, **kwargs)
         self._last_result = result
         if not ok:
+            timestamp = time.time()
             self._violation_history.append({
-                "timestamp": time.time(),
+                "timestamp": timestamp,
                 **result.to_dict(),
             })
             if len(self._violation_history) > self.MAX_VIOLATION_HISTORY:
                 self._violation_history = self._violation_history[-self.MAX_VIOLATION_HISTORY:]
+            self._maybe_report_operator_alert(result, timestamp)
         return result
+
+    def _maybe_report_operator_alert(self, result: DataQualityResult, timestamp: float) -> None:
+        if self._operator_alert_service is None:
+            return
+        threshold = int(getattr(self._cfg, "violation_alert_threshold", 0) or 0)
+        if threshold <= 0:
+            return
+        window_sec = float(getattr(self._cfg, "violation_alert_window_sec", 60.0) or 60.0)
+        cooldown_sec = float(getattr(self._cfg, "alert_cooldown_sec", 60.0) or 60.0)
+        reason = result.reason or "unknown"
+        alert_key = f"data_quality:{reason}"
+        last_alert_ts = self._last_operator_alert_ts.get(alert_key)
+        if last_alert_ts is not None and timestamp - last_alert_ts < cooldown_sec:
+            return
+
+        window_start = timestamp - window_sec
+        recent = [
+            item for item in self._violation_history
+            if item.get("reason") == reason and float(item.get("timestamp", 0.0)) >= window_start
+        ]
+        if len(recent) < threshold:
+            return
+
+        self._last_operator_alert_ts[alert_key] = timestamp
+        sample_codes = []
+        for item in recent[-5:]:
+            code = item.get("code")
+            if code and code not in sample_codes:
+                sample_codes.append(code)
+        metadata = {
+            "alert_type": "data_quality_violation_threshold",
+            "reason": reason,
+            "severity": result.severity,
+            "violation_count": len(recent),
+            "window_sec": window_sec,
+            "sample_codes": sample_codes,
+            "latest": result.to_dict(),
+        }
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        task = loop.create_task(
+            self._operator_alert_service.report(
+                AlertSource.DATA_QUALITY,
+                alert_key,
+                result.severity or "error",
+                "데이터 품질 위반 증가",
+                f"{reason}: 최근 {int(window_sec)}초 {len(recent)}건",
+                metadata=metadata,
+            )
+        )
+
+        def _log_failure(done: asyncio.Task) -> None:
+            try:
+                exc = done.exception()
+            except asyncio.CancelledError:
+                return
+            if exc and self._logger:
+                self._logger.warning(f"DataQuality 운영자 알림 전송 실패: {exc}")
+
+        task.add_done_callback(_log_failure)
 
     def get_violation_history(
         self,

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -101,6 +101,8 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.is_paper_trading is True
     assert config.strategy_performance_degradation.window_size == 20
     assert config.strategy_performance_degradation.warn_profit_factor_below == 1.0
+    assert config.data_quality.violation_alert_threshold == 5
+    assert config.data_quality.violation_alert_window_sec == 60.0
 
 def test_app_config_validation_invalid_url():
     """AppConfig base_url 유효성 검사 실패 테스트"""

--- a/tests/unit_test/services/test_data_quality_service.py
+++ b/tests/unit_test/services/test_data_quality_service.py
@@ -1,7 +1,9 @@
 import time
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from common.operator_alert_types import AlertSource
 from common.types import ErrorCode, ResCommonResponse
 from config.config_loader import DataQualityConfig
 from services.data_quality_service import DataQualityService
@@ -75,6 +77,53 @@ def test_violation_history_records_and_filters_failures():
     assert by_code[0]["code"] == "005930"
     assert by_reason[0]["code"] == "000660"
     assert health["violation_count"] == 2
+
+
+def test_repeated_violations_report_operator_alert_once_per_cooldown(monkeypatch):
+    class ScheduledTask:
+        def add_done_callback(self, callback):
+            return None
+
+    class FakeLoop:
+        def __init__(self):
+            self.created = []
+
+        def create_task(self, coroutine):
+            self.created.append(coroutine)
+            coroutine.close()
+            return ScheduledTask()
+
+    fake_loop = FakeLoop()
+    monkeypatch.setattr(
+        "services.data_quality_service.asyncio.get_running_loop",
+        lambda: fake_loop,
+    )
+    operator_alert = MagicMock()
+    operator_alert.report = AsyncMock()
+    svc = DataQualityService(
+        DataQualityConfig(
+            violation_alert_threshold=2,
+            violation_alert_window_sec=10.0,
+            alert_cooldown_sec=60.0,
+        ),
+        operator_alert_service=operator_alert,
+    )
+
+    svc.validate_price_tick({"유가증권단축종목코드": "005930", "주식현재가": "-1", "누적거래량": "1"})
+    svc.validate_price_tick({"유가증권단축종목코드": "000660", "주식현재가": "-1", "누적거래량": "1"})
+
+    assert operator_alert.report.call_count == 1
+    assert len(fake_loop.created) == 1
+    args, kwargs = operator_alert.report.call_args
+    assert args[0] == AlertSource.DATA_QUALITY
+    assert args[1] == "data_quality:invalid_tick"
+    assert args[2] == "error"
+    assert kwargs["metadata"]["reason"] == "invalid_tick"
+    assert kwargs["metadata"]["violation_count"] == 2
+
+    svc.validate_price_tick({"유가증권단축종목코드": "035420", "주식현재가": "-1", "누적거래량": "1"})
+
+    assert operator_alert.report.call_count == 1
 
 
 def test_validate_api_response_required_data_keys():

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-15 (4-1 전략별 성과 저하 감지 계획 보강)
+최종 업데이트: 2026-05-15 (4-3 데이터 품질 집계 알림 연결)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -368,8 +368,10 @@
 
 - [x] OperatorAlertService(dedup·전이 이벤트), 운영자 대시보드 페이지(/operator), Kill Switch·Risk Gate·Reconcile·WebSocket Watchdog를 operator_alert_service에 연결
 - [x] 알림은 신규 차단, 위험도 상승, 자동 해제/복구를 구분해 중복 발송을 줄인다.
-- [ ] 전략별 성과 저하 알림 — 4-1(전략 성과 감지 임계값) 완료 후 `AlertSource.STRATEGY_PERF`로 연결
-- [ ] 데이터 품질 차단 알림 — DataQualityService 위반율 집계(N건/M초) 후 임계값 초과 시 report(); 현재는 per-tick 동기 호출이라 직접 연결 불가
+- [x] 전략별 성과 저하 알림 — `StrategyLogReportTask`에서 `AlertSource.STRATEGY_PERF`로 연결
+- [x] 데이터 품질 차단 알림 — `DataQualityService` 위반율 집계(N건/M초) 후 임계값 초과 시 `AlertSource.DATA_QUALITY`로 연결
+  - 기본값: 동일 reason 위반 60초 내 5건 이상, 동일 reason 알림 cooldown 60초.
+  - `WebAppContext`에서 `DataQualityService`에 `operator_alert_service`를 주입한다.
 
 ---
 
@@ -410,7 +412,6 @@
 
 5. P3/P4 유지보수와 운영 품질
    - 전략별 성과 저하 감지 지표 집계
-   - `AlertSource.STRATEGY_PERF` 기반 운영자 알림 연결
    - `WebAppContext` 분리
    - ServiceContainer / Factory 도입
    - `OrderExecutionService` 역할 분리

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -362,6 +362,7 @@ class WebAppContext:
                 config=getattr(self.full_config, "data_quality", None) or DataQualityConfig(),
                 market_clock=self.market_clock,
                 logger=self.logger,
+                operator_alert_service=self.operator_alert_service,
             )
             self.data_quality_service.apply_trading_mode(bool(getattr(self.env, "is_paper_trading", True)))
             self.market_data_service._data_quality_service = self.data_quality_service


### PR DESCRIPTION
…답이 필요해서 지금은 blocked라, 코드로 진전 가능한 다음 항목을 처리했어요.

변경 내용:

services/data_quality_service.py: 동일 reason 데이터 품질 위반이 최근 N초 안에 임계값 이상 쌓이면 AlertSource.DATA_QUALITY로 OperatorAlertService.report()를 예약 config/config_loader.py: 기본값 추가
violation_alert_threshold = 5
violation_alert_window_sec = 60.0
view/web/web_app_initializer.py: DataQualityService에 operator_alert_service 주입 todo_list.md: 4-3 전략 성과 알림 / 데이터 품질 알림 완료 상태 반영
검증:

C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v → 4423 passed C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v → 233 passed