### PR TITLE
팀 공유 (Git 커밋 대상)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ nul
 
 search_results.txt
 Changes.md
+
+# Claude 개인 설정 (팀 공유 파일은 CLAUDE.md / SKILL.md)
+CLAUDE.local.md
+SKILL.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,10 @@
 # CLAUDE.md — Investment Project Context
 
-> **작업 전 필수**: 모든 작업 시작 전 아래 두 파일을 반드시 `Read` 도구로 읽고 규칙을 준수한다.
+> **작업 전 필수**: 모든 작업 시작 전 아래 파일들을 반드시 `Read` 도구로 읽고 규칙을 준수한다.
 >
 > 1. `Read("SKILL.md")` — Claude 작업 패턴 규칙 (Edit/Read/Write 방식)
 > 2. `Read("CODEBASE_SUMMARY.md")` — 프로젝트 운영 지식, 수정 난이도 지도, 작업 경로
-
-## 파일 읽기 규칙
-파일을 **탐색·분석** 목적으로 읽을 때는 `mcp__plugin_context-mode_context-mode__ctx_execute` (shell/python) 도구를 사용한다.
-`Read` 도구는 **Edit를 위해 파일 내용을 컨텍스트에 올려야 할 때만** 사용한다.
+> 3. 존재할 경우: `Read("CLAUDE.local.md")`, `Read("SKILL.local.md")` — 개인 환경/도구 설정 (gitignore 대상)
 
 ## 작업 행동 원칙 (Karpathy Guidelines 적용)
 LLM 코딩 시 자주 발생하는 실수를 줄이기 위한 원칙. 사소한 작업은 판단에 맡긴다.
@@ -78,9 +75,6 @@ pytest tests/integration_test -v    # 통합 테스트
 .\2.integration_test_with_coverage.bat  # 통합 테스트 + 커버리지
 ```
 - pytest 설정: `asyncio_mode=auto`, `pytest-xdist -n auto` 병렬 실행
-
-## Pytest 실행 방법 예시
-cd /c/Users/Kyungsoo/Documents/Code/Investment && /c/Users/Kyungsoo/anaconda3/envs/py310/python.exe -m pytest tests/unit_test/test_korea_invest_websocket_api.py::test_disconnect_with_receive_task_exception -v 2>&1 | tail -50
 
 ## 디렉토리 구조
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,6 +2,7 @@
 
 > 이 문서는 Claude의 `Read`, `Edit`, `Write` 도구 사용 규칙이다.
 > Codex는 작업 시작 시 이 문서를 읽지 않고, [AGENTS.md](AGENTS.md)의 Codex 작업 규칙을 따른다.
+> 개인 도구 사용 패턴은 [SKILL.local.md](SKILL.local.md) (존재 시, gitignore 대상) 참고.
 
 ---
 
@@ -110,30 +111,6 @@ Read(file_path)  # 전체 읽기
 
 ---
 
-## 규칙 6. JSONL 로그 시간 분석
-
-JSONL 로그에서 성능을 분석할 때 턴 유형에 따라 시간 구분을 다르게 해석한다.
-
-| 구간 | 직전 턴 유형 | 의미 |
-|------|-------------|------|
-| 타임스탬프 차이 | `assistant` 턴 직전 | **LLM 대기 시간** (모델 응답 생성) |
-| 타임스탬프 차이 | `user` 턴 직전 | **Tool 실행 시간** (도구 호출·결과 반환) |
-
-```python
-# 분석 예시
-for i, entry in enumerate(log):
-    if i == 0: continue
-    delta = entry.timestamp - log[i-1].timestamp
-    if entry.role == "assistant":
-        print(f"LLM 대기: {delta}s")   # 이전 user(tool_result) → assistant
-    elif entry.role == "user":
-        print(f"Tool 실행: {delta}s")  # 이전 assistant(tool_use) → user
-```
-
-**Why:** LLM 지연과 Tool 지연을 혼동하면 병목 분석이 틀린다. 역할 기준으로 명확히 구분해야 한다.
-
----
-
 ## 체크리스트
 
 작업 시작 전 다음을 확인한다:
@@ -147,4 +124,3 @@ for i, entry in enumerate(log):
   - [ ] Changes Specification
   - [ ] Test Update Specification
   - [ ] Execution Notes
-- [ ] JSONL 로그 분석 시 assistant/user 턴 기준으로 LLM 대기·Tool 실행을 구분하는가?


### PR DESCRIPTION
CLAUDE.md — ## 파일 읽기 규칙, ## Pytest 실행 방법 예시 제거. 헤더에 "local 파일 있으면 함께 읽기" 안내 추가. SKILL.md — ## 규칙 6. JSONL 로그 시간 분석 및 체크리스트 마지막 줄 제거. 헤더에 SKILL.local.md 안내 추가. 개인 (.gitignore 등록)

CLAUDE.local.md — 신규. 파일 읽기 규칙(ctx_execute) + Pytest 개인 절대경로 예시. SKILL.local.md — 신규. 규칙 6 JSONL 로그 시간 분석 + 해당 체크리스트. .gitignore — CLAUDE.local.md, SKILL.local.md 추가.

테스트 면제 사유: 순수 *.md 문서 수정만 발생 (CLAUDE.md 명시 예외 조항). 통합 테스트 생략.

확인 권장: git status로 두 local 파일이 untracked로 안 잡히는지(=ignore 정상 동작) 확인하시면 됩니다.