### PR TITLE
다음 작업 진행 완료했습니다. Walk-forward 검증에 embargo_days를 추가해서 tune과 test 사이 N거…

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -77,6 +77,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--wf-test-days", type=int, default=5, dest="wf_test_days")
     parser.add_argument("--wf-step-days", type=int, default=None, dest="wf_step_days")
     parser.add_argument(
+        "--wf-embargo-days",
+        type=int,
+        default=0,
+        dest="wf_embargo_days",
+        help="walk-forward tune/test 경계 사이에 제외할 거래일 수 (default: 0)",
+    )
+    parser.add_argument(
         "--monte-carlo",
         action="store_true",
         default=False,
@@ -466,6 +473,7 @@ def _format_walk_forward_console(result) -> str:
     lines = [
         "[WALK-FORWARD BACKTEST RESULT]",
         f"구간 수: {summary.get('segment_count', 0)}",
+        f"embargo 일수: {summary.get('embargo_days', 0)}",
         f"train 일수 합계: {summary.get('train_days', 0)}",
         f"tune 일수 합계: {summary.get('tune_days', 0)}",
         f"test 일수 합계: {summary.get('test_days', 0)}",
@@ -1133,6 +1141,7 @@ async def _run(args: argparse.Namespace) -> None:
                 tune_size=args.wf_tune_days,
                 test_size=args.wf_test_days,
                 step_size=args.wf_step_days,
+                embargo_days=args.wf_embargo_days,
             )
 
             def runner_factory(phase: str, segment):

--- a/services/backtest_walk_forward.py
+++ b/services/backtest_walk_forward.py
@@ -16,6 +16,7 @@ class BacktestWalkForwardConfig:
     tune_size: int
     test_size: int
     step_size: int | None = None
+    embargo_days: int = 0
 
     def __post_init__(self) -> None:
         for field_name in ("train_size", "tune_size", "test_size"):
@@ -23,6 +24,8 @@ class BacktestWalkForwardConfig:
                 raise ValueError(f"{field_name} must be positive")
         if self.step_size is not None and self.step_size <= 0:
             raise ValueError("step_size must be positive")
+        if self.embargo_days < 0:
+            raise ValueError("embargo_days must be zero or positive")
 
     @property
     def normalized_step_size(self) -> int:
@@ -59,11 +62,12 @@ def build_walk_forward_segments(
     start = 0
     min_train_tune_end = config.train_size + config.tune_size
 
-    while start + min_train_tune_end < len(ordered_dates):
+    while start + min_train_tune_end + config.embargo_days < len(ordered_dates):
         train_end = start + config.train_size
         tune_end = train_end + config.tune_size
-        test_end = min(tune_end + config.test_size, len(ordered_dates))
-        test_dates = ordered_dates[tune_end:test_end]
+        test_start = tune_end + config.embargo_days
+        test_end = min(test_start + config.test_size, len(ordered_dates))
+        test_dates = ordered_dates[test_start:test_end]
         if not test_dates:
             break
 
@@ -131,6 +135,7 @@ class BacktestWalkForwardRunner:
 
         return {
             "segment_count": len(segments),
+            "embargo_days": self._config.embargo_days,
             "train_days": sum(len(segment.train_dates) for segment in segments),
             "tune_days": sum(len(segment.tune_dates) for segment in segments),
             "test_days": sum(len(segment.test_dates) for segment in segments),

--- a/tests/unit_test/scripts/test_run_backtest.py
+++ b/tests/unit_test/scripts/test_run_backtest.py
@@ -74,6 +74,8 @@ def test_parse_args_accepts_walk_forward_options(monkeypatch):
             "3",
             "--wf-step-days",
             "2",
+            "--wf-embargo-days",
+            "1",
         ],
     )
 
@@ -84,6 +86,7 @@ def test_parse_args_accepts_walk_forward_options(monkeypatch):
     assert args.wf_tune_days == 5
     assert args.wf_test_days == 3
     assert args.wf_step_days == 2
+    assert args.wf_embargo_days == 1
 
 
 def test_parse_args_accepts_monte_carlo_options(monkeypatch):
@@ -308,6 +311,7 @@ def test_format_walk_forward_console_summarizes_test_windows():
     result = SimpleNamespace(
         summary={
             "segment_count": 2,
+            "embargo_days": 1,
             "train_days": 40,
             "tune_days": 10,
             "test_days": 6,
@@ -321,6 +325,7 @@ def test_format_walk_forward_console_summarizes_test_windows():
 
     assert "[WALK-FORWARD BACKTEST RESULT]" in text
     assert "구간 수: 2" in text
+    assert "embargo 일수: 1" in text
     assert "검증 실현손익(순): 120,000" in text
     assert "검증 체결 수: 7" in text
     assert "검증 거부 기록: 3" in text

--- a/tests/unit_test/services/test_backtest_walk_forward.py
+++ b/tests/unit_test/services/test_backtest_walk_forward.py
@@ -55,6 +55,39 @@ def test_build_walk_forward_segments_defaults_step_to_test_size():
     assert segments[1].test_dates == ["20260106"]
 
 
+def test_build_walk_forward_segments_applies_embargo_between_tune_and_test():
+    dates = [
+        "20260101",
+        "20260102",
+        "20260103",
+        "20260104",
+        "20260105",
+        "20260106",
+        "20260107",
+        "20260108",
+    ]
+
+    segments = build_walk_forward_segments(
+        dates,
+        BacktestWalkForwardConfig(
+            train_size=2,
+            tune_size=1,
+            test_size=1,
+            step_size=1,
+            embargo_days=1,
+        ),
+    )
+
+    assert len(segments) == 4
+    assert segments[0].train_dates == ["20260101", "20260102"]
+    assert segments[0].tune_dates == ["20260103"]
+    # 20260104 is embargoed, so test starts at 20260105.
+    assert segments[0].test_dates == ["20260105"]
+    assert segments[1].train_dates == ["20260102", "20260103"]
+    assert segments[1].tune_dates == ["20260104"]
+    assert segments[1].test_dates == ["20260106"]
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -62,6 +95,7 @@ def test_build_walk_forward_segments_defaults_step_to_test_size():
         {"train_size": 1, "tune_size": 0, "test_size": 1},
         {"train_size": 1, "tune_size": 1, "test_size": 0},
         {"train_size": 1, "tune_size": 1, "test_size": 1, "step_size": 0},
+        {"train_size": 1, "tune_size": 1, "test_size": 1, "embargo_days": -1},
     ],
 )
 def test_walk_forward_config_rejects_non_positive_sizes(kwargs):
@@ -134,6 +168,7 @@ async def test_walk_forward_summary_aggregates_test_phase_only():
 
     assert result.summary == {
         "segment_count": 2,
+        "embargo_days": 0,
         "train_days": 4,
         "tune_days": 2,
         "test_days": 2,

--- a/todo_list.md
+++ b/todo_list.md
@@ -168,7 +168,8 @@
   - 완료된 부분: 활성 7개 전략 전부에 `strategies/<key>_parameter_stability.py` preset(각 3 dimension × 5 sweep 점) 추가 — `oneil_pocket_pivot`(pp_ma_proximity_upper_pct/bgu_gap_pct/execution_strength_min), `oneil_squeeze_breakout`(volume_breakout_multiplier/execution_strength_min/osb_max_extension_pct), `high_tight_flag`(pole_min_surge_ratio/flag_max_drawdown_pct/volume_breakout_multiplier), `first_pullback`(pullback_upper_pct/rapid_surge_pct/execution_strength_min), `larry_williams_vbo`(k_value/confidence_threshold/program_buy_ratio), `rsi2_pullback`(rsi_threshold/hard_stop_pct/take_profit_ma_period), `larry_williams_channel_breakout`(adx_threshold/volume_multiplier/rs_rating_min).
   - 완료된 부분: `scripts/run_backtest.py` 에 `--parameter-stability`/`--parameter-stability-dimensions` 옵션, sweep 점마다 `AblationVariant(config_overrides={dim.parameter: value})` 를 합성해 기존 `make_runner(variant=...)` 재사용. console/JSON 출력에 baseline 대비 dimension 별 metric 표 + stability flag 노출.
   - 완료된 부분: hard gate 통합 — `strategy_profitability_gate` 가 parameter stability summary의 `spike`/`cliff` dimension을 차단 사유(`parameter_stability_<flag>:<dimension>`)로 반영한다. 기본값은 report 결과가 있을 때만 적용하며, `block_parameter_stability_flags=[]` 로 report-only 운용도 가능하다.
-- [ ] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.
+- [x] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.
+  - 완료된 부분: `BacktestWalkForwardConfig.embargo_days`와 `scripts/run_backtest.py --wf-embargo-days` 옵션을 추가했다. 1차 정책은 tune/test 경계 사이의 N거래일을 test에서 제외해 contiguous 검증 누수를 줄이는 방식이며, 기본값 0은 기존 동작을 유지한다.
 - [ ] Deflated Sharpe / PBO 같은 다중 전략 실험 착시 방지 지표를 도입할지 검토한다.
 - [ ] regime-balanced validation을 추가한다.
   - 상승장 데이터에만 최적화된 전략이 횡보/하락장에서 손실을 키우지 않는지 분리 검증한다.


### PR DESCRIPTION
…래일을 제외할 수 있게 했고, CLI에는 --wf-embargo-days 옵션을 붙였습니다. 기본값은 0이라 기존 동작은 그대로 유지됩니다.

변경 파일:

services/backtest_walk_forward.py (line 19)
scripts/run_backtest.py (line 80)
todo_list.md (line 171)
검증:

python -m pytest tests/unit_test -v 통과
python -m pytest tests/integration_test -v 통과, 233 passed 통합 테스트 종료 후 기존 비동기 pending task 경고가 몇 줄 출력됐지만, 테스트 결과 자체는 모두 통과했습니다.