### PR TITLE
다중 실험 착시 방지 1차 작업도 완료했습니다.

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -214,6 +214,9 @@ class StrategyProfitabilityGateConfig(BaseModel):
         default_factory=lambda: ["KOSPI_BULL", "KOSDAQ_BULL", "SIDEWAYS", "BEAR"]
     )
     regime_balance_min_trades: int = 5
+    multiple_testing_min_trials: int = 5
+    multiple_testing_top_to_median_warning_ratio: float = 3.0
+    multiple_testing_primary_metric: str = "total_net_pnl"
 
     model_config = {"extra": "allow"}
 

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -521,6 +521,20 @@ def _format_profitability_gate_console_lines(result: dict[str, Any]) -> list[str
             insufficient=summary.get("insufficient_sample_count", 0),
         )
     )
+    warnings = result.get("warnings") or []
+    if warnings:
+        lines.append(f"warnings: {', '.join(warnings)}")
+    bias = result.get("multiple_testing_bias") or {}
+    if bias.get("bias_warning"):
+        ratio = bias.get("top_to_median_ratio")
+        ratio_str = f"{ratio:.2f}" if isinstance(ratio, (int, float)) else "n/a"
+        lines.append(
+            "multiple-testing trials={trial_count} best={best} top/median={ratio}".format(
+                trial_count=bias.get("trial_count", 0),
+                best=bias.get("best_strategy") or "n/a",
+                ratio=ratio_str,
+            )
+        )
     for strategy, item in sorted((result.get("strategies") or {}).items()):
         reasons = item.get("blocking_reasons") or []
         warnings = item.get("warnings") or []

--- a/services/multiple_testing_bias_service.py
+++ b/services/multiple_testing_bias_service.py
@@ -1,0 +1,66 @@
+"""Lightweight multiple-testing bias report helpers.
+
+This is a report-only proxy, not a formal Deflated Sharpe or PBO
+implementation. It flags cases where many strategy trials are compared and the
+best result towers over the median result, which can indicate selection bias.
+"""
+from __future__ import annotations
+
+from statistics import median
+from typing import Any, Mapping
+
+
+def compute_multiple_testing_bias_summary(
+    metrics_by_strategy: Mapping[str, Mapping[str, Any]],
+    *,
+    min_trials: int = 5,
+    top_to_median_warning_ratio: float = 3.0,
+    primary_metric: str = "total_net_pnl",
+) -> dict[str, Any]:
+    rows: list[tuple[str, float]] = []
+    for strategy, metrics in metrics_by_strategy.items():
+        value = _to_float(metrics.get(primary_metric))
+        if value is None:
+            continue
+        rows.append((str(strategy), value))
+
+    rows.sort(key=lambda item: item[1], reverse=True)
+    trial_count = len(rows)
+    warning_reasons: list[str] = []
+
+    best_strategy = rows[0][0] if rows else None
+    best_value = rows[0][1] if rows else None
+    median_value = float(median([value for _, value in rows])) if rows else None
+    ratio = None
+
+    if trial_count >= max(int(min_trials or 0), 1) and best_value is not None:
+        if median_value is not None and median_value > 0:
+            ratio = best_value / median_value
+            if ratio >= float(top_to_median_warning_ratio):
+                warning_reasons.append("best_over_median_ratio_high")
+        elif best_value > 0:
+            warning_reasons.append("best_positive_median_non_positive")
+
+    return {
+        "trial_count": trial_count,
+        "primary_metric": primary_metric,
+        "best_strategy": best_strategy,
+        "best_value": best_value,
+        "median_value": median_value,
+        "top_to_median_ratio": round(ratio, 3) if ratio is not None else None,
+        "warning_reasons": warning_reasons,
+        "bias_warning": bool(warning_reasons),
+        "rankings": [
+            {"strategy": strategy, primary_metric: value}
+            for strategy, value in rows
+        ],
+    }
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/services/strategy_profitability_gate_service.py
+++ b/services/strategy_profitability_gate_service.py
@@ -14,6 +14,7 @@ from services.regime_performance_service import (
     compute_regime_balance_summary,
 )
 from services.strategy_performance_degradation_service import compute_strategy_window_metrics
+from services.multiple_testing_bias_service import compute_multiple_testing_bias_summary
 
 
 @dataclass(frozen=True)
@@ -39,6 +40,9 @@ class StrategyProfitabilityGateConfig:
         "BEAR",
     )
     regime_balance_min_trades: int = 5
+    multiple_testing_min_trials: int = 5
+    multiple_testing_top_to_median_warning_ratio: float = 3.0
+    multiple_testing_primary_metric: str = "total_net_pnl"
 
 
 def evaluate_strategy_profitability_gate(
@@ -72,6 +76,21 @@ def evaluate_strategy_profitability_gate(
         )
 
     statuses = [item["status"] for item in by_strategy.values()]
+    metrics_by_strategy = {
+        strategy: item.get("metrics", {})
+        for strategy, item in by_strategy.items()
+    }
+    multiple_testing_bias = compute_multiple_testing_bias_summary(
+        metrics_by_strategy,
+        min_trials=cfg.multiple_testing_min_trials,
+        top_to_median_warning_ratio=cfg.multiple_testing_top_to_median_warning_ratio,
+        primary_metric=cfg.multiple_testing_primary_metric,
+    )
+    warnings = (
+        ["multiple_testing_bias_warning"]
+        if multiple_testing_bias.get("bias_warning")
+        else []
+    )
     return {
         "config": _config_to_dict(cfg),
         "summary": {
@@ -80,6 +99,8 @@ def evaluate_strategy_profitability_gate(
             "fail_count": statuses.count("fail"),
             "insufficient_sample_count": statuses.count("insufficient_sample"),
         },
+        "warnings": warnings,
+        "multiple_testing_bias": multiple_testing_bias,
         "strategies": by_strategy,
     }
 

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -115,6 +115,8 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
         "BEAR",
     ]
     assert config.strategy_profitability_gate.regime_balance_min_trades == 5
+    assert config.strategy_profitability_gate.multiple_testing_min_trials == 5
+    assert config.strategy_profitability_gate.multiple_testing_top_to_median_warning_ratio == 3.0
     assert config.data_quality.violation_alert_threshold == 5
     assert config.data_quality.violation_alert_window_sec == 60.0
 

--- a/tests/unit_test/scripts/test_run_backtest.py
+++ b/tests/unit_test/scripts/test_run_backtest.py
@@ -332,6 +332,36 @@ def test_format_console_includes_profitability_gate_warnings():
     assert "오닐PP/BGU: pass [warn: regime_balance_incomplete]" in text
 
 
+def test_format_console_includes_profitability_gate_top_level_warnings():
+    result = SimpleNamespace(
+        strategy_name="오닐PP/BGU",
+        dates=["20260501"],
+        execution_reports=[],
+        journal_records=[],
+        saved_journal_run={},
+        portfolio={"cash": 1_000_000, "available_cash": 1_000_000, "positions": {}},
+        profitability_gate={
+            "summary": {"pass_count": 2, "fail_count": 0, "insufficient_sample_count": 0},
+            "warnings": ["multiple_testing_bias_warning"],
+            "multiple_testing_bias": {
+                "bias_warning": True,
+                "trial_count": 5,
+                "best_strategy": "S1",
+                "top_to_median_ratio": 12.5,
+            },
+            "strategies": {
+                "S1": {"status": "pass", "blocking_reasons": [], "warnings": []},
+                "S2": {"status": "pass", "blocking_reasons": [], "warnings": []},
+            },
+        },
+    )
+
+    text = _format_console(result)
+
+    assert "warnings: multiple_testing_bias_warning" in text
+    assert "multiple-testing trials=5 best=S1 top/median=12.50" in text
+
+
 def test_format_walk_forward_console_summarizes_test_windows():
     result = SimpleNamespace(
         summary={

--- a/tests/unit_test/services/test_multiple_testing_bias_service.py
+++ b/tests/unit_test/services/test_multiple_testing_bias_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from services.multiple_testing_bias_service import compute_multiple_testing_bias_summary
+
+
+def test_multiple_testing_bias_summary_skips_when_trial_count_is_small():
+    summary = compute_multiple_testing_bias_summary(
+        {
+            "S1": {"total_net_pnl": 100},
+            "S2": {"total_net_pnl": 50},
+        },
+        min_trials=3,
+    )
+
+    assert summary["trial_count"] == 2
+    assert summary["bias_warning"] is False
+    assert summary["warning_reasons"] == []
+
+
+def test_multiple_testing_bias_summary_warns_when_best_towers_over_median():
+    summary = compute_multiple_testing_bias_summary(
+        {
+            "S1": {"total_net_pnl": 1_000},
+            "S2": {"total_net_pnl": 100},
+            "S3": {"total_net_pnl": 80},
+            "S4": {"total_net_pnl": 60},
+            "S5": {"total_net_pnl": 40},
+        },
+        min_trials=5,
+        top_to_median_warning_ratio=3.0,
+    )
+
+    assert summary["bias_warning"] is True
+    assert summary["best_strategy"] == "S1"
+    assert summary["median_value"] == 80.0
+    assert summary["top_to_median_ratio"] == 12.5
+    assert "best_over_median_ratio_high" in summary["warning_reasons"]
+
+
+def test_multiple_testing_bias_summary_warns_when_best_positive_but_median_non_positive():
+    summary = compute_multiple_testing_bias_summary(
+        {
+            "S1": {"total_net_pnl": 100},
+            "S2": {"total_net_pnl": 0},
+            "S3": {"total_net_pnl": -10},
+            "S4": {"total_net_pnl": -20},
+            "S5": {"total_net_pnl": -30},
+        },
+        min_trials=5,
+    )
+
+    assert summary["bias_warning"] is True
+    assert summary["median_value"] == -10.0
+    assert summary["top_to_median_ratio"] is None
+    assert "best_positive_median_non_positive" in summary["warning_reasons"]

--- a/tests/unit_test/services/test_strategy_profitability_gate_service.py
+++ b/tests/unit_test/services/test_strategy_profitability_gate_service.py
@@ -235,3 +235,37 @@ def test_profitability_gate_warns_on_regime_balance_gaps_without_blocking():
         "SIDEWAYS",
         "BEAR",
     ]
+
+
+def test_profitability_gate_reports_multiple_testing_bias_warning():
+    records = []
+    for strategy, pnl in [
+        ("S1", 1_000),
+        ("S2", 100),
+        ("S3", 80),
+        ("S4", 60),
+        ("S5", 40),
+    ]:
+        records.append(_sold(pnl, 1.0, strategy=strategy, signal_time="2026-05-01"))
+
+    cfg = StrategyProfitabilityGateConfig(
+        min_trades=1,
+        min_profit_factor=None,
+        min_payoff_ratio=None,
+        min_win_rate=0.0,
+        min_avg_net_return=None,
+        require_positive_total_net_pnl=False,
+        max_mdd_pct=None,
+        max_monte_carlo_ruin_probability=None,
+        max_monte_carlo_worst_mdd_pct=None,
+        require_non_negative_regime_pnl=False,
+        regime_balance_required_buckets=(),
+        multiple_testing_min_trials=5,
+        multiple_testing_top_to_median_warning_ratio=3.0,
+    )
+
+    result = evaluate_strategy_profitability_gate(records, cfg)
+
+    assert "multiple_testing_bias_warning" in result["warnings"]
+    assert result["multiple_testing_bias"]["bias_warning"] is True
+    assert result["multiple_testing_bias"]["best_strategy"] == "S1"

--- a/todo_list.md
+++ b/todo_list.md
@@ -170,7 +170,8 @@
   - 완료된 부분: hard gate 통합 — `strategy_profitability_gate` 가 parameter stability summary의 `spike`/`cliff` dimension을 차단 사유(`parameter_stability_<flag>:<dimension>`)로 반영한다. 기본값은 report 결과가 있을 때만 적용하며, `block_parameter_stability_flags=[]` 로 report-only 운용도 가능하다.
 - [x] purged/embargo cross-validation 또는 종목·기간 누수 방지 규칙을 walk-forward 검증에 추가할지 검토한다.
   - 완료된 부분: `BacktestWalkForwardConfig.embargo_days`와 `scripts/run_backtest.py --wf-embargo-days` 옵션을 추가했다. 1차 정책은 tune/test 경계 사이의 N거래일을 test에서 제외해 contiguous 검증 누수를 줄이는 방식이며, 기본값 0은 기존 동작을 유지한다.
-- [ ] Deflated Sharpe / PBO 같은 다중 전략 실험 착시 방지 지표를 도입할지 검토한다.
+- [x] Deflated Sharpe / PBO 같은 다중 전략 실험 착시 방지 지표를 도입할지 검토한다.
+  - 완료된 부분: 1차 report-only proxy로 `compute_multiple_testing_bias_summary()`를 추가했다. 여러 전략 trial 중 best `total_net_pnl`이 median 대비 과도하게 크거나 median이 비양수인데 best만 양수인 경우 `multiple_testing_bias_warning`을 profitability gate top-level warning으로 노출한다. 정식 Deflated Sharpe/PBO hard gate는 표본·실험 로그 축적 후 별도 검토한다.
 - [x] regime-balanced validation을 추가한다.
   - 완료된 부분: `compute_regime_balance_summary()`를 추가해 필수 국면별 최소 표본 충족 여부(`balanced_pass`, `missing_regimes`, `weak_regimes`)를 산출한다. `strategy_profitability_gate`는 기본 필수 국면(`KOSPI_BULL`, `KOSDAQ_BULL`, `SIDEWAYS`, `BEAR`)과 `regime_balance_min_trades=5` 기준으로 report warning(`regime_balance_incomplete`)을 노출하되, 1차에서는 hard block으로 쓰지 않는다.
   - 상승장 데이터에만 최적화된 전략이 횡보/하락장에서 손실을 키우지 않는지 분리 검증한다.


### PR DESCRIPTION
이번에 추가한 내용은 report-only proxy입니다. services/multiple_testing_bias_service.py (line 13)에서 여러 전략 trial의 total_net_pnl을 비교해 best가 median 대비 과도하게 튀거나, median이 비양수인데 best만 양수인 경우 multiple_testing_bias_warning을 냅니다. 이 warning은 strategy_profitability_gate_service.py (line 43)의 top-level gate 결과에 붙고, run_backtest.py (line 525) console 출력에도 표시됩니다. todo_list.md (line 173)도 해당 항목 완료로 갱신했습니다. 정식 Deflated Sharpe/PBO hard gate는 아직 넣지 않고, 표본과 실험 로그가 더 쌓인 뒤 별도 검토로 남겼습니다. 검증:
python -m pytest tests/unit_test -v 통과
python -m pytest tests/integration_test -v 통과, 233 passed