### PR TITLE
완료. 결과 요약:

### DIFF
--- a/scripts/analyze_event_shadow_parity.py
+++ b/scripts/analyze_event_shadow_parity.py
@@ -1,0 +1,421 @@
+"""CLI: VBO event-driven shadow ↔ polling 신호 parity 분석.
+
+P2 2-4 PR-2.5 선행 도구. shadow jsonl(`logs/strategies/event_shadow/YYYYMMDD.jsonl`)
+과 폴링 signal_history(`data/StrategyScheduler/scheduler.db`)를 거래일 단위로
+매칭해 다음 지표를 산출한다.
+
+  - matched              : 같은 (strategy, code, trade_date) 에서 shadow + polling 모두 발생 → full gate parity
+  - shadow_only          : shadow 만 발생 → fast path over-fire (execution_strength / program_buy 등을 생략한 결과)
+  - polling_only         : polling 만 발생 → fast path miss (snapshot/router 가 놓친 케이스)
+  - duplicates_shadow/polling : 같은 그룹키에서 2건 이상 발생한 추가 신호
+  - lead_time_seconds    : matched 신호의 (shadow_ts - polling_ts) 통계 — 음수면 shadow 가 빠름
+
+매칭 알고리즘: 그룹키 별 first-vs-first greedy nearest. 윈도우(`--match-window-sec`)
+초과 시 매칭 실패로 처리하고 둘 다 *_only 로 분류한다. 두 번째 이후 신호는 모두
+duplicate 로 빼놓는다 — VBO 는 `_bought_today` 가드로 동일 코드 재진입을 막으므로
+실제 운영에서는 드물지만, fast path 가 가드 적용 전이라 발생 가능하다.
+
+Examples:
+    python scripts/analyze_event_shadow_parity.py \
+        --date-from 20260520 --date-to 20260524 \
+        --output-json reports/vbo_parity.json \
+        --output-markdown reports/vbo_parity.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import statistics
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
+
+
+_KST = ZoneInfo("Asia/Seoul")
+_DEFAULT_STRATEGY = "래리윌리엄스VBO"
+
+
+@dataclass
+class ParityRecord:
+    source: str           # "event_shadow" / "polling"
+    strategy: str
+    code: str
+    action: str           # "BUY" / "SELL"
+    ts_epoch: float
+    ts_iso: str
+    trade_date: str       # YYYYMMDD (KST)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+# ── Loaders ────────────────────────────────────────────────────────────────
+
+def _epoch_to_kst(epoch: float) -> Tuple[str, str]:
+    dt = datetime.fromtimestamp(epoch, tz=_KST)
+    return dt.strftime("%Y%m%d"), dt.isoformat()
+
+
+def _kst_str_to_epoch(s: str) -> float:
+    dt = datetime.strptime(s, "%Y-%m-%d %H:%M:%S").replace(tzinfo=_KST)
+    return dt.timestamp()
+
+
+def load_shadow_records(
+    shadow_dir: Path,
+    date_from: str,
+    date_to: str,
+    strategy_filter: Optional[str] = None,
+) -> List[ParityRecord]:
+    """`<shadow_dir>/YYYYMMDD.jsonl` 파일들을 스캔해 ParityRecord 로 반환."""
+    shadow_dir = Path(shadow_dir)
+    if not shadow_dir.exists():
+        return []
+
+    out: List[ParityRecord] = []
+    for path in sorted(shadow_dir.glob("*.jsonl")):
+        stem = path.stem
+        if not (len(stem) == 8 and stem.isdigit()):
+            continue
+        if not (date_from <= stem <= date_to):
+            continue
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                strategy = raw.get("strategy") or ""
+                if strategy_filter and strategy != strategy_filter:
+                    continue
+                code = raw.get("code") or ""
+                signal = raw.get("signal") or {}
+                action = signal.get("action") or "BUY"
+                recorded_at = float(raw.get("recorded_at") or 0.0)
+                if not code or recorded_at <= 0:
+                    continue
+                trade_date, ts_iso = _epoch_to_kst(recorded_at)
+                # 파일명과 trade_date 가 어긋나는 라인(타임존 경계 케이스)은 파일명 우선
+                if not (date_from <= trade_date <= date_to):
+                    continue
+                out.append(ParityRecord(
+                    source="event_shadow",
+                    strategy=strategy,
+                    code=code,
+                    action=action,
+                    ts_epoch=recorded_at,
+                    ts_iso=ts_iso,
+                    trade_date=trade_date,
+                    raw=raw,
+                ))
+    return out
+
+
+def load_polling_records(
+    db_path: Path,
+    date_from: str,
+    date_to: str,
+    strategy_filter: Optional[str] = None,
+    action: str = "BUY",
+    require_api_success: bool = True,
+) -> List[ParityRecord]:
+    """`scheduler.db` 의 signal_history 에서 조건에 맞는 신호를 ParityRecord 로 반환."""
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return []
+
+    # date_from/to (YYYYMMDD) → "YYYY-MM-DD" (timestamp 의 date prefix 비교용)
+    from_iso = f"{date_from[:4]}-{date_from[4:6]}-{date_from[6:8]}"
+    to_iso = f"{date_to[:4]}-{date_to[4:6]}-{date_to[6:8]}"
+
+    sql = (
+        "SELECT strategy_name, code, name, action, price, qty, "
+        "       return_rate, reason, timestamp, api_success "
+        "FROM signal_history "
+        "WHERE substr(timestamp, 1, 10) BETWEEN ? AND ? "
+        "  AND action = ?"
+    )
+    params: list = [from_iso, to_iso, action]
+    if strategy_filter:
+        sql += " AND strategy_name = ?"
+        params.append(strategy_filter)
+    if require_api_success:
+        sql += " AND api_success = 1"
+    sql += " ORDER BY timestamp ASC"
+
+    out: List[ParityRecord] = []
+    with sqlite3.connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            (strategy_name, code, name, act, price, qty,
+             return_rate, reason, timestamp, api_success) = row
+            try:
+                ts_epoch = _kst_str_to_epoch(timestamp)
+            except ValueError:
+                continue
+            trade_date, ts_iso = _epoch_to_kst(ts_epoch)
+            out.append(ParityRecord(
+                source="polling",
+                strategy=strategy_name,
+                code=code,
+                action=act,
+                ts_epoch=ts_epoch,
+                ts_iso=ts_iso,
+                trade_date=trade_date,
+                raw={
+                    "name": name, "price": price, "qty": qty,
+                    "return_rate": return_rate, "reason": reason,
+                    "timestamp": timestamp, "api_success": bool(api_success),
+                },
+            ))
+    return out
+
+
+# ── Report ─────────────────────────────────────────────────────────────────
+
+def _group_key(rec: ParityRecord) -> Tuple[str, str, str]:
+    return (rec.strategy, rec.code, rec.trade_date)
+
+
+def _record_to_brief(rec: ParityRecord) -> Dict[str, Any]:
+    return {
+        "strategy": rec.strategy,
+        "code": rec.code,
+        "trade_date": rec.trade_date,
+        "ts_iso": rec.ts_iso,
+        "ts_epoch": rec.ts_epoch,
+    }
+
+
+def compute_parity_report(
+    shadow: List[ParityRecord],
+    polling: List[ParityRecord],
+    match_window_sec: float,
+) -> Dict[str, Any]:
+    groups: Dict[Tuple[str, str, str], Dict[str, List[ParityRecord]]] = {}
+    for r in shadow:
+        groups.setdefault(_group_key(r), {"shadow": [], "polling": []})["shadow"].append(r)
+    for r in polling:
+        groups.setdefault(_group_key(r), {"shadow": [], "polling": []})["polling"].append(r)
+
+    matched_pairs: List[Tuple[ParityRecord, ParityRecord]] = []
+    shadow_only: List[ParityRecord] = []
+    polling_only: List[ParityRecord] = []
+    duplicates_shadow: List[ParityRecord] = []
+    duplicates_polling: List[ParityRecord] = []
+
+    for key, bucket in groups.items():
+        s_sorted = sorted(bucket["shadow"], key=lambda r: r.ts_epoch)
+        p_sorted = sorted(bucket["polling"], key=lambda r: r.ts_epoch)
+        if len(s_sorted) > 1:
+            duplicates_shadow.extend(s_sorted[1:])
+        if len(p_sorted) > 1:
+            duplicates_polling.extend(p_sorted[1:])
+        s0 = s_sorted[0] if s_sorted else None
+        p0 = p_sorted[0] if p_sorted else None
+        if s0 and p0:
+            if abs(s0.ts_epoch - p0.ts_epoch) <= match_window_sec:
+                matched_pairs.append((s0, p0))
+            else:
+                shadow_only.append(s0)
+                polling_only.append(p0)
+        elif s0:
+            shadow_only.append(s0)
+        elif p0:
+            polling_only.append(p0)
+
+    lead_times = [s.ts_epoch - p.ts_epoch for s, p in matched_pairs]
+    lead_stats = _lead_time_stats(lead_times)
+
+    per_date: Dict[str, Dict[str, int]] = {}
+    for s, p in matched_pairs:
+        per_date.setdefault(s.trade_date, _empty_bucket())["matched"] += 1
+    for r in shadow_only:
+        per_date.setdefault(r.trade_date, _empty_bucket())["shadow_only"] += 1
+    for r in polling_only:
+        per_date.setdefault(r.trade_date, _empty_bucket())["polling_only"] += 1
+    for r in duplicates_shadow:
+        per_date.setdefault(r.trade_date, _empty_bucket())["duplicates_shadow"] += 1
+    for r in duplicates_polling:
+        per_date.setdefault(r.trade_date, _empty_bucket())["duplicates_polling"] += 1
+
+    total_matched = len(matched_pairs)
+    total_shadow_only = len(shadow_only)
+    total_polling_only = len(polling_only)
+    denom = total_matched + total_shadow_only + total_polling_only
+    match_rate = (total_matched / denom) if denom else 0.0
+
+    return {
+        "totals": {
+            "matched": total_matched,
+            "shadow_only": total_shadow_only,
+            "polling_only": total_polling_only,
+            "duplicates_shadow": len(duplicates_shadow),
+            "duplicates_polling": len(duplicates_polling),
+            "match_rate": match_rate,
+        },
+        "lead_time_seconds": lead_stats,
+        "per_date": dict(sorted(per_date.items())),
+        "details": {
+            "matched": [
+                {"shadow": _record_to_brief(s), "polling": _record_to_brief(p),
+                 "lead_time_seconds": s.ts_epoch - p.ts_epoch}
+                for s, p in matched_pairs
+            ],
+            "shadow_only": [_record_to_brief(r) for r in shadow_only],
+            "polling_only": [_record_to_brief(r) for r in polling_only],
+            "duplicates_shadow": [_record_to_brief(r) for r in duplicates_shadow],
+            "duplicates_polling": [_record_to_brief(r) for r in duplicates_polling],
+        },
+    }
+
+
+def _empty_bucket() -> Dict[str, int]:
+    return {"matched": 0, "shadow_only": 0, "polling_only": 0,
+            "duplicates_shadow": 0, "duplicates_polling": 0}
+
+
+def _lead_time_stats(values: List[float]) -> Dict[str, Any]:
+    if not values:
+        return {"count": 0, "avg": None, "median": None, "min": None, "max": None}
+    return {
+        "count": len(values),
+        "avg": sum(values) / len(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+# ── Markdown rendering ─────────────────────────────────────────────────────
+
+def format_markdown_report(report: Dict[str, Any]) -> str:
+    cfg = report.get("config", {})
+    totals = report["totals"]
+    lt = report["lead_time_seconds"]
+    per_date = report.get("per_date", {})
+
+    lines: List[str] = []
+    lines.append("# VBO Shadow ↔ Polling Parity Report")
+    lines.append("")
+    if cfg:
+        lines.append(
+            f"- strategy: `{cfg.get('strategy', '')}`  "
+            f"date: `{cfg.get('date_from', '')} ~ {cfg.get('date_to', '')}`  "
+            f"window: `{cfg.get('match_window_sec', '')}s`"
+        )
+        lines.append("")
+
+    lines.append("## 전체 집계")
+    lines.append("")
+    lines.append("| 항목 | 건수 |")
+    lines.append("|---|---:|")
+    lines.append(f"| matched (full gate parity) | {totals['matched']} |")
+    lines.append(f"| shadow_only (fast path over-fire) | {totals['shadow_only']} |")
+    lines.append(f"| polling_only (fast path miss) | {totals['polling_only']} |")
+    lines.append(f"| duplicates_shadow | {totals['duplicates_shadow']} |")
+    lines.append(f"| duplicates_polling | {totals['duplicates_polling']} |")
+    lines.append(f"| match_rate | {totals['match_rate']:.3f} |")
+    lines.append("")
+
+    lines.append("## Lead time (shadow_ts − polling_ts, seconds)")
+    lines.append("")
+    if lt.get("count"):
+        lines.append(f"- count: {lt['count']}")
+        lines.append(f"- avg: {lt['avg']:.3f}")
+        lines.append(f"- median: {lt['median']:.3f}")
+        lines.append(f"- min: {lt['min']:.3f}")
+        lines.append(f"- max: {lt['max']:.3f}")
+    else:
+        lines.append("- (no matched pairs)")
+    lines.append("")
+
+    if per_date:
+        lines.append("## 거래일별")
+        lines.append("")
+        lines.append("| date | matched | shadow_only | polling_only | dup_s | dup_p |")
+        lines.append("|---|---:|---:|---:|---:|---:|")
+        for date, bucket in per_date.items():
+            lines.append(
+                f"| {date} | {bucket['matched']} | {bucket['shadow_only']} | "
+                f"{bucket['polling_only']} | {bucket['duplicates_shadow']} | "
+                f"{bucket['duplicates_polling']} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="VBO shadow jsonl ↔ polling signal_history parity 분석",
+    )
+    parser.add_argument("--shadow-dir", default="logs/strategies/event_shadow")
+    parser.add_argument("--scheduler-db", default="data/StrategyScheduler/scheduler.db")
+    parser.add_argument("--date-from", required=True, help="YYYYMMDD")
+    parser.add_argument("--date-to", required=True, help="YYYYMMDD")
+    parser.add_argument("--strategy", default=_DEFAULT_STRATEGY)
+    parser.add_argument("--match-window-sec", type=float, default=300.0)
+    parser.add_argument("--output-json", default=None)
+    parser.add_argument("--output-markdown", default=None)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    shadow = load_shadow_records(
+        shadow_dir=Path(args.shadow_dir),
+        date_from=args.date_from,
+        date_to=args.date_to,
+        strategy_filter=args.strategy or None,
+    )
+    polling = load_polling_records(
+        db_path=Path(args.scheduler_db),
+        date_from=args.date_from,
+        date_to=args.date_to,
+        strategy_filter=args.strategy or None,
+        action="BUY",
+        require_api_success=True,
+    )
+
+    report = compute_parity_report(
+        shadow=shadow,
+        polling=polling,
+        match_window_sec=args.match_window_sec,
+    )
+    report["config"] = {
+        "strategy": args.strategy,
+        "date_from": args.date_from,
+        "date_to": args.date_to,
+        "match_window_sec": args.match_window_sec,
+        "shadow_dir": str(args.shadow_dir),
+        "scheduler_db": str(args.scheduler_db),
+    }
+
+    if args.output_json:
+        out_json = Path(args.output_json)
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(json.dumps(report, ensure_ascii=False, indent=2),
+                            encoding="utf-8")
+        print(f"[INFO] JSON report: {out_json}")
+    if args.output_markdown:
+        out_md = Path(args.output_markdown)
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(format_markdown_report(report), encoding="utf-8")
+        print(f"[INFO] Markdown report: {out_md}")
+
+    if not (args.output_json or args.output_markdown):
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_test/scripts/test_analyze_event_shadow_parity.py
+++ b/tests/unit_test/scripts/test_analyze_event_shadow_parity.py
@@ -1,0 +1,353 @@
+"""P2 2-4 PR-2.5 선행: shadow ↔ polling parity 분석기 단위 테스트."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scripts.analyze_event_shadow_parity import (
+    compute_parity_report,
+    format_markdown_report,
+    load_polling_records,
+    load_shadow_records,
+    main,
+)
+
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _kst_epoch(yyyymmdd: str, hh: int, mm: int, ss: int = 0) -> float:
+    dt = datetime(
+        int(yyyymmdd[:4]), int(yyyymmdd[4:6]), int(yyyymmdd[6:8]),
+        hh, mm, ss, tzinfo=_KST,
+    )
+    return dt.timestamp()
+
+
+def _kst_ts_str(yyyymmdd: str, hh: int, mm: int, ss: int = 0) -> str:
+    return f"{yyyymmdd[:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]} {hh:02d}:{mm:02d}:{ss:02d}"
+
+
+def _write_shadow_jsonl(shadow_dir: Path, yyyymmdd: str, lines: list[dict]) -> Path:
+    shadow_dir.mkdir(parents=True, exist_ok=True)
+    path = shadow_dir / f"{yyyymmdd}.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for rec in lines:
+            f.write(json.dumps(rec, ensure_ascii=False))
+            f.write("\n")
+    return path
+
+
+def _shadow_record(*, strategy: str, code: str, recorded_at: float,
+                   price: int = 10000, action: str = "BUY") -> dict:
+    return {
+        "recorded_at": recorded_at,
+        "strategy": strategy,
+        "code": code,
+        "signal_source": "event_shadow",
+        "signal": {"code": code, "name": code, "action": action, "price": price,
+                   "strategy_name": strategy, "reason": "test"},
+        "snapshot": {"price": price, "open": price - 100},
+    }
+
+
+def _create_scheduler_db(db_path: Path, rows: list[dict]) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS signal_history (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                strategy_name TEXT    NOT NULL,
+                code          TEXT    NOT NULL,
+                name          TEXT    NOT NULL,
+                action        TEXT    NOT NULL,
+                price         INTEGER NOT NULL,
+                qty           INTEGER NOT NULL DEFAULT 1,
+                return_rate   REAL,
+                reason        TEXT,
+                timestamp     TEXT    NOT NULL,
+                api_success   INTEGER NOT NULL DEFAULT 1
+            )"""
+        )
+        for r in rows:
+            conn.execute(
+                """INSERT INTO signal_history
+                   (strategy_name, code, name, action, price, qty,
+                    return_rate, reason, timestamp, api_success)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    r.get("strategy_name", "래리윌리엄스VBO"),
+                    r["code"],
+                    r.get("name", r["code"]),
+                    r.get("action", "BUY"),
+                    r.get("price", 10000),
+                    r.get("qty", 1),
+                    r.get("return_rate"),
+                    r.get("reason", "test"),
+                    r["timestamp"],
+                    1 if r.get("api_success", True) else 0,
+                ),
+            )
+        conn.commit()
+
+
+# ── load_shadow_records ────────────────────────────────────────────────────
+
+def test_load_shadow_records_filters_by_date_range_and_strategy(tmp_path):
+    shadow_dir = tmp_path / "shadow"
+    _write_shadow_jsonl(shadow_dir, "20260520", [
+        _shadow_record(strategy="래리윌리엄스VBO", code="000001",
+                       recorded_at=_kst_epoch("20260520", 9, 15)),
+        _shadow_record(strategy="OtherStrategy", code="000002",
+                       recorded_at=_kst_epoch("20260520", 9, 16)),
+    ])
+    _write_shadow_jsonl(shadow_dir, "20260521", [
+        _shadow_record(strategy="래리윌리엄스VBO", code="000003",
+                       recorded_at=_kst_epoch("20260521", 9, 20)),
+    ])
+    # out of range
+    _write_shadow_jsonl(shadow_dir, "20260522", [
+        _shadow_record(strategy="래리윌리엄스VBO", code="000004",
+                       recorded_at=_kst_epoch("20260522", 9, 25)),
+    ])
+
+    recs = load_shadow_records(
+        shadow_dir=shadow_dir,
+        date_from="20260520",
+        date_to="20260521",
+        strategy_filter="래리윌리엄스VBO",
+    )
+
+    codes = sorted(r.code for r in recs)
+    assert codes == ["000001", "000003"]
+    assert all(r.source == "event_shadow" for r in recs)
+    assert all(r.action == "BUY" for r in recs)
+    assert all(r.strategy == "래리윌리엄스VBO" for r in recs)
+
+
+# ── load_polling_records ───────────────────────────────────────────────────
+
+def test_load_polling_records_filters_by_strategy_action_success(tmp_path):
+    db_path = tmp_path / "scheduler.db"
+    _create_scheduler_db(db_path, [
+        {"code": "000001", "timestamp": _kst_ts_str("20260520", 9, 15),
+         "strategy_name": "래리윌리엄스VBO", "action": "BUY", "api_success": True},
+        # 다른 전략
+        {"code": "000002", "timestamp": _kst_ts_str("20260520", 9, 16),
+         "strategy_name": "OtherStrategy", "action": "BUY", "api_success": True},
+        # SELL — 매칭 대상 아님
+        {"code": "000003", "timestamp": _kst_ts_str("20260520", 14, 30),
+         "strategy_name": "래리윌리엄스VBO", "action": "SELL", "api_success": True},
+        # api_success=False — 매칭 대상 아님
+        {"code": "000004", "timestamp": _kst_ts_str("20260520", 9, 20),
+         "strategy_name": "래리윌리엄스VBO", "action": "BUY", "api_success": False},
+        # 날짜 범위 밖
+        {"code": "000005", "timestamp": _kst_ts_str("20260522", 9, 25),
+         "strategy_name": "래리윌리엄스VBO", "action": "BUY", "api_success": True},
+    ])
+
+    recs = load_polling_records(
+        db_path=db_path,
+        date_from="20260520",
+        date_to="20260521",
+        strategy_filter="래리윌리엄스VBO",
+        action="BUY",
+        require_api_success=True,
+    )
+
+    codes = sorted(r.code for r in recs)
+    assert codes == ["000001"]
+    assert recs[0].source == "polling"
+
+
+# ── compute_parity_report ──────────────────────────────────────────────────
+
+def _polling_rec(code: str, ts_epoch: float, strategy: str = "래리윌리엄스VBO"):
+    from scripts.analyze_event_shadow_parity import ParityRecord
+    kst_dt = datetime.fromtimestamp(ts_epoch, tz=_KST)
+    return ParityRecord(
+        source="polling", strategy=strategy, code=code, action="BUY",
+        ts_epoch=ts_epoch, ts_iso=kst_dt.isoformat(),
+        trade_date=kst_dt.strftime("%Y%m%d"),
+        raw={},
+    )
+
+
+def _shadow_rec(code: str, ts_epoch: float, strategy: str = "래리윌리엄스VBO"):
+    from scripts.analyze_event_shadow_parity import ParityRecord
+    kst_dt = datetime.fromtimestamp(ts_epoch, tz=_KST)
+    return ParityRecord(
+        source="event_shadow", strategy=strategy, code=code, action="BUY",
+        ts_epoch=ts_epoch, ts_iso=kst_dt.isoformat(),
+        trade_date=kst_dt.strftime("%Y%m%d"),
+        raw={},
+    )
+
+
+def test_compute_parity_report_matched_within_window():
+    p_ts = _kst_epoch("20260520", 9, 15, 30)
+    s_ts = _kst_epoch("20260520", 9, 15, 35)  # 5초 차이
+    polling = [_polling_rec("000001", p_ts)]
+    shadow = [_shadow_rec("000001", s_ts)]
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    assert report["totals"]["matched"] == 1
+    assert report["totals"]["shadow_only"] == 0
+    assert report["totals"]["polling_only"] == 0
+    assert report["totals"]["match_rate"] == pytest.approx(1.0)
+
+
+def test_compute_parity_report_shadow_only_classified_as_over_fire():
+    s_ts = _kst_epoch("20260520", 9, 15, 35)
+    shadow = [_shadow_rec("000001", s_ts)]
+    polling: list = []
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    assert report["totals"]["shadow_only"] == 1
+    assert report["totals"]["matched"] == 0
+    assert report["totals"]["polling_only"] == 0
+    # shadow-only 는 fast path over-fire 라벨링
+    assert report["details"]["shadow_only"][0]["code"] == "000001"
+
+
+def test_compute_parity_report_polling_only_classified_as_miss():
+    p_ts = _kst_epoch("20260520", 9, 15, 30)
+    polling = [_polling_rec("000001", p_ts)]
+    shadow: list = []
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    assert report["totals"]["polling_only"] == 1
+    assert report["totals"]["matched"] == 0
+    assert report["totals"]["shadow_only"] == 0
+    assert report["details"]["polling_only"][0]["code"] == "000001"
+
+
+def test_compute_parity_report_lead_time_negative_when_shadow_earlier():
+    # shadow 가 polling 보다 3초 빨라야 함 → lead_time = shadow - polling = -3
+    s_ts = _kst_epoch("20260520", 9, 15, 30)
+    p_ts = _kst_epoch("20260520", 9, 15, 33)
+    polling = [_polling_rec("000001", p_ts)]
+    shadow = [_shadow_rec("000001", s_ts)]
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    stats = report["lead_time_seconds"]
+    assert stats["count"] == 1
+    assert stats["avg"] == pytest.approx(-3.0)
+    assert stats["min"] == pytest.approx(-3.0)
+    assert stats["max"] == pytest.approx(-3.0)
+
+
+def test_compute_parity_report_duplicate_signals_counted_per_source():
+    base = _kst_epoch("20260520", 9, 15, 30)
+    shadow = [
+        _shadow_rec("000001", base),
+        _shadow_rec("000001", base + 1.0),  # 같은 그룹키 → duplicate
+    ]
+    polling = [
+        _polling_rec("000001", base + 2.0),
+        _polling_rec("000001", base + 3.0),  # duplicate
+        _polling_rec("000001", base + 4.0),  # duplicate
+    ]
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    assert report["totals"]["matched"] == 1
+    assert report["totals"]["duplicates_shadow"] == 1
+    assert report["totals"]["duplicates_polling"] == 2
+
+
+def test_compute_parity_report_match_window_excludes_distant_signals():
+    # 5분 윈도우인데 10분 차이 → 매칭 실패, 둘 다 _only 로 분류
+    p_ts = _kst_epoch("20260520", 9, 15, 0)
+    s_ts = _kst_epoch("20260520", 9, 25, 0)
+    polling = [_polling_rec("000001", p_ts)]
+    shadow = [_shadow_rec("000001", s_ts)]
+
+    report = compute_parity_report(shadow, polling, match_window_sec=300.0)
+
+    assert report["totals"]["matched"] == 0
+    assert report["totals"]["shadow_only"] == 1
+    assert report["totals"]["polling_only"] == 1
+
+
+def test_compute_parity_report_per_date_breakdown():
+    p1 = _kst_epoch("20260520", 9, 15)
+    s1 = _kst_epoch("20260520", 9, 15)
+    p2 = _kst_epoch("20260521", 10, 0)
+    shadow = [_shadow_rec("000001", s1)]
+    polling = [_polling_rec("000001", p1), _polling_rec("000002", p2)]
+
+    report = compute_parity_report(shadow, polling, match_window_sec=60.0)
+
+    by_date = report["per_date"]
+    assert by_date["20260520"]["matched"] == 1
+    assert by_date["20260520"]["polling_only"] == 0
+    assert by_date["20260521"]["polling_only"] == 1
+
+
+# ── main / CLI ─────────────────────────────────────────────────────────────
+
+def test_main_writes_json_and_markdown_outputs(tmp_path, capsys):
+    shadow_dir = tmp_path / "shadow"
+    db_path = tmp_path / "scheduler.db"
+
+    s_ts = _kst_epoch("20260520", 9, 15, 30)
+    _write_shadow_jsonl(shadow_dir, "20260520", [
+        _shadow_record(strategy="래리윌리엄스VBO", code="000001", recorded_at=s_ts),
+    ])
+    _create_scheduler_db(db_path, [
+        {"code": "000001", "timestamp": _kst_ts_str("20260520", 9, 15, 30),
+         "strategy_name": "래리윌리엄스VBO", "action": "BUY", "api_success": True},
+    ])
+
+    json_out = tmp_path / "report.json"
+    md_out = tmp_path / "report.md"
+    exit_code = main([
+        "--shadow-dir", str(shadow_dir),
+        "--scheduler-db", str(db_path),
+        "--date-from", "20260520",
+        "--date-to", "20260520",
+        "--strategy", "래리윌리엄스VBO",
+        "--match-window-sec", "60",
+        "--output-json", str(json_out),
+        "--output-markdown", str(md_out),
+    ])
+    assert exit_code == 0
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["totals"]["matched"] == 1
+    md_text = md_out.read_text(encoding="utf-8")
+    assert "matched" in md_text.lower() or "전체" in md_text
+    # stdout 에 output 경로가 적어도 노출되어야 함
+    out = capsys.readouterr().out
+    assert str(json_out) in out
+
+
+def test_format_markdown_report_basic_structure():
+    fake_report = {
+        "totals": {
+            "matched": 3, "shadow_only": 1, "polling_only": 2,
+            "duplicates_shadow": 0, "duplicates_polling": 0,
+            "match_rate": 0.5,
+        },
+        "lead_time_seconds": {"count": 3, "avg": -2.0, "min": -5.0, "max": 1.0,
+                              "median": -2.0},
+        "per_date": {
+            "20260520": {"matched": 3, "shadow_only": 1, "polling_only": 2,
+                         "duplicates_shadow": 0, "duplicates_polling": 0},
+        },
+        "details": {"shadow_only": [], "polling_only": []},
+        "config": {"strategy": "래리윌리엄스VBO", "match_window_sec": 60.0,
+                   "date_from": "20260520", "date_to": "20260520"},
+    }
+    md = format_markdown_report(fake_report)
+    assert "래리윌리엄스VBO" in md
+    assert "matched" in md.lower() or "전체" in md


### PR DESCRIPTION
신규 파일

scripts/analyze_event_shadow_parity.py — 분석기 CLI + 테스트 가능 함수(load_shadow_records, load_polling_records, compute_parity_report, format_markdown_report, main) tests/unit_test/scripts/test_analyze_event_shadow_parity.py — 11개 케이스 (TDD) Changes.md — 작업 사양 (이전 P0 0-1 내용 덮어쓴 상태)
기존 파일 수정: 없음 (외과수술 원칙)

산출 지표 (todo_list.md L98-99 요구사항 매핑)

matched (full gate parity) ↔ shadow + polling 동시 발생 shadow_only (fast path over-fire) ↔ shadow는 통과했지만 폴링 full gate에서 차단됨 (execution_strength / program_buy 검사 차이) polling_only (fast path miss) ↔ 폴링은 발견했는데 fast path가 놓침 — 가장 중요한 정밀도 지표 lead_time_seconds avg/median/min/max — 신호 선행 시간
duplicates_shadow / duplicates_polling — duplicate signal rate per_date 분할 통계 — 거래일별 추세
검증

단위: 5607 passed (신규 11/11 포함)
통합: 235 passed
회귀 없음
사용 예시 (5거래일 수집 완료 후)

python scripts/analyze_event_shadow_parity.py `
    --date-from 20260527 --date-to 20260602 `
    --output-json reports/vbo_parity.json `
    --output-markdown reports/vbo_parity.md
미커버 항목: missed trade PnL 은 향후 OHLCV 조회가 필요한 별도 계산이라 이번 스코프에서 제외 — 매칭 결과에 trade_date/code/ts가 모두 남아있어, 후속 스크립트에서 polling_only/shadow_only 리스트를 받아 종가/익일 시가 기준 PnL을 붙이는 식으로 확장 가능합니다.