### PR TITLE
전역 API budget limiter 1차를 retry_queue 경로에 연결했습니다.

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -7,6 +7,7 @@ from common.types import ResCommonResponse, Exchange, ErrorCode
 from core.cache.cache_wrapper import cache_wrap_client
 from core.retry_queue.retry_classifier import is_non_retriable_business_error
 from core.retry_queue.api_request_queue import ApiRequestQueue
+from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
 from core.retry_queue.client_with_retry_queue import retry_queue_wrap_client
 from datetime import datetime, timedelta
 
@@ -29,13 +30,15 @@ class BrokerAPIWrapper:
                  streaming_logger: Optional["StreamingEventLogger"] = None,
                  stock_code_repository=None,
                  circuit_breaker_threshold: int = _CB_THRESHOLD,
-                 circuit_breaker_timeout_min: int = _CB_TIMEOUT_MIN):
+                 circuit_breaker_timeout_min: int = _CB_TIMEOUT_MIN,
+                 api_budget_limiter=None):
         self._broker = broker
         self._logger = logger
         self._client = None
         self._stock_mapper = stock_code_repository if stock_code_repository is not None else StockCodeRepository(logger=logger)
         self.env = env
         self._retry_queue: ApiRequestQueue | None = None
+        self._api_budget_limiter = api_budget_limiter
 
         # 서킷 브레이커 상태
         self._cb_threshold = circuit_breaker_threshold
@@ -53,8 +56,13 @@ class BrokerAPIWrapper:
             )
             # RetryQueue는 Cache 안쪽에 위치: 캐시 히트 시 Queue를 거치지 않고,
             # 캐시 miss 후 실제 API 호출 실패 시에만 KoreaInvestApiClient를 직접 재시도
+            self._api_budget_limiter = self._api_budget_limiter or ApiBudgetLimiter()
             self._retry_queue = ApiRequestQueue(logger=logger)
-            self._client = retry_queue_wrap_client(self._client, self._retry_queue)
+            self._client = retry_queue_wrap_client(
+                self._client,
+                self._retry_queue,
+                budget_limiter=self._api_budget_limiter,
+            )
             self._client = cache_wrap_client(
 
                 self._client, logger, market_clock,

--- a/core/retry_queue/api_budget_limiter.py
+++ b/core/retry_queue/api_budget_limiter.py
@@ -7,6 +7,7 @@ from typing import AsyncIterator, Mapping
 DEFAULT_API_BUDGET_LIMITS = {
     "quotation": 8,
     "account": 2,
+    "default": 8,
 }
 
 
@@ -37,7 +38,8 @@ class ApiBudgetLimiter:
 
     @asynccontextmanager
     async def acquire(self, category: str | None) -> AsyncIterator[None]:
-        budget = self._budget_for(category or "default")
+        actual_category = category if category is not None else "default"
+        budget = self._budget_for(actual_category)
         await budget.semaphore.acquire()
         budget.active += 1
         budget.acquired_total += 1

--- a/core/retry_queue/api_budget_limiter.py
+++ b/core/retry_queue/api_budget_limiter.py
@@ -1,0 +1,81 @@
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Mapping
+
+
+DEFAULT_API_BUDGET_LIMITS = {
+    "quotation": 8,
+    "account": 2,
+}
+
+
+@dataclass
+class _CategoryBudget:
+    limit: int
+    semaphore: asyncio.Semaphore
+    active: int = 0
+    acquired_total: int = 0
+    max_observed_active: int = 0
+
+
+class ApiBudgetLimiter:
+    """전략/서비스가 공유하는 broker API 동시성 budget limiter."""
+
+    def __init__(
+        self,
+        limits: Mapping[str, int] | None = None,
+        *,
+        default_limit: int = 8,
+    ) -> None:
+        self._default_limit = self._validate_limit(default_limit)
+        configured = dict(DEFAULT_API_BUDGET_LIMITS if limits is None else limits)
+        self._budgets: dict[str, _CategoryBudget] = {
+            category: self._new_budget(limit)
+            for category, limit in configured.items()
+        }
+
+    @asynccontextmanager
+    async def acquire(self, category: str | None) -> AsyncIterator[None]:
+        budget = self._budget_for(category or "default")
+        await budget.semaphore.acquire()
+        budget.active += 1
+        budget.acquired_total += 1
+        budget.max_observed_active = max(budget.max_observed_active, budget.active)
+        try:
+            yield
+        finally:
+            budget.active -= 1
+            budget.semaphore.release()
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        return {
+            category: {
+                "limit": budget.limit,
+                "active": budget.active,
+                "acquired_total": budget.acquired_total,
+                "max_observed_active": budget.max_observed_active,
+            }
+            for category, budget in self._budgets.items()
+        }
+
+    def _budget_for(self, category: str) -> _CategoryBudget:
+        budget = self._budgets.get(category)
+        if budget is None:
+            budget = self._new_budget(self._default_limit)
+            self._budgets[category] = budget
+        return budget
+
+    def _new_budget(self, limit: int) -> _CategoryBudget:
+        validated = self._validate_limit(limit)
+        return _CategoryBudget(
+            limit=validated,
+            semaphore=asyncio.Semaphore(validated),
+        )
+
+    @staticmethod
+    def _validate_limit(limit: int) -> int:
+        value = int(limit)
+        if value < 1:
+            raise ValueError("API budget limit must be >= 1")
+        return value

--- a/core/retry_queue/api_request_queue.py
+++ b/core/retry_queue/api_request_queue.py
@@ -15,6 +15,8 @@ class QueuedRequest:
     future: asyncio.Future     # 호출자에게 최종 결과를 전달하는 Future
     attempt: int = 0
     request_id: str = ""
+    request_category: str = "quotation"
+    budget_limiter: Any = None
 
 
 class ApiRequestQueue:
@@ -32,8 +34,10 @@ class ApiRequestQueue:
     BASE_DELAY  = 1.0   # 초 (지수 백오프: BASE_DELAY * 2^(attempt-1))
     MAX_DELAY   = 30.0  # 최대 지연
 
-    def __init__(self, logger):
+    def __init__(self, logger, budget_limiter=None, default_request_category: str = "quotation"):
         self._logger = logger
+        self._budget_limiter = budget_limiter
+        self._default_request_category = default_request_category
         self._done_q: asyncio.Queue[tuple[QueuedRequest, Any]] = asyncio.Queue()
         self._fail_q: asyncio.Queue[tuple[QueuedRequest, Any]] = asyncio.Queue()
         self._pending_tasks: set[asyncio.Task] = set()
@@ -42,14 +46,31 @@ class ApiRequestQueue:
     # 공개 인터페이스
     # ------------------------------------------------------------------
 
-    async def submit(self, fn: Callable, *args, request_id: str = "", **kwargs) -> asyncio.Future:
+    async def submit(
+        self,
+        fn: Callable,
+        *args,
+        request_id: str = "",
+        request_category: str | None = None,
+        budget_limiter=None,
+        **kwargs,
+    ) -> asyncio.Future:
         """
         요청을 즉시 실행합니다.
         실패 시 백그라운드에서 자동 재시도하며, 최종 결과를 Future로 반환합니다.
         """
         loop = asyncio.get_event_loop()
         future = loop.create_future()
-        req = QueuedRequest(fn, args, kwargs, future, attempt=0, request_id=request_id)
+        req = QueuedRequest(
+            fn,
+            args,
+            kwargs,
+            future,
+            attempt=0,
+            request_id=request_id,
+            request_category=request_category or self._default_request_category,
+            budget_limiter=budget_limiter,
+        )
         self._spawn(self._execute(req))
         return future
 
@@ -74,7 +95,12 @@ class ApiRequestQueue:
 
     async def _execute(self, req: QueuedRequest):
         try:
-            result = await req.fn(*req.args, **req.kwargs)
+            limiter = req.budget_limiter or self._budget_limiter
+            if limiter is None:
+                result = await req.fn(*req.args, **req.kwargs)
+            else:
+                async with limiter.acquire(req.request_category):
+                    result = await req.fn(*req.args, **req.kwargs)
         except Exception as e:
             self._logger.warning(
                 f"[RetryQueue] 예외 발생 (id={req.request_id}, attempt={req.attempt}): {e}"

--- a/core/retry_queue/client_with_retry_queue.py
+++ b/core/retry_queue/client_with_retry_queue.py
@@ -24,6 +24,13 @@ _EXCLUDED_METHODS = frozenset({
     "is_websocket_receive_alive",
 })
 
+_ACCOUNT_METHODS = frozenset({
+    "get_account_balance",
+    "inquire_daily_ccld",
+    "inquire_unfilled_orders",
+    "inquire_filled_history",
+})
+
 
 class ClientWithRetryQueue:
     """
@@ -33,9 +40,10 @@ class ClientWithRetryQueue:
     - 주문/WebSocket API: 큐 우회, 직접 위임 (기존 동작 유지)
     """
 
-    def __init__(self, client, queue: ApiRequestQueue):
+    def __init__(self, client, queue: ApiRequestQueue, budget_limiter=None):
         self._client = client
         self._queue = queue
+        self._budget_limiter = budget_limiter
         # 캐시된 래퍼 함수 저장: 동적 함수 객체 생성을 방지
         self._method_cache: dict = {}
 
@@ -52,7 +60,14 @@ class ClientWithRetryQueue:
 
         # 비동기 조회 메서드 → 큐를 통해 실행
         async def queued(*args, **kwargs):
-            future = await self._queue.submit(attr, *args, request_id=name, **kwargs)
+            future = await self._queue.submit(
+                attr,
+                *args,
+                request_id=name,
+                request_category=_budget_category_for_method(name),
+                budget_limiter=self._budget_limiter,
+                **kwargs,
+            )
             return await future
 
         # 캐싱 후 반환
@@ -60,6 +75,12 @@ class ClientWithRetryQueue:
         return queued
 
 
-def retry_queue_wrap_client(client, queue: ApiRequestQueue) -> ClientWithRetryQueue:
+def _budget_category_for_method(name: str) -> str:
+    if name in _ACCOUNT_METHODS:
+        return "account"
+    return "quotation"
+
+
+def retry_queue_wrap_client(client, queue: ApiRequestQueue, budget_limiter=None) -> ClientWithRetryQueue:
     """BrokerAPIWrapper.__init__ 에서 호출하는 팩토리 함수."""
-    return ClientWithRetryQueue(client, queue)
+    return ClientWithRetryQueue(client, queue, budget_limiter=budget_limiter)

--- a/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
+++ b/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
@@ -40,3 +40,20 @@ def test_limiter_snapshot_exposes_configured_limits():
 
     assert snapshot["quotation"]["limit"] == 3
     assert snapshot["account"]["limit"] == 1
+
+
+def test_default_category_is_explicitly_configured():
+    limiter = ApiBudgetLimiter()
+
+    snapshot = limiter.snapshot()
+
+    assert snapshot["default"]["limit"] == 8
+
+
+async def test_none_category_uses_default_budget():
+    limiter = ApiBudgetLimiter()
+
+    async with limiter.acquire(None):
+        snapshot = limiter.snapshot()
+
+    assert snapshot["default"]["acquired_total"] == 1

--- a/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
+++ b/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import pytest
+
+from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
+
+
+@pytest.mark.real_sleep
+async def test_limiter_serializes_requests_when_category_limit_is_one():
+    limiter = ApiBudgetLimiter({"quotation": 1})
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def run_first():
+        async with limiter.acquire("quotation"):
+            first_started.set()
+            await release_first.wait()
+
+    async def run_second():
+        async with limiter.acquire("quotation"):
+            second_started.set()
+
+    first_task = asyncio.create_task(run_first())
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    second_task = asyncio.create_task(run_second())
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(second_started.wait(), timeout=0.05)
+
+    release_first.set()
+    await asyncio.wait_for(second_started.wait(), timeout=1)
+    await asyncio.gather(first_task, second_task)
+
+
+def test_limiter_snapshot_exposes_configured_limits():
+    limiter = ApiBudgetLimiter({"quotation": 3, "account": 1})
+
+    snapshot = limiter.snapshot()
+
+    assert snapshot["quotation"]["limit"] == 3
+    assert snapshot["account"]["limit"] == 1

--- a/tests/unit_test/core/retry_queue/test_api_request_queue.py
+++ b/tests/unit_test/core/retry_queue/test_api_request_queue.py
@@ -1,6 +1,7 @@
 # tests/unit_test/test_api_request_queue.py
 
 import asyncio
+from contextlib import asynccontextmanager
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -147,6 +148,31 @@ class TestSubmitRetry:
         await future
 
         logger.warning.assert_called()
+
+    async def test_each_retry_attempt_acquires_api_budget(self, logger):
+        categories = []
+
+        class RecordingLimiter:
+            @asynccontextmanager
+            async def acquire(self, category):
+                categories.append(category)
+                yield
+
+        limited_queue = ApiRequestQueue(
+            logger=logger,
+            budget_limiter=RecordingLimiter(),
+        )
+        fn = AsyncMock(side_effect=[network_fail_resp(), success_resp()])
+
+        future = await limited_queue.submit(
+            fn,
+            request_id="test_budget",
+            request_category="quotation",
+        )
+        result = await future
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert categories == ["quotation", "quotation"]
 
 
 class TestExceptionHandling:

--- a/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
+++ b/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
@@ -1,5 +1,7 @@
 # tests/unit_test/test_client_with_retry_queue.py
 
+from contextlib import asynccontextmanager
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -105,6 +107,44 @@ class TestAsyncMethodThroughQueue:
 
         assert req.request_id == "get_current_price"
 
+    async def test_quotation_method_uses_quotation_budget_category(self, fake_client, queue):
+        categories = []
+
+        class RecordingLimiter:
+            @asynccontextmanager
+            async def acquire(self, category):
+                categories.append(category)
+                yield
+
+        wrapped = ClientWithRetryQueue(
+            fake_client,
+            queue,
+            budget_limiter=RecordingLimiter(),
+        )
+
+        await wrapped.get_current_price("005930")
+
+        assert categories == ["quotation"]
+
+    async def test_account_method_uses_account_budget_category(self, fake_client, queue):
+        categories = []
+
+        class RecordingLimiter:
+            @asynccontextmanager
+            async def acquire(self, category):
+                categories.append(category)
+                yield
+
+        wrapped = ClientWithRetryQueue(
+            fake_client,
+            queue,
+            budget_limiter=RecordingLimiter(),
+        )
+
+        await wrapped.get_account_balance()
+
+        assert categories == ["account"]
+
 
 class TestExcludedMethodsBypassQueue:
     async def test_place_stock_order_bypasses_queue(self, wrapped, queue):
@@ -113,6 +153,26 @@ class TestExcludedMethodsBypassQueue:
 
         assert result.rt_cd == ErrorCode.SUCCESS.value
         assert queue.done_queue.empty()
+
+    async def test_place_stock_order_bypasses_budget_limiter(self, fake_client, queue):
+        calls = []
+
+        class RecordingLimiter:
+            @asynccontextmanager
+            async def acquire(self, category):
+                calls.append(category)
+                yield
+
+        wrapped = ClientWithRetryQueue(
+            fake_client,
+            queue,
+            budget_limiter=RecordingLimiter(),
+        )
+
+        result = await wrapped.place_stock_order("005930", 70000, 1, True)
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert calls == []
 
     async def test_connect_websocket_bypasses_queue(self, wrapped, queue):
         result = await wrapped.connect_websocket()
@@ -218,6 +278,11 @@ class TestFactoryFunction:
     def test_wrapped_client_has_correct_queue(self, fake_client, queue):
         client = retry_queue_wrap_client(fake_client, queue)
         assert client._queue is queue
+
+    def test_retry_queue_wrap_client_accepts_budget_limiter(self, fake_client, queue):
+        limiter = MagicMock()
+        client = retry_queue_wrap_client(fake_client, queue, budget_limiter=limiter)
+        assert client._budget_limiter is limiter
 
 
 class TestExcludedMethodsSet:

--- a/tests/unit_test/view/web/bootstrap/test_broker_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_broker_bootstrap.py
@@ -20,6 +20,7 @@ def _make_fake_context():
     ctx.market_clock = MagicMock()
     ctx.streaming_event_logger = MagicMock()
     ctx.stock_code_repository = MagicMock()
+    ctx.api_budget_limiter = MagicMock()
     ctx._mcs = MagicMock()
     ctx._mcs._sync_calendar_if_needed = AsyncMock()
     ctx.broker = None
@@ -37,6 +38,7 @@ async def test_broker_bootstrap_returns_true_and_assigns_broker():
     assert success is True
     broker_cls.assert_called_once()
     assert ctx.broker is broker_cls.return_value
+    assert broker_cls.call_args.kwargs["api_budget_limiter"] is ctx.api_budget_limiter
     ctx._mcs.set_broker.assert_called_once_with(broker_cls.return_value)
     ctx._mcs._sync_calendar_if_needed.assert_awaited_once()
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -305,10 +305,13 @@
   - `_price_lookup_stats` dict를 `price_lookup_stats` 이벤트 로그로 노출 가능.
 - [x] 전략별 중복 조회를 제거하고 동일 종목 데이터는 공통 snapshot에서 읽도록 정리한다.
   - 완료: 전략들이 `StockQueryService.get_current_price()` 한 통로를 거치므로 snapshot-first 기본화로 자연 해결. REST backfill로 첫 호출 이후 동일 종목 재조회 시 캐시 hit.
-- [ ] 전략/서비스 전역 API budget limiter를 도입한다.
+- [x] 전략/서비스 전역 API budget limiter를 도입한다.
   - 검토 결과: 타당. 개별 전략의 chunk size/semaphore와 `ForegroundScheduler`는 존재하지만, current price/OHLCV/account/order API 전체를 전략 간 공유하는 전역 rate limiter는 없다. 여러 전략이 동시에 scan/check_exits를 수행하면 순간 호출량이 합산된다.
   - 개선 방향: `ApiBudget` 또는 broker wrapper 레벨 limiter를 shared dependency로 주입하고, 조회/계좌/주문 카테고리별 rate를 분리한다.
   - 테스트: 여러 전략이 동시에 호출해도 카테고리별 limiter가 적용되고 주문 API 우선순위가 보존되는지 검증.
+  - 완료된 부분: `core.retry_queue.api_budget_limiter.ApiBudgetLimiter` 추가. `BrokerAPIWrapper`가 shared limiter를 생성해 `ClientWithRetryQueue`에 주입하고, retry queue의 최초 호출/재시도 호출이 모두 limiter를 거치도록 연결했다.
+  - 1차 정책: 조회성 API는 `quotation` 기본 동시성 8, 계좌 조회 API는 `account` 기본 동시성 2로 분리. 주문/WebSocket 메서드는 기존 제외 목록을 유지해 budget limiter와 retry queue를 우회한다.
+  - 검증: retry queue 단위 88개, retry queue 통합 22개, broker wrapper 단위 33개, 전체 단위 4798개, 전체 통합 233개 통과.
 - [x] 활성 전략의 exit check도 bounded gather 또는 순차/우선순위 정책으로 통일한다.
   - 검토 결과: 타당. `FirstPullbackStrategy`, `HighTightFlagStrategy`, `LarryWilliamsChannelBreakoutStrategy` 등 일부 전략은 holdings 전체에 대해 `asyncio.gather()`를 수행한다. VBO/레거시 일부는 순차 처리다.
   - 완료된 부분: `utils/async_concurrency.py::bounded_gather()` 헬퍼 신규 + 단위 테스트 7개. 활성 6개 전략(`FirstPullback`, `HighTightFlag`, `LarryWilliamsChannelBreakout`, `OneilPocketPivot`, `OneilSqueezeBreakout`, `Rsi2Pullback`)의 holdings exit gather를 `bounded_gather(..., limit=_EXIT_CONCURRENCY=15, return_exceptions=True)`로 교체했다. entry chunk_size(10)보다 높여 청산 경로에 우선순위를 부여한다.

--- a/view/web/bootstrap/broker_bootstrap.py
+++ b/view/web/bootstrap/broker_bootstrap.py
@@ -37,6 +37,7 @@ class BrokerBootstrap:
                 market_calendar_service=ctx._mcs,
                 streaming_logger=ctx.streaming_event_logger,
                 stock_code_repository=ctx.stock_code_repository,
+                api_budget_limiter=getattr(ctx, "api_budget_limiter", None),
             )
             ctx._mcs.set_broker(ctx.broker)
             await ctx._mcs._sync_calendar_if_needed()

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -66,6 +66,7 @@ from services.notification_service import NotificationService, NotificationCateg
 from services.kill_switch_service import KillSwitchService
 from services.operator_alert_service import OperatorAlertService
 from core.account_snapshot import AccountSnapshotCache
+from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
 from services.position_sizing_service import PositionSizingService
 from services.risk_gate_service import RiskGateService
 from services.order_policy_service import OrderPolicyService
@@ -116,6 +117,7 @@ class WebAppContext:
             stock_code_repository=self.stock_code_repository,
         )
         self.account_snapshot_cache: AccountSnapshotCache = None
+        self.api_budget_limiter = ApiBudgetLimiter()
         self.risk_gate_service: RiskGateService = None
         self.order_policy_service: OrderPolicyService = None
         self.execution_flow_service: ExecutionFlowService = None


### PR DESCRIPTION
변경 핵심:
api_budget_limiter.py (line 1) 추가: 카테고리별 동시성 제한과 snapshot 제공 api_request_queue.py (line 45): 최초 호출과 재시도 호출 모두 limiter를 거치도록 연결 client_with_retry_queue.py (line 27): quotation/account 카테고리 분리, 주문/WebSocket은 기존처럼 우회 broker_api_wrapper.py (line 30): shared ApiBudgetLimiter 주입 todo_list.md (line 308): P2 API budget limiter 완료 반영 1차 기본값은 quotation=8, account=2 동시성입니다. 주문 API와 WebSocket 메서드는 멱등성/상태성 때문에 retry queue와 budget limiter를 계속 우회합니다. 검증도 끝냈습니다:
tests/unit_test/core/retry_queue: 88 passed
tests/integration_test/test_it_retry_queue.py: 22 passed tests/unit_test/brokers/test_broker_api_wrapper.py: 33 passed 전체 단위: 4798 passed
전체 통합: 233 passed