### PR TITLE
P0 0-1 후속: HTF 전략 추가 개선 4건 완료

### DIFF
--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -219,6 +219,46 @@ class HighTightFlagStrategy(LiveStrategy):
         if flag_avg_vol > avg_vol_50d * self._cfg.flag_volume_shrink_ratio:
             return None
 
+        # VCP 타이트함: 깃발 최근 N일 평균 변동폭이 깃대 평균 변동폭 대비 충분히 축소되었는지
+        pole_highs = highs[pole_start:peak_idx + 1]
+        pole_range_avg = (
+            sum(h - l for h, l in zip(pole_highs, pole_lows)) / len(pole_lows)
+            if pole_lows else 0.0
+        )
+        recent_n = min(self._cfg.vcp_recent_flag_days, flag_days)
+        flag_highs = highs[peak_idx + 1:]
+        flag_lows = lows[peak_idx + 1:]
+        recent_flag_range_avg = (
+            sum(h - l for h, l in zip(flag_highs[-recent_n:], flag_lows[-recent_n:])) / recent_n
+            if recent_n > 0 else 0.0
+        )
+        vcp_tightness_ratio = (
+            recent_flag_range_avg / pole_range_avg if pole_range_avg > 0 else 0.0
+        )
+        if (
+            self._cfg.vcp_tightness_check_enabled
+            and pole_range_avg > 0
+            and vcp_tightness_ratio > self._cfg.vcp_max_tightness_ratio
+        ):
+            return None
+
+        # 깃발 기간 20MA 지지: 깃발 각 일의 종가가 그 시점 20MA 대비 min_pct 이하로 떨어진 적이 없는지
+        ma20_min_deviation_pct = 0.0
+        if self._cfg.ma20_support_check_enabled:
+            for flag_idx in range(peak_idx + 1, n):
+                window_start = flag_idx - 19
+                if window_start < 0:
+                    continue
+                window = closes[window_start:flag_idx + 1]
+                ma20 = sum(window) / len(window)
+                if ma20 <= 0:
+                    continue
+                deviation_pct = (closes[flag_idx] - ma20) / ma20 * 100
+                if deviation_pct < ma20_min_deviation_pct:
+                    ma20_min_deviation_pct = deviation_pct
+                if deviation_pct < self._cfg.ma20_support_min_pct:
+                    return None
+
         return {
             "pole_high": peak_high,
             "pole_low": pole_low,
@@ -227,6 +267,10 @@ class HighTightFlagStrategy(LiveStrategy):
             "drawdown_pct": drawdown_pct,
             "avg_vol_50d": avg_vol_50d,
             "flag_avg_vol": flag_avg_vol,
+            "pole_range_avg": pole_range_avg,
+            "recent_flag_range_avg": recent_flag_range_avg,
+            "vcp_tightness_ratio": vcp_tightness_ratio,
+            "ma20_min_deviation_pct": ma20_min_deviation_pct,
         }
 
     async def _check_breakout(self, code, item, pattern, ohlcv, progress, market_timing_cache=None) -> Optional[TradeSignal]:
@@ -291,6 +335,29 @@ class HighTightFlagStrategy(LiveStrategy):
                 band=[int(min_entry), int(max_entry)],
             )
             return None
+
+        # 2-1. 돌파 확인 지연: pole_high 위 임계가에 분봉 종가가 N분 연속 유지되는지
+        if self._cfg.breakout_hold_check_enabled:
+            minutes = await self._sqs.get_day_intraday_minutes_list(code, session="REGULAR")
+            n_check = self._cfg.breakout_hold_minutes
+            if not minutes or len(minutes) < n_check:
+                self._log_entry_rejected(
+                    code, item, "breakout_hold_insufficient_data",
+                    minute_count=len(minutes) if minutes else 0,
+                    required=n_check,
+                )
+                return None
+            hold_threshold = pole_high * (1 + self._cfg.breakout_hold_min_pct / 100)
+            recent_prices = [int(m.get("stck_prpr", 0) or 0) for m in minutes[-n_check:]]
+            min_recent = min(recent_prices) if recent_prices else 0
+            if min_recent < hold_threshold:
+                self._log_entry_rejected(
+                    code, item, "breakout_hold_failed",
+                    threshold=int(hold_threshold),
+                    min_recent_price=min_recent,
+                    window_minutes=n_check,
+                )
+                return None
 
         # 🚨 [관문 2] 캔들 품질 검증 (Strict Quality!)
         day_range = day_high - day_low
@@ -396,6 +463,9 @@ class HighTightFlagStrategy(LiveStrategy):
         pg_mc_ratio = sm_metrics.get("pg_to_mc_pct", 0.0)
         pg_buy_amount = sm_metrics.get("pg_buy_amount", 0)
 
+        # 이격도: 매수 시점 가격이 pole_high 대비 몇 % 이격되었는지 (과확장 사후 분석용)
+        deviation_from_pole_high_pct = (current / pole_high - 1.0) * 100 if pole_high > 0 else 0.0
+
         # 2. 포지션 상태 저장
         self._position_state[code] = HTFPositionState(
             entry_price=current,
@@ -432,6 +502,9 @@ class HighTightFlagStrategy(LiveStrategy):
                 "pg_market_cap_pct": round(pg_mc_ratio, 3),
                 "execution_strength": cgld_val,
                 "candle_relative_pos": round(relative_pos, 2),
+                "deviation_from_pole_high_pct": round(deviation_from_pole_high_pct, 2),
+                "vcp_tightness_ratio": round(pattern.get("vcp_tightness_ratio", 0.0), 3),
+                "ma20_min_deviation_pct": round(pattern.get("ma20_min_deviation_pct", 0.0), 2),
                 "surge_ratio": round(pattern["surge_ratio"], 2),
                 "flag_days": pattern["flag_days"],
                 "drawdown_pct": round(pattern["drawdown_pct"], 1),

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -288,6 +288,20 @@ class HTFConfig(BaseStrategyConfig):
     afternoon_volume_multiplier: float = 3.0      # 오후 12시 이후 거래량 허들 강화 (2.0 → 3.0)
     afternoon_cutoff_hour: int = 12               # 오후 가중치 적용 기준 시각 (KST)
 
+    # VCP 타이트함: 깃발 최근 N일 일변동폭(고가-저가) 평균이 깃대 변동폭 평균 대비 충분히 축소되었는지
+    vcp_tightness_check_enabled: bool = False    # default off — 관찰 누적 후 hard gate 도입 결정
+    vcp_recent_flag_days: int = 5                # 깃발 마지막 N일 평균
+    vcp_max_tightness_ratio: float = 0.7         # flag_recent_range_avg / pole_range_avg <= 0.7
+
+    # 깃발 기간 20MA 지지: 깃발 종가가 그 시점 20일 MA 대비 일정 % 이상 하락한 적이 없는지
+    ma20_support_check_enabled: bool = False     # default off — 관찰 누적 후 hard gate 도입 결정
+    ma20_support_min_pct: float = -2.0           # 20MA 대비 -2% 이하 종가가 한 번이라도 있으면 거절
+
+    # 돌파 확인 지연: pole_high 돌파 후 N분간 분봉 종가가 임계가 위에 유지되는지 확인
+    breakout_hold_check_enabled: bool = False    # default off — 분봉 API 호출 비용 누적 후 도입 결정
+    breakout_hold_minutes: int = 3               # 최근 N개 분봉 검사
+    breakout_hold_min_pct: float = 0.0           # pole_high * (1 + min_pct/100) 임계가
+
 @dataclass
 class HTFPositionState:
     """HTF 포지션 추적 상태."""

--- a/tests/unit_test/strategies/test_high_tight_flag_strategy.py
+++ b/tests/unit_test/strategies/test_high_tight_flag_strategy.py
@@ -207,6 +207,58 @@ class TestDetectPoleAndFlag:
         result = strategy._detect_pole_and_flag(ohlcv)
         assert result is None
 
+    def test_pattern_dict_exposes_vcp_and_ma20_metrics(self, mock_deps):
+        """default off 상태에서도 pattern dict에 신규 metric 키가 포함되어 패턴은 감지된다."""
+        strategy = self._make_strategy(mock_deps)
+        ohlcv = _make_ohlcv_pole_and_flag(
+            pole_days=25, pole_start_price=5000, pole_end_price=10000,
+            flag_days=18, flag_drawdown_pct=10.0,
+            pole_volume=500000, flag_volume=100000,
+        )
+
+        result = strategy._detect_pole_and_flag(ohlcv)
+
+        assert result is not None
+        assert "vcp_tightness_ratio" in result
+        assert "ma20_min_deviation_pct" in result
+        assert result["pole_range_avg"] > 0
+        assert result["recent_flag_range_avg"] >= 0
+
+    def test_vcp_tightness_check_rejects_wide_flag(self, mock_deps):
+        """vcp_tightness_check_enabled=True + 매우 타이트한 임계값 → 깃발 변동폭이 임계 초과 → None."""
+        strategy = self._make_strategy(
+            mock_deps,
+            vcp_tightness_check_enabled=True,
+            vcp_recent_flag_days=5,
+            vcp_max_tightness_ratio=0.01,  # 깃발 변동폭이 깃대의 1% 이하여야 — 합성 데이터는 통과 불가
+        )
+        ohlcv = _make_ohlcv_pole_and_flag(
+            pole_days=25, pole_start_price=5000, pole_end_price=10000,
+            flag_days=18, flag_drawdown_pct=10.0,
+            pole_volume=500000, flag_volume=100000,
+        )
+
+        result = strategy._detect_pole_and_flag(ohlcv)
+        assert result is None
+
+    def test_ma20_support_check_rejects_deep_drop(self, mock_deps):
+        """ma20_support_check_enabled=True + 깃발 종가가 20MA 대비 -10% → None."""
+        strategy = self._make_strategy(
+            mock_deps,
+            ma20_support_check_enabled=True,
+            ma20_support_min_pct=-2.0,
+        )
+        ohlcv = _make_ohlcv_pole_and_flag(
+            pole_days=25, pole_start_price=5000, pole_end_price=10000,
+            flag_days=18, flag_drawdown_pct=10.0,
+            pole_volume=500000, flag_volume=100000,
+        )
+        # 깃발 중간에 종가 폭락 한 점 주입 (20MA 대비 약 -15%)
+        ohlcv[35]["close"] = int(ohlcv[35]["close"] * 0.85)
+
+        result = strategy._detect_pole_and_flag(ohlcv)
+        assert result is None
+
 
 # ── scan() 통합 테스트 ───────────────────────────────────────────────
 
@@ -248,6 +300,90 @@ async def test_scan_buy_signal(htf_scan_setup):
     assert "HTF돌파" in signals[0].reason
     assert "강도 151.0%" in signals[0].reason
     assert "정석" in signals[0].reason
+
+    # 이격도 메트릭이 buy_signal_generated 이벤트에 포함되는지 검증 (#4)
+    buy_events = [
+        call.args[0] for call in strategy._logger.info.call_args_list
+        if isinstance(call.args[0], dict) and call.args[0].get("event") == "buy_signal_generated"
+    ]
+    assert len(buy_events) == 1
+    metrics = buy_events[0]["metrics"]
+    assert "deviation_from_pole_high_pct" in metrics
+    # 현재가 10150 / pole_high 10000 → 1.50%
+    assert metrics["deviation_from_pole_high_pct"] == pytest.approx(1.5, abs=0.01)
+    assert "vcp_tightness_ratio" in metrics
+    assert "ma20_min_deviation_pct" in metrics
+
+
+@pytest.mark.asyncio
+async def test_scan_breakout_hold_check_rejects_when_below_threshold(htf_scan_setup):
+    """breakout_hold_check_enabled=True + 최근 분봉 종가가 pole_high 미만 → 시그널 없음 (#2)."""
+    strategy, sqs, _, _, _ = htf_scan_setup
+    strategy._cfg.breakout_hold_check_enabled = True
+    strategy._cfg.breakout_hold_minutes = 3
+    strategy._cfg.breakout_hold_min_pct = 0.0
+
+    ohlcv = _make_ohlcv_pole_and_flag(
+        pole_days=25, pole_start_price=5000, pole_end_price=10000,
+        flag_days=18, flag_drawdown_pct=10.0,
+        pole_volume=500000, flag_volume=100000,
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "10150", "stck_hgpr": "10160", "stck_lwpr": "10050",
+            "acml_vol": "700000", "pgtr_ntby_qty": "200000",
+            "acml_tr_pbmn": "6000000000",
+        }}
+    )
+    sqs.get_stock_conclusion.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": [{"tday_rltv": "151.0"}]}
+    )
+    # 최근 3분 중 하나가 pole_high(10000) 미만 → reject
+    sqs.get_day_intraday_minutes_list = AsyncMock(return_value=[
+        {"stck_cntg_hour": "115700", "stck_prpr": "10100"},
+        {"stck_cntg_hour": "115800", "stck_prpr": "9980"},
+        {"stck_cntg_hour": "115900", "stck_prpr": "10150"},
+    ])
+
+    signals = await strategy.scan()
+    assert signals == []
+    sqs.get_day_intraday_minutes_list.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_breakout_hold_check_passes_when_all_above_threshold(htf_scan_setup):
+    """breakout_hold_check_enabled=True + 모든 최근 분봉이 임계가 이상 → 시그널 정상 발생 (#2)."""
+    strategy, sqs, _, _, _ = htf_scan_setup
+    strategy._cfg.breakout_hold_check_enabled = True
+    strategy._cfg.breakout_hold_minutes = 3
+    strategy._cfg.breakout_hold_min_pct = 0.0
+
+    ohlcv = _make_ohlcv_pole_and_flag(
+        pole_days=25, pole_start_price=5000, pole_end_price=10000,
+        flag_days=18, flag_drawdown_pct=10.0,
+        pole_volume=500000, flag_volume=100000,
+    )
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {
+            "stck_prpr": "10150", "stck_hgpr": "10160", "stck_lwpr": "10050",
+            "acml_vol": "700000", "pgtr_ntby_qty": "200000",
+            "acml_tr_pbmn": "6000000000",
+        }}
+    )
+    sqs.get_stock_conclusion.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": [{"tday_rltv": "151.0"}]}
+    )
+    sqs.get_day_intraday_minutes_list = AsyncMock(return_value=[
+        {"stck_cntg_hour": "115700", "stck_prpr": "10100"},
+        {"stck_cntg_hour": "115800", "stck_prpr": "10120"},
+        {"stck_cntg_hour": "115900", "stck_prpr": "10150"},
+    ])
+
+    signals = await strategy.scan()
+    assert len(signals) == 1
+    assert signals[0].action == "BUY"
 
 
 @pytest.mark.asyncio

--- a/todo_list.md
+++ b/todo_list.md
@@ -740,7 +740,12 @@
 
 ## HTF 전략 추가 개선 (차후 검토)
 
-- [ ] **VCP 타이트함 검증**: 깃발 최근 3~5일 일변동폭(고가-저가) 평균이 깃대 구간 변동폭 대비 현저히 축소되었는지 `_detect_pole_and_flag`에 추가
-- [ ] **돌파 확인 지연**: pole_high 돌파 후 3~5분간 가격 유지 확인 로직 (현재는 +0.5% 버퍼로 대체)
-- [ ] **깃발 기간 20MA 지지**: 횡보 구간 최저점이 20일선을 심각하게 훼손하지 않았는지 확인
-- [ ] **이격도 모니터링**: 매수 시그널 발생 시 `(current/pole_high - 1) * 100`을 metrics 로그·대시보드에 노출
+- [x] **VCP 타이트함 검증**: 깃발 최근 3~5일 일변동폭(고가-저가) 평균이 깃대 구간 변동폭 대비 현저히 축소되었는지 `_detect_pole_and_flag`에 추가
+  - 완료(2026-05-24): `HTFConfig`에 `vcp_tightness_check_enabled: bool = False`(default off), `vcp_recent_flag_days: int = 5`, `vcp_max_tightness_ratio: float = 0.7` 추가. `_detect_pole_and_flag()`가 깃대 평균 변동폭과 깃발 최근 N일 평균 변동폭을 계산하고 ratio가 임계값 초과 시 None 반환. pattern dict에 `pole_range_avg`, `recent_flag_range_avg`, `vcp_tightness_ratio` 노출. 단위 테스트 2건 추가 (`test_pattern_dict_exposes_vcp_and_ma20_metrics`, `test_vcp_tightness_check_rejects_wide_flag`).
+- [x] **돌파 확인 지연**: pole_high 돌파 후 3~5분간 가격 유지 확인 로직 (현재는 +0.5% 버퍼로 대체)
+  - 완료(2026-05-24): `HTFConfig`에 `breakout_hold_check_enabled: bool = False`(default off), `breakout_hold_minutes: int = 3`, `breakout_hold_min_pct: float = 0.0` 추가. `_check_breakout()`에서 가격 돌파 밴드 통과 직후 `_sqs.get_day_intraday_minutes_list()`로 분봉 조회, 최근 N개 분봉 종가 중 하나라도 `pole_high * (1 + min_pct/100)` 미만이면 `breakout_hold_failed`로 차단. 데이터 부족 시 `breakout_hold_insufficient_data`. 단위 테스트 2건 추가 (`test_scan_breakout_hold_check_rejects_when_below_threshold`, `test_scan_breakout_hold_check_passes_when_all_above_threshold`).
+- [x] **깃발 기간 20MA 지지**: 횡보 구간 최저점이 20일선을 심각하게 훼손하지 않았는지 확인
+  - 완료(2026-05-24): `HTFConfig`에 `ma20_support_check_enabled: bool = False`(default off), `ma20_support_min_pct: float = -2.0` 추가. `_detect_pole_and_flag()`가 깃발 각 일의 그 시점 20일 MA를 계산하고 종가가 ma20 대비 `min_pct` 이하로 떨어진 적이 있으면 None 반환. 데이터 부족 일(window_start < 0)은 skip. pattern dict에 `ma20_min_deviation_pct` 노출. 단위 테스트 1건 추가 (`test_ma20_support_check_rejects_deep_drop`).
+- [x] **이격도 모니터링**: 매수 시그널 발생 시 `(current/pole_high - 1) * 100`을 metrics 로그·대시보드에 노출
+  - 완료(2026-05-24): `_check_breakout()` 매수 시그널 생성 직전 `deviation_from_pole_high_pct = (current / pole_high - 1) * 100`을 계산해 `buy_signal_generated` 이벤트의 `metrics` dict에 추가. `vcp_tightness_ratio`, `ma20_min_deviation_pct`도 함께 노출. 기존 `test_scan_buy_signal`에 metric assertion 추가.
+  - 검증: 단위 5338(이전 5333 → +5 신규), 통합 235 통과.


### PR DESCRIPTION
변경 파일
strategies/oneil_common_types.py — HTFConfig에 3개 게이트(6 필드) + 분봉 hold 게이트(3 필드) 추가 (모두 default off) strategies/high_tight_flag_strategy.py — _detect_pole_and_flag() VCP/MA20 게이트, _check_breakout() 분봉 hold 게이트, buy_signal_generated metrics에 deviation_from_pole_high_pct / vcp_tightness_ratio / ma20_min_deviation_pct 추가 tests/unit_test/strategies/test_high_tight_flag_strategy.py — 단위 테스트 5건 신규 + 기존 test_scan_buy_signal에 metric assertion 추가 todo_list.md — HTF 4건 모두 [x] + 구현 상세 기록
검증
단위 테스트: 5338 passed (이전 5333 → +5)
통합 테스트: 235 passed
외과수술적 변경 원칙 준수
모든 신규 게이트 *_check_enabled: bool = False default → 활성 운영 baseline 무영향 VCP/MA20 계산은 항상 수행해 pattern dict에 노출 (관찰 누적용), gate는 enabled일 때만 reject 분봉 API 호출은 breakout_hold_check_enabled=True일 때만 발생 → 비용 발생 없음