### PR TITLE
9개 전략 BUY 신호 변동성 hook 적용 완료

### DIFF
--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -263,13 +263,15 @@ class FirstPullbackStrategy(LiveStrategy):
                 "rs_rating": getattr(item, "rs_rating", 0),
                 "total_score": getattr(item, "total_score", 0.0),
                 "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
+                "volatility_20d_annualized": getattr(item, "volatility_20d_annualized", None),
             },
             "reason": reason_msg,
         })
 
         return TradeSignal(
             code=code, name=item.name, action="BUY", price=current,
-            reason=reason_msg, strategy_name=self.name
+            reason=reason_msg, strategy_name=self.name,
+            volatility_20d_annualized=getattr(item, "volatility_20d_annualized", None),
         )
 
     # ── Phase 1 검사 메서드 ────────────────────────────────────────

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -428,6 +428,7 @@ class HighTightFlagStrategy(LiveStrategy):
                 "rs_rating": getattr(item, "rs_rating", 0), #
                 "total_score": getattr(item, "total_score", 0.0),
                 "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None, #
+                "volatility_20d_annualized": getattr(item, "volatility_20d_annualized", None),
             },
             "reason": reason_msg,
         })
@@ -436,6 +437,7 @@ class HighTightFlagStrategy(LiveStrategy):
             code=code, name=item.name, action="BUY", price=current,
             reason=reason_msg, strategy_name=self.name,
             stop_loss_pct=self._cfg.stop_loss_pct,
+            volatility_20d_annualized=getattr(item, "volatility_20d_annualized", None),
         )
 
     # ── check_exits ──────────────────────────────────────────────────

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -262,6 +262,7 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
             code=code, name=item.name, action="BUY", price=current,
             reason=reason_msg, strategy_name=self.name,
             stop_loss_pct=stop_loss_pct,
+            volatility_20d_annualized=getattr(item, "volatility_20d_annualized", None),
         )
 
     # ── check_exits ─────────────────────────────────────────────────

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -12,9 +12,21 @@ from core.market_clock import MarketClock
 from interfaces.live_strategy import LiveStrategy
 from services.stock_query_service import StockQueryService
 from strategies.base_strategy_config import BaseStrategyConfig
+from utils.volatility_utils import annualized_return_std
 
 if TYPE_CHECKING:
     from services.oneil_universe_service import OneilUniverseService
+
+
+async def _fetch_volatility_for_signal(sqs: StockQueryService, code: str) -> Optional[float]:
+    """매수 신호 발화 직전 1회 호출: 21일 종가로 연환산 변동성 계산."""
+    try:
+        resp = await sqs.get_recent_daily_ohlcv(code, limit=21)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+            return None
+        return annualized_return_std([r.get("close") for r in resp.data])
+    except Exception:
+        return None
 
 _ENTRY_START = time(9, 10)
 _ENTRY_CUTOFF = time(14, 0)
@@ -201,15 +213,18 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                     f"VBO돌파: Open({open_price:,})+Range({rng:.0f})×K{self._cfg.k_value}"
                     f"=Target({round(target):,}) / 현재({current:,}) / 체결강도({cgld:.1f}%)"
                 )
+                volatility = await _fetch_volatility_for_signal(self._sqs, code)
                 signals.append(TradeSignal(
                     code=code, name=name, action="BUY", price=current,
                     reason=reason, strategy_name=self.name,
                     stop_loss_pct=self._cfg.stop_loss_pct,
+                    volatility_20d_annualized=volatility,
                 ))
                 self._bought_today.add(code)
                 self._logger.info({
                     "event": "buy_signal_generated", "strategy_name": self.name,
                     "code": code, "name": name, "price": current, "reason": reason,
+                    "metrics": {"volatility_20d_annualized": volatility},
                 })
 
             except Exception as e:

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -281,13 +281,15 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 "rs_rating": getattr(item, "rs_rating", 0),
                 "total_score": getattr(item, "total_score", 0.0),
                 "market_timing": market_timing_cache.get(item.market) if market_timing_cache else None,
+                "volatility_20d_annualized": getattr(item, "volatility_20d_annualized", None),
             },
             "reason": reason_msg,
         })
 
         return TradeSignal(
             code=code, name=item.name, action="BUY", price=current,
-            reason=reason_msg, strategy_name=self.name
+            reason=reason_msg, strategy_name=self.name,
+            volatility_20d_annualized=getattr(item, "volatility_20d_annualized", None),
         )
 
     # ── 조건 A: Pocket Pivot ──────────────────────────────────────

--- a/strategies/program_buy_follow_strategy.py
+++ b/strategies/program_buy_follow_strategy.py
@@ -11,6 +11,18 @@ from services.stock_query_service import StockQueryService
 from core.market_clock import MarketClock
 from strategies.base_strategy_config import BaseStrategyConfig
 from core.logger import get_strategy_logger
+from utils.volatility_utils import annualized_return_std
+
+
+async def _fetch_volatility_for_signal(sqs: StockQueryService, code: str) -> Optional[float]:
+    """매수 신호 발화 직전 1회 호출: 21일 종가로 연환산 변동성 계산."""
+    try:
+        resp = await sqs.get_recent_daily_ohlcv(code, limit=21)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+            return None
+        return annualized_return_std([r.get("close") for r in resp.data])
+    except Exception:
+        return None
 
 
 @dataclass
@@ -155,15 +167,18 @@ class ProgramBuyFollowStrategy(LiveStrategy):
                 f"PG추종(PG매수 {pg_buy_amt // 100_000_000:,}억({pg_ratio:.1f}%), "
                 f"누적대금 {trade_value // 100_000_000:,}억)"
             )
+            volatility = await _fetch_volatility_for_signal(self._sqs, code)
             signals.append(TradeSignal(
                 code=code, name=stock_name, action="BUY", price=current,
                 reason=reason_msg, strategy_name=self.name,
+                volatility_20d_annualized=volatility,
             ))
             self._bought_today.add(code)  # 매수 신호 발생 기록
             self._logger.info({
                 "event": "buy_signal_generated",
                 "code": code, "name": stock_name, "price": current,
                 "reason": reason_msg, "data": log_data,
+                "metrics": {"volatility_20d_annualized": volatility},
             })
 
         self._logger.info({"event": "scan_finished", "signals_found": len(signals)})

--- a/strategies/rsi2_pullback_strategy.py
+++ b/strategies/rsi2_pullback_strategy.py
@@ -206,7 +206,8 @@ class RSI2PullbackStrategy(LiveStrategy):
         })
         return TradeSignal(
             code=code, name=item.name, action="BUY", price=current,
-            reason=reason_msg, strategy_name=self.name
+            reason=reason_msg, strategy_name=self.name,
+            volatility_20d_annualized=getattr(item, "volatility_20d_annualized", None),
         )
 
     # ── check_exits ─────────────────────────────────────────────────

--- a/strategies/traditional_volume_breakout_strategy.py
+++ b/strategies/traditional_volume_breakout_strategy.py
@@ -19,6 +19,7 @@ from repositories.stock_code_repository import StockCodeRepository
 from core.market_clock import MarketClock
 from strategies.base_strategy_config import BaseStrategyConfig
 from core.logger import get_strategy_logger
+from utils.volatility_utils import annualized_return_std
 
 
 @dataclass
@@ -53,6 +54,7 @@ class WatchlistItem:
     ma_20d: float          # 20일 이동평균
     avg_vol_20d: float     # 20일 평균 거래량
     avg_trading_value_5d: float  # 5일 평균 거래대금
+    volatility_20d_annualized: float | None = None  # 신호 직전 변동성 (리포트용)
 
 
 @dataclass
@@ -205,11 +207,13 @@ class TraditionalVolumeBreakoutStrategy(LiveStrategy):
                 "event": "buy_signal_generated",
                 "code": code, "name": item.name, "price": current, "qty": qty,
                 "reason": reason_msg, "data": log_data,
+                "metrics": {"volatility_20d_annualized": item.volatility_20d_annualized},
             })
             return TradeSignal(
                 code=code, name=item.name, action="BUY", price=current,
                 reason=reason_msg, strategy_name=self.name,
                 stop_loss_pct=self._cfg.stop_loss_pct,
+                volatility_20d_annualized=item.volatility_20d_annualized,
             )
         except Exception as e:
             self._logger.error({"event": "scan_error", "code": code, "error": str(e)}, exc_info=True)
@@ -349,7 +353,8 @@ class TraditionalVolumeBreakoutStrategy(LiveStrategy):
             stock_name = stock.get("hts_kor_isnm", "") or self.stock_code_repository.get_name_by_code(code) or code
 
             try:
-                ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=self._cfg.high_period)
+                # 변동성(20일 std × √252) 계산에 21개 종가가 필요하므로 max(high_period, 21)
+                ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=max(self._cfg.high_period, 21))
                 ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
                 if not ohlcv or len(ohlcv) < self._cfg.ma_period:
                     continue
@@ -416,9 +421,11 @@ class TraditionalVolumeBreakoutStrategy(LiveStrategy):
                 return None
         
         self._logger.debug({"event": "ohlcv_filter_passed", **log_data})
+        volatility = annualized_return_std([r.get("close") for r in ohlcv])
         return WatchlistItem(
             code=code, name=name, high_20d=high_20d, ma_20d=ma_20d,
             avg_vol_20d=avg_vol_20d, avg_trading_value_5d=avg_trading_value_5d,
+            volatility_20d_annualized=volatility,
         )
 
     # ── 상태 저장/복원 ──

--- a/strategies/volume_breakout_live_strategy.py
+++ b/strategies/volume_breakout_live_strategy.py
@@ -10,6 +10,18 @@ from services.stock_query_service import StockQueryService
 from strategies.volume_breakout_strategy import VolumeBreakoutConfig
 from core.market_clock import MarketClock
 from core.logger import get_strategy_logger
+from utils.volatility_utils import annualized_return_std
+
+
+async def _fetch_volatility_for_signal(sqs: StockQueryService, code: str) -> Optional[float]:
+    """매수 신호 발화 직전 1회 호출: 21일 종가로 연환산 변동성 계산."""
+    try:
+        resp = await sqs.get_recent_daily_ohlcv(code, limit=21)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+            return None
+        return annualized_return_std([r.get("close") for r in resp.data])
+    except Exception:
+        return None
 
 
 class VolumeBreakoutLiveStrategy(LiveStrategy):
@@ -128,9 +140,11 @@ class VolumeBreakoutLiveStrategy(LiveStrategy):
                     f"상승확인 {open_price:,}->{current:,}, "
                     f"누적거래량 {current_vol:,})"
                 )
+                volatility = await _fetch_volatility_for_signal(self._sqs, code)
                 signals.append(TradeSignal(
                     code=code, name=stock_name, action="BUY", price=current,
                     reason=reason_msg, strategy_name=self.name,
+                    volatility_20d_annualized=volatility,
                 ))
                 self._bought_today.add(code)  # 매수 신호 발생 기록
                 self._logger.info({
@@ -141,6 +155,7 @@ class VolumeBreakoutLiveStrategy(LiveStrategy):
                     "price": current,
                     "reason": reason_msg,
                     "data": log_data,
+                    "metrics": {"volatility_20d_annualized": volatility},
                 })
 
             except Exception as e:

--- a/tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py
@@ -153,7 +153,9 @@ async def test_vbo_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     await strategy.scan()
 
     assert mock_get_price.call_count == 0,    "캐시 적중 시 현재가 API는 호출되지 않아야 함"
-    assert mock_get_ohlcv.call_count == 0,    "당일 Range 캐시 적중 시 일봉 API는 재호출되지 않아야 함"
+    # Range 캐시 적중과 별개로 BUY 신호 발화 시 변동성(21일 OHLCV) 1회 호출은 허용
+    assert mock_get_ohlcv.call_count <= 1, \
+        "Range 캐시 적중 시 일봉 API는 변동성 fetch 1회 외 재호출되지 않아야 함"
     assert mock_get_conclusion.call_count == calls_conclusion_on_miss, \
         "체결강도 실시간 API는 캐시와 무관하게 항상 호출되어야 함"
     assert stock_repo.get_cache_stats()["hits"] > 0


### PR DESCRIPTION
변경 사항 (전략별)

OneilUniverseService(공유 item.volatility) 경로 — TradeSignal 한 줄 추가:

strategies/high_tight_flag_strategy.py:435 — log metrics + TradeSignal strategies/oneil_pocket_pivot_strategy.py:288
strategies/first_pullback_strategy.py:270
strategies/larry_williams_channel_breakout_strategy.py:261 strategies/rsi2_pullback_strategy.py:207
자체 OHLCV 로드 경로 — 기존 흐름에 변동성 계산 주입:

strategies/traditional_volume_breakout_strategy.py — WatchlistItem 필드 추가 / fetch limit max(high_period, 21) 보정 / _analyze_ohlcv에서 annualized_return_std(closes) 계산 / log + TradeSignal 주입 OHLCV 미로드 경로 — 신호 발화 시점에만 1회 fetch:

strategies/volume_breakout_live_strategy.py, strategies/program_buy_follow_strategy.py, strategies/larry_williams_vbo_strategy.py — 각 파일에 _fetch_volatility_for_signal 모듈 헬퍼 추가 (21일 OHLCV fetch + std 계산, 실패 시 None) / BUY 시그널 발화 직전 호출 / log + TradeSignal 주입 회귀 테스트 갱신:

tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py:156 — Range 캐시 적중 시 일봉 API 재호출 ≤ 1회 (변동성 fetch 허용)로 완화 검증

단위 4465개: ✅ passed (172s)
통합 233개: ✅ passed (117s)
이제 모든 전략의 BUY 신호가 volatility를 carry하며, Task 1·2·3 데이터 흐름(전략 → TradeSignal → DB 컬럼 → HTML 리포트 섹션)이 9개 전략 모두에서 작동합니다. 커밋 진행하시면 됩니다.