### PR TITLE
분석 및 개선 완료했습니다.

### DIFF
--- a/services/execution_quality_reporter.py
+++ b/services/execution_quality_reporter.py
@@ -256,12 +256,6 @@ class ExecutionQualityReporter:
             cfg.warn_avg_first_fill_latency_sec,
             cfg.candidate_avg_first_fill_latency_sec,
         )
-        _add(
-            "unfilled_ratio_pct",
-            event.get("unfilled_ratio_pct"),
-            cfg.warn_avg_unfilled_ratio_pct,
-            cfg.candidate_avg_unfilled_ratio_pct,
-        )
         if event.get("state") in {OrderState.CANCELED.value, OrderState.REJECTED.value}:
             _add(
                 "incomplete_fill_ratio_pct",

--- a/tests/unit_test/services/test_execution_quality_reporter.py
+++ b/tests/unit_test/services/test_execution_quality_reporter.py
@@ -327,6 +327,48 @@ def test_emit_alert_includes_incomplete_fill_only_for_terminal_canceled_or_rejec
     assert "incomplete_fill_ratio_pct" in metrics
 
 
+def test_emit_alert_ignores_unfilled_ratio_for_active_partial_fill():
+    """부분체결 중 잔량은 아직 대기 중인 수량이므로 미체결 품질 알람 대상이 아니다."""
+    cfg = ExecutionQualityReportConfig(
+        warn_avg_unfilled_ratio_pct=20.0,
+        candidate_avg_unfilled_ratio_pct=40.0,
+        warn_incomplete_fill_ratio_pct=20.0,
+    )
+    notif = AsyncMock()
+    reporter, _logger, _ = _make_reporter(config=cfg, notification=notif)
+    event = {
+        "slippage_pct": 0.0,
+        "first_fill_latency_sec": 2.17,
+        "unfilled_ratio_pct": 75.47,
+        "state": OrderState.PARTIAL_FILLED.value,
+    }
+
+    breaches = reporter._find_breaches(event)
+
+    assert breaches == []
+
+
+def test_emit_alert_uses_incomplete_metric_for_terminal_remaining_qty():
+    cfg = ExecutionQualityReportConfig(
+        warn_avg_unfilled_ratio_pct=20.0,
+        candidate_avg_unfilled_ratio_pct=40.0,
+        warn_incomplete_fill_ratio_pct=20.0,
+    )
+    notif = AsyncMock()
+    reporter, _logger, _ = _make_reporter(config=cfg, notification=notif)
+    event = {
+        "slippage_pct": None,
+        "first_fill_latency_sec": None,
+        "unfilled_ratio_pct": 75.47,
+        "state": OrderState.CANCELED.value,
+    }
+
+    breaches = reporter._find_breaches(event)
+    metrics = {b["metric"] for b in breaches}
+
+    assert metrics == {"incomplete_fill_ratio_pct"}
+
+
 # ── _fmt_optional ───────────────────────────────────────────────────────────
 
 def test_fmt_optional_handles_none_and_numbers_and_garbage():


### PR DESCRIPTION
원인은 실제 체결 실패가 아니라, 032500 주문이 아직 PARTIAL_FILLED 상태였는데 잔량 비율을 즉시 알람 기준에 넣은 것이었습니다. 로그상 2026-05-22 09:46:42에 53주 중 13주만 먼저 체결되어 unfilled_ratio_pct=75.47가 찍혔고, 09:46:47에는 53주 전량 체결로 종료됐습니다. 즉 “대기 중 잔량”을 “최종 미체결 품질 문제”로 오판한 케이스입니다. 수정은 execution_quality_reporter.py (line 254)에 적용했습니다. 실시간 알람 판정에서 unfilled_ratio_pct 단독 알람을 제거했고, 주문이 CANCELED 또는 REJECTED로 끝난 경우에만 잔량을 incomplete_fill_ratio_pct로 알리도록 했습니다. 부분체결 로그 자체는 유지됩니다. 테스트도 추가했습니다: test_execution_quality_reporter.py (line 330) 검증:
pytest tests/unit_test -v → 4804 passed
pytest tests/integration_test -v → 233 passed
통합 테스트 종료 시 기존성으로 보이는 pending task/close 경고가 출력되긴 했지만, 테스트 결과는 모두 통과했습니다.