### PR TITLE
원인은 pre_market_health_check가 완료 후 IDLE 상태가 되면 /api/background/status에…

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -490,13 +490,19 @@ def test_get_background_status_module_names(web_client, mock_web_ctx):
 
 
 def test_get_background_status_pre_market_health_check_schedule_type(web_client, mock_web_ctx):
-    """pre_market_health_check는 일반 장중 태스크가 아니라 장전 점검으로 분류한다."""
+    """pre_market_health_check는 IDLE이어도 실제 점검 progress를 반환한다."""
     class PreMarketTask:
         pass
 
     PreMarketTask.__module__ = "task.background.intraday.pre_market_health_check_task"
     mock_task = PreMarketTask()
-    mock_task.get_progress = MagicMock(return_value={"running": False, "last_checked_date": None})
+    mock_task.get_progress = MagicMock(
+        return_value={
+            "running": False,
+            "last_checked_date": "20260526",
+            "last_result": {"ok": True, "issues": []},
+        }
+    )
 
     mock_web_ctx.background_scheduler = MagicMock()
     mock_web_ctx.background_scheduler.get_all_status.return_value = [
@@ -510,7 +516,12 @@ def test_get_background_status_pre_market_health_check_schedule_type(web_client,
     data = response.json()["data"]
     assert data[0]["name"] == "pre_market_health_check"
     assert data[0]["schedule_type"] == "pre_market"
-    assert data[0]["progress"] == {"running": False, "status": "Waiting to start"}
+    assert data[0]["progress"] == {
+        "running": False,
+        "last_checked_date": "20260526",
+        "last_result": {"ok": True, "issues": []},
+    }
+    mock_task.get_progress.assert_called_once()
 
 
 def test_get_background_status_cache_warmup_schedule_type(web_client, mock_web_ctx):

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -419,7 +419,11 @@ async def get_background_status():
         if task:
             if state_str == "idle" and name != "strategy_scheduler":
                 # If the task exposes an internal progress or running flag, call get_progress()
-                if getattr(task, "_is_refreshing", False) or hasattr(task, "_progress"):
+                if (
+                    name == "pre_market_health_check"
+                    or getattr(task, "_is_refreshing", False)
+                    or hasattr(task, "_progress")
+                ):
                     try:
                         progress = task.get_progress()
                     except Exception as e:

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -402,6 +402,23 @@ function _renderProgressBody(progress, taskName) {
         return html;
     }
 
+    // ── 장전 헬스 체크 ──
+    if (taskName === 'pre_market_health_check') {
+        if (progress.running) {
+            return '<span style="background:var(--primary-color,#2196F3); color:#fff; padding:1px 7px; border-radius:8px; font-size:0.82em;">점검 중</span>';
+        }
+        const result = progress.last_result || {};
+        const issues = result.issues || [];
+        if (progress.last_checked_date) {
+            if (result.ok === false || issues.length > 0) {
+                const detail = issues.length ? ` · ${issues.join(', ')}` : '';
+                return `<span style="background:var(--danger-color,#f44336); color:#fff; padding:1px 7px; border-radius:8px; font-size:0.82em;">점검 실패</span> <span style="font-size:0.85em; color:#888;">${progress.last_checked_date}${detail}</span>`;
+            }
+            return `<span style="background:var(--success-color,#4CAF50); color:#fff; padding:1px 7px; border-radius:8px; font-size:0.82em;">완료</span> <span style="font-size:0.85em; color:#888;">${progress.last_checked_date} · 이상 없음</span>`;
+        }
+        return '<span style="color:#888; font-size:0.88em;">대기 중</span>';
+    }
+
     // ── 전일 기준 우량주 생성 ──
     if (taskName === '전일기준주도주_생성') {
         if (progress.running) {


### PR DESCRIPTION
…서 실제 get_progress() 값 대신 Waiting to start를 내려보내고, system.js에도 last_checked_date/last_result를 완료 상태로 렌더링하는 분기가 없던 점이었습니다.

변경 내용:
system.py (line 419): pre_market_health_check는 IDLE이어도 get_progress()를 호출해 실제 점검 결과를 내려주도록 수정 system.js (line 402): pre_market_health_check 전용 렌더링 추가실행 중: 점검 중 성공 완료: 완료 · 이상 없음
실패/이슈 있음: 점검 실패 · issues

test_web_routes_system.py (line 492): IDLE 상태에서도 실제 progress가 반환되는 회귀 테스트로 갱신 검증:
system.js 렌더 함수 Node VM 검증 통과
pytest tests/unit_test -v 통과: 5596 passed
pytest tests/integration_test -v 통과: 235 passed, 1 warning 통합 테스트의 warning은 기존 비동기 pending task 관련 경고로 보이며, 이번 변경 파일과 직접 관련된 실패는 없었습니다.