### PR TITLE
원인 확인했고 수정까지 완료했습니다.

### DIFF
--- a/repositories/program_trading_repo.py
+++ b/repositories/program_trading_repo.py
@@ -109,6 +109,12 @@ class ProgramTradingRepo:
                         updated_at REAL NOT NULL
                     )
                 """)
+
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS pt_subscriptions (
+                        code TEXT PRIMARY KEY
+                    )
+                """)
             self._logger.info("ProgramTradingRepo: SQLite DB 초기화 완료")
         except Exception as e:
             self._logger.error(f"SQLite DB 초기화 실패: {e}")

--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -23,7 +23,7 @@ import logging
 import sqlite3
 import threading
 from enum import Enum
-from typing import Dict, Optional, Set
+from typing import Dict, Iterable, Optional, Set
 
 
 class StreamingType(str, Enum):
@@ -59,14 +59,50 @@ class StreamingStockRepo:
 
     # ── 초기화 / 영속성 ──────────────────────────────────────────────
 
-    def load_pt_desired_from_db(self, db_path: str) -> None:
-        """앱 시작 시 SQLite pt_subscriptions 테이블에서 PT desired 상태를 복원."""
+    def _ensure_pt_subscription_table_locked(self) -> None:
+        """pt_subscriptions 테이블을 보장한다. 호출자는 _db_lock을 보유해야 한다."""
+        self._db_conn.execute(
+            "CREATE TABLE IF NOT EXISTS pt_subscriptions (code TEXT PRIMARY KEY)"
+        )
+
+    @staticmethod
+    def _normalize_codes(codes: Optional[Iterable[str]]) -> Set[str]:
+        if not codes:
+            return set()
+        normalized = set()
+        for code in codes:
+            if code is None:
+                continue
+            text = str(code).strip()
+            if text:
+                normalized.add(text)
+        return normalized
+
+    def load_pt_desired_from_db(
+        self,
+        db_path: str,
+        fallback_codes: Optional[Iterable[str]] = None,
+    ) -> None:
+        """앱 시작 시 SQLite pt_subscriptions 테이블에서 PT desired 상태를 복원.
+
+        구버전 DB처럼 테이블이 없으면 생성한다. DB에 저장된 desired가 아직 없고
+        스냅샷에 구독 코드가 남아 있으면 1회 이관해 UI 상태와 실제 구독 SSOT를 맞춘다.
+        """
         self._db_path = db_path
         try:
             self._db_conn = sqlite3.connect(db_path, check_same_thread=False)
             with self._db_lock:
+                self._ensure_pt_subscription_table_locked()
                 cursor = self._db_conn.execute("SELECT code FROM pt_subscriptions")
                 codes = {row[0] for row in cursor.fetchall()}
+                if not codes:
+                    codes = self._normalize_codes(fallback_codes)
+                    if codes:
+                        self._db_conn.executemany(
+                            "INSERT OR IGNORE INTO pt_subscriptions (code) VALUES (?)",
+                            [(code,) for code in sorted(codes)],
+                        )
+                self._db_conn.commit()
             # desired 초기화 (lock 불필요 — 앱 시작 단계, 단일 스레드)
             self._desired[StreamingType.PROGRAM_TRADING] = codes
             if codes:
@@ -92,6 +128,7 @@ class StreamingStockRepo:
             self._pending_desired_ops.clear()
         try:
             with self._db_lock:
+                self._ensure_pt_subscription_table_locked()
                 for code, add in ops:
                     if add:
                         self._db_conn.execute(

--- a/tests/unit_test/repositories/test_streaming_stock_repo.py
+++ b/tests/unit_test/repositories/test_streaming_stock_repo.py
@@ -85,18 +85,16 @@ async def test_get_status(repo):
 async def test_pt_persistence_flow(tmp_path, mock_logger):
     """SQLite DB를 활용한 PROGRAM_TRADING 영속화 흐름 통합 검증"""
     db_path = str(tmp_path / "test_pt.db")
-    
-    # 1. 초기 테이블 구성 (앱에서는 ProgramTradingStreamService가 테이블을 생성함)
-    conn = sqlite3.connect(db_path)
-    conn.execute("CREATE TABLE pt_subscriptions (code TEXT PRIMARY KEY)")
-    conn.commit()
-    conn.close()
 
-    # 2. repo 설정 및 DB 연결
+    # 1. repo 설정 및 DB 연결 — 테이블이 없으면 직접 생성한다.
     repo1 = StreamingStockRepo(logger=mock_logger)
     repo1.load_pt_desired_from_db(db_path)
+    conn = sqlite3.connect(db_path)
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert "pt_subscriptions" in tables
     
-    # 3. 구독 대상 추가 — flush 전에는 in-memory만 반영, DB는 미반영
+    # 2. 구독 대상 추가 — flush 전에는 in-memory만 반영, DB는 미반영
     await repo1.mark_desired("005930", StreamingType.PROGRAM_TRADING)
     await repo1.mark_desired("000660", StreamingType.PROGRAM_TRADING)
 
@@ -115,14 +113,14 @@ async def test_pt_persistence_flow(tmp_path, mock_logger):
     assert "005930" in rows
     assert "000660" in rows
 
-    # 4. 새로운 repo 객체로 DB에서 복원 검증
+    # 3. 새로운 repo 객체로 DB에서 복원 검증
     repo2 = StreamingStockRepo(logger=mock_logger)
     repo2.load_pt_desired_from_db(db_path)
     desired2 = repo2.get_desired(StreamingType.PROGRAM_TRADING)
     assert "005930" in desired2
     assert "000660" in desired2
 
-    # 5. 구독 대상 제거 검증 — flush 후 DB 반영
+    # 4. 구독 대상 제거 검증 — flush 후 DB 반영
     await repo1.unmark_desired("005930", StreamingType.PROGRAM_TRADING)
     repo1.flush_pt_desired_sync()
 
@@ -131,6 +129,37 @@ async def test_pt_persistence_flow(tmp_path, mock_logger):
     desired3 = repo3.get_desired(StreamingType.PROGRAM_TRADING)
     assert "005930" not in desired3
     assert "000660" in desired3
+
+
+def test_load_pt_desired_from_db_uses_snapshot_fallback_when_db_empty(tmp_path, mock_logger):
+    """기존 스냅샷 구독 종목을 빈 pt_subscriptions 테이블로 1회 이관한다."""
+    db_path = str(tmp_path / "test_pt.db")
+    repo = StreamingStockRepo(logger=mock_logger)
+
+    repo.load_pt_desired_from_db(db_path, fallback_codes=["005930", "000660", "005930", ""])
+
+    desired = repo.get_desired(StreamingType.PROGRAM_TRADING)
+    assert desired == {"005930", "000660"}
+
+    conn = sqlite3.connect(db_path)
+    rows = {row[0] for row in conn.execute("SELECT code FROM pt_subscriptions").fetchall()}
+    conn.close()
+    assert rows == {"005930", "000660"}
+
+
+def test_load_pt_desired_from_db_prefers_existing_db_over_snapshot_fallback(tmp_path, mock_logger):
+    """DB에 저장된 구독 상태가 있으면 오래된 스냅샷 구독 코드는 섞지 않는다."""
+    db_path = str(tmp_path / "test_pt.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE pt_subscriptions (code TEXT PRIMARY KEY)")
+    conn.execute("INSERT INTO pt_subscriptions (code) VALUES ('080220')")
+    conn.commit()
+    conn.close()
+
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path, fallback_codes=["005930", "000660"])
+
+    assert repo.get_desired(StreamingType.PROGRAM_TRADING) == {"080220"}
 
 
 def test_load_pt_desired_from_db_failure(mock_logger):

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -51,8 +51,9 @@ def test_init_creates_db(manager, tmp_db_dir):
 
     assert 'pt_history' in tables
     assert 'pt_snapshot' in tables
-    # pt_subscriptions는 StreamingStockRepo가 SSOT로 관리 — ProgramTradingRepo에서 생성하지 않음
-    assert 'pt_subscriptions' not in tables
+    # 구독 상태의 읽기/쓰기는 StreamingStockRepo가 SSOT로 담당하지만,
+    # 같은 DB를 공유하므로 ProgramTradingRepo가 테이블 스키마를 보장한다.
+    assert 'pt_subscriptions' in tables
 
 
 def test_init_db_failure():

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -130,6 +130,23 @@ def test_service_container_creates_streaming_chain(patched_service_container_dep
     ctx.streaming_service.set_streaming_stock_repo.assert_not_called()
 
 
+def test_service_container_restores_pt_desired_from_snapshot_fallback(patched_service_container_deps):
+    """부팅 시 저장 스냅샷의 PT 구독 종목을 StreamingStockRepo 복원 fallback으로 전달한다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.program_trading_stream_service.load_snapshot.return_value = {
+        "subscribedCodes": ["005930", "000660"],
+    }
+    ServiceContainer(ctx).run()
+
+    repo = patched_service_container_deps["StreamingStockRepo"].return_value
+    repo.load_pt_desired_from_db.assert_called_once_with(
+        "data/program_subscribe/program_trading.db",
+        fallback_codes=["005930", "000660"],
+    )
+
+
 def test_service_container_batch_mode_skips_streaming_and_intraday_web_tasks(patched_service_container_deps):
     """BATCH 단독은 장마감 작업에 불필요한 실시간/장중/웹 task 생성을 건너뛴다."""
     from view.web.bootstrap.service_container import ServiceContainer

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -315,7 +315,16 @@ class ServiceContainer:
                 )
                 # NOTE: data_quality / streaming / stock_query <-> price_stream wiring is performed by WiringPhase.
                 ctx.streaming_stock_repo = StreamingStockRepo(logger=ctx.logger)
-                ctx.streaming_stock_repo.load_pt_desired_from_db("data/program_subscribe/program_trading.db")
+                pt_snapshot = ctx.program_trading_stream_service.load_snapshot()
+                fallback_pt_codes = []
+                if isinstance(pt_snapshot, dict):
+                    raw_codes = pt_snapshot.get("subscribedCodes", [])
+                    if isinstance(raw_codes, list):
+                        fallback_pt_codes = raw_codes
+                ctx.streaming_stock_repo.load_pt_desired_from_db(
+                    "data/program_subscribe/program_trading.db",
+                    fallback_codes=fallback_pt_codes,
+                )
                 ctx.price_subscription_service = PriceSubscriptionService(
                     streaming_service=ctx.streaming_service,
                     stock_repo=ctx.stock_repository,


### PR DESCRIPTION
2026-05-20 실제 DB 상태는 data/program_subscribe/program_trading.db 기준으로 pt_history가 0건이었습니다. 스냅샷에는 삼성전자 005930, SK하이닉스 000660, 제주반도체 080220이 subscribedCodes로 남아 있었지만, 각 종목의 valueData/volumeData도 0건이라 실제 프로그램매매 tick이 백엔드에 수신/저장된 흔적은 없었습니다. 알림이 안 온 직접 원인은 텔레그램 문제가 아니라, 백엔드 실제 PT 구독 SSOT인 pt_subscriptions 테이블이 없어서 시작 시 복원이 실패한 것입니다. 로그에도 no such table: pt_subscriptions가 있었고, 스트리밍 로그의 PT 복원 대상은 하루 종일 pt_codes: []였습니다. 즉 UI 스냅샷에는 3종목이 구독처럼 남아 있었지만, 서버가 실제로는 PT 구독할 종목이 없다고 보고 있었습니다. 수정 내용:
repositories/program_trading_repo.py (line 114): pt_subscriptions 테이블을 DB 초기화 때 생성하도록 수정 repositories/streaming_stock_repo.py (line 81): 테이블이 없는 기존 DB도 자동 생성하고, DB가 비어 있으면 저장 스냅샷의 subscribedCodes를 1회 이관 view/web/bootstrap/service_container.py (line 319): 앱 부팅 시 스냅샷 구독 종목을 fallback으로 전달 관련 회귀 테스트 추가/수정
검증:
pytest tests/unit_test -v 통과
pytest tests/integration_test -v 통과, 233 passed
참고로 실제 DB는 제가 직접 변경하지 않았고, 복사본으로 마이그레이션 검증했습니다. 현재 스냅샷 기준으로 앱 재시작 시 ['000660', '005930', '080220']가 pt_subscriptions로 이관되어 이후 워치독/알림이 실제 구독 목록을 보게 됩니다.