### PR TITLE
구현 완료했습니다.

### DIFF
--- a/repositories/program_trading_repo.py
+++ b/repositories/program_trading_repo.py
@@ -368,6 +368,38 @@ class ProgramTradingRepo:
             status["error"] = str(e)
         return status
 
+    def get_history_timestamps_by_code(
+        self,
+        codes: list[str],
+        start_ts: float,
+        end_ts: float,
+    ) -> dict[str, list[float]]:
+        """지정 종목들의 저장 timestamp를 기간 내에서 조회한다."""
+        result = {code: [] for code in codes}
+        if not codes:
+            return result
+
+        placeholders = ",".join("?" for _ in codes)
+        params = [*codes, start_ts, end_ts]
+        try:
+            with self._get_connection() as conn:
+                cursor = conn.execute(
+                    f"""
+                    SELECT code, created_at
+                    FROM pt_history
+                    WHERE code IN ({placeholders})
+                      AND created_at >= ?
+                      AND created_at <= ?
+                    ORDER BY code, created_at
+                    """,
+                    params,
+                )
+                for code, created_at in cursor.fetchall():
+                    result.setdefault(code, []).append(created_at)
+        except Exception as e:
+            self._logger.error(f"히스토리 timestamp 조회 중 오류: {e}")
+        return result
+
     # ── 생명주기 ─────────────────────────────────────────────────────
 
     def start_flush_loop(self):

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -1,8 +1,10 @@
 import asyncio
+import html
+import inspect
 import json
 import time
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from contextlib import contextmanager
 
 from repositories.program_trading_repo import ProgramTradingRepo
@@ -24,16 +26,24 @@ class ProgramTradingStreamService:
     RETENTION_DAYS = 7
     FLUSH_INTERVAL_SEC = 1.0
     FLUSH_BATCH_SIZE = 100
+    HOURLY_TICK_ALERT_INTERVAL_SEC = 60 * 60
 
     def __init__(self, logger=None):
         self.logger = logger if logger else logging.getLogger(__name__)
 
         # 메모리 캐시 (성능 최적화)
         self._pt_history: dict = {}
+        self._last_tick_ts_by_code: dict[str, float] = {}
         self.last_data_ts = 0.0
 
         # 클라이언트 스트리밍 큐
         self._pt_queues: list = []
+        self._alert_tasks: list[asyncio.Task] = []
+        self._last_db_check_report_date: str | None = None
+        self._streaming_stock_repo = None
+        self._telegram_reporter = None
+        self._market_calendar_service = None
+        self._market_clock = None
 
         # SQLite 레이어는 ProgramTradingRepo에 위임
         self._repo = ProgramTradingRepo(
@@ -143,6 +153,7 @@ class ProgramTradingStreamService:
             self.logger.info(f"실시간 데이터 수신 재개 (Gap: {now - self.last_data_ts:.1f}초)")
 
         self.last_data_ts = now
+        self._last_tick_ts_by_code[code] = now
 
         # 1. 메모리 저장 (기존 프론트엔드/백엔드 호환용 원본 유지)
         self._pt_history.setdefault(code, []).append(data)
@@ -217,16 +228,255 @@ class ProgramTradingStreamService:
 
     def wire_streaming_stock_repo(self, streaming_stock_repo) -> None:
         """StreamingStockRepo를 사후 주입하여 desired flush를 repo의 flush_loop에 통합한다."""
+        self._streaming_stock_repo = streaming_stock_repo
         self._repo._streaming_stock_repo = streaming_stock_repo
+
+    def wire_alert_dependencies(
+        self,
+        telegram_reporter=None,
+        market_calendar_service=None,
+        market_clock=None,
+    ) -> None:
+        """운영 알림에 필요한 외부 의존성을 사후 주입한다."""
+        self._telegram_reporter = telegram_reporter
+        self._market_calendar_service = market_calendar_service
+        self._market_clock = market_clock
+
+    # ── 운영 알림 ──────────────────────────────────────────────────
+
+    def _get_subscribed_program_codes(self) -> list[str]:
+        if not self._streaming_stock_repo:
+            return []
+        try:
+            from repositories.streaming_stock_repo import StreamingType
+
+            return sorted(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING))
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 구독 목록 조회 실패: {e}")
+            return []
+
+    @staticmethod
+    def _format_int(value) -> str:
+        try:
+            return f"{int(str(value).replace(',', '')):,}"
+        except (TypeError, ValueError):
+            return "0"
+
+    @staticmethod
+    def _format_rate(value) -> str:
+        try:
+            return f"{float(value):+.2f}%"
+        except (TypeError, ValueError):
+            return "0.00%"
+
+    def _format_last_tick_report(self, codes: list[str]) -> str:
+        lines = [
+            "<b>프로그램매매 구독 Tick 상태</b>",
+            f"생성: {html.escape(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))}",
+            f"구독 종목: {len(codes)}개",
+            "",
+        ]
+        for code in codes:
+            history = self._pt_history.get(code) or []
+            if not history:
+                lines.append(f"{html.escape(code)}: 수신 없음")
+                continue
+
+            tick = history[-1]
+            received_ts = self._last_tick_ts_by_code.get(code)
+            received_at = (
+                datetime.fromtimestamp(received_ts).strftime("%H:%M:%S")
+                if received_ts else "-"
+            )
+            trade_time = str(tick.get("주식체결시간", "") or "-")
+            price = self._format_int(tick.get("price", 0))
+            rate = self._format_rate(tick.get("rate", 0.0))
+            net_amt = self._format_int(tick.get("순매수거래대금", 0))
+            lines.append(
+                f"{html.escape(code)}: {price}원 ({rate}) "
+                f"체결:{html.escape(trade_time)} 수신:{received_at} 순매수대금:{net_amt}"
+            )
+        return "\n".join(lines)
+
+    async def _send_telegram_message(self, message: str) -> bool:
+        if not self._telegram_reporter:
+            return False
+        sender = getattr(self._telegram_reporter, "_send_message", None)
+        if sender is None:
+            self.logger.warning("TelegramReporter에 _send_message가 없어 PT 알림을 전송할 수 없습니다.")
+            return False
+        try:
+            result = sender(message)
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception as e:
+            self.logger.error(f"프로그램매매 텔레그램 알림 전송 실패: {e}", exc_info=True)
+            return False
+
+    async def send_subscribed_last_tick_alert(self) -> bool:
+        """구독 중인 PT 종목들의 마지막 수신 tick을 텔레그램으로 전송한다."""
+        codes = self._get_subscribed_program_codes()
+        if not codes:
+            return False
+        message = self._format_last_tick_report(codes)
+        return await self._send_telegram_message(message)
+
+    def _build_trading_window(self, trading_date: str):
+        digits = "".join(ch for ch in str(trading_date) if ch.isdigit())
+        if len(digits) < 8:
+            digits = datetime.now().strftime("%Y%m%d")
+        digits = digits[:8]
+        day = datetime.strptime(digits, "%Y%m%d")
+
+        open_time = getattr(self._market_clock, "market_open_time_str", "09:00")
+        close_time = getattr(self._market_clock, "market_close_time_str", "15:40")
+        open_hour, open_minute = map(int, open_time.split(":"))
+        close_hour, close_minute = map(int, close_time.split(":"))
+        start_dt = datetime(day.year, day.month, day.day, open_hour, open_minute)
+        end_dt = datetime(day.year, day.month, day.day, close_hour, close_minute)
+
+        timezone = getattr(self._market_clock, "market_timezone", None)
+        if timezone is not None:
+            start_dt = timezone.localize(start_dt)
+            end_dt = timezone.localize(end_dt)
+
+        expected_minutes = []
+        cursor = start_dt.replace(second=0, microsecond=0)
+        end_cursor = end_dt.replace(second=0, microsecond=0)
+        while cursor <= end_cursor:
+            expected_minutes.append(cursor.strftime("%H:%M"))
+            cursor += timedelta(minutes=1)
+
+        return start_dt, end_dt, expected_minutes, timezone
+
+    def build_db_minute_persistence_status(self, codes: list[str], trading_date: str) -> dict:
+        """구독 종목별로 장중 DB 저장이 1분 단위로 존재하는지 계산한다."""
+        start_dt, end_dt, expected_minutes, timezone = self._build_trading_window(trading_date)
+        timestamps = self._repo.get_history_timestamps_by_code(
+            codes,
+            start_dt.timestamp(),
+            end_dt.timestamp(),
+        )
+        expected_set = set(expected_minutes)
+
+        status = {
+            "date": trading_date,
+            "window": {
+                "start": start_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                "end": end_dt.strftime("%Y-%m-%d %H:%M:%S"),
+            },
+            "expected_minute_count": len(expected_minutes),
+            "codes": {},
+        }
+        for code in codes:
+            saved_minutes = set()
+            for created_at in timestamps.get(code, []):
+                dt = datetime.fromtimestamp(created_at, tz=timezone) if timezone else datetime.fromtimestamp(created_at)
+                saved_minutes.add(dt.strftime("%H:%M"))
+            missing = [minute for minute in expected_minutes if minute not in saved_minutes]
+            status["codes"][code] = {
+                "ok": not missing,
+                "saved_minute_count": len(saved_minutes & expected_set),
+                "missing_minute_count": len(missing),
+                "missing_minutes": missing,
+            }
+        return status
+
+    def _format_db_persistence_report(self, status: dict) -> str:
+        lines = [
+            f"<b>프로그램매매 DB 저장 점검 ({html.escape(str(status.get('date', '')))}일)</b>",
+            f"구간: {html.escape(status['window']['start'])} ~ {html.escape(status['window']['end'])}",
+            f"기대 분봉: {status['expected_minute_count']}분",
+            "",
+        ]
+        for code, item in status["codes"].items():
+            saved = item["saved_minute_count"]
+            expected = status["expected_minute_count"]
+            if item["ok"]:
+                lines.append(f"{html.escape(code)}: OK ({saved}/{expected})")
+            else:
+                sample = ", ".join(item["missing_minutes"][:10])
+                extra = "" if item["missing_minute_count"] <= 10 else f" 외 {item['missing_minute_count'] - 10}분"
+                lines.append(
+                    f"{html.escape(code)}: 누락 {item['missing_minute_count']}분 "
+                    f"({saved}/{expected}) 예: {html.escape(sample)}{extra}"
+                )
+        return "\n".join(lines)
+
+    async def send_db_persistence_report(self, trading_date: str) -> bool:
+        """장마감 후 구독 종목의 1분 단위 DB 저장 여부를 텔레그램으로 전송한다."""
+        codes = self._get_subscribed_program_codes()
+        if not codes:
+            return False
+        await self._flush_write_buffer()
+        status = self.build_db_minute_persistence_status(codes, trading_date)
+        message = self._format_db_persistence_report(status)
+        return await self._send_telegram_message(message)
+
+    async def _hourly_tick_alert_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.HOURLY_TICK_ALERT_INTERVAL_SEC)
+                await self.send_subscribed_last_tick_alert()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.logger.error(f"프로그램매매 시간별 tick 알림 루프 종료: {e}", exc_info=True)
+
+    async def _after_market_db_check_loop(self) -> None:
+        from scheduler.after_market_loop import run_after_market_loop
+
+        async def _on_market_closed(latest_trading_date: str) -> None:
+            if self._last_db_check_report_date == latest_trading_date:
+                return
+            sent = await self.send_db_persistence_report(latest_trading_date)
+            if sent:
+                self._last_db_check_report_date = latest_trading_date
+
+        await run_after_market_loop(
+            mcs=self._market_calendar_service,
+            market_clock=self._market_clock,
+            logger=self.logger,
+            on_market_closed=_on_market_closed,
+            label="ProgramTradingDbCheck",
+        )
+
+    def _start_alert_tasks(self) -> None:
+        self._alert_tasks = [task for task in self._alert_tasks if not task.done()]
+        if not self._telegram_reporter:
+            return
+
+        hourly_running = any(
+            getattr(task.get_coro(), "__name__", "") == "_hourly_tick_alert_loop"
+            for task in self._alert_tasks
+        )
+        if not hourly_running:
+            self._alert_tasks.append(asyncio.create_task(self._hourly_tick_alert_loop()))
+
+        if self._market_calendar_service and self._market_clock:
+            db_check_running = any(
+                getattr(task.get_coro(), "__name__", "") == "_after_market_db_check_loop"
+                for task in self._alert_tasks
+            )
+            if not db_check_running:
+                self._alert_tasks.append(asyncio.create_task(self._after_market_db_check_loop()))
 
     # ── 생명주기 관리 ────────────────────────────────────────────────
 
     def start_background_tasks(self):
         """백그라운드 태스크 시작 (데이터 정리 + 버퍼 플러시 루프)."""
         self._repo.start_flush_loop()
+        self._start_alert_tasks()
         self.logger.info("ProgramTradingStreamService: 초기화 완료 (버퍼 기반 일괄 저장 모드)")
 
     async def shutdown(self):
         """서비스 종료 처리."""
+        for task in self._alert_tasks:
+            if not task.done():
+                task.cancel()
+        if self._alert_tasks:
+            await asyncio.gather(*self._alert_tasks, return_exceptions=True)
+        self._alert_tasks.clear()
         await self._repo.shutdown()
         self.logger.info("ProgramTradingStreamService: 종료 완료")

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -4,8 +4,10 @@ import json
 import os
 import sqlite3
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from core.market_clock import MarketClock
+from repositories.streaming_stock_repo import StreamingType
 from services.program_trading_stream_service import ProgramTradingStreamService
 
 
@@ -483,3 +485,94 @@ def test_wire_streaming_stock_repo(manager):
     manager.wire_streaming_stock_repo(mock_ssr)
 
     assert manager._repo._streaming_stock_repo is mock_ssr
+
+
+# --- 텔레그램 운영 알림 ---
+
+@pytest.mark.asyncio
+async def test_send_subscribed_last_tick_alert_sends_last_tick_for_desired_codes(manager):
+    """구독 중인 PT 종목의 마지막 수신 tick을 텔레그램으로 전송한다."""
+    mock_ssr = MagicMock()
+    mock_ssr.get_desired.return_value = {"005930", "000660"}
+    mock_reporter = MagicMock()
+    mock_reporter._send_message = AsyncMock(return_value=True)
+
+    manager.wire_streaming_stock_repo(mock_ssr)
+    manager.wire_alert_dependencies(telegram_reporter=mock_reporter)
+    manager.on_data_received({
+        "유가증권단축종목코드": "005930",
+        "주식체결시간": "101530",
+        "price": "72000",
+        "rate": "1.25",
+        "순매수거래대금": "123456",
+    })
+
+    sent = await manager.send_subscribed_last_tick_alert()
+
+    assert sent is True
+    mock_ssr.get_desired.assert_called_once_with(StreamingType.PROGRAM_TRADING)
+    mock_reporter._send_message.assert_awaited_once()
+    message = mock_reporter._send_message.call_args[0][0]
+    assert "프로그램매매 구독 Tick" in message
+    assert "005930" in message
+    assert "72,000" in message
+    assert "101530" in message
+    assert "000660" in message
+    assert "수신 없음" in message
+
+
+def test_build_db_minute_persistence_status_reports_missing_minutes(manager):
+    """장중 1분 단위 저장 여부를 종목별로 계산한다."""
+    clock = MarketClock(market_open_time="09:00", market_close_time="09:02")
+    manager.wire_alert_dependencies(market_clock=clock)
+
+    day = clock.market_timezone.localize(datetime(2026, 5, 19, 9, 0, 0))
+    with manager._get_connection() as conn:
+        conn.executemany(
+            "INSERT INTO pt_history (code, created_at) VALUES (?, ?)",
+            [
+                ("005930", day.timestamp()),
+                ("005930", (day.timestamp() + 120)),
+                ("000660", day.timestamp()),
+                ("000660", (day.timestamp() + 60)),
+                ("000660", (day.timestamp() + 120)),
+            ],
+        )
+
+    status = manager.build_db_minute_persistence_status(["005930", "000660"], "20260519")
+
+    assert status["expected_minute_count"] == 3
+    assert status["codes"]["005930"]["saved_minute_count"] == 2
+    assert status["codes"]["005930"]["missing_minutes"] == ["09:01"]
+    assert status["codes"]["005930"]["ok"] is False
+    assert status["codes"]["000660"]["saved_minute_count"] == 3
+    assert status["codes"]["000660"]["missing_minutes"] == []
+    assert status["codes"]["000660"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_db_persistence_report_sends_summary(manager):
+    """장마감 DB 저장 점검 결과를 텔레그램으로 전송한다."""
+    clock = MarketClock(market_open_time="09:00", market_close_time="09:00")
+    mock_ssr = MagicMock()
+    mock_ssr.get_desired.return_value = {"005930"}
+    mock_reporter = MagicMock()
+    mock_reporter._send_message = AsyncMock(return_value=True)
+
+    manager.wire_streaming_stock_repo(mock_ssr)
+    manager.wire_alert_dependencies(telegram_reporter=mock_reporter, market_clock=clock)
+    day = clock.market_timezone.localize(datetime(2026, 5, 19, 9, 0, 0))
+    with manager._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO pt_history (code, created_at) VALUES (?, ?)",
+            ("005930", day.timestamp()),
+        )
+
+    sent = await manager.send_db_persistence_report("20260519")
+
+    assert sent is True
+    mock_reporter._send_message.assert_awaited_once()
+    message = mock_reporter._send_message.call_args[0][0]
+    assert "프로그램매매 DB 저장 점검" in message
+    assert "005930" in message
+    assert "OK" in message

--- a/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
+++ b/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
@@ -28,6 +28,9 @@ def _make_fake_context():
     ctx.streaming_service = MagicMock()
     ctx.streaming_stock_repo = MagicMock()
     ctx.program_trading_stream_service = MagicMock()
+    ctx.telegram_reporter = MagicMock()
+    ctx._mcs = MagicMock()
+    ctx.market_clock = MagicMock()
     ctx.order_execution_service = MagicMock()
     return ctx
 
@@ -86,6 +89,11 @@ def test_wiring_phase_wires_streaming_chain():
     ctx.streaming_service.set_price_stream_service.assert_called_once_with(ctx.price_stream_service)
     ctx.streaming_service.set_streaming_stock_repo.assert_called_once_with(ctx.streaming_stock_repo)
     ctx.program_trading_stream_service.wire_streaming_stock_repo.assert_called_once_with(ctx.streaming_stock_repo)
+    ctx.program_trading_stream_service.wire_alert_dependencies.assert_called_once_with(
+        telegram_reporter=ctx.telegram_reporter,
+        market_calendar_service=ctx._mcs,
+        market_clock=ctx.market_clock,
+    )
     assert ctx.stock_query_service.price_stream_service is ctx.price_stream_service
     assert ctx.stock_query_service.price_subscription_service is ctx.price_subscription_service
 
@@ -104,6 +112,11 @@ def test_wiring_phase_skips_streaming_chain_when_runtime_does_not_create_it():
 
     ctx.data_quality_service.set_price_stream_service.assert_not_called()
     ctx.program_trading_stream_service.wire_streaming_stock_repo.assert_not_called()
+    ctx.program_trading_stream_service.wire_alert_dependencies.assert_called_once_with(
+        telegram_reporter=ctx.telegram_reporter,
+        market_calendar_service=ctx._mcs,
+        market_clock=ctx.market_clock,
+    )
     assert ctx.stock_query_service.price_stream_service is None
     assert ctx.stock_query_service.price_subscription_service is None
 

--- a/view/web/bootstrap/wiring_phase.py
+++ b/view/web/bootstrap/wiring_phase.py
@@ -68,6 +68,14 @@ class WiringPhase:
         if ctx.streaming_stock_repo:
             ctx.program_trading_stream_service.wire_streaming_stock_repo(ctx.streaming_stock_repo)
 
+        # ProgramTrading 운영 알림 ← TelegramReporter / MarketCalendar / MarketClock
+        if ctx.program_trading_stream_service:
+            ctx.program_trading_stream_service.wire_alert_dependencies(
+                telegram_reporter=getattr(ctx, "telegram_reporter", None),
+                market_calendar_service=getattr(ctx, "_mcs", None),
+                market_clock=getattr(ctx, "market_clock", None),
+            )
+
         # Streaming signing_notice callback ← OrderExecution
         if ctx.streaming_service and ctx.order_execution_service:
             ctx.streaming_service.register_handler(


### PR DESCRIPTION
program_trading_stream_service.py (line 234)에 텔레그램/캘린더 의존성 주입, 1시간 주기 마지막 tick 알림, 장마감 후 DB 1분 단위 저장 점검 알림을 추가했습니다. DB 점검은 설정된 장 시작/마감 시간 기준으로 종목별 저장 minute를 계산하고, 누락 minute 샘플을 텔레그램 메시지에 포함합니다.

추가로 program_trading_repo.py (line 371)에 기간별 저장 timestamp 조회 메서드를 넣고, wiring_phase.py (line 71)에서 TelegramReporter, MarketCalendarService, MarketClock이 서비스로 연결되게 했습니다.

검증:

C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v 통과 C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v 통과 (233 passed)