### PR TITLE
변경 요약

### DIFF
--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -12,6 +12,7 @@ from core.market_clock import MarketClock
 from interfaces.live_strategy import LiveStrategy
 from services.stock_query_service import StockQueryService
 from strategies.base_strategy_config import BaseStrategyConfig
+from utils.async_concurrency import bounded_gather
 from utils.volatility_utils import annualized_return_std
 
 if TYPE_CHECKING:
@@ -31,6 +32,8 @@ async def _fetch_volatility_for_signal(sqs: StockQueryService, code: str) -> Opt
 _ENTRY_START = time(9, 10)
 _ENTRY_CUTOFF = time(14, 0)
 _EOD_FLATTEN = time(15, 20)
+
+_RANGE_CACHE_CONCURRENCY = 10
 
 
 @dataclass
@@ -444,23 +447,30 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
         self._range_cache.date = today
         self._range_cache.ranges.clear()
 
-        for code in codes:
-            try:
-                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=2)
-                if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
-                    continue
-                rows: list = resp.data or []
-                if not rows:
-                    continue
+        if not codes:
+            return
 
-                yesterday = rows[0]  # 가장 최근 완성된 일봉
-                high = int(yesterday.get("high", 0) or 0)
-                low = int(yesterday.get("low", 0) or 0)
-                if high > low > 0:
-                    self._range_cache.ranges[code] = float(high - low)
+        results = await bounded_gather(
+            [self._sqs.get_recent_daily_ohlcv(code, limit=2) for code in codes],
+            limit=_RANGE_CACHE_CONCURRENCY,
+            return_exceptions=True,
+        )
 
-            except Exception as e:
-                self._logger.warning({"event": "range_cache_error", "code": code, "error": str(e)})
+        for code, resp in zip(codes, results):
+            if isinstance(resp, Exception):
+                self._logger.warning({"event": "range_cache_error", "code": code, "error": str(resp)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+                continue
+            rows: list = resp.data or []
+            if not rows:
+                continue
+
+            yesterday = rows[0]  # 가장 최근 완성된 일봉
+            high = int(yesterday.get("high", 0) or 0)
+            low = int(yesterday.get("low", 0) or 0)
+            if high > low > 0:
+                self._range_cache.ranges[code] = float(high - low)
 
     def _passes_validity_filter(self, stock: dict, log_data: dict) -> bool:
         """시가총액 / 5일 평균 거래대금 필터.

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -548,6 +548,60 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strategy._range_cache.ranges, {})
         self.assertEqual(sqs.get_recent_daily_ohlcv.call_count, 2)
 
+    async def test_refresh_range_cache_respects_concurrency_limit(self):
+        """일봉 조회는 _RANGE_CACHE_CONCURRENCY를 초과해 동시에 in-flight 되지 않는다."""
+        import asyncio
+
+        from strategies import larry_williams_vbo_strategy as vbo_mod
+
+        strategy, sqs, _ = self._make_strategy()
+
+        concurrency_limit = vbo_mod._RANGE_CACHE_CONCURRENCY
+        in_flight = 0
+        peak = 0
+        gate = asyncio.Event()
+        call_count = 0
+
+        async def _tracked(code: str, limit: int = 2) -> ResCommonResponse:
+            nonlocal in_flight, peak, call_count
+            call_count += 1
+            in_flight += 1
+            peak = max(peak, in_flight)
+            if in_flight >= concurrency_limit:
+                gate.set()
+            try:
+                await gate.wait()
+                return _ohlcv_resp(high=72000, low=70000)
+            finally:
+                in_flight -= 1
+
+        sqs.get_recent_daily_ohlcv = _tracked
+
+        codes = [f"C{i:04d}" for i in range(concurrency_limit * 3)]
+        await strategy._refresh_range_cache("20260115", codes)
+
+        self.assertEqual(peak, concurrency_limit)
+        self.assertEqual(call_count, len(codes))
+        self.assertEqual(len(strategy._range_cache.ranges), len(codes))
+
+    async def test_refresh_range_cache_parallel_preserves_per_code_isolation(self):
+        """일부 코드가 예외/실패 응답이어도 나머지 코드의 range는 정상 저장된다 (zip 순서 매핑)."""
+        strategy, sqs, _ = self._make_strategy()
+
+        good = _ohlcv_resp(high=72000, low=70000)  # range = 2000
+        bad = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="err", data=None)
+        sqs.get_recent_daily_ohlcv.side_effect = [
+            good,
+            RuntimeError("ohlcv down"),
+            bad,
+            good,
+        ]
+
+        codes = ["OK1", "RAISE", "FAIL", "OK2"]
+        await strategy._refresh_range_cache("20260115", codes)
+
+        self.assertEqual(strategy._range_cache.ranges, {"OK1": 2000.0, "OK2": 2000.0})
+
     async def test_get_execution_strength_returns_zero_on_exception(self):
         strategy, sqs, _ = self._make_strategy()
         sqs.get_stock_conclusion.side_effect = RuntimeError("conclusion down")


### PR DESCRIPTION
strategies/larry_williams_vbo_strategy.py: bounded_gather import + 모듈 상수 _RANGE_CACHE_CONCURRENCY = 10 + _refresh_range_cache 본문을 bounded gather + zip 순차 캐시 갱신 구조로 교체 tests/unit_test/strategies/test_larry_williams_vbo_strategy.py: 신규 테스트 2건 추가 test_refresh_range_cache_respects_concurrency_limit — gate 기반 peak in-flight = 10 검증 test_refresh_range_cache_parallel_preserves_per_code_isolation — 일부 종목 실패 시 나머지의 zip 순서 매핑 정확성 검증 검증 결과

VBO 단위 테스트: 33/33 통과
형제 테스트 + async_concurrency: 26/26 통과
전체 단위 테스트: 4791 passed (164s)
전체 통합 테스트: 233 passed (142s)
기존 회귀 케이스 (test_range_cache_refreshes_on_date_change, test_refresh_range_cache_skips_empty_rows_and_logs_exceptions)는 모두 그대로 통과 — 외부 동작 동등성 확인.