### PR TITLE
P0 0-2 완료 보고

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -44,6 +44,12 @@ risk_gate:
   max_daily_order_amount_won: 50000000
   max_pending_orders: 10
   max_total_exposure_pct: 95.0
+  # is_paper_trading=false (실전) 일 때 자동 적용되는 canary overlay.
+  # 검증 전 운영을 보호하기 위해 더 보수적인 한도를 강제한다. paper 동작은 영향 없음.
+  # production 등급으로 풀고 싶을 때만 명시값을 주면 yaml 값이 우선한다.
+  real_mode_overrides:
+    max_total_exposure_pct: 30.0
+    max_pending_orders: 5
 
 # Order policy / liquidity guard before order submit
 order_policy:
@@ -69,6 +75,12 @@ order_policy:
   block_investment_caution: false
   blocked_stock_status_codes: ["51", "52", "53", "58"]
   quote_fail_policy: "block"
+  # 실전 모드에서 fail-close 지향 canary overlay.
+  real_mode_overrides:
+    allow_market_buy: false
+    max_market_slippage_pct: 0.5
+    max_spread_pct: 0.5
+    max_top_of_book_participation_pct: 10.0
 
 # 주문 제출 재시도 정책
 order_execution:
@@ -161,3 +173,7 @@ position_sizing:
   atr_multiplier: 2.0
   min_stop_distance_pct: 1.0       # 산식 보호용 최소 손절 거리 (%)
   snapshot_ttl_sec: 60             # 잔고 스냅샷 안전망 TTL (초)
+  # 실전 모드에서 자동 적용되는 canary overlay.
+  real_mode_overrides:
+    per_trade_risk_pct: 0.5
+    max_per_position_pct: 3.0

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -34,6 +34,17 @@ class KillSwitchConfig(BaseModel):
     abnormal_fill_deviation_pct: float = 3.0
     state_file_path: str = "data/kill_switch_state.json"
 
+class PositionSizingRealOverrides(BaseModel):
+    """실전(real) 모드 전용 PositionSizing overlay. paper 동작은 영향 없음.
+
+    canary 임계로 default 값을 잡았다. 운영 검증 후 더 느슨한 값을 쓰려면 yaml 에서 명시.
+    """
+    per_trade_risk_pct: float = 0.5        # canary: 0.25~0.5 권장 중 보수값
+    max_per_position_pct: float = 3.0      # canary: 2.0~3.0 권장 중 보수값
+
+    model_config = {"extra": "allow"}
+
+
 class PositionSizingConfig(BaseModel):
     enabled: bool = True
     per_trade_risk_pct: float = 1.5        # 1주당 리스크 한도 (총자산 대비 %)
@@ -43,6 +54,7 @@ class PositionSizingConfig(BaseModel):
     atr_multiplier: float = 2.0
     min_stop_distance_pct: float = 1.0     # 분모 보호용 최소 손절 거리 (%)
     snapshot_ttl_sec: int = 60             # 잔고 스냅샷 TTL (초)
+    real_mode_overrides: PositionSizingRealOverrides = Field(default_factory=PositionSizingRealOverrides)
 
     model_config = {"extra": "allow"}
 
@@ -71,6 +83,14 @@ class RiskGateFailOpenConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class RiskGateRealOverrides(BaseModel):
+    """실전(real) 모드 전용 RiskGate overlay. paper 동작은 영향 없음."""
+    max_total_exposure_pct: float = 30.0   # canary: 20.0~35.0 권장 중 중앙값
+    max_pending_orders: int = 5            # canary: 3~5 권장 중 보수값
+
+    model_config = {"extra": "allow"}
+
+
 class RiskGateConfig(BaseModel):
     enabled: bool = True
     max_order_amount_won: int = 2_000_000
@@ -81,6 +101,23 @@ class RiskGateConfig(BaseModel):
     default_strategy_limit: RiskGateStrategyLimitConfig = Field(default_factory=RiskGateStrategyLimitConfig)
     strategy_limits: Dict[str, RiskGateStrategyLimitConfig] = Field(default_factory=dict)
     fail_open_allowed: RiskGateFailOpenConfig = Field(default_factory=RiskGateFailOpenConfig)
+    real_mode_overrides: RiskGateRealOverrides = Field(default_factory=RiskGateRealOverrides)
+
+    model_config = {"extra": "allow"}
+
+
+class OrderPolicyRealOverrides(BaseModel):
+    """실전(real) 모드 전용 OrderPolicy overlay. paper 동작은 영향 없음.
+
+    fail-close 지향 canary 기본값:
+    - 시장가 매수 차단 (시장 변동성에 대한 과다 노출 방지)
+    - 슬리피지/스프레드 0.5% 제한
+    - 1호가 잔량 대비 최대 10% 참여
+    """
+    allow_market_buy: bool = False
+    max_market_slippage_pct: float = 0.5
+    max_spread_pct: float = 0.5
+    max_top_of_book_participation_pct: float = 10.0
 
     model_config = {"extra": "allow"}
 
@@ -115,6 +152,7 @@ class OrderPolicyConfig(BaseModel):
     blocked_market_warning_codes: List[str] = Field(default_factory=lambda: ["2", "3"])
     blocked_sell_stock_status_codes: List[str] = Field(default_factory=lambda: ["58"])
     quote_fail_policy: str = "block"        # allow | block
+    real_mode_overrides: OrderPolicyRealOverrides = Field(default_factory=OrderPolicyRealOverrides)
 
     model_config = {"extra": "allow"}
 

--- a/services/order_policy_service.py
+++ b/services/order_policy_service.py
@@ -70,12 +70,40 @@ class OrderPolicyService:
         security_info_provider: Optional[SecurityInfoProvider] = None,
         trade_flow_provider: Optional[TradeFlowProvider] = None,
         logger: Optional[logging.Logger] = None,
+        env: Optional[Any] = None,
     ):
         self._cfg = config
         self._quote_provider = quote_provider
         self._security_info_provider = security_info_provider
         self._trade_flow_provider = trade_flow_provider
         self._logger = logger or logging.getLogger(__name__)
+        self._env = env
+
+    def _is_real_mode(self) -> bool:
+        env = self._env
+        if env is None:
+            return False
+        return not bool(getattr(env, "is_paper_trading", True))
+
+    def _effective_allow_market_buy(self) -> bool:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.allow_market_buy
+        return self._cfg.allow_market_buy
+
+    def _effective_max_market_slippage_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_market_slippage_pct
+        return self._cfg.max_market_slippage_pct
+
+    def _effective_max_spread_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_spread_pct
+        return self._cfg.max_spread_pct
+
+    def _effective_max_top_of_book_participation_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_top_of_book_participation_pct
+        return self._cfg.max_top_of_book_participation_pct
 
     async def validate_order(
         self,
@@ -394,7 +422,7 @@ class OrderPolicyService:
                 "NXT 거래소에서는 시장가 주문을 허용하지 않습니다.",
                 exchange=exchange.value,
             )
-        if side == OrderSide.BUY and not self._cfg.allow_market_buy:
+        if side == OrderSide.BUY and not self._effective_allow_market_buy():
             return self._blocked("market_buy_disabled", "시장가 매수 주문이 비활성화되어 있습니다.")
         if side == OrderSide.SELL and not self._cfg.allow_market_sell:
             return self._blocked("market_sell_disabled", "시장가 매도 주문이 비활성화되어 있습니다.")
@@ -493,7 +521,8 @@ class OrderPolicyService:
 
         mid = (ask + bid) / 2 if ask > 0 and bid > 0 else current_price
         spread_pct = ((ask - bid) / mid * 100) if mid and ask > 0 and bid > 0 else 0.0
-        if spread_pct > self._cfg.max_spread_pct:
+        effective_max_spread_pct = self._effective_max_spread_pct()
+        if spread_pct > effective_max_spread_pct:
             return self._blocked(
                 "spread_too_wide",
                 "스프레드가 허용 범위를 초과했습니다.",
@@ -501,7 +530,7 @@ class OrderPolicyService:
                 ask=ask,
                 bid=bid,
                 spread_pct=round(spread_pct, 3),
-                max_spread_pct=self._cfg.max_spread_pct,
+                max_spread_pct=effective_max_spread_pct,
             )
 
         executable_price = ask if side == OrderSide.BUY else bid
@@ -513,7 +542,8 @@ class OrderPolicyService:
                 if reference_price and executable_price
                 else 0.0
             )
-        if order_type == "market" and slippage_pct > self._cfg.max_market_slippage_pct:
+        effective_max_market_slippage_pct = self._effective_max_market_slippage_pct()
+        if order_type == "market" and slippage_pct > effective_max_market_slippage_pct:
             return self._blocked(
                 "market_slippage_too_high",
                 "시장가 예상 슬리피지가 허용 범위를 초과했습니다.",
@@ -522,7 +552,7 @@ class OrderPolicyService:
                 executable_price=executable_price,
                 reference_price=reference_price,
                 slippage_pct=round(slippage_pct, 3),
-                max_market_slippage_pct=self._cfg.max_market_slippage_pct,
+                max_market_slippage_pct=effective_max_market_slippage_pct,
             )
 
         if self._cfg.min_trading_value_won > 0:
@@ -556,9 +586,10 @@ class OrderPolicyService:
                 top_of_book_qty=top_of_book_qty,
                 available_book_qty=book_qty,
             )
-        if book_qty > 0 and self._cfg.max_top_of_book_participation_pct > 0:
+        effective_max_top_participation_pct = self._effective_max_top_of_book_participation_pct()
+        if book_qty > 0 and effective_max_top_participation_pct > 0:
             participation_pct = qty / book_qty * 100
-            if participation_pct > self._cfg.max_top_of_book_participation_pct:
+            if participation_pct > effective_max_top_participation_pct:
                 return self._blocked(
                     "top_of_book_participation_too_high",
                     "주문 수량이 최우선 호가 잔량 대비 허용 비율을 초과합니다.",
@@ -568,7 +599,7 @@ class OrderPolicyService:
                     top_of_book_qty=top_of_book_qty,
                     available_book_qty=book_qty,
                     participation_pct=round(participation_pct, 3),
-                    max_top_of_book_participation_pct=self._cfg.max_top_of_book_participation_pct,
+                    max_top_of_book_participation_pct=effective_max_top_participation_pct,
                 )
 
         return OrderPolicyDecision(

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -43,6 +43,7 @@ class PositionSizingService:
         risk_gate_config: Optional["RiskGateConfig"] = None,
         quote_provider: Optional[QuoteProvider] = None,
         order_policy_config: Optional["OrderPolicyConfig"] = None,
+        env: Optional[Any] = None,
     ):
         self._cache = account_snapshot_cache
         self._indicator = indicator_service
@@ -51,6 +52,24 @@ class PositionSizingService:
         self._risk_gate_config = risk_gate_config
         self._quote_provider = quote_provider
         self._order_policy_config = order_policy_config
+        self._env = env
+
+    def _is_real_mode(self) -> bool:
+        """env 미주입이면 paper 로 간주 (보수적 default)."""
+        env = self._env
+        if env is None:
+            return False
+        return not bool(getattr(env, "is_paper_trading", True))
+
+    def _effective_per_trade_risk_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.per_trade_risk_pct
+        return self._cfg.per_trade_risk_pct
+
+    def _effective_max_per_position_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_per_position_pct
+        return self._cfg.max_per_position_pct
 
     # ── 공개 API ──────────────────────────────────────────────────
 
@@ -92,12 +111,12 @@ class PositionSizingService:
         per_share_risk = await self._get_per_share_risk_krw(signal, price)
 
         # 3. risk_qty (Penbold Fixed Fractional)
-        total_risk_krw = total_equity * self._cfg.per_trade_risk_pct / 100
+        total_risk_krw = total_equity * self._effective_per_trade_risk_pct() / 100
         risk_qty = math.floor(total_risk_krw / per_share_risk) if per_share_risk > 0 else 0
 
         # 4. cap_qty (단일 종목 비중 상한 — 기존 보유분 차감)
         weight_budget = max(
-            total_equity * self._cfg.max_per_position_pct / 100 - current_position_value,
+            total_equity * self._effective_max_per_position_pct() / 100 - current_position_value,
             0,
         )
         cap_qty = math.floor(weight_budget / price) if price > 0 else 0

--- a/services/predeploy_check_service.py
+++ b/services/predeploy_check_service.py
@@ -361,6 +361,71 @@ class PreDeployCheckService:
 
         return await self._measured("api_budget_limiter", run)
 
+    async def check_real_mode_policy_strictness(self) -> CheckResult:
+        """real 모드일 때 effective PositionSizing / RiskGate / OrderPolicy 값이
+        canary 임계보다 느슨하면 WARN 또는 FAIL 을 낸다.
+
+        canary 임계는 각 RealOverrides 클래스의 default 값 (P0 0-2 정책 합의값).
+        loose factor 1.5× 까지는 WARN, 그 이상은 FAIL.
+        OrderPolicy.allow_market_buy=True 는 real 모드에서 즉시 FAIL.
+        paper 모드면 SKIPPED.
+        """
+        async def run() -> CheckResult:
+            cfg = self._cached_config or self._config_loader()
+            self._cached_config = cfg
+            is_paper = bool(getattr(cfg, "is_paper_trading", True))
+            if is_paper:
+                return CheckResult(name="", status=CheckStatus.SKIPPED, detail="paper 모드 — strictness check skip")
+
+            warns: List[str] = []
+            fails: List[str] = []
+
+            ps_cfg = getattr(cfg, "position_sizing", None)
+            rg_cfg = getattr(cfg, "risk_gate", None)
+            op_cfg = getattr(cfg, "order_policy", None)
+
+            def _grade(name: str, effective: float, canary: float, *, lower_is_safer: bool = True) -> None:
+                """effective 가 canary 임계보다 얼마나 느슨한지 평가."""
+                if lower_is_safer:
+                    if effective > canary * 1.5:
+                        fails.append(f"{name}={effective} (canary={canary}, loose>1.5x)")
+                    elif effective > canary:
+                        warns.append(f"{name}={effective} (canary={canary})")
+                else:
+                    if effective < canary / 1.5:
+                        fails.append(f"{name}={effective} (canary={canary}, tight<0.67x)")
+                    elif effective < canary:
+                        warns.append(f"{name}={effective} (canary={canary})")
+
+            if ps_cfg is not None:
+                ov = ps_cfg.real_mode_overrides
+                _grade("position_sizing.per_trade_risk_pct", ov.per_trade_risk_pct, 0.5)
+                _grade("position_sizing.max_per_position_pct", ov.max_per_position_pct, 3.0)
+
+            if rg_cfg is not None:
+                ov = rg_cfg.real_mode_overrides
+                _grade("risk_gate.max_total_exposure_pct", ov.max_total_exposure_pct, 30.0)
+                _grade("risk_gate.max_pending_orders", ov.max_pending_orders, 5)
+
+            if op_cfg is not None:
+                ov = op_cfg.real_mode_overrides
+                if ov.allow_market_buy:
+                    fails.append("order_policy.allow_market_buy=True (real 모드 fail-close 위반)")
+                _grade("order_policy.max_market_slippage_pct", ov.max_market_slippage_pct, 0.5)
+                _grade("order_policy.max_spread_pct", ov.max_spread_pct, 0.5)
+                _grade("order_policy.max_top_of_book_participation_pct", ov.max_top_of_book_participation_pct, 10.0)
+
+            if fails:
+                detail = "FAIL: " + "; ".join(fails)
+                if warns:
+                    detail += " | WARN: " + "; ".join(warns)
+                return CheckResult(name="", status=CheckStatus.FAIL, detail=detail)
+            if warns:
+                return CheckResult(name="", status=CheckStatus.WARN, detail="WARN: " + "; ".join(warns))
+            return CheckResult(name="", status=CheckStatus.PASS, detail="real 모드 정책이 canary 임계 안에 있음")
+
+        return await self._measured("real_mode_policy_strictness", run)
+
     # -- runner -------------------------------------------------------------
 
     async def run_all(self, *, offline: bool = False) -> PreDeployCheckSummary:
@@ -372,4 +437,5 @@ class PreDeployCheckService:
         results.append(await self.check_websocket_subscription(offline=offline))
         results.append(await self.check_account_snapshot(offline=offline))
         results.append(await self.check_api_budget_limiter())
+        results.append(await self.check_real_mode_policy_strictness())
         return PreDeployCheckSummary(results=results)

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -126,12 +126,13 @@ class RiskGateService:
                 side=side.value,
             )
 
-        if active_order_count >= self._cfg.max_pending_orders:
+        effective_max_pending = self._effective_max_pending_orders()
+        if active_order_count >= effective_max_pending:
             return self._blocked(
                 "max_pending_orders",
                 "진행 중 주문 수 초과",
                 active_order_count=active_order_count,
-                max_pending_orders=self._cfg.max_pending_orders,
+                max_pending_orders=effective_max_pending,
             )
 
         effective_price = price
@@ -368,6 +369,16 @@ class RiskGateService:
             return not bool(getattr(fail_open_cfg, "real", False))
         return not bool(getattr(fail_open_cfg, "paper", True))
 
+    def _effective_max_total_exposure_pct(self) -> float:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_total_exposure_pct
+        return self._cfg.max_total_exposure_pct
+
+    def _effective_max_pending_orders(self) -> int:
+        if self._is_real_mode():
+            return self._cfg.real_mode_overrides.max_pending_orders
+        return self._cfg.max_pending_orders
+
     async def _resolve_market_buy_reference_price(
         self,
         stock_code: str,
@@ -471,7 +482,8 @@ class RiskGateService:
 
         current_exposure = sum(max(value, 0) for value in snapshot.positions.values())
         next_exposure_pct = (current_exposure + order_amount) / snapshot.total_equity * 100
-        if next_exposure_pct > self._cfg.max_total_exposure_pct:
+        effective_max_exposure_pct = self._effective_max_total_exposure_pct()
+        if next_exposure_pct > effective_max_exposure_pct:
             return self._blocked(
                 "max_total_exposure",
                 "계좌 노출 한도 초과",
@@ -480,7 +492,7 @@ class RiskGateService:
                 order_amount=order_amount,
                 total_equity=snapshot.total_equity,
                 next_exposure_pct=round(next_exposure_pct, 2),
-                max_total_exposure_pct=self._cfg.max_total_exposure_pct,
+                max_total_exposure_pct=effective_max_exposure_pct,
             )
 
         return None

--- a/tests/integration_test/test_it_predeploy_check.py
+++ b/tests/integration_test/test_it_predeploy_check.py
@@ -30,7 +30,7 @@ async def test_offline_predeploy_check_runs_to_completion(tmp_path):
     summary = await service.run_all(offline=True)
 
     # 모든 점검이 끝까지 실행되어야 한다
-    assert len(summary.results) == 7
+    assert len(summary.results) == 8
     names = {r.name for r in summary.results}
     assert names == {
         "config_validation",
@@ -40,6 +40,7 @@ async def test_offline_predeploy_check_runs_to_completion(tmp_path):
         "websocket_subscription_health",
         "account_snapshot_freshness",
         "api_budget_limiter",
+        "real_mode_policy_strictness",
     }
 
     # offline 모드에서 broker 의존 점검은 SKIPPED

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -133,6 +133,59 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.order_execution.order_retry_delay_sec == 3
 
 
+def test_position_sizing_real_mode_overrides_defaults_are_canary_friendly():
+    """P0 0-2: 실전 모드 기본 overlay 가 canary 임계 안에 있는지 회귀."""
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+    )
+    overrides = config.position_sizing.real_mode_overrides
+    assert overrides.per_trade_risk_pct == 0.5
+    assert overrides.max_per_position_pct == 3.0
+
+
+def test_risk_gate_real_mode_overrides_defaults_are_canary_friendly():
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+    )
+    overrides = config.risk_gate.real_mode_overrides
+    assert overrides.max_total_exposure_pct == 30.0
+    assert overrides.max_pending_orders == 5
+
+
+def test_order_policy_real_mode_overrides_defaults_are_canary_friendly():
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+    )
+    overrides = config.order_policy.real_mode_overrides
+    assert overrides.allow_market_buy is False
+    assert overrides.max_market_slippage_pct == 0.5
+    assert overrides.max_spread_pct == 0.5
+    assert overrides.max_top_of_book_participation_pct == 10.0
+
+
+def test_real_mode_overrides_accept_user_yaml_values():
+    """운영자가 production 등급으로 overlay 값을 풀고 싶을 때 yaml 로드가 동작하는지."""
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        position_sizing={"real_mode_overrides": {"per_trade_risk_pct": 0.25, "max_per_position_pct": 2.0}},
+        risk_gate={"real_mode_overrides": {"max_total_exposure_pct": 20.0, "max_pending_orders": 3}},
+        order_policy={
+            "real_mode_overrides": {
+                "allow_market_buy": True,
+                "max_market_slippage_pct": 0.3,
+                "max_spread_pct": 0.3,
+                "max_top_of_book_participation_pct": 5.0,
+            }
+        },
+    )
+    assert config.position_sizing.real_mode_overrides.per_trade_risk_pct == 0.25
+    assert config.position_sizing.real_mode_overrides.max_per_position_pct == 2.0
+    assert config.risk_gate.real_mode_overrides.max_total_exposure_pct == 20.0
+    assert config.risk_gate.real_mode_overrides.max_pending_orders == 3
+    assert config.order_policy.real_mode_overrides.allow_market_buy is True
+    assert config.order_policy.real_mode_overrides.max_market_slippage_pct == 0.3
+
+
 def test_app_config_accepts_order_execution_retry_policy():
     config = AppConfig(
         web={"host": "localhost", "port": 8080},

--- a/tests/unit_test/services/test_order_policy_service.py
+++ b/tests/unit_test/services/test_order_policy_service.py
@@ -9,7 +9,7 @@ from services.execution_flow_service import ExecutionFlowSnapshot
 from services.order_policy_service import OrderPolicyDecision, OrderPolicyService
 
 
-def _service(*, config=None, quote_provider=None, security_info_provider=None, trade_flow_provider=None, logger=None):
+def _service(*, config=None, quote_provider=None, security_info_provider=None, trade_flow_provider=None, logger=None, env=None):
     cfg = config or OrderPolicyConfig()
     if security_info_provider is None:
         cfg = cfg.model_copy(update={"security_status_checks_enabled": False})
@@ -21,6 +21,7 @@ def _service(*, config=None, quote_provider=None, security_info_provider=None, t
         security_info_provider=security_info_provider,
         trade_flow_provider=trade_flow_provider,
         logger=logger or MagicMock(),
+        env=env,
     )
 
 
@@ -1100,3 +1101,66 @@ async def test_trade_flow_blocks_conclusion_unavailable_and_low_strength():
 
     assert conclusion.context["trade_flow_error"] == "conclusion_unavailable"
     assert low_strength.rule == "trade_flow_strength_too_low"
+
+
+# ── P0 0-2: OrderPolicy real_mode_overrides 분기 ──────────────────────
+
+class _PaperEnv:
+    is_paper_trading = True
+
+
+class _RealEnv:
+    is_paper_trading = False
+
+
+def test_order_policy_paper_uses_top_level():
+    cfg = OrderPolicyConfig(allow_market_buy=True, max_spread_pct=1.0, max_market_slippage_pct=1.0, max_top_of_book_participation_pct=100.0)
+    svc = _service(config=cfg, env=_PaperEnv())
+    assert svc._effective_allow_market_buy() is True
+    assert svc._effective_max_spread_pct() == 1.0
+    assert svc._effective_max_market_slippage_pct() == 1.0
+    assert svc._effective_max_top_of_book_participation_pct() == 100.0
+
+
+def test_order_policy_real_uses_override_defaults():
+    cfg = OrderPolicyConfig(allow_market_buy=True, max_spread_pct=1.0, max_market_slippage_pct=1.0, max_top_of_book_participation_pct=100.0)
+    svc = _service(config=cfg, env=_RealEnv())
+    # canary 기본값
+    assert svc._effective_allow_market_buy() is False
+    assert svc._effective_max_spread_pct() == 0.5
+    assert svc._effective_max_market_slippage_pct() == 0.5
+    assert svc._effective_max_top_of_book_participation_pct() == 10.0
+
+
+def test_order_policy_real_user_yaml_overrides():
+    cfg = OrderPolicyConfig(
+        allow_market_buy=True,
+        max_spread_pct=1.0,
+        max_market_slippage_pct=1.0,
+        max_top_of_book_participation_pct=100.0,
+        real_mode_overrides={
+            "allow_market_buy": True,
+            "max_spread_pct": 0.3,
+            "max_market_slippage_pct": 0.3,
+            "max_top_of_book_participation_pct": 5.0,
+        },
+    )
+    svc = _service(config=cfg, env=_RealEnv())
+    assert svc._effective_allow_market_buy() is True
+    assert svc._effective_max_spread_pct() == 0.3
+    assert svc._effective_max_market_slippage_pct() == 0.3
+    assert svc._effective_max_top_of_book_participation_pct() == 5.0
+
+
+def test_order_policy_real_mode_blocks_market_buy():
+    """paper 에서 통과하던 시장가 매수가 real canary overlay 에서 차단되어야 한다."""
+    cfg = OrderPolicyConfig(allow_market_buy=True)
+    paper_svc = _service(config=cfg, env=_PaperEnv())
+    real_svc = _service(config=cfg, env=_RealEnv())
+
+    paper_decision = paper_svc._check_market_order_type(side=OrderSide.BUY, exchange=Exchange.KRX)
+    real_decision = real_svc._check_market_order_type(side=OrderSide.BUY, exchange=Exchange.KRX)
+
+    assert paper_decision is None
+    assert real_decision is not None
+    assert real_decision.rule == "market_buy_disabled"

--- a/tests/unit_test/services/test_position_sizing_service.py
+++ b/tests/unit_test/services/test_position_sizing_service.py
@@ -445,3 +445,97 @@ async def test_no_order_amount_cap_when_risk_gate_not_set():
 
     assert qty == 5
     assert reason == "ok"
+
+
+# ── P0 0-2: real_mode_overrides 분기 ──────────────────────────────────
+
+def _env(is_paper_trading: bool):
+    env = MagicMock()
+    env.is_paper_trading = is_paper_trading
+    return env
+
+
+def _make_service_with_env(env, cfg=None):
+    cache = AsyncMock()
+    cache.get.return_value = _make_snapshot(
+        total_equity=10_000_000,
+        available_cash=10_000_000,
+    )
+    indicator = AsyncMock()
+    indicator.calculate_atr.return_value = None
+    svc = PositionSizingService(
+        account_snapshot_cache=cache,
+        indicator_service=indicator,
+        config=cfg or _make_config(),
+        env=env,
+    )
+    return svc
+
+
+def test_position_sizing_is_real_mode_default_false_when_env_missing():
+    svc = _make_service_with_env(env=None)
+    assert svc._is_real_mode() is False
+
+
+def test_position_sizing_is_real_mode_false_for_paper_env():
+    svc = _make_service_with_env(env=_env(is_paper_trading=True))
+    assert svc._is_real_mode() is False
+
+
+def test_position_sizing_is_real_mode_true_for_real_env():
+    svc = _make_service_with_env(env=_env(is_paper_trading=False))
+    assert svc._is_real_mode() is True
+
+
+def test_position_sizing_paper_uses_top_level_values():
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_env(env=_env(is_paper_trading=True), cfg=cfg)
+    assert svc._effective_per_trade_risk_pct() == 1.5
+    assert svc._effective_max_per_position_pct() == 5.0
+
+
+def test_position_sizing_real_uses_overrides():
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_env(env=_env(is_paper_trading=False), cfg=cfg)
+    # overrides default canary 값 적용
+    assert svc._effective_per_trade_risk_pct() == 0.5
+    assert svc._effective_max_per_position_pct() == 3.0
+
+
+def test_position_sizing_real_uses_overrides_user_yaml():
+    cfg = PositionSizingConfig(
+        per_trade_risk_pct=1.5,
+        max_per_position_pct=5.0,
+        real_mode_overrides={"per_trade_risk_pct": 0.25, "max_per_position_pct": 2.0},
+    )
+    svc = _make_service_with_env(env=_env(is_paper_trading=False), cfg=cfg)
+    assert svc._effective_per_trade_risk_pct() == 0.25
+    assert svc._effective_max_per_position_pct() == 2.0
+
+
+@pytest.mark.asyncio
+async def test_position_sizing_real_mode_shrinks_risk_qty():
+    """동일 paper/real 설정에서 real 은 canary overrides 로 인해 qty 가 더 작아야 한다."""
+    snap = _make_snapshot(total_equity=10_000_000, available_cash=10_000_000)
+    cfg = _make_config(per_trade_risk_pct=1.0, default_stop_loss_pct=-5.0, min_stop_distance_pct=0.0)
+    cache = AsyncMock()
+    cache.get.return_value = snap
+    indicator = AsyncMock()
+    indicator.calculate_atr.return_value = None
+
+    paper_svc = PositionSizingService(
+        account_snapshot_cache=cache, indicator_service=indicator,
+        config=cfg, env=_env(is_paper_trading=True),
+    )
+    real_svc = PositionSizingService(
+        account_snapshot_cache=cache, indicator_service=indicator,
+        config=cfg, env=_env(is_paper_trading=False),
+    )
+    sig = _buy_signal(price=10_000, qty=10_000, stop_loss_pct=-5.0)
+
+    paper_qty, _ = await paper_svc.adjust_buy_qty(sig)
+    real_qty, _ = await real_svc.adjust_buy_qty(sig)
+
+    # paper: per_trade_risk_pct=1.0 / max_per_position_pct=10.0
+    # real overlay: per_trade_risk_pct=0.5 / max_per_position_pct=3.0 → 둘 다 빠듯해진다
+    assert paper_qty > real_qty > 0

--- a/tests/unit_test/services/test_predeploy_check_service.py
+++ b/tests/unit_test/services/test_predeploy_check_service.py
@@ -394,7 +394,7 @@ async def test_run_all_offline_skips_live_checks():
 
     summary = await svc.run_all(offline=True)
     assert isinstance(summary, PreDeployCheckSummary)
-    assert len(summary.results) == 7
+    assert len(summary.results) == 8
     probe.assert_not_awaited()
     broker.get_account_balance.assert_not_awaited()
 
@@ -407,6 +407,7 @@ async def test_run_all_offline_skips_live_checks():
         "websocket_subscription_health",
         "account_snapshot_freshness",
         "api_budget_limiter",
+        "real_mode_policy_strictness",
     ]
 
 
@@ -441,3 +442,100 @@ async def test_summary_no_failure():
         ]
     )
     assert summary.has_failure is False
+
+
+# ── check_real_mode_policy_strictness ─────────────────────────────────
+
+
+def _policy_cfg(
+    *,
+    is_paper_trading: bool,
+    ps_overrides: dict | None = None,
+    rg_overrides: dict | None = None,
+    op_overrides: dict | None = None,
+):
+    """real_mode_overrides 만 다르게 채워서 cfg 생성."""
+    from config.config_loader import (
+        OrderPolicyConfig,
+        OrderPolicyRealOverrides,
+        PositionSizingConfig,
+        PositionSizingRealOverrides,
+        RiskGateConfig,
+        RiskGateRealOverrides,
+    )
+
+    ps = PositionSizingConfig(real_mode_overrides=PositionSizingRealOverrides(**(ps_overrides or {})))
+    rg = RiskGateConfig(real_mode_overrides=RiskGateRealOverrides(**(rg_overrides or {})))
+    op = OrderPolicyConfig(real_mode_overrides=OrderPolicyRealOverrides(**(op_overrides or {})))
+    return SimpleNamespace(
+        is_paper_trading=is_paper_trading,
+        position_sizing=ps,
+        risk_gate=rg,
+        order_policy=op,
+    )
+
+
+async def test_real_mode_policy_strictness_skipped_in_paper():
+    svc = _service(config_loader=lambda: _policy_cfg(is_paper_trading=True))
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.SKIPPED
+    assert result.name == "real_mode_policy_strictness"
+
+
+async def test_real_mode_policy_strictness_passes_with_canary_defaults():
+    svc = _service(config_loader=lambda: _policy_cfg(is_paper_trading=False))
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.PASS, result.detail
+
+
+async def test_real_mode_policy_strictness_warns_when_slightly_loose():
+    """canary(0.5) < value <= 1.5x(0.75) → WARN."""
+    svc = _service(
+        config_loader=lambda: _policy_cfg(
+            is_paper_trading=False,
+            ps_overrides={"per_trade_risk_pct": 0.7},
+        )
+    )
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.WARN
+    assert "per_trade_risk_pct" in result.detail
+
+
+async def test_real_mode_policy_strictness_fails_when_more_than_1_5x_loose():
+    """canary(0.5) 의 1.5x 초과(0.76 이상) → FAIL."""
+    svc = _service(
+        config_loader=lambda: _policy_cfg(
+            is_paper_trading=False,
+            ps_overrides={"per_trade_risk_pct": 1.5},
+        )
+    )
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.FAIL
+    assert "per_trade_risk_pct" in result.detail
+
+
+async def test_real_mode_policy_strictness_fails_on_allow_market_buy_true():
+    svc = _service(
+        config_loader=lambda: _policy_cfg(
+            is_paper_trading=False,
+            op_overrides={"allow_market_buy": True},
+        )
+    )
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.FAIL
+    assert "allow_market_buy" in result.detail
+
+
+async def test_real_mode_policy_strictness_fail_takes_priority_over_warn():
+    """FAIL 과 WARN 이 동시에 있으면 FAIL 로 보고하되 둘 다 detail 에 노출."""
+    svc = _service(
+        config_loader=lambda: _policy_cfg(
+            is_paper_trading=False,
+            ps_overrides={"per_trade_risk_pct": 0.7},  # WARN
+            op_overrides={"allow_market_buy": True},   # FAIL
+        )
+    )
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.FAIL
+    assert "allow_market_buy" in result.detail
+    assert "per_trade_risk_pct" in result.detail

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -1005,3 +1005,98 @@ async def test_real_mode_fail_close_can_be_opted_out_via_config():
     )
 
     assert result is None
+
+
+# ── P0 0-2: RiskGate real_mode_overrides 분기 ─────────────────────────
+
+class _PaperEnv:
+    is_paper_trading = True
+    _base_url = "https://openapivts.koreainvestment.com:29443"
+    active_config = {"stock_account_number": "98765432"}
+    stock_account_number = None
+    paper_stock_account_number = "98765432"
+
+
+def test_risk_gate_effective_max_pending_orders_paper_uses_top_level():
+    cfg = RiskGateConfig(max_pending_orders=10)
+    svc, _, _ = _service(config=cfg, env=_PaperEnv())
+    assert svc._effective_max_pending_orders() == 10
+
+
+def test_risk_gate_effective_max_pending_orders_real_uses_override_default():
+    cfg = RiskGateConfig(max_pending_orders=10)  # paper top-level
+    svc, _, _ = _service(config=cfg, env=_RealEnv())
+    # default canary overlay = 5
+    assert svc._effective_max_pending_orders() == 5
+
+
+def test_risk_gate_effective_max_total_exposure_paper_uses_top_level():
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0)
+    svc, _, _ = _service(config=cfg, env=_PaperEnv())
+    assert svc._effective_max_total_exposure_pct() == 95.0
+
+
+def test_risk_gate_effective_max_total_exposure_real_uses_override_default():
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0)
+    svc, _, _ = _service(config=cfg, env=_RealEnv())
+    assert svc._effective_max_total_exposure_pct() == 30.0
+
+
+def test_risk_gate_real_mode_overrides_user_yaml():
+    cfg = RiskGateConfig(
+        max_pending_orders=10,
+        max_total_exposure_pct=95.0,
+        real_mode_overrides={"max_total_exposure_pct": 20.0, "max_pending_orders": 3},
+    )
+    svc, _, _ = _service(config=cfg, env=_RealEnv())
+    assert svc._effective_max_pending_orders() == 3
+    assert svc._effective_max_total_exposure_pct() == 20.0
+
+
+@pytest.mark.asyncio
+async def test_risk_gate_real_mode_blocks_exposure_under_canary_threshold():
+    """paper 에서 통과하던 50% 노출이 real canary overlay 30% 에서는 차단되어야 한다."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0)
+    # 50M positions on 100M equity → 50% exposure
+    snapshot = AccountSnapshot(
+        total_equity=100_000_000,
+        available_cash=50_000_000,
+        positions={"000660": 50_000_000},
+    )
+    # paper: passes (50% < 95%)
+    paper_svc, _, _ = _service(config=cfg, env=_PaperEnv(), snapshot=snapshot)
+    paper_result = await paper_svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, 0
+    )
+    assert paper_result is None  # not blocked
+
+    # real: blocked (50%+ > 30% canary overlay)
+    real_svc, _, _ = _service(config=cfg, env=_RealEnv(), snapshot=snapshot)
+    real_result = await real_svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, 0
+    )
+    assert real_result is not None
+    assert real_result.data["rule"] == "max_total_exposure"
+    assert real_result.data["max_total_exposure_pct"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_risk_gate_real_mode_blocks_pending_orders_under_canary_threshold():
+    """paper 에서 통과하던 7개 pending 이 real canary overlay 5 에서는 차단되어야 한다."""
+    cfg = RiskGateConfig(max_pending_orders=10)
+    # paper: 7 pending < 10 → max_pending_orders rule 로는 차단되지 않아야 함
+    paper_svc, _, _ = _service(config=cfg, env=_PaperEnv())
+    paper_result = await paper_svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, active_order_count=7
+    )
+    if paper_result is not None:
+        assert paper_result.data.get("rule") != "max_pending_orders"
+
+    # real: 7 pending >= 5 (canary overlay) → 차단
+    real_svc, _, _ = _service(config=cfg, env=_RealEnv())
+    real_result = await real_svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, active_order_count=7
+    )
+    assert real_result is not None
+    assert real_result.data["rule"] == "max_pending_orders"
+    assert real_result.data["max_pending_orders"] == 5

--- a/todo_list.md
+++ b/todo_list.md
@@ -48,14 +48,19 @@
 
 ### 0-2. Canary 기본 리스크/주문 정책 보수화
 
-- [ ] 실전 canary 전용 config/profile을 분리하거나 기본 운영값을 낮춘다.
+- [x] 실전 canary 전용 config/profile을 분리하거나 기본 운영값을 낮춘다.
   - 리뷰 기준: 현재 `PositionSizingConfig.per_trade_risk_pct=1.5`, `max_per_position_pct=5.0`, `RiskGateConfig.max_total_exposure_pct=95.0`, `max_pending_orders=10`은 검증 전 자동매매 canary에는 공격적이다.
   - canary 목표값: `per_trade_risk_pct=0.25~0.5`, `max_per_position_pct=2.0~3.0`, `max_total_exposure_pct=20.0~35.0`, `max_pending_orders=3~5`.
-- [ ] 실전 BUY 주문 정책을 canary 기준으로 fail-close에 가깝게 보수화한다.
+  - 완료된 부분(2026-05-25): nested overlay 패턴 채택(`RiskGateFailOpenConfig`/`DataQualityConfig` 선례 일관). 신규 BaseModel 3종: `PositionSizingRealOverrides{per_trade_risk_pct=0.5, max_per_position_pct=3.0}`, `RiskGateRealOverrides{max_total_exposure_pct=30.0, max_pending_orders=5}`. 각 부모 config에 `real_mode_overrides: <Type>RealOverrides = Field(default_factory=...)` 필드 추가. paper 동작 보존(top-level 필드 그대로), real 모드에서만 자동 적용. yaml 명시값이 우선해 production 등급 운영자는 overlay 풀 수 있음. `config/config.yaml.example`에 commented overlay 블록 포함.
+- [x] 실전 BUY 주문 정책을 canary 기준으로 fail-close에 가깝게 보수화한다.
   - 리뷰 기준: 현재 `OrderPolicyConfig.allow_market_buy=True`, `min_trading_value_won=0`, `min_market_cap_won=0`, `max_top_of_book_participation_pct=100.0`은 초기 실전 운용 기준으로 느슨하다.
   - canary 목표값: `allow_market_buy=false`, `max_market_slippage_pct=0.3~0.5`, `max_spread_pct=0.3~0.5`, `min_trading_value_won`/`min_market_cap_won` 전략별 하한 설정, `max_top_of_book_participation_pct=5~15`.
-- [ ] `PreDeployCheckService`가 real mode에서 canary profile 또는 production profile의 리스크/주문 정책이 과도하게 느슨하면 WARN/FAIL을 내도록 검증한다.
-- [ ] config 변경 후 `RiskGateService`, `PositionSizingService`, `OrderPolicyService`, web order path, scheduler order path의 paper/real 분기 회귀 테스트를 추가한다.
+  - 완료된 부분(2026-05-25): `OrderPolicyRealOverrides{allow_market_buy=False, max_market_slippage_pct=0.5, max_spread_pct=0.5, max_top_of_book_participation_pct=10.0}` 추가. real 모드에서 시장가 매수 fail-close, 슬리피지/스프레드 0.5% 제한, 1호가 잔량 대비 최대 10% 참여. `min_trading_value_won`/`min_market_cap_won`은 todo 명시대로 전략별 하한이라 overlay 미포함(`RiskGateStrategyLimitConfig` 경로 유지).
+  - 후속(blocked → 정책 합의 후): 전략별 `min_trading_value_won`/`min_market_cap_won` 하한 설정은 별도 PR에서 진행.
+- [x] `PreDeployCheckService`가 real mode에서 canary profile 또는 production profile의 리스크/주문 정책이 과도하게 느슨하면 WARN/FAIL을 내도록 검증한다.
+  - 완료된 부분(2026-05-25): `check_real_mode_policy_strictness()` 신규 등록. paper 모드 → SKIPPED. real 모드에서는 effective override 값을 canary 임계값(각 RealOverrides의 default)과 비교: `value > canary*1.5` → FAIL, `canary < value ≤ canary*1.5` → WARN. `allow_market_buy=True`는 real 모드에서 즉시 FAIL. `run_all()`에 등록되어 배포 전 자동 점검. 6건 단위 테스트(skipped/pass/warn/fail/market_buy_fail/fail_priority_over_warn) + 통합 테스트 8 checks expectation 갱신.
+- [x] config 변경 후 `RiskGateService`, `PositionSizingService`, `OrderPolicyService`, web order path, scheduler order path의 paper/real 분기 회귀 테스트를 추가한다.
+  - 완료된 부분(2026-05-25): 서비스 분기 로직 일관 패턴 적용. `RiskGateService`는 기존 `env` + `_is_real_mode()` 보유 → `_effective_max_total_exposure_pct()` / `_effective_max_pending_orders()` 헬퍼 추가. `PositionSizingService` / `OrderPolicyService` 생성자에 `env: Optional[Any] = None` keyword-only 인자 추가(기존 호출자 무변동) + `_is_real_mode()` + `_effective_*()` 헬퍼. 직접 `self._cfg.X` 읽기를 effective 헬퍼 호출로 교체. `view/web/bootstrap/service_container.py` 두 서비스 호출부에 `env=getattr(ctx.broker, "env", None)` 전달. 단위 테스트 추가: PositionSizing 8건(real_mode 분기 5 + risk_qty shrinks 1 + 기타), RiskGate 7건(effective_max 2종 paper/real 각 1 + user yaml + exposure/pending 차단 회귀 2 + 기타), OrderPolicy 4건(paper/real defaults + user yaml + market_buy 차단). 단위 5520 + 통합 235 통과.
 
 주요 파일:
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -431,6 +431,7 @@ class ServiceContainer:
                 risk_gate_config=_rg_cfg,
                 quote_provider=ctx.broker,
                 order_policy_config=_op_cfg,
+                env=getattr(ctx.broker, "env", None),
             )
             ctx.risk_gate_service = RiskGateService(
                 config=_rg_cfg,
@@ -458,6 +459,7 @@ class ServiceContainer:
                 security_info_provider=ctx.broker,
                 trade_flow_provider=ctx.execution_flow_service,
                 logger=ctx.logger,
+                env=getattr(ctx.broker, "env", None),
             )
             ctx.deferred_order_queue = DeferredOrderQueue(ctx.logger)
             _oe_cfg = _config_value(config_dict, "order_execution", {})


### PR DESCRIPTION
변경 요약 (4개 sub-task 모두 [x])
Config 스키마 (config/config_loader.py) — 3개 신규 RealOverrides BaseModel + 부모 config 필드:

PositionSizingRealOverrides{per_trade_risk_pct=0.5, max_per_position_pct=3.0} RiskGateRealOverrides{max_total_exposure_pct=30.0, max_pending_orders=5} OrderPolicyRealOverrides{allow_market_buy=False, max_market_slippage_pct=0.5, max_spread_pct=0.5, max_top_of_book_participation_pct=10.0} 서비스 분기:

services/position_sizing_service.py: env keyword param + _is_real_mode() + 2개 _effective_*() 헬퍼
services/risk_gate_service.py: 2개 _effective_*() 헬퍼 추가 (env/_is_real_mode 기존)
services/order_policy_service.py: env keyword param + 4개 _effective_*() 헬퍼
view/web/bootstrap/service_container.py: 두 서비스에 env=getattr(ctx.broker, "env", None) 전달
PreDeployCheck (services/predeploy_check_service.py): 신규 check_real_mode_policy_strictness(). real에서 effective 값이 canary 임계 대비 >1.5x → FAIL, >1x → WARN, allow_market_buy=True → 즉시 FAIL. paper → SKIPPED.

문서: config/config.yaml.example 3개 config에 overlay 블록 추가.

테스트
신규 단위 32건 추가 (config 4, PositionSizing 8, RiskGate 7, OrderPolicy 4, PreDeploy 6 + 통합 1건 expectation 갱신) 단위 5520 + 통합 235 모두 통과
설계 결정 요약
항목	결정	근거
overlay 위치	nested per-config (real_mode_overrides)	RiskGateFailOpenConfig/DataQualityConfig 선례, 8+ 필드의 그룹화 paper 회귀	영향 없음	env 미주입 시 _is_real_mode=False, 기존 호출 경로 무변동 operator override	yaml에서 overlay 값 명시 가능	production 등급 운용자가 풀 수 있는 경로 보존 min_trading_value_won/min_market_cap_won overlay	미포함	todo 명시대로 전략별 하한이라 RiskGateStrategyLimitConfig 경로 유지 todo_list.md L49-87도 완료 상태로 갱신 완료. 후속 작업으로는 todo 추천 1번 카테고리 중 P1 1-1 (Profitability gate), P2 2-2 (API budget coverage matrix), P3 3-4 (BUY signal field audit) 가 즉시 가능 상태로 남아있습니다.