### PR TITLE
프로그램매매 리포트는 이제 종목코드 대신 종목명을 사용합니다. stock_code_repository를 운영 알림 의존성에 …

### DIFF
--- a/repositories/program_trading_repo.py
+++ b/repositories/program_trading_repo.py
@@ -406,6 +406,41 @@ class ProgramTradingRepo:
             self._logger.error(f"히스토리 timestamp 조회 중 오류: {e}")
         return result
 
+    def get_history_records_for_persistence_by_code(
+        self,
+        codes: list[str],
+        start_ts: float,
+        end_ts: float,
+    ) -> dict[str, list[dict]]:
+        """지정 종목들의 저장 점검용 체결시간/저장시간을 조회한다."""
+        result = {code: [] for code in codes}
+        if not codes:
+            return result
+
+        placeholders = ",".join("?" for _ in codes)
+        params = [*codes, start_ts, end_ts]
+        try:
+            with self._get_connection() as conn:
+                cursor = conn.execute(
+                    f"""
+                    SELECT code, trade_time, created_at
+                    FROM pt_history
+                    WHERE code IN ({placeholders})
+                      AND created_at >= ?
+                      AND created_at <= ?
+                    ORDER BY code, created_at
+                    """,
+                    params,
+                )
+                for code, trade_time, created_at in cursor.fetchall():
+                    result.setdefault(code, []).append({
+                        "trade_time": trade_time,
+                        "created_at": created_at,
+                    })
+        except Exception as e:
+            self._logger.error(f"히스토리 저장 점검 레코드 조회 중 오류: {e}")
+        return result
+
     # ── 생명주기 ─────────────────────────────────────────────────────
 
     def start_flush_loop(self):

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -44,6 +44,7 @@ class ProgramTradingStreamService:
         self._telegram_reporter = None
         self._market_calendar_service = None
         self._market_clock = None
+        self._stock_code_repository = None
 
         # SQLite 레이어는 ProgramTradingRepo에 위임
         self._repo = ProgramTradingRepo(
@@ -236,11 +237,14 @@ class ProgramTradingStreamService:
         telegram_reporter=None,
         market_calendar_service=None,
         market_clock=None,
+        stock_code_repository=None,
     ) -> None:
         """운영 알림에 필요한 외부 의존성을 사후 주입한다."""
         self._telegram_reporter = telegram_reporter
         self._market_calendar_service = market_calendar_service
         self._market_clock = market_clock
+        if stock_code_repository is not None:
+            self._stock_code_repository = stock_code_repository
 
     # ── 운영 알림 ──────────────────────────────────────────────────
 
@@ -269,6 +273,16 @@ class ProgramTradingStreamService:
         except (TypeError, ValueError):
             return "0.00%"
 
+    def _format_stock_label(self, code: str) -> str:
+        if self._stock_code_repository is None:
+            return code
+        try:
+            name = self._stock_code_repository.get_name_by_code(code)
+            return name if name and name != code else code
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 종목명 조회 실패: code={code}, error={e}")
+            return code
+
     def _format_last_tick_report(self, codes: list[str]) -> str:
         lines = [
             "<b>프로그램매매 구독 Tick 상태</b>",
@@ -277,9 +291,10 @@ class ProgramTradingStreamService:
             "",
         ]
         for code in codes:
+            label = self._format_stock_label(code)
             history = self._pt_history.get(code) or []
             if not history:
-                lines.append(f"{html.escape(code)}: 수신 없음")
+                lines.append(f"{html.escape(label)}: 수신 없음")
                 continue
 
             tick = history[-1]
@@ -293,7 +308,7 @@ class ProgramTradingStreamService:
             rate = self._format_rate(tick.get("rate", 0.0))
             net_amt = self._format_int(tick.get("순매수거래대금", 0))
             lines.append(
-                f"{html.escape(code)}: {price}원 ({rate}) "
+                f"{html.escape(label)}: {price}원 ({rate}) "
                 f"체결:{html.escape(trade_time)} 수신:{received_at} 순매수대금:{net_amt}"
             )
         return "\n".join(lines)
@@ -350,10 +365,29 @@ class ProgramTradingStreamService:
 
         return start_dt, end_dt, expected_minutes, timezone
 
+    @staticmethod
+    def _minute_from_trade_time(trade_time) -> str | None:
+        digits = "".join(ch for ch in str(trade_time or "") if ch.isdigit())
+        if len(digits) < 4:
+            return None
+        hour = int(digits[:2])
+        minute = int(digits[2:4])
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            return None
+        return f"{hour:02d}:{minute:02d}"
+
+    def _history_minutes_from_memory(self, code: str, expected_set: set[str]) -> set[str]:
+        minutes: set[str] = set()
+        for tick in self._pt_history.get(code) or []:
+            minute = self._minute_from_trade_time(tick.get("주식체결시간"))
+            if minute in expected_set:
+                minutes.add(minute)
+        return minutes
+
     def build_db_minute_persistence_status(self, codes: list[str], trading_date: str) -> dict:
-        """구독 종목별로 장중 DB 저장이 1분 단위로 존재하는지 계산한다."""
+        """구독 종목별로 수신 분봉과 DB 저장 분봉을 분리해 계산한다."""
         start_dt, end_dt, expected_minutes, timezone = self._build_trading_window(trading_date)
-        timestamps = self._repo.get_history_timestamps_by_code(
+        records = self._repo.get_history_records_for_persistence_by_code(
             codes,
             start_dt.timestamp(),
             end_dt.timestamp(),
@@ -371,15 +405,36 @@ class ProgramTradingStreamService:
         }
         for code in codes:
             saved_minutes = set()
-            for created_at in timestamps.get(code, []):
-                dt = datetime.fromtimestamp(created_at, tz=timezone) if timezone else datetime.fromtimestamp(created_at)
-                saved_minutes.add(dt.strftime("%H:%M"))
+            for record in records.get(code, []):
+                minute = self._minute_from_trade_time(record.get("trade_time"))
+                if minute is None:
+                    created_at = record.get("created_at")
+                    dt = datetime.fromtimestamp(created_at, tz=timezone) if timezone else datetime.fromtimestamp(created_at)
+                    minute = dt.strftime("%H:%M")
+                if minute in expected_set:
+                    saved_minutes.add(minute)
+            received_minutes = self._history_minutes_from_memory(code, expected_set)
+            if not received_minutes:
+                received_minutes = set(saved_minutes)
             missing = [minute for minute in expected_minutes if minute not in saved_minutes]
+            unsaved_received = [
+                minute for minute in expected_minutes
+                if minute in received_minutes and minute not in saved_minutes
+            ]
+            no_tick = [
+                minute for minute in expected_minutes
+                if minute not in received_minutes
+            ]
             status["codes"][code] = {
                 "ok": not missing,
                 "saved_minute_count": len(saved_minutes & expected_set),
+                "received_minute_count": len(received_minutes & expected_set),
                 "missing_minute_count": len(missing),
                 "missing_minutes": missing,
+                "unsaved_received_minute_count": len(unsaved_received),
+                "unsaved_received_minutes": unsaved_received,
+                "no_tick_minute_count": len(no_tick),
+                "no_tick_minutes": no_tick,
             }
         return status
 
@@ -388,21 +443,48 @@ class ProgramTradingStreamService:
             f"<b>프로그램매매 DB 저장 점검 ({html.escape(str(status.get('date', '')))}일)</b>",
             f"구간: {html.escape(status['window']['start'])} ~ {html.escape(status['window']['end'])}",
             f"기대 분봉: {status['expected_minute_count']}분",
+            "기준: 체결시간 기준, 수신 분봉 대비 DB 저장 여부",
             "",
         ]
         for code, item in status["codes"].items():
+            label = self._format_stock_label(code)
             saved = item["saved_minute_count"]
             expected = status["expected_minute_count"]
             if item["ok"]:
-                lines.append(f"{html.escape(code)}: OK ({saved}/{expected})")
+                lines.append(f"{html.escape(label)}: OK ({saved}/{expected})")
             else:
                 sample = ", ".join(item["missing_minutes"][:10])
                 extra = "" if item["missing_minute_count"] <= 10 else f" 외 {item['missing_minute_count'] - 10}분"
+                unsaved = item.get("unsaved_received_minute_count", 0)
+                no_tick = item.get("no_tick_minute_count", item["missing_minute_count"])
                 lines.append(
-                    f"{html.escape(code)}: 누락 {item['missing_minute_count']}분 "
-                    f"({saved}/{expected}) 예: {html.escape(sample)}{extra}"
+                    f"{html.escape(label)}: 누락 {item['missing_minute_count']}분 "
+                    f"(DB 미저장 {unsaved}분, 수신없음 {no_tick}분, 저장 {saved}/{expected}) "
+                    f"예: {html.escape(sample)}{extra}"
                 )
         return "\n".join(lines)
+
+    def get_background_task_status(self) -> dict:
+        """system.py에서 서비스 내부 백그라운드 루프 상태를 노출하기 위한 요약."""
+        flush_task = self._flush_task
+        alert_tasks = [task for task in self._alert_tasks if not task.done()]
+
+        def _is_coro_running(name: str) -> bool:
+            return any(getattr(task.get_coro(), "__name__", "") == name for task in alert_tasks)
+
+        last_received_at = None
+        if self.last_data_ts > 0:
+            last_received_at = datetime.fromtimestamp(self.last_data_ts).strftime("%Y-%m-%d %H:%M:%S")
+
+        return {
+            "running": bool((flush_task and not flush_task.done()) or alert_tasks),
+            "flush_loop_alive": bool(flush_task and not flush_task.done()),
+            "alert_task_count": len(alert_tasks),
+            "hourly_tick_alert_alive": _is_coro_running("_hourly_tick_alert_loop"),
+            "db_check_alive": _is_coro_running("_after_market_db_check_loop"),
+            "last_db_check_report_date": self._last_db_check_report_date,
+            "last_received_at": last_received_at,
+        }
 
     async def send_db_persistence_report(self, trading_date: str) -> bool:
         """장마감 후 구독 종목의 1분 단위 DB 저장 여부를 텔레그램으로 전송한다."""

--- a/tests/unit_test/repositories/test_program_trading_repo.py
+++ b/tests/unit_test/repositories/test_program_trading_repo.py
@@ -294,6 +294,32 @@ def test_inspect_db_status_sets_error_on_failure(repo):
     repo._logger.error.assert_called_once()
 
 
+def test_get_history_records_for_persistence_by_code_returns_trade_time_and_created_at(repo):
+    now = time.time()
+    with repo._get_connection() as conn:
+        conn.executemany(
+            """
+            INSERT INTO pt_history (code, trade_time, created_at)
+            VALUES (?, ?, ?)
+            """,
+            [
+                ("005930", "090000", now),
+                ("000660", "090100", now + 60),
+                ("035720", "090200", now + 120),
+            ],
+        )
+
+    records = repo.get_history_records_for_persistence_by_code(
+        ["005930", "000660"],
+        now - 1,
+        now + 61,
+    )
+
+    assert records["005930"] == [{"trade_time": "090000", "created_at": now}]
+    assert records["000660"] == [{"trade_time": "090100", "created_at": now + 60}]
+    assert "035720" not in records
+
+
 @pytest.mark.asyncio
 async def test_start_flush_loop_runs_cleanup_and_creates_task(repo):
     fake_task = MagicMock()

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -497,9 +497,17 @@ async def test_send_subscribed_last_tick_alert_sends_last_tick_for_desired_codes
     mock_ssr.get_desired.return_value = {"005930", "000660"}
     mock_reporter = MagicMock()
     mock_reporter._send_message = AsyncMock(return_value=True)
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.side_effect = lambda code: {
+        "005930": "삼성전자",
+        "000660": "SK하이닉스",
+    }.get(code, code)
 
     manager.wire_streaming_stock_repo(mock_ssr)
-    manager.wire_alert_dependencies(telegram_reporter=mock_reporter)
+    manager.wire_alert_dependencies(
+        telegram_reporter=mock_reporter,
+        stock_code_repository=mock_stock_repo,
+    )
     manager.on_data_received({
         "유가증권단축종목코드": "005930",
         "주식체결시간": "101530",
@@ -515,10 +523,11 @@ async def test_send_subscribed_last_tick_alert_sends_last_tick_for_desired_codes
     mock_reporter._send_message.assert_awaited_once()
     message = mock_reporter._send_message.call_args[0][0]
     assert "프로그램매매 구독 Tick" in message
-    assert "005930" in message
+    assert "삼성전자" in message
+    assert "005930" not in message
     assert "72,000" in message
     assert "101530" in message
-    assert "000660" in message
+    assert "SK하이닉스" in message
     assert "수신 없음" in message
 
 
@@ -551,6 +560,31 @@ def test_build_db_minute_persistence_status_reports_missing_minutes(manager):
     assert status["codes"]["000660"]["ok"] is True
 
 
+def test_build_db_minute_persistence_status_splits_unsaved_and_no_tick_minutes(manager):
+    """수신된 분의 DB 미저장과 수신 자체가 없는 분을 분리한다."""
+    clock = MarketClock(market_open_time="09:00", market_close_time="09:02")
+    manager.wire_alert_dependencies(market_clock=clock)
+
+    day = clock.market_timezone.localize(datetime(2026, 5, 19, 9, 0, 0))
+    manager._pt_history["005930"] = [
+        {"주식체결시간": "090000"},
+        {"주식체결시간": "090100"},
+    ]
+    with manager._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO pt_history (code, trade_time, created_at) VALUES (?, ?, ?)",
+            ("005930", "090000", day.timestamp()),
+        )
+
+    status = manager.build_db_minute_persistence_status(["005930"], "20260519")
+    item = status["codes"]["005930"]
+
+    assert item["saved_minute_count"] == 1
+    assert item["received_minute_count"] == 2
+    assert item["unsaved_received_minutes"] == ["09:01"]
+    assert item["no_tick_minutes"] == ["09:02"]
+
+
 @pytest.mark.asyncio
 async def test_send_db_persistence_report_sends_summary(manager):
     """장마감 DB 저장 점검 결과를 텔레그램으로 전송한다."""
@@ -559,9 +593,15 @@ async def test_send_db_persistence_report_sends_summary(manager):
     mock_ssr.get_desired.return_value = {"005930"}
     mock_reporter = MagicMock()
     mock_reporter._send_message = AsyncMock(return_value=True)
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.return_value = "삼성전자"
 
     manager.wire_streaming_stock_repo(mock_ssr)
-    manager.wire_alert_dependencies(telegram_reporter=mock_reporter, market_clock=clock)
+    manager.wire_alert_dependencies(
+        telegram_reporter=mock_reporter,
+        market_clock=clock,
+        stock_code_repository=mock_stock_repo,
+    )
     day = clock.market_timezone.localize(datetime(2026, 5, 19, 9, 0, 0))
     with manager._get_connection() as conn:
         conn.execute(
@@ -575,8 +615,47 @@ async def test_send_db_persistence_report_sends_summary(manager):
     mock_reporter._send_message.assert_awaited_once()
     message = mock_reporter._send_message.call_args[0][0]
     assert "프로그램매매 DB 저장 점검" in message
-    assert "005930" in message
+    assert "삼성전자" in message
     assert "OK" in message
+
+
+def test_format_db_persistence_report_explains_no_tick_cause(manager):
+    """DB 누락 리포트가 수신없음과 실제 DB 미저장을 함께 보여준다."""
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.return_value = "삼성전자"
+    manager.wire_alert_dependencies(stock_code_repository=mock_stock_repo)
+
+    message = manager._format_db_persistence_report({
+        "date": "20260526",
+        "window": {"start": "2026-05-26 09:00:00", "end": "2026-05-26 09:02:00"},
+        "expected_minute_count": 3,
+        "codes": {
+            "005930": {
+                "ok": False,
+                "saved_minute_count": 1,
+                "missing_minute_count": 2,
+                "missing_minutes": ["09:01", "09:02"],
+                "unsaved_received_minute_count": 1,
+                "no_tick_minute_count": 1,
+            }
+        },
+    })
+
+    assert "삼성전자: 누락 2분" in message
+    assert "DB 미저장 1분" in message
+    assert "수신없음 1분" in message
+
+
+def test_get_background_task_status_reports_internal_loops(manager):
+    """서비스 내부 루프 상태를 system.py에서 읽을 수 있는 형태로 반환한다."""
+    manager._flush_task = MagicMock()
+    manager._flush_task.done.return_value = False
+
+    status = manager.get_background_task_status()
+
+    assert status["running"] is True
+    assert status["flush_loop_alive"] is True
+    assert status["alert_task_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
+++ b/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
@@ -31,6 +31,7 @@ def _make_fake_context():
     ctx.telegram_reporter = MagicMock()
     ctx._mcs = MagicMock()
     ctx.market_clock = MagicMock()
+    ctx.stock_code_repository = MagicMock()
     ctx.order_execution_service = MagicMock()
     return ctx
 
@@ -93,6 +94,7 @@ def test_wiring_phase_wires_streaming_chain():
         telegram_reporter=ctx.telegram_reporter,
         market_calendar_service=ctx._mcs,
         market_clock=ctx.market_clock,
+        stock_code_repository=ctx.stock_code_repository,
     )
     assert ctx.stock_query_service.price_stream_service is ctx.price_stream_service
     assert ctx.stock_query_service.price_subscription_service is ctx.price_subscription_service
@@ -116,6 +118,7 @@ def test_wiring_phase_skips_streaming_chain_when_runtime_does_not_create_it():
         telegram_reporter=ctx.telegram_reporter,
         market_calendar_service=ctx._mcs,
         market_clock=ctx.market_clock,
+        stock_code_repository=ctx.stock_code_repository,
     )
     assert ctx.stock_query_service.price_stream_service is None
     assert ctx.stock_query_service.price_subscription_service is None

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, AsyncMock
 from core.account_snapshot import AccountSnapshot
 from repositories.streaming_stock_repo import StreamingType
+from services.program_trading_stream_service import ProgramTradingStreamService
 from view.web import api_common
 
 
@@ -322,6 +323,37 @@ def test_get_background_status_empty_scheduler(web_client, mock_web_ctx):
 
     assert response.status_code == 200
     assert response.json()["data"] == []
+
+
+def test_get_background_status_includes_program_trading_monitor(web_client, mock_web_ctx, tmp_path):
+    """ProgramTradingStreamService 내부 루프도 운영 task 목록에 노출한다."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            ProgramTradingStreamService,
+            "_get_base_dir",
+            lambda self: str(tmp_path / "program_subscribe"),
+        )
+        svc = ProgramTradingStreamService(logger=MagicMock())
+
+    try:
+        svc._flush_task = MagicMock()
+        svc._flush_task.done.return_value = False
+        mock_web_ctx.program_trading_stream_service = svc
+        mock_web_ctx.background_scheduler = MagicMock()
+        mock_web_ctx.background_scheduler.get_all_status.return_value = []
+
+        response = web_client.get("/api/background/status")
+    finally:
+        if svc._conn:
+            svc._conn.close()
+        svc._executor.shutdown(wait=False)
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data[0]["name"] == "program_trading_monitor"
+    assert data[0]["schedule_type"] == "always_on"
+    assert data[0]["state"] == "running"
+    assert data[0]["progress"]["flush_loop_alive"] is True
 
 
 def test_get_background_status_returns_task_info(web_client, mock_web_ctx):

--- a/view/web/bootstrap/wiring_phase.py
+++ b/view/web/bootstrap/wiring_phase.py
@@ -74,6 +74,7 @@ class WiringPhase:
                 telegram_reporter=getattr(ctx, "telegram_reporter", None),
                 market_calendar_service=getattr(ctx, "_mcs", None),
                 market_clock=getattr(ctx, "market_clock", None),
+                stock_code_repository=getattr(ctx, "stock_code_repository", None),
             )
 
         # Streaming realtime_program_trading callback ← ProgramTradingStreamService

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -28,6 +28,7 @@ _SCHEDULE_TYPES = {
     "전일기준주도주_생성":  "after_market",
     "newhigh":             "after_market",
     "notification_queue_task":  "always_on",
+    "program_trading_monitor":  "always_on",
 }
 
 _SCHEDULE_ORDER = {
@@ -383,7 +384,9 @@ async def get_background_status():
             pass
 
     if not ctx.background_scheduler:
-        return {"success": True, "foreground": foreground_info, "time_dispatcher": time_dispatcher_info, "data": []}
+        result = []
+        _append_program_trading_monitor_status(ctx, result)
+        return {"success": True, "foreground": foreground_info, "time_dispatcher": time_dispatcher_info, "data": result}
 
     delays = load_after_market_delays()  # {task_name: delay_sec}
 
@@ -447,9 +450,40 @@ async def get_background_status():
             "progress": progress,
         })
 
+    _append_program_trading_monitor_status(ctx, result)
+
     # 스케줄 유형(실시간 -> 장중 -> 장마감) 순서로 정렬, 같은 유형 내에서는 실행 순서(delay_sec) 기준
     result.sort(key=lambda x: (x["schedule_order"], x["delay_sec"]))
     return {"success": True, "foreground": foreground_info, "time_dispatcher": time_dispatcher_info, "data": result}
+
+
+def _append_program_trading_monitor_status(ctx, result: list) -> None:
+    """ProgramTradingStreamService 내부 루프를 background/status에 노출한다.
+
+    이 루프는 SchedulableTask가 아니라 WebSocketWatchdogTask.start()에서 시작되므로
+    BackgroundScheduler.get_all_status()에는 나타나지 않는다.
+    """
+    if any(item.get("name") == "program_trading_monitor" for item in result):
+        return
+    svc = getattr(ctx, "program_trading_stream_service", None)
+    status_getter = getattr(type(svc), "get_background_task_status", None)
+    if svc is None or not callable(status_getter):
+        return
+    try:
+        progress = svc.get_background_task_status()
+    except Exception as e:
+        progress = {"running": False, "error": str(e)}
+    running = bool(isinstance(progress, dict) and progress.get("running"))
+    schedule_type = _SCHEDULE_TYPES["program_trading_monitor"]
+    result.append({
+        "name": "program_trading_monitor",
+        "state": "running" if running else "idle",
+        "priority": 50,
+        "schedule_type": schedule_type,
+        "schedule_order": _SCHEDULE_ORDER.get(schedule_type, 99),
+        "delay_sec": 0,
+        "progress": progress,
+    })
 
 
 # ── 장 마감 후 태스크 강제 수집 엔드포인트 ─────────────────────────────


### PR DESCRIPTION
…연결했고, 알림 포맷에서 이름 조회 실패 시에만 코드로 fallback합니다: program_trading_stream_service.py (line 276), wiring_phase.py (line 77)

DB 저장 점검은 기존처럼 “분봉 누락”만 말하지 않고, 원인을 분리합니다. 체결시간 기준으로 DB 저장 분을 계산하고, 메모리 수신 분과 비교해서 DB 미저장 N분과 수신없음 N분을 따로 리포트합니다. 그래서 실제 저장 실패인지, 애초에 해당 분에 프로그램매매 tick이 없었던 것인지 구분됩니다: program_trading_stream_service.py (line 387), program_trading_repo.py (line 409) system.py에 보이지 않던 이유도 반영했습니다. 프로그램매매 DB 점검/틱 알림 루프는 SchedulableTask로 등록된 독립 task가 아니라 ProgramTradingStreamService 내부 루프라 background_scheduler.get_all_status()에 안 잡히는 구조였습니다. /background/status에 program_trading_monitor 항목으로 내부 flush/alert/db-check 상태를 노출하도록 보강했습니다: system.py (line 456) 검증:
C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v 통과 C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v 통과, 235 passed. 통합 테스트에서 기존성으로 보이는 pending task/경고 1건은 남았지만 실패는 없습니다.