### PR TITLE
적용 완료했습니다.

### DIFF
--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -148,18 +148,22 @@ class RiskGateService:
 
         if effective_price > 0:
             order_amount = effective_price * qty
-            if order_amount > self._cfg.max_order_amount_won:
-                return self._blocked(
-                    "max_order_amount",
-                    "주문 금액 초과",
-                    stock_code=stock_code,
-                    order_amount=order_amount,
-                    max_order_amount_won=self._cfg.max_order_amount_won,
-                )
+            if not is_force_exit_sell:
+                if order_amount > self._cfg.max_order_amount_won:
+                    return self._blocked(
+                        "max_order_amount",
+                        "주문 금액 초과",
+                        stock_code=stock_code,
+                        side=side.value,
+                        source=source,
+                        strategy_name=strategy_name,
+                        order_amount=order_amount,
+                        max_order_amount_won=self._cfg.max_order_amount_won,
+                    )
 
-            daily_blocked = self._check_daily_cap(stock_code=stock_code, order_amount=order_amount, side=side)
-            if daily_blocked is not None:
-                return daily_blocked
+                daily_blocked = self._check_daily_cap(stock_code=stock_code, order_amount=order_amount, side=side)
+                if daily_blocked is not None:
+                    return daily_blocked
 
             if side == OrderSide.BUY:
                 strategy_blocked = await self._check_strategy_risk(
@@ -176,7 +180,8 @@ class RiskGateService:
                 if exposure_blocked is not None:
                     return exposure_blocked
 
-            self._record_daily_amount(order_amount)
+            if not is_force_exit_sell:
+                self._record_daily_amount(order_amount)
 
         return None
 

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -126,6 +126,23 @@ async def test_order_amount_over_limit_blocks_buy():
 
 
 @pytest.mark.asyncio
+async def test_force_exit_sell_bypasses_order_amount_cap():
+    svc, _, _ = _service(config=RiskGateConfig(max_order_amount_won=2_000_000))
+
+    result = await svc.validate_order(
+        "053610",
+        96_500,
+        21,
+        OrderSide.SELL,
+        Exchange.KRX,
+        0,
+        source="strategy_force_exit:래리윌리엄스VBO",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_negative_price_blocks():
     svc, _, _ = _service()
 
@@ -367,6 +384,27 @@ async def test_daily_cap_blocks_when_accumulated_amount_exceeds_limit():
     r3 = await svc.validate_order("005930", 1, 1, OrderSide.SELL, Exchange.KRX, 0)
     assert r3 is not None
     assert r3.data["rule"] == "max_daily_order_amount"
+
+
+@pytest.mark.asyncio
+async def test_force_exit_sell_bypasses_daily_order_amount_cap():
+    cfg = RiskGateConfig(
+        max_order_amount_won=100_000_000,
+        max_daily_order_amount_won=1_000_000,
+    )
+    svc, _, _ = _service(config=cfg)
+
+    result = await svc.validate_order(
+        "053610",
+        96_500,
+        21,
+        OrderSide.SELL,
+        Exchange.KRX,
+        0,
+        source="strategy_force_exit:래리윌리엄스VBO",
+    )
+
+    assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
강제청산 매도(source="strategy_force_exit:...")는 단건 주문금액 한도와 일일 누적 주문금액 한도에서 제외되도록 risk_gate_service.py (line 149)를 수정했습니다. 일반 BUY/SELL의 한도 차단은 유지했고, 일반 차단 응답에는 side, source, strategy_name도 포함되도록 보강했습니다.

회귀 테스트도 추가했습니다: 프로텍 케이스와 같은 96,500원 × 21주 = 2,026,500원 강제청산 SELL이 단건/일일 금액 캡을 통과하는지 test_risk_gate_service.py (line 128)에 검증했습니다.

검증:

타깃 Risk Gate 테스트 통과
python -m pytest tests/unit_test -v 통과: 4776 passed python -m pytest tests/integration_test -v 통과: 233 passed