### PR TITLE
API budget limiter를 단순 quotation/account 동시성 제한에서 endpoint 성격별 운영 정책으…

### DIFF
--- a/core/retry_queue/api_budget_limiter.py
+++ b/core/retry_queue/api_budget_limiter.py
@@ -1,38 +1,73 @@
 import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import AsyncIterator, Mapping
+import time
+from typing import AsyncIterator, Awaitable, Callable, Mapping
 
 
 DEFAULT_API_BUDGET_LIMITS = {
-    "quotation": 8,
-    "account": 2,
-    "default": 8,
+    "quotation_price": 4,
+    "quotation_ohlcv": 2,
+    "quotation_conclusion": 3,
+    "quotation": 4,
+    "account_balance": 1,
+    "account_reconciliation": 1,
+    "account": 1,
+    "default": 4,
+}
+
+DEFAULT_API_RATE_LIMITS_PER_SEC = {
+    "quotation_price": 8.0,
+    "quotation_ohlcv": 3.0,
+    "quotation_conclusion": 5.0,
+    "quotation": 8.0,
+    "account_balance": 2.0,
+    "account_reconciliation": 2.0,
+    "account": 2.0,
+    "default": 8.0,
 }
 
 
 @dataclass
 class _CategoryBudget:
     limit: int
+    rate_limit_per_sec: float
     semaphore: asyncio.Semaphore
+    rate_lock: asyncio.Lock
+    next_available_at: float = 0.0
     active: int = 0
     acquired_total: int = 0
     max_observed_active: int = 0
 
 
 class ApiBudgetLimiter:
-    """전략/서비스가 공유하는 broker API 동시성 budget limiter."""
+    """전략/서비스가 공유하는 broker API 동시성/rate budget limiter."""
 
     def __init__(
         self,
         limits: Mapping[str, int] | None = None,
         *,
-        default_limit: int = 8,
+        rate_limits_per_sec: Mapping[str, float] | None = None,
+        default_limit: int = 4,
+        default_rate_limit_per_sec: float = 8.0,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         self._default_limit = self._validate_limit(default_limit)
+        self._default_rate_limit_per_sec = self._validate_rate_limit(default_rate_limit_per_sec)
+        self._sleep = sleep
+        self._monotonic = monotonic
         configured = dict(DEFAULT_API_BUDGET_LIMITS if limits is None else limits)
+        configured_rates = dict(
+            DEFAULT_API_RATE_LIMITS_PER_SEC
+            if rate_limits_per_sec is None
+            else rate_limits_per_sec
+        )
         self._budgets: dict[str, _CategoryBudget] = {
-            category: self._new_budget(limit)
+            category: self._new_budget(
+                limit,
+                configured_rates.get(category, self._default_rate_limit_per_sec),
+            )
             for category, limit in configured.items()
         }
 
@@ -40,6 +75,7 @@ class ApiBudgetLimiter:
     async def acquire(self, category: str | None) -> AsyncIterator[None]:
         actual_category = category if category is not None else "default"
         budget = self._budget_for(actual_category)
+        await self._wait_for_rate_slot(budget)
         await budget.semaphore.acquire()
         budget.active += 1
         budget.acquired_total += 1
@@ -54,6 +90,7 @@ class ApiBudgetLimiter:
         return {
             category: {
                 "limit": budget.limit,
+                "rate_limit_per_sec": budget.rate_limit_per_sec,
                 "active": budget.active,
                 "acquired_total": budget.acquired_total,
                 "max_observed_active": budget.max_observed_active,
@@ -64,15 +101,21 @@ class ApiBudgetLimiter:
     def _budget_for(self, category: str) -> _CategoryBudget:
         budget = self._budgets.get(category)
         if budget is None:
-            budget = self._new_budget(self._default_limit)
+            budget = self._new_budget(
+                self._default_limit,
+                self._default_rate_limit_per_sec,
+            )
             self._budgets[category] = budget
         return budget
 
-    def _new_budget(self, limit: int) -> _CategoryBudget:
+    def _new_budget(self, limit: int, rate_limit_per_sec: float) -> _CategoryBudget:
         validated = self._validate_limit(limit)
+        validated_rate = self._validate_rate_limit(rate_limit_per_sec)
         return _CategoryBudget(
             limit=validated,
+            rate_limit_per_sec=validated_rate,
             semaphore=asyncio.Semaphore(validated),
+            rate_lock=asyncio.Lock(),
         )
 
     @staticmethod
@@ -81,3 +124,20 @@ class ApiBudgetLimiter:
         if value < 1:
             raise ValueError("API budget limit must be >= 1")
         return value
+
+    @staticmethod
+    def _validate_rate_limit(rate_limit_per_sec: float) -> float:
+        value = float(rate_limit_per_sec)
+        if value <= 0:
+            raise ValueError("API rate limit must be > 0")
+        return value
+
+    async def _wait_for_rate_slot(self, budget: _CategoryBudget) -> None:
+        interval_sec = 1.0 / budget.rate_limit_per_sec
+        async with budget.rate_lock:
+            now = self._monotonic()
+            wait_sec = max(0.0, budget.next_available_at - now)
+            scheduled_at = max(now, budget.next_available_at)
+            budget.next_available_at = scheduled_at + interval_sec
+        if wait_sec > 0:
+            await self._sleep(wait_sec)

--- a/core/retry_queue/client_with_retry_queue.py
+++ b/core/retry_queue/client_with_retry_queue.py
@@ -31,6 +31,18 @@ _ACCOUNT_METHODS = frozenset({
     "inquire_filled_history",
 })
 
+_METHOD_BUDGET_CATEGORIES = {
+    "get_current_price": "quotation_price",
+    "get_current_conclusion": "quotation_conclusion",
+    "inquire_daily_itemchartprice": "quotation_ohlcv",
+    "inquire_time_itemchartprice": "quotation_ohlcv",
+    "inquire_time_dailychartprice": "quotation_ohlcv",
+    "get_account_balance": "account_balance",
+    "inquire_daily_ccld": "account_reconciliation",
+    "inquire_unfilled_orders": "account_reconciliation",
+    "inquire_filled_history": "account_reconciliation",
+}
+
 
 class ClientWithRetryQueue:
     """
@@ -76,6 +88,9 @@ class ClientWithRetryQueue:
 
 
 def _budget_category_for_method(name: str) -> str:
+    category = _METHOD_BUDGET_CATEGORIES.get(name)
+    if category is not None:
+        return category
     if name in _ACCOUNT_METHODS:
         return "account"
     return "quotation"

--- a/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
+++ b/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
@@ -2,7 +2,11 @@ import asyncio
 
 import pytest
 
-from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
+from core.retry_queue.api_budget_limiter import (
+    DEFAULT_API_BUDGET_LIMITS,
+    DEFAULT_API_RATE_LIMITS_PER_SEC,
+    ApiBudgetLimiter,
+)
 
 
 @pytest.mark.real_sleep
@@ -47,7 +51,42 @@ def test_default_category_is_explicitly_configured():
 
     snapshot = limiter.snapshot()
 
-    assert snapshot["default"]["limit"] == 8
+    assert snapshot["default"]["limit"] == 4
+
+
+def test_default_limits_include_endpoint_specific_real_operation_categories():
+    assert DEFAULT_API_BUDGET_LIMITS == {
+        "quotation_price": 4,
+        "quotation_ohlcv": 2,
+        "quotation_conclusion": 3,
+        "quotation": 4,
+        "account_balance": 1,
+        "account_reconciliation": 1,
+        "account": 1,
+        "default": 4,
+    }
+
+
+def test_default_rate_limits_use_conservative_operation_defaults():
+    assert DEFAULT_API_RATE_LIMITS_PER_SEC == {
+        "quotation_price": 8.0,
+        "quotation_ohlcv": 3.0,
+        "quotation_conclusion": 5.0,
+        "quotation": 8.0,
+        "account_balance": 2.0,
+        "account_reconciliation": 2.0,
+        "account": 2.0,
+        "default": 8.0,
+    }
+
+
+def test_limiter_snapshot_exposes_rate_limits():
+    limiter = ApiBudgetLimiter()
+
+    snapshot = limiter.snapshot()
+
+    assert snapshot["quotation_price"]["rate_limit_per_sec"] == 8.0
+    assert snapshot["account_reconciliation"]["rate_limit_per_sec"] == 2.0
 
 
 async def test_none_category_uses_default_budget():
@@ -57,3 +96,65 @@ async def test_none_category_uses_default_budget():
         snapshot = limiter.snapshot()
 
     assert snapshot["default"]["acquired_total"] == 1
+
+
+async def test_rate_limiter_reserves_future_slots_without_busy_loop():
+    sleeps = []
+    now = 100.0
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    limiter = ApiBudgetLimiter(
+        {"quotation_price": 4},
+        rate_limits_per_sec={"quotation_price": 2.0},
+        monotonic=lambda: now,
+        sleep=fake_sleep,
+    )
+
+    async with limiter.acquire("quotation_price"):
+        pass
+    async with limiter.acquire("quotation_price"):
+        pass
+    async with limiter.acquire("quotation_price"):
+        pass
+
+    assert sleeps == [0.5, 1.0]
+
+
+@pytest.mark.real_sleep
+async def test_account_reconciliation_budget_is_independent_from_quotation_scan_budget():
+    limiter = ApiBudgetLimiter(
+        {"quotation_price": 1, "account_reconciliation": 1},
+        rate_limits_per_sec={"quotation_price": 100.0, "account_reconciliation": 100.0},
+    )
+    quote_started = asyncio.Event()
+    release_quote = asyncio.Event()
+    blocked_quote_started = asyncio.Event()
+    reconcile_started = asyncio.Event()
+
+    async def hold_quote():
+        async with limiter.acquire("quotation_price"):
+            quote_started.set()
+            await release_quote.wait()
+
+    async def blocked_quote():
+        async with limiter.acquire("quotation_price"):
+            blocked_quote_started.set()
+
+    async def reconcile():
+        async with limiter.acquire("account_reconciliation"):
+            reconcile_started.set()
+
+    quote_task = asyncio.create_task(hold_quote())
+    await asyncio.wait_for(quote_started.wait(), timeout=1)
+
+    blocked_quote_task = asyncio.create_task(blocked_quote())
+    reconcile_task = asyncio.create_task(reconcile())
+
+    await asyncio.wait_for(reconcile_started.wait(), timeout=1)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(blocked_quote_started.wait(), timeout=0.05)
+
+    release_quote.set()
+    await asyncio.gather(quote_task, blocked_quote_task, reconcile_task)

--- a/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
+++ b/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
@@ -11,6 +11,7 @@ from core.retry_queue.client_with_retry_queue import (
     ClientWithRetryQueue,
     retry_queue_wrap_client,
     _EXCLUDED_METHODS,
+    _budget_category_for_method,
 )
 
 
@@ -25,6 +26,24 @@ class FakeClient:
         return success_resp()
 
     async def get_account_balance(self) -> ResCommonResponse:
+        return success_resp()
+
+    async def inquire_daily_ccld(self) -> ResCommonResponse:
+        return success_resp()
+
+    async def inquire_unfilled_orders(self) -> ResCommonResponse:
+        return success_resp()
+
+    async def inquire_daily_itemchartprice(self, stock_code: str) -> ResCommonResponse:
+        return success_resp()
+
+    async def inquire_time_itemchartprice(self, stock_code: str) -> ResCommonResponse:
+        return success_resp()
+
+    async def inquire_time_dailychartprice(self, stock_code: str) -> ResCommonResponse:
+        return success_resp()
+
+    async def get_current_conclusion(self, stock_code: str) -> ResCommonResponse:
         return success_resp()
 
     async def place_stock_order(self, code, price, qty, is_buy) -> ResCommonResponse:
@@ -107,7 +126,7 @@ class TestAsyncMethodThroughQueue:
 
         assert req.request_id == "get_current_price"
 
-    async def test_quotation_method_uses_quotation_budget_category(self, fake_client, queue):
+    async def test_quotation_method_uses_price_budget_category(self, fake_client, queue):
         categories = []
 
         class RecordingLimiter:
@@ -124,9 +143,9 @@ class TestAsyncMethodThroughQueue:
 
         await wrapped.get_current_price("005930")
 
-        assert categories == ["quotation"]
+        assert categories == ["quotation_price"]
 
-    async def test_account_method_uses_account_budget_category(self, fake_client, queue):
+    async def test_account_method_uses_balance_budget_category(self, fake_client, queue):
         categories = []
 
         class RecordingLimiter:
@@ -143,7 +162,24 @@ class TestAsyncMethodThroughQueue:
 
         await wrapped.get_account_balance()
 
-        assert categories == ["account"]
+        assert categories == ["account_balance"]
+
+    @pytest.mark.parametrize(
+        ("method_name", "expected_category"),
+        [
+            ("get_current_price", "quotation_price"),
+            ("get_current_conclusion", "quotation_conclusion"),
+            ("inquire_daily_itemchartprice", "quotation_ohlcv"),
+            ("inquire_time_itemchartprice", "quotation_ohlcv"),
+            ("inquire_time_dailychartprice", "quotation_ohlcv"),
+            ("get_account_balance", "account_balance"),
+            ("inquire_daily_ccld", "account_reconciliation"),
+            ("inquire_unfilled_orders", "account_reconciliation"),
+            ("unknown_lookup", "quotation"),
+        ],
+    )
+    def test_budget_category_for_method_uses_endpoint_specific_policy(self, method_name, expected_category):
+        assert _budget_category_for_method(method_name) == expected_category
 
 
 class TestExcludedMethodsBypassQueue:

--- a/todo_list.md
+++ b/todo_list.md
@@ -358,9 +358,10 @@
   - 완료된 부분: `core.retry_queue.api_budget_limiter.ApiBudgetLimiter` 추가. `BrokerAPIWrapper`가 shared limiter를 생성해 `ClientWithRetryQueue`에 주입하고, retry queue의 최초 호출/재시도 호출이 모두 limiter를 거치도록 연결했다.
   - 1차 정책: 조회성 API는 `quotation` 기본 동시성 8, 계좌 조회 API는 `account` 기본 동시성 2로 분리. 주문/WebSocket 메서드는 기존 제외 목록을 유지해 budget limiter와 retry queue를 우회한다.
   - 검증: retry queue 단위 88개, retry queue 통합 22개, broker wrapper 단위 33개, 전체 단위 4798개, 전체 통합 233개 통과.
-- [ ] API budget limiter 운영 정책을 실전 한도 기준으로 보정한다.
+- [x] API budget limiter 운영 정책을 실전 한도 기준으로 보정한다.
   - 2026-05-24 최신 main 리뷰 반영: 중앙 limiter 구조는 생겼지만, 실제 KIS endpoint별 제한과 운영 우선순위까지 확정된 것은 아니다.
-  - 남은 것: `quotation`/`account` 외에 OHLCV, current price, 주문, 체결조회, 잔고조회별 rate budget을 명시하고, 주문/청산/대사 경로가 조회성 scan 폭주에 밀리지 않는지 부하 테스트로 확인한다.
+  - 목표: `quotation`/`account` 외에 OHLCV, current price, 주문, 체결조회, 잔고조회별 rate budget을 명시하고, 주문/청산/대사 경로가 조회성 scan 폭주에 밀리지 않는지 부하 테스트로 확인한다.
+  - 완료된 부분(2026-05-25): `ApiBudgetLimiter` 기본 정책을 endpoint 성격별 category로 세분화했다. 동시성 budget은 `quotation_price=4`, `quotation_ohlcv=2`, `quotation_conclusion=3`, `quotation=4`, `account_balance=1`, `account_reconciliation=1`, `account=1`, `default=4`로 보수화하고, category별 초당 rate 예약 throttle(`rate_limit_per_sec`)을 추가했다. `ClientWithRetryQueue._budget_category_for_method()`가 current price / OHLCV / 체결강도 / 잔고 / 체결·미체결 대사 조회를 각각 분류한다. 주문/WebSocket은 기존처럼 retry queue와 budget limiter를 우회해 scan 조회 budget에 막히지 않는다. 회귀 테스트: endpoint 분류, rate snapshot, busy-loop 없는 rate 예약, quotation scan budget과 account reconciliation budget 독립성을 추가 검증. 공식 포털에는 2026-04-20 기준 REST/WebSocket 유량 공지가 노출되지만 상세 수치는 운영 전 재확인이 필요하므로, 기본값은 한도 단정이 아니라 실전 보호용 보수 운영값으로 둔다.
 - [x] 활성 전략의 exit check도 bounded gather 또는 순차/우선순위 정책으로 통일한다.
   - 검토 결과: 타당. `FirstPullbackStrategy`, `HighTightFlagStrategy`, `LarryWilliamsChannelBreakoutStrategy` 등 일부 전략은 holdings 전체에 대해 `asyncio.gather()`를 수행한다. VBO/레거시 일부는 순차 처리다.
   - 완료된 부분: `utils/async_concurrency.py::bounded_gather()` 헬퍼 신규 + 단위 테스트 7개. 활성 6개 전략(`FirstPullback`, `HighTightFlag`, `LarryWilliamsChannelBreakout`, `OneilPocketPivot`, `OneilSqueezeBreakout`, `Rsi2Pullback`)의 holdings exit gather를 `bounded_gather(..., limit=_EXIT_CONCURRENCY=15, return_exceptions=True)`로 교체했다. entry chunk_size(10)보다 높여 청산 경로에 우선순위를 부여한다.


### PR DESCRIPTION
…로 나눴습니다.

변경 핵심:
api_budget_limiter.py (line 8): 기본 category를 quotation_price, quotation_ohlcv, quotation_conclusion, account_balance, account_reconciliation 등으로 세분화하고 category별 초당 rate 예약 throttle을 추가했습니다. client_with_retry_queue.py (line 34): KIS 조회 메서드를 endpoint별 budget category로 매핑했습니다. 주문/WebSocket API는 기존처럼 retry queue와 budget limiter를 우회합니다. 즉 scan 조회 budget 때문에 주문/청산 호출 자체가 밀리지 않는 정책은 유지했습니다. todo_list.md (line 361): 해당 항목 완료로 갱신했습니다.
검증:
pytest tests/unit_test -v 통과, 5433개 수집
pytest tests/integration_test -v 통과, 235 passed
통합 테스트에서 기존 StrategyStateIO.save_atomic 종료 타이밍 warning 1건이 있었고 실패는 없었습니다. git diff --check 통과, Windows CRLF 변환 warning만 있었습니다. 참고로 KIS 공식 포털에는 2026-04-20 기준 REST/WebSocket 유량 안내 공지가 노출되어 있어 최신 한도는 운영 전 재확인이 필요합니다: KIS Developers 공지 목록. 이번 기본값은 한도 단정이 아니라 실전 보호용 보수 운영값으로 잡았습니다.