### PR TITLE
진행 완료했습니다. P1-0을 1차 구현으로 끊어서, 실전 투입 전 수익성 기준선을 판정 산출물로 만들었습니다.

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -193,6 +193,23 @@ class StrategyPerformanceDegradationConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class StrategyProfitabilityGateConfig(BaseModel):
+    min_trades: int = 30
+    min_profit_factor: Optional[float] = 1.2
+    min_payoff_ratio: Optional[float] = 1.0
+    min_win_rate: Optional[float] = 0.35
+    min_avg_net_return: Optional[float] = 0.0
+    require_positive_total_net_pnl: bool = True
+    max_mdd_pct: Optional[float] = 20.0
+    capital_base_won: Optional[float] = None
+    max_monte_carlo_ruin_probability: Optional[float] = 0.05
+    max_monte_carlo_worst_mdd_pct: Optional[float] = 30.0
+    min_regime_trade_count: int = 5
+    require_non_negative_regime_pnl: bool = True
+
+    model_config = {"extra": "allow"}
+
+
 class OpeningPositionReconcileConfig(BaseModel):
     enabled: bool = True
     check_interval_sec: int = 30
@@ -229,6 +246,9 @@ class AppConfig(BaseModel):
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)
     strategy_performance_degradation: StrategyPerformanceDegradationConfig = Field(
         default_factory=StrategyPerformanceDegradationConfig
+    )
+    strategy_profitability_gate: StrategyProfitabilityGateConfig = Field(
+        default_factory=StrategyProfitabilityGateConfig
     )
     opening_position_reconcile: OpeningPositionReconcileConfig = Field(default_factory=OpeningPositionReconcileConfig)
     

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -92,6 +92,13 @@ def _parse_args() -> argparse.Namespace:
         help="MDD가 이 비율 이상이면 ruin으로 집계 (default: 30)",
     )
     parser.add_argument(
+        "--profitability-gate",
+        action="store_true",
+        default=False,
+        dest="profitability_gate",
+        help="전략별 실전 투입 수익성 기준선 통과 여부를 산출",
+    )
+    parser.add_argument(
         "--paper",
         action="store_true",
         default=False,
@@ -360,6 +367,9 @@ def _format_console(result) -> str:
     monte_carlo = getattr(result, "monte_carlo", None)
     if monte_carlo:
         lines.extend(_format_monte_carlo_console_lines(monte_carlo))
+    profitability_gate = getattr(result, "profitability_gate", None)
+    if profitability_gate:
+        lines.extend(_format_profitability_gate_console_lines(profitability_gate))
     return "\n".join(lines)
 
 
@@ -386,6 +396,7 @@ def _result_to_payload(result) -> dict[str, Any]:
         "saved_journal_run": getattr(result, "saved_journal_run", {}),
         "execution_bar_policy": getattr(result, "execution_bar_policy", ""),
         "monte_carlo": getattr(result, "monte_carlo", None),
+        "profitability_gate": getattr(result, "profitability_gate", None),
     }
 
 
@@ -409,6 +420,9 @@ def _format_walk_forward_console(result) -> str:
     monte_carlo = getattr(result, "monte_carlo", None)
     if monte_carlo:
         lines.extend(_format_monte_carlo_console_lines(monte_carlo))
+    profitability_gate = getattr(result, "profitability_gate", None)
+    if profitability_gate:
+        lines.extend(_format_profitability_gate_console_lines(profitability_gate))
     return "\n".join(lines)
 
 
@@ -416,6 +430,7 @@ def _format_walk_forward_json(result) -> str:
     payload = {
         "summary": result.summary,
         "monte_carlo": getattr(result, "monte_carlo", None),
+        "profitability_gate": getattr(result, "profitability_gate", None),
         "segments": [
             {
                 "index": segment.index,
@@ -430,6 +445,23 @@ def _format_walk_forward_json(result) -> str:
         ],
     }
     return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _format_profitability_gate_console_lines(result: dict[str, Any]) -> list[str]:
+    lines = ["", "[PROFITABILITY GATE]"]
+    summary = result.get("summary") or {}
+    lines.append(
+        "통과 {pass_count}, 실패 {fail_count}, 표본부족 {insufficient}".format(
+            pass_count=summary.get("pass_count", 0),
+            fail_count=summary.get("fail_count", 0),
+            insufficient=summary.get("insufficient_sample_count", 0),
+        )
+    )
+    for strategy, item in sorted((result.get("strategies") or {}).items()):
+        reasons = item.get("blocking_reasons") or []
+        suffix = f" ({', '.join(reasons)})" if reasons else ""
+        lines.append(f"{strategy}: {item.get('status')}{suffix}")
+    return lines
 
 
 def _format_monte_carlo_console_lines(summary: dict[str, Any]) -> list[str]:
@@ -482,6 +514,67 @@ def _run_monte_carlo_for_walk_forward(result, args: argparse.Namespace) -> None:
             ruin_drawdown_pct=args.mc_ruin_drawdown_pct,
         )
     ).run(trade_net_pnls).to_dict())
+
+
+def _run_profitability_gate_for_result(result, app_config: Any, *, initial_cash: float) -> None:
+    from services.strategy_profitability_gate_service import evaluate_strategy_profitability_gate
+
+    gate_config = _build_profitability_gate_config(app_config, initial_cash=initial_cash)
+    object.__setattr__(
+        result,
+        "profitability_gate",
+        evaluate_strategy_profitability_gate(
+            getattr(result, "journal_records", []) or [],
+            gate_config,
+            monte_carlo=getattr(result, "monte_carlo", None),
+        ),
+    )
+
+
+def _run_profitability_gate_for_walk_forward(result, app_config: Any, *, initial_cash: float) -> None:
+    from services.strategy_profitability_gate_service import evaluate_strategy_profitability_gate
+
+    records: list[dict] = []
+    for segment in getattr(result, "segments", []) or []:
+        records.extend(getattr(segment.test_result, "journal_records", []) or [])
+    gate_config = _build_profitability_gate_config(app_config, initial_cash=initial_cash)
+    object.__setattr__(
+        result,
+        "profitability_gate",
+        evaluate_strategy_profitability_gate(
+            records,
+            gate_config,
+            monte_carlo=getattr(result, "monte_carlo", None),
+        ),
+    )
+
+
+def _build_profitability_gate_config(app_config: Any, *, initial_cash: float):
+    from services.strategy_profitability_gate_service import StrategyProfitabilityGateConfig
+
+    raw = getattr(app_config, "strategy_profitability_gate", None)
+    if isinstance(raw, StrategyProfitabilityGateConfig):
+        values = {
+            field: getattr(raw, field)
+            for field in StrategyProfitabilityGateConfig.__dataclass_fields__
+        }
+    elif hasattr(raw, "model_dump"):
+        values = raw.model_dump()
+    elif isinstance(raw, dict):
+        values = dict(raw)
+    elif raw is not None:
+        values = {
+            field: getattr(raw, field)
+            for field in StrategyProfitabilityGateConfig.__dataclass_fields__
+            if hasattr(raw, field)
+        }
+    else:
+        values = {}
+
+    if values.get("capital_base_won") is None:
+        values["capital_base_won"] = initial_cash
+    allowed = StrategyProfitabilityGateConfig.__dataclass_fields__
+    return StrategyProfitabilityGateConfig(**{k: v for k, v in values.items() if k in allowed})
 
 
 async def _run(args: argparse.Namespace) -> None:
@@ -624,6 +717,8 @@ async def _run(args: argparse.Namespace) -> None:
             ).run(dates)
             if args.monte_carlo:
                 _run_monte_carlo_for_walk_forward(result, args)
+            if args.profitability_gate:
+                _run_profitability_gate_for_walk_forward(result, app_config, initial_cash=args.initial_cash)
             rendered = (
                 _format_walk_forward_json(result)
                 if args.output == "json"
@@ -634,6 +729,8 @@ async def _run(args: argparse.Namespace) -> None:
             result = await make_runner().run(dates)
             if args.monte_carlo:
                 _run_monte_carlo_for_result(result, args)
+            if args.profitability_gate:
+                _run_profitability_gate_for_result(result, app_config, initial_cash=args.initial_cash)
             rendered = _format_json(result) if args.output == "json" else _format_console(result)
 
     if args.output_file:

--- a/services/strategy_profitability_gate_service.py
+++ b/services/strategy_profitability_gate_service.py
@@ -1,0 +1,263 @@
+"""Strategy profitability gate for live-expansion decisions.
+
+This module is intentionally pure. Callers provide standard journal records
+and optional validation summaries, and receive pass/fail decisions without
+filesystem, broker, or scheduler dependencies.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+
+from services.regime_performance_service import compute_performance_by_regime
+from services.strategy_performance_degradation_service import compute_strategy_window_metrics
+
+
+@dataclass(frozen=True)
+class StrategyProfitabilityGateConfig:
+    min_trades: int = 30
+    min_profit_factor: Optional[float] = 1.2
+    min_payoff_ratio: Optional[float] = 1.0
+    min_win_rate: Optional[float] = 0.35
+    min_avg_net_return: Optional[float] = 0.0
+    require_positive_total_net_pnl: bool = True
+    max_mdd_pct: Optional[float] = 20.0
+    capital_base_won: Optional[float] = None
+    max_monte_carlo_ruin_probability: Optional[float] = 0.05
+    max_monte_carlo_worst_mdd_pct: Optional[float] = 30.0
+    min_regime_trade_count: int = 5
+    require_non_negative_regime_pnl: bool = True
+
+
+def evaluate_strategy_profitability_gate(
+    records: Iterable[Mapping[str, Any]],
+    config: StrategyProfitabilityGateConfig | None = None,
+    *,
+    monte_carlo: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate whether each strategy clears the live-expansion baseline."""
+    cfg = config or StrategyProfitabilityGateConfig()
+    sold_records = [
+        record for record in records
+        if str(record.get("status") or "").upper() == "SOLD"
+        and str(record.get("strategy") or "").strip()
+    ]
+    strategy_names = sorted({str(record.get("strategy") or "").strip() for record in sold_records})
+    by_strategy: dict[str, dict[str, Any]] = {}
+
+    for strategy in strategy_names:
+        strategy_records = [
+            record for record in sold_records
+            if str(record.get("strategy") or "").strip() == strategy
+        ]
+        by_strategy[strategy] = _evaluate_one_strategy(
+            strategy,
+            strategy_records,
+            cfg,
+            monte_carlo=monte_carlo,
+        )
+
+    statuses = [item["status"] for item in by_strategy.values()]
+    return {
+        "config": _config_to_dict(cfg),
+        "summary": {
+            "strategy_count": len(by_strategy),
+            "pass_count": statuses.count("pass"),
+            "fail_count": statuses.count("fail"),
+            "insufficient_sample_count": statuses.count("insufficient_sample"),
+        },
+        "strategies": by_strategy,
+    }
+
+
+def _evaluate_one_strategy(
+    strategy: str,
+    records: list[Mapping[str, Any]],
+    cfg: StrategyProfitabilityGateConfig,
+    *,
+    monte_carlo: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    metrics = compute_strategy_window_metrics(
+        records,
+        window_size=max(len(records), 1),
+        capital_base_won=cfg.capital_base_won,
+    ).get(strategy, _empty_metrics())
+    metrics["mdd_pct"] = (
+        float(metrics["mdd_ratio"]) * 100.0
+        if metrics.get("mdd_ratio") is not None
+        else None
+    )
+
+    blocking_reasons: list[str] = []
+    warnings: list[str] = []
+
+    if int(metrics["trade_count"]) < cfg.min_trades:
+        blocking_reasons.append("insufficient_trades")
+        return _decision(
+            strategy=strategy,
+            status="insufficient_sample",
+            metrics=metrics,
+            blocking_reasons=blocking_reasons,
+            warnings=warnings,
+            regime_performance=compute_performance_by_regime(records),
+        )
+
+    _append_metric_failures(metrics, cfg, blocking_reasons, warnings)
+    _append_monte_carlo_failures(monte_carlo, cfg, blocking_reasons, warnings)
+    regime_performance = compute_performance_by_regime(records)
+    _append_regime_failures(regime_performance, cfg, blocking_reasons)
+
+    return _decision(
+        strategy=strategy,
+        status="fail" if blocking_reasons else "pass",
+        metrics=metrics,
+        blocking_reasons=blocking_reasons,
+        warnings=warnings,
+        regime_performance=regime_performance,
+    )
+
+
+def _append_metric_failures(
+    metrics: Mapping[str, Any],
+    cfg: StrategyProfitabilityGateConfig,
+    blocking_reasons: list[str],
+    warnings: list[str],
+) -> None:
+    if cfg.min_profit_factor is not None and not _meets_min_optional(
+        metrics.get("profit_factor"),
+        cfg.min_profit_factor,
+        no_loss_pass=metrics.get("win_count", 0) > 0 and metrics.get("loss_count", 0) == 0,
+    ):
+        blocking_reasons.append("profit_factor_below")
+
+    if cfg.min_payoff_ratio is not None and not _meets_min_optional(
+        metrics.get("payoff_ratio"),
+        cfg.min_payoff_ratio,
+        no_loss_pass=metrics.get("win_count", 0) > 0 and metrics.get("loss_count", 0) == 0,
+    ):
+        blocking_reasons.append("payoff_ratio_below")
+
+    if cfg.min_win_rate is not None and float(metrics.get("win_rate") or 0.0) < cfg.min_win_rate:
+        blocking_reasons.append("win_rate_below")
+
+    if cfg.min_avg_net_return is not None and float(metrics.get("avg_net_return") or 0.0) < cfg.min_avg_net_return:
+        blocking_reasons.append("avg_net_return_below")
+
+    if cfg.require_positive_total_net_pnl and float(metrics.get("total_net_pnl") or 0.0) <= 0:
+        blocking_reasons.append("total_net_pnl_not_positive")
+
+    mdd_pct = metrics.get("mdd_pct")
+    if cfg.max_mdd_pct is not None:
+        if mdd_pct is None:
+            warnings.append("mdd_pct_unavailable")
+        elif float(mdd_pct) > cfg.max_mdd_pct:
+            blocking_reasons.append("mdd_pct_above")
+
+
+def _append_monte_carlo_failures(
+    monte_carlo: Mapping[str, Any] | None,
+    cfg: StrategyProfitabilityGateConfig,
+    blocking_reasons: list[str],
+    warnings: list[str],
+) -> None:
+    if monte_carlo is None:
+        if (
+            cfg.max_monte_carlo_ruin_probability is not None
+            or cfg.max_monte_carlo_worst_mdd_pct is not None
+        ):
+            warnings.append("monte_carlo_unavailable")
+        return
+
+    ruin_probability = _to_float(monte_carlo.get("ruin_probability"))
+    if (
+        cfg.max_monte_carlo_ruin_probability is not None
+        and ruin_probability is not None
+        and ruin_probability > cfg.max_monte_carlo_ruin_probability
+    ):
+        blocking_reasons.append("monte_carlo_ruin_probability_above")
+
+    worst_mdd_pct = _to_float(monte_carlo.get("worst_max_drawdown_pct"))
+    if (
+        cfg.max_monte_carlo_worst_mdd_pct is not None
+        and worst_mdd_pct is not None
+        and worst_mdd_pct > cfg.max_monte_carlo_worst_mdd_pct
+    ):
+        blocking_reasons.append("monte_carlo_worst_mdd_pct_above")
+
+
+def _append_regime_failures(
+    regime_performance: Mapping[str, Mapping[str, Any]],
+    cfg: StrategyProfitabilityGateConfig,
+    blocking_reasons: list[str],
+) -> None:
+    if not cfg.require_non_negative_regime_pnl:
+        return
+    min_count = max(int(cfg.min_regime_trade_count or 0), 1)
+    for bucket, metrics in regime_performance.items():
+        if int(metrics.get("trade_count") or 0) < min_count:
+            continue
+        if float(metrics.get("total_net_pnl") or 0.0) < 0:
+            blocking_reasons.append(f"regime_{bucket}_negative_pnl")
+
+
+def _decision(
+    *,
+    strategy: str,
+    status: str,
+    metrics: Mapping[str, Any],
+    blocking_reasons: list[str],
+    warnings: list[str],
+    regime_performance: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "strategy": strategy,
+        "status": status,
+        "passed": status == "pass",
+        "blocking_reasons": blocking_reasons,
+        "warnings": warnings,
+        "metrics": dict(metrics),
+        "regime_performance": dict(regime_performance),
+    }
+
+
+def _meets_min_optional(value: Any, threshold: float, *, no_loss_pass: bool) -> bool:
+    if value is None:
+        return no_loss_pass
+    return float(value) >= threshold
+
+
+def _empty_metrics() -> dict[str, Any]:
+    return {
+        "trade_count": 0,
+        "win_count": 0,
+        "loss_count": 0,
+        "win_rate": 0.0,
+        "avg_net_return": 0.0,
+        "total_net_pnl": 0.0,
+        "payoff_ratio": None,
+        "profit_factor": None,
+        "mdd_amount": 0.0,
+        "mdd_ratio": None,
+        "mdd_pct": None,
+        "max_consecutive_losses": 0,
+        "avg_mfe": None,
+        "avg_mae": None,
+        "missing_mfe_count": 0,
+        "missing_mae_count": 0,
+    }
+
+
+def _config_to_dict(cfg: StrategyProfitabilityGateConfig) -> dict[str, Any]:
+    return {
+        field: getattr(cfg, field)
+        for field in StrategyProfitabilityGateConfig.__dataclass_fields__
+    }
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -101,6 +101,8 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.is_paper_trading is True
     assert config.strategy_performance_degradation.window_size == 20
     assert config.strategy_performance_degradation.warn_profit_factor_below == 1.0
+    assert config.strategy_profitability_gate.min_trades == 30
+    assert config.strategy_profitability_gate.min_profit_factor == 1.2
     assert config.data_quality.violation_alert_threshold == 5
     assert config.data_quality.violation_alert_window_sec == 60.0
 

--- a/tests/unit_test/scripts/test_run_backtest.py
+++ b/tests/unit_test/scripts/test_run_backtest.py
@@ -21,6 +21,8 @@ from scripts.run_backtest import (
     _format_walk_forward_json,
     _get_program_provider,
     _parse_args,
+    _run_profitability_gate_for_result,
+    _run_profitability_gate_for_walk_forward,
     _run_monte_carlo_for_result,
     _run_monte_carlo_for_walk_forward,
 )
@@ -107,6 +109,22 @@ def test_parse_args_accepts_monte_carlo_options(monkeypatch):
     assert args.mc_runs == 50
     assert args.mc_seed == 123
     assert args.mc_ruin_drawdown_pct == 15.0
+
+
+def test_parse_args_accepts_profitability_gate(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_backtest",
+            "--dates",
+            "20260501",
+            "--profitability-gate",
+        ],
+    )
+
+    args = _parse_args()
+
+    assert args.profitability_gate is True
 
 
 def test_parse_args_accepts_execution_bar_policy(monkeypatch):
@@ -260,6 +278,32 @@ def test_format_console_includes_monte_carlo_summary_when_present():
     assert "ruin probability: 25.00%" in text
 
 
+def test_format_console_includes_profitability_gate_when_present():
+    result = SimpleNamespace(
+        strategy_name="오닐PP/BGU",
+        dates=["20260501"],
+        execution_reports=[],
+        journal_records=[],
+        saved_journal_run={},
+        portfolio={"cash": 1_000_000, "available_cash": 1_000_000, "positions": {}},
+        profitability_gate={
+            "summary": {"pass_count": 1, "fail_count": 0, "insufficient_sample_count": 0},
+            "strategies": {
+                "오닐PP/BGU": {
+                    "status": "pass",
+                    "blocking_reasons": [],
+                    "warnings": [],
+                }
+            },
+        },
+    )
+
+    text = _format_console(result)
+
+    assert "[PROFITABILITY GATE]" in text
+    assert "오닐PP/BGU: pass" in text
+
+
 def test_format_walk_forward_console_summarizes_test_windows():
     result = SimpleNamespace(
         summary={
@@ -306,6 +350,36 @@ def test_format_walk_forward_console_includes_monte_carlo_summary_when_present()
 
     assert "Monte Carlo 거래 수: 2" in text
     assert "ruin probability: 10.00%" in text
+
+
+def test_format_walk_forward_console_includes_profitability_gate_when_present():
+    result = SimpleNamespace(
+        summary={
+            "segment_count": 1,
+            "train_days": 20,
+            "tune_days": 5,
+            "test_days": 5,
+            "test_realized_net_pnl": 0,
+            "test_execution_count": 0,
+            "test_rejected_count": 0,
+        },
+        profitability_gate={
+            "summary": {"pass_count": 0, "fail_count": 1, "insufficient_sample_count": 0},
+            "strategies": {
+                "오닐PP/BGU": {
+                    "status": "fail",
+                    "blocking_reasons": ["profit_factor_below"],
+                    "warnings": [],
+                }
+            },
+        },
+    )
+
+    text = _format_walk_forward_console(result)
+
+    assert "[PROFITABILITY GATE]" in text
+    assert "오닐PP/BGU: fail" in text
+    assert "profit_factor_below" in text
 
 
 def test_format_walk_forward_json_includes_summary_and_segment_phase_runs():
@@ -387,6 +461,74 @@ def test_run_monte_carlo_for_walk_forward_uses_test_phase_journals_only():
 
     assert result.monte_carlo["trade_count"] == 2
     assert result.monte_carlo["runs"] == 5
+
+
+def test_run_profitability_gate_for_result_uses_result_journal_records():
+    result = SimpleNamespace(
+        journal_records=[
+            {"status": "SOLD", "strategy": "S1", "net_pnl": 100, "net_return": 1.0},
+            {"status": "SOLD", "strategy": "S1", "net_pnl": -10, "net_return": -0.1},
+        ],
+        monte_carlo={"ruin_probability": 0.0, "worst_max_drawdown_pct": 1.0},
+        profitability_gate=None,
+    )
+    config = SimpleNamespace(
+        strategy_profitability_gate=SimpleNamespace(
+            min_trades=2,
+            min_profit_factor=1.0,
+            min_payoff_ratio=1.0,
+            min_win_rate=0.5,
+            min_avg_net_return=0.0,
+            max_mdd_pct=10.0,
+            capital_base_won=1_000,
+            max_monte_carlo_ruin_probability=0.1,
+            max_monte_carlo_worst_mdd_pct=10.0,
+        )
+    )
+
+    _run_profitability_gate_for_result(result, config, initial_cash=1_000)
+
+    assert result.profitability_gate["strategies"]["S1"]["status"] == "pass"
+
+
+def test_run_profitability_gate_for_walk_forward_uses_test_phase_journals_only():
+    result = SimpleNamespace(
+        segments=[
+            SimpleNamespace(
+                train_result=SimpleNamespace(
+                    journal_records=[{"status": "SOLD", "strategy": "S1", "net_pnl": -999, "net_return": -9.0}]
+                ),
+                tune_result=SimpleNamespace(journal_records=[]),
+                test_result=SimpleNamespace(
+                    journal_records=[{"status": "SOLD", "strategy": "S1", "net_pnl": 100, "net_return": 1.0}]
+                ),
+            ),
+            SimpleNamespace(
+                train_result=SimpleNamespace(journal_records=[]),
+                tune_result=SimpleNamespace(journal_records=[]),
+                test_result=SimpleNamespace(
+                    journal_records=[{"status": "SOLD", "strategy": "S1", "net_pnl": -10, "net_return": -0.1}]
+                ),
+            ),
+        ],
+        monte_carlo={"ruin_probability": 0.0, "worst_max_drawdown_pct": 1.0},
+        profitability_gate=None,
+    )
+    config = SimpleNamespace(
+        strategy_profitability_gate=SimpleNamespace(
+            min_trades=2,
+            min_profit_factor=1.0,
+            min_payoff_ratio=1.0,
+            min_win_rate=0.5,
+            min_avg_net_return=0.0,
+            max_mdd_pct=10.0,
+            capital_base_won=1_000,
+        )
+    )
+
+    _run_profitability_gate_for_walk_forward(result, config, initial_cash=1_000)
+
+    assert result.profitability_gate["strategies"]["S1"]["status"] == "pass"
 
 
 def test_get_program_provider_uses_market_data_broker_when_available():

--- a/tests/unit_test/services/test_strategy_profitability_gate_service.py
+++ b/tests/unit_test/services/test_strategy_profitability_gate_service.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from services.strategy_profitability_gate_service import (
+    StrategyProfitabilityGateConfig,
+    evaluate_strategy_profitability_gate,
+)
+
+
+def _sold(
+    pnl: float,
+    ret: float,
+    *,
+    strategy: str = "S1",
+    signal_time: str = "2026-05-01",
+    regime: dict | None = None,
+) -> dict:
+    record = {
+        "status": "SOLD",
+        "strategy": strategy,
+        "net_pnl": pnl,
+        "net_return": ret,
+        "signal_time": signal_time,
+    }
+    if regime is not None:
+        record["market_regime"] = regime
+    return record
+
+
+def test_profitability_gate_passes_when_core_thresholds_are_met():
+    records = [
+        _sold(120, 2.0, signal_time="2026-05-01"),
+        _sold(-40, -0.5, signal_time="2026-05-02"),
+        _sold(100, 1.5, signal_time="2026-05-03"),
+        _sold(-30, -0.4, signal_time="2026-05-04"),
+        _sold(80, 1.0, signal_time="2026-05-05"),
+    ]
+    cfg = StrategyProfitabilityGateConfig(
+        min_trades=5,
+        min_profit_factor=1.5,
+        min_payoff_ratio=1.0,
+        min_win_rate=0.5,
+        min_avg_net_return=0.2,
+        max_mdd_pct=10.0,
+        capital_base_won=1_000,
+    )
+
+    result = evaluate_strategy_profitability_gate(records, cfg)
+
+    s1 = result["strategies"]["S1"]
+    assert s1["status"] == "pass"
+    assert s1["passed"] is True
+    assert s1["blocking_reasons"] == []
+    assert s1["metrics"]["profit_factor"] == pytest.approx(300 / 70)
+    assert result["summary"]["pass_count"] == 1
+
+
+def test_profitability_gate_marks_insufficient_sample_before_metric_failures():
+    records = [_sold(-100, -2.0), _sold(-50, -1.0)]
+    cfg = StrategyProfitabilityGateConfig(min_trades=3, capital_base_won=1_000)
+
+    result = evaluate_strategy_profitability_gate(records, cfg)
+
+    s1 = result["strategies"]["S1"]
+    assert s1["status"] == "insufficient_sample"
+    assert s1["passed"] is False
+    assert s1["blocking_reasons"] == ["insufficient_trades"]
+
+
+def test_profitability_gate_fails_on_profitability_drawdown_monte_carlo_and_regime():
+    records = [
+        _sold(100, 1.0, signal_time="2026-05-01", regime={"kospi": "bear", "kosdaq": "sideways"}),
+        _sold(-130, -2.0, signal_time="2026-05-02", regime={"kospi": "bear", "kosdaq": "sideways"}),
+        _sold(80, 0.8, signal_time="2026-05-03", regime={"kospi": "bear", "kosdaq": "sideways"}),
+        _sold(-140, -2.1, signal_time="2026-05-04", regime={"kospi": "bear", "kosdaq": "sideways"}),
+    ]
+    cfg = StrategyProfitabilityGateConfig(
+        min_trades=4,
+        min_profit_factor=1.2,
+        min_payoff_ratio=1.0,
+        min_win_rate=0.6,
+        min_avg_net_return=0.0,
+        max_mdd_pct=10.0,
+        capital_base_won=1_000,
+        max_monte_carlo_ruin_probability=0.05,
+        max_monte_carlo_worst_mdd_pct=15.0,
+        min_regime_trade_count=2,
+        require_non_negative_regime_pnl=True,
+    )
+
+    result = evaluate_strategy_profitability_gate(
+        records,
+        cfg,
+        monte_carlo={
+            "ruin_probability": 0.25,
+            "worst_max_drawdown_pct": 22.0,
+        },
+    )
+
+    s1 = result["strategies"]["S1"]
+    assert s1["status"] == "fail"
+    assert s1["passed"] is False
+    assert "profit_factor_below" in s1["blocking_reasons"]
+    assert "win_rate_below" in s1["blocking_reasons"]
+    assert "avg_net_return_below" in s1["blocking_reasons"]
+    assert "mdd_pct_above" in s1["blocking_reasons"]
+    assert "monte_carlo_ruin_probability_above" in s1["blocking_reasons"]
+    assert "monte_carlo_worst_mdd_pct_above" in s1["blocking_reasons"]
+    assert "regime_BEAR_negative_pnl" in s1["blocking_reasons"]
+    assert result["summary"]["fail_count"] == 1

--- a/todo_list.md
+++ b/todo_list.md
@@ -145,10 +145,13 @@
 
 ### 1-0. 실거래 투입 전 전략별 수익성 통과 기준
 
-- [ ] 전략별 “돈 버는 기준선”을 명시하고, 기준 미달 전략은 실계좌 자동주문 대상에서 제외한다.
+- [~] 전략별 “돈 버는 기준선”을 명시하고, 기준 미달 전략은 실계좌 자동주문 대상에서 제외한다.
   - 검토 결과: 타당. 현재 P1에 walk-forward, Monte Carlo, 국면별 성과 검증은 있으나 “통과/탈락 기준”이 약하다. 실전 투입 판단에는 절대 수익보다 비용·슬리피지·미체결 반영 후에도 기대값이 남는지가 핵심이다.
   - 최소 기준 후보: 전략별 충분한 표본 수, out-of-sample Profit Factor, 평균 손익비, MDD, 비용 반영 후 기대값, 슬리피지 2배 스트레스, KOSPI/KOSDAQ 대비 초과수익, 하락장 손실 제한.
   - 산출물: 전략별 `거래 수 / CAGR 또는 기간수익률 / MDD / PF / 승률 / 평균손익비 / 비용·슬리피지 후 성과 / 시장 국면별 성과` 표.
+  - 1차 완료: `services/strategy_profitability_gate_service.py` 추가. 표준 journal의 SOLD 기록 기준으로 `min_trades`, Profit Factor, payoff ratio, win rate, 평균 net return, total net PnL, MDD, Monte Carlo ruin probability/worst MDD, regime별 손익 기준을 평가해 `pass` / `fail` / `insufficient_sample`을 반환한다.
+  - 1차 완료: `scripts/run_backtest.py --profitability-gate` 옵션 추가. 일반 기간 백테스트는 전체 journal, walk-forward는 test phase journal만 기준선 판정에 사용하고 console/json 출력에 `profitability_gate`를 포함한다.
+  - 진행 필요: 기준 미달 전략을 실계좌 자동주문 대상에서 제외하는 운영 gate 연결은 아직 미적용. P1 기준값 안정화와 P0 안전 경로 확인 후 별도 적용.
 - [ ] P1 수익성 검증을 실전 확대 gate로 승격한다.
   - 정책: P0 주문 안정성 완료 후에도, P1 수익성 기준을 통과하지 못하면 full-auto/자금 확대 금지. 허용 범위는 backtest, paper/shadow, 제한적 소액 canary까지로 둔다.
 


### PR DESCRIPTION
변경 핵심:
strategy_profitability_gate_service.py: 표준 journal SOLD 기록 기준으로 pass / fail / insufficient_sample 판정 config_loader.py: strategy_profitability_gate 기본 설정 추가 run_backtest.py: --profitability-gate 옵션 추가일반 백테스트: 전체 journal 기준 walk-forward: test phase journal만 기준
console/json 출력에 profitability_gate 포함

todo_list.md: P1-0을 부분 완료로 갱신
검증도 완료했습니다.
pytest tests/unit_test/services/test_strategy_profitability_gate_service.py tests/unit_test/scripts/test_run_backtest.py tests/unit_test/config/test_config_loader.py -v → 56 passed pytest tests/unit_test -v → 4764 passed
pytest tests/integration_test -v → 233 passed
자동 주문 차단까지는 연결하지 않았습니다. 지금은 의도대로 “실전 확대 판단용 gate 리포트” 단계에서 멈췄고, 실제 실계좌 자동주문 제외는 기준값을 운용해 본 뒤 별도 작업으로 묶는 게 안전합니다.