### PR TITLE
요약

### DIFF
--- a/config/cache_config.yaml
+++ b/config/cache_config.yaml
@@ -4,9 +4,12 @@ cache:
   memory_cache_enabled: 1
   use_db_cache: 1
   enabled_methods: # 실시간성 필요 없는 함수 list
+    # NOTE: get_current_price는 MarketDataService 내부의 3초 단기 캐시 +
+    # 장 마감 후 DB 스냅샷 폴백이 이미 캐싱을 담당하므로 전역 캐시에서 제외한다.
+    # ClientWithCache의 after-hours 캐시는 다음 거래일 개장까지 유지되어
+    # 주문/손절/리스크 경로의 신선도 요구(force_fresh=True)와 충돌한다.
     - get_stock_info_by_code
     - get_top_market_cap_stocks_code
-    - get_current_price
     - get_price_summary
     - get_market_cap
     - get_filtered_stocks_by_momentum

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -16,6 +16,7 @@ from core.market_clock import MarketClock
 from strategies.first_pullback_types import FirstPullbackConfig, FPPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.strategy_state_io import StrategyStateIO
 
 
 class FirstPullbackStrategy(LiveStrategy):
@@ -588,21 +589,25 @@ class FirstPullbackStrategy(LiveStrategy):
         loop.create_task(self._load_state_async())
 
     async def _load_state_async(self):
-        if not os.path.exists(self.STATE_FILE):
-            return
         try:
-            def _read_file():
-                with open(self.STATE_FILE, "r") as f:
-                    return json.load(f)
-
-            data = await asyncio.to_thread(_read_file)
-            positions = data.get("positions", data) if isinstance(data, dict) else {}
-            self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
-            for k, v in positions.items():
-                if k not in self._position_state:
-                    self._position_state[k] = FPPositionState(**v)
+            data = await StrategyStateIO.load(self.STATE_FILE)
         except Exception as e:
             self._logger.error(f"Failed to load state async for {self.name}: {e}")
+            return
+        if data is None:
+            return
+        positions = data.get("positions", data) if isinstance(data, dict) else {}
+        self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
+        for k, v in positions.items():
+            if k not in self._position_state:
+                self._position_state[k] = FPPositionState(**v)
+
+    async def load_state(self):
+        """초기화 직후 scan 전에 호출. _load_state_async() 를 명시적으로 await.
+
+        Idempotent: `if k not in self._position_state` 가드로 중복 호출 안전.
+        """
+        await self._load_state_async()
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -622,14 +627,9 @@ class FirstPullbackStrategy(LiveStrategy):
         loop.create_task(self._save_state_async())
 
     async def _save_state_async(self):
-        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        """StrategyStateIO 로 atomic write + per-file lock 저장."""
+        data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
         try:
-            def _write_file(data):
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
-
-            data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-            await asyncio.to_thread(_write_file, data)
+            await StrategyStateIO.save_atomic(self.STATE_FILE, data)
         except Exception as e:
             self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -15,6 +15,7 @@ from core.market_clock import MarketClock
 from strategies.oneil_common_types import HTFConfig, HTFPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.strategy_state_io import StrategyStateIO
 
 
 class HighTightFlagStrategy(LiveStrategy):
@@ -673,21 +674,25 @@ class HighTightFlagStrategy(LiveStrategy):
         loop.create_task(self._load_state_async())
 
     async def _load_state_async(self):
-        if not os.path.exists(self.STATE_FILE):
-            return
         try:
-            def _read_file():
-                with open(self.STATE_FILE, "r") as f:
-                    return json.load(f)
-
-            data = await asyncio.to_thread(_read_file)
-            positions = data.get("positions", data) if isinstance(data, dict) else {}
-            self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
-            for k, v in positions.items():
-                if k not in self._position_state:
-                    self._position_state[k] = HTFPositionState(**v)
+            data = await StrategyStateIO.load(self.STATE_FILE)
         except Exception as e:
             self._logger.error(f"Failed to load state async for {self.name}: {e}")
+            return
+        if data is None:
+            return
+        positions = data.get("positions", data) if isinstance(data, dict) else {}
+        self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
+        for k, v in positions.items():
+            if k not in self._position_state:
+                self._position_state[k] = HTFPositionState(**v)
+
+    async def load_state(self):
+        """초기화 직후 scan 전에 호출. _load_state_async() 를 명시적으로 await.
+
+        Idempotent: `if k not in self._position_state` 가드로 중복 호출 안전.
+        """
+        await self._load_state_async()
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -707,14 +712,9 @@ class HighTightFlagStrategy(LiveStrategy):
         loop.create_task(self._save_state_async())
 
     async def _save_state_async(self):
-        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        """StrategyStateIO 로 atomic write + per-file lock 저장."""
+        data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
         try:
-            def _write_file(data):
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
-
-            data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-            await asyncio.to_thread(_write_file, data)
+            await StrategyStateIO.save_atomic(self.STATE_FILE, data)
         except Exception as e:
             self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -17,6 +17,7 @@ from core.market_clock import MarketClock
 from strategies.oneil_common_types import OneilPocketPivotConfig, PPPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.strategy_state_io import StrategyStateIO
 
 
 class OneilPocketPivotStrategy(LiveStrategy):
@@ -816,21 +817,25 @@ class OneilPocketPivotStrategy(LiveStrategy):
         loop.create_task(self._load_state_async())
 
     async def _load_state_async(self):
-        if not os.path.exists(self.STATE_FILE):
-            return
         try:
-            def _read_file():
-                with open(self.STATE_FILE, "r") as f:
-                    return json.load(f)
-
-            data = await asyncio.to_thread(_read_file)
-            positions = data.get("positions", data) if isinstance(data, dict) else {}
-            self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
-            for k, v in positions.items():
-                if k not in self._position_state:
-                    self._position_state[k] = PPPositionState(**v)
+            data = await StrategyStateIO.load(self.STATE_FILE)
         except Exception as e:
             self._logger.error(f"Failed to load state async for {self.name}: {e}")
+            return
+        if data is None:
+            return
+        positions = data.get("positions", data) if isinstance(data, dict) else {}
+        self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
+        for k, v in positions.items():
+            if k not in self._position_state:
+                self._position_state[k] = PPPositionState(**v)
+
+    async def load_state(self):
+        """초기화 직후 scan 전에 호출. _load_state_async() 를 명시적으로 await.
+
+        Idempotent: `if k not in self._position_state` 가드로 중복 호출 안전.
+        """
+        await self._load_state_async()
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼: 이벤트 루프가 있으면 백그라운드에 저장 태스크를 생성,
@@ -853,14 +858,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
         loop.create_task(self._save_state_async())
 
     async def _save_state_async(self):
-        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        """StrategyStateIO 로 atomic write + per-file lock 저장."""
+        data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
         try:
-            def _write_file(data):
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
-
-            data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-            await asyncio.to_thread(_write_file, data)
+            await StrategyStateIO.save_atomic(self.STATE_FILE, data)
         except Exception as e:
             self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -17,6 +17,7 @@ from strategies.oneil_common_types import OneilBreakoutConfig, OSBPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.volatility_utils import annualized_return_std
+from utils.strategy_state_io import StrategyStateIO
 
 
 class OneilSqueezeBreakoutStrategy(LiveStrategy):
@@ -627,21 +628,25 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         loop.create_task(self._load_state_async())
 
     async def _load_state_async(self):
-        if not os.path.exists(self.STATE_FILE):
-            return
         try:
-            def _read_file():
-                with open(self.STATE_FILE, "r") as f:
-                    return json.load(f)
-
-            data = await asyncio.to_thread(_read_file)
-            positions = data.get("positions", data) if isinstance(data, dict) else {}
-            self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
-            for k, v in positions.items():
-                if k not in self._position_state:
-                    self._position_state[k] = OSBPositionState(**v)
+            data = await StrategyStateIO.load(self.STATE_FILE)
         except Exception as e:
             self._logger.error(f"Failed to load state async for {self.name}: {e}")
+            return
+        if data is None:
+            return
+        positions = data.get("positions", data) if isinstance(data, dict) else {}
+        self._cooldown = data.get("cooldown", {}) if isinstance(data, dict) and "positions" in data else {}
+        for k, v in positions.items():
+            if k not in self._position_state:
+                self._position_state[k] = OSBPositionState(**v)
+
+    async def load_state(self):
+        """초기화 직후 scan 전에 호출. _load_state_async() 를 명시적으로 await.
+
+        Idempotent: `if k not in self._position_state` 가드로 중복 호출 안전.
+        """
+        await self._load_state_async()
 
     def _save_state(self):
         """백워드 호환성 있는 동기-스케줄러 래퍼."""
@@ -661,14 +666,9 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         loop.create_task(self._save_state_async())
 
     async def _save_state_async(self):
-        """비동기 방식으로 상태 파일을 저장합니다 (파일 I/O는 스레드로 오프로드)."""
+        """StrategyStateIO 로 atomic write + per-file lock 저장."""
+        data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
         try:
-            def _write_file(data):
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
-
-            data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-            await asyncio.to_thread(_write_file, data)
+            await StrategyStateIO.save_atomic(self.STATE_FILE, data)
         except Exception as e:
             self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -70,6 +70,7 @@ def fake_web_ctx():
     ctx.load_config_and_env = MagicMock()
     ctx.initialize_services = AsyncMock(return_value=True)
     ctx.initialize_scheduler = MagicMock()
+    ctx.ensure_strategy_states_loaded = AsyncMock()
     ctx.start_background_tasks = MagicMock()
     ctx.shutdown = AsyncMock()
 

--- a/tests/unit_test/config/test_cache_config_yaml.py
+++ b/tests/unit_test/config/test_cache_config_yaml.py
@@ -1,0 +1,33 @@
+"""Regression tests for config/cache_config.yaml invariants.
+
+These tests pin policy decisions about which methods are eligible for
+ClientWithCache's after-hours caching. The cache wrapper bypasses the cache
+during market hours, but for after-hours it returns the cached payload until
+the next trading day. That behavior is unsafe for methods that already have
+short-lived caching elsewhere (e.g. StockRepository 3s cache + DB snapshot
+fallback in MarketDataService), so those methods MUST NOT appear in
+``enabled_methods``.
+"""
+from __future__ import annotations
+
+from core.cache.cache_config import load_cache_config
+
+
+def test_get_current_price_is_not_globally_cached():
+    """get_current_price는 ClientWithCache의 전역 캐시 대상에서 제외되어야 한다.
+
+    이유:
+    - MarketDataService가 이미 자체적으로 3초 단기 캐시(StockRepository) +
+      장 마감 후 DB 스냅샷 폴백을 운영한다.
+    - ClientWithCache의 after-hours 캐시는 동일 거래일 내 첫 호출 결과를
+      다음 거래일 개장 전까지 그대로 반환한다. force_fresh=True 의도가
+      broker wrapper 계층까지 전파되지 않아 주문/손절/리스크 경로의 신선도
+      요구와 충돌한다.
+    """
+    config = load_cache_config()
+    enabled_methods = config["cache"]["enabled_methods"]
+    assert "get_current_price" not in enabled_methods, (
+        "get_current_price는 짧은 TTL이 필요한 핵심 시세 메서드이므로 "
+        "enabled_methods에서 제거되어 있어야 한다. "
+        "MarketDataService 내부의 단기 캐시/DB 스냅샷 폴백이 캐싱을 담당한다."
+    )

--- a/tests/unit_test/strategies/test_strategy_load_state_await.py
+++ b/tests/unit_test/strategies/test_strategy_load_state_await.py
@@ -1,0 +1,169 @@
+"""4개 전략의 `load_state()` 명시적 await 회귀 테스트.
+
+각 전략의 `__init__` 은 이벤트 루프가 있으면 fire-and-forget 으로
+`_load_state_async()` 를 스케줄한다. 그 자체로는 scan 이전에 state 가
+반드시 로드되었음을 보장하지 못한다. `load_state()` 는 호출자가 명시적으로
+await 할 수 있게 만든 public API 다.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from strategies.first_pullback_strategy import FirstPullbackStrategy
+from strategies.high_tight_flag_strategy import HighTightFlagStrategy
+from strategies.oneil_pocket_pivot_strategy import OneilPocketPivotStrategy
+from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
+from utils.strategy_state_io import StrategyStateIO
+
+
+@pytest.fixture(autouse=True)
+def _reset_state_io():
+    StrategyStateIO._reset_for_test()
+    yield
+    StrategyStateIO._reset_for_test()
+
+
+def _common_kwargs():
+    return dict(
+        stock_query_service=MagicMock(),
+        universe_service=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pp_load_state_reads_positions(tmp_path: Path):
+    """OneilPocketPivotStrategy.load_state() 가 STATE_FILE 의 positions 를 반영."""
+    state_file = tmp_path / "pp_state.json"
+    payload = {
+        "positions": {
+            "005930": {
+                "entry_type": "PP",
+                "entry_price": 70000,
+                "entry_date": "20260520",
+                "peak_price": 71000,
+                "supporting_ma": "20",
+                "gap_day_low": 0,
+            }
+        },
+        "cooldown": {"000660": "20260519"},
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    strat = OneilPocketPivotStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()
+
+    assert "005930" in strat._position_state
+    assert strat._position_state["005930"].entry_price == 70000
+    assert strat._cooldown == {"000660": "20260519"}
+
+
+@pytest.mark.asyncio
+async def test_pp_load_state_idempotent(tmp_path: Path):
+    """load_state() 를 2회 호출해도 안전 (idempotency)."""
+    state_file = tmp_path / "pp_state.json"
+    payload = {
+        "positions": {
+            "005930": {
+                "entry_type": "BGU",
+                "entry_price": 70000,
+                "entry_date": "20260520",
+                "peak_price": 70000,
+                "supporting_ma": "",
+                "gap_day_low": 69000,
+            }
+        },
+        "cooldown": {},
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    strat = OneilPocketPivotStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()
+    await strat.load_state()  # 두 번 호출
+
+    assert len(strat._position_state) == 1
+    assert strat._position_state["005930"].entry_price == 70000
+
+
+@pytest.mark.asyncio
+async def test_fp_load_state_reads_positions(tmp_path: Path):
+    state_file = tmp_path / "fp_state.json"
+    payload = {
+        "positions": {
+            "005930": {
+                "entry_price": 70000,
+                "entry_date": "20260520",
+                "peak_price": 70500,
+                "surge_day_high": 72000,
+            }
+        },
+        "cooldown": {},
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    strat = FirstPullbackStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()
+
+    assert "005930" in strat._position_state
+    assert strat._position_state["005930"].entry_price == 70000
+
+
+@pytest.mark.asyncio
+async def test_htf_load_state_reads_positions(tmp_path: Path):
+    state_file = tmp_path / "htf_state.json"
+    payload = {
+        "positions": {
+            "005930": {
+                "entry_price": 70000,
+                "entry_date": "20260520",
+                "peak_price": 71000,
+                "pole_high": 75000,
+            }
+        },
+        "cooldown": {},
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    strat = HighTightFlagStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()
+
+    assert "005930" in strat._position_state
+    assert strat._position_state["005930"].entry_price == 70000
+
+
+@pytest.mark.asyncio
+async def test_osb_load_state_reads_positions(tmp_path: Path):
+    state_file = tmp_path / "osb_state.json"
+    payload = {
+        "positions": {
+            "005930": {
+                "entry_price": 70000,
+                "entry_date": "20260520",
+                "peak_price": 71000,
+                "breakout_level": 70000,
+            }
+        },
+        "cooldown": {"000660": "20260519"},
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    strat = OneilSqueezeBreakoutStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()
+
+    assert "005930" in strat._position_state
+    assert strat._position_state["005930"].entry_price == 70000
+    assert strat._cooldown == {"000660": "20260519"}
+
+
+@pytest.mark.asyncio
+async def test_load_state_safe_when_file_missing(tmp_path: Path):
+    """STATE_FILE 이 없으면 load_state() 가 조용히 통과한다."""
+    state_file = tmp_path / "missing.json"
+    strat = OneilPocketPivotStrategy(**_common_kwargs(), state_file=str(state_file))
+    await strat.load_state()  # 예외 없이 종료
+    assert strat._position_state == {}

--- a/tests/unit_test/utils/test_strategy_state_io.py
+++ b/tests/unit_test/utils/test_strategy_state_io.py
@@ -1,0 +1,135 @@
+"""StrategyStateIO atomic load/save + per-file lock + flush_pending 회귀 테스트."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utils.strategy_state_io import StrategyStateIO
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    StrategyStateIO._reset_for_test()
+    yield
+    StrategyStateIO._reset_for_test()
+
+
+@pytest.mark.asyncio
+async def test_save_atomic_creates_file(tmp_path: Path):
+    """save_atomic 은 지정 경로에 JSON 파일을 생성한다."""
+    target = tmp_path / "state.json"
+    payload = {"positions": {"005930": {"qty": 1}}, "cooldown": {}}
+
+    await StrategyStateIO.save_atomic(str(target), payload)
+
+    assert target.exists()
+    with open(target, "r", encoding="utf-8") as f:
+        assert json.load(f) == payload
+
+
+@pytest.mark.asyncio
+async def test_save_atomic_creates_parent_directory(tmp_path: Path):
+    """save_atomic 은 부모 디렉토리가 없으면 생성한다."""
+    target = tmp_path / "nested" / "deeper" / "state.json"
+    await StrategyStateIO.save_atomic(str(target), {"k": 1})
+    assert target.exists()
+
+
+@pytest.mark.asyncio
+async def test_save_atomic_preserves_original_on_write_failure(tmp_path: Path):
+    """os.replace 가 실패해도 기존 파일이 보존되고 temp 파일이 청소된다.
+
+    Atomic 성격의 핵심: replace 가 실패하면 commit 전이므로 원본은 절대 손상되지 않는다.
+    """
+    target = tmp_path / "state.json"
+    original = {"positions": {"005930": {"qty": 1}}, "cooldown": {}}
+    target.write_text(json.dumps(original), encoding="utf-8")
+
+    new_payload = {"positions": {"000660": {"qty": 99}}, "cooldown": {"a": "b"}}
+
+    with patch("utils.strategy_state_io.os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            await StrategyStateIO.save_atomic(str(target), new_payload)
+
+    # 기존 파일은 그대로
+    with open(target, "r", encoding="utf-8") as f:
+        assert json.load(f) == original
+
+    # mkstemp 가 만든 temp 파일이 정리됨 (prefix=state.json. suffix=.tmp)
+    tmp_leftovers = list(tmp_path.glob("state.json.*.tmp"))
+    assert tmp_leftovers == [], f"temp files leaked: {tmp_leftovers}"
+
+
+@pytest.mark.asyncio
+async def test_save_atomic_serializes_concurrent_writes(tmp_path: Path):
+    """동일 파일 동시 save 는 per-file lock 으로 직렬화되어 부분 기록이 없다."""
+    target = tmp_path / "state.json"
+
+    payload_a = {"v": "A" * 1000}
+    payload_b = {"v": "B" * 1000}
+
+    # 두 save 를 동시에 시작
+    await asyncio.gather(
+        StrategyStateIO.save_atomic(str(target), payload_a),
+        StrategyStateIO.save_atomic(str(target), payload_b),
+    )
+
+    # 최종 파일은 둘 중 하나의 완전한 내용 (interleaved 가 아닌)
+    with open(target, "r", encoding="utf-8") as f:
+        final = json.load(f)
+    assert final in (payload_a, payload_b)
+
+
+@pytest.mark.asyncio
+async def test_load_returns_none_when_missing(tmp_path: Path):
+    """파일이 없으면 None 반환."""
+    missing = tmp_path / "no_such_state.json"
+    assert await StrategyStateIO.load(str(missing)) is None
+
+
+@pytest.mark.asyncio
+async def test_load_reads_json_content(tmp_path: Path):
+    """기존 파일은 dict 로 반환."""
+    target = tmp_path / "state.json"
+    payload = {"positions": {"005930": {"qty": 5}}, "cooldown": {"x": "y"}}
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert await StrategyStateIO.load(str(target)) == payload
+
+
+@pytest.mark.asyncio
+async def test_save_then_load_roundtrip(tmp_path: Path):
+    """save → load 가 동일 페이로드를 반환."""
+    target = tmp_path / "state.json"
+    payload = {"positions": {"a": 1}, "cooldown": {"b": "c"}}
+    await StrategyStateIO.save_atomic(str(target), payload)
+    assert await StrategyStateIO.load(str(target)) == payload
+
+
+@pytest.mark.asyncio
+async def test_flush_pending_awaits_scheduled_saves(tmp_path: Path):
+    """schedule_save 로 시작된 background task 가 flush_pending 으로 완료 대기된다."""
+    target = tmp_path / "state.json"
+
+    task = StrategyStateIO.schedule_save(str(target), {"v": 42})
+    assert task in StrategyStateIO._pending
+
+    await StrategyStateIO.flush_pending()
+
+    # 파일이 완성되어 있음
+    with open(target, "r", encoding="utf-8") as f:
+        assert json.load(f) == {"v": 42}
+
+    # pending set 비워짐
+    assert len(StrategyStateIO._pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_flush_pending_noop_when_empty():
+    """pending 이 비어 있으면 즉시 반환."""
+    await StrategyStateIO.flush_pending()  # 예외 없이 종료

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -24,6 +24,7 @@ def mock_web_app_context_cls():
         mock_instance.load_config_and_env = MagicMock()
         mock_instance.initialize_services = AsyncMock(return_value=True)
         mock_instance.initialize_scheduler = MagicMock()
+        mock_instance.ensure_strategy_states_loaded = AsyncMock()
         mock_instance.scheduler = MagicMock()
         mock_instance.scheduler.restore_state = AsyncMock()
         mock_instance.scheduler._running = True

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-19 (실전 모드 RiskGate fail-close 전환 완료)
+최종 업데이트: 2026-05-20 (get_current_price 전역 캐시 제거 + 전략 state atomic write/lock + 명시적 load_state await)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -38,13 +38,15 @@
   - 개선 방향: paper/backtest는 fail-open 허용, real은 신규 BUY 차단. 예: `risk_gate.fail_open_allowed.paper=true`, `risk_gate.fail_open_allowed.real=false`.
   - 테스트: real mode에서 snapshot/provider 오류, total_equity<=0, strategy holds 조회 실패가 BUY를 차단하고, paper mode 기존 동작은 명시적으로 유지되는지 검증.
   - 완료 내용: `config/config_loader.py`에 `RiskGateFailOpenConfig(paper=True, real=False)` 추가, `RiskGateConfig.fail_open_allowed` 필드로 연결. `RiskGateService._should_fail_close()` 헬퍼 도입 후 6개 fail-open 지점을 real 모드 BUY 시 차단으로 전환: `_check_buy_exposure`(snapshot cache None, equity<=0), `_check_duplicate_strategy_position`(provider 예외), `_check_strategy_loss_limit`(history provider 예외), `_check_strategy_capital_cap`(snapshot None / equity<=0 / holds 예외), `_check_strategy_exposure_limit`(snapshot None / equity<=0 / holds 예외). SELL 경로는 `validate_order`의 `if side == BUY` 가드로 변경 없음 → 강제 청산 보존. env=None 및 paper 모드는 기본 `fail_open_allowed.paper=True`로 기존 fail-open 동작 유지. opt-out 위해 `fail_open_allowed.real=True` 설정 가능. 신규 테스트 9건 추가 (snapshot 부재, zero equity BUY, SELL 비차단, paper/env=None 회귀, strategy exposure/capital/loss/duplicate provider 예외, config opt-out). 단위 4716건 + 통합 233건 통과.
-- [ ] `get_current_price`를 일반 300초 캐시 대상에서 제거하거나 메서드별 짧은 TTL로 분리한다.
+- [x] `get_current_price`를 일반 300초 캐시 대상에서 제거하거나 메서드별 짧은 TTL로 분리한다. (2026-05-20 완료)
   - 검토 결과: 타당. `config/cache_config.yaml`의 `enabled_methods`에 `get_current_price`가 남아 있고 기본 TTL은 300초다. `StockQueryService`/`MarketDataService` 내부 단기 snapshot·repository 캐시는 별도로 3~5초 범위로 관리되므로 전역 캐시 대상과 충돌한다.
   - 개선 방향: `enabled_methods`에서 `get_current_price` 제거. 캐시가 꼭 필요하면 `method_ttl.get_current_price <= 1~2초`와 주문/손절/리스크 경로 `force_fresh=True`를 테스트로 고정.
-- [ ] 전략 state load/save를 명시적 await + atomic write + lock 구조로 정리한다.
+  - 완료 내용: `config/cache_config.yaml`의 `enabled_methods`에서 `get_current_price`를 제거하고 제거 이유 주석 추가. `MarketDataService`는 이미 `_stock_repo.get_current_price(max_age_sec=3.0)` 단기 캐시 + 장 마감 후 `_stock_repo.get_latest_daily_snapshot()` DB 폴백 + REST 응답 캐시 갱신을 운영하므로 ClientWithCache 계층 제거 후에도 캐싱 책임은 유지된다. ClientWithCache는 장 중 캐시 우회, 장 마감 후 cached payload를 다음 거래일 개장 전까지 유지하므로 주문/손절/리스크의 `force_fresh=True` 의도가 broker wrapper로 전파되지 않는 충돌이 있었다. 정책 invariant를 회귀 테스트 1건으로 고정(`tests/unit_test/config/test_cache_config_yaml.py::test_get_current_price_is_not_globally_cached`). 단위 4720건 + 통합 233건 통과.
+- [x] 전략 state load/save를 명시적 await + atomic write + lock 구조로 정리한다. (2026-05-20 완료)
   - 검토 결과: 타당. `OneilPocketPivotStrategy`, `HighTightFlagStrategy`, `FirstPullbackStrategy`, `OneilSqueezeBreakoutStrategy`가 이벤트 루프 존재 시 `_load_state_async()` / `_save_state_async()`를 background task로 실행하고, 파일 저장은 직접 overwrite다.
   - 개선 방향: scheduler/strategy factory 초기화 단계에서 `await strategy.load_state()`를 보장하고, 저장은 per-strategy lock + temp file + `os.replace()`로 원자화한다. 종료 시 pending save flush도 추가한다.
   - 테스트: 생성 직후 scan 전에 state 로드 완료, 저장 task 경합 시 최신 상태 보존, 저장 중 장애 시 기존 파일 보존.
+  - 완료 내용: 신규 `utils/strategy_state_io.py` (`StrategyStateIO`) — `save_atomic()` 은 `tempfile.mkstemp` → `fsync` → `os.replace()` 로 원자 교체 + 파일 경로별 `asyncio.Lock` 으로 동시 save 직렬화. `load()` 는 단순 async 로드, `schedule_save()` + `flush_pending()` 으로 graceful shutdown 시 in-flight save 완료 대기. 4개 전략의 `_load_state_async()` / `_save_state_async()` 본문을 헬퍼 위임으로 교체, 신규 public `async def load_state(self)` 추가 (`_load_state_async` 의 `if k not in self._position_state` 가드로 idempotent). `WebAppContext.ensure_strategy_states_loaded()` 신설하여 등록된 모든 전략의 `load_state` 를 명시적으로 await; `view/web/web_main.py::lifespan` 에서 `initialize_scheduler()` 직후 호출 + 종료 시 `await StrategyStateIO.flush_pending(timeout=5.0)`. 기존 `_load_state()` / `_save_state()` sync 폴백 및 fire-and-forget create_task 는 보존하여 standalone 호환. 테스트 15건 신규 추가 (`tests/unit_test/utils/test_strategy_state_io.py` 9건: atomic write/preserve-on-failure/concurrent serialization/load missing & roundtrip/flush_pending; `tests/unit_test/strategies/test_strategy_load_state_await.py` 6건: 4개 전략 await 로드 + idempotent + missing file). 기존 `tests/unit_test/view/test_web_main.py` 와 `tests/integration_test/test_it_web_app_e2e_smoke.py` 에 `ensure_strategy_states_loaded` AsyncMock 추가. 단위 4735건 + 통합 233건 통과.
 
 주요 파일:
 

--- a/utils/strategy_state_io.py
+++ b/utils/strategy_state_io.py
@@ -1,0 +1,109 @@
+"""전략 state 파일 atomic load/save 헬퍼.
+
+전략은 다수의 비동기 진입점(scan, 매수/매도 콜백, 강제청산)에서 동일 state 파일을
+저장한다. 직접 `with open(path, "w")` 로 truncate 후 쓰는 기존 패턴은
+- 동시 save 경합 시 partial-write 위험
+- 저장 중 프로세스 종료 시 truncate 된 빈 파일이 남는 위험
+을 가진다.
+
+이 모듈은 다음을 보장한다.
+
+- **Atomic write**: temp 파일에 기록 → `fsync` → `os.replace()` 로 원자 교체.
+- **Per-file lock**: 동일 파일 경로에 대해 `asyncio.Lock` 으로 save 직렬화.
+- **Pending flush**: 백그라운드 `schedule_save()` 로 시작된 save task 를
+  `flush_pending()` 으로 graceful shutdown 시 await 가능.
+
+설계 가정: 단일 event loop. 멀티 루프는 본 프로젝트 시나리오가 아니다.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+from typing import Any, Dict, Optional, Set
+
+
+class StrategyStateIO:
+    """Atomic + lock 기반 전략 state 파일 헬퍼.
+
+    클래스 변수로 lock dict / pending task set 을 보관한다. 단일 event loop
+    가정하에 4개 전략이 공유한다.
+    """
+
+    _locks: Dict[str, asyncio.Lock] = {}
+    _pending: Set[asyncio.Task] = set()
+
+    @classmethod
+    def _lock_for(cls, file_path: str) -> asyncio.Lock:
+        lock = cls._locks.get(file_path)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._locks[file_path] = lock
+        return lock
+
+    @classmethod
+    async def save_atomic(cls, file_path: str, data: Any) -> None:
+        """data 를 file_path 에 atomic 하게 저장한다. 동일 경로 동시 호출은 직렬화된다."""
+        lock = cls._lock_for(file_path)
+        async with lock:
+            await asyncio.to_thread(cls._write_atomic, file_path, data)
+
+    @staticmethod
+    def _write_atomic(file_path: str, data: Any) -> None:
+        directory = os.path.dirname(file_path) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=os.path.basename(file_path) + ".",
+            suffix=".tmp",
+            dir=directory,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, file_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    @classmethod
+    async def load(cls, file_path: str) -> Optional[Any]:
+        """file_path 의 JSON 을 로드. 파일이 없으면 None."""
+        if not os.path.exists(file_path):
+            return None
+        return await asyncio.to_thread(cls._read_file, file_path)
+
+    @staticmethod
+    def _read_file(file_path: str) -> Any:
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    @classmethod
+    def schedule_save(cls, file_path: str, data: Any) -> asyncio.Task:
+        """백그라운드 save task 생성 후 _pending 에 등록. flush_pending() 추적 대상."""
+        task = asyncio.create_task(cls.save_atomic(file_path, data))
+        cls._pending.add(task)
+        task.add_done_callback(cls._pending.discard)
+        return task
+
+    @classmethod
+    async def flush_pending(cls, timeout: Optional[float] = None) -> None:
+        """등록된 모든 save task 완료까지 대기. timeout=None 이면 무한 대기."""
+        if not cls._pending:
+            return
+        tasks = list(cls._pending)
+        if timeout is None:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        else:
+            await asyncio.wait(tasks, timeout=timeout)
+
+    @classmethod
+    def _reset_for_test(cls) -> None:
+        """테스트용: lock/pending 상태 초기화."""
+        cls._locks.clear()
+        cls._pending.clear()

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -315,6 +315,27 @@ class WebAppContext:
         from view.web.bootstrap.strategy_factory import StrategyFactory
         StrategyFactory(self).build()
 
+    async def ensure_strategy_states_loaded(self):
+        """등록된 전략 중 `load_state()` 를 가진 전략의 state 를 명시적으로 await 로드한다.
+
+        StrategyFactory.build() 직후 + scheduler.start() 전에 호출. 기존 `__init__` 의
+        fire-and-forget `_load_state()` 가 scan 보다 늦게 끝나는 race 를 제거한다.
+        """
+        if self.scheduler is None:
+            return
+        for cfg in getattr(self.scheduler, "_strategies", []):
+            strategy = getattr(cfg, "strategy", None)
+            load_fn = getattr(strategy, "load_state", None)
+            if load_fn is None:
+                continue
+            try:
+                await load_fn()
+            except Exception as exc:
+                if self.logger:
+                    self.logger.error(
+                        f"[WebAppContext] strategy.load_state() 실패 ({getattr(strategy, 'name', '?')}): {exc}"
+                    )
+
     def start_background_tasks(self):
         """백그라운드 태스크 시작 — BackgroundScheduler에 위임."""
         # StreamingService에 콜백 등록 (내부 저장 → 재연결 시에도 자동 유지됨)

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -119,6 +119,10 @@ async def lifespan(app: FastAPI):
     # TRADING 비활성이면 StrategyFactory 가 내부에서 no-op.
     ctx.initialize_scheduler()
 
+    # 4-1. 전략 state(positions/cooldown) 를 명시적으로 await 로드.
+    # __init__ 의 fire-and-forget create_task 만으로는 scan 전에 로드 완료가 보장되지 않는다.
+    await ctx.ensure_strategy_states_loaded()
+
     # 5. 실전 주문 상태 복원 및 reconcile (WebSocket 구독 전, 전략 스케줄러 전).
     # WEB / TRADING 어느 한쪽이라도 켜져 있으면 수행 — /api/order 가 살아 있는 한
     # broker 와 동기화 안 된 상태로 신규 주문이 나가는 위험을 차단해야 한다.
@@ -140,6 +144,10 @@ async def lifespan(app: FastAPI):
     # 종료 시 스케줄러 상태 저장 후 정지
     if ctx.scheduler and ctx.scheduler._running:
         await ctx.scheduler.stop(save_state=True)
+
+    # StrategyStateIO 백그라운드 save task 가 남아 있으면 flush.
+    from utils.strategy_state_io import StrategyStateIO
+    await StrategyStateIO.flush_pending(timeout=5.0)
 
 # 1. FastAPI 앱 인스턴스 생성 (lifespan 추가)
 app = FastAPI(title="Trading App", lifespan=lifespan)


### PR DESCRIPTION
Item 1: get_current_price 전역 캐시 제거
config/cache_config.yaml: enabled_methods 에서 get_current_price 제거 + 제거 이유 주석. tests/unit_test/config/test_cache_config_yaml.py: 정책 invariant 회귀 테스트 1건. MarketDataService의 3초 단기 캐시 + DB 스냅샷 폴백이 캐싱을 담당. ClientWithCache의 다음 거래일까지 유지되던 stale 캐시와 force_fresh=True 의도 충돌 해소. Item 2: 전략 state atomic write + lock + 명시적 load
utils/strategy_state_io.py: 신규 StrategyStateIO — save_atomic() (temp file → fsync → os.replace() + per-file asyncio.Lock), load(), schedule_save()/flush_pending(). 4개 전략 (oneil_pocket_pivot, first_pullback, high_tight_flag, oneil_squeeze_breakout): _load_state_async() / _save_state_async() 본문을 헬퍼 위임으로 교체 + public async def load_state(self) 추가. view/web/web_app_initializer.py: WebAppContext.ensure_strategy_states_loaded() 신설. view/web/web_main.py: initialize_scheduler() 직후 await ctx.ensure_strategy_states_loaded(), shutdown 시 await StrategyStateIO.flush_pending(timeout=5.0). 신규 단위 테스트 15건 (test_strategy_state_io.py 9 + test_strategy_load_state_await.py 6). 기존 lifespan mock 2곳에 ensure_strategy_states_loaded=AsyncMock() 추가. 검증: 단위 4735건 + 통합 233건 모두 통과.