### PR TITLE
P1-1: O'Neil PP/BGU ablation test MVP

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Awaitable, Callable, Iterable, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -97,6 +97,20 @@ def _parse_args() -> argparse.Namespace:
         default=False,
         dest="profitability_gate",
         help="전략별 실전 투입 수익성 기준선 통과 여부를 산출",
+    )
+    parser.add_argument(
+        "--ablation",
+        default=None,
+        help=(
+            "Ablation 백테스트 대상 전략 키 (예: oneil_pocket_pivot). 지정하면 baseline "
+            "실행 후 preset 의 각 variant 를 동일 기간/데이터로 재실행해 metric 차이를 출력."
+        ),
+    )
+    parser.add_argument(
+        "--ablation-variants",
+        default=None,
+        dest="ablation_variants",
+        help="실행할 variant 이름 (쉼표 구분). 미지정 시 preset 의 모든 variant 실행.",
     )
     parser.add_argument(
         "--paper",
@@ -211,8 +225,14 @@ def _build_backtest_strategy(
     state_dir: str,
     state_suffix: str = "",
     logger: logging.Logger | None = None,
+    config: Any = None,
 ):
-    """Build an active strategy with replay data and a pinned backtest clock."""
+    """Build an active strategy with replay data and a pinned backtest clock.
+
+    ``config`` is an optional strategy-specific config instance (e.g.
+    ``OneilPocketPivotConfig``). When None, the strategy's default config is
+    used. Ablation runs supply a config built from preset overrides.
+    """
     strategy_logger = logger or logging.getLogger(f"backtest.{strategy_key}")
 
     if strategy_key == "oneil_pocket_pivot":
@@ -224,6 +244,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "oneil_squeeze_breakout":
         from strategies.oneil_squeeze_breakout_strategy import OneilSqueezeBreakoutStrategy
@@ -370,6 +391,11 @@ def _format_console(result) -> str:
     profitability_gate = getattr(result, "profitability_gate", None)
     if profitability_gate:
         lines.extend(_format_profitability_gate_console_lines(profitability_gate))
+    ablation = getattr(result, "ablation", None)
+    if ablation:
+        lines.extend(
+            _format_ablation_console_lines(ablation["strategy_key"], ablation["summary"])
+        )
     return "\n".join(lines)
 
 
@@ -397,6 +423,7 @@ def _result_to_payload(result) -> dict[str, Any]:
         "execution_bar_policy": getattr(result, "execution_bar_policy", ""),
         "monte_carlo": getattr(result, "monte_carlo", None),
         "profitability_gate": getattr(result, "profitability_gate", None),
+        "ablation": getattr(result, "ablation", None),
     }
 
 
@@ -577,6 +604,152 @@ def _build_profitability_gate_config(app_config: Any, *, initial_cash: float):
     return StrategyProfitabilityGateConfig(**{k: v for k, v in values.items() if k in allowed})
 
 
+def _build_ablation_overrides(
+    *,
+    strategy_key: str,
+    base_universe: Any,
+    variant: Any,
+) -> tuple[Any, Any]:
+    """Return ``(universe, config)`` for the given variant, or pass-throughs.
+
+    When ``variant`` is None, returns ``(base_universe, None)`` so the baseline
+    path is unchanged. When the variant has ``force_market_timing_ok=True``,
+    the universe is wrapped. When the variant has ``config_overrides``, a
+    fresh strategy-specific default config is built and overrides are applied.
+    """
+    if variant is None:
+        return base_universe, None
+    from services.strategy_ablation_service import (
+        ForceMarketTimingOkUniverseWrapper,
+        apply_config_overrides,
+    )
+
+    universe = base_universe
+    if variant.universe_overrides.get("force_market_timing_ok"):
+        universe = ForceMarketTimingOkUniverseWrapper(base_universe)
+
+    config = None
+    if variant.config_overrides:
+        if strategy_key == "oneil_pocket_pivot":
+            from strategies.oneil_common_types import OneilPocketPivotConfig
+
+            config = apply_config_overrides(
+                OneilPocketPivotConfig(), variant.config_overrides
+            )
+        else:
+            raise ValueError(
+                f"Ablation default config not defined for strategy '{strategy_key}'."
+            )
+    return universe, config
+
+
+def _resolve_ablation_preset(strategy_key: str):
+    from services.strategy_ablation_service import AblationPreset
+
+    if strategy_key == "oneil_pocket_pivot":
+        from strategies.oneil_pocket_pivot_ablation import (
+            ONEIL_POCKET_PIVOT_ABLATION_PRESET,
+        )
+        return ONEIL_POCKET_PIVOT_ABLATION_PRESET
+    raise ValueError(
+        f"Ablation preset 이 정의되지 않은 전략입니다: '{strategy_key}'. "
+        f"현재 지원: oneil_pocket_pivot"
+    )
+
+
+def _filter_ablation_variants(preset, names: Optional[str]):
+    if not names:
+        return preset.variants
+    name_set = {n.strip() for n in str(names).split(",") if n.strip()}
+    known = {v.name for v in preset.variants}
+    unknown = name_set - known
+    if unknown:
+        raise ValueError(
+            f"{preset.strategy_key} 에 정의되지 않은 ablation variant: {sorted(unknown)}. "
+            f"사용 가능: {sorted(known)}"
+        )
+    # Preserve preset variant order (deterministic)
+    return tuple(v for v in preset.variants if v.name in name_set)
+
+
+async def _run_ablation_for_result(
+    result,
+    args: argparse.Namespace,
+    *,
+    run_variant_fn: Callable[[Any], Awaitable[Any]],
+) -> None:
+    """Run each variant via ``run_variant_fn`` and attach summary to ``result``.
+
+    ``run_variant_fn`` is supplied by the script's ``_run`` so the variant runner
+    can reuse the same dates, ledger, simulator, and replay context. Tests stub
+    it with an async function returning a ``BacktestPeriodRunResult``.
+    """
+    if not getattr(args, "ablation", None):
+        return
+    from services.strategy_ablation_service import compute_ablation_summary
+
+    preset = _resolve_ablation_preset(args.ablation)
+    variants = _filter_ablation_variants(preset, getattr(args, "ablation_variants", None))
+
+    variant_records: dict[str, list[dict]] = {}
+    for variant in variants:
+        variant_result = await run_variant_fn(variant)
+        variant_records[variant.name] = list(
+            getattr(variant_result, "journal_records", []) or []
+        )
+
+    summary = compute_ablation_summary(
+        baseline_records=list(getattr(result, "journal_records", []) or []),
+        variant_records=variant_records,
+        capital_base_won=float(getattr(args, "initial_cash", 0.0)) or None,
+    )
+    object.__setattr__(
+        result,
+        "ablation",
+        {"strategy_key": preset.strategy_key, "summary": summary},
+    )
+
+
+def _format_ablation_console_lines(strategy_key: str, summary: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    lines.append(f"[ABLATION] strategy={strategy_key}")
+    baseline_metrics = summary.get("baseline", {}).get("metrics", {})
+    lines.append(_format_ablation_row("baseline", baseline_metrics, delta=None))
+    for variant_name, payload in summary.get("variants", {}).items():
+        lines.append(
+            _format_ablation_row(
+                variant_name,
+                payload.get("metrics", {}),
+                delta=payload.get("delta"),
+            )
+        )
+    return lines
+
+
+def _format_ablation_row(
+    name: str,
+    metrics: dict[str, Any],
+    delta: Optional[dict[str, Any]],
+) -> str:
+    pf = metrics.get("profit_factor")
+    payoff = metrics.get("payoff_ratio")
+    pf_str = f"{pf:.2f}" if isinstance(pf, (int, float)) else "n/a"
+    payoff_str = f"{payoff:.2f}" if isinstance(payoff, (int, float)) else "n/a"
+    base = (
+        f"  {name:<28} trades={int(metrics.get('trade_count', 0)):>3} "
+        f"win_rate={float(metrics.get('win_rate', 0.0)):.2%} "
+        f"avg_ret={float(metrics.get('avg_net_return', 0.0)):.3f} "
+        f"net_pnl={float(metrics.get('total_net_pnl', 0.0)):>12,.0f} "
+        f"pf={pf_str} payoff={payoff_str} "
+        f"mdd={float(metrics.get('mdd_amount', 0.0)):>12,.0f}"
+    )
+    if not delta:
+        return base
+    pnl_diff = float(delta.get("total_net_pnl_diff", 0.0))
+    trade_diff = int(delta.get("trade_count_diff", 0))
+    return base + f"  Δtrades={trade_diff:+d} Δnet_pnl={pnl_diff:+,.0f}"
+
+
 async def _run(args: argparse.Namespace) -> None:
     from scripts._bootstrap import bootstrap_pp_strategy, make_stdout_logger
     from config.config_loader import load_configs
@@ -629,6 +802,7 @@ async def _run(args: argparse.Namespace) -> None:
             phase: str | None = None,
             segment=None,
             phase_dates: list[str] | None = None,
+            variant=None,
         ) -> BacktestPeriodRunner:
             ledger = BacktestPortfolioLedger(initial_cash=args.initial_cash)
             risk_sizing = _build_risk_sizing_services(
@@ -639,15 +813,23 @@ async def _run(args: argparse.Namespace) -> None:
                 logger=bootstrap_logger,
             )
             state_suffix = f"_{segment.index}_{phase}" if segment is not None else ""
+            if variant is not None:
+                state_suffix = f"{state_suffix}_ablation_{variant.name}"
+            variant_universe, variant_config = _build_ablation_overrides(
+                strategy_key=args.strategy,
+                base_universe=universe_service,
+                variant=variant,
+            )
             strategy = _build_backtest_strategy(
                 strategy_key=args.strategy,
                 replay_sqs=replay_sqs,
-                universe_service=universe_service,
+                universe_service=variant_universe,
                 indicator_service=indicator_service,
                 backtest_clock=backtest_clock,
                 state_dir=tmp_dir,
                 state_suffix=state_suffix,
                 logger=logging.getLogger(f"backtest.{args.strategy}"),
+                config=variant_config,
             )
             max_positions = (
                 {strategy.name: args.max_positions}
@@ -731,6 +913,20 @@ async def _run(args: argparse.Namespace) -> None:
                 _run_monte_carlo_for_result(result, args)
             if args.profitability_gate:
                 _run_profitability_gate_for_result(result, app_config, initial_cash=args.initial_cash)
+            if args.ablation:
+                if args.strategy != args.ablation:
+                    raise ValueError(
+                        f"--ablation({args.ablation}) 과 --strategy({args.strategy}) 가 다릅니다. "
+                        "ablation 은 baseline 과 같은 전략에 대해서만 의미가 있습니다."
+                    )
+
+                async def _variant_runner(variant):
+                    print(f"[INFO] ablation variant 실행: {variant.name}")
+                    return await make_runner(variant=variant).run(dates)
+
+                await _run_ablation_for_result(
+                    result, args, run_variant_fn=_variant_runner
+                )
             rendered = _format_json(result) if args.output == "json" else _format_console(result)
 
     if args.output_file:

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -255,6 +255,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "high_tight_flag":
         from strategies.high_tight_flag_strategy import HighTightFlagStrategy
@@ -265,6 +266,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "first_pullback":
         from strategies.first_pullback_strategy import FirstPullbackStrategy
@@ -275,6 +277,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "larry_williams_vbo":
         from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOStrategy
@@ -284,6 +287,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             universe_service=universe_service,
             logger=strategy_logger,
+            config=config,
         )
     if strategy_key == "rsi2_pullback":
         from strategies.rsi2_pullback_strategy import RSI2PullbackStrategy
@@ -295,6 +299,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "larry_williams_channel_breakout":
         from strategies.larry_williams_channel_breakout_strategy import (
@@ -308,6 +313,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
 
     raise ValueError(f"지원하지 않는 백테스트 전략입니다: {strategy_key}")
@@ -604,6 +610,41 @@ def _build_profitability_gate_config(app_config: Any, *, initial_cash: float):
     return StrategyProfitabilityGateConfig(**{k: v for k, v in values.items() if k in allowed})
 
 
+def _build_default_strategy_config(strategy_key: str) -> Any:
+    """Return a fresh strategy-specific default config instance."""
+    if strategy_key == "oneil_pocket_pivot":
+        from strategies.oneil_common_types import OneilPocketPivotConfig
+
+        return OneilPocketPivotConfig()
+    if strategy_key == "oneil_squeeze_breakout":
+        from strategies.oneil_common_types import OneilBreakoutConfig
+
+        return OneilBreakoutConfig()
+    if strategy_key == "high_tight_flag":
+        from strategies.oneil_common_types import HTFConfig
+
+        return HTFConfig()
+    if strategy_key == "first_pullback":
+        from strategies.first_pullback_types import FirstPullbackConfig
+
+        return FirstPullbackConfig()
+    if strategy_key == "larry_williams_vbo":
+        from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOConfig
+
+        return LarryWilliamsVBOConfig()
+    if strategy_key == "rsi2_pullback":
+        from strategies.rsi2_pullback_types import RSI2PullbackConfig
+
+        return RSI2PullbackConfig()
+    if strategy_key == "larry_williams_channel_breakout":
+        from strategies.larry_williams_cb_types import LarryWilliamsCBConfig
+
+        return LarryWilliamsCBConfig()
+    raise ValueError(
+        f"Ablation default config not defined for strategy '{strategy_key}'."
+    )
+
+
 def _build_ablation_overrides(
     *,
     strategy_key: str,
@@ -630,30 +671,50 @@ def _build_ablation_overrides(
 
     config = None
     if variant.config_overrides:
-        if strategy_key == "oneil_pocket_pivot":
-            from strategies.oneil_common_types import OneilPocketPivotConfig
-
-            config = apply_config_overrides(
-                OneilPocketPivotConfig(), variant.config_overrides
-            )
-        else:
-            raise ValueError(
-                f"Ablation default config not defined for strategy '{strategy_key}'."
-            )
+        config = apply_config_overrides(
+            _build_default_strategy_config(strategy_key), variant.config_overrides
+        )
     return universe, config
 
 
 def _resolve_ablation_preset(strategy_key: str):
-    from services.strategy_ablation_service import AblationPreset
-
     if strategy_key == "oneil_pocket_pivot":
         from strategies.oneil_pocket_pivot_ablation import (
             ONEIL_POCKET_PIVOT_ABLATION_PRESET,
         )
         return ONEIL_POCKET_PIVOT_ABLATION_PRESET
+    if strategy_key == "oneil_squeeze_breakout":
+        from strategies.oneil_squeeze_breakout_ablation import (
+            ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+        )
+        return ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET
+    if strategy_key == "high_tight_flag":
+        from strategies.high_tight_flag_ablation import (
+            HIGH_TIGHT_FLAG_ABLATION_PRESET,
+        )
+        return HIGH_TIGHT_FLAG_ABLATION_PRESET
+    if strategy_key == "first_pullback":
+        from strategies.first_pullback_ablation import (
+            FIRST_PULLBACK_ABLATION_PRESET,
+        )
+        return FIRST_PULLBACK_ABLATION_PRESET
+    if strategy_key == "larry_williams_vbo":
+        from strategies.larry_williams_vbo_ablation import (
+            LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+        )
+        return LARRY_WILLIAMS_VBO_ABLATION_PRESET
+    if strategy_key == "rsi2_pullback":
+        from strategies.rsi2_pullback_ablation import (
+            RSI2_PULLBACK_ABLATION_PRESET,
+        )
+        return RSI2_PULLBACK_ABLATION_PRESET
+    if strategy_key == "larry_williams_channel_breakout":
+        from strategies.larry_williams_channel_breakout_ablation import (
+            LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+        )
+        return LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET
     raise ValueError(
-        f"Ablation preset 이 정의되지 않은 전략입니다: '{strategy_key}'. "
-        f"현재 지원: oneil_pocket_pivot"
+        f"Ablation preset 이 정의되지 않은 전략입니다: '{strategy_key}'."
     )
 
 

--- a/services/strategy_ablation_service.py
+++ b/services/strategy_ablation_service.py
@@ -1,0 +1,190 @@
+"""Strategy ablation analysis.
+
+Pure helpers that drive ablation backtests: building variant configs by
+overriding fields on a dataclass, wrapping the universe service to neutralize
+market-timing gates, and aggregating per-variant trade metrics into a
+comparison summary.
+
+The caller (e.g. ``scripts.run_backtest``) is responsible for running the
+backtest itself; this module never touches brokers, schedulers, or files.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional
+
+from services.strategy_performance_degradation_service import (
+    compute_strategy_window_metrics,
+)
+
+
+_BASELINE_KEY = "baseline"
+
+
+@dataclass(frozen=True)
+class AblationVariant:
+    """A single ablation variant — what to override and why."""
+
+    name: str
+    description: str = ""
+    config_overrides: Mapping[str, Any] = field(default_factory=dict)
+    universe_overrides: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AblationPreset:
+    """An ordered set of variants for one strategy."""
+
+    strategy_key: str
+    variants: tuple[AblationVariant, ...]
+
+    def __post_init__(self) -> None:
+        if not self.variants:
+            raise ValueError("AblationPreset requires at least one variant.")
+        names = [v.name for v in self.variants]
+        if _BASELINE_KEY in names:
+            raise ValueError(
+                f"AblationVariant name '{_BASELINE_KEY}' is reserved for the baseline run."
+            )
+        if len(set(names)) != len(names):
+            raise ValueError(f"AblationPreset has duplicate variant names: {names}")
+
+    def variant_names(self) -> tuple[str, ...]:
+        return tuple(v.name for v in self.variants)
+
+
+def apply_config_overrides(config_obj: Any, overrides: Mapping[str, Any]) -> Any:
+    """Return a new dataclass copy with the given fields overridden.
+
+    Unknown fields raise ``ValueError`` so a typo in a preset surfaces loudly
+    instead of silently affecting nothing.
+    """
+    if not isinstance(overrides, Mapping):
+        raise TypeError(
+            f"overrides must be a Mapping, got {type(overrides).__name__}"
+        )
+    if not overrides:
+        return dataclasses.replace(config_obj)
+
+    valid_fields = {f.name for f in dataclasses.fields(config_obj)}
+    unknown = sorted(set(overrides.keys()) - valid_fields)
+    if unknown:
+        raise ValueError(
+            f"Unknown config field(s) for {type(config_obj).__name__}: {unknown}"
+        )
+    return dataclasses.replace(config_obj, **dict(overrides))
+
+
+class ForceMarketTimingOkUniverseWrapper:
+    """Universe-service wrapper that forces ``is_market_timing_ok`` to True.
+
+    Used by ablation runs that need to neutralize the market-timing gate while
+    keeping every other universe behavior (watchlist, subscription policy,
+    candidate filtering) intact. All other attribute access is delegated to
+    the wrapped instance.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    async def is_market_timing_ok(
+        self, market: str, caller: str = "", logger: Any = None
+    ) -> bool:
+        return True
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def compute_ablation_summary(
+    *,
+    baseline_records: Iterable[Mapping[str, Any]],
+    variant_records: Mapping[str, Iterable[Mapping[str, Any]]],
+    capital_base_won: Optional[float] = None,
+) -> dict[str, Any]:
+    """Return baseline metrics, per-variant metrics, and deltas vs baseline."""
+    baseline_metrics = _compute_metrics(baseline_records, capital_base_won)
+
+    variants: dict[str, dict[str, Any]] = {}
+    for variant_name, records in variant_records.items():
+        variant_metrics = _compute_metrics(records, capital_base_won)
+        variants[variant_name] = {
+            "metrics": variant_metrics,
+            "delta": _compute_delta(baseline_metrics, variant_metrics),
+        }
+
+    return {
+        "capital_base_won": capital_base_won,
+        "baseline": {"metrics": baseline_metrics},
+        "variants": variants,
+        "variant_count": len(variants),
+    }
+
+
+def _compute_metrics(
+    records: Iterable[Mapping[str, Any]],
+    capital_base_won: Optional[float],
+) -> dict[str, Any]:
+    sold = [
+        record
+        for record in records
+        if str(record.get("status") or "").upper() == "SOLD"
+    ]
+    if not sold:
+        return _empty_metrics()
+
+    # Group everything under a single synthetic key — compute_strategy_window_metrics
+    # buckets by record["strategy"], so we normalize to one bucket here.
+    flat_records = [dict(record, strategy="__ablation__") for record in sold]
+    by_strategy = compute_strategy_window_metrics(
+        flat_records,
+        window_size=max(len(flat_records), 1),
+        capital_base_won=capital_base_won,
+    )
+    metrics = by_strategy.get("__ablation__", _empty_metrics())
+    return dict(metrics)
+
+
+def _empty_metrics() -> dict[str, Any]:
+    return {
+        "trade_count": 0,
+        "win_count": 0,
+        "loss_count": 0,
+        "win_rate": 0.0,
+        "avg_net_return": 0.0,
+        "total_net_pnl": 0.0,
+        "payoff_ratio": None,
+        "profit_factor": None,
+        "mdd_amount": 0.0,
+        "mdd_ratio": None,
+        "max_consecutive_losses": 0,
+        "avg_mfe": None,
+        "avg_mae": None,
+    }
+
+
+def _compute_delta(
+    baseline: Mapping[str, Any], variant: Mapping[str, Any]
+) -> dict[str, Any]:
+    return {
+        "trade_count_diff": int(variant["trade_count"]) - int(baseline["trade_count"]),
+        "win_rate_diff": float(variant["win_rate"]) - float(baseline["win_rate"]),
+        "avg_net_return_diff": float(variant["avg_net_return"])
+        - float(baseline["avg_net_return"]),
+        "total_net_pnl_diff": float(variant["total_net_pnl"])
+        - float(baseline["total_net_pnl"]),
+        "profit_factor_diff": _optional_diff(
+            variant.get("profit_factor"), baseline.get("profit_factor")
+        ),
+        "payoff_ratio_diff": _optional_diff(
+            variant.get("payoff_ratio"), baseline.get("payoff_ratio")
+        ),
+        "mdd_amount_diff": float(variant["mdd_amount"]) - float(baseline["mdd_amount"]),
+    }
+
+
+def _optional_diff(left: Any, right: Any) -> Optional[float]:
+    if left is None or right is None:
+        return None
+    return float(left) - float(right)

--- a/strategies/first_pullback_ablation.py
+++ b/strategies/first_pullback_ablation.py
@@ -1,0 +1,62 @@
+"""Ablation variants for the First Pullback strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+FIRST_PULLBACK_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_rapid_surge",
+    "disable_ma_rising",
+    "widen_pullback_range",
+)
+
+
+FIRST_PULLBACK_ABLATION_PRESET = AblationPreset(
+    strategy_key="first_pullback",
+    variants=(
+        AblationVariant(
+            name="disable_execution_strength",
+            description="Zero execution-strength so cgld_val checks never reject.",
+            config_overrides={"execution_strength_min": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_rapid_surge",
+            description=(
+                "Zero rapid-surge percent so any prior price change qualifies the "
+                "candidate as a surge."
+            ),
+            config_overrides={"rapid_surge_pct": 0.0},
+        ),
+        AblationVariant(
+            name="disable_ma_rising",
+            description=(
+                "Set ma_rising_min_count to 0 so the rising-MA confirmation never "
+                "rejects."
+            ),
+            config_overrides={"ma_rising_min_count": 0},
+        ),
+        AblationVariant(
+            name="widen_pullback_range",
+            description=(
+                "Expand the MA pullback band to ±99% so the pullback location "
+                "check always matches."
+            ),
+            config_overrides={
+                "pullback_lower_pct": -99.0,
+                "pullback_upper_pct": 99.0,
+            },
+        ),
+    ),
+)

--- a/strategies/high_tight_flag_ablation.py
+++ b/strategies/high_tight_flag_ablation.py
@@ -1,0 +1,70 @@
+"""Ablation variants for the High Tight Flag (HTF) strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+HTF_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_smart_money",
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_volume_filter",
+    "relax_pattern_check",
+)
+
+
+HIGH_TIGHT_FLAG_ABLATION_PRESET = AblationPreset(
+    strategy_key="high_tight_flag",
+    variants=(
+        AblationVariant(
+            name="disable_smart_money",
+            description=(
+                "Zero the program-to-market-cap threshold so the HTF smart-money "
+                "filter always passes."
+            ),
+            config_overrides={"program_to_market_cap_pct": 0.0},
+        ),
+        AblationVariant(
+            name="disable_execution_strength",
+            description=(
+                "Zero execution-strength thresholds so cgld_val checks never reject."
+            ),
+            config_overrides={
+                "execution_strength_min": 0.0,
+                "sm_flexible_execution_strength": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero breakout / afternoon volume multipliers so volume gates never "
+                "reject."
+            ),
+            config_overrides={
+                "volume_breakout_multiplier": 0.0,
+                "afternoon_volume_multiplier": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="relax_pattern_check",
+            description=(
+                "Disable pole surge and flag drawdown gates: any candidate with a "
+                "qualifying breakout will pass."
+            ),
+            config_overrides={
+                "pole_min_surge_ratio": 0.0,
+                "flag_max_drawdown_pct": 999.0,
+            },
+        ),
+    ),
+)

--- a/strategies/larry_williams_channel_breakout_ablation.py
+++ b/strategies/larry_williams_channel_breakout_ablation.py
@@ -1,0 +1,51 @@
+"""Ablation variants for the Larry Williams Channel Breakout strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+CB_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_rs_rating",
+    "disable_adx_filter",
+    "disable_volume_filter",
+    "disable_market_timing",
+)
+
+
+LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET = AblationPreset(
+    strategy_key="larry_williams_channel_breakout",
+    variants=(
+        AblationVariant(
+            name="disable_rs_rating",
+            description=(
+                "Zero rs_rating_min so the relative-strength floor never rejects."
+            ),
+            config_overrides={"rs_rating_min": 0},
+        ),
+        AblationVariant(
+            name="disable_adx_filter",
+            description=(
+                "Zero adx_threshold so the trend-strength gate always passes."
+            ),
+            config_overrides={"adx_threshold": 0.0},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero volume_multiplier so the volume-confirmation gate never "
+                "rejects."
+            ),
+            config_overrides={"volume_multiplier": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+    ),
+)

--- a/strategies/larry_williams_vbo_ablation.py
+++ b/strategies/larry_williams_vbo_ablation.py
@@ -1,0 +1,55 @@
+"""Ablation variants for the Larry Williams VBO strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+VBO_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_program_buy",
+    "disable_confidence_threshold",
+    "disable_market_timing",
+    "disable_liquidity_filter",
+)
+
+
+LARRY_WILLIAMS_VBO_ABLATION_PRESET = AblationPreset(
+    strategy_key="larry_williams_vbo",
+    variants=(
+        AblationVariant(
+            name="disable_program_buy",
+            description=(
+                "Zero program_buy_ratio so the program-buy ratio gate always passes."
+            ),
+            config_overrides={"program_buy_ratio": 0.0},
+        ),
+        AblationVariant(
+            name="disable_confidence_threshold",
+            description=(
+                "Zero confidence_threshold so execution-strength snapshot never "
+                "rejects."
+            ),
+            config_overrides={"confidence_threshold": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_liquidity_filter",
+            description=(
+                "Zero market-cap and 5-day trading-value floors so liquidity "
+                "filtering does not reject candidates."
+            ),
+            config_overrides={
+                "min_market_cap": 0,
+                "min_5d_trading_value": 0,
+            },
+        ),
+    ),
+)

--- a/strategies/oneil_pocket_pivot_ablation.py
+++ b/strategies/oneil_pocket_pivot_ablation.py
@@ -1,0 +1,75 @@
+"""Ablation variants for the O'Neil Pocket Pivot / BGU strategy.
+
+Each variant neutralizes a specific gate so a backtest can measure that
+gate's contribution to live performance. See [todo_list.md](../todo_list.md)
+section P1-1 for context.
+
+Note: ``disable_smart_money`` only zeroes out the threshold values. The
+``pg_buy > 0`` data-presence guard inside ``_check_smart_money`` remains
+active because it is not threshold-configurable.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+PP_BGU_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_smart_money",
+    "disable_execution_strength",
+    "disable_market_timing",
+    "pp_only",
+    "bgu_only",
+)
+
+
+ONEIL_POCKET_PIVOT_ABLATION_PRESET = AblationPreset(
+    strategy_key="oneil_pocket_pivot",
+    variants=(
+        AblationVariant(
+            name="disable_smart_money",
+            description=(
+                "Zero program-buy thresholds so the smart-money gate always passes "
+                "when program-buy data is available."
+            ),
+            config_overrides={
+                "program_to_trade_value_pct": 0.0,
+                "program_to_market_cap_pct": 0.0,
+                "bgu_min_pg_tv_pct": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_execution_strength",
+            description=(
+                "Zero execution-strength thresholds so cgld_val checks never reject."
+            ),
+            config_overrides={
+                "execution_strength_min": 0.0,
+                "sm_flexible_execution_strength": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper. "
+                "Strategy code is untouched."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="pp_only",
+            description=(
+                "Push BGU gap threshold past any realistic gap so only Pocket "
+                "Pivot entries fire."
+            ),
+            config_overrides={"bgu_gap_pct": 9_999.0},
+        ),
+        AblationVariant(
+            name="bgu_only",
+            description=(
+                "Set PP MA proximity upper bound below -99% so the MA proximity "
+                "check never matches and only BGU entries fire."
+            ),
+            config_overrides={"pp_ma_proximity_upper_pct": -99.0},
+        ),
+    ),
+)

--- a/strategies/oneil_squeeze_breakout_ablation.py
+++ b/strategies/oneil_squeeze_breakout_ablation.py
@@ -1,0 +1,62 @@
+"""Ablation variants for the O'Neil Squeeze Breakout strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+OSB_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_smart_money",
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_volume_filter",
+)
+
+
+ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET = AblationPreset(
+    strategy_key="oneil_squeeze_breakout",
+    variants=(
+        AblationVariant(
+            name="disable_smart_money",
+            description=(
+                "Zero program-buy thresholds so the smart-money gate always passes "
+                "when program-buy data is available."
+            ),
+            config_overrides={
+                "program_to_trade_value_pct": 0.0,
+                "program_to_market_cap_pct": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_execution_strength",
+            description=(
+                "Zero execution-strength thresholds so cgld_val checks never reject."
+            ),
+            config_overrides={
+                "execution_strength_min": 0.0,
+                "sm_flexible_execution_strength": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero baseline / morning / breakout volume ratios so volume gates "
+                "never reject."
+            ),
+            config_overrides={
+                "baseline_min_vol_ratio": 0.0,
+                "morning_min_vol_ratio": 0.0,
+                "volume_breakout_multiplier": 0.0,
+            },
+        ),
+    ),
+)

--- a/strategies/rsi2_pullback_ablation.py
+++ b/strategies/rsi2_pullback_ablation.py
@@ -1,0 +1,43 @@
+"""Ablation variants for the RSI(2) Pullback strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+RSI2_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_minervini_stage2",
+    "disable_market_timing",
+    "disable_rsi_oversold",
+)
+
+
+RSI2_PULLBACK_ABLATION_PRESET = AblationPreset(
+    strategy_key="rsi2_pullback",
+    variants=(
+        AblationVariant(
+            name="disable_minervini_stage2",
+            description=(
+                "Drop the Stage 2 requirement so non-Stage-2 candidates are not "
+                "filtered out."
+            ),
+            config_overrides={"require_minervini_stage2": False},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_rsi_oversold",
+            description=(
+                "Raise rsi_threshold to 100 so any RSI value qualifies as oversold."
+            ),
+            config_overrides={"rsi_threshold": 100.0},
+        ),
+    ),
+)

--- a/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
+++ b/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from scripts.run_backtest import (
+    ACTIVE_BACKTEST_STRATEGIES,
+    _build_default_strategy_config,
     _filter_ablation_variants,
     _format_ablation_console_lines,
     _parse_args,
@@ -13,7 +15,7 @@ from scripts.run_backtest import (
     _run_ablation_for_result,
 )
 from services.backtest_period_runner import BacktestPeriodRunResult
-from services.strategy_ablation_service import AblationVariant
+from services.strategy_ablation_service import AblationPreset, AblationVariant
 from strategies.oneil_pocket_pivot_ablation import (
     ONEIL_POCKET_PIVOT_ABLATION_PRESET,
 )
@@ -55,8 +57,28 @@ def test_resolve_ablation_preset_returns_known_preset():
 
 
 def test_resolve_ablation_preset_raises_on_unknown_strategy():
-    with pytest.raises(ValueError, match="oneil_squeeze_breakout"):
-        _resolve_ablation_preset("oneil_squeeze_breakout")
+    with pytest.raises(ValueError, match="not_a_real_strategy"):
+        _resolve_ablation_preset("not_a_real_strategy")
+
+
+@pytest.mark.parametrize("strategy_key", list(ACTIVE_BACKTEST_STRATEGIES))
+def test_resolve_ablation_preset_covers_every_active_strategy(strategy_key):
+    preset = _resolve_ablation_preset(strategy_key)
+
+    assert isinstance(preset, AblationPreset)
+    assert preset.strategy_key == strategy_key
+    assert len(preset.variants) >= 3
+
+
+@pytest.mark.parametrize("strategy_key", list(ACTIVE_BACKTEST_STRATEGIES))
+def test_build_default_strategy_config_returns_dataclass_instance(strategy_key):
+    import dataclasses
+
+    config = _build_default_strategy_config(strategy_key)
+
+    assert dataclasses.is_dataclass(config), (
+        f"_build_default_strategy_config('{strategy_key}') must return a dataclass instance"
+    )
 
 
 def test_filter_ablation_variants_returns_all_when_none():

--- a/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
+++ b/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.run_backtest import (
+    _filter_ablation_variants,
+    _format_ablation_console_lines,
+    _parse_args,
+    _resolve_ablation_preset,
+    _run_ablation_for_result,
+)
+from services.backtest_period_runner import BacktestPeriodRunResult
+from services.strategy_ablation_service import AblationVariant
+from strategies.oneil_pocket_pivot_ablation import (
+    ONEIL_POCKET_PIVOT_ABLATION_PRESET,
+)
+
+
+def test_parse_args_accepts_ablation_options(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_backtest",
+            "--dates",
+            "20260501",
+            "--ablation",
+            "oneil_pocket_pivot",
+            "--ablation-variants",
+            "disable_smart_money,pp_only",
+        ],
+    )
+
+    args = _parse_args()
+
+    assert args.ablation == "oneil_pocket_pivot"
+    assert args.ablation_variants == "disable_smart_money,pp_only"
+
+
+def test_parse_args_ablation_defaults_to_none(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["run_backtest", "--dates", "20260501"])
+
+    args = _parse_args()
+
+    assert args.ablation is None
+    assert args.ablation_variants is None
+
+
+def test_resolve_ablation_preset_returns_known_preset():
+    preset = _resolve_ablation_preset("oneil_pocket_pivot")
+
+    assert preset is ONEIL_POCKET_PIVOT_ABLATION_PRESET
+
+
+def test_resolve_ablation_preset_raises_on_unknown_strategy():
+    with pytest.raises(ValueError, match="oneil_squeeze_breakout"):
+        _resolve_ablation_preset("oneil_squeeze_breakout")
+
+
+def test_filter_ablation_variants_returns_all_when_none():
+    selected = _filter_ablation_variants(ONEIL_POCKET_PIVOT_ABLATION_PRESET, None)
+
+    assert selected == ONEIL_POCKET_PIVOT_ABLATION_PRESET.variants
+
+
+def test_filter_ablation_variants_returns_subset_when_named():
+    selected = _filter_ablation_variants(
+        ONEIL_POCKET_PIVOT_ABLATION_PRESET, "pp_only,bgu_only"
+    )
+
+    names = tuple(v.name for v in selected)
+    assert names == ("pp_only", "bgu_only")
+
+
+def test_filter_ablation_variants_raises_on_unknown_variant():
+    with pytest.raises(ValueError, match="not_a_real_variant"):
+        _filter_ablation_variants(
+            ONEIL_POCKET_PIVOT_ABLATION_PRESET, "pp_only,not_a_real_variant"
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_ablation_for_result_runs_each_variant_and_attaches_summary():
+    baseline = BacktestPeriodRunResult(
+        strategy_name="오닐PP/BGU",
+        dates=["20260501"],
+        journal_records=[
+            {"status": "SOLD", "strategy": "S", "net_pnl": 100, "net_return": 1.0},
+            {"status": "SOLD", "strategy": "S", "net_pnl": -50, "net_return": -0.5},
+        ],
+    )
+
+    captured_variants: list[str] = []
+
+    async def fake_run_variant(variant: AblationVariant) -> BacktestPeriodRunResult:
+        captured_variants.append(variant.name)
+        return BacktestPeriodRunResult(
+            strategy_name="오닐PP/BGU",
+            dates=["20260501"],
+            journal_records=[
+                {
+                    "status": "SOLD",
+                    "strategy": "S",
+                    "net_pnl": 10,
+                    "net_return": 0.1,
+                },
+            ],
+        )
+
+    args = SimpleNamespace(
+        ablation="oneil_pocket_pivot",
+        ablation_variants="pp_only,bgu_only",
+        initial_cash=1_000_000.0,
+    )
+
+    await _run_ablation_for_result(baseline, args, run_variant_fn=fake_run_variant)
+
+    assert captured_variants == ["pp_only", "bgu_only"]
+    payload = getattr(baseline, "ablation")
+    assert payload["strategy_key"] == "oneil_pocket_pivot"
+    summary = payload["summary"]
+    assert set(summary["variants"].keys()) == {"pp_only", "bgu_only"}
+    assert summary["variants"]["pp_only"]["metrics"]["trade_count"] == 1
+    assert summary["baseline"]["metrics"]["trade_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_ablation_for_result_skips_when_ablation_arg_missing():
+    baseline = BacktestPeriodRunResult(
+        strategy_name="S", dates=["20260501"], journal_records=[]
+    )
+    args = SimpleNamespace(
+        ablation=None, ablation_variants=None, initial_cash=1.0
+    )
+    runner = AsyncMock()
+
+    await _run_ablation_for_result(baseline, args, run_variant_fn=runner)
+
+    runner.assert_not_awaited()
+    assert not hasattr(baseline, "ablation") or baseline.ablation is None  # type: ignore[attr-defined]
+
+
+def test_format_ablation_console_lines_produces_header_and_rows():
+    summary = {
+        "capital_base_won": 1_000_000,
+        "baseline": {
+            "metrics": {
+                "trade_count": 2,
+                "win_rate": 0.5,
+                "avg_net_return": 0.25,
+                "total_net_pnl": 50.0,
+                "profit_factor": 2.0,
+                "payoff_ratio": 2.0,
+                "mdd_amount": 50.0,
+            }
+        },
+        "variants": {
+            "pp_only": {
+                "metrics": {
+                    "trade_count": 1,
+                    "win_rate": 1.0,
+                    "avg_net_return": 0.5,
+                    "total_net_pnl": 50.0,
+                    "profit_factor": None,
+                    "payoff_ratio": None,
+                    "mdd_amount": 0.0,
+                },
+                "delta": {
+                    "trade_count_diff": -1,
+                    "win_rate_diff": 0.5,
+                    "avg_net_return_diff": 0.25,
+                    "total_net_pnl_diff": 0.0,
+                    "profit_factor_diff": None,
+                    "payoff_ratio_diff": None,
+                    "mdd_amount_diff": -50.0,
+                },
+            }
+        },
+        "variant_count": 1,
+    }
+
+    lines = _format_ablation_console_lines("oneil_pocket_pivot", summary)
+
+    rendered = "\n".join(lines)
+    assert "oneil_pocket_pivot" in rendered
+    assert "baseline" in rendered.lower()
+    assert "pp_only" in rendered
+    # Variant metrics should appear
+    assert any("trade" in line.lower() for line in lines)

--- a/tests/unit_test/services/test_strategy_ablation_service.py
+++ b/tests/unit_test/services/test_strategy_ablation_service.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from services.strategy_ablation_service import (
+    AblationPreset,
+    AblationVariant,
+    ForceMarketTimingOkUniverseWrapper,
+    apply_config_overrides,
+    compute_ablation_summary,
+)
+
+
+@dataclass
+class _SampleConfig:
+    threshold_a: float = 1.0
+    threshold_b: int = 10
+
+
+def _sold(pnl: float, ret: float, *, signal_time: str = "2026-05-01") -> dict:
+    return {
+        "status": "SOLD",
+        "strategy": "S",
+        "net_pnl": pnl,
+        "net_return": ret,
+        "signal_time": signal_time,
+    }
+
+
+def test_apply_config_overrides_replaces_named_fields():
+    base = _SampleConfig()
+
+    overridden = apply_config_overrides(base, {"threshold_a": 5.0})
+
+    assert overridden.threshold_a == 5.0
+    assert overridden.threshold_b == 10
+    assert base.threshold_a == 1.0  # base untouched
+
+
+def test_apply_config_overrides_raises_on_unknown_field():
+    base = _SampleConfig()
+
+    with pytest.raises(ValueError, match="unknown_field"):
+        apply_config_overrides(base, {"unknown_field": 99})
+
+
+def test_apply_config_overrides_empty_returns_equal_copy():
+    base = _SampleConfig()
+
+    result = apply_config_overrides(base, {})
+
+    assert result.threshold_a == base.threshold_a
+    assert result.threshold_b == base.threshold_b
+
+
+def test_apply_config_overrides_rejects_non_mapping():
+    base = _SampleConfig()
+
+    with pytest.raises(TypeError):
+        apply_config_overrides(base, [("threshold_a", 1.0)])  # type: ignore[arg-type]
+
+
+def test_compute_ablation_summary_returns_baseline_and_variant_metrics():
+    baseline_records = [
+        _sold(100, 1.0, signal_time="2026-05-01"),
+        _sold(-40, -0.5, signal_time="2026-05-02"),
+    ]
+    variant_records = {
+        "disable_smart_money": [_sold(-50, -0.5, signal_time="2026-05-01")],
+    }
+
+    summary = compute_ablation_summary(
+        baseline_records=baseline_records,
+        variant_records=variant_records,
+        capital_base_won=10_000,
+    )
+
+    assert summary["baseline"]["metrics"]["trade_count"] == 2
+    variant = summary["variants"]["disable_smart_money"]
+    assert variant["metrics"]["trade_count"] == 1
+    assert variant["delta"]["trade_count_diff"] == -1
+    assert variant["delta"]["total_net_pnl_diff"] == pytest.approx(-50 - 60)
+    assert summary["variant_count"] == 1
+    assert summary["capital_base_won"] == 10_000
+
+
+def test_compute_ablation_summary_handles_empty_variant_records():
+    baseline_records = [_sold(100, 1.0)]
+
+    summary = compute_ablation_summary(
+        baseline_records=baseline_records,
+        variant_records={"empty_variant": []},
+        capital_base_won=None,
+    )
+
+    assert summary["variants"]["empty_variant"]["metrics"]["trade_count"] == 0
+    assert summary["variants"]["empty_variant"]["delta"]["trade_count_diff"] == -1
+
+
+def test_compute_ablation_summary_filters_non_sold_records():
+    baseline_records = [
+        _sold(100, 1.0),
+        {"status": "BUY", "strategy": "S"},
+        {"status": "REJECTED", "strategy": "S"},
+    ]
+
+    summary = compute_ablation_summary(
+        baseline_records=baseline_records,
+        variant_records={},
+    )
+
+    assert summary["baseline"]["metrics"]["trade_count"] == 1
+    assert summary["variant_count"] == 0
+
+
+def test_compute_ablation_summary_orders_variants_deterministically():
+    baseline_records = [_sold(100, 1.0), _sold(-50, -0.5)]
+    summary = compute_ablation_summary(
+        baseline_records=baseline_records,
+        variant_records={
+            "v_b": [_sold(20, 0.2)],
+            "v_a": [_sold(10, 0.1)],
+        },
+    )
+
+    # Insertion order preserved (dict insertion order in Python 3.7+)
+    assert list(summary["variants"].keys()) == ["v_b", "v_a"]
+
+
+def test_ablation_variant_is_frozen():
+    variant = AblationVariant(name="v1", description="test")
+
+    with pytest.raises(Exception):
+        variant.name = "changed"  # type: ignore[misc]
+
+
+def test_ablation_variant_defaults_to_empty_overrides():
+    variant = AblationVariant(name="v1")
+
+    assert dict(variant.config_overrides) == {}
+    assert dict(variant.universe_overrides) == {}
+
+
+def test_ablation_preset_collects_variants():
+    preset = AblationPreset(
+        strategy_key="oneil_pocket_pivot",
+        variants=(
+            AblationVariant(name="v1"),
+            AblationVariant(name="v2"),
+        ),
+    )
+
+    assert preset.strategy_key == "oneil_pocket_pivot"
+    assert preset.variant_names() == ("v1", "v2")
+
+
+def test_ablation_preset_rejects_duplicate_variant_names():
+    with pytest.raises(ValueError, match="duplicate"):
+        AblationPreset(
+            strategy_key="x",
+            variants=(
+                AblationVariant(name="v1"),
+                AblationVariant(name="v1"),
+            ),
+        )
+
+
+def test_ablation_preset_rejects_reserved_baseline_variant_name():
+    with pytest.raises(ValueError, match="baseline"):
+        AblationPreset(
+            strategy_key="x",
+            variants=(AblationVariant(name="baseline"),),
+        )
+
+
+def test_ablation_preset_rejects_empty_variants():
+    with pytest.raises(ValueError, match="at least one"):
+        AblationPreset(strategy_key="x", variants=())
+
+
+@pytest.mark.asyncio
+async def test_force_market_timing_wrapper_returns_true_and_delegates_others():
+    class _StubUniverse:
+        def __init__(self) -> None:
+            self.timing_calls = 0
+            self.watchlist_calls = 0
+
+        async def is_market_timing_ok(self, market, caller="", logger=None):
+            self.timing_calls += 1
+            return False  # baseline would block
+
+        async def get_watchlist(self, *args, **kwargs):
+            self.watchlist_calls += 1
+            return ["005930"]
+
+        @property
+        def some_attr(self) -> str:
+            return "attr_value"
+
+    inner = _StubUniverse()
+    wrapper = ForceMarketTimingOkUniverseWrapper(inner)
+
+    assert await wrapper.is_market_timing_ok("KOSPI") is True
+    assert await wrapper.is_market_timing_ok("KOSDAQ", caller="x", logger=None) is True
+    # Wrapper short-circuits — inner timing not called
+    assert inner.timing_calls == 0
+
+    # Other methods delegated
+    assert await wrapper.get_watchlist() == ["005930"]
+    assert inner.watchlist_calls == 1
+    assert wrapper.some_attr == "attr_value"

--- a/tests/unit_test/strategies/test_active_strategies_ablation_presets.py
+++ b/tests/unit_test/strategies/test_active_strategies_ablation_presets.py
@@ -1,0 +1,218 @@
+"""Ablation preset coverage for the remaining 6 active strategies.
+
+The O'Neil Pocket Pivot / BGU preset has its own dedicated file at
+``test_oneil_pocket_pivot_ablation.py`` because it predates this batch. The
+tests here apply identical structural checks across the rest of the active
+strategy registry.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.strategy_ablation_service import (
+    AblationPreset,
+    apply_config_overrides,
+)
+from strategies.first_pullback_ablation import (
+    FIRST_PULLBACK_ABLATION_PRESET,
+    FIRST_PULLBACK_VARIANT_NAMES,
+)
+from strategies.first_pullback_types import FirstPullbackConfig
+from strategies.high_tight_flag_ablation import (
+    HIGH_TIGHT_FLAG_ABLATION_PRESET,
+    HTF_VARIANT_NAMES,
+)
+from strategies.larry_williams_cb_types import LarryWilliamsCBConfig
+from strategies.larry_williams_channel_breakout_ablation import (
+    CB_VARIANT_NAMES,
+    LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+)
+from strategies.larry_williams_vbo_ablation import (
+    LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+    VBO_VARIANT_NAMES,
+)
+from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOConfig
+from strategies.oneil_common_types import HTFConfig, OneilBreakoutConfig
+from strategies.oneil_squeeze_breakout_ablation import (
+    ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+    OSB_VARIANT_NAMES,
+)
+from strategies.rsi2_pullback_ablation import (
+    RSI2_PULLBACK_ABLATION_PRESET,
+    RSI2_VARIANT_NAMES,
+)
+from strategies.rsi2_pullback_types import RSI2PullbackConfig
+
+
+# (strategy_key, preset, variant_names_tuple, default_config_factory)
+_PRESETS = [
+    (
+        "oneil_squeeze_breakout",
+        ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+        OSB_VARIANT_NAMES,
+        OneilBreakoutConfig,
+    ),
+    (
+        "high_tight_flag",
+        HIGH_TIGHT_FLAG_ABLATION_PRESET,
+        HTF_VARIANT_NAMES,
+        HTFConfig,
+    ),
+    (
+        "first_pullback",
+        FIRST_PULLBACK_ABLATION_PRESET,
+        FIRST_PULLBACK_VARIANT_NAMES,
+        FirstPullbackConfig,
+    ),
+    (
+        "larry_williams_vbo",
+        LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+        VBO_VARIANT_NAMES,
+        LarryWilliamsVBOConfig,
+    ),
+    (
+        "rsi2_pullback",
+        RSI2_PULLBACK_ABLATION_PRESET,
+        RSI2_VARIANT_NAMES,
+        RSI2PullbackConfig,
+    ),
+    (
+        "larry_williams_channel_breakout",
+        LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+        CB_VARIANT_NAMES,
+        LarryWilliamsCBConfig,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "strategy_key,preset,expected_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_preset_metadata_matches_strategy_key(
+    strategy_key, preset: AblationPreset, expected_names, _factory
+):
+    assert preset.strategy_key == strategy_key
+    assert preset.variant_names() == expected_names
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_every_variant_has_a_non_empty_description(
+    _strategy_key, preset: AblationPreset, _names, _factory
+):
+    for variant in preset.variants:
+        assert variant.description.strip(), (
+            f"Variant '{variant.name}' in '{preset.strategy_key}' "
+            "must have a non-empty description"
+        )
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,config_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_every_variant_config_overrides_target_known_fields(
+    _strategy_key, preset: AblationPreset, _names, config_factory
+):
+    for variant in preset.variants:
+        # Should not raise — apply_config_overrides validates field names
+        apply_config_overrides(config_factory(), variant.config_overrides)
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_market_timing_variant_uses_universe_override_not_config(
+    _strategy_key, preset: AblationPreset, _names, _factory
+):
+    timing_variants = [
+        v for v in preset.variants if v.name == "disable_market_timing"
+    ]
+    assert timing_variants, (
+        f"Every active-strategy preset should expose a 'disable_market_timing' "
+        f"variant; preset '{preset.strategy_key}' has none."
+    )
+    variant = timing_variants[0]
+    assert dict(variant.config_overrides) == {}
+    assert variant.universe_overrides == {"force_market_timing_ok": True}
+
+
+def test_osb_disable_smart_money_zeroes_program_thresholds():
+    variant = next(
+        v for v in ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET.variants
+        if v.name == "disable_smart_money"
+    )
+    config = apply_config_overrides(OneilBreakoutConfig(), variant.config_overrides)
+
+    assert config.program_to_trade_value_pct == 0.0
+    assert config.program_to_market_cap_pct == 0.0
+
+
+def test_htf_relax_pattern_check_neutralizes_pole_and_flag_gates():
+    variant = next(
+        v for v in HIGH_TIGHT_FLAG_ABLATION_PRESET.variants
+        if v.name == "relax_pattern_check"
+    )
+    config = apply_config_overrides(HTFConfig(), variant.config_overrides)
+
+    assert config.pole_min_surge_ratio == 0.0
+    assert config.flag_max_drawdown_pct >= 999.0
+
+
+def test_first_pullback_widen_range_accepts_full_pullback_band():
+    variant = next(
+        v for v in FIRST_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "widen_pullback_range"
+    )
+    config = apply_config_overrides(FirstPullbackConfig(), variant.config_overrides)
+
+    assert config.pullback_lower_pct <= -99.0
+    assert config.pullback_upper_pct >= 99.0
+
+
+def test_vbo_disable_program_buy_zeroes_ratio():
+    variant = next(
+        v for v in LARRY_WILLIAMS_VBO_ABLATION_PRESET.variants
+        if v.name == "disable_program_buy"
+    )
+    config = apply_config_overrides(LarryWilliamsVBOConfig(), variant.config_overrides)
+
+    assert config.program_buy_ratio == 0.0
+
+
+def test_rsi2_disable_rsi_oversold_raises_threshold_to_100():
+    variant = next(
+        v for v in RSI2_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "disable_rsi_oversold"
+    )
+    config = apply_config_overrides(RSI2PullbackConfig(), variant.config_overrides)
+
+    assert config.rsi_threshold >= 100.0
+
+
+def test_rsi2_disable_minervini_flips_boolean_to_false():
+    variant = next(
+        v for v in RSI2_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "disable_minervini_stage2"
+    )
+    config = apply_config_overrides(RSI2PullbackConfig(), variant.config_overrides)
+
+    assert config.require_minervini_stage2 is False
+
+
+def test_channel_breakout_disable_adx_zeroes_threshold():
+    variant = next(
+        v for v in LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET.variants
+        if v.name == "disable_adx_filter"
+    )
+    config = apply_config_overrides(LarryWilliamsCBConfig(), variant.config_overrides)
+
+    assert config.adx_threshold == 0.0

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_ablation.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_ablation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from services.strategy_ablation_service import apply_config_overrides
+from strategies.oneil_common_types import OneilPocketPivotConfig
+from strategies.oneil_pocket_pivot_ablation import (
+    ONEIL_POCKET_PIVOT_ABLATION_PRESET,
+    PP_BGU_VARIANT_NAMES,
+)
+
+
+def test_preset_strategy_key_matches_run_backtest_registry():
+    assert ONEIL_POCKET_PIVOT_ABLATION_PRESET.strategy_key == "oneil_pocket_pivot"
+
+
+def test_preset_exposes_all_expected_variants():
+    assert ONEIL_POCKET_PIVOT_ABLATION_PRESET.variant_names() == PP_BGU_VARIANT_NAMES
+    assert PP_BGU_VARIANT_NAMES == (
+        "disable_smart_money",
+        "disable_execution_strength",
+        "disable_market_timing",
+        "pp_only",
+        "bgu_only",
+    )
+
+
+def test_every_variant_has_a_description():
+    for variant in ONEIL_POCKET_PIVOT_ABLATION_PRESET.variants:
+        assert variant.description.strip(), (
+            f"Variant '{variant.name}' must have a non-empty description"
+        )
+
+
+def _variant(name: str):
+    for variant in ONEIL_POCKET_PIVOT_ABLATION_PRESET.variants:
+        if variant.name == name:
+            return variant
+    raise KeyError(name)
+
+
+def test_disable_smart_money_neutralizes_program_buy_thresholds():
+    variant = _variant("disable_smart_money")
+    config = apply_config_overrides(OneilPocketPivotConfig(), variant.config_overrides)
+
+    # PP smart-money standard path: thresholds at 0% always pass when pg_buy > 0
+    assert config.program_to_trade_value_pct == 0.0
+    assert config.program_to_market_cap_pct == 0.0
+    # BGU smart-money minimum also off
+    assert config.bgu_min_pg_tv_pct == 0.0
+
+
+def test_disable_execution_strength_zeroes_strength_thresholds():
+    variant = _variant("disable_execution_strength")
+    config = apply_config_overrides(OneilPocketPivotConfig(), variant.config_overrides)
+
+    assert config.execution_strength_min == 0.0
+    assert config.sm_flexible_execution_strength == 0.0
+
+
+def test_disable_market_timing_uses_universe_override_not_config():
+    variant = _variant("disable_market_timing")
+
+    assert dict(variant.config_overrides) == {}
+    assert variant.universe_overrides == {"force_market_timing_ok": True}
+
+
+def test_pp_only_disables_bgu_entry():
+    variant = _variant("pp_only")
+    config = apply_config_overrides(OneilPocketPivotConfig(), variant.config_overrides)
+
+    # BGU gap threshold pushed past any realistic gap so BGU never triggers
+    assert config.bgu_gap_pct >= 9_999.0
+
+
+def test_bgu_only_disables_pp_entry():
+    variant = _variant("bgu_only")
+    config = apply_config_overrides(OneilPocketPivotConfig(), variant.config_overrides)
+
+    # PP MA upper proximity below -100% so MA proximity check never passes
+    assert config.pp_ma_proximity_upper_pct <= -99.0
+
+
+@pytest.mark.parametrize("variant_name", PP_BGU_VARIANT_NAMES)
+def test_all_overrides_target_known_config_fields(variant_name):
+    variant = _variant(variant_name)
+    # Should not raise — apply_config_overrides validates field names
+    apply_config_overrides(OneilPocketPivotConfig(), variant.config_overrides)

--- a/todo_list.md
+++ b/todo_list.md
@@ -158,8 +158,10 @@
 
 ### 1-1. 과최적화 방지 검증
 
-- [ ] 전략별 ablation test를 추가한다.
+- [~] 전략별 ablation test를 추가한다.
   - 예: O'Neil PP/BGU의 smart money, execution strength, market timing, BGU/PP 조건을 하나씩 제거해 실제 기여도를 확인한다.
+  - 완료된 부분: `services/strategy_ablation_service.py`(`AblationVariant`/`AblationPreset`/`apply_config_overrides`/`ForceMarketTimingOkUniverseWrapper`/`compute_ablation_summary`)와 `strategies/oneil_pocket_pivot_ablation.py` preset(5 variant: `disable_smart_money`, `disable_execution_strength`, `disable_market_timing`, `pp_only`, `bgu_only`) 추가. `scripts/run_backtest.py`에 `--ablation`/`--ablation-variants` 옵션과 baseline 대비 metric delta 출력(console/JSON) 연결.
+  - 남은 작업: 나머지 6개 활성 전략(OSB, HTF, FirstPullback, RSI2, LarryVBO, LarryCB)의 preset 추가.
 - [ ] parameter stability surface를 리포트한다.
   - 특정 임계값 하나에서만 성과가 튀는 전략은 실전 후보에서 제외하거나 canary로만 둔다.
 - [ ] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.

--- a/todo_list.md
+++ b/todo_list.md
@@ -158,10 +158,10 @@
 
 ### 1-1. 과최적화 방지 검증
 
-- [~] 전략별 ablation test를 추가한다.
+- [x] 전략별 ablation test를 추가한다.
   - 예: O'Neil PP/BGU의 smart money, execution strength, market timing, BGU/PP 조건을 하나씩 제거해 실제 기여도를 확인한다.
-  - 완료된 부분: `services/strategy_ablation_service.py`(`AblationVariant`/`AblationPreset`/`apply_config_overrides`/`ForceMarketTimingOkUniverseWrapper`/`compute_ablation_summary`)와 `strategies/oneil_pocket_pivot_ablation.py` preset(5 variant: `disable_smart_money`, `disable_execution_strength`, `disable_market_timing`, `pp_only`, `bgu_only`) 추가. `scripts/run_backtest.py`에 `--ablation`/`--ablation-variants` 옵션과 baseline 대비 metric delta 출력(console/JSON) 연결.
-  - 남은 작업: 나머지 6개 활성 전략(OSB, HTF, FirstPullback, RSI2, LarryVBO, LarryCB)의 preset 추가.
+  - 완료된 부분: `services/strategy_ablation_service.py`(`AblationVariant`/`AblationPreset`/`apply_config_overrides`/`ForceMarketTimingOkUniverseWrapper`/`compute_ablation_summary`) 추가. `scripts/run_backtest.py`에 `--ablation`/`--ablation-variants` 옵션과 baseline 대비 metric delta 출력(console/JSON) 연결.
+  - 완료된 부분: 활성 7개 전략 전부에 preset 추가 — `oneil_pocket_pivot`(5 variants), `oneil_squeeze_breakout`(4), `high_tight_flag`(5), `first_pullback`(5), `larry_williams_vbo`(4), `rsi2_pullback`(3), `larry_williams_channel_breakout`(4). 각 preset 은 가능하면 `disable_smart_money`/`disable_execution_strength`/`disable_market_timing`/`disable_volume_filter` 패턴을 따르고, 전략 고유 게이트(예: HTF `relax_pattern_check`, FirstPullback `widen_pullback_range`, RSI2 `disable_minervini_stage2`/`disable_rsi_oversold`, CB `disable_adx_filter`/`disable_rs_rating`)는 별도 variant 로 둔다.
 - [ ] parameter stability surface를 리포트한다.
   - 특정 임계값 하나에서만 성과가 튀는 전략은 실전 후보에서 제외하거나 canary로만 둔다.
 - [ ] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.


### PR DESCRIPTION
## Summary

- todo_list.md P1-1 ("전략별 ablation test") 1차 — O'Neil PP/BGU 한정 MVP.
- 전략 코드 0줄 수정. config override + universe wrapper 로 5개 variant 를 baseline 대비 실행.
- `scripts/run_backtest.py --ablation oneil_pocket_pivot` 으로 console/JSON 출력에 variant 별 metric delta 포함.

## 변경 파일

| 파일 | 유형 | 핵심 |
|---|---|---|
| `services/strategy_ablation_service.py` | 신규 | `AblationVariant`/`AblationPreset` dataclass + `apply_config_overrides` + `ForceMarketTimingOkUniverseWrapper` + `compute_ablation_summary` |
| `strategies/oneil_pocket_pivot_ablation.py` | 신규 | 5개 variant preset (`disable_smart_money`, `disable_execution_strength`, `disable_market_timing`, `pp_only`, `bgu_only`) |
| `scripts/run_backtest.py` | 수정 (외과수술적) | `--ablation`/`--ablation-variants` 옵션, `make_runner(variant=)`, console/JSON payload 에 ablation 통합 |
| `tests/unit_test/services/test_strategy_ablation_service.py` | 신규 | 15 tests |
| `tests/unit_test/strategies/test_oneil_pocket_pivot_ablation.py` | 신규 | 13 tests |
| `tests/unit_test/scripts/test_run_backtest_ablation_smoke.py` | 신규 | 10 tests |
| `todo_list.md` | 수정 | P1-1 첫 항목 `[~]` 갱신 + 완료/남은 작업 명시 |

## 검증

- `pytest tests/unit_test`: **4840 passed** (이전 4802 → +38 ablation tests)
- `pytest tests/integration_test`: **233 passed** (no regression)

## 범위 외 (별도 PR/항목)

- P1-1 나머지 6개 활성 전략 preset (OSB, HTF, FirstPullback, RSI2, LarryVBO, LarryCB)
- P1-1 parameter stability surface (grid sweep)
- P1-1 purged/embargo CV, Deflated Sharpe/PBO, regime-balanced validation

## Test plan

- [x] `pytest tests/unit_test/services/test_strategy_ablation_service.py -v`
- [x] `pytest tests/unit_test/strategies/test_oneil_pocket_pivot_ablation.py -v`
- [x] `pytest tests/unit_test/scripts/test_run_backtest_ablation_smoke.py -v`
- [x] `pytest tests/unit_test`
- [x] `pytest tests/integration_test`
- [ ] (선택) 실 데이터로 `python -m scripts.run_backtest --strategy oneil_pocket_pivot --dates 20260501 --ablation oneil_pocket_pivot` 한 번 돌려 console 표 확인