### PR TITLE
P1-1 Phase 2: ablation preset 활성 7개 전략 전체 확장

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -255,6 +255,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "high_tight_flag":
         from strategies.high_tight_flag_strategy import HighTightFlagStrategy
@@ -265,6 +266,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "first_pullback":
         from strategies.first_pullback_strategy import FirstPullbackStrategy
@@ -275,6 +277,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "larry_williams_vbo":
         from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOStrategy
@@ -284,6 +287,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             universe_service=universe_service,
             logger=strategy_logger,
+            config=config,
         )
     if strategy_key == "rsi2_pullback":
         from strategies.rsi2_pullback_strategy import RSI2PullbackStrategy
@@ -295,6 +299,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
     if strategy_key == "larry_williams_channel_breakout":
         from strategies.larry_williams_channel_breakout_strategy import (
@@ -308,6 +313,7 @@ def _build_backtest_strategy(
             market_clock=backtest_clock,
             logger=strategy_logger,
             state_file=_state_file(state_dir, strategy_key, state_suffix),
+            config=config,
         )
 
     raise ValueError(f"지원하지 않는 백테스트 전략입니다: {strategy_key}")
@@ -604,6 +610,41 @@ def _build_profitability_gate_config(app_config: Any, *, initial_cash: float):
     return StrategyProfitabilityGateConfig(**{k: v for k, v in values.items() if k in allowed})
 
 
+def _build_default_strategy_config(strategy_key: str) -> Any:
+    """Return a fresh strategy-specific default config instance."""
+    if strategy_key == "oneil_pocket_pivot":
+        from strategies.oneil_common_types import OneilPocketPivotConfig
+
+        return OneilPocketPivotConfig()
+    if strategy_key == "oneil_squeeze_breakout":
+        from strategies.oneil_common_types import OneilBreakoutConfig
+
+        return OneilBreakoutConfig()
+    if strategy_key == "high_tight_flag":
+        from strategies.oneil_common_types import HTFConfig
+
+        return HTFConfig()
+    if strategy_key == "first_pullback":
+        from strategies.first_pullback_types import FirstPullbackConfig
+
+        return FirstPullbackConfig()
+    if strategy_key == "larry_williams_vbo":
+        from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOConfig
+
+        return LarryWilliamsVBOConfig()
+    if strategy_key == "rsi2_pullback":
+        from strategies.rsi2_pullback_types import RSI2PullbackConfig
+
+        return RSI2PullbackConfig()
+    if strategy_key == "larry_williams_channel_breakout":
+        from strategies.larry_williams_cb_types import LarryWilliamsCBConfig
+
+        return LarryWilliamsCBConfig()
+    raise ValueError(
+        f"Ablation default config not defined for strategy '{strategy_key}'."
+    )
+
+
 def _build_ablation_overrides(
     *,
     strategy_key: str,
@@ -630,30 +671,50 @@ def _build_ablation_overrides(
 
     config = None
     if variant.config_overrides:
-        if strategy_key == "oneil_pocket_pivot":
-            from strategies.oneil_common_types import OneilPocketPivotConfig
-
-            config = apply_config_overrides(
-                OneilPocketPivotConfig(), variant.config_overrides
-            )
-        else:
-            raise ValueError(
-                f"Ablation default config not defined for strategy '{strategy_key}'."
-            )
+        config = apply_config_overrides(
+            _build_default_strategy_config(strategy_key), variant.config_overrides
+        )
     return universe, config
 
 
 def _resolve_ablation_preset(strategy_key: str):
-    from services.strategy_ablation_service import AblationPreset
-
     if strategy_key == "oneil_pocket_pivot":
         from strategies.oneil_pocket_pivot_ablation import (
             ONEIL_POCKET_PIVOT_ABLATION_PRESET,
         )
         return ONEIL_POCKET_PIVOT_ABLATION_PRESET
+    if strategy_key == "oneil_squeeze_breakout":
+        from strategies.oneil_squeeze_breakout_ablation import (
+            ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+        )
+        return ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET
+    if strategy_key == "high_tight_flag":
+        from strategies.high_tight_flag_ablation import (
+            HIGH_TIGHT_FLAG_ABLATION_PRESET,
+        )
+        return HIGH_TIGHT_FLAG_ABLATION_PRESET
+    if strategy_key == "first_pullback":
+        from strategies.first_pullback_ablation import (
+            FIRST_PULLBACK_ABLATION_PRESET,
+        )
+        return FIRST_PULLBACK_ABLATION_PRESET
+    if strategy_key == "larry_williams_vbo":
+        from strategies.larry_williams_vbo_ablation import (
+            LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+        )
+        return LARRY_WILLIAMS_VBO_ABLATION_PRESET
+    if strategy_key == "rsi2_pullback":
+        from strategies.rsi2_pullback_ablation import (
+            RSI2_PULLBACK_ABLATION_PRESET,
+        )
+        return RSI2_PULLBACK_ABLATION_PRESET
+    if strategy_key == "larry_williams_channel_breakout":
+        from strategies.larry_williams_channel_breakout_ablation import (
+            LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+        )
+        return LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET
     raise ValueError(
-        f"Ablation preset 이 정의되지 않은 전략입니다: '{strategy_key}'. "
-        f"현재 지원: oneil_pocket_pivot"
+        f"Ablation preset 이 정의되지 않은 전략입니다: '{strategy_key}'."
     )
 
 

--- a/strategies/first_pullback_ablation.py
+++ b/strategies/first_pullback_ablation.py
@@ -1,0 +1,62 @@
+"""Ablation variants for the First Pullback strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+FIRST_PULLBACK_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_rapid_surge",
+    "disable_ma_rising",
+    "widen_pullback_range",
+)
+
+
+FIRST_PULLBACK_ABLATION_PRESET = AblationPreset(
+    strategy_key="first_pullback",
+    variants=(
+        AblationVariant(
+            name="disable_execution_strength",
+            description="Zero execution-strength so cgld_val checks never reject.",
+            config_overrides={"execution_strength_min": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_rapid_surge",
+            description=(
+                "Zero rapid-surge percent so any prior price change qualifies the "
+                "candidate as a surge."
+            ),
+            config_overrides={"rapid_surge_pct": 0.0},
+        ),
+        AblationVariant(
+            name="disable_ma_rising",
+            description=(
+                "Set ma_rising_min_count to 0 so the rising-MA confirmation never "
+                "rejects."
+            ),
+            config_overrides={"ma_rising_min_count": 0},
+        ),
+        AblationVariant(
+            name="widen_pullback_range",
+            description=(
+                "Expand the MA pullback band to ±99% so the pullback location "
+                "check always matches."
+            ),
+            config_overrides={
+                "pullback_lower_pct": -99.0,
+                "pullback_upper_pct": 99.0,
+            },
+        ),
+    ),
+)

--- a/strategies/high_tight_flag_ablation.py
+++ b/strategies/high_tight_flag_ablation.py
@@ -1,0 +1,70 @@
+"""Ablation variants for the High Tight Flag (HTF) strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+HTF_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_smart_money",
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_volume_filter",
+    "relax_pattern_check",
+)
+
+
+HIGH_TIGHT_FLAG_ABLATION_PRESET = AblationPreset(
+    strategy_key="high_tight_flag",
+    variants=(
+        AblationVariant(
+            name="disable_smart_money",
+            description=(
+                "Zero the program-to-market-cap threshold so the HTF smart-money "
+                "filter always passes."
+            ),
+            config_overrides={"program_to_market_cap_pct": 0.0},
+        ),
+        AblationVariant(
+            name="disable_execution_strength",
+            description=(
+                "Zero execution-strength thresholds so cgld_val checks never reject."
+            ),
+            config_overrides={
+                "execution_strength_min": 0.0,
+                "sm_flexible_execution_strength": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero breakout / afternoon volume multipliers so volume gates never "
+                "reject."
+            ),
+            config_overrides={
+                "volume_breakout_multiplier": 0.0,
+                "afternoon_volume_multiplier": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="relax_pattern_check",
+            description=(
+                "Disable pole surge and flag drawdown gates: any candidate with a "
+                "qualifying breakout will pass."
+            ),
+            config_overrides={
+                "pole_min_surge_ratio": 0.0,
+                "flag_max_drawdown_pct": 999.0,
+            },
+        ),
+    ),
+)

--- a/strategies/larry_williams_channel_breakout_ablation.py
+++ b/strategies/larry_williams_channel_breakout_ablation.py
@@ -1,0 +1,51 @@
+"""Ablation variants for the Larry Williams Channel Breakout strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+CB_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_rs_rating",
+    "disable_adx_filter",
+    "disable_volume_filter",
+    "disable_market_timing",
+)
+
+
+LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET = AblationPreset(
+    strategy_key="larry_williams_channel_breakout",
+    variants=(
+        AblationVariant(
+            name="disable_rs_rating",
+            description=(
+                "Zero rs_rating_min so the relative-strength floor never rejects."
+            ),
+            config_overrides={"rs_rating_min": 0},
+        ),
+        AblationVariant(
+            name="disable_adx_filter",
+            description=(
+                "Zero adx_threshold so the trend-strength gate always passes."
+            ),
+            config_overrides={"adx_threshold": 0.0},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero volume_multiplier so the volume-confirmation gate never "
+                "rejects."
+            ),
+            config_overrides={"volume_multiplier": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+    ),
+)

--- a/strategies/larry_williams_vbo_ablation.py
+++ b/strategies/larry_williams_vbo_ablation.py
@@ -1,0 +1,55 @@
+"""Ablation variants for the Larry Williams VBO strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+VBO_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_program_buy",
+    "disable_confidence_threshold",
+    "disable_market_timing",
+    "disable_liquidity_filter",
+)
+
+
+LARRY_WILLIAMS_VBO_ABLATION_PRESET = AblationPreset(
+    strategy_key="larry_williams_vbo",
+    variants=(
+        AblationVariant(
+            name="disable_program_buy",
+            description=(
+                "Zero program_buy_ratio so the program-buy ratio gate always passes."
+            ),
+            config_overrides={"program_buy_ratio": 0.0},
+        ),
+        AblationVariant(
+            name="disable_confidence_threshold",
+            description=(
+                "Zero confidence_threshold so execution-strength snapshot never "
+                "rejects."
+            ),
+            config_overrides={"confidence_threshold": 0.0},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_liquidity_filter",
+            description=(
+                "Zero market-cap and 5-day trading-value floors so liquidity "
+                "filtering does not reject candidates."
+            ),
+            config_overrides={
+                "min_market_cap": 0,
+                "min_5d_trading_value": 0,
+            },
+        ),
+    ),
+)

--- a/strategies/oneil_squeeze_breakout_ablation.py
+++ b/strategies/oneil_squeeze_breakout_ablation.py
@@ -1,0 +1,62 @@
+"""Ablation variants for the O'Neil Squeeze Breakout strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+OSB_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_smart_money",
+    "disable_execution_strength",
+    "disable_market_timing",
+    "disable_volume_filter",
+)
+
+
+ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET = AblationPreset(
+    strategy_key="oneil_squeeze_breakout",
+    variants=(
+        AblationVariant(
+            name="disable_smart_money",
+            description=(
+                "Zero program-buy thresholds so the smart-money gate always passes "
+                "when program-buy data is available."
+            ),
+            config_overrides={
+                "program_to_trade_value_pct": 0.0,
+                "program_to_market_cap_pct": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_execution_strength",
+            description=(
+                "Zero execution-strength thresholds so cgld_val checks never reject."
+            ),
+            config_overrides={
+                "execution_strength_min": 0.0,
+                "sm_flexible_execution_strength": 0.0,
+            },
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_volume_filter",
+            description=(
+                "Zero baseline / morning / breakout volume ratios so volume gates "
+                "never reject."
+            ),
+            config_overrides={
+                "baseline_min_vol_ratio": 0.0,
+                "morning_min_vol_ratio": 0.0,
+                "volume_breakout_multiplier": 0.0,
+            },
+        ),
+    ),
+)

--- a/strategies/rsi2_pullback_ablation.py
+++ b/strategies/rsi2_pullback_ablation.py
@@ -1,0 +1,43 @@
+"""Ablation variants for the RSI(2) Pullback strategy.
+
+See [todo_list.md](../todo_list.md) section P1-1 for context.
+"""
+from __future__ import annotations
+
+from services.strategy_ablation_service import AblationPreset, AblationVariant
+
+
+RSI2_VARIANT_NAMES: tuple[str, ...] = (
+    "disable_minervini_stage2",
+    "disable_market_timing",
+    "disable_rsi_oversold",
+)
+
+
+RSI2_PULLBACK_ABLATION_PRESET = AblationPreset(
+    strategy_key="rsi2_pullback",
+    variants=(
+        AblationVariant(
+            name="disable_minervini_stage2",
+            description=(
+                "Drop the Stage 2 requirement so non-Stage-2 candidates are not "
+                "filtered out."
+            ),
+            config_overrides={"require_minervini_stage2": False},
+        ),
+        AblationVariant(
+            name="disable_market_timing",
+            description=(
+                "Force is_market_timing_ok to True via a universe-service wrapper."
+            ),
+            universe_overrides={"force_market_timing_ok": True},
+        ),
+        AblationVariant(
+            name="disable_rsi_oversold",
+            description=(
+                "Raise rsi_threshold to 100 so any RSI value qualifies as oversold."
+            ),
+            config_overrides={"rsi_threshold": 100.0},
+        ),
+    ),
+)

--- a/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
+++ b/tests/unit_test/scripts/test_run_backtest_ablation_smoke.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from scripts.run_backtest import (
+    ACTIVE_BACKTEST_STRATEGIES,
+    _build_default_strategy_config,
     _filter_ablation_variants,
     _format_ablation_console_lines,
     _parse_args,
@@ -13,7 +15,7 @@ from scripts.run_backtest import (
     _run_ablation_for_result,
 )
 from services.backtest_period_runner import BacktestPeriodRunResult
-from services.strategy_ablation_service import AblationVariant
+from services.strategy_ablation_service import AblationPreset, AblationVariant
 from strategies.oneil_pocket_pivot_ablation import (
     ONEIL_POCKET_PIVOT_ABLATION_PRESET,
 )
@@ -55,8 +57,28 @@ def test_resolve_ablation_preset_returns_known_preset():
 
 
 def test_resolve_ablation_preset_raises_on_unknown_strategy():
-    with pytest.raises(ValueError, match="oneil_squeeze_breakout"):
-        _resolve_ablation_preset("oneil_squeeze_breakout")
+    with pytest.raises(ValueError, match="not_a_real_strategy"):
+        _resolve_ablation_preset("not_a_real_strategy")
+
+
+@pytest.mark.parametrize("strategy_key", list(ACTIVE_BACKTEST_STRATEGIES))
+def test_resolve_ablation_preset_covers_every_active_strategy(strategy_key):
+    preset = _resolve_ablation_preset(strategy_key)
+
+    assert isinstance(preset, AblationPreset)
+    assert preset.strategy_key == strategy_key
+    assert len(preset.variants) >= 3
+
+
+@pytest.mark.parametrize("strategy_key", list(ACTIVE_BACKTEST_STRATEGIES))
+def test_build_default_strategy_config_returns_dataclass_instance(strategy_key):
+    import dataclasses
+
+    config = _build_default_strategy_config(strategy_key)
+
+    assert dataclasses.is_dataclass(config), (
+        f"_build_default_strategy_config('{strategy_key}') must return a dataclass instance"
+    )
 
 
 def test_filter_ablation_variants_returns_all_when_none():

--- a/tests/unit_test/strategies/test_active_strategies_ablation_presets.py
+++ b/tests/unit_test/strategies/test_active_strategies_ablation_presets.py
@@ -1,0 +1,218 @@
+"""Ablation preset coverage for the remaining 6 active strategies.
+
+The O'Neil Pocket Pivot / BGU preset has its own dedicated file at
+``test_oneil_pocket_pivot_ablation.py`` because it predates this batch. The
+tests here apply identical structural checks across the rest of the active
+strategy registry.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.strategy_ablation_service import (
+    AblationPreset,
+    apply_config_overrides,
+)
+from strategies.first_pullback_ablation import (
+    FIRST_PULLBACK_ABLATION_PRESET,
+    FIRST_PULLBACK_VARIANT_NAMES,
+)
+from strategies.first_pullback_types import FirstPullbackConfig
+from strategies.high_tight_flag_ablation import (
+    HIGH_TIGHT_FLAG_ABLATION_PRESET,
+    HTF_VARIANT_NAMES,
+)
+from strategies.larry_williams_cb_types import LarryWilliamsCBConfig
+from strategies.larry_williams_channel_breakout_ablation import (
+    CB_VARIANT_NAMES,
+    LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+)
+from strategies.larry_williams_vbo_ablation import (
+    LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+    VBO_VARIANT_NAMES,
+)
+from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOConfig
+from strategies.oneil_common_types import HTFConfig, OneilBreakoutConfig
+from strategies.oneil_squeeze_breakout_ablation import (
+    ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+    OSB_VARIANT_NAMES,
+)
+from strategies.rsi2_pullback_ablation import (
+    RSI2_PULLBACK_ABLATION_PRESET,
+    RSI2_VARIANT_NAMES,
+)
+from strategies.rsi2_pullback_types import RSI2PullbackConfig
+
+
+# (strategy_key, preset, variant_names_tuple, default_config_factory)
+_PRESETS = [
+    (
+        "oneil_squeeze_breakout",
+        ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET,
+        OSB_VARIANT_NAMES,
+        OneilBreakoutConfig,
+    ),
+    (
+        "high_tight_flag",
+        HIGH_TIGHT_FLAG_ABLATION_PRESET,
+        HTF_VARIANT_NAMES,
+        HTFConfig,
+    ),
+    (
+        "first_pullback",
+        FIRST_PULLBACK_ABLATION_PRESET,
+        FIRST_PULLBACK_VARIANT_NAMES,
+        FirstPullbackConfig,
+    ),
+    (
+        "larry_williams_vbo",
+        LARRY_WILLIAMS_VBO_ABLATION_PRESET,
+        VBO_VARIANT_NAMES,
+        LarryWilliamsVBOConfig,
+    ),
+    (
+        "rsi2_pullback",
+        RSI2_PULLBACK_ABLATION_PRESET,
+        RSI2_VARIANT_NAMES,
+        RSI2PullbackConfig,
+    ),
+    (
+        "larry_williams_channel_breakout",
+        LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET,
+        CB_VARIANT_NAMES,
+        LarryWilliamsCBConfig,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "strategy_key,preset,expected_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_preset_metadata_matches_strategy_key(
+    strategy_key, preset: AblationPreset, expected_names, _factory
+):
+    assert preset.strategy_key == strategy_key
+    assert preset.variant_names() == expected_names
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_every_variant_has_a_non_empty_description(
+    _strategy_key, preset: AblationPreset, _names, _factory
+):
+    for variant in preset.variants:
+        assert variant.description.strip(), (
+            f"Variant '{variant.name}' in '{preset.strategy_key}' "
+            "must have a non-empty description"
+        )
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,config_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_every_variant_config_overrides_target_known_fields(
+    _strategy_key, preset: AblationPreset, _names, config_factory
+):
+    for variant in preset.variants:
+        # Should not raise — apply_config_overrides validates field names
+        apply_config_overrides(config_factory(), variant.config_overrides)
+
+
+@pytest.mark.parametrize(
+    "_strategy_key,preset,_names,_factory",
+    _PRESETS,
+    ids=[entry[0] for entry in _PRESETS],
+)
+def test_market_timing_variant_uses_universe_override_not_config(
+    _strategy_key, preset: AblationPreset, _names, _factory
+):
+    timing_variants = [
+        v for v in preset.variants if v.name == "disable_market_timing"
+    ]
+    assert timing_variants, (
+        f"Every active-strategy preset should expose a 'disable_market_timing' "
+        f"variant; preset '{preset.strategy_key}' has none."
+    )
+    variant = timing_variants[0]
+    assert dict(variant.config_overrides) == {}
+    assert variant.universe_overrides == {"force_market_timing_ok": True}
+
+
+def test_osb_disable_smart_money_zeroes_program_thresholds():
+    variant = next(
+        v for v in ONEIL_SQUEEZE_BREAKOUT_ABLATION_PRESET.variants
+        if v.name == "disable_smart_money"
+    )
+    config = apply_config_overrides(OneilBreakoutConfig(), variant.config_overrides)
+
+    assert config.program_to_trade_value_pct == 0.0
+    assert config.program_to_market_cap_pct == 0.0
+
+
+def test_htf_relax_pattern_check_neutralizes_pole_and_flag_gates():
+    variant = next(
+        v for v in HIGH_TIGHT_FLAG_ABLATION_PRESET.variants
+        if v.name == "relax_pattern_check"
+    )
+    config = apply_config_overrides(HTFConfig(), variant.config_overrides)
+
+    assert config.pole_min_surge_ratio == 0.0
+    assert config.flag_max_drawdown_pct >= 999.0
+
+
+def test_first_pullback_widen_range_accepts_full_pullback_band():
+    variant = next(
+        v for v in FIRST_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "widen_pullback_range"
+    )
+    config = apply_config_overrides(FirstPullbackConfig(), variant.config_overrides)
+
+    assert config.pullback_lower_pct <= -99.0
+    assert config.pullback_upper_pct >= 99.0
+
+
+def test_vbo_disable_program_buy_zeroes_ratio():
+    variant = next(
+        v for v in LARRY_WILLIAMS_VBO_ABLATION_PRESET.variants
+        if v.name == "disable_program_buy"
+    )
+    config = apply_config_overrides(LarryWilliamsVBOConfig(), variant.config_overrides)
+
+    assert config.program_buy_ratio == 0.0
+
+
+def test_rsi2_disable_rsi_oversold_raises_threshold_to_100():
+    variant = next(
+        v for v in RSI2_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "disable_rsi_oversold"
+    )
+    config = apply_config_overrides(RSI2PullbackConfig(), variant.config_overrides)
+
+    assert config.rsi_threshold >= 100.0
+
+
+def test_rsi2_disable_minervini_flips_boolean_to_false():
+    variant = next(
+        v for v in RSI2_PULLBACK_ABLATION_PRESET.variants
+        if v.name == "disable_minervini_stage2"
+    )
+    config = apply_config_overrides(RSI2PullbackConfig(), variant.config_overrides)
+
+    assert config.require_minervini_stage2 is False
+
+
+def test_channel_breakout_disable_adx_zeroes_threshold():
+    variant = next(
+        v for v in LARRY_WILLIAMS_CHANNEL_BREAKOUT_ABLATION_PRESET.variants
+        if v.name == "disable_adx_filter"
+    )
+    config = apply_config_overrides(LarryWilliamsCBConfig(), variant.config_overrides)
+
+    assert config.adx_threshold == 0.0

--- a/todo_list.md
+++ b/todo_list.md
@@ -158,10 +158,10 @@
 
 ### 1-1. 과최적화 방지 검증
 
-- [~] 전략별 ablation test를 추가한다.
+- [x] 전략별 ablation test를 추가한다.
   - 예: O'Neil PP/BGU의 smart money, execution strength, market timing, BGU/PP 조건을 하나씩 제거해 실제 기여도를 확인한다.
-  - 완료된 부분: `services/strategy_ablation_service.py`(`AblationVariant`/`AblationPreset`/`apply_config_overrides`/`ForceMarketTimingOkUniverseWrapper`/`compute_ablation_summary`)와 `strategies/oneil_pocket_pivot_ablation.py` preset(5 variant: `disable_smart_money`, `disable_execution_strength`, `disable_market_timing`, `pp_only`, `bgu_only`) 추가. `scripts/run_backtest.py`에 `--ablation`/`--ablation-variants` 옵션과 baseline 대비 metric delta 출력(console/JSON) 연결.
-  - 남은 작업: 나머지 6개 활성 전략(OSB, HTF, FirstPullback, RSI2, LarryVBO, LarryCB)의 preset 추가.
+  - 완료된 부분: `services/strategy_ablation_service.py`(`AblationVariant`/`AblationPreset`/`apply_config_overrides`/`ForceMarketTimingOkUniverseWrapper`/`compute_ablation_summary`) 추가. `scripts/run_backtest.py`에 `--ablation`/`--ablation-variants` 옵션과 baseline 대비 metric delta 출력(console/JSON) 연결.
+  - 완료된 부분: 활성 7개 전략 전부에 preset 추가 — `oneil_pocket_pivot`(5 variants), `oneil_squeeze_breakout`(4), `high_tight_flag`(5), `first_pullback`(5), `larry_williams_vbo`(4), `rsi2_pullback`(3), `larry_williams_channel_breakout`(4). 각 preset 은 가능하면 `disable_smart_money`/`disable_execution_strength`/`disable_market_timing`/`disable_volume_filter` 패턴을 따르고, 전략 고유 게이트(예: HTF `relax_pattern_check`, FirstPullback `widen_pullback_range`, RSI2 `disable_minervini_stage2`/`disable_rsi_oversold`, CB `disable_adx_filter`/`disable_rs_rating`)는 별도 variant 로 둔다.
 - [ ] parameter stability surface를 리포트한다.
   - 특정 임계값 하나에서만 성과가 튀는 전략은 실전 후보에서 제외하거나 canary로만 둔다.
 - [ ] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.


### PR DESCRIPTION
## Summary

- PR #440 (Phase 1, O'Neil PP/BGU MVP) 위에 쌓는 후속 작업.
- 활성 7개 전략 전부에 ablation preset 추가 — todo_list.md P1-1 "전략별 ablation test" 항목 `[x]` 완료.
- `scripts/run_backtest.py --ablation <strategy_key>` 가 7개 전략 모두 동작.

> Base 브랜치를 `feature/ablation_test`(PR #440) 로 두었습니다. PR #440 이 main 에 merge 되면 GitHub 가 자동으로 base 를 main 으로 재타겟합니다.

## 변경 파일

| 파일 | 유형 | 핵심 |
|---|---|---|
| `strategies/oneil_squeeze_breakout_ablation.py` | 신규 | OSB preset (4 variants: smart_money / execution_strength / market_timing / volume_filter) |
| `strategies/high_tight_flag_ablation.py` | 신규 | HTF preset (5 variants — 위 4 + `relax_pattern_check` 로 pole/flag 게이트 무력화) |
| `strategies/first_pullback_ablation.py` | 신규 | FirstPullback preset (5 variants: execution_strength / market_timing / rapid_surge / ma_rising / widen_pullback_range) |
| `strategies/larry_williams_vbo_ablation.py` | 신규 | VBO preset (4 variants: program_buy / confidence_threshold / market_timing / liquidity_filter) |
| `strategies/rsi2_pullback_ablation.py` | 신규 | RSI2 preset (3 variants: minervini_stage2 / market_timing / rsi_oversold) |
| `strategies/larry_williams_channel_breakout_ablation.py` | 신규 | CB preset (4 variants: rs_rating / adx_filter / volume_filter / market_timing) |
| `scripts/run_backtest.py` | 수정 (외과수술적) | `_build_default_strategy_config()` 헬퍼 분리, `_resolve_ablation_preset` 7개 매핑, `_build_backtest_strategy` 6개 브랜치에 `config=config` 전달 추가 |
| `tests/unit_test/strategies/test_active_strategies_ablation_presets.py` | 신규 | 31 parametrized + 단언 테스트 |
| `tests/unit_test/scripts/test_run_backtest_ablation_smoke.py` | 수정 | unknown-strategy 케이스 갱신 + 7 strategy 매핑/dataclass 검증 추가 |
| `todo_list.md` | 수정 | P1-1 첫 항목 `[x]` + 7개 전략 preset 완료 명시 |

## 설계 메모

- variant 정의 시 `apply_config_overrides()` 가 unknown field 를 ValueError 로 거절하므로 preset 의 오타가 즉시 검출됨.
- `disable_market_timing` 은 어떤 전략에서도 config 가 아닌 `universe_overrides={"force_market_timing_ok": True}` 로 통일 — 전략 코드 0줄 수정.
- 전략별 variant 수가 다른 이유: 게이트 수가 다르고, 의미 있는 ablation 만 정의했습니다 (예: RSI2 의 `entry_cutoff_hour` 는 시간 필터라 ablate 의미 없음).

## 검증

- `pytest tests/unit_test`: **4887 passed** (이전 4840 → +47, ablation 관련 +47)
- `pytest tests/integration_test`: **233 passed** (no regression)

## Test plan

- [x] `pytest tests/unit_test/strategies/test_active_strategies_ablation_presets.py -v`
- [x] `pytest tests/unit_test/scripts/test_run_backtest_ablation_smoke.py -v`
- [x] `pytest tests/unit_test`
- [x] `pytest tests/integration_test`
- [ ] (선택) 7개 전략 각각에 대해 `python -m scripts.run_backtest --strategy <key> --dates 20260501 --ablation <key>` 로 console 표 확인