### PR TITLE
수정 완료했습니다.

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -1145,41 +1145,47 @@ def test_get_subscription_status_no_streaming_service(web_client, mock_web_ctx):
     assert data["pending_by_priority"]["HIGH"][0]["received_at"] is None
 
 
-def test_get_subscription_status_adds_program_trading_to_critical(web_client, mock_web_ctx):
-    """PT active/desired 상태는 기존 bucket과 별개로 CRITICAL에도 노출된다."""
+def test_get_subscription_status_uses_program_trading_repo_as_critical_source(web_client, mock_web_ctx):
+    """CRITICAL은 PT 저장소의 현재 desired와 active 상태를 기준으로 노출된다."""
     mock_svc = MagicMock()
     mock_svc.get_status.return_value = {
         "active_count": 2,
         "max_subscriptions": 40,
-        "active_codes_price": ["005930"],
-        "active_codes_pt": ["035720"],
-        "pending_count": 2,
+        "active_codes_price": ["000660"],
+        "active_codes_pt": [],
+        "pending_count": 3,
         "pending_by_priority": {
-            "CRITICAL": [],
-            "HIGH": ["005930"],
-            "MEDIUM": ["035720"],
+            "CRITICAL": ["000660"],  # 정책 refs에 남은 오래된 PT 종목
+            "HIGH": [],
+            "MEDIUM": [],
             "LOW": [],
         },
     }
     mock_web_ctx.price_subscription_service = mock_svc
     mock_web_ctx.streaming_stock_repo = MagicMock()
-    mock_web_ctx.streaming_stock_repo.get_desired.side_effect = (
-        lambda stream_type: {"035720"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    mock_web_ctx.streaming_stock_repo.get_desired.side_effect = lambda stream_type: (
+        {"005930", "080220"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    mock_web_ctx.streaming_stock_repo.get_active.side_effect = lambda stream_type: (
+        {"005930", "080220"} if stream_type == StreamingType.PROGRAM_TRADING else set()
     )
     mock_web_ctx.streaming_service.get_cached_realtime_price.return_value = None
     mock_web_ctx.stock_code_repository.get_name_by_code.side_effect = lambda c: {
-        "005930": "005930",
-        "035720": "035720",
+        "000660": "SK하이닉스",
+        "005930": "삼성전자",
+        "080220": "제주반도체",
     }.get(c, c)
 
     response = web_client.get("/api/subscriptions/status")
 
     assert response.status_code == 200
     data = response.json()["data"]
+    assert data["active_count"] == 3
+    assert data["active_codes_pt"] == ["005930", "080220"]
     assert data["pending_count"] == 2
-    assert data["pending_by_priority"]["CRITICAL"][0]["code"] == "035720"
-    assert data["pending_by_priority"]["CRITICAL"][0]["active"] is True
-    assert data["pending_by_priority"]["MEDIUM"][0]["code"] == "035720"
+    critical = data["pending_by_priority"]["CRITICAL"]
+    assert [row["code"] for row in critical] == ["005930", "080220"]
+    assert [row["active"] for row in critical] == [True, True]
 
 
 def test_get_subscription_status_ignores_repo_error(web_client, mock_web_ctx):

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -482,6 +482,12 @@ def get_subscription_status():
         return {"success": True, "data": None}
 
     status = svc.get_status()
+
+    def _code_set(value):
+        if not isinstance(value, (set, frozenset, list, tuple)):
+            return None
+        return {str(code) for code in value if code is not None and str(code)}
+
     pending_by_priority = {
         "CRITICAL": set(status.get("pending_by_priority", {}).get("CRITICAL", [])),
         "HIGH": set(status.get("pending_by_priority", {}).get("HIGH", [])),
@@ -489,24 +495,31 @@ def get_subscription_status():
         "LOW": set(status.get("pending_by_priority", {}).get("LOW", [])),
     }
 
-    # 수정 포인트: active_codes_price와 active_codes_pt를 병합하여 active_set 구성
     streaming_svc = getattr(ctx, "streaming_service", None)
-    active_set = set(status.get("active_codes_price", [])) | set(status.get("active_codes_pt", []))
-    pt_codes = set(status.get("active_codes_pt", []))
+    active_codes_price = set(status.get("active_codes_price", []))
+    active_codes_pt = set(status.get("active_codes_pt", []))
 
     repo = getattr(ctx, "streaming_stock_repo", None)
     if repo is not None:
         try:
             desired_pt = repo.get_desired(StreamingType.PROGRAM_TRADING)
-            if isinstance(desired_pt, (set, frozenset, list, tuple)):
-                pt_codes.update(str(code) for code in desired_pt)
+            desired_pt_set = _code_set(desired_pt)
+            if desired_pt_set is not None:
+                pending_by_priority["CRITICAL"] = desired_pt_set
+
+            active_pt_set = _code_set(repo.get_active(StreamingType.PROGRAM_TRADING))
+            if active_pt_set is not None:
+                active_codes_pt.update(active_pt_set)
+
+            active_price_set = _code_set(repo.get_active(StreamingType.UNIFIED_PRICE))
+            if active_price_set is not None:
+                active_codes_price.update(active_price_set)
         except Exception:
             pass
 
-    if pt_codes:
-        pending_by_priority["CRITICAL"].update(pt_codes)
-
     pending_count = len(set().union(*pending_by_priority.values()))
+    active_set = active_codes_price | active_codes_pt
+    active_count = len(active_codes_price) + len(active_codes_pt)
 
     def _enrich(codes: list) -> list:
         result = []
@@ -531,10 +544,10 @@ def get_subscription_status():
     return {
         "success": True,
         "data": {
-            "active_count": status.get("active_count", 0),
+            "active_count": active_count,
             "max_subscriptions": status.get("max_subscriptions", 40),
-            "active_codes_price": status.get("active_codes_price", []),
-            "active_codes_pt": status.get("active_codes_pt", []),
+            "active_codes_price": sorted(active_codes_price),
+            "active_codes_pt": sorted(active_codes_pt),
             "pending_count": pending_count,
             "pending_by_priority": {
                 "CRITICAL": _enrich(sorted(pending_by_priority["CRITICAL"])),


### PR DESCRIPTION
system.py (line 477)에서 /api/subscriptions/status가 이제 프로그램매매 CRITICAL 목록을 price_subscription_service의 오래된 refs가 아니라 StreamingStockRepo의 현재 PROGRAM_TRADING desired 기준으로 맞춥니다. 그래서 SK하이닉스처럼 PT 저장소에 없는 stale CRITICAL 종목은 빠지고, 삼성전자/제주반도체만 CRITICAL에 남게 됩니다. 또한 활성 상태 판정과 active_codes_pt도 StreamingStockRepo.get_active(PROGRAM_TRADING)까지 병합하도록 바꿔서, PT 저장소에서 활성인 삼성전자/제주반도체가 “대기”가 아니라 “구독 중”으로 표시됩니다. 테스트도 갱신했습니다: test_web_routes_system.py (line 1148) 검증:
pytest tests/unit_test/view/web/routes/test_web_routes_system.py -v 통과 pytest tests/unit_test -v 통과
pytest tests/integration_test -v 통과, 233 passed
통합 테스트 끝에 기존 비동기 cleanup 경고(Task was destroyed but it is pending)가 출력됐지만, 테스트 결과 자체는 성공입니다.