### PR TITLE
수정 완료했습니다. 원인은 두 갈래였습니다.

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -347,7 +347,7 @@ class KoreaInvestWebSocketAPI:
                     self._logger.warning(f"체결통보 암호화 해제 실패: AES 키/IV 없음. TR_ID: {tr_id}, 메시지: {message[:50]}...")
                     return
 
-            elif tr_id == self._env.active_config['tr_ids']['websocket'].get('realtime_program_trading', 'H0STPGM0'):
+            elif tr_id in self._get_program_trading_tr_ids():
                 parsed_data = self._parse_program_trading_data(data_body)
                 message_type = 'realtime_program_trading'
 
@@ -652,6 +652,13 @@ class KoreaInvestWebSocketAPI:
         keys = menulist.split('|')
         values = data_str.split('^')
         return dict(zip(keys, values[:len(keys)]))
+
+    def _get_program_trading_tr_ids(self) -> set[str]:
+        websocket_config = self._env.active_config.get('tr_ids', {}).get('websocket', {})
+        return {
+            websocket_config.get('realtime_program_trading', 'H0STPGM0'),
+            websocket_config.get('nxt_realtime_program_trading', 'H0NXPGM0'),
+        }
 
     async def subscribe_program_trading(self, stock_code: str):
         """국내주식 실시간 프로그램매매 동향 (H0STPGM0) 구독."""

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -414,11 +414,23 @@ class ProgramTradingStreamService:
         message = self._format_db_persistence_report(status)
         return await self._send_telegram_message(message)
 
+    async def _is_market_open_for_tick_alert(self) -> bool:
+        if not self._market_calendar_service:
+            return True
+        try:
+            return bool(await self._market_calendar_service.is_market_open_now())
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 tick 알림 장중 여부 확인 실패: {e}")
+            return False
+
     async def _hourly_tick_alert_loop(self) -> None:
         try:
             while True:
                 await asyncio.sleep(self.HOURLY_TICK_ALERT_INTERVAL_SEC)
-                await self.send_subscribed_last_tick_alert()
+                if await self._is_market_open_for_tick_alert():
+                    await self.send_subscribed_last_tick_alert()
+                else:
+                    self.logger.debug("장중이 아니므로 프로그램매매 tick 상태 알림을 생략합니다.")
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -2350,6 +2350,22 @@ def test_handle_websocket_message_program_trading_success(websocket_api_instance
     assert result["data"]["순매수체결량"] == "10"
 
 
+def test_handle_websocket_message_nxt_program_trading_success(websocket_api_instance):
+    api = websocket_api_instance
+    api._env.active_config["tr_ids"]["websocket"]["nxt_realtime_program_trading"] = "H0NXPGM0"
+    api.on_realtime_message_callback = MagicMock()
+    data_str = "005930^120000^10^10000^20^20000^10^10000^100^200^300"
+    message = f"0|H0NXPGM0|dummy|{data_str}"
+
+    api._handle_websocket_message(message)
+
+    api.on_realtime_message_callback.assert_called_once()
+    result = api.on_realtime_message_callback.call_args[0][0]
+    assert result["type"] == "realtime_program_trading"
+    assert result["tr_id"] == "H0NXPGM0"
+    assert result["data"]["순매수체결량"] == "10"
+
+
 @pytest.mark.asyncio
 async def test_receive_messages_appkey_collision_retry_logs(websocket_api_instance):
     api = websocket_api_instance

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -577,3 +577,22 @@ async def test_send_db_persistence_report_sends_summary(manager):
     assert "프로그램매매 DB 저장 점검" in message
     assert "005930" in message
     assert "OK" in message
+
+
+@pytest.mark.asyncio
+async def test_hourly_tick_alert_loop_skips_when_market_closed(manager):
+    """장마감 후에는 시간별 tick 상태 알림을 보내지 않는다."""
+    manager.send_subscribed_last_tick_alert = AsyncMock(return_value=True)
+    mock_mcs = MagicMock()
+    mock_mcs.is_market_open_now = AsyncMock(return_value=False)
+    manager.wire_alert_dependencies(market_calendar_service=mock_mcs)
+
+    with patch(
+        "services.program_trading_stream_service.asyncio.sleep",
+        new_callable=AsyncMock,
+        side_effect=[None, asyncio.CancelledError],
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await manager._hourly_tick_alert_loop()
+
+    manager.send_subscribed_last_tick_alert.assert_not_awaited()

--- a/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
+++ b/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
@@ -127,7 +127,20 @@ def test_wiring_phase_registers_signing_notice_handler():
     ctx = _make_fake_context()
     WiringPhase(ctx).run()
 
-    ctx.streaming_service.register_handler.assert_called_once_with(
+    ctx.streaming_service.register_handler.assert_any_call(
         "signing_notice",
         ctx.order_execution_service.handle_signing_notice,
+    )
+
+
+def test_wiring_phase_registers_program_trading_handler():
+    """PT WebSocket 수신 데이터가 ProgramTradingStreamService까지 전달되도록 연결한다."""
+    from view.web.bootstrap.wiring_phase import WiringPhase
+
+    ctx = _make_fake_context()
+    WiringPhase(ctx).run()
+
+    ctx.streaming_service.register_handler.assert_any_call(
+        "realtime_program_trading",
+        ctx.program_trading_stream_service.on_data_received,
     )

--- a/view/web/bootstrap/wiring_phase.py
+++ b/view/web/bootstrap/wiring_phase.py
@@ -76,6 +76,13 @@ class WiringPhase:
                 market_clock=getattr(ctx, "market_clock", None),
             )
 
+        # Streaming realtime_program_trading callback ← ProgramTradingStreamService
+        if ctx.streaming_service and ctx.program_trading_stream_service:
+            ctx.streaming_service.register_handler(
+                "realtime_program_trading",
+                ctx.program_trading_stream_service.on_data_received,
+            )
+
         # Streaming signing_notice callback ← OrderExecution
         if ctx.streaming_service and ctx.order_execution_service:
             ctx.streaming_service.register_handler(


### PR DESCRIPTION
프로그램매매 WebSocket 메시지가 파싱되어도 ProgramTradingStreamService.on_data_received가 StreamingService 옵저버에 등록되지 않아 DB 저장/브로드캐스트로 이어지지 않았습니다. 수정: wiring_phase.py
장마감 후에도 시간별 tick 상태 알림 루프가 시장 개장 여부를 확인하지 않고 계속 전송했습니다. 수정: program_trading_stream_service.py
추가로 NXT 프로그램매매 TR_ID(H0NXPGM0)도 동일하게 프로그램매매 데이터로 파싱되도록 보강했습니다. 수정: korea_invest_websocket_api.py
테스트도 추가했습니다:

PT handler wiring 누락 방지
장마감 후 tick 상태 알림 생략
NXT 프로그램매매 TR_ID 수신 처리
검증:

pytest tests/unit_test -v 통과
pytest tests/integration_test -v 통과, 233 passed
통합 테스트 끝에 StockOhlcvRepository was not closed explicitly. 경고 2건이 출력됐지만 테스트는 모두 통과했고, 이번 변경과 직접 관련된 실패는 없었습니다.