### PR TITLE
P0 0-1 broker order mapper 확장 완료

### DIFF
--- a/services/broker_order_submitter.py
+++ b/services/broker_order_submitter.py
@@ -27,6 +27,7 @@ class BrokerOrderSubmitter:
         state_provider: Optional[Callable[[], dict]] = None,
         transition_fn: Optional[Callable[..., object]] = None,
         extract_broker_order_no_fn: Optional[Callable[[ResCommonResponse], Optional[str]]] = None,
+        on_missing_broker_order_no_fn: Optional[Callable[[ResCommonResponse, str, str], None]] = None,
         max_retries: int = 3,
         retry_delay_sec: int = 3,
     ) -> None:
@@ -37,6 +38,7 @@ class BrokerOrderSubmitter:
         self._state_provider = state_provider
         self._transition_fn = transition_fn
         self._extract_broker_order_no_fn = extract_broker_order_no_fn
+        self._on_missing_broker_order_no_fn = on_missing_broker_order_no_fn
         self._max_retries = max_retries
         self._retry_delay_sec = retry_delay_sec
 
@@ -74,6 +76,17 @@ class BrokerOrderSubmitter:
                         if self._extract_broker_order_no_fn
                         else None
                     )
+                    if broker_no is None and self._on_missing_broker_order_no_fn is not None:
+                        self.logger.warning(
+                            f"주문번호 추출 실패 — stock_code={stock_code}, order_key={order_key}, "
+                            f"rt_cd={result.rt_cd}, msg1={result.msg1}, raw_data={result.data!r}"
+                        )
+                        try:
+                            self._on_missing_broker_order_no_fn(result, stock_code, order_key)
+                        except Exception as cb_exc:  # noqa: BLE001 — 콜백 실패가 주문 흐름 차단하지 않도록 흡수
+                            self.logger.exception(
+                                f"on_missing_broker_order_no_fn 콜백 실행 중 예외: {cb_exc}"
+                            )
                     self._transition_fn(
                         order_key,
                         OrderState.SUBMITTED,

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -113,6 +113,57 @@ class FillReconciliationService:
         self._notification_tasks.add(task)
         task.add_done_callback(self._notification_tasks.discard)
 
+    def on_broker_order_no_missing(
+        self,
+        result: ResCommonResponse,
+        stock_code: str,
+        order_key: str,
+    ) -> None:
+        """주문 응답에서 broker_order_no 를 추출하지 못했을 때 신규 주문 차단 + 알림 승격.
+
+        FSM 컨텍스트는 broker_order_no=None 으로 SUBMITTED 전이가 이미 수행되어 있으며,
+        이후 reconcile/체결 매칭에서 누락될 위험이 있으므로 reconcile_alarm 으로 즉시
+        신규 주문을 차단하고, raw payload 를 운영자 알림 metadata 에 보존한다.
+        """
+        self._reconcile_alarm = True
+        self._critical_alarm_manual_required = True
+        raw_data_repr = repr(result.data) if result is not None else ""
+        rt_cd = result.rt_cd if result is not None else ""
+        msg1 = result.msg1 if result is not None else ""
+        message = (
+            f"주문 응답에서 broker_order_no 추출 실패로 신규 주문 차단: "
+            f"stock_code={stock_code}, order_key={order_key}, "
+            f"rt_cd={rt_cd}, msg1={msg1}, raw_data={raw_data_repr}"
+        )
+        self.logger.error(message)
+        if self._notification_service is None:
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.logger.warning(
+                "broker_order_no_missing notification skipped: running event loop 없음"
+            )
+            return
+
+        task = loop.create_task(self._notification_service.emit(
+            NotificationCategory.TRADE,
+            NotificationLevel.CRITICAL,
+            "Order Block: Broker Order No Missing",
+            message,
+            metadata={
+                "alert_type": "broker_order_no_missing",
+                "stock_code": stock_code,
+                "order_key": order_key,
+                "rt_cd": rt_cd,
+                "msg1": msg1,
+                "raw_data": raw_data_repr,
+            },
+        ))
+        self._notification_tasks.add(task)
+        task.add_done_callback(self._notification_tasks.discard)
+
     # ── source 분류 헬퍼 (OES._strategy_name_from_source 와 중복 — 결합 회피 목적의 의도된 사본) ──
     @staticmethod
     def _strategy_name_from_source(source: str) -> tuple[str, bool]:

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -85,17 +85,6 @@ class OrderExecutionService:
             fast_poll_interval_sec=self._FAST_POLL_INTERVAL_SEC,
             default_active_poll_interval_sec=self._DEFAULT_ACTIVE_ORDER_POLL_INTERVAL_SEC,
         )
-        self._broker_submitter = BrokerOrderSubmitter(
-            broker_api_wrapper=broker_api_wrapper,
-            logger=logger,
-            kill_switch=kill_switch_service,
-            market_clock=market_clock,
-            state_provider=lambda: self._fsm._order_states,
-            transition_fn=self._fsm.transition,
-            extract_broker_order_no_fn=OrderStateMachine.extract_broker_order_no,
-            max_retries=self._ORDER_MAX_RETRIES,
-            retry_delay_sec=self._ORDER_RETRY_DELAY_SEC,
-        )
         self._fill_reconciliation = FillReconciliationService(
             broker_api_wrapper=broker_api_wrapper,
             logger=logger,
@@ -110,6 +99,18 @@ class OrderExecutionService:
             is_paper_trading_fn=self._is_paper_trading_mode,
             stuck_order_warning_sec=self._STUCK_ORDER_WARNING_SEC,
             stuck_order_critical_sec=self._STUCK_ORDER_CRITICAL_SEC,
+        )
+        self._broker_submitter = BrokerOrderSubmitter(
+            broker_api_wrapper=broker_api_wrapper,
+            logger=logger,
+            kill_switch=kill_switch_service,
+            market_clock=market_clock,
+            state_provider=lambda: self._fsm._order_states,
+            transition_fn=self._fsm.transition,
+            extract_broker_order_no_fn=OrderStateMachine.extract_broker_order_no,
+            on_missing_broker_order_no_fn=self._fill_reconciliation.on_broker_order_no_missing,
+            max_retries=self._ORDER_MAX_RETRIES,
+            retry_delay_sec=self._ORDER_RETRY_DELAY_SEC,
         )
         self._fsm.set_on_critical_mismatch(
             self._fill_reconciliation.on_safe_transition_critical

--- a/tests/unit_test/services/test_broker_order_submitter.py
+++ b/tests/unit_test/services/test_broker_order_submitter.py
@@ -47,6 +47,7 @@ def _make_submitter(
     states: dict | None = None,
     transition: MagicMock | None = None,
     extract_no_fn=None,
+    on_missing_fn=None,
 ) -> BrokerOrderSubmitter:
     states = states if states is not None else {}
     return BrokerOrderSubmitter(
@@ -57,6 +58,7 @@ def _make_submitter(
         state_provider=(lambda: states),
         transition_fn=transition,
         extract_broker_order_no_fn=extract_no_fn or (lambda r: (r.data or {}).get("ordno") if r else None),
+        on_missing_broker_order_no_fn=on_missing_fn,
         max_retries=3,
         retry_delay_sec=3,
     )
@@ -97,6 +99,110 @@ async def test_submit_transitions_to_submitted_on_success_with_order_key(mock_br
     assert args[1] == OrderState.SUBMITTED
     assert kwargs["attempt_count"] == 1
     assert kwargs["broker_order_no"] == "B0001"
+
+
+# ── submit_with_retry: broker order no 추출 실패 콜백 ─────────────────────
+
+@pytest.mark.asyncio
+async def test_submit_invokes_missing_broker_no_callback_when_extraction_returns_none(
+    mock_market_clock,
+):
+    broker = AsyncMock()
+    broker.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="정상처리", data={"unexpected_key": "VAL"}
+    )
+    transition = MagicMock()
+    on_missing = MagicMock()
+    submitter = _make_submitter(
+        broker=broker,
+        market_clock=mock_market_clock,
+        states={"K1": object()},
+        transition=transition,
+        extract_no_fn=lambda r: None,
+        on_missing_fn=on_missing,
+    )
+
+    await submitter.submit_with_retry(
+        "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX, order_key="K1",
+    )
+
+    on_missing.assert_called_once()
+    args, _ = on_missing.call_args
+    assert args[0].rt_cd == ErrorCode.SUCCESS.value
+    assert args[0].data == {"unexpected_key": "VAL"}
+    assert args[1] == "005930"
+    assert args[2] == "K1"
+    # transition_fn 은 broker_order_no=None 으로 호출되어야 한다 (기존 동작 유지)
+    transition.assert_called_once()
+    _, kwargs = transition.call_args
+    assert kwargs["broker_order_no"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_skips_callback_when_broker_no_extracted(mock_broker, mock_market_clock):
+    on_missing = MagicMock()
+    submitter = _make_submitter(
+        broker=mock_broker,
+        market_clock=mock_market_clock,
+        states={"K1": object()},
+        transition=MagicMock(),
+        on_missing_fn=on_missing,
+    )
+
+    await submitter.submit_with_retry(
+        "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX, order_key="K1",
+    )
+
+    on_missing.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_skips_callback_when_response_not_success(mock_market_clock):
+    broker = AsyncMock()
+    broker.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="잔고 부족", data=None
+    )
+    on_missing = MagicMock()
+    submitter = _make_submitter(
+        broker=broker,
+        market_clock=mock_market_clock,
+        states={"K1": object()},
+        transition=MagicMock(),
+        on_missing_fn=on_missing,
+    )
+
+    await submitter.submit_with_retry(
+        "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX, order_key="K1",
+    )
+
+    on_missing.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_no_callback_provided_does_not_raise(mock_market_clock):
+    """on_missing_broker_order_no_fn 미주입 + 추출 실패 시 silently SUBMITTED 전이 유지."""
+    broker = AsyncMock()
+    broker.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"unexpected_key": "X"}
+    )
+    transition = MagicMock()
+    submitter = _make_submitter(
+        broker=broker,
+        market_clock=mock_market_clock,
+        states={"K1": object()},
+        transition=transition,
+        extract_no_fn=lambda r: None,
+        on_missing_fn=None,
+    )
+
+    result = await submitter.submit_with_retry(
+        "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX, order_key="K1",
+    )
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    transition.assert_called_once()
+    _, kwargs = transition.call_args
+    assert kwargs["broker_order_no"] is None
 
 
 # ── submit_with_retry: 재시도 케이스 ───────────────────────────────────────

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -305,6 +305,63 @@ async def test_on_safe_transition_critical_sets_alarm_and_emits(broker, fsm, rep
 
 
 @pytest.mark.asyncio
+async def test_on_broker_order_no_missing_sets_alarm_and_emits_notification(
+    broker, fsm, reporter, fixed_now
+):
+    notification = AsyncMock()
+    logger = _Logger()
+    svc = _make_service(
+        broker=broker,
+        fsm=fsm,
+        reporter=reporter,
+        fixed_now=fixed_now,
+        notification_service=notification,
+        logger=logger,
+    )
+    raw_payload = {"KRX_FWDG_ORD_ORGNO": "00950", "unexpected_key": "VAL1"}
+    result = ResCommonResponse(rt_cd="0", msg1="정상처리 되었습니다.", data=raw_payload)
+
+    svc.on_broker_order_no_missing(result, "005930", "KRX:005930:BUY")
+    await asyncio.gather(*list(svc._notification_tasks))
+
+    assert svc.is_reconcile_alarm_active() is True
+    assert svc._critical_alarm_manual_required is True
+    notification.emit.assert_awaited_once()
+    args, kwargs = notification.emit.await_args
+    assert args[0] == NotificationCategory.TRADE
+    assert args[1] == NotificationLevel.CRITICAL
+    metadata = kwargs["metadata"]
+    assert metadata["alert_type"] == "broker_order_no_missing"
+    assert metadata["stock_code"] == "005930"
+    assert metadata["order_key"] == "KRX:005930:BUY"
+    assert metadata["rt_cd"] == "0"
+    assert metadata["msg1"] == "정상처리 되었습니다."
+    assert "KRX_FWDG_ORD_ORGNO" in metadata["raw_data"]
+    logger.error.assert_called()
+
+
+def test_on_broker_order_no_missing_without_notification_service_only_sets_alarm(
+    broker, fsm, reporter, fixed_now
+):
+    logger = _Logger()
+    svc = _make_service(
+        broker=broker,
+        fsm=fsm,
+        reporter=reporter,
+        fixed_now=fixed_now,
+        notification_service=None,
+        logger=logger,
+    )
+    result = ResCommonResponse(rt_cd="0", msg1="OK", data={"foo": "bar"})
+
+    svc.on_broker_order_no_missing(result, "005930", "KRX:005930:BUY")
+
+    assert svc.is_reconcile_alarm_active() is True
+    assert svc._critical_alarm_manual_required is True
+    logger.error.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_critical_alarm_skips_auto_reset(broker, fsm, reporter, fixed_now):
     logger = _Logger()
     svc = _make_service(

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -619,7 +619,7 @@ async def test_sell_all_stocks_success(handler, mock_broker_api_wrapper, mock_lo
     )
     # 삼성전자는 성공, SK하이닉스는 API 실패 반환을 시뮬레이션
     mock_broker_api_wrapper.place_stock_order.side_effect = [
-        ResCommonResponse(rt_cd="0", msg1="매도 성공", data=None),
+        ResCommonResponse(rt_cd="0", msg1="매도 성공", data={"ordno": "O0001"}),
         ResCommonResponse(rt_cd="1", msg1="매도 실패", data=None)
     ]
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -50,9 +50,11 @@
 - [blocked] 민감정보를 제거한 fixture를 추가한다. (실전 응답 확보 후 진행)
 - [blocked] paper fixture와 real fixture의 필드 차이를 회귀 테스트에 반영한다. (실전 응답 확보 후 진행)
 - [blocked] 주문번호, 종목코드, 매수/매도 구분, 주문수량, 누적체결수량, 미체결수량, 평균체결가, 취소/거부 필드 매핑을 확정한다. (실전 응답 확보 후 진행)
-- [ ] 주문 접수 응답의 broker order number mapper를 실전/모의 fixture 기반으로 확장한다.
+- [x] 주문 접수 응답의 broker order number mapper를 실전/모의 fixture 기반으로 확장한다.
   - 검토 결과: 부분 타당. 현재 `OrderStateMachine.extract_broker_order_no()`는 `ordno`, `order_no`, `odno`만 확인한다. `inquire-daily-ccld`/미체결 조회 복원 쪽은 `ODNO`/`주문번호`도 일부 처리하지만, 최초 주문 응답 mapper는 더 좁다.
   - 개선 방향: raw broker response payload를 journal/diagnostic에 보존하고, 주문번호 추출 실패 시 reconcile alarm 또는 운영자 알림으로 승격한다.
+  - 완료된 부분(2026-05-24): `FillReconciliationService.on_broker_order_no_missing(result, stock_code, order_key)` 신규 메서드 추가 — `_reconcile_alarm = True` + `_critical_alarm_manual_required = True` 설정, `logger.error` 에 raw payload(`result.data` repr) 포함, `NotificationCategory.TRADE` + `NotificationLevel.CRITICAL` 운영자 알림 emit(`alert_type=broker_order_no_missing`, metadata 에 stock_code/order_key/rt_cd/msg1/raw_data 보존). `BrokerOrderSubmitter` 에 `on_missing_broker_order_no_fn` 콜백 파라미터 추가, success 응답에서 broker_no 추출 실패 시 raw payload 로그 + 콜백 호출(콜백 예외는 흡수해 주문 흐름 차단 방지). `OrderExecutionService` 가 `_fill_reconciliation` 을 `_broker_submitter` 보다 먼저 생성하고 콜백 wire. 다음 reconcile 사이클까지 신규 주문이 차단되며 운영자가 raw payload 로 누락 필드 진단 가능. 단위 5333, 통합 235 통과.
+  - 후속(blocked): 실전/모의 fixture 확보 후 mapper 에 `ODNO`(대문자), `주문번호`(한글) 등 추가 키 확장 — fixture 의존 항목.
 
 주요 파일:
 


### PR DESCRIPTION
변경 파일
services/fill_reconciliation_service.py — on_broker_order_no_missing() 메서드 추가 (on_safe_transition_critical 패턴) services/broker_order_submitter.py — on_missing_broker_order_no_fn 콜백 파라미터 추가, success 응답에서 broker_no 추출 실패 시 raw payload 로그 + 콜백 호출 services/order_execution_service.py — _fill_reconciliation 을 _broker_submitter 보다 먼저 생성하고 콜백 wire tests/unit_test/services/test_fill_reconciliation_service.py — 신규 테스트 2건 tests/unit_test/services/test_broker_order_submitter.py — 신규 테스트 4건 tests/unit_test/services/test_order_execution_service.py — test_sell_all_stocks_success mock fixture 를 현실적인 data={"ordno": "O0001"} 로 수정 todo_list.md — 항목 완료 표시
동작
주문 SUCCESS 응답이지만 extract_broker_order_no() 가 None 반환 시: WARNING 로그에 raw payload(result.data repr) 포함
FillReconciliationService.on_broker_order_no_missing() 콜백 호출 콜백은:
_reconcile_alarm = True + _critical_alarm_manual_required = True 설정 → OrderSubmissionCoordinator 가 신규 주문 차단 ERROR 로그 발행
NotificationCategory.TRADE + NotificationLevel.CRITICAL 운영자 알림 emit (metadata 에 stock_code/order_key/rt_cd/msg1/raw_data 보존) 검증
단위 테스트: 5333 passed (175s)
통합 테스트: 235 passed (148s)
외과수술적 변경, backward-compatible (모든 신규 파라미터 default None) 후속 항목(ODNO 대문자/주문번호 한글 키 확장)은 실전 fixture 의존이라 blocked 상태로 남겼습니다.