### PR TITLE
order_state_machine.py (line 120)에서 주문번호 추출 로직을 보강한 것입니다. 이제 기존 ordno…

### DIFF
--- a/services/order_state_machine.py
+++ b/services/order_state_machine.py
@@ -123,7 +123,18 @@ class OrderStateMachine:
         if hasattr(result.data, "ordno"):
             return result.data.ordno
         if isinstance(result.data, dict):
-            return result.data.get("ordno") or result.data.get("order_no") or result.data.get("odno")
+            return OrderStateMachine._extract_broker_order_no_from_dict(result.data)
+        return None
+
+    @staticmethod
+    def _extract_broker_order_no_from_dict(data: dict) -> Optional[str]:
+        for key in ("ordno", "order_no", "odno", "ORDNO", "ORDER_NO", "ODNO"):
+            value = data.get(key)
+            if value:
+                return str(value).strip()
+        output = data.get("output")
+        if isinstance(output, dict):
+            return OrderStateMachine._extract_broker_order_no_from_dict(output)
         return None
 
     # ── register / transition ─────────────────────────────────────────

--- a/tests/unit_test/services/test_order_state_machine.py
+++ b/tests/unit_test/services/test_order_state_machine.py
@@ -122,6 +122,13 @@ def test_extract_broker_order_no_from_dict_variants():
     assert OrderStateMachine.extract_broker_order_no(
         ResCommonResponse(rt_cd="0", msg1="", data={"odno": "Z"})
     ) == "Z"
+    assert OrderStateMachine.extract_broker_order_no(
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="",
+            data={"output": {"KRX_FWDG_ORD_ORGNO": "00950", "ODNO": "0000003900"}},
+        )
+    ) == "0000003900"
 
 
 # ── transition ────────────────────────────────────────────────────────────


### PR DESCRIPTION
…/order_no/odno뿐 아니라, 실제 장애 로그에 나온 KIS 응답 형태인 data.output.ODNO도 정상적으로 broker_order_no로 인식합니다. 그래서 성공 주문인데 주문번호를 못 읽어서 reconcile_alarm을 켜는 일이 재발하지 않게 됩니다.

회귀 테스트도 test_order_state_machine.py (line 113)에 추가했습니다. 실제 로그 payload와 같은 {"output": {"ODNO": "0000003900"}} 케이스를 고정했습니다. 검증:
실패 테스트 먼저 확인: 기존 로직에서 None 반환으로 실패
수정 후 대상 테스트 통과
pytest tests/unit_test -v: 5596 passed
pytest tests/integration_test -v: 235 passed, 1 warning 통합 테스트의 warning은 기존 비동기 cleanup 관련 Task was destroyed but it is pending 계열로, 이번 주문번호 추출 변경과는 별개입니다.