### PR TITLE
작업 완료했습니다.

### DIFF
--- a/services/broker_order_submitter.py
+++ b/services/broker_order_submitter.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Callable, Optional
 
 from common.types import ErrorCode, Exchange, OrderState, ResCommonResponse
@@ -118,8 +119,11 @@ class BrokerOrderSubmitter:
                     f"주문 재시도 {attempt}/{self._max_retries}: "
                     f"{stock_code}, 사유: {result.msg1 if result else '응답 없음'}"
                 )
+                delay = self._retry_delay_sec * attempt
                 if self._market_clock is not None:
-                    await self._market_clock.async_sleep(self._retry_delay_sec * attempt)
+                    await self._market_clock.async_sleep(delay)
+                else:
+                    await asyncio.sleep(delay)
                 continue
             break
         return last_result

--- a/tests/unit_test/services/test_broker_order_submitter.py
+++ b/tests/unit_test/services/test_broker_order_submitter.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -149,6 +149,64 @@ async def test_submit_uses_exponential_backoff_for_retry_sleep(mock_broker, mock
     # attempt 1 → sleep(3*1=3), attempt 2 → sleep(3*2=6)
     assert mock_market_clock.async_sleep.await_args_list[0].args == (3,)
     assert mock_market_clock.async_sleep.await_args_list[1].args == (6,)
+
+
+# ── submit_with_retry: market_clock=None fallback (asyncio.sleep) ─────────
+
+@pytest.mark.asyncio
+async def test_submit_retries_with_asyncio_sleep_when_market_clock_is_none(mock_broker):
+    """market_clock 미주입 시에도 asyncio.sleep 으로 backoff 후 재시도한다."""
+    mock_broker.place_stock_order.side_effect = [
+        ResCommonResponse(rt_cd=ErrorCode.NETWORK_ERROR.value, msg1="네트워크 오류", data=None),
+        ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="주문 성공", data={"ordno": "B0003"}),
+    ]
+    submitter = _make_submitter(broker=mock_broker, market_clock=None)
+
+    with patch("services.broker_order_submitter.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        result = await submitter.submit_with_retry(
+            "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX
+        )
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert mock_broker.place_stock_order.await_count == 2
+    mock_sleep.assert_awaited_once_with(3)
+
+
+@pytest.mark.asyncio
+async def test_submit_uses_exponential_backoff_via_asyncio_sleep_when_market_clock_is_none(mock_broker):
+    """market_clock=None 일 때도 attempt 별 지수 backoff 가 적용된다."""
+    mock_broker.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.NETWORK_ERROR.value, msg1="네트워크", data=None
+    )
+    submitter = _make_submitter(broker=mock_broker, market_clock=None)
+
+    with patch("services.broker_order_submitter.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await submitter.submit_with_retry(
+            "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX
+        )
+
+    # attempt 1 → sleep(3), attempt 2 → sleep(6), 마지막 시도 직후엔 sleep 하지 않음
+    assert mock_sleep.await_count == 2
+    assert mock_sleep.await_args_list[0].args == (3,)
+    assert mock_sleep.await_args_list[1].args == (6,)
+
+
+@pytest.mark.asyncio
+async def test_submit_business_reject_does_not_sleep_when_market_clock_is_none(mock_broker):
+    """market_clock=None 이어도 비즈니스 거부 시 sleep 호출 없이 즉시 종료한다."""
+    mock_broker.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="잔고 부족", data=None
+    )
+    submitter = _make_submitter(broker=mock_broker, market_clock=None)
+
+    with patch("services.broker_order_submitter.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        result = await submitter.submit_with_retry(
+            "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX
+        )
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    assert mock_broker.place_stock_order.await_count == 1
+    mock_sleep.assert_not_awaited()
 
 
 # ── submit_with_retry: 비즈니스 거부 (FAIL) ─────────────────────────────────

--- a/todo_list.md
+++ b/todo_list.md
@@ -28,10 +28,11 @@
   - 테스트: 시장가 BUY가 기준가격 없이 차단되는지, 기준가격 산정 성공 시 한도 초과가 차단되는지, SELL/force_exit 예외 정책이 유지되는지 검증.
   - 완료 내용: `RiskGateService.__init__()`에 `market_buy_reference_price_provider` 주입 옵션 추가, `validate_order()`에 real mode + `price==0` + BUY 분기 추가. provider 미주입 또는 None 반환 시 `market_buy_no_reference_price` 룰로 차단, 가격 반환 시 `effective_price`로 amount/daily/strategy/exposure 검증. paper/`env=None`/SELL/`force_exit`는 기존 동작 유지. 테스트 8건 추가 (`tests/unit_test/services/test_risk_gate_service.py`).
   - 후속 완료: `view/web/bootstrap/service_container.py`에 `_resolve_market_buy_reference_price()` 헬퍼 추가 (최우선매도호가 `askp1` → 현재가 `stck_prpr` fallback). `RiskGateService` 인스턴스화 시 `market_buy_reference_price_provider`로 lambda 주입. 헬퍼 단위 테스트 13건 + ServiceContainer 주입 검증 1건 추가 (`tests/unit_test/view/web/bootstrap/test_market_buy_reference_price_resolver.py`, `test_service_container.py`). 단위 + 통합 4936건 통과.
-- [ ] `BrokerOrderSubmitter.submit_with_retry()`가 `market_clock=None`이어도 정상 backoff 후 재시도하도록 수정한다.
+- [x] `BrokerOrderSubmitter.submit_with_retry()`가 `market_clock=None`이어도 정상 backoff 후 재시도하도록 수정한다. (2026-05-19 완료)
   - 검토 결과: 타당. 현재 재시도 루프는 돌지만 `market_clock`이 없으면 sleep 없이 즉시 다음 시도로 넘어간다.
   - 개선 방향: `market_clock.async_sleep()`이 없으면 `asyncio.sleep(delay)`로 fallback.
   - 테스트: `market_clock=None`, `market_clock` 주입, retryable/non-retryable error를 각각 검증.
+  - 완료 내용: `services/broker_order_submitter.py`에 `import asyncio` 추가 및 재시도 backoff 분기에 `market_clock is None` → `await asyncio.sleep(delay)` fallback 적용. 기존 `market_clock` 주입 경로/지수 backoff 동작은 불변. 단위 테스트 3건 추가 (`test_submit_retries_with_asyncio_sleep_when_market_clock_is_none`, `test_submit_uses_exponential_backoff_via_asyncio_sleep_when_market_clock_is_none`, `test_submit_business_reject_does_not_sleep_when_market_clock_is_none`). 단위 4706건 + 통합 233건 통과.
 - [ ] 실전 모드 RiskGate를 fail-close로 전환한다.
   - 검토 결과: 타당. `account_snapshot_cache is None`, `total_equity <= 0`, 전략 risk provider 예외에서 일부 노출/전략 검증이 skip 또는 fail-open 된다. 기존 테스트도 `test_strategy_exposure_limit_fails_open_on_zero_equity_and_hold_error`로 현재 동작을 고정하고 있다.
   - 개선 방향: paper/backtest는 fail-open 허용, real은 신규 BUY 차단. 예: `risk_gate.fail_open_allowed.paper=true`, `risk_gate.fail_open_allowed.real=false`.


### PR DESCRIPTION
수정 요약 — P0 0-0: BrokerOrderSubmitter.submit_with_retry market_clock fallback

변경 파일
services/broker_order_submitter.py:1 — import asyncio 추가 services/broker_order_submitter.py:117-125 — backoff 분기에 market_clock is None 시 await asyncio.sleep(delay) fallback 추가 테스트 (TDD: 실패 확인 후 구현)
tests/unit_test/services/test_broker_order_submitter.py:157-211 — 3건 신규 market_clock=None + retryable 오류 → asyncio.sleep(3) 후 재시도 성공 market_clock=None + retryable 오류 반복 → 지수 backoff (3, 6) 순서 market_clock=None + 비즈니스 거부(non-retryable) → sleep 호출 없이 즉시 종료 검증
단위 테스트 4706건, 통합 테스트 233건 모두 통과
todo_list.md:31 항목 [x] (2026-05-19 완료)로 마킹