### PR TITLE
P2-2: VBO fallback liquidity 차단 작업을 fail-closed reject 방향으로 완료했습니다.

### DIFF
--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -428,7 +428,7 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                     "code": code,
                     "name": item.get("hts_kor_isnm", code),
                     "market_cap": int(item.get("stck_avls", "0") or "0"),
-                    "avg_5d_tv": 0,  # fallback 시 미제공 → 필터 스킵
+                    "avg_5d_tv": 0,  # fallback 시 미제공 → validity filter에서 fail-closed reject
                 })
         return result
 
@@ -466,7 +466,7 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
         """시가총액 / 5일 평균 거래대금 필터.
 
         OSBWatchlistItem 기반(universe_service 사용 시): market_cap, avg_5d_tv 직접 사용.
-        fallback 시: market_cap만 체크 (avg_5d_tv=0이면 스킵).
+        fallback 시: avg_5d_tv 미제공이면 fail-closed로 차단한다.
         """
         market_cap = stock.get("market_cap", 0) or 0
         avg_5d_tv = stock.get("avg_5d_tv", 0) or 0
@@ -479,7 +479,15 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
             )
             return False
 
-        if avg_5d_tv > 0 and avg_5d_tv < self._cfg.min_5d_trading_value:
+        if avg_5d_tv <= 0:
+            self._log_entry_rejected(
+                log_data,
+                "avg_trading_value_unknown",
+                "5일평균거래대금 미제공 (fallback 경로)",
+            )
+            return False
+
+        if avg_5d_tv < self._cfg.min_5d_trading_value:
             self._log_entry_rejected(
                 log_data,
                 "avg_trading_value_below_min",

--- a/tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py
@@ -52,13 +52,18 @@ async def test_vbo_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     stock_repo = md_service._stock_repo
     mock_sqs = deep_paper_ctx.stock_query_service
 
-    # 2. Pool B 로드 (universe_service=None fallback 경로 → sqs.get_top_trading_value_stocks)
+    # 2. Pool B 로드 — universe_service 미주입이지만 validity filter 통과를 위해
+    #    _load_pool_b 가 avg_5d_tv 포함 dict 를 직접 반환하도록 patch.
     mocker.patch.object(
         mock_sqs, "get_top_trading_value_stocks", new_callable=AsyncMock,
         return_value=ResCommonResponse(rt_cd="0", msg1="ok", data=[
             {"mksc_shrn_iscd": code_a, "hts_kor_isnm": "테스트종목A", "stck_avls": "500000000000"},
         ])
     )
+    _pool_b_dict = [{
+        "code": code_a, "name": "테스트종목A", "market": "",
+        "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+    }]
 
     # 3. 현재가 API 모킹 (Broker 레벨 — 캐시 계층 통과)
     # Range = 72000 - 70000 = 2000, K=0.5 → Target = 70000 + 1000 = 71000
@@ -126,6 +131,7 @@ async def test_vbo_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
             stop_loss_pct=-3.0,
         ),
     )
+    strategy._load_pool_b = AsyncMock(return_value=_pool_b_dict)
 
     # ── [상황 A] 초기 스캔 (Cache Miss) ─────────────────────────────────
     stock_repo._price_repo._price_cache.clear()

--- a/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
@@ -121,11 +121,15 @@ async def test_bull_regime_passes_gate_and_evaluates_filters():
 async def test_universe_none_bypasses_market_gate():
     """universe_service 미주입 시 게이트 우회 (fallback 호환)."""
     strategy, sqs = _make_strategy(universe=None)
-    # fallback 경로 — 거래대금 상위 API 결과로 진행
+    # fallback 경로 — universe 미주입이지만 dict 직접 주입으로 validity filter 통과까지 검증
     sqs.get_top_trading_value_stocks = AsyncMock(return_value=ResCommonResponse(
         rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
         data=[{"mksc_shrn_iscd": "005930", "hts_kor_isnm": "삼성전자", "stck_avls": "500000000000"}],
     ))
+    strategy._load_pool_b = AsyncMock(return_value=[{
+        "code": "005930", "name": "삼성전자", "market": "",
+        "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+    }])
     sqs.handle_get_current_stock_price.return_value = ResCommonResponse(
         rt_cd=ErrorCode.SUCCESS.value, msg1="OK",
         data={"price": "70000", "open": "69000", "pgtr_ntby_qty": "0", "acml_tr_pbmn": "0"},

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -123,6 +123,10 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         """Target 돌파 + 체결강도 120%+ + 프로그램 순매수 10%+ → BUY 신호."""
         strategy, sqs, _ = self._make_strategy(k_value=0.5)
         sqs.get_top_trading_value_stocks.return_value = self._pool_b()
+        strategy._load_pool_b = AsyncMock(return_value=[{
+            "code": "005930", "name": "삼성전자", "market": "",
+            "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+        }])
         # Range=2000, K=0.5 → Target = 70000 + 1000 = 71000
         # current=72000 > target=71000 → 돌파
         sqs.get_recent_daily_ohlcv.return_value = _ohlcv_resp(high=72000, low=70000)
@@ -228,6 +232,10 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         """allow_reentry=False: 당일 동일 종목 두 번째 신호 차단."""
         strategy, sqs, _ = self._make_strategy(k_value=0.5)
         sqs.get_top_trading_value_stocks.return_value = self._pool_b()
+        strategy._load_pool_b = AsyncMock(return_value=[{
+            "code": "005930", "name": "삼성전자", "market": "",
+            "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+        }])
         sqs.get_recent_daily_ohlcv.return_value = _ohlcv_resp(high=72000, low=70000)
         sqs.handle_get_current_stock_price.return_value = _price_resp(
             current=72000, open_price=70000,
@@ -490,6 +498,31 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(strategy._passes_validity_filter(
             {"market_cap": 300_000_000_000, "avg_5d_tv": 1_000_000_000},
             {"code": "LOW_TV"},
+        ))
+
+    async def test_validity_filter_rejects_unknown_trading_value(self):
+        """fallback 경로에서 avg_5d_tv 가 0 또는 누락이면 fail-closed reject."""
+        strategy, _, _ = self._make_strategy(
+            min_market_cap=200_000_000_000,
+            min_5d_trading_value=10_000_000_000,
+        )
+
+        # avg_5d_tv == 0 (fallback 기본값)
+        self.assertFalse(strategy._passes_validity_filter(
+            {"market_cap": 300_000_000_000, "avg_5d_tv": 0},
+            {"code": "UNKNOWN_TV_ZERO"},
+        ))
+
+        # avg_5d_tv 누락
+        self.assertFalse(strategy._passes_validity_filter(
+            {"market_cap": 300_000_000_000},
+            {"code": "UNKNOWN_TV_MISSING"},
+        ))
+
+        # avg_5d_tv == None
+        self.assertFalse(strategy._passes_validity_filter(
+            {"market_cap": 300_000_000_000, "avg_5d_tv": None},
+            {"code": "UNKNOWN_TV_NONE"},
         ))
 
     async def test_load_pool_b_returns_empty_when_universe_raises(self):

--- a/todo_list.md
+++ b/todo_list.md
@@ -315,9 +315,9 @@
 - [ ] VBO range cache 갱신을 bounded concurrency로 바꾸고 precompute 경로를 검토한다.
   - 검토 결과: 타당. `LarryWilliamsVBOStrategy._refresh_range_cache()`가 후보 코드를 순차 순회하며 `get_recent_daily_ohlcv()`를 호출한다.
   - 개선 방향: semaphore 기반 bounded gather 또는 장 시작 전/Watchlist 생성 시 range precompute.
-- [ ] VBO fallback 후보의 unknown liquidity를 통과시키지 않는다.
+- [x] VBO fallback 후보의 unknown liquidity를 통과시키지 않는다.
   - 검토 결과: 타당. universe 미주입 fallback에서 `avg_5d_tv=0`을 넣고, validity filter는 `avg_5d_tv > 0 and avg_5d_tv < min`일 때만 탈락시킨다.
-  - 개선 방향: fallback에서도 5일 평균 거래대금을 계산하거나, `avg_5d_tv <= 0`은 `avg_trading_value_unknown`으로 reject.
+  - 완료된 부분: fail-closed reject로 전환. `_passes_validity_filter`에서 `avg_5d_tv <= 0`이면 `avg_trading_value_unknown` reason으로 차단. fallback 경로(`_load_pool_b` API 응답 기반)는 거래대금 검증 없이는 매수 신호를 만들 수 없다. 단위/통합 테스트로 회귀 고정.
 - [ ] scan cycle 단위 데이터 공유와 성능 계측을 강화한다.
   - 후보: 동일 종목 current price/OHLCV/conclusion/program trading memoization, strategy scan latency, candidate count, API calls per scan, cache hit ratio, REST fallback ratio, rejected reason distribution, signal-to-order latency, order-to-fill latency.
   - 목표: 성능 개선을 감이 아니라 병목 지표 기반으로 진행한다.


### PR DESCRIPTION
변경 내용
strategies/larry_williams_vbo_strategy.py:465-498: _passes_validity_filter에 avg_5d_tv <= 0 분기 추가 — avg_trading_value_unknown reason으로 reject. 기존 < min 차단은 그대로. strategies/larry_williams_vbo_strategy.py:431: fallback 경로 주석 갱신 ("필터 스킵" → "fail-closed reject"). tests/unit_test/strategies/test_larry_williams_vbo_strategy.py: test_validity_filter_rejects_unknown_trading_value 추가 (0/누락/None 3케이스). 기존 buy signal 테스트 2개는 _load_pool_b mock으로 fixture 보강. tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py:121-140: test_universe_none_bypasses_market_gate fixture 보강. tests/integration_test/strategies/test_it_api_larry_williams_vbo_strategy.py: 캐시 동작 검증 통합 테스트 fixture 보강. todo_list.md:317-319: 항목 [x] 완료 처리.
검증
단위 테스트 4777 passed (전체)
통합 테스트 233 passed (전체)
효과
universe_service 미주입 상태에서 거래대금이 검증되지 않은 종목이 슬쩍 매수 후보로 통과되던 결함이 막혔습니다. P0/P1 fail-closed 정책과 일관됩니다.