### PR TITLE
요약

### DIFF
--- a/docs/event_driven_architecture.md
+++ b/docs/event_driven_architecture.md
@@ -1,0 +1,226 @@
+# Event-Driven Architecture Plan (P2 2-4)
+
+> 상태: 설계안 (구현 전)
+> 작성일: 2026-05-17
+> 관련 TODO: `todo_list.md` P2 2-4
+
+## 1. 목표
+
+폴링 기반 `StrategyScheduler._loop()`을 점진적으로 이벤트 기반 평가로 전환하여:
+
+- **반응 지연 단축**: `interval_minutes` 주기(현재 1~5분) 대신 체결 이벤트 도착 즉시 평가 후보 검토.
+- **API 호출 절감**: 같은 데이터를 반복 폴링하지 않고, snapshot 업데이트 시점에만 평가.
+- **전략 자원 충돌 완화**: 평가가 시간 균등 분포로 옮겨가 `STAGGER_INTERVAL_SEC` 의존도 감소.
+
+**비범위 (Non-goals)**
+- 폴링 루프 완전 제거. 시간 기반 강제 청산(`force_exit_on_close`), 원장 대사(`_run_reconciliation`), 미체결 주문 폴(`_poll_active_orders_if_due`), 비활성/저빈도 전략은 폴링 유지.
+- 백테스트 경로 변경. `BacktestPeriodRunner`/`BacktestExecutionSimulator`는 결정론적 bar-by-bar 진행을 유지.
+- 신규 WebSocket 채널 도입. 기존 `H0STCNT0`(체결가) / `H0STASP0`(호가) / `H0STCNI0`(체결통보) 범위 내.
+
+## 2. 현재 아키텍처 (Polling)
+
+```
+                 ┌─────────────────────────────┐
+                 │ StrategyScheduler._loop()   │
+                 │   LOOP_INTERVAL_SEC=1       │
+                 │   while market_open:        │
+                 │     for cfg in strategies:  │
+                 │       if elapsed >= interval│
+                 │         run_strategy(cfg)   │
+                 └────────────┬────────────────┘
+                              │ 매 N분마다
+                              ▼
+                  ┌───────────────────────┐
+                  │ Strategy.execute(...) │  ← 종목 리스트 전체 평가
+                  │   StrategyExecutor    │     (liquidity → stage → signal)
+                  └───────────────────────┘
+
+(병렬 흐름)
+WebSocket → on_realtime_message_callback → PriceStreamService.on_price_tick()
+                                              └ snapshot 캐시 갱신만 수행
+                                                (전략 평가 트리거 없음)
+```
+
+**현재의 문제**
+- WebSocket 캐시는 풍부하지만 전략은 다음 폴링 주기까지 활용 불가 → 신호 지연.
+- 후보 종목 50개 × 1분 주기 = 분당 50회 평가가 시간차 없이 묶여 실행 (STAGGER_INTERVAL_SEC=60초로 강제 분산).
+- 활성 후보군이 줄어든 시점에도 동일 주기로 풀스캔.
+
+## 3. 목표 아키텍처 (Event-Driven Hybrid)
+
+폴링 루프는 유지하되, **HIGH 우선순위 종목**에 한해 이벤트 트리거 평가를 추가하는 **하이브리드** 모델.
+
+```
+WebSocket realtime tick
+  └→ KoreaInvestWebSocketAPI.on_realtime_message_callback
+      └→ PriceStreamService.on_price_tick()
+          ├→ snapshot 캐시 갱신 (기존)
+          ├→ DataQualityService.validate_price_tick() (기존)
+          └→ [신규] EventDispatcher.publish(PriceTickEvent)
+                    │
+                    ▼
+          ┌─────────────────────────────────┐
+          │ StrategyEventRouter             │
+          │   subscribers: {code → [cfg]}   │  ← SubscriptionPolicy와 동일 카테고리 키 재사용
+          │   debounce/throttle per (code,  │     ("strategy_oneil" 등)
+          │      strategy)                  │
+          └────────────┬────────────────────┘
+                       │ 매칭된 전략만
+                       ▼
+          ┌──────────────────────────────┐
+          │ Strategy.evaluate_single(    │  ← 단일 종목 평가 (신규 contract)
+          │   code, snapshot, ctx)       │     기존 execute()는 폴링용으로 유지
+          └────────────┬─────────────────┘
+                       │ TradeSignal
+                       ▼
+          (기존 경로 그대로) RiskGate → OrderExecution → KillSwitch hook
+```
+
+**핵심 원칙**
+1. **이벤트는 트리거일 뿐, 평가 로직은 공유**. `Strategy.evaluate_single(code, snapshot)`은 `Strategy.execute([code])`의 단일 종목 fast-path; 동일한 필터(`_apply_liquidity_filter`, `_apply_stage_guard`)를 호출.
+2. **이중 실행 차단**. `evaluate_single` 결과로 신호가 났더라도 같은 `(strategy, code)`가 그 분 내 폴링 경로에서 다시 평가되면 cooldown으로 차단 (`_last_evaluated[(strategy, code)]`).
+3. **이벤트가 끊겨도 폴링이 안전망**. 30초 이상 tick 없으면 폴링 루프가 평가하여 시그널을 놓치지 않음.
+
+## 4. 컴포넌트별 변경
+
+### 4-1. 신규: `services/strategy_event_router.py`
+
+```python
+class StrategyEventRouter:
+    def __init__(self, logger, market_clock, throttle_sec: float = 0.5):
+        self._subscribers: dict[str, list[StrategyConfig]] = {}  # code → strategies
+        self._last_dispatched: dict[tuple[str, str], float] = {}  # (strategy, code) → ts
+
+    def subscribe(self, code: str, cfg: StrategySchedulerConfig) -> None: ...
+    def unsubscribe(self, code: str, strategy_name: str) -> None: ...
+    async def on_price_tick(self, code: str, snapshot: dict) -> None:
+        # throttle, market_open 체크, kill switch 체크 후
+        # 매칭된 전략의 evaluate_single을 asyncio.create_task로 디스패치
+```
+
+- `PriceStreamService.on_price_tick()` 마지막에 `event_router.on_price_tick(stock_code, snapshot)` 호출 추가.
+- `StrategyScheduler`가 register 시점에 후보 종목을 `event_router.subscribe()`로 등록.
+
+### 4-2. 신규 contract: `LiveStrategy.evaluate_single(code, snapshot, ctx) -> Optional[TradeSignal]`
+
+- 기본 구현(`LiveStrategy`)은 `await self.execute([code])`를 호출하고 결과에서 해당 코드 신호만 추출 — 점진 마이그레이션 안전망.
+- 우선순위 전략부터 오버라이드하여 snapshot 활용 fast-path 구현 (4-4 참고).
+
+### 4-3. `StrategyScheduler` 변경
+
+- `__init__`에 `event_router: Optional[StrategyEventRouter] = None` 추가.
+- `register(cfg)`에서 `cfg.event_driven: bool = False` 플래그 확인 후 router에 등록.
+- `_run_strategy(cfg)` 내부 watchlist sync 시점에 router 구독 codes 갱신.
+- `_execute_signal_inner`는 호출 경로(polling/event) 표시를 metadata에 기록하여 로그 추적성 확보.
+
+### 4-4. 단계적 적용 우선순위
+
+| 단계 | 전략 | 이유 | 검증 |
+|---|---|---|---|
+| 0 | (해당 없음) | Router/이벤트 인프라만 도입 | event flow unit test |
+| 1 | `LarryWilliamsVBOStrategy` | 단순 가격 돌파 → snapshot만으로 평가 가능 | live shadow mode 1주 |
+| 2 | `OneilSqueezeBreakoutStrategy` | 가격 + 거래량 (snapshot에 누적량 존재) | live shadow mode 1주 |
+| 3 | `HighTightFlagStrategy` | 가격 + 거래량 + 깃대 패턴 | OHLCV 별도 조회 필요 — fast-path 보류 후 재평가 |
+| 4 | 기타 전략 | 적용 효익 재평가 | — |
+
+**0단계 우선 착수 권고**. 1단계 이후는 결과 보고 후 결정.
+
+### 4-5. 변경 없음
+
+- `RiskGateService`, `KillSwitchService`, `OrderExecutionService`, `PositionSizingService`, `SubscriptionPolicy`: 동일 contract.
+- 백테스트 경로 전체.
+- 비활성 전략군.
+
+## 5. 이벤트 흐름 (전체)
+
+```
+체결 이벤트 (KIS H0STCNT0)
+  ↓
+KoreaInvestWebSocketAPI._handle_message
+  ↓ on_realtime_message_callback
+PriceStreamService.on_price_tick
+  ├ DataQualityService.validate_price_tick (기존)
+  ├ _latest_prices / market_snapshot 캐시 갱신 (기존)
+  ├ SSE queue publish (기존)
+  └ [신규] StrategyEventRouter.on_price_tick
+       ├ throttle check ((strategy, code) → last_dispatched)
+       ├ market_open / kill_switch 게이트
+       └ for cfg in subscribers[code]:
+            asyncio.create_task(_evaluate_one(cfg, code, snapshot))
+                ↓
+            cfg.strategy.evaluate_single(code, snapshot, ctx)
+                ↓ TradeSignal (or None)
+            StrategyScheduler._execute_signal
+                ↓
+            RiskGateService.validate_order  (기존)
+                ↓
+            OrderExecutionService.submit_buy_order  (기존)
+                ↓ 체결 콜백
+            KillSwitchService.record_strategy_trade_result  (기존)
+            VirtualTradeRepository.log_buy  (기존)
+```
+
+## 6. 검증 전략
+
+### 6-1. 단위 테스트
+
+- `tests/unit_test/services/test_strategy_event_router.py` 신규
+  - subscribe/unsubscribe ref-count
+  - throttle (`(strategy, code)` 0.5초 내 중복 차단)
+  - market_open=False 시 dispatch 없음
+  - kill_switch trip 시 dispatch 없음 (force_exit 제외)
+  - `evaluate_single`이 None 반환 시 신호 미발생
+
+### 6-2. 통합 테스트
+
+- `tests/integration_test/test_it_event_driven_flow.py` 신규
+  - WebSocket mock → PriceStreamService → Router → 전략 1개 → RiskGate stub → 신호 기록까지 end-to-end
+  - 이중 실행 차단: 같은 (strategy, code)가 router/scheduler 양쪽에서 트리거되어도 1회만 신호
+
+### 6-3. Shadow mode
+
+- 첫 적용 전략(`LarryWilliamsVBOStrategy`)은 1주간 **신호만 로깅, 주문 미발생** 모드로 운영.
+- 폴링 경로 신호와 event 경로 신호를 같은 journal에 `signal_source=polling|event` 태그로 저장.
+- 결과 비교: 동일 신호 발생 여부, 시간 차이, missed signal 여부.
+
+## 7. 리스크와 완화
+
+| 리스크 | 완화 |
+|---|---|
+| 이벤트 폭주로 평가 thread 포화 | `StrategyEventRouter` throttle + `asyncio.Semaphore` 동시성 상한 |
+| WebSocket 끊김 시 시그널 누락 | 폴링 루프 안전망 유지 (event 경로는 *추가*, *대체* 아님) |
+| Event/Polling 중복 신호 | `(strategy, code) → last_evaluated_ts` cooldown으로 분 단위 dedup |
+| Snapshot stale 사용 | `PriceStreamService.get_subscription_age()`로 N초 이상 stale 시 router dispatch 차단 |
+| 신호 폭증으로 RiskGate 부담 | RiskGate는 이미 token bucket; 추가 변경 불필요 |
+
+## 8. 작업 분해 (Migration Tasks)
+
+이 plan 자체가 2-4 첫 번째 체크박스를 충족. 후속 구현은 별도 PR.
+
+1. **PR-1: Event router 인프라 도입**
+   - `services/strategy_event_router.py` 신규
+   - `PriceStreamService.on_price_tick()`에 router hook 추가 (router=None 시 no-op)
+   - `LiveStrategy.evaluate_single()` 기본 구현 (execute 위임)
+   - 단위 테스트
+   - **PoC 전략 미연결**. 인프라만.
+
+2. **PR-2: VBO shadow mode**
+   - `LarryWilliamsVBOStrategy.evaluate_single()` 오버라이드
+   - `StrategySchedulerConfig.event_driven_shadow: bool` 플래그
+   - shadow signal을 별도 journal에 기록 (`signal_source=event_shadow`)
+   - 1주 운영 후 결과 분석
+
+3. **PR-3: VBO 실 적용 / OSB shadow**
+   - PR-2 결과 양호하면 VBO `event_driven=True`로 승격
+   - OSB는 shadow로 진입
+
+4. **PR-4 이후**: 단계적 확장 (4-4 표 참고)
+
+## 9. 결정이 필요한 사항
+
+구현 PR 진입 전 사용자 확인 필요:
+
+- **(Q1) 이벤트 throttle 기본값**: 같은 `(strategy, code)` 최소 간격. 기본 `0.5초` 제안 — 너무 짧으면 평가 폭주, 너무 길면 반응성 손실.
+- **(Q2) Stale snapshot 임계**: 마지막 tick으로부터 몇 초까지 dispatch 허용? `5초` 제안.
+- **(Q3) Shadow mode 운영 기간**: VBO 1주 제안 — 거래일 부족 시 연장 여부.
+- **(Q4) signal_source 컬럼**: `VirtualTradeRepository`에 `signal_source TEXT` 컬럼 추가 (schema migration 필요). 또는 기존 `metadata` JSON에 포함만 할지.

--- a/tests/unit_test/view/web/bootstrap/test_runtime_mode.py
+++ b/tests/unit_test/view/web/bootstrap/test_runtime_mode.py
@@ -1,0 +1,71 @@
+"""RuntimeMode 단위 테스트.
+
+- 환경변수 미설정 / 빈 문자열 → ALL
+- 단일/조합 토큰 파싱
+- 알 수 없는 토큰 → ALL fallback + WARN 로그
+- `mode & RuntimeMode.X` 진리값 sanity
+"""
+import logging
+
+import pytest
+
+from view.web.bootstrap.runtime_mode import RuntimeMode
+
+
+def test_from_env_defaults_to_all_when_missing():
+    assert RuntimeMode.from_env(env={}) is RuntimeMode.ALL
+
+
+def test_from_env_defaults_to_all_when_blank():
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": ""}) is RuntimeMode.ALL
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "   "}) is RuntimeMode.ALL
+
+
+def test_from_env_parses_single_token():
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "WEB"}) is RuntimeMode.WEB
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "TRADING"}) is RuntimeMode.TRADING
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "BATCH"}) is RuntimeMode.BATCH
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "ALL"}) is RuntimeMode.ALL
+
+
+def test_from_env_parses_pipe_combination():
+    mode = RuntimeMode.from_env(env={"RUNTIME_MODE": "WEB|BATCH"})
+    assert mode & RuntimeMode.WEB
+    assert mode & RuntimeMode.BATCH
+    assert not (mode & RuntimeMode.TRADING)
+
+
+def test_from_env_parses_comma_combination():
+    mode = RuntimeMode.from_env(env={"RUNTIME_MODE": "WEB,TRADING"})
+    assert mode & RuntimeMode.WEB
+    assert mode & RuntimeMode.TRADING
+    assert not (mode & RuntimeMode.BATCH)
+
+
+def test_from_env_case_insensitive():
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "web"}) is RuntimeMode.WEB
+    assert RuntimeMode.from_env(env={"RUNTIME_MODE": "Web|Batch"}) == (
+        RuntimeMode.WEB | RuntimeMode.BATCH
+    )
+
+
+def test_from_env_unknown_token_falls_back_to_all(caplog):
+    with caplog.at_level(logging.WARNING, logger="view.web.bootstrap.runtime_mode"):
+        result = RuntimeMode.from_env(env={"RUNTIME_MODE": "WEB|FOOBAR"})
+    assert result is RuntimeMode.ALL
+    assert any("unknown token" in r.message and "FOOBAR" in r.message for r in caplog.records)
+
+
+def test_bitwise_truthiness_sanity():
+    """`mode & RuntimeMode.X` 진리값이 의도대로 동작한다."""
+    assert RuntimeMode.ALL & RuntimeMode.WEB
+    assert RuntimeMode.ALL & RuntimeMode.TRADING
+    assert RuntimeMode.ALL & RuntimeMode.BATCH
+    assert not (RuntimeMode.BATCH & RuntimeMode.WEB)
+    assert not (RuntimeMode.WEB & RuntimeMode.BATCH)
+    assert (RuntimeMode.WEB | RuntimeMode.TRADING) & RuntimeMode.TRADING
+    assert not ((RuntimeMode.WEB | RuntimeMode.TRADING) & RuntimeMode.BATCH)
+
+
+def test_all_equals_or_of_components():
+    assert RuntimeMode.ALL == (RuntimeMode.WEB | RuntimeMode.TRADING | RuntimeMode.BATCH)

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -3,12 +3,18 @@
 `WebAppContext._bootstrap_schedulers()` 본문에서 추출된 SchedulerBootstrap이
 TimeDispatcher 태스크 등록, BackgroundScheduler / ForegroundScheduler 생성을
 정상 수행하는지 검증한다.
+
+또한 `WebAppContext.runtime_mode` 별로 task 등록이 그룹 단위로 분기되는지
+검증한다. StrategySchedulerTaskAdapter 는 StrategyFactory 책임이라 여기서
+다루지 않는다 (총 14개 = SchedulerBootstrap 등록 분, 15번째 adapter 는 별도).
 """
 import contextlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from view.web.bootstrap.runtime_mode import RuntimeMode
 
 
 @pytest.fixture
@@ -27,8 +33,9 @@ def patched_scheduler_deps():
         yield mocks
 
 
-def _make_fake_context():
+def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
     ctx = SimpleNamespace()
+    ctx.runtime_mode = runtime_mode
     ctx.logger = MagicMock()
     ctx.pm = None
     ctx.worker_pool = MagicMock()
@@ -50,50 +57,123 @@ def _make_fake_context():
     return ctx
 
 
-def test_scheduler_bootstrap_creates_background_and_foreground(patched_scheduler_deps):
+def _run(ctx):
     from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
-
-    ctx = _make_fake_context()
-    with patch("view.web.bootstrap.scheduler_bootstrap.asyncio.create_task"):
+    with patch("view.web.bootstrap.scheduler_bootstrap.asyncio.create_task") as create_task:
         SchedulerBootstrap(ctx).run()
+    return create_task
 
+
+# ---------- 인프라 생성 (mode 무관) ----------
+
+def test_creates_background_and_foreground_in_all_mode(patched_scheduler_deps):
+    ctx = _make_fake_context()
+    _run(ctx)
     assert ctx.background_scheduler is patched_scheduler_deps["BackgroundScheduler"].return_value
     assert ctx.foreground_scheduler is patched_scheduler_deps["ForegroundScheduler"].return_value
 
 
-def test_scheduler_bootstrap_registers_time_dispatcher_tasks(patched_scheduler_deps):
-    """TimeDispatcher.register_task 가 활성 태스크 수만큼 호출된다."""
-    from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
-
-    ctx = _make_fake_context()
-    with patch("view.web.bootstrap.scheduler_bootstrap.asyncio.create_task"):
-        SchedulerBootstrap(ctx).run()
-
-    # 10개 태스크가 TimeDispatcher 에 등록된다 (`_bootstrap_schedulers` 의 첫번째 리스트).
-    assert ctx.time_dispatcher.register_task.call_count == 10
+def test_creates_foreground_even_in_web_only_mode(patched_scheduler_deps):
+    """WEB 단독에서도 ForegroundScheduler 가 생성되어야 한다 (rate-limit middleware 의존)."""
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    _run(ctx)
+    assert ctx.foreground_scheduler is patched_scheduler_deps["ForegroundScheduler"].return_value
 
 
-def test_scheduler_bootstrap_registers_background_scheduler_tasks(patched_scheduler_deps):
-    """BackgroundScheduler.register 가 14개 태스크에 대해 호출된다."""
-    from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
+def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.BATCH)
+    _run(ctx)
+    assert ctx.foreground_scheduler is patched_scheduler_deps["ForegroundScheduler"].return_value
 
-    ctx = _make_fake_context()
-    with patch("view.web.bootstrap.scheduler_bootstrap.asyncio.create_task"):
-        SchedulerBootstrap(ctx).run()
 
+# ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
+
+def test_all_mode_registers_14_tasks_to_background(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.ALL)
+    _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
     assert bg.register.call_count == 14
 
 
-def test_scheduler_bootstrap_skips_none_tasks(patched_scheduler_deps):
-    """opening_position_reconcile_task 가 None 이면 등록되지 않는다."""
-    from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
+def test_all_mode_registers_10_tasks_to_time_dispatcher(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.ALL)
+    _run(ctx)
+    assert ctx.time_dispatcher.register_task.call_count == 10
 
+
+# ---------- mode 별 task 등록 ----------
+
+def _registered_bg_task_names(patched_scheduler_deps) -> set:
+    bg = patched_scheduler_deps["BackgroundScheduler"].return_value
+    return {call.args[0].task_name for call in bg.register.call_args_list}
+
+
+def test_web_only_registers_notification_and_watchdog(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert names == {"notification_queue_task", "websocket_watchdog_task"}
+
+
+def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.TRADING)
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert names == {
+        "pre_market_health_check_task",
+        "opening_position_reconcile_task",
+        "cache_warmup_task",
+        "websocket_watchdog_task",
+    }
+
+
+def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.BATCH)
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    expected = {
+        "ranking_task", "minervini_update_task", "daily_price_collector_task",
+        "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
+        "log_cleanup_task", "strategy_log_report_task", "after_market_reconcile_task",
+    }
+    assert names == expected
+    assert "websocket_watchdog_task" not in names
+
+
+def test_web_and_trading_registers_watchdog_exactly_once(patched_scheduler_deps):
+    """websocket_watchdog 가 WEB|TRADING 양쪽 mode 에서 중복 등록되지 않는다."""
+    ctx = _make_fake_context(RuntimeMode.WEB | RuntimeMode.TRADING)
+    _run(ctx)
+    bg = patched_scheduler_deps["BackgroundScheduler"].return_value
+    watchdog_calls = [
+        c for c in bg.register.call_args_list if c.args[0].task_name == "websocket_watchdog_task"
+    ]
+    assert len(watchdog_calls) == 1
+
+
+# ---------- _initialize_price_subscriptions gating ----------
+
+def test_price_subscriptions_called_in_web_or_trading(patched_scheduler_deps):
+    for mode in [RuntimeMode.WEB, RuntimeMode.TRADING, RuntimeMode.WEB | RuntimeMode.TRADING, RuntimeMode.ALL]:
+        ctx = _make_fake_context(mode)
+        create_task = _run(ctx)
+        assert create_task.call_count == 1, f"mode={mode}"
+
+
+def test_price_subscriptions_skipped_in_batch_only(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.BATCH)
+    create_task = _run(ctx)
+    assert create_task.call_count == 0
+
+
+# ---------- None task skip ----------
+
+def test_skips_none_tasks(patched_scheduler_deps):
     ctx = _make_fake_context()
     ctx.opening_position_reconcile_task = None
-    with patch("view.web.bootstrap.scheduler_bootstrap.asyncio.create_task"):
-        SchedulerBootstrap(ctx).run()
-
+    _run(ctx)
+    # opening_position_reconcile_task 는 TRADING 그룹 + TimeDispatcher 등록 대상이었으므로
+    # 둘 다 -1 감소한다.
     assert ctx.time_dispatcher.register_task.call_count == 9
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
     assert bg.register.call_count == 13

--- a/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
+++ b/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from view.web.bootstrap.runtime_mode import RuntimeMode
+
 
 STRATEGY_CLASS_NAMES = [
     "OneilSqueezeBreakoutStrategy",
@@ -38,8 +40,9 @@ def patched_factory_deps():
         yield mocks
 
 
-def _make_fake_context():
+def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
     ctx = SimpleNamespace()
+    ctx.runtime_mode = runtime_mode
     ctx.logger = MagicMock()
     ctx.pm = None
     ctx.virtual_trade_service = MagicMock()
@@ -111,3 +114,43 @@ def test_strategy_factory_skips_adapter_when_background_scheduler_missing(patche
     StrategyFactory(ctx).build()
 
     patched_factory_deps["StrategySchedulerTaskAdapter"].assert_not_called()
+
+
+# ---------- runtime_mode TRADING gating ----------
+
+def test_strategy_factory_noop_when_trading_disabled_batch_only(patched_factory_deps):
+    """mode=BATCH (TRADING 비포함) 이면 StrategyScheduler / 전략 / adapter 모두 미생성."""
+    from view.web.bootstrap.strategy_factory import StrategyFactory
+
+    ctx = _make_fake_context(RuntimeMode.BATCH)
+    StrategyFactory(ctx).build()
+
+    patched_factory_deps["StrategyScheduler"].assert_not_called()
+    patched_factory_deps["StrategySchedulerTaskAdapter"].assert_not_called()
+    assert not hasattr(ctx, "scheduler") or ctx.scheduler is None or isinstance(ctx.scheduler, MagicMock) is False
+    ctx.background_scheduler.register.assert_not_called()
+
+
+def test_strategy_factory_noop_when_trading_disabled_web_only(patched_factory_deps):
+    """mode=WEB (TRADING 비포함) 이면 StrategyScheduler / 전략 / adapter 모두 미생성."""
+    from view.web.bootstrap.strategy_factory import StrategyFactory
+
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    StrategyFactory(ctx).build()
+
+    patched_factory_deps["StrategyScheduler"].assert_not_called()
+    patched_factory_deps["StrategySchedulerTaskAdapter"].assert_not_called()
+    for cls_name in STRATEGY_CLASS_NAMES:
+        patched_factory_deps[cls_name].assert_not_called()
+
+
+def test_strategy_factory_builds_when_trading_enabled_via_combination(patched_factory_deps):
+    """mode=WEB|TRADING 이면 StrategyScheduler + 전략 + adapter 모두 생성."""
+    from view.web.bootstrap.strategy_factory import StrategyFactory
+
+    ctx = _make_fake_context(RuntimeMode.WEB | RuntimeMode.TRADING)
+    StrategyFactory(ctx).build()
+
+    assert ctx.scheduler is patched_factory_deps["StrategyScheduler"].return_value
+    assert ctx.scheduler.register.call_count == 7
+    patched_factory_deps["StrategySchedulerTaskAdapter"].assert_called_once()

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -58,12 +58,45 @@ def test_initialization(mock_deps):
     """WebAppContext 객체 생성 시 초기 상태 검증"""
     # Arrange
     mock_app_ctx = MagicMock()
-    
+
     # Act
     ctx = WebAppContext(mock_app_ctx)
-    
+
     # Assert
     assert ctx.initialized is False
+
+
+def test_runtime_mode_defaults_to_all(mock_deps):
+    """runtime_mode 미지정 시 default = ALL (현행 동작 회귀 방지)."""
+    from view.web.bootstrap.runtime_mode import RuntimeMode
+
+    ctx = WebAppContext(None)
+    assert ctx.runtime_mode is RuntimeMode.ALL
+
+
+def test_runtime_mode_injection(mock_deps):
+    """runtime_mode 주입 시 ctx 에 보존된다."""
+    from view.web.bootstrap.runtime_mode import RuntimeMode
+
+    ctx = WebAppContext(None, runtime_mode=RuntimeMode.WEB)
+    assert ctx.runtime_mode is RuntimeMode.WEB
+
+    ctx2 = WebAppContext(None, runtime_mode=RuntimeMode.WEB | RuntimeMode.TRADING)
+    assert ctx2.runtime_mode == (RuntimeMode.WEB | RuntimeMode.TRADING)
+
+
+def test_initialize_scheduler_noop_when_trading_disabled(mock_deps):
+    """runtime_mode=WEB 일 때 initialize_scheduler() 가 StrategyScheduler 를 생성하지 않는다."""
+    from view.web.bootstrap.runtime_mode import RuntimeMode
+
+    ctx = WebAppContext(None, runtime_mode=RuntimeMode.WEB)
+    ctx.background_scheduler = MagicMock()
+    ctx.initialize_scheduler()
+
+    # StrategyScheduler 는 호출되지 않아야 한다.
+    mock_deps["sched"].assert_not_called()
+    assert ctx.scheduler is None
+
 
 def test_load_config_and_env(mock_deps):
     """설정 로드 및 환경 객체 초기화 검증"""

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-15 (P1 1-4 변동성 컬럼 리포트 1차 도입)
+최종 업데이트: 2026-05-17 (P3 3-2 1차 PR 완료 — RuntimeMode 도입 + scheduler/task 등록 경계 분리)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -132,11 +132,14 @@
 - [x] 코스피/코스닥 지수 기반 전략 ON/OFF 조건을 추가한다.
   - 기존 5개 전략(FirstPullback, HighTightFlag, OneilPocketPivot, OneilSqueezeBreakout, RSI2Pullback)이 이미 `is_market_timing_ok` 게이트 사용 — `MarketRegimeService` 위임으로 자동 반영.
   - 누락된 LarryWilliamsVBO, LarryWilliamsCB에 동일 hard gate 추가 (`_position_state` 변경 전 위치, `reason=market_timing_off` 로깅).
-- [~] 변동성 기반 진입 제한을 검토한다.
+- [x] 변동성 기반 진입 제한을 검토한다.
   - 1차 PR에서는 hard gate 미도입 — 리포트 컬럼으로 먼저 검증 후 도입 결정. 후속 PR에서 `RiskGateConfig.max_volatility_pct` 추가 검토.
   - 완료된 부분: 20일 종가 수익률 표준편차(annualized) 유틸 `utils/volatility_utils.py` 추가, `STANDARD_TRADE_JOURNAL_FIELDS`에 `volatility_20d_annualized` 필드 + `SCHEMA_VERSION = 3` 승격, `normalize_virtual_trade`/`normalize_backtest_trade`/`normalize_backtest_decision`/`normalize_backtest_execution` 4개 모두 Optional 인자 + record/metadata fallback 지원. `compute_performance_by_regime`가 버킷별 `volatility_sample_count`, `avg_volatility_20d_annualized`, `median_volatility_20d_annualized`를 산출해 `GET /api/strategies/performance-by-regime` JSON에 자동 노출.
   - 완료된 부분: `TradeSignal.volatility_20d_annualized` Optional 필드 추가. `BacktestPeriodRunner._rejected_signal_record` / `_execution_record` 양쪽이 signal의 변동성을 journal record로 전파(BUY 체결, SELL 정산, risk gate 차단, position sizing skip 4개 경로 단위 테스트 검증).
-  - 남은 작업: 각 전략(`OneilSqueezeBreakoutStrategy` 등)에서 `utils.volatility_utils.annualized_return_std`로 OHLCV → 변동성을 계산해 `TradeSignal.volatility_20d_annualized`에 채우는 hook. live 경로(`VirtualTradeRepository`)의 변동성 컬럼 도입. HTML 일일 리포트(`strategy_log_report_service`)에 변동성 섹션 추가 검토.
+  - 완료된 부분: 활성 7개 전략(`FirstPullbackStrategy`, `HighTightFlagStrategy`, `LarryWilliamsChannelBreakoutStrategy`, `LarryWilliamsVBOStrategy`, `OneilPocketPivotStrategy`, `OneilSqueezeBreakoutStrategy`, `Rsi2PullbackStrategy`)이 `utils.volatility_utils.annualized_return_std`로 OHLCV → 변동성을 계산해 `TradeSignal.volatility_20d_annualized`에 채운다. 비활성 3개 전략(`ProgramBuyFollow`, `TraditionalVolumeBreakout`, `VolumeBreakoutLive`)에도 동일 hook 적용.
+  - 완료된 부분: `VirtualTradeRepository`에 `volatility_20d_annualized REAL` 컬럼 + ALTER TABLE migration, `log_buy()` 인자 추가, INSERT/SELECT 매핑 완료 (`test_virtual_trade_repository_volatility.py` 검증).
+  - 완료된 부분: `strategy_log_report_service._build_volatility_section()` 추가, HTML 일일 리포트 body에 변동성 섹션 통합 (`test_strategy_log_report_volatility.py` 검증).
+  - 후속 검토(P1 별도 항목): 리포트 누적 후 hard gate(`RiskGateConfig.max_volatility_pct`) 도입 여부 결정.
 - [x] 장 초반/후반 타임 필터를 전략 실행 전에 적용한다.
   - `StrategySchedulerConfig.skip_minutes_after_open` / `skip_minutes_before_close` 필드 추가.
   - `_is_scan_time_window_blocked()` 가 `cfg.strategy.scan()` 만 skip (force_exit/check_exits 영향 없음).
@@ -165,9 +168,10 @@
 - [x] walk-forward 검증을 추가한다. 기간을 train/tune/test로 나누고, 파라미터 튜닝 구간과 검증 구간을 분리한다.
 - [x] 몬테카를로 시뮬레이션을 추가한다. trade 결과 순서를 섞어 최악 MDD, 연속 손실, ruin probability를 계산한다.
 - [x] 활성 전략별 fixture parity를 period runner와 strategy debug runner 양쪽에서 검증한다.
-- [~] 실제 replay fixture를 통과 케이스까지 확장한다.
-  - 남은 작업: 장중 후보 종목의 프로그램매매 WebSocket 샘플을 확보하고, `scripts.capture_backtest_microstructure` 결과를 replay fixture overlay로 결합한다.
-  - 선택 작업: 필요 시 `20260506`, `20260511`, `20260504`, `20260416` 표본 fixture를 추가 생성한다.
+- [blocked] 실제 replay fixture를 통과 케이스까지 확장한다. (장중 프로그램매매 WebSocket 샘플 미확보)
+  - 차단 사유: 장중 후보 종목의 프로그램매매 WebSocket 샘플을 실시간으로 캡처해야 하며, 장 마감 후에는 재생성 불가.
+  - 차단 해제 조건: 장중에 `scripts.capture_backtest_microstructure`로 후보 종목 WebSocket 샘플 확보 → replay fixture overlay로 결합.
+  - 선택 작업(차단 해제 후): 필요 시 `20260506`, `20260511`, `20260504`, `20260416` 표본 fixture를 추가 생성한다.
 
 주요 파일:
 
@@ -297,10 +301,19 @@
 
 ### 3-2. 웹 / 운영 / 전략 runtime 경계 분리
 
-- [ ] 웹 화면/API, 장중 전략/주문 실행, 장마감 데이터 수집/리포트, 수동 운영 점검 runtime 경계를 명확히 한다.
-- [ ] 웹 서버 초기화가 모든 after-market task와 장중 scheduler를 직접 끌어안지 않도록 분리한다.
+- [~] 웹 화면/API, 장중 전략/주문 실행, 장마감 데이터 수집/리포트, 수동 운영 점검 runtime 경계를 명확히 한다.
+  - 1차 완료: `view/web/bootstrap/runtime_mode.py` 의 `RuntimeMode` enum (WEB / TRADING / BATCH / ALL) 로 15 개 task (`SchedulerBootstrap` 등록 14 + `StrategyFactory` 등록 1) 의 runtime 소유권 명시.
+  - 1차 완료: `SchedulerBootstrap.run()` 을 `_register_web_tasks`/`_register_trading_tasks`/`_register_batch_tasks`/`_register_websocket_watchdog` 4 개 그룹 메서드로 분리. websocket_watchdog 은 WEB | TRADING 양쪽 mode 에서 1 회만 등록.
+  - 1차 완료: `StrategyFactory.build()` 가 TRADING 비활성 시 즉시 return (StrategyScheduler / 7 개 전략 / Adapter 모두 미생성).
+  - 후속: `ServiceContainer` 의 service 객체 생성 단계 분할 (현재 모든 service 와 task 객체는 mode 와 무관하게 항상 생성됨), 별도 진입점 (`web_app.py` / `trading_runtime.py` / `batch_runtime.py` / `admin_runtime.py`) 파일, admin runtime 정의.
+- [~] 웹 서버 초기화가 모든 after-market task와 장중 scheduler를 직접 끌어안지 않도록 분리한다.
+  - 1차 완료: `web_main.py` lifespan 이 `RUNTIME_MODE` env (default `ALL` = 현행 동작 100% 유지) 를 읽어 `WebAppContext(runtime_mode=...)` 로 주입. mode 별로 task 등록과 StrategyScheduler 생성을 분기.
+  - 1차 완료: `BackgroundScheduler` / `ForegroundScheduler` 객체 생성은 mode 와 무관하게 항상 수행 (foreground middleware 가 rate-limit 경합 제어에 의존).
+  - 1차 완료: 가격 구독 초기화 (`_initialize_price_subscriptions`) 는 WEB | TRADING 에서만 호출. BATCH 단독에서는 생략.
+  - 안전성 정책: `restore_state_from_broker` / `reconcile_orders_with_broker` 는 WEB | TRADING 어느 한쪽이라도 켜져 있으면 항상 호출 (`/api/order` 가 WEB 에서 살아 있는 한 stale 주문 상태 위험 차단). "WEB_ONLY = read-only" 정책 확정 시에만 TRADING 단독 gate 로 좁힐 수 있음.
+  - 후속: 별도 프로세스 배포, cross-runtime IPC, event bus.
 
-분리 후보:
+분리 후보 (후속 PR):
 
 - `web_app.py` — 화면/API
 - `trading_runtime.py` — 장중 전략/주문 실행

--- a/view/web/bootstrap/runtime_mode.py
+++ b/view/web/bootstrap/runtime_mode.py
@@ -1,0 +1,47 @@
+"""RuntimeMode — `WebAppContext` 의 task/scheduler 등록 경계를 분기하는 enum.
+
+- WEB     : 화면/API, NotificationQueueTask, WebSocket watchdog (TRADING 과 공유)
+- TRADING : StrategyScheduler + 활성 전략, intraday tasks
+- BATCH   : after-market task 그룹
+- ALL     : 위 3 개 모두 (default. 현행 동작)
+
+판정 패턴: `mode & RuntimeMode.X` 의 비트 truthiness 를 사용한다.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from enum import Flag, auto
+
+_ENV_VAR_NAME = "RUNTIME_MODE"
+_logger = logging.getLogger(__name__)
+
+
+class RuntimeMode(Flag):
+    WEB = auto()
+    TRADING = auto()
+    BATCH = auto()
+    ALL = WEB | TRADING | BATCH
+
+    @classmethod
+    def from_env(cls, env: dict | None = None) -> "RuntimeMode":
+        source = env if env is not None else os.environ
+        raw = source.get(_ENV_VAR_NAME, "").strip()
+        if not raw:
+            return cls.ALL
+
+        tokens = [t.strip().upper() for t in raw.replace(",", "|").split("|") if t.strip()]
+        if not tokens:
+            return cls.ALL
+
+        result: RuntimeMode | None = None
+        for token in tokens:
+            member = cls.__members__.get(token)
+            if member is None:
+                _logger.warning(
+                    "[RuntimeMode] unknown token %r in %s=%r; falling back to ALL.",
+                    token, _ENV_VAR_NAME, raw,
+                )
+                return cls.ALL
+            result = member if result is None else result | member
+        return result if result is not None else cls.ALL

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -3,6 +3,10 @@
 TimeDispatcher 태스크 등록, BackgroundScheduler / ForegroundScheduler 생성과
 초기 가격 구독 부트스트랩까지의 범위만 책임진다. StrategyScheduler 생성은
 `StrategyFactory` 가 담당한다.
+
+`WebAppContext.runtime_mode` 에 따라 task 등록을 그룹별로 분기한다.
+BackgroundScheduler / ForegroundScheduler 생성 자체는 mode 와 무관하게 항상 수행한다
+(foreground middleware 가 WEB API rate-limit 경합 제어에 의존).
 """
 from __future__ import annotations
 
@@ -13,6 +17,7 @@ from config.task_config_loader import load_after_market_delays
 from interfaces.schedulable_task import TaskPriority
 from scheduler.background_scheduler import BackgroundScheduler
 from scheduler.foreground_scheduler import ForegroundScheduler
+from view.web.bootstrap.runtime_mode import RuntimeMode
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -23,59 +28,85 @@ class SchedulerBootstrap:
 
     def __init__(self, context: "WebAppContext") -> None:
         self._ctx = context
+        self._delays: dict[str, int] = {}
 
     def run(self) -> None:
         ctx = self._ctx
+        mode = ctx.runtime_mode
         try:
-            _delays = load_after_market_delays()
-            for task, priority in [
-                (ctx.ranking_task,                     TaskPriority.LOW),
-                (ctx.minervini_update_task,             TaskPriority.LOW),
-                (ctx.daily_price_collector_task,        TaskPriority.LOW),
-                (ctx.ohlcv_update_task,                 TaskPriority.LOW),
-                (ctx.premium_watchlist_generator_task,  TaskPriority.LOW),
-                (ctx.newhigh_task,                      TaskPriority.LOW),
-                (ctx.log_cleanup_task,                  TaskPriority.MAINTENANCE),
-                (ctx.strategy_log_report_task,          TaskPriority.LOW),
-                (ctx.opening_position_reconcile_task,   TaskPriority.HIGH),
-                (ctx.after_market_reconcile_task,       TaskPriority.LOW),
-            ]:
-                if task:
-                    ctx.time_dispatcher.register_task(
-                        task.task_name, priority, delay_sec=_delays.get(task.task_name, 0)
-                    )
+            self._delays = load_after_market_delays()
 
-            ctx.background_scheduler = BackgroundScheduler(
-                logger=ctx.logger,
-                performance_profiler=ctx.pm,
-                worker_pool=ctx.worker_pool,
-                time_dispatcher=ctx.time_dispatcher,
-            )
-            for task in [
-                ctx.ranking_task,
-                ctx.minervini_update_task,
-                ctx.websocket_watchdog_task,
-                ctx.pre_market_health_check_task,
-                ctx.daily_price_collector_task,
-                ctx.ohlcv_update_task,
-                ctx.premium_watchlist_generator_task,
-                ctx.cache_warmup_task,
-                ctx.log_cleanup_task,
-                ctx.newhigh_task,
-                ctx.notification_queue_task,
-                ctx.strategy_log_report_task,
-                ctx.opening_position_reconcile_task,
-                ctx.after_market_reconcile_task,
-            ]:
-                if task:
-                    ctx.background_scheduler.register(task)
+            self._create_background_scheduler()
 
-            ctx.foreground_scheduler = ForegroundScheduler(
-                background_scheduler=ctx.background_scheduler,
-                logger=ctx.logger,
-                performance_profiler=ctx.pm,
-            )
-            asyncio.create_task(ctx._initialize_price_subscriptions())
+            if mode & RuntimeMode.WEB:
+                self._register_web_tasks()
+            if mode & RuntimeMode.TRADING:
+                self._register_trading_tasks()
+            if mode & RuntimeMode.BATCH:
+                self._register_batch_tasks()
+            # websocket_watchdog: WEB | TRADING 어느 한쪽이라도 켜져 있으면 한 번만 등록.
+            if mode & (RuntimeMode.WEB | RuntimeMode.TRADING):
+                self._register_websocket_watchdog()
+
+            self._create_foreground_scheduler()
+
+            # 가격 구독 초기화: 웹 화면 + 장중 전략 양쪽이 의존. BATCH 단독에서는 불필요.
+            if mode & (RuntimeMode.WEB | RuntimeMode.TRADING):
+                asyncio.create_task(ctx._initialize_price_subscriptions())
         except Exception as e:
             ctx.logger.critical(f"[SchedulerBootstrap] 초기화 실패: {e}", exc_info=True)
             raise
+
+    def _create_background_scheduler(self) -> None:
+        ctx = self._ctx
+        ctx.background_scheduler = BackgroundScheduler(
+            logger=ctx.logger,
+            performance_profiler=ctx.pm,
+            worker_pool=ctx.worker_pool,
+            time_dispatcher=ctx.time_dispatcher,
+        )
+
+    def _create_foreground_scheduler(self) -> None:
+        ctx = self._ctx
+        ctx.foreground_scheduler = ForegroundScheduler(
+            background_scheduler=ctx.background_scheduler,
+            logger=ctx.logger,
+            performance_profiler=ctx.pm,
+        )
+
+    def _register(self, task, priority: TaskPriority | None = None) -> None:
+        if not task:
+            return
+        ctx = self._ctx
+        if priority is not None:
+            ctx.time_dispatcher.register_task(
+                task.task_name, priority, delay_sec=self._delays.get(task.task_name, 0)
+            )
+        ctx.background_scheduler.register(task)
+
+    def _register_web_tasks(self) -> None:
+        ctx = self._ctx
+        # NotificationQueueTask 는 TimeDispatcher 등록 대상이 아님 (always-on)
+        self._register(ctx.notification_queue_task)
+
+    def _register_trading_tasks(self) -> None:
+        ctx = self._ctx
+        self._register(ctx.pre_market_health_check_task)
+        self._register(ctx.opening_position_reconcile_task, TaskPriority.HIGH)
+        self._register(ctx.cache_warmup_task)
+
+    def _register_batch_tasks(self) -> None:
+        ctx = self._ctx
+        self._register(ctx.ranking_task, TaskPriority.LOW)
+        self._register(ctx.minervini_update_task, TaskPriority.LOW)
+        self._register(ctx.daily_price_collector_task, TaskPriority.LOW)
+        self._register(ctx.ohlcv_update_task, TaskPriority.LOW)
+        self._register(ctx.premium_watchlist_generator_task, TaskPriority.LOW)
+        self._register(ctx.newhigh_task, TaskPriority.LOW)
+        self._register(ctx.log_cleanup_task, TaskPriority.MAINTENANCE)
+        self._register(ctx.strategy_log_report_task, TaskPriority.LOW)
+        self._register(ctx.after_market_reconcile_task, TaskPriority.LOW)
+
+    def _register_websocket_watchdog(self) -> None:
+        # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).
+        self._register(self._ctx.websocket_watchdog_task)

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -17,6 +17,7 @@ from strategies.oneil_pocket_pivot_strategy import OneilPocketPivotStrategy
 from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
 from strategies.rsi2_pullback_strategy import RSI2PullbackStrategy
 from task.background.intraday.strategy_scheduler_task_adapter import StrategySchedulerTaskAdapter
+from view.web.bootstrap.runtime_mode import RuntimeMode
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -30,6 +31,12 @@ class StrategyFactory:
 
     def build(self) -> None:
         ctx = self._ctx
+        if not (ctx.runtime_mode & RuntimeMode.TRADING):
+            ctx.logger.info(
+                "[StrategyFactory] runtime_mode=%s — TRADING 비활성, StrategyScheduler 미생성.",
+                ctx.runtime_mode,
+            )
+            return
         ctx.scheduler = StrategyScheduler(
             virtual_trade_service=ctx.virtual_trade_service,
             order_execution_service=ctx.order_execution_service,

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -89,8 +89,10 @@ class WebAppContext:
 
     REST_PRICE_REFRESH_COOLDOWN_SEC = 10.0
 
-    def __init__(self, app_context):
+    def __init__(self, app_context, runtime_mode=None):
+        from view.web.bootstrap.runtime_mode import RuntimeMode
         self.logger = Logger()
+        self.runtime_mode: RuntimeMode = runtime_mode if runtime_mode is not None else RuntimeMode.ALL
         self.env = app_context.env if app_context else None
         self.full_config = {}  # [추가] 전체 설정을 담을 그릇
         self.market_clock: MarketClock = None

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -103,21 +103,28 @@ async def lifespan(app: FastAPI):
     _install_asyncio_exception_filter()
 
     # 1. 초기화 객체 생성 (app_context 대용으로 빈 객체 전달)
+    from view.web.bootstrap.runtime_mode import RuntimeMode
+    runtime_mode = RuntimeMode.from_env()
     class SimpleContext: env = None
-    ctx = WebAppContext(SimpleContext())
-    
+    ctx = WebAppContext(SimpleContext(), runtime_mode=runtime_mode)
+
     # 2. 환경 설정 로드 및 서비스 초기화
     ctx.load_config_and_env()
     await ctx.initialize_services(is_paper_trading=True) # 기본 모의투자 설정
-    
+
     # 3. web_api에 완성된 ctx 연결 (이게 없어서 503 에러가 났던 것임)
     web_api.set_ctx(ctx)
 
-    # 4. 전략 스케줄러 초기화 (상태 복원은 BackgroundScheduler 어댑터에서 단일 진입)
+    # 4. 전략 스케줄러 초기화 (상태 복원은 BackgroundScheduler 어댑터에서 단일 진입).
+    # TRADING 비활성이면 StrategyFactory 가 내부에서 no-op.
     ctx.initialize_scheduler()
 
-    # 5. 실전 주문 상태 복원 및 reconcile (WebSocket 구독 전, 전략 스케줄러 전)
-    if ctx.order_execution_service:
+    # 5. 실전 주문 상태 복원 및 reconcile (WebSocket 구독 전, 전략 스케줄러 전).
+    # WEB / TRADING 어느 한쪽이라도 켜져 있으면 수행 — /api/order 가 살아 있는 한
+    # broker 와 동기화 안 된 상태로 신규 주문이 나가는 위험을 차단해야 한다.
+    if ctx.order_execution_service and (
+        ctx.runtime_mode & (RuntimeMode.WEB | RuntimeMode.TRADING)
+    ):
         await ctx.order_execution_service.restore_state_from_broker()
         await ctx.order_execution_service.reconcile_orders_with_broker()
 


### PR DESCRIPTION
변경 파일 (5)

view/web/bootstrap/runtime_mode.py — 신규 RuntimeMode Flag enum + from_env() (대소문자/쉼표/파이프 파싱, 오타 시 WARN + ALL fallback) view/web/bootstrap/scheduler_bootstrap.py — run() 을 _register_web_tasks / _register_trading_tasks / _register_batch_tasks / _register_websocket_watchdog 4 그룹 메서드로 split. BackgroundScheduler/ForegroundScheduler 생성은 mode 와 무관하게 항상 수행 view/web/bootstrap/strategy_factory.py — build() 진입부에서 TRADING 비활성 시 즉시 return view/web/web_app_initializer.py — __init__(self, app_context, runtime_mode=None) 로 runtime_mode 매개변수 추가 (default ALL) view/web/web_main.py — RuntimeMode.from_env() 호출 + restore_state_from_broker / reconcile_orders_with_broker 는 WEB | TRADING 일 때 호출 (안전성) 테스트 (3 파일)

test_runtime_mode.py — 신규 9 케이스
test_scheduler_bootstrap.py — 14 케이스 (mode 별 등록 분기, watchdog 중복 등록 회귀 방지, ForegroundScheduler 항상 생성, price subscription gating) test_strategy_factory.py — TRADING gating 3 케이스 추가 test_web_app_initializer.py — runtime_mode 주입 3 케이스 추가 테스트 결과: unit 4520 passed / integration 233 passed, 회귀 0.

todo_list.md: 3-2 두 체크박스를 [~] 로 갱신, 1차 PR 완료 항목과 후속 작업 명시.

기본 동작 변화 없음: RUNTIME_MODE 미설정 시 ALL 이므로 python main.py 는 기존과 동일. RUNTIME_MODE=WEB 등을 명시할 때만 selective 등록 활성화.