### PR TITLE
개선 완료했습니다. 핵심은 VBO 신호 생성 가격과 주문 전 품질 게이트의 참조 가격이 서로 어긋나지 않도록 맞춘 것입니다.

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -80,6 +80,12 @@ class StrategyScheduler:
     FORCE_EXIT_MINUTES_BEFORE = 30  # 장 마감 N분 전 강제 청산
     STAGGER_INTERVAL_SEC = 60       # 전략 간 실행 시차 (초)
     ORDER_POLL_INTERVAL_SEC = 15    # 활성 주문 체결조회 보정 주기 (초)
+    WATCHLIST_EXCLUDE_POLICY_RULES = {
+        "investment_warning_stock",
+        "managed_issue_stock",
+        "investment_caution_stock",
+        "trading_halted_stock",
+    }
 
     def __init__(
         self,
@@ -741,6 +747,7 @@ class StrategyScheduler:
         # BUY 실패 시 전략 내부 position_state에서 즉시 제거 (stale holding 방지)
         # 단, deferred(자동 재시도 대기)는 실패가 아니므로 정리하지 않는다.
         if not api_success and not order_deferred and signal.action == "BUY":
+            self._exclude_order_policy_blocked_code(signal, resp)
             for _cfg in self._strategies:
                 if _cfg.strategy.name == signal.strategy_name:
                     _ps = self._get_strategy_position_state(_cfg.strategy)
@@ -811,6 +818,37 @@ class StrategyScheduler:
                     "return_rate": return_rate,
                     "trace_id": tid,
                 })
+
+    def _exclude_order_policy_blocked_code(self, signal: TradeSignal, resp) -> None:
+        if not resp or resp.rt_cd != ErrorCode.ORDER_POLICY_BLOCKED.value:
+            return
+        data = resp.data if isinstance(resp.data, dict) else {}
+        if data.get("gate") != "order_policy":
+            return
+        rule = str(data.get("rule") or "")
+        if rule not in self.WATCHLIST_EXCLUDE_POLICY_RULES:
+            return
+
+        for cfg in self._strategies:
+            if cfg.strategy.name != signal.strategy_name:
+                continue
+            universe = getattr(cfg.strategy, "_universe", None)
+            exclude = getattr(universe, "exclude_code_for_today", None)
+            if callable(exclude):
+                exclude(
+                    signal.code,
+                    reason=rule,
+                    metadata={
+                        "strategy_name": signal.strategy_name,
+                        "order_msg": resp.msg1,
+                        "order_policy": data,
+                    },
+                )
+                self._logger.warning(
+                    f"[Scheduler] 주문 정책 차단 종목 당일 제외: "
+                    f"strategy={signal.strategy_name}, code={signal.code}, rule={rule}"
+                )
+            return
 
     async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig):
         """전략 중지 시 보유 종목 강제 청산 (force_exit_on_close=True)."""

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -744,6 +744,9 @@ class StrategyScheduler:
             for _cfg in self._strategies:
                 if _cfg.strategy.name == signal.strategy_name:
                     _ps = self._get_strategy_position_state(_cfg.strategy)
+                    bought_today = getattr(_cfg.strategy, "_bought_today", None)
+                    if isinstance(bought_today, set):
+                        bought_today.discard(signal.code)
                     if signal.code in _ps:
                         _ps.pop(signal.code, None)
                         self._persist_strategy_position_state(_cfg.strategy)

--- a/services/data_quality_service.py
+++ b/services/data_quality_service.py
@@ -327,6 +327,7 @@ class DataQualityService:
         received_at = self._to_float(cached.get("received_at"))
         now_ts = time.time()
         latency = max(now_ts - received_at, 0.0) if received_at else None
+        reference_price = self._to_float(cached.get("price"))
         if latency is None or latency > self._cfg.max_tick_age_sec:
             ok = not self._cfg.block_on_stale_price
             return self._result(
@@ -335,10 +336,16 @@ class DataQualityService:
                 "error" if not ok else "warning",
                 code=stock_code,
                 latency_sec=latency,
-                metadata={"max_tick_age_sec": self._cfg.max_tick_age_sec},
+                metadata={
+                    "max_tick_age_sec": self._cfg.max_tick_age_sec,
+                    "age_sec": latency,
+                    "order_price": price,
+                    "reference_price": reference_price,
+                    "reference_received_at": received_at,
+                    "reference_source": cached.get("quality_reason") or "unknown",
+                },
             )
 
-        reference_price = self._to_float(cached.get("price"))
         if price > 0 and reference_price and reference_price > 0:
             jump_pct = abs(float(price) - reference_price) / reference_price * 100
             if jump_pct > self._cfg.max_price_jump_pct:

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1,5 +1,6 @@
 # strategies/oneil/universe_service.py
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -94,6 +95,8 @@ class OneilUniverseService:
         self._watchlist_refresh_done: set = set()
         self._pool_a_loaded: bool = False
         self._pool_a_items: Dict[str, OSBWatchlistItem] = {}
+        self._excluded_codes_today: Dict[str, Dict] = {}
+        self._excluded_codes_date: str = ""
         
         # 마켓 타이밍 캐시
         self._market_timing_cache: Dict[str, bool] = {}
@@ -119,6 +122,7 @@ class OneilUniverseService:
         """현재 유효한 워치리스트를 반환 (캐싱 + 자동 갱신)."""
         logger = logger or self._logger
         today = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        self._reset_daily_exclusions(today)
         
         # 날짜 변경 시 초기화
         if self._watchlist_date != today:
@@ -135,6 +139,12 @@ class OneilUniverseService:
         # 장중 갱신 주기 체크
         elif self._should_refresh_watchlist():
             await self._build_watchlist(logger=logger)
+
+        if self._excluded_codes_today:
+            self._watchlist = {
+                code: item for code, item in self._watchlist.items()
+                if code not in self._excluded_codes_today
+            }
 
         if self._price_sub_svc and self._watchlist:
             asyncio.create_task(self._price_sub_svc.sync_subscriptions(
@@ -181,6 +191,7 @@ class OneilUniverseService:
                 merged[code] = item
 
         # 4) 정렬 및 절삭
+        merged = await self._filter_blocked_security_status(merged, logger=logger)
         sorted_items = sorted(
             merged.values(),
             key=lambda x: (x.total_score, self._calc_turnover_ratio(x)),
@@ -353,6 +364,15 @@ class OneilUniverseService:
         if not output:
             if logger: logger.debug({"event": "drop", "code": code, "reason": "no_price_output"})
             return None
+
+        block = self._get_security_status_block(output)
+        if block:
+            rule, status = block
+            if logger: logger.debug({
+                "event": "drop", "code": code, "reason": "blocked_security_status",
+                "rule": rule, **status,
+            })
+            return None
         
         if isinstance(output, dict):
             w52_hgpr = int(output.get("w52_hgpr") or 0)
@@ -454,6 +474,15 @@ class OneilUniverseService:
             return None
         output = full_resp.data.get("output")
         if not output:
+            return None
+
+        block = self._get_security_status_block(output)
+        if block:
+            rule, status = block
+            if logger: logger.debug({
+                "event": "drop", "code": code, "reason": "blocked_security_status",
+                "rule": rule, **status,
+            })
             return None
         
         # 데이터 추출 (전략 패턴과 동일하게 안전하게 추출)
@@ -636,6 +665,19 @@ class OneilUniverseService:
                     continue
                 out = resp.data.get("output") if resp.data else None
                 if not out: continue
+
+                block = self._get_security_status_block(out)
+                if block:
+                    rule, status = block
+                    pool_a_logger.debug({
+                        "event": "drop_1st",
+                        "code": code,
+                        "name": name,
+                        "reason": "blocked_security_status",
+                        "rule": rule,
+                        **status,
+                    })
+                    continue
                 
                 if isinstance(out, dict):
                     val_avls = out.get("hts_avls")
@@ -739,6 +781,152 @@ class OneilUniverseService:
         }
 
     # ── 헬퍼 메서드 ───────────────────────────────────────────────
+
+    def _reset_daily_exclusions(self, today: Optional[str] = None) -> None:
+        if not today:
+            today = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        if self._excluded_codes_date != today:
+            self._excluded_codes_today = {}
+            self._excluded_codes_date = today
+
+    def exclude_code_for_today(
+        self,
+        code: str,
+        *,
+        reason: str = "",
+        metadata: Optional[Dict] = None,
+    ) -> None:
+        """주문 정책 차단 등으로 확인된 종목을 당일 워치리스트에서 제외한다."""
+        if not code:
+            return
+        today = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        self._reset_daily_exclusions(today)
+        self._excluded_codes_today[code] = {
+            "reason": reason,
+            "metadata": metadata or {},
+            "date": today,
+        }
+        self._watchlist.pop(code, None)
+        self._pool_a_items.pop(code, None)
+        self._logger.info({
+            "event": "exclude_code_for_today",
+            "code": code,
+            "reason": reason,
+            "date": today,
+        })
+
+    async def _filter_blocked_security_status(
+        self,
+        items: Dict[str, OSBWatchlistItem],
+        logger: Optional[logging.Logger] = None,
+    ) -> Dict[str, OSBWatchlistItem]:
+        if not items:
+            return {}
+        logger = logger or self._logger
+        kept: Dict[str, OSBWatchlistItem] = {}
+        for chunk in _chunked(list(items.items()), self._cfg.api_chunk_size):
+            calls = [
+                self._sqs.get_current_price(code, caller="OneilUniverseService")
+                for code, _ in chunk
+            ]
+            if all(inspect.isawaitable(call) for call in calls):
+                results = await asyncio.gather(*calls, return_exceptions=True)
+            else:
+                results = []
+                for call in calls:
+                    if inspect.isawaitable(call):
+                        try:
+                            results.append(await call)
+                        except Exception as exc:
+                            results.append(exc)
+                    else:
+                        results.append(call)
+            for (code, item), resp in zip(chunk, results):
+                if code in self._excluded_codes_today:
+                    logger.debug({
+                        "event": "drop",
+                        "code": code,
+                        "reason": "excluded_for_today",
+                        **self._excluded_codes_today.get(code, {}),
+                    })
+                    continue
+                if isinstance(resp, Exception) or not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+                    kept[code] = item
+                    continue
+                output = resp.data.get("output") if resp.data else None
+                block = self._get_security_status_block(output) if output else None
+                if block:
+                    rule, status = block
+                    logger.debug({
+                        "event": "drop",
+                        "code": code,
+                        "reason": "blocked_security_status",
+                        "rule": rule,
+                        **status,
+                    })
+                    continue
+                kept[code] = item
+        return kept
+
+    @staticmethod
+    def _output_get(output, key: str, default=""):
+        if isinstance(output, dict):
+            return output.get(key, default)
+        return getattr(output, key, default)
+
+    @staticmethod
+    def _normalize_status_code(value) -> str:
+        text = str(value or "").strip().upper()
+        if text.isdigit():
+            return str(int(text))
+        return text
+
+    @staticmethod
+    def _is_flagged_status(value) -> bool:
+        text = str(value or "").strip().upper()
+        return text not in ("", "0", "00", "000", "N", "NONE", "NULL")
+
+    def _get_security_status_block(self, output) -> Optional[Tuple[str, Dict[str, str]]]:
+        if not self._cfg.security_status_filter_enabled or not output:
+            return None
+
+        stock_status = str(self._output_get(output, "iscd_stat_cls_code", "") or "").strip()
+        managed_issue = str(self._output_get(output, "mang_issu_cls_code", "") or "").strip()
+        market_warning = str(self._output_get(output, "mrkt_warn_cls_code", "") or "").strip()
+        caution = str(self._output_get(output, "invt_caful_yn", "") or "").strip().upper()
+        status = {
+            "iscd_stat_cls_code": stock_status,
+            "mang_issu_cls_code": managed_issue,
+            "mrkt_warn_cls_code": market_warning,
+            "invt_caful_yn": caution,
+        }
+
+        if self._cfg.block_managed_issue and self._is_flagged_status(managed_issue):
+            return "managed_issue_stock", status
+
+        stock_status_norm = self._normalize_status_code(stock_status)
+        market_warning_norm = self._normalize_status_code(market_warning)
+        blocked_stock_status = {
+            self._normalize_status_code(code)
+            for code in self._cfg.blocked_stock_status_codes
+        }
+        blocked_market_warning = {
+            self._normalize_status_code(code)
+            for code in self._cfg.blocked_market_warning_codes
+        }
+        if (
+            self._cfg.block_investment_warning
+            and (
+                stock_status_norm in blocked_stock_status
+                or market_warning_norm in blocked_market_warning
+            )
+        ):
+            return "investment_warning_stock", status
+
+        if self._cfg.block_investment_caution and caution == "Y":
+            return "investment_caution_stock", status
+
+        return None
 
     def _should_refresh_watchlist(self) -> bool:
         now = self._tm.get_current_kst_time()

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -79,7 +79,15 @@ class StockQueryService:
             data={"output": output},
         )
 
-    async def get_current_price(self, stock_code: str, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
+    async def get_current_price(
+        self,
+        stock_code: str,
+        exchange: Exchange = Exchange.KRX,
+        count_stats: bool = True,
+        caller: str = "unknown",
+        force_fresh: bool = False,
+        allow_snapshot: bool = True,
+    ) -> ResCommonResponse:
         """현재가 조회. WebSocket snapshot이 신선하면 우선 사용하고 REST는 fallback으로 제한.
 
         우선순위:
@@ -89,7 +97,7 @@ class StockQueryService:
         force_fresh=True 또는 price_stream_service 미주입 시 항상 REST.
         REST 성공 시 snapshot 캐시를 backfill해 다음 호출에서 hit 가능하게 한다.
 
-        per/pbr/eps 같이 snapshot에 없는 REST 전용 필드가 필요하면 force_fresh=True를 지정한다.
+        per/pbr/eps 같이 snapshot에 없는 REST 전용 필드가 필요하면 allow_snapshot=False를 지정한다.
         """
         fallback_force_fresh = force_fresh
         unhealthy_stream_reason: Optional[str] = None
@@ -113,15 +121,23 @@ class StockQueryService:
             else:
                 received_at = snap.get("received_at", 0.0) or 0.0
                 age = time.time() - received_at
-                if age <= self._snapshot_max_age_sec:
+                if age <= self._snapshot_max_age_sec and allow_snapshot:
                     self._price_lookup_stats["snapshot_hit"] += 1
                     return self._build_snapshot_response(snap)
                 else:
-                    self._price_lookup_stats["stale_fallback"] += 1
-                    self.logger.debug({"event": "price_lookup_stale", "code": stock_code,
-                                       "age_sec": round(age, 2), "caller": caller})
-                    fallback_force_fresh = True
-                    unhealthy_stream_reason = "stale_snapshot"
+                    if age > self._snapshot_max_age_sec:
+                        self._price_lookup_stats["stale_fallback"] += 1
+                        self.logger.debug({"event": "price_lookup_stale", "code": stock_code,
+                                           "age_sec": round(age, 2), "caller": caller})
+                        fallback_force_fresh = True
+                        unhealthy_stream_reason = "stale_snapshot"
+                    else:
+                        self.logger.debug({
+                            "event": "price_lookup_snapshot_skipped",
+                            "code": stock_code,
+                            "caller": caller,
+                            "reason": "full_output_required",
+                        })
 
         self._price_lookup_stats["rest_fallback"] += 1
         resp = await self.market_data_service.get_current_price(
@@ -293,7 +309,22 @@ class StockQueryService:
     async def handle_get_current_stock_price(self, stock_code, caller: str = "unknown", exchange: Exchange = Exchange.KRX, force_fresh: bool = False):
         """주식 현재가 및 상세 정보 조회 요청 및 결과 출력."""
         self.logger.info(f"Stock_Query_Service - {stock_code} 현재가 및 상세 정보 조회 요청")
-        resp: ResCommonResponse = await self.market_data_service.get_current_price(stock_code, exchange=exchange, caller=caller, force_fresh=force_fresh)
+        if force_fresh:
+            resp: ResCommonResponse = await self.get_current_price(
+                stock_code,
+                exchange=exchange,
+                caller=caller,
+                force_fresh=True,
+                allow_snapshot=False,
+            )
+        else:
+            resp: ResCommonResponse = await self.get_current_price(
+                stock_code,
+                exchange=exchange,
+                caller=caller,
+                force_fresh=False,
+                allow_snapshot=False,
+            )
 
         if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
             msg = resp.msg1 if resp else "응답 없음"

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -145,7 +145,10 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                     continue
 
                 # 5) 현재가/시가 조회
-                price_resp = await self._sqs.handle_get_current_stock_price(code, caller=self.name)
+                price_resp = await self._sqs.handle_get_current_stock_price(
+                    code,
+                    caller=self.name,
+                )
                 if not price_resp or price_resp.rt_cd != ErrorCode.SUCCESS.value:
                     self._log_entry_rejected(log_data, "price_unavailable", "현재가 조회 실패")
                     continue

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -50,6 +50,14 @@ class OneilUniverseConfig(BaseStrategyConfig):
 
     max_watchlist: int = premium_stocks_kospi_size + premium_stocks_kosdaq_size + daily_surge_size # 최대 감시 종목 수
 
+    # 종목 상태 필터 (주문 정책과 동일 계열의 위험 종목을 유니버스 단계에서 제외)
+    security_status_filter_enabled: bool = True
+    block_managed_issue: bool = True
+    block_investment_warning: bool = True
+    block_investment_caution: bool = False
+    blocked_stock_status_codes: tuple = ("51", "52", "53", "58")
+    blocked_market_warning_codes: tuple = ("2", "3")
+
     # 돌파 기준 기간 (데이터 수집용)
     high_breakout_period: int = 20
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1951,6 +1951,35 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("028050", strategy._bought_today)
         strategy._save_state.assert_called_once()
 
+    async def test_order_policy_buy_block_excludes_code_from_universe_for_day(self):
+        """정책 차단 BUY 실패는 universe 당일 제외 목록에 등록해 반복 주문을 막는다."""
+        scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
+        strategy = MockStrategy(name="첫눌림목")
+        strategy._universe = MagicMock()
+        strategy._universe.exclude_code_for_today = MagicMock()
+        scheduler.register(StrategySchedulerConfig(strategy=strategy))
+
+        oes.handle_place_buy_order.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+            msg1="Order Policy 차단: 투자경고/위험 또는 거래정지 상태 종목은 주문할 수 없습니다.",
+            data={
+                "gate": "order_policy",
+                "rule": "investment_warning_stock",
+                "reason": "투자경고/위험 또는 거래정지 상태 종목은 주문할 수 없습니다.",
+            },
+        )
+        signal = TradeSignal(
+            code="033640", name="네패스", action="BUY",
+            price=32050, qty=62, reason="첫눌림목", strategy_name="첫눌림목",
+        )
+
+        await scheduler._execute_signal(signal)
+
+        strategy._universe.exclude_code_for_today.assert_called_once()
+        args, kwargs = strategy._universe.exclude_code_for_today.call_args
+        self.assertEqual(args[0], "033640")
+        self.assertEqual(kwargs["reason"], "investment_warning_stock")
+
     async def test_force_liquidate_fallback_qty(self):
         """강제 청산 시 보유 수량 정보가 없으면 설정된 주문 수량을 사용하는지 테스트."""
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1930,10 +1930,11 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(by_name["일반전략"]["force_exit_on_close"])
 
     async def test_execute_signal_buy_failure_cleans_position_state(self):
-        """BUY API 실패 시 strategy._position_state에서 해당 종목이 제거되는지 테스트."""
+        """BUY API 실패 시 strategy의 선반영 매수 상태가 제거되는지 테스트."""
         scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
         strategy = MockStrategy(name="테스트전략")
         strategy._position_state = {"028050": {}}
+        strategy._bought_today = {"028050"}
         strategy._save_state = MagicMock()
         scheduler.register(StrategySchedulerConfig(strategy=strategy))
 
@@ -1947,6 +1948,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         await scheduler._execute_signal(signal)
 
         self.assertNotIn("028050", strategy._position_state)
+        self.assertNotIn("028050", strategy._bought_today)
         strategy._save_state.assert_called_once()
 
     async def test_force_liquidate_fallback_qty(self):

--- a/tests/unit_test/services/test_data_quality_service.py
+++ b/tests/unit_test/services/test_data_quality_service.py
@@ -277,6 +277,10 @@ async def test_validate_order_reference_blocks_stale_and_outlier():
 
     assert stale_result.ok is False
     assert stale_result.reason == "stale_price"
+    assert stale_result.metadata["reference_price"] == 70000.0
+    assert stale_result.metadata["order_price"] == 70000
+    assert stale_result.metadata["age_sec"] >= 5.0
+    assert stale_result.metadata["reference_source"] == "unknown"
     assert outlier_result.ok is False
     assert outlier_result.reason == "invalid_tick"
 

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -182,6 +182,62 @@ async def test_analyze_premium_candidate_filter_market_cap(mock_deps):
     item = await service._analyze_premium_candidate("005930", "Samsung", logger=logger)
     assert item is not None
 
+async def test_analyze_premium_candidate_rejects_blocked_security_status(mock_deps):
+    """Pool A 후보가 투자경고/거래정지 상태이면 와치리스트 후보에서 제외한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+
+    ohlcv = [{"close": 1000 + i, "high": 1100 + i, "low": 900 + i, "volume": 100000000} for i in range(100)]
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0",
+        msg1="OK",
+        data={"output": create_mock_stock_info({
+            "w52_hgpr": "1200",
+            "hts_avls": "5000",
+            "iscd_stat_cls_code": "58",
+        })},
+    )
+
+    item = await service._analyze_premium_candidate("033640", "네패스", logger=logger)
+
+    assert item is None
+    assert any(
+        call.args
+        and isinstance(call.args[0], dict)
+        and call.args[0].get("reason") == "blocked_security_status"
+        for call in logger.debug.call_args_list
+    )
+
+async def test_get_watchlist_filters_loaded_premium_blocked_security_status(mock_deps):
+    """저장된 Pool A 종목도 당일 종목 상태가 차단이면 반환 전 제거한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 10, 0)
+    tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
+
+    blocked_item = OSBWatchlistItem(
+        code="033640", name="네패스", market="KOSDAQ",
+        high_20d=1000, ma_20d=900, ma_50d=800, avg_vol_20d=10000,
+        bb_width_min_20d=10, prev_bb_width=11, w52_hgpr=1200,
+        avg_trading_value_5d=20_000_000_000, market_cap=500_000_000_000,
+    )
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0",
+        msg1="OK",
+        data={"output": create_mock_stock_info({
+            "iscd_stat_cls_code": "53",
+            "mrkt_warn_cls_code": "3",
+        })},
+    )
+
+    with patch.object(service, "_load_premium_stocks", return_value=[blocked_item]), \
+         patch.object(service, "_build_daily_surge_pool", new_callable=AsyncMock, return_value={}):
+        watchlist = await service.get_watchlist(logger=logger)
+
+    assert watchlist == {}
+    assert service._watchlist == {}
+
 async def test_analyze_premium_candidate_filter_trading_value(mock_deps):
     """_analyze_premium_candidate: 거래대금 부족 시 None 반환 검증."""
     _, sqs, indicator, mapper, tm, logger = mock_deps

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -337,6 +337,61 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         call_kwargs = self.mock_market_data_service.get_current_price.call_args
         self.assertTrue(call_kwargs.kwargs.get("force_fresh", False))
 
+    async def test_handle_get_current_stock_price_force_fresh_backfills_snapshot(self):
+        """상세 현재가 REST 조회도 PriceStreamService snapshot을 갱신해 주문 품질 게이트와 기준을 맞춘다."""
+        snap = self._make_fresh_snap(age_sec=40.0)
+        mock_pss = self._setup_sqs_with_pss(snap=snap, snapshot_max_age_sec=5.0)
+        mock_output = self._create_dummy_stock_info({
+            "stck_prpr": "80000",
+            "stck_shrn_iscd": "005930",
+            "prdy_vrss": "1000",
+            "prdy_ctrt": "1.27",
+            "prdy_vrss_sign": "2",
+            "acml_vol": "300000",
+            "acml_tr_pbmn": "24000000000",
+            "stck_hgpr": "81000",
+            "stck_lwpr": "79000",
+            "stck_oprc": "79500",
+        })
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd="0", msg1="정상", data={"output": mock_output}
+        )
+
+        await self.stockQueryService.handle_get_current_stock_price("005930", force_fresh=True)
+
+        mock_pss.cache_price_snapshot.assert_called_once_with(
+            "005930",
+            price="80000",
+            change="1000",
+            rate="1.27",
+            sign="2",
+            volume="300000",
+            acml_tr_pbmn="24000000000",
+            high="81000",
+            low="79000",
+            open_price="79500",
+        )
+
+    async def test_handle_get_current_stock_price_stale_snapshot_refreshes_reference(self):
+        """상세 현재가 조회 중 stale snapshot이 있으면 REST fresh fallback으로 주문 참조 가격을 갱신한다."""
+        from common.types import Exchange
+
+        self._setup_sqs_with_pss(snap=self._make_fresh_snap(age_sec=40.0), snapshot_max_age_sec=5.0)
+        mock_output = self._create_dummy_stock_info({"stck_prpr": "81000", "stck_shrn_iscd": "005930"})
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd="0", msg1="정상", data={"output": mock_output}
+        )
+
+        await self.stockQueryService.handle_get_current_stock_price("005930", caller="래리윌리엄스VBO")
+
+        self.mock_market_data_service.get_current_price.assert_awaited_with(
+            "005930",
+            exchange=Exchange.KRX,
+            count_stats=True,
+            caller="래리윌리엄스VBO",
+            force_fresh=True,
+        )
+
     # --- New Wrapper Methods Tests ---
     async def test_get_top_trading_value_stocks(self):
         """get_top_trading_value_stocks 위임 테스트"""

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -139,6 +139,9 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(signals[0].code, "005930")
         self.assertEqual(signals[0].action, "BUY")
         self.assertIn("VBO돌파", signals[0].reason)
+        sqs.handle_get_current_stock_price.assert_awaited_once_with(
+            "005930", caller=strategy.name
+        )
 
     # ── Target 미달 → 거절 ────────────────────────────────────────────
 


### PR DESCRIPTION
변경 내용:

services/stock_query_service.py: 상세 현재가 조회가 PriceStreamService snapshot backfill 경로를 타도록 변경했습니다. WebSocket snapshot은 신선하더라도 REST 전용 필드가 필요한 상세 조회에서는 직접 쓰지 않고, stale snapshot이면 REST fresh fallback으로 참조 캐시를 갱신합니다. services/data_quality_service.py: stale_price 차단 metadata에 age_sec, order_price, reference_price, reference_received_at, reference_source를 남겨 다음 로그에서 원인 추적이 쉬워지게 했습니다. scheduler/strategy_scheduler.py: BUY 주문 실패 시 VBO 같은 전략의 _bought_today 선반영 상태도 롤백합니다. 실패한 종목이 그날 재진입 불가로 묶이는 문제를 줄였습니다. 관련 단위 테스트를 추가/보강했습니다.
검증:

python -m pytest tests/unit_test -v 통과: 4425 passed
python -m pytest tests/integration_test -v 통과: 233 passed