### PR TITLE
수정 완료했습니다.

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -81,6 +81,7 @@ class StrategyScheduler:
     LOOP_INTERVAL_SEC = 1           # 메인 루프 깨어나는 주기
     MARKET_CLOSED_SLEEP_SEC = 60    # 장 외 시간 sleep
     FORCE_EXIT_MINUTES_BEFORE = 30  # 장 마감 N분 전 강제 청산
+    ORDER_CUTOFF_MINUTES_BEFORE_CLOSE = 20  # 15:40 설정 기준 15:20 이후 전략 주문 중단
     STAGGER_INTERVAL_SEC = 60       # 전략 간 실행 시차 (초)
     ORDER_POLL_INTERVAL_SEC = 15    # 활성 주문 체결조회 보정 주기 (초)
     WATCHLIST_EXCLUDE_POLICY_RULES = {
@@ -139,6 +140,7 @@ class StrategyScheduler:
         self._last_execution_time: Optional[datetime] = None  # 전략 간 실행 쿨다운용
         self._last_order_poll_time: Optional[datetime] = None
         self._force_exit_done: set = set()  # 당일 강제 청산 완료된 전략
+        self._force_exit_done_date: Optional[str] = None
         self._reconciled_dates: set = set()  # 원장 대사 완료된 날짜 (YYYY-MM-DD)
         self.MAX_HISTORY = 200  # 최대 보관 이력 수
         self._signal_history: List[SignalRecord] = self._load_signal_history()
@@ -211,25 +213,7 @@ class StrategyScheduler:
                 market_open = await self._mcs.is_market_open_now()
 
                 if not market_open:
-                    # 장이 닫힌 직후(15:40~) 아직 강제 청산 미완료된 전략이 있으면 실행
-                    if self._force_exit_done is not None:
-                        for cfg in self._strategies:
-                            if (cfg.enabled and cfg.force_exit_on_close
-                                    and cfg.strategy.name not in self._force_exit_done):
-                                name = cfg.strategy.name
-                                self._force_exit_done.add(name)
-                                self._logger.info(
-                                    f"[Scheduler] {name}: 장 마감 후 미처리 강제 청산 실행"
-                                )
-                                try:
-                                    await self._run_strategy(cfg, force_exit_only=True)
-                                except Exception as e:
-                                    self._logger.error(
-                                        f"[Scheduler] {name} 강제 청산 오류: {e}", exc_info=True
-                                    )
-
                     self._logger.info("현재는 휴장일이거나 장 운영 시간이 아닙니다.")
-                    self._force_exit_done.clear()
                     await self._mcs.wait_until_next_open(
                         max_sleep_seconds=self.MARKET_CLOSED_SLEEP_SEC
                     )
@@ -240,6 +224,16 @@ class StrategyScheduler:
                 close_time = self._tm.get_market_close_time()
                 minutes_to_close = (close_time - now).total_seconds() / 60
                 await self._poll_active_orders_if_due(now)
+                self._sync_force_exit_done_date(now)
+
+                if self._is_after_order_cutoff(now, close_time):
+                    self._logger.info(
+                        f"[Scheduler] 주문 컷오프 이후 전략 실행 스킵 "
+                        f"(now={now.strftime('%H:%M:%S')}, cutoff="
+                        f"{self._get_order_cutoff_time(close_time).strftime('%H:%M:%S')})"
+                    )
+                    await asyncio.sleep(self.LOOP_INTERVAL_SEC)
+                    continue
 
                 # 원장 대사: 당일 첫 장 진입 시 1회 실행
                 today_str = now.strftime("%Y-%m-%d")
@@ -323,6 +317,19 @@ class StrategyScheduler:
                 await asyncio.sleep(self.LOOP_INTERVAL_SEC)
 
     # ── 전략 실행 ──
+
+    def _sync_force_exit_done_date(self, now: datetime) -> None:
+        today = now.strftime("%Y-%m-%d")
+        if self._force_exit_done_date == today:
+            return
+        self._force_exit_done.clear()
+        self._force_exit_done_date = today
+
+    def _get_order_cutoff_time(self, close_time: datetime) -> datetime:
+        return close_time - timedelta(minutes=self.ORDER_CUTOFF_MINUTES_BEFORE_CLOSE)
+
+    def _is_after_order_cutoff(self, now: datetime, close_time: datetime) -> bool:
+        return now >= self._get_order_cutoff_time(close_time)
 
     async def _poll_active_orders_if_due(self, now: Optional[datetime] = None) -> int:
         """기존 스케줄러 루프에서 활성 주문 상태를 주기적으로 보정합니다."""

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1226,6 +1226,30 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         # 달력 매니저의 대기 메서드가 호출되었는지 완벽하게 확인됨!
         mcs.wait_until_next_open.assert_awaited_once()
 
+    async def test_loop_market_closed_does_not_force_exit(self):
+        """장 종료 후에는 force_exit 시그널을 새로 만들지 않는다."""
+        scheduler, _, _, _, mcs = self._make_scheduler()
+        mcs.is_market_open_now.return_value = False
+        mcs.wait_until_next_open.side_effect = asyncio.CancelledError()
+
+        strategy = MockStrategy(name="전략A")
+        config = StrategySchedulerConfig(
+            strategy=strategy,
+            force_exit_on_close=True,
+            enabled=True,
+        )
+        scheduler.register(config)
+        scheduler._running = True
+
+        with patch.object(scheduler, "_run_strategy", new_callable=AsyncMock) as mock_run:
+            try:
+                await scheduler._loop()
+            except asyncio.CancelledError:
+                pass
+
+        mock_run.assert_not_awaited()
+        mcs.wait_until_next_open.assert_awaited_once()
+
     async def test_loop_force_exit(self):
         """장 마감 임박 시 강제 청산 로직 테스트 (전략별 설정 구분 확인)."""
         scheduler, vm, _, tm, _ = self._make_scheduler()
@@ -1240,13 +1264,13 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         config_b = StrategySchedulerConfig(strategy=strategy_b, force_exit_on_close=False, interval_minutes=0)
         scheduler.register(config_b)
 
-        # 현재 시간: 15:20, 마감 시간: 15:40 (10분 남음 -> FORCE_EXIT_MINUTES_BEFORE(15) 이내)
+        # 현재 시간: 15:05, 마감 시간: 15:30 (25분 남음 -> 강제청산 윈도우 이내, 컷오프 이전)
         import pytz
         from datetime import datetime
         kst = pytz.timezone("Asia/Seoul")
-        now = kst.localize(datetime(2023, 1, 1, 15, 20))
+        now = kst.localize(datetime(2023, 1, 1, 15, 5))
         # 두 번째 루프에서는 쿨다운(60초) 이후 시점
-        now_after_cooldown = kst.localize(datetime(2023, 1, 1, 15, 21, 1))
+        now_after_cooldown = kst.localize(datetime(2023, 1, 1, 15, 6, 1))
         close_time = kst.localize(datetime(2023, 1, 1, 15, 30))
 
         tm.get_current_kst_time.side_effect = [now, now_after_cooldown]
@@ -1268,6 +1292,34 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
             # 전략 B는 일반 모드(False)로 실행되어야 함 (쿨다운 이후 두 번째 루프에서 실행)
             mock_run.assert_any_call(config_b, force_exit_only=False)
+
+    async def test_loop_skips_strategy_after_order_cutoff(self):
+        """주문 컷오프 이후에는 일반 실행과 강제청산 모두 시그널을 만들지 않는다."""
+        from datetime import datetime
+
+        scheduler, _, _, tm, mcs = self._make_scheduler()
+        now_dt = datetime(2026, 5, 19, 15, 20, 0)
+        close_dt = datetime(2026, 5, 19, 15, 40, 0)
+        tm.get_current_kst_time.return_value = now_dt
+        tm.get_market_close_time.return_value = close_dt
+
+        strategy = MockStrategy(name="전략A")
+        config = StrategySchedulerConfig(
+            strategy=strategy,
+            force_exit_on_close=True,
+            interval_minutes=0,
+        )
+        scheduler.register(config)
+        scheduler._running = True
+        mcs.is_market_open_now.side_effect = [True, asyncio.CancelledError()]
+
+        with patch.object(scheduler, "_run_strategy", new_callable=AsyncMock) as mock_run:
+            try:
+                await scheduler._loop()
+            except asyncio.CancelledError:
+                pass
+
+        mock_run.assert_not_awaited()
 
     async def test_loop_exception_handling(self):
         """루프 내 예외 발생 시 계속 실행되는지 테스트."""
@@ -2374,10 +2426,10 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         
         mock_price_sub.remove_category.assert_awaited_once_with("scheduler_전략A")
 
-    async def test_loop_force_exit_exception(self):
-        """루프 중 장 마감 직후 강제 청산 시 예외가 발생해도 루프가 죽지 않는지 테스트."""
+    async def test_loop_market_closed_does_not_run_force_exit_exception_path(self):
+        """장 마감 후에는 강제 청산을 시도하지 않아 예외 경로도 타지 않는다."""
         scheduler, vm, _, tm, mcs = self._make_scheduler()
-        
+
         mcs.is_market_open_now.return_value = False
         mcs.wait_until_next_open.side_effect = asyncio.CancelledError() # 루프 탈출용
         
@@ -2388,13 +2440,14 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         scheduler._force_exit_done = set() 
         scheduler._running = True
         
-        with patch.object(scheduler, '_run_strategy', side_effect=Exception("Liquidate Error")):
+        with patch.object(scheduler, '_run_strategy', side_effect=Exception("Liquidate Error")) as mock_run:
             try:
                 await scheduler._loop()
             except asyncio.CancelledError:
                 pass
-            
-            scheduler._logger.error.assert_called()
+
+        mock_run.assert_not_called()
+        scheduler._logger.error.assert_not_called()
 
     # ── Kill Switch 테스트 ───────────────────────────────────────────────────
 


### PR DESCRIPTION
원인은 두 가지였습니다.
장 종료 후 분기에서 “미처리 강제청산”을 실행한 뒤 _force_exit_done.clear()를 매 루프마다 호출하고 있었습니다. 그래서 60초마다 “오늘 이미 청산함” 표시가 지워져 같은 강제청산 SELL 시그널이 계속 재생성됐습니다. kill switch 중에도 strategy_force_exit:* SELL은 기존 설계상 허용되고 있었습니다. 노출을 줄이기 위한 강제청산 예외인데, 위 반복 버그 때문에 “kill switch인데 매도를 계속 시도”하는 것처럼 보인 겁니다. 변경 내용:
scheduler/strategy_scheduler.py (line 84)market_close_time - 20분을 주문 컷오프로 추가했습니다. 현재 설정이 15:40이면 15:20 이후 전략 실행/강제청산 시그널이 생성되지 않습니다. 장 종료 후에는 더 이상 force-exit을 새로 실행하지 않게 했습니다.
_force_exit_done은 장 외 루프마다 지우지 않고, 장중 날짜가 바뀔 때만 초기화되게 했습니다.

테스트:
tests/unit_test/scheduler/test_strategy_scheduler.py (line 1229)장 종료 후 force-exit 미실행 테스트 추가 15:20 컷오프 이후 시그널 미생성 테스트 추가
기존 장마감 후 force-exit 예외 테스트를 새 정책에 맞게 수정

검증 통과:
pytest tests/unit_test -v → 4681 passed
pytest tests/integration_test -v → 233 passed