### PR TITLE
진행 완료했습니다.

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -71,6 +71,13 @@ class StrategySchedulerConfig:
     event_driven_shadow: bool = False
 
 
+@dataclass(frozen=True)
+class _LiveExpansionGateDecision:
+    allowed: bool
+    reason: str
+    details: dict
+
+
 class StrategyScheduler:
     """asyncio 기반 단일 스레드 전략 스케줄러.
 
@@ -110,6 +117,7 @@ class StrategyScheduler:
         position_sizing_service: Optional[PositionSizingService] = None,
         event_router=None,
         event_shadow_journal=None,
+        live_expansion_gate_service=None,
     ):
         self._virtual_trade_service = virtual_trade_service
         self._oes = order_execution_service
@@ -129,6 +137,7 @@ class StrategyScheduler:
         self._position_sizer = position_sizing_service
         self._event_router = event_router
         self._event_shadow_journal = event_shadow_journal
+        self._live_expansion_gate = live_expansion_gate_service
         # strategy_name → 현재 router 에 구독된 종목 set
         self._event_shadow_subscriptions: Dict[str, set[str]] = {}
 
@@ -429,6 +438,18 @@ class StrategyScheduler:
                     await f
 
         # 2) 새 매수 스캔
+        entry_gate = self._check_live_expansion_gate(name)
+        if not entry_gate.allowed:
+            self._logger.warning({
+                "event": "scheduler_skip",
+                "strategy_name": name,
+                "reason": "profitability_gate_blocked",
+                "gate_reason": entry_gate.reason,
+                "gate_details": entry_gate.details,
+            })
+            self._pm.log_timer(f"{name}.run_strategy", t_run)
+            return
+
         current_holdings = self._get_strategy_holdings(cfg)
         current_holds_count = len(current_holdings)
 
@@ -543,6 +564,18 @@ class StrategyScheduler:
 
     # ── 시그널 실행 ──
 
+    def _check_live_expansion_gate(self, strategy_name: str):
+        if self._dry_run or self._live_expansion_gate is None:
+            return _LiveExpansionGateDecision(True, "not_applicable", {})
+        check = getattr(self._live_expansion_gate, "check_strategy", None)
+        if not callable(check):
+            return _LiveExpansionGateDecision(True, "not_applicable", {})
+        decision = check(strategy_name)
+        allowed = bool(getattr(decision, "allowed", False))
+        reason = str(getattr(decision, "reason", "") or "unknown")
+        details = getattr(decision, "details", {}) or {}
+        return _LiveExpansionGateDecision(allowed, reason, details)
+
     async def _execute_signal(self, signal: TradeSignal):
         tid = get_trace_id() or new_trace_id(signal.strategy_name)
         with trace_scope(tid):
@@ -654,69 +687,88 @@ class StrategyScheduler:
                 except ValueError:
                     signal_exchange = Exchange.KRX
                 if signal.action == "BUY":
-                    # 포지션 사이징 보정
-                    buy_qty = signal.qty
-                    if self._position_sizer is not None:
-                        buy_qty, sizing_reason = await self._position_sizer.adjust_buy_qty(
-                            signal, signal_exchange
+                    entry_gate = self._check_live_expansion_gate(signal.strategy_name)
+                    if not entry_gate.allowed:
+                        api_success = False
+                        order_error_msg = f"profitability gate blocked: {entry_gate.reason}"
+                        signal.reason = (
+                            f"{signal.reason}|profitability_gate_blocked:{entry_gate.reason}"
+                            if signal.reason else
+                            f"profitability_gate_blocked:{entry_gate.reason}"
                         )
-                        if buy_qty == 0:
-                            self._logger.warning(
-                                f"[Scheduler] 포지션 사이징 결과 qty=0, 주문 skip: "
-                                f"{signal.code} reason={sizing_reason}"
+                        self._logger.warning({
+                            "event": "signal_rejected",
+                            "strategy_name": signal.strategy_name,
+                            "code": signal.code,
+                            "action": signal.action,
+                            "reason": "profitability_gate_blocked",
+                            "gate_reason": entry_gate.reason,
+                            "gate_details": entry_gate.details,
+                        })
+                    else:
+                    # 포지션 사이징 보정
+                        buy_qty = signal.qty
+                        if self._position_sizer is not None:
+                            buy_qty, sizing_reason = await self._position_sizer.adjust_buy_qty(
+                                signal, signal_exchange
                             )
-                            _skip_now = self._tm.get_current_kst_time()
-                            _skip_record = SignalRecord(
-                                strategy_name=signal.strategy_name,
-                                code=signal.code,
-                                name=signal.name,
-                                action=signal.action,
-                                price=signal.price,
-                                qty=0,
-                                reason=f"sizing_skip:{sizing_reason}",
-                                timestamp=_skip_now.strftime("%Y-%m-%d %H:%M:%S"),
-                                api_success=False,
-                                trace_id=tid,
-                            )
-                            self._signal_history.append(_skip_record)
-                            if len(self._signal_history) > self.MAX_HISTORY:
-                                self._signal_history = self._signal_history[-self.MAX_HISTORY:]
-                            await self._append_signal_db(_skip_record)
-                            await self._notify_subscribers(_skip_record)
-                            if self._notification_service:
-                                await self._notification_service.emit(
-                                    NotificationCategory.STRATEGY,
-                                    NotificationLevel.ERROR,
-                                    f"[{signal.strategy_name}] {signal.name} 매수 실패",
-                                    (
-                                        f"종목: {signal.name}({signal.code})\n"
-                                        f"주문 스킵: 포지션 사이징 결과 수량 0\n"
-                                        f"사유: {sizing_reason}"
-                                    ),
-                                    metadata={
-                                        "strategy_name": signal.strategy_name,
-                                        "code": signal.code,
-                                        "action": signal.action,
-                                        "price": signal.price,
-                                        "qty": 0,
-                                        "reason": f"sizing_skip:{sizing_reason}",
-                                        "api_success": False,
-                                        "trace_id": tid,
-                                    },
+                            if buy_qty == 0:
+                                self._logger.warning(
+                                    f"[Scheduler] 포지션 사이징 결과 qty=0, 주문 skip: "
+                                    f"{signal.code} reason={sizing_reason}"
                                 )
-                            return
-                        signal.qty = buy_qty
+                                _skip_now = self._tm.get_current_kst_time()
+                                _skip_record = SignalRecord(
+                                    strategy_name=signal.strategy_name,
+                                    code=signal.code,
+                                    name=signal.name,
+                                    action=signal.action,
+                                    price=signal.price,
+                                    qty=0,
+                                    reason=f"sizing_skip:{sizing_reason}",
+                                    timestamp=_skip_now.strftime("%Y-%m-%d %H:%M:%S"),
+                                    api_success=False,
+                                    trace_id=tid,
+                                )
+                                self._signal_history.append(_skip_record)
+                                if len(self._signal_history) > self.MAX_HISTORY:
+                                    self._signal_history = self._signal_history[-self.MAX_HISTORY:]
+                                await self._append_signal_db(_skip_record)
+                                await self._notify_subscribers(_skip_record)
+                                if self._notification_service:
+                                    await self._notification_service.emit(
+                                        NotificationCategory.STRATEGY,
+                                        NotificationLevel.ERROR,
+                                        f"[{signal.strategy_name}] {signal.name} 매수 실패",
+                                        (
+                                            f"종목: {signal.name}({signal.code})\n"
+                                            f"주문 스킵: 포지션 사이징 결과 수량 0\n"
+                                            f"사유: {sizing_reason}"
+                                        ),
+                                        metadata={
+                                            "strategy_name": signal.strategy_name,
+                                            "code": signal.code,
+                                            "action": signal.action,
+                                            "price": signal.price,
+                                            "qty": 0,
+                                            "reason": f"sizing_skip:{sizing_reason}",
+                                            "api_success": False,
+                                            "trace_id": tid,
+                                        },
+                                    )
+                                return
+                            signal.qty = buy_qty
 
-                    resp = await self._oes.handle_place_buy_order(
-                        signal.code,
-                        signal.price,
-                        buy_qty,
-                        exchange=signal_exchange,
-                        source=f"strategy:{signal.strategy_name}",
-                        finalize_immediately=False,
-                        trace_id=tid,
-                        volatility_20d_annualized=signal.volatility_20d_annualized,
-                    )
+                        resp = await self._oes.handle_place_buy_order(
+                            signal.code,
+                            signal.price,
+                            buy_qty,
+                            exchange=signal_exchange,
+                            source=f"strategy:{signal.strategy_name}",
+                            finalize_immediately=False,
+                            trace_id=tid,
+                            volatility_20d_annualized=signal.volatility_20d_annualized,
+                        )
                 else:
                     adjusted_sell_price = await self._resolve_strategy_sell_price(signal, signal_exchange)
                     if adjusted_sell_price != signal.price:

--- a/services/strategy_live_expansion_gate_service.py
+++ b/services/strategy_live_expansion_gate_service.py
@@ -1,0 +1,108 @@
+"""Runtime gate for allowing live strategy expansion.
+
+The profitability evaluator is pure and report-oriented. This adapter turns its
+result into a small runtime decision that can be used by schedulers before they
+open new real-money positions.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping
+
+from services.strategy_profitability_gate_service import (
+    StrategyProfitabilityGateConfig,
+    evaluate_strategy_profitability_gate,
+)
+
+
+@dataclass(frozen=True)
+class StrategyLiveExpansionDecision:
+    allowed: bool
+    reason: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class StrategyLiveExpansionGateService:
+    """Decide whether a strategy may open new positions in real trading."""
+
+    def __init__(
+        self,
+        *,
+        journal_records_provider: Callable[[], Iterable[Mapping[str, Any]]] | None,
+        is_paper_trading_fn: Callable[[], bool],
+        profitability_gate_config: StrategyProfitabilityGateConfig | Any | None = None,
+        enabled: bool = True,
+        logger=None,
+    ) -> None:
+        self._journal_records_provider = journal_records_provider
+        self._is_paper_trading_fn = is_paper_trading_fn
+        self._config = _coerce_config(profitability_gate_config)
+        self._enabled = enabled
+        self._logger = logger
+
+    def check_strategy(self, strategy_name: str) -> StrategyLiveExpansionDecision:
+        strategy_name = str(strategy_name or "").strip()
+        if not self._enabled:
+            return StrategyLiveExpansionDecision(True, "gate_disabled")
+        if self._is_paper_trading():
+            return StrategyLiveExpansionDecision(True, "paper_mode")
+        if self._journal_records_provider is None:
+            return StrategyLiveExpansionDecision(False, "profitability_gate_unavailable")
+
+        try:
+            records = list(self._journal_records_provider() or [])
+            result = evaluate_strategy_profitability_gate(records, self._config)
+        except Exception as exc:
+            if self._logger:
+                self._logger.warning(
+                    "[StrategyLiveExpansionGate] profitability gate evaluation failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+            return StrategyLiveExpansionDecision(
+                False,
+                "profitability_gate_error",
+                {"error": str(exc)},
+            )
+
+        strategy_result = result.get("strategies", {}).get(strategy_name)
+        if strategy_result is None:
+            return StrategyLiveExpansionDecision(
+                False,
+                "profitability_gate_missing",
+                {"summary": result.get("summary", {})},
+            )
+        if bool(strategy_result.get("passed")):
+            return StrategyLiveExpansionDecision(
+                True,
+                "profitability_gate_pass",
+                {"status": strategy_result.get("status")},
+            )
+        return StrategyLiveExpansionDecision(
+            False,
+            f"profitability_gate_{strategy_result.get('status') or 'fail'}",
+            {
+                "status": strategy_result.get("status"),
+                "blocking_reasons": list(strategy_result.get("blocking_reasons") or []),
+                "warnings": list(strategy_result.get("warnings") or []),
+            },
+        )
+
+    def _is_paper_trading(self) -> bool:
+        try:
+            return bool(self._is_paper_trading_fn())
+        except Exception:
+            return False
+
+
+def _coerce_config(config: StrategyProfitabilityGateConfig | Any | None) -> StrategyProfitabilityGateConfig:
+    if config is None:
+        return StrategyProfitabilityGateConfig()
+    if isinstance(config, StrategyProfitabilityGateConfig):
+        return config
+
+    values: dict[str, Any] = {}
+    for field_name in StrategyProfitabilityGateConfig.__dataclass_fields__:
+        if hasattr(config, field_name):
+            values[field_name] = getattr(config, field_name)
+    return StrategyProfitabilityGateConfig(**values)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -44,7 +44,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             self._scheduler = None
         shutil.rmtree(self.test_dir)
 
-    def _make_scheduler(self, dry_run=True):
+    def _make_scheduler(self, dry_run=True, live_expansion_gate_service=None):
         vm = MagicMock()
         vm.get_holds_by_strategy.return_value = []
         vm.log_buy_async = AsyncMock(return_value=True)
@@ -96,6 +96,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             logger=mock_logger,
             dry_run=dry_run,
             store=mock_store,
+            live_expansion_gate_service=live_expansion_gate_service,
         )
         self._scheduler = scheduler
         return scheduler, vm, oes, tm, mcs
@@ -469,6 +470,90 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         # max_positions 도달 → log_buy 호출 안됨
         vm.log_buy_async.assert_not_called()
+
+    async def test_run_strategy_allows_exits_but_skips_scan_when_live_gate_blocks_entries(self):
+        """실전 확대 gate 차단은 기존 포지션 청산을 유지하고 신규 scan만 막는다."""
+        gate = MagicMock()
+        gate.check_strategy.return_value = SimpleNamespace(
+            allowed=False,
+            reason="profitability_gate_missing",
+            details={},
+        )
+        scheduler, vm, _, _, _ = self._make_scheduler(
+            dry_run=False,
+            live_expansion_gate_service=gate,
+        )
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "name": "삼성전자", "buy_price": 70000, "qty": 1},
+        ]
+        sell_signal = TradeSignal(
+            code="005930", name="삼성전자", action="SELL",
+            price=72000, qty=1, reason="익절", strategy_name="테스트전략"
+        )
+        strategy = MockStrategy(
+            scan_signals=[
+                TradeSignal(
+                    code="000660", name="SK하이닉스", action="BUY",
+                    price=120000, qty=1, reason="스캔", strategy_name="테스트전략"
+                )
+            ],
+            exit_signals=[sell_signal],
+        )
+        strategy.scan = AsyncMock(return_value=strategy._scan_signals)
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=3)
+        scheduler.register(config)
+
+        with patch.object(scheduler, "_execute_signal", new_callable=AsyncMock) as mock_execute:
+            await scheduler._run_strategy(config)
+
+        mock_execute.assert_awaited_once_with(sell_signal)
+        strategy.scan.assert_not_awaited()
+        scheduler._logger.warning.assert_called()
+
+    async def test_execute_buy_signal_blocks_order_when_live_gate_blocks_entries(self):
+        """방어선: scan 밖에서 들어온 BUY도 실전 확대 gate 미통과면 주문하지 않는다."""
+        gate = MagicMock()
+        gate.check_strategy.return_value = SimpleNamespace(
+            allowed=False,
+            reason="profitability_gate_fail",
+            details={"blocking_reasons": ["profit_factor_below"]},
+        )
+        scheduler, _, oes, _, _ = self._make_scheduler(
+            dry_run=False,
+            live_expansion_gate_service=gate,
+        )
+
+        signal = TradeSignal(
+            code="005930", name="삼성전자", action="BUY",
+            price=70000, qty=1, reason="테스트", strategy_name="테스트전략"
+        )
+        await scheduler._execute_signal(signal)
+
+        oes.handle_place_buy_order.assert_not_called()
+        self.assertEqual(scheduler._signal_history[-1].api_success, False)
+        self.assertIn("profitability_gate_blocked", scheduler._signal_history[-1].reason)
+
+    async def test_execute_sell_signal_ignores_live_gate(self):
+        """실전 확대 gate는 청산 주문을 막지 않는다."""
+        gate = MagicMock()
+        gate.check_strategy.return_value = SimpleNamespace(
+            allowed=False,
+            reason="profitability_gate_fail",
+            details={},
+        )
+        scheduler, _, oes, _, _ = self._make_scheduler(
+            dry_run=False,
+            live_expansion_gate_service=gate,
+        )
+
+        signal = TradeSignal(
+            code="005930", name="삼성전자", action="SELL",
+            price=72000, qty=1, reason="익절", strategy_name="테스트전략"
+        )
+        await scheduler._execute_signal(signal)
+
+        gate.check_strategy.assert_not_called()
+        oes.handle_place_sell_order.assert_awaited_once()
 
     async def test_run_strategy_scans_and_logs_rejections_when_position_full_option_enabled(self):
         """옵션이 켜져 있으면 max_positions 도달 후에도 스캔하고 매수 신호를 reject 로그로 남긴다."""

--- a/tests/unit_test/services/test_strategy_live_expansion_gate_service.py
+++ b/tests/unit_test/services/test_strategy_live_expansion_gate_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from services.strategy_live_expansion_gate_service import StrategyLiveExpansionGateService
+from services.strategy_profitability_gate_service import StrategyProfitabilityGateConfig
+
+
+def _sold(strategy: str, pnl: float, ret: float, signal_time: str) -> dict:
+    return {
+        "status": "SOLD",
+        "strategy": strategy,
+        "net_pnl": pnl,
+        "net_return": ret,
+        "signal_time": signal_time,
+    }
+
+
+def test_live_expansion_gate_allows_paper_without_records():
+    service = StrategyLiveExpansionGateService(
+        journal_records_provider=lambda: [],
+        is_paper_trading_fn=lambda: True,
+    )
+
+    decision = service.check_strategy("S1")
+
+    assert decision.allowed is True
+    assert decision.reason == "paper_mode"
+
+
+def test_live_expansion_gate_blocks_real_when_strategy_result_missing():
+    service = StrategyLiveExpansionGateService(
+        journal_records_provider=lambda: [],
+        is_paper_trading_fn=lambda: False,
+        profitability_gate_config=StrategyProfitabilityGateConfig(min_trades=1),
+    )
+
+    decision = service.check_strategy("S1")
+
+    assert decision.allowed is False
+    assert decision.reason == "profitability_gate_missing"
+
+
+def test_live_expansion_gate_allows_real_strategy_that_passes_thresholds():
+    service = StrategyLiveExpansionGateService(
+        journal_records_provider=lambda: [
+            _sold("S1", 100, 1.0, "2026-05-01"),
+            _sold("S1", -20, -0.2, "2026-05-02"),
+        ],
+        is_paper_trading_fn=lambda: False,
+        profitability_gate_config=StrategyProfitabilityGateConfig(
+            min_trades=2,
+            min_profit_factor=1.0,
+            min_payoff_ratio=1.0,
+            min_win_rate=0.5,
+            min_avg_net_return=0.0,
+            require_positive_total_net_pnl=True,
+            max_mdd_pct=10.0,
+            capital_base_won=1_000,
+            max_monte_carlo_ruin_probability=None,
+            max_monte_carlo_worst_mdd_pct=None,
+            require_non_negative_regime_pnl=False,
+        ),
+    )
+
+    decision = service.check_strategy("S1")
+
+    assert decision.allowed is True
+    assert decision.reason == "profitability_gate_pass"
+
+
+def test_live_expansion_gate_blocks_real_strategy_that_fails_thresholds():
+    service = StrategyLiveExpansionGateService(
+        journal_records_provider=lambda: [
+            _sold("S1", -100, -1.0, "2026-05-01"),
+            _sold("S1", -50, -0.5, "2026-05-02"),
+        ],
+        is_paper_trading_fn=lambda: False,
+        profitability_gate_config=StrategyProfitabilityGateConfig(
+            min_trades=2,
+            min_profit_factor=1.0,
+            min_payoff_ratio=1.0,
+            min_win_rate=0.5,
+            require_positive_total_net_pnl=True,
+            max_monte_carlo_ruin_probability=None,
+            max_monte_carlo_worst_mdd_pct=None,
+        ),
+    )
+
+    decision = service.check_strategy("S1")
+
+    assert decision.allowed is False
+    assert decision.reason == "profitability_gate_fail"
+    assert "total_net_pnl_not_positive" in decision.details["blocking_reasons"]

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-20 (P0 0-0 정적 리뷰 5건 완료 후 항목 정리, 추천 순서 #1 제거)
+최종 업데이트: 2026-05-21 (P1 실전 확대 gate 런타임 연결)
 
 이 문서는 현재 남은 실행 항목만 추린 목록입니다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거했습니다.
 
@@ -145,15 +145,16 @@
 
 ### 1-0. 실거래 투입 전 전략별 수익성 통과 기준
 
-- [~] 전략별 “돈 버는 기준선”을 명시하고, 기준 미달 전략은 실계좌 자동주문 대상에서 제외한다.
+- [x] 전략별 “돈 버는 기준선”을 명시하고, 기준 미달 전략은 실계좌 자동주문 대상에서 제외한다.
   - 검토 결과: 타당. 현재 P1에 walk-forward, Monte Carlo, 국면별 성과 검증은 있으나 “통과/탈락 기준”이 약하다. 실전 투입 판단에는 절대 수익보다 비용·슬리피지·미체결 반영 후에도 기대값이 남는지가 핵심이다.
   - 최소 기준 후보: 전략별 충분한 표본 수, out-of-sample Profit Factor, 평균 손익비, MDD, 비용 반영 후 기대값, 슬리피지 2배 스트레스, KOSPI/KOSDAQ 대비 초과수익, 하락장 손실 제한.
   - 산출물: 전략별 `거래 수 / CAGR 또는 기간수익률 / MDD / PF / 승률 / 평균손익비 / 비용·슬리피지 후 성과 / 시장 국면별 성과` 표.
   - 1차 완료: `services/strategy_profitability_gate_service.py` 추가. 표준 journal의 SOLD 기록 기준으로 `min_trades`, Profit Factor, payoff ratio, win rate, 평균 net return, total net PnL, MDD, Monte Carlo ruin probability/worst MDD, regime별 손익 기준을 평가해 `pass` / `fail` / `insufficient_sample`을 반환한다.
   - 1차 완료: `scripts/run_backtest.py --profitability-gate` 옵션 추가. 일반 기간 백테스트는 전체 journal, walk-forward는 test phase journal만 기준선 판정에 사용하고 console/json 출력에 `profitability_gate`를 포함한다.
-  - 진행 필요: 기준 미달 전략을 실계좌 자동주문 대상에서 제외하는 운영 gate 연결은 아직 미적용. P1 기준값 안정화와 P0 안전 경로 확인 후 별도 적용.
-- [ ] P1 수익성 검증을 실전 확대 gate로 승격한다.
+  - 완료된 부분: `StrategyLiveExpansionGateService`를 추가하고 `StrategyScheduler`에 연결했다. paper/dry-run은 허용하고, real 모드에서는 수익성 gate 결과가 없거나 미통과인 전략의 신규 scan/BUY 주문을 fail-closed로 차단한다. 기존 보유 청산/force-exit 경로는 차단하지 않는다.
+- [x] P1 수익성 검증을 실전 확대 gate로 승격한다.
   - 정책: P0 주문 안정성 완료 후에도, P1 수익성 기준을 통과하지 못하면 full-auto/자금 확대 금지. 허용 범위는 backtest, paper/shadow, 제한적 소액 canary까지로 둔다.
+  - 완료된 부분: `StrategyFactory`가 표준 journal provider(`VirtualTradeService.get_standard_journal_records`)와 `strategy_profitability_gate` 설정을 사용해 live expansion gate를 scheduler에 주입한다. 향후 backtest gate 결과 저장소가 별도 구축되면 provider만 교체한다.
 
 ### 1-1. 과최적화 방지 검증
 

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -16,6 +16,7 @@ from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOStrategy
 from strategies.oneil_pocket_pivot_strategy import OneilPocketPivotStrategy
 from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
 from strategies.rsi2_pullback_strategy import RSI2PullbackStrategy
+from services.strategy_live_expansion_gate_service import StrategyLiveExpansionGateService
 from task.background.intraday.strategy_scheduler_task_adapter import StrategySchedulerTaskAdapter
 from view.web.bootstrap.runtime_mode import RuntimeMode
 
@@ -54,6 +55,16 @@ class StrategyFactory:
             position_sizing_service=ctx.position_sizing_service,
             event_router=getattr(ctx, "strategy_event_router", None),
             event_shadow_journal=getattr(ctx, "event_shadow_journal_service", None),
+            live_expansion_gate_service=StrategyLiveExpansionGateService(
+                journal_records_provider=ctx.virtual_trade_service.get_standard_journal_records,
+                is_paper_trading_fn=lambda: bool(getattr(ctx.env, "is_paper_trading", True)),
+                profitability_gate_config=getattr(
+                    getattr(ctx, "full_config", None),
+                    "strategy_profitability_gate",
+                    None,
+                ),
+                logger=ctx.logger,
+            ),
         )
 
         # 오닐 스퀴즈 돌파 전략 등록


### PR DESCRIPTION
P1 실전 확대 gate를 런타임에 연결했습니다. 새 strategy_live_expansion_gate_service.py (line 25)는 paper 모드는 허용하고, real 모드에서는 수익성 gate 결과가 없거나 미통과인 전략을 fail-closed로 막습니다. strategy_scheduler.py (line 446)에는 청산은 먼저 허용하되 신규 scan/BUY만 차단하는 방어선을 넣었고, scan 밖에서 직접 들어온 BUY도 같은 gate (line 567)를 통과해야 주문됩니다. StrategyFactory (line 58)에서 VirtualTradeService.get_standard_journal_records와 strategy_profitability_gate 설정을 주입하도록 연결했고, todo_list.md (line 1)도 P1 완료 상태로 갱신했습니다. 검증:
pytest tests/unit_test -v → 4771 passed
pytest tests/integration_test -v → 233 passed