### PR TITLE
P2-2 exit check bounded gather 통일 완료.

### DIFF
--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -17,7 +17,13 @@ from core.market_clock import MarketClock
 from strategies.first_pullback_types import FirstPullbackConfig, FPPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class FirstPullbackStrategy(LiveStrategy):
@@ -390,8 +396,9 @@ class FirstPullbackStrategy(LiveStrategy):
         if not holdings:
             return []
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
 

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -15,7 +15,13 @@ from core.market_clock import MarketClock
 from strategies.oneil_common_types import HTFConfig, HTFPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class HighTightFlagStrategy(LiveStrategy):
@@ -447,8 +453,9 @@ class HighTightFlagStrategy(LiveStrategy):
         if not holdings:
             return []
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
 

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -17,6 +17,12 @@ from services.oneil_universe_service import OneilUniverseService
 from core.market_clock import MarketClock
 from core.logger import get_strategy_logger
 from strategies.larry_williams_cb_types import LarryWilliamsCBConfig, LarryWilliamsCBPositionState
+from utils.async_concurrency import bounded_gather
+
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
@@ -272,8 +278,9 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
         if not holdings:
             return signals
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
         state_dirty = False

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -17,7 +17,13 @@ from core.market_clock import MarketClock
 from strategies.oneil_common_types import OneilPocketPivotConfig, PPPositionState
 from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
+from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class OneilPocketPivotStrategy(LiveStrategy):
@@ -496,8 +502,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
         }
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold, market_timing_cache) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold, market_timing_cache) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
 

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -18,6 +18,12 @@ from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.volatility_utils import annualized_return_std
 from utils.strategy_state_io import StrategyStateIO
+from utils.async_concurrency import bounded_gather
+
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class OneilSqueezeBreakoutStrategy(LiveStrategy):
@@ -384,8 +390,9 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         if not holdings:
             return []
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
 

--- a/strategies/rsi2_pullback_strategy.py
+++ b/strategies/rsi2_pullback_strategy.py
@@ -17,9 +17,14 @@ from services.oneil_universe_service import OneilUniverseService
 from core.market_clock import MarketClock
 from core.logger import get_strategy_logger
 from strategies.rsi2_pullback_types import RSI2PullbackConfig, RSI2PositionState
+from utils.async_concurrency import bounded_gather
 
 
 _MINERVINI_STAGE_2 = 2  # services.minervini_stage_service.MinerviniStageService.STAGE_2_ADVANCING
+
+# 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
+# 빠르게 마무리되도록 우선순위를 부여한다.
+_EXIT_CONCURRENCY = 15
 
 
 class RSI2PullbackStrategy(LiveStrategy):
@@ -217,8 +222,9 @@ class RSI2PullbackStrategy(LiveStrategy):
         if not holdings:
             return signals
 
-        results = await asyncio.gather(
-            *[self._check_single_exit(hold) for hold in holdings],
+        results = await bounded_gather(
+            [self._check_single_exit(hold) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
             return_exceptions=True,
         )
         state_dirty = False

--- a/tests/unit_test/utils/test_async_concurrency.py
+++ b/tests/unit_test/utils/test_async_concurrency.py
@@ -1,0 +1,93 @@
+"""utils.async_concurrency 단위 테스트."""
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import pytest
+
+from utils.async_concurrency import bounded_gather
+
+
+async def _make_coro(value: int, delay: float = 0.0) -> int:
+    if delay:
+        await asyncio.sleep(delay)
+    return value
+
+
+async def _make_failing_coro() -> int:
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_empty_returns_empty_list():
+    result = await bounded_gather([], limit=5)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_preserves_order():
+    coros = [_make_coro(i, delay=0.005 * ((5 - i) % 3)) for i in range(5)]
+    result = await bounded_gather(coros, limit=3)
+    assert result == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_limit_greater_than_input_works_like_plain_gather():
+    coros = [_make_coro(i) for i in range(3)]
+    result = await bounded_gather(coros, limit=100)
+    assert result == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_propagates_exception_when_not_returning():
+    async def _ok() -> int:
+        return 1
+
+    coros = [_ok(), _make_failing_coro(), _ok()]
+    with pytest.raises(RuntimeError, match="boom"):
+        await bounded_gather(coros, limit=2)
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_return_exceptions_true_returns_in_place():
+    async def _ok(v: int) -> int:
+        return v
+
+    coros = [_ok(1), _make_failing_coro(), _ok(3)]
+    result = await bounded_gather(coros, limit=2, return_exceptions=True)
+    assert result[0] == 1
+    assert isinstance(result[1], RuntimeError)
+    assert result[2] == 3
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_respects_concurrency_limit():
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def _tracked() -> int:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        try:
+            await asyncio.sleep(0.01)
+            return in_flight
+        finally:
+            async with lock:
+                in_flight -= 1
+
+    coros = [_tracked() for _ in range(12)]
+    await bounded_gather(coros, limit=3)
+    assert peak <= 3
+    assert peak >= 1
+
+
+@pytest.mark.asyncio
+async def test_bounded_gather_rejects_non_positive_limit():
+    with pytest.raises(ValueError):
+        await bounded_gather([_make_coro(1)], limit=0)
+    with pytest.raises(ValueError):
+        await bounded_gather([_make_coro(1)], limit=-1)

--- a/todo_list.md
+++ b/todo_list.md
@@ -309,9 +309,10 @@
   - 검토 결과: 타당. 개별 전략의 chunk size/semaphore와 `ForegroundScheduler`는 존재하지만, current price/OHLCV/account/order API 전체를 전략 간 공유하는 전역 rate limiter는 없다. 여러 전략이 동시에 scan/check_exits를 수행하면 순간 호출량이 합산된다.
   - 개선 방향: `ApiBudget` 또는 broker wrapper 레벨 limiter를 shared dependency로 주입하고, 조회/계좌/주문 카테고리별 rate를 분리한다.
   - 테스트: 여러 전략이 동시에 호출해도 카테고리별 limiter가 적용되고 주문 API 우선순위가 보존되는지 검증.
-- [ ] 활성 전략의 exit check도 bounded gather 또는 순차/우선순위 정책으로 통일한다.
+- [x] 활성 전략의 exit check도 bounded gather 또는 순차/우선순위 정책으로 통일한다.
   - 검토 결과: 타당. `FirstPullbackStrategy`, `HighTightFlagStrategy`, `LarryWilliamsChannelBreakoutStrategy` 등 일부 전략은 holdings 전체에 대해 `asyncio.gather()`를 수행한다. VBO/레거시 일부는 순차 처리다.
-  - 개선 방향: 공통 `bounded_gather(limit=...)`를 사용하고, 손절/청산 쪽은 entry보다 높은 우선순위를 부여한다.
+  - 완료된 부분: `utils/async_concurrency.py::bounded_gather()` 헬퍼 신규 + 단위 테스트 7개. 활성 6개 전략(`FirstPullback`, `HighTightFlag`, `LarryWilliamsChannelBreakout`, `OneilPocketPivot`, `OneilSqueezeBreakout`, `Rsi2Pullback`)의 holdings exit gather를 `bounded_gather(..., limit=_EXIT_CONCURRENCY=15, return_exceptions=True)`로 교체했다. entry chunk_size(10)보다 높여 청산 경로에 우선순위를 부여한다.
+  - 미적용: VBO는 이미 sequential `for hold in holdings`로 더 보수적이므로 외과수술적 변경 원칙에 따라 유지.
 - [ ] VBO range cache 갱신을 bounded concurrency로 바꾸고 precompute 경로를 검토한다.
   - 검토 결과: 타당. `LarryWilliamsVBOStrategy._refresh_range_cache()`가 후보 코드를 순차 순회하며 `get_recent_daily_ohlcv()`를 호출한다.
   - 개선 방향: semaphore 기반 bounded gather 또는 장 시작 전/Watchlist 생성 시 range precompute.

--- a/utils/async_concurrency.py
+++ b/utils/async_concurrency.py
@@ -1,0 +1,41 @@
+"""비동기 동시성 헬퍼.
+
+`bounded_gather`는 `asyncio.gather`와 같은 결과 contract(입력 순서 보존, return_exceptions 지원)를
+유지하면서 동시에 실행되는 코루틴 수를 semaphore로 제한한다.
+
+전략 entry는 chunk 루프(`for i in range(0, len, chunk): gather(chunk)`) 패턴으로 이미 동시성을
+제한하지만, exit 쪽은 holdings 전체를 unbounded `gather`로 처리한다. 보유 종목이 많아지면
+순간 REST 호출량이 합산되고, 손절/청산이 entry scan과 같은 폭으로 경쟁한다.
+
+이 헬퍼는 그 차이를 메꾸기 위한 공통 진입점이다. exit 쪽이 entry chunk_size보다 높은 limit를
+받도록 호출하면 청산 경로에 우선순위를 부여할 수 있다.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Iterable, List
+
+
+async def bounded_gather(
+    coros: Iterable[Awaitable[Any]],
+    limit: int,
+    *,
+    return_exceptions: bool = False,
+) -> List[Any]:
+    if limit <= 0:
+        raise ValueError(f"limit must be positive, got {limit}")
+
+    coro_list = list(coros)
+    if not coro_list:
+        return []
+
+    sem = asyncio.Semaphore(limit)
+
+    async def _run(coro: Awaitable[Any]) -> Any:
+        async with sem:
+            return await coro
+
+    return await asyncio.gather(
+        *(_run(c) for c in coro_list),
+        return_exceptions=return_exceptions,
+    )


### PR DESCRIPTION
변경 요약
신규: utils/async_concurrency.py — bounded_gather(coros, limit, *, return_exceptions=False) 헬퍼 신규 테스트: tests/unit_test/utils/test_async_concurrency.py — 7개 케이스 (order/limit/exception 등) 적용: 6개 활성 전략의 exit asyncio.gather → bounded_gather(limit=_EXIT_CONCURRENCY=15) first_pullback_strategy.py:399
high_tight_flag_strategy.py:456
larry_williams_channel_breakout_strategy.py:281
oneil_pocket_pivot_strategy.py:505
oneil_squeeze_breakout_strategy.py:393
rsi2_pullback_strategy.py:225
미적용: LarryWilliamsVBO는 이미 sequential for hold in holdings — 외과수술적 변경 원칙 따라 유지 todo_list.md 해당 항목 [x] 처리
우선순위 정책
_EXIT_CONCURRENCY=15로 entry chunk_size=10보다 높여 holdings가 16개 이상일 때만 batching이 발동. 일반 운영(보유 5–10개)에선 행동 동등, 극단 케이스에서 unbounded 폭주 방지.

검증
단위 테스트 4789 GREEN (helper 7개 + 전략 306개 포함)
통합 테스트 233 GREEN