### PR TITLE
기본 off로 바꿔뒀습니다.

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -28,7 +28,7 @@ market_timezone: "Asia/Seoul"
 
 # 계좌 보호용 Kill Switch
 kill_switch:
-  enabled: true
+  enabled: false
   notify_only: false                       # true이면 트립/알림/상태 기록만 수행하고 주문·전략은 차단하지 않음.
   daily_loss_threshold_won: 1000000      # 일손실 한도 (원). 초과 시 트립.
   daily_loss_threshold_pct: 5.0          # 일손실 한도 (%). 원화/% 중 하나라도 초과하면 트립.

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -25,7 +25,7 @@ class CacheConfig(BaseModel):
     file_cache_enabled: bool = True
 
 class KillSwitchConfig(BaseModel):
-    enabled: bool = True
+    enabled: bool = False
     notify_only: bool = False
     daily_loss_threshold_won: int = 1_000_000
     daily_loss_threshold_pct: float = 5.0

--- a/services/kill_switch_service.py
+++ b/services/kill_switch_service.py
@@ -459,6 +459,8 @@ class KillSwitchService:
 
     def _load_state(self) -> None:
         """재시작 시 JSON 파일에서 상태 복원."""
+        if not self._cfg.enabled:
+            return
         if not self._state_path.exists():
             return
         try:

--- a/tests/unit_test/services/test_kill_switch_service.py
+++ b/tests/unit_test/services/test_kill_switch_service.py
@@ -52,6 +52,13 @@ def _make_ks(cfg, mock_notif, logger, tmp_path=None):
 # ── enabled=False 바이패스 ────────────────────────────────────────────
 
 
+def test_kill_switch_config_defaults_to_disabled():
+    """개발 중 안전 기본값은 Kill Switch 비활성화."""
+    cfg = KillSwitchConfig()
+
+    assert cfg.enabled is False
+
+
 async def test_disabled_orders_always_allowed(cfg, mock_notif, logger):
     cfg = cfg.model_copy(update={"enabled": False})
     ks = _make_ks(cfg, mock_notif, logger)
@@ -380,6 +387,27 @@ async def test_state_load_restores_trip(cfg, mock_notif, logger, tmp_path):
     assert ks._trip_reason == "복원 테스트"
     assert ks._consecutive_losses == 2
     assert ks._daily_realized_loss_won == -200_000
+
+
+async def test_state_load_skips_persisted_trip_when_disabled(cfg, mock_notif, logger, tmp_path):
+    state_file = tmp_path / "ks_state.json"
+    state_file.write_text(json.dumps({
+        "is_tripped": True,
+        "trip_reason": "비활성화 시 복원하지 않음",
+        "trip_timestamp": "2026-01-01T10:00:00+09:00",
+        "trip_metadata": {},
+        "consecutive_losses": 2,
+        "consecutive_api_errors": 3,
+        "daily_realized_loss_won": -200_000,
+    }))
+
+    cfg2 = cfg.model_copy(update={"enabled": False, "state_file_path": str(state_file)})
+    ks = KillSwitchService(cfg2, mock_notif, logger)
+
+    assert ks._is_tripped is False
+    assert ks._trip_reason is None
+    assert ks._consecutive_losses == 0
+    assert ks._daily_realized_loss_won == 0
 
 
 async def test_state_load_missing_file_is_noop(cfg, mock_notif, logger, tmp_path):


### PR DESCRIPTION
변경 내용:

config_loader.py (line 27): KillSwitchConfig.enabled 기본값 True -> False kill_switch_service.py (line 460): enabled=False일 때는 기존 data/kill_switch_state.json의 트립 상태도 복원하지 않도록 처리 config.yaml.example (line 30): 예시 기본값도 enabled: false 로컬 config.yaml (line 48): 현재 개발 설정도 enabled: false 테스트도 추가했습니다:

기본값이 disabled인지 확인
disabled 상태에서는 persisted trip state를 복원하지 않는지 확인
검증 완료:

pytest tests/unit_test -v → 4740 passed
pytest tests/integration_test -v → 233 passed