### PR TITLE
P0 0-7 완료

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -19,6 +19,14 @@ paper_websocket_url: "ws://ops.koreainvestment.com:31000"
 # 실전/모의 선택 (true: 모의, false: 실전)
 is_paper_trading: true
 
+# 운영 profile (P0 0-7): 실전 모드에서 어떤 overlay 를 적용할지 결정.
+#   canary       : 총 노출 5%, 동시 보유 2종, 1주문 1M — 실계좌 소액 검증 단계 (docs/canary_procedure.md 기준)
+#   real_limited : 총 노출 30%, 동시 보유 5종 — canary 통과 후 별도 ack 거쳐 진입하는 중간 단계
+#   real_full    : overlay 미적용, base 값 사용 — formal 검증 + 자금 확대 승인 후에만 사용
+# paper 모드에서는 profile 무시. predeploy/pre-market health check 에 현재 profile 이 표시되며,
+# canary 외 profile 은 WARN 으로 보고된다.
+operating_profile: "canary"
+
 # 선택
 htsid: ""
 custtype: "P"
@@ -44,9 +52,14 @@ risk_gate:
   max_daily_order_amount_won: 50000000
   max_pending_orders: 10
   max_total_exposure_pct: 95.0
-  # is_paper_trading=false (실전) 일 때 자동 적용되는 canary overlay.
-  # 검증 전 운영을 보호하기 위해 더 보수적인 한도를 강제한다. paper 동작은 영향 없음.
-  # production 등급으로 풀고 싶을 때만 명시값을 주면 yaml 값이 우선한다.
+  # operating_profile=canary 시 적용되는 overlay (실계좌 소액 검증).
+  # docs/canary_procedure.md 표 기준 — 총 노출 5%, 동시 보유 2종, 1주문 1M.
+  canary_overrides:
+    max_total_exposure_pct: 5.0
+    max_pending_orders: 2
+    max_order_amount_won: 1000000
+  # operating_profile=real_limited 시 적용되는 overlay (canary 통과 후 중간 단계).
+  # canary 보다 느슨, real_full 보다는 보수. 별도 ack 후에만 진입.
   real_mode_overrides:
     max_total_exposure_pct: 30.0
     max_pending_orders: 5
@@ -190,7 +203,12 @@ position_sizing:
   atr_multiplier: 2.0
   min_stop_distance_pct: 1.0       # 산식 보호용 최소 손절 거리 (%)
   snapshot_ttl_sec: 60             # 잔고 스냅샷 안전망 TTL (초)
-  # 실전 모드에서 자동 적용되는 canary overlay.
+  # operating_profile=canary 시 적용되는 overlay (실계좌 소액 검증).
+  # docs/canary_procedure.md 표 기준 — 1주당 리스크 0.25%, 단일 포지션 1.5%.
+  canary_overrides:
+    per_trade_risk_pct: 0.25
+    max_per_position_pct: 1.5
+  # operating_profile=real_limited 시 적용되는 overlay (canary 통과 후 중간 단계).
   real_mode_overrides:
     per_trade_risk_pct: 0.5
     max_per_position_pct: 3.0

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -2,7 +2,7 @@
 import yaml
 import os
 import json
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Literal, Optional, List
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 # config.yaml 및 tr_ids_config.yaml 파일 경로 설정
@@ -35,12 +35,24 @@ class KillSwitchConfig(BaseModel):
     state_file_path: str = "data/kill_switch_state.json"
 
 class PositionSizingRealOverrides(BaseModel):
-    """실전(real) 모드 전용 PositionSizing overlay. paper 동작은 영향 없음.
+    """real_limited overlay (실전 제한 운영). paper 동작은 영향 없음.
 
-    canary 임계로 default 값을 잡았다. 운영 검증 후 더 느슨한 값을 쓰려면 yaml 에서 명시.
+    operating_profile=real_limited 시 적용. canary 와 별도로 운영 검증 단계의
+    중간 한도(0.5%/3.0%)를 표현한다.
     """
-    per_trade_risk_pct: float = 0.5        # canary: 0.25~0.5 권장 중 보수값
-    max_per_position_pct: float = 3.0      # canary: 2.0~3.0 권장 중 보수값
+    per_trade_risk_pct: float = 0.5
+    max_per_position_pct: float = 3.0
+
+    model_config = {"extra": "allow"}
+
+
+class PositionSizingCanaryOverrides(BaseModel):
+    """canary overlay (실전 소액 검증). operating_profile=canary 시 적용.
+
+    docs/canary_procedure.md 표 기준 보수 운영값.
+    """
+    per_trade_risk_pct: float = 0.25       # 1주당 리스크 0.25%
+    max_per_position_pct: float = 1.5      # 단일 포지션 1.5%
 
     model_config = {"extra": "allow"}
 
@@ -55,6 +67,7 @@ class PositionSizingConfig(BaseModel):
     min_stop_distance_pct: float = 1.0     # 분모 보호용 최소 손절 거리 (%)
     snapshot_ttl_sec: int = 60             # 잔고 스냅샷 TTL (초)
     real_mode_overrides: PositionSizingRealOverrides = Field(default_factory=PositionSizingRealOverrides)
+    canary_overrides: PositionSizingCanaryOverrides = Field(default_factory=PositionSizingCanaryOverrides)
 
     model_config = {"extra": "allow"}
 
@@ -84,9 +97,24 @@ class RiskGateFailOpenConfig(BaseModel):
 
 
 class RiskGateRealOverrides(BaseModel):
-    """실전(real) 모드 전용 RiskGate overlay. paper 동작은 영향 없음."""
-    max_total_exposure_pct: float = 30.0   # canary: 20.0~35.0 권장 중 중앙값
-    max_pending_orders: int = 5            # canary: 3~5 권장 중 보수값
+    """real_limited overlay (실전 제한 운영). operating_profile=real_limited 시 적용.
+
+    paper 동작은 영향 없음. canary 와 full 사이의 중간 검증 단계 한도.
+    """
+    max_total_exposure_pct: float = 30.0
+    max_pending_orders: int = 5
+
+    model_config = {"extra": "allow"}
+
+
+class RiskGateCanaryOverrides(BaseModel):
+    """canary overlay (실전 소액 검증). operating_profile=canary 시 적용.
+
+    docs/canary_procedure.md 표 기준: 총 노출 5%, 동시 보유 2종, 1주문 1M.
+    """
+    max_total_exposure_pct: float = 5.0
+    max_pending_orders: int = 2
+    max_order_amount_won: int = 1_000_000
 
     model_config = {"extra": "allow"}
 
@@ -102,6 +130,7 @@ class RiskGateConfig(BaseModel):
     strategy_limits: Dict[str, RiskGateStrategyLimitConfig] = Field(default_factory=dict)
     fail_open_allowed: RiskGateFailOpenConfig = Field(default_factory=RiskGateFailOpenConfig)
     real_mode_overrides: RiskGateRealOverrides = Field(default_factory=RiskGateRealOverrides)
+    canary_overrides: RiskGateCanaryOverrides = Field(default_factory=RiskGateCanaryOverrides)
 
     model_config = {"extra": "allow"}
 
@@ -337,7 +366,11 @@ class AppConfig(BaseModel):
     
     # Flags
     is_paper_trading: bool = True
-    
+
+    # Operating profile (P0 0-7): canary 5% 노출 vs real_limited 30% vs real_full 95% 운영 한도 분리.
+    # paper 모드에서는 base 값을 사용하므로 profile 무관. real 모드에서 overlay 선택.
+    operating_profile: Literal["canary", "real_limited", "real_full"] = "canary"
+
     # Sub-configs
     web: WebConfig
     cache: CacheConfig = Field(default_factory=CacheConfig)

--- a/docs/canary_procedure.md
+++ b/docs/canary_procedure.md
@@ -24,18 +24,28 @@
 
 ## 운영 한도 (Canary 단계)
 
-canary 단계는 full-auto 대비 한도를 별도로 낮게 둔다. 아래 값은 *초기 권장 기본값* 이며 운영 첫 주 결과를 바탕으로 재조정한다. 변경 시 본 문서와 `config/config.yaml` 의 `risk_gate.*` 를 동시에 갱신한다.
+운영 단계는 `config/config.yaml` 의 `operating_profile` 로 구분한다 (P0 0-7):
 
-| 항목 | Canary 한도 | Full 한도(참고) | 적용 위치 |
-| --- | --- | --- | --- |
-| 동시 보유 종목 수 | 2종 | 전략 별 capital 한도 내 무제한 | 전략 capital 설정 + `max_pending_orders` |
-| 단일 주문 금액 | 1,000,000 KRW | 전략 자본의 1포지션 비중 | `risk_gate.max_order_amount` |
-| 전략 1일 손실 한도 | -1.0% | -3.0% | `risk_gate.strategy_loss_limit` |
-| 전략 연속 손실 한도 | 3회 | 5회 | 전략 별 cooldown 정책 |
-| 미체결 허용 시간 | 5분 | 30분 | `FillReconciliationService` reconcile 윈도우 |
-| 계좌 총 노출 한도 | 총자산의 5% | 총자산의 30% | `risk_gate.max_total_exposure` |
-| Kill Switch 연속 API 오류 한도 | 3회 | `KillSwitchConfig.max_consecutive_api_errors` 운영 기본값 | `config/config.yaml` `kill_switch.max_consecutive_api_errors` |
-| 활성 전략 수 | 검증된 1\~2개 전략만 | 전체 활성 전략 | `StrategyFactory` 등록 |
+- `canary` — 실계좌 소액 검증 단계. 본 문서의 표가 기본값이다.
+- `real_limited` — canary 통과 후 별도 ack 거쳐 진입하는 중간 단계 (총 노출 30%).
+- `real_full` — formal 검증 + 자금 확대 승인 후에만 사용. overlay 미적용, base 값 사용.
+
+`predeploy` / `pre-market health check` 는 현재 profile 을 표시하며, canary 외 profile 은 WARN 으로 보고된다. 변경 시 본 문서와 `config/config.yaml` 의 `risk_gate.*`, `position_sizing.*`, `operating_profile` 을 함께 갱신한다.
+
+canary 단계는 full-auto 대비 한도를 별도로 낮게 둔다. 아래 값은 *초기 권장 기본값* 이며 운영 첫 주 결과를 바탕으로 재조정한다.
+
+| 항목 | Canary 한도 | real_limited 한도 | real_full 한도 | 적용 위치 |
+| --- | --- | --- | --- | --- |
+| 동시 보유 종목 수 | 2종 | 5종 | 전략 자본 한도 내 무제한 | `risk_gate.{canary,real_mode}_overrides.max_pending_orders` |
+| 단일 주문 금액 | 1,000,000 KRW | base 값 사용 | 전략 자본의 1포지션 비중 | `risk_gate.canary_overrides.max_order_amount_won` |
+| 전략 1일 손실 한도 | -1.0% | -2.0% | -3.0% | `risk_gate.strategy_loss_limit` |
+| 전략 연속 손실 한도 | 3회 | 4회 | 5회 | 전략 별 cooldown 정책 |
+| 미체결 허용 시간 | 5분 | 15분 | 30분 | `FillReconciliationService` reconcile 윈도우 |
+| 계좌 총 노출 한도 | 총자산의 5% | 총자산의 30% | 총자산의 95% (base) | `risk_gate.{canary,real_mode}_overrides.max_total_exposure_pct` |
+| 1주당 리스크 한도 | 0.25% | 0.5% | base 값 (1.5%) | `position_sizing.{canary,real_mode}_overrides.per_trade_risk_pct` |
+| 단일 종목 비중 상한 | 1.5% | 3.0% | base 값 (5.0%) | `position_sizing.{canary,real_mode}_overrides.max_per_position_pct` |
+| Kill Switch 연속 API 오류 한도 | 3회 | 5회 | `KillSwitchConfig.max_consecutive_api_errors` 운영 기본값 | `config/config.yaml` `kill_switch.max_consecutive_api_errors` |
+| 활성 전략 수 | 검증된 1\~2개 전략만 | 검증된 3~4개 | 전체 활성 전략 | `StrategyFactory` 등록 |
 
 ## 관찰 기간
 

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -44,6 +44,7 @@ class PositionSizingService:
         quote_provider: Optional[QuoteProvider] = None,
         order_policy_config: Optional["OrderPolicyConfig"] = None,
         env: Optional[Any] = None,
+        operating_profile: str = "canary",
     ):
         self._cache = account_snapshot_cache
         self._indicator = indicator_service
@@ -53,6 +54,7 @@ class PositionSizingService:
         self._quote_provider = quote_provider
         self._order_policy_config = order_policy_config
         self._env = env
+        self._operating_profile = operating_profile
 
     def _is_real_mode(self) -> bool:
         """env 미주입이면 paper 로 간주 (보수적 default)."""
@@ -62,14 +64,23 @@ class PositionSizingService:
         return not bool(getattr(env, "is_paper_trading", True))
 
     def _effective_per_trade_risk_pct(self) -> float:
-        if self._is_real_mode():
-            return self._cfg.real_mode_overrides.per_trade_risk_pct
-        return self._cfg.per_trade_risk_pct
+        if not self._is_real_mode():
+            return self._cfg.per_trade_risk_pct
+        if self._operating_profile == "canary":
+            return self._cfg.canary_overrides.per_trade_risk_pct
+        if self._operating_profile == "real_full":
+            return self._cfg.per_trade_risk_pct
+        # real_limited (default fallback)
+        return self._cfg.real_mode_overrides.per_trade_risk_pct
 
     def _effective_max_per_position_pct(self) -> float:
-        if self._is_real_mode():
-            return self._cfg.real_mode_overrides.max_per_position_pct
-        return self._cfg.max_per_position_pct
+        if not self._is_real_mode():
+            return self._cfg.max_per_position_pct
+        if self._operating_profile == "canary":
+            return self._cfg.canary_overrides.max_per_position_pct
+        if self._operating_profile == "real_full":
+            return self._cfg.max_per_position_pct
+        return self._cfg.real_mode_overrides.max_per_position_pct
 
     # ── 공개 API ──────────────────────────────────────────────────
 

--- a/services/predeploy_check_service.py
+++ b/services/predeploy_check_service.py
@@ -361,11 +361,39 @@ class PreDeployCheckService:
 
         return await self._measured("api_budget_limiter", run)
 
+    async def check_operating_profile(self) -> CheckResult:
+        """현재 operating_profile 을 표시하고 canary 외 profile 에는 경고를 낸다.
+
+        - paper + canary: PASS (안전한 기본값)
+        - paper + non-canary: WARN (운영자 의도 불명확)
+        - real + canary: PASS (P0 0-7 정책 기본)
+        - real + real_limited/real_full: WARN (canary 성과 검증 후 별도 ack 필요)
+        """
+        async def run() -> CheckResult:
+            cfg = self._cached_config or self._config_loader()
+            self._cached_config = cfg
+            is_paper = bool(getattr(cfg, "is_paper_trading", True))
+            profile = str(getattr(cfg, "operating_profile", "canary"))
+            mode = "paper" if is_paper else "real"
+            detail = f"operating_profile={profile}, mode={mode}"
+            if profile == "canary":
+                return CheckResult(name="", status=CheckStatus.PASS, detail=detail)
+            return CheckResult(
+                name="",
+                status=CheckStatus.WARN,
+                detail=detail + " — canary 외 profile 은 별도 ack/검증 후에만 사용 (docs/canary_procedure.md)",
+            )
+
+        return await self._measured("operating_profile", run)
+
     async def check_real_mode_policy_strictness(self) -> CheckResult:
         """real 모드일 때 effective PositionSizing / RiskGate / OrderPolicy 값이
-        canary 임계보다 느슨하면 WARN 또는 FAIL 을 낸다.
+        profile 임계보다 느슨하면 WARN 또는 FAIL 을 낸다.
 
-        canary 임계는 각 RealOverrides 클래스의 default 값 (P0 0-2 정책 합의값).
+        profile 임계는 operating_profile 에 따라 결정:
+          - canary: canary_overrides default (5%/2/0.25%/1.5% 등 가장 보수)
+          - real_limited: real_mode_overrides default (30%/5/0.5%/3.0% 등 중간)
+          - real_full: strictness check 자체를 SKIP (운영자 ack 전제)
         loose factor 1.5× 까지는 WARN, 그 이상은 FAIL.
         OrderPolicy.allow_market_buy=True 는 real 모드에서 즉시 FAIL.
         paper 모드면 SKIPPED.
@@ -377,6 +405,14 @@ class PreDeployCheckService:
             if is_paper:
                 return CheckResult(name="", status=CheckStatus.SKIPPED, detail="paper 모드 — strictness check skip")
 
+            profile = str(getattr(cfg, "operating_profile", "canary"))
+            if profile == "real_full":
+                return CheckResult(
+                    name="",
+                    status=CheckStatus.SKIPPED,
+                    detail="real_full profile — strictness 기대값 미정 (operating_profile 별도 ack)",
+                )
+
             warns: List[str] = []
             fails: List[str] = []
 
@@ -384,28 +420,38 @@ class PreDeployCheckService:
             rg_cfg = getattr(cfg, "risk_gate", None)
             op_cfg = getattr(cfg, "order_policy", None)
 
-            def _grade(name: str, effective: float, canary: float, *, lower_is_safer: bool = True) -> None:
-                """effective 가 canary 임계보다 얼마나 느슨한지 평가."""
+            def _grade(name: str, effective: float, threshold: float, *, lower_is_safer: bool = True) -> None:
+                """effective 가 profile 임계보다 얼마나 느슨한지 평가."""
                 if lower_is_safer:
-                    if effective > canary * 1.5:
-                        fails.append(f"{name}={effective} (canary={canary}, loose>1.5x)")
-                    elif effective > canary:
-                        warns.append(f"{name}={effective} (canary={canary})")
+                    if effective > threshold * 1.5:
+                        fails.append(f"{name}={effective} ({profile}={threshold}, loose>1.5x)")
+                    elif effective > threshold:
+                        warns.append(f"{name}={effective} ({profile}={threshold})")
                 else:
-                    if effective < canary / 1.5:
-                        fails.append(f"{name}={effective} (canary={canary}, tight<0.67x)")
-                    elif effective < canary:
-                        warns.append(f"{name}={effective} (canary={canary})")
+                    if effective < threshold / 1.5:
+                        fails.append(f"{name}={effective} ({profile}={threshold}, tight<0.67x)")
+                    elif effective < threshold:
+                        warns.append(f"{name}={effective} ({profile}={threshold})")
 
             if ps_cfg is not None:
-                ov = ps_cfg.real_mode_overrides
-                _grade("position_sizing.per_trade_risk_pct", ov.per_trade_risk_pct, 0.5)
-                _grade("position_sizing.max_per_position_pct", ov.max_per_position_pct, 3.0)
+                if profile == "canary":
+                    ov = ps_cfg.canary_overrides
+                    _grade("position_sizing.per_trade_risk_pct", ov.per_trade_risk_pct, 0.25)
+                    _grade("position_sizing.max_per_position_pct", ov.max_per_position_pct, 1.5)
+                else:  # real_limited
+                    ov = ps_cfg.real_mode_overrides
+                    _grade("position_sizing.per_trade_risk_pct", ov.per_trade_risk_pct, 0.5)
+                    _grade("position_sizing.max_per_position_pct", ov.max_per_position_pct, 3.0)
 
             if rg_cfg is not None:
-                ov = rg_cfg.real_mode_overrides
-                _grade("risk_gate.max_total_exposure_pct", ov.max_total_exposure_pct, 30.0)
-                _grade("risk_gate.max_pending_orders", ov.max_pending_orders, 5)
+                if profile == "canary":
+                    ov = rg_cfg.canary_overrides
+                    _grade("risk_gate.max_total_exposure_pct", ov.max_total_exposure_pct, 5.0)
+                    _grade("risk_gate.max_pending_orders", ov.max_pending_orders, 2)
+                else:  # real_limited
+                    ov = rg_cfg.real_mode_overrides
+                    _grade("risk_gate.max_total_exposure_pct", ov.max_total_exposure_pct, 30.0)
+                    _grade("risk_gate.max_pending_orders", ov.max_pending_orders, 5)
 
             if op_cfg is not None:
                 ov = op_cfg.real_mode_overrides
@@ -422,7 +468,7 @@ class PreDeployCheckService:
                 return CheckResult(name="", status=CheckStatus.FAIL, detail=detail)
             if warns:
                 return CheckResult(name="", status=CheckStatus.WARN, detail="WARN: " + "; ".join(warns))
-            return CheckResult(name="", status=CheckStatus.PASS, detail="real 모드 정책이 canary 임계 안에 있음")
+            return CheckResult(name="", status=CheckStatus.PASS, detail=f"real 모드 정책이 {profile} 임계 안에 있음")
 
         return await self._measured("real_mode_policy_strictness", run)
 
@@ -432,6 +478,7 @@ class PreDeployCheckService:
         results: List[CheckResult] = []
         results.append(await self.check_config())
         results.append(await self.check_token_env_consistency())
+        results.append(await self.check_operating_profile())
         results.append(await self.check_latest_trading_date())
         results.append(await self.check_event_shadow())
         results.append(await self.check_websocket_subscription(offline=offline))

--- a/services/risk_gate_service.py
+++ b/services/risk_gate_service.py
@@ -67,6 +67,7 @@ class RiskGateService:
         market_buy_reference_price_provider: Optional[
             Callable[[str, Exchange], Union[Optional[int], Awaitable[Optional[int]]]]
         ] = None,
+        operating_profile: str = "canary",
     ):
         self._cfg = config
         self._kill_switch = kill_switch_service
@@ -78,6 +79,7 @@ class RiskGateService:
         self._market_buy_reference_price_provider = market_buy_reference_price_provider
         self._daily_total: dict[date, int] = defaultdict(int)
         self._strategy_resolver = STRATEGY_IDENTITY_RESOLVER
+        self._operating_profile = operating_profile
 
     async def validate_order(
         self,
@@ -172,7 +174,8 @@ class RiskGateService:
             if not is_force_exit_sell:
                 # 1회 주문 금액 한도는 신규 노출을 늘리는 BUY에만 적용한다.
                 # SELL은 손절/익절 청산 경로라 금액 한도로 막으면 리스크가 더 커질 수 있다.
-                if side == OrderSide.BUY and order_amount > self._cfg.max_order_amount_won:
+                effective_max_order_amount = self._effective_max_order_amount_won()
+                if side == OrderSide.BUY and order_amount > effective_max_order_amount:
                     return self._blocked(
                         "max_order_amount",
                         "주문 금액 초과",
@@ -181,7 +184,7 @@ class RiskGateService:
                         source=source,
                         strategy_name=strategy_name,
                         order_amount=order_amount,
-                        max_order_amount_won=self._cfg.max_order_amount_won,
+                        max_order_amount_won=effective_max_order_amount,
                     )
 
                 daily_blocked = self._check_daily_cap(stock_code=stock_code, order_amount=order_amount, side=side)
@@ -370,14 +373,32 @@ class RiskGateService:
         return not bool(getattr(fail_open_cfg, "paper", True))
 
     def _effective_max_total_exposure_pct(self) -> float:
-        if self._is_real_mode():
-            return self._cfg.real_mode_overrides.max_total_exposure_pct
-        return self._cfg.max_total_exposure_pct
+        if not self._is_real_mode():
+            return self._cfg.max_total_exposure_pct
+        if self._operating_profile == "canary":
+            return self._cfg.canary_overrides.max_total_exposure_pct
+        if self._operating_profile == "real_full":
+            return self._cfg.max_total_exposure_pct
+        # real_limited (default fallback)
+        return self._cfg.real_mode_overrides.max_total_exposure_pct
 
     def _effective_max_pending_orders(self) -> int:
-        if self._is_real_mode():
-            return self._cfg.real_mode_overrides.max_pending_orders
-        return self._cfg.max_pending_orders
+        if not self._is_real_mode():
+            return self._cfg.max_pending_orders
+        if self._operating_profile == "canary":
+            return self._cfg.canary_overrides.max_pending_orders
+        if self._operating_profile == "real_full":
+            return self._cfg.max_pending_orders
+        return self._cfg.real_mode_overrides.max_pending_orders
+
+    def _effective_max_order_amount_won(self) -> int:
+        """canary profile 시 1회 주문 금액 한도를 더 보수적으로 적용.
+
+        real_limited/real_full 은 base 사용 (real_mode_overrides 에는 이 필드 없음).
+        """
+        if self._is_real_mode() and self._operating_profile == "canary":
+            return self._cfg.canary_overrides.max_order_amount_won
+        return self._cfg.max_order_amount_won
 
     async def _resolve_market_buy_reference_price(
         self,

--- a/tests/integration_test/test_it_predeploy_check.py
+++ b/tests/integration_test/test_it_predeploy_check.py
@@ -30,11 +30,12 @@ async def test_offline_predeploy_check_runs_to_completion(tmp_path):
     summary = await service.run_all(offline=True)
 
     # 모든 점검이 끝까지 실행되어야 한다
-    assert len(summary.results) == 8
+    assert len(summary.results) == 9
     names = {r.name for r in summary.results}
     assert names == {
         "config_validation",
         "broker_env_consistency",
+        "operating_profile",
         "latest_trading_date",
         "event_shadow_status",
         "websocket_subscription_health",

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -331,3 +331,64 @@ def test_load_configs_missing_optional_field_defaults():
         # cache가 없어도 기본값으로 생성되어야 함
         assert config.cache.base_dir == ".cache"
         assert config.cache.memory_cache_enabled is True
+
+
+# ── P0 0-7: operating_profile + profile-specific overrides ──────────────────
+
+
+def _minimal_app_config(**overrides):
+    base = {"web": {"host": "127.0.0.1", "port": 8000}}
+    base.update(overrides)
+    return AppConfig(**base)
+
+
+def test_app_config_default_operating_profile_is_canary():
+    cfg = _minimal_app_config()
+    assert cfg.operating_profile == "canary"
+
+
+def test_app_config_accepts_real_limited_profile():
+    cfg = _minimal_app_config(operating_profile="real_limited")
+    assert cfg.operating_profile == "real_limited"
+
+
+def test_app_config_accepts_real_full_profile():
+    cfg = _minimal_app_config(operating_profile="real_full")
+    assert cfg.operating_profile == "real_full"
+
+
+def test_app_config_rejects_invalid_profile():
+    with pytest.raises(ValidationError):
+        _minimal_app_config(operating_profile="canary_full")
+
+
+def test_risk_gate_canary_overrides_defaults_match_canary_procedure():
+    """canary profile 기본값: docs/canary_procedure.md 운영 한도와 일치."""
+    from config.config_loader import RiskGateConfig
+    cfg = RiskGateConfig()
+    assert cfg.canary_overrides.max_total_exposure_pct == 5.0
+    assert cfg.canary_overrides.max_pending_orders == 2
+    assert cfg.canary_overrides.max_order_amount_won == 1_000_000
+
+
+def test_position_sizing_canary_overrides_defaults_match_canary_procedure():
+    """canary profile 기본값: 1주당 리스크 0.25%, 단일 포지션 1.5%."""
+    from config.config_loader import PositionSizingConfig
+    cfg = PositionSizingConfig()
+    assert cfg.canary_overrides.per_trade_risk_pct == 0.25
+    assert cfg.canary_overrides.max_per_position_pct == 1.5
+
+
+def test_risk_gate_real_mode_overrides_still_default_real_limited():
+    """real_mode_overrides 의 기본값은 그대로 (real_limited overlay) — backward compat."""
+    from config.config_loader import RiskGateConfig
+    cfg = RiskGateConfig()
+    assert cfg.real_mode_overrides.max_total_exposure_pct == 30.0
+    assert cfg.real_mode_overrides.max_pending_orders == 5
+
+
+def test_position_sizing_real_mode_overrides_still_default_real_limited():
+    from config.config_loader import PositionSizingConfig
+    cfg = PositionSizingConfig()
+    assert cfg.real_mode_overrides.per_trade_risk_pct == 0.5
+    assert cfg.real_mode_overrides.max_per_position_pct == 3.0

--- a/tests/unit_test/services/test_position_sizing_service.py
+++ b/tests/unit_test/services/test_position_sizing_service.py
@@ -456,6 +456,9 @@ def _env(is_paper_trading: bool):
 
 
 def _make_service_with_env(env, cfg=None):
+    # NOTE: P0 0-7 — 기존 real_mode_overrides 동작 검증 테스트가 의존하므로
+    # helper default 는 "real_limited" overlay 를 사용. canary 분기 테스트는
+    # 별도 `_make_service_with_profile` 또는 명시적 operating_profile 인자를 사용한다.
     cache = AsyncMock()
     cache.get.return_value = _make_snapshot(
         total_equity=10_000_000,
@@ -468,6 +471,7 @@ def _make_service_with_env(env, cfg=None):
         indicator_service=indicator,
         config=cfg or _make_config(),
         env=env,
+        operating_profile="real_limited",
     )
     return svc
 
@@ -539,3 +543,86 @@ async def test_position_sizing_real_mode_shrinks_risk_qty():
     # paper: per_trade_risk_pct=1.0 / max_per_position_pct=10.0
     # real overlay: per_trade_risk_pct=0.5 / max_per_position_pct=3.0 → 둘 다 빠듯해진다
     assert paper_qty > real_qty > 0
+
+
+# ── P0 0-7: operating_profile 분기 ────────────────────────────────────
+
+
+def _make_service_with_profile(env, cfg=None, operating_profile="canary"):
+    cache = AsyncMock()
+    cache.get.return_value = _make_snapshot(
+        total_equity=10_000_000,
+        available_cash=10_000_000,
+    )
+    indicator = AsyncMock()
+    indicator.calculate_atr.return_value = None
+    svc = PositionSizingService(
+        account_snapshot_cache=cache,
+        indicator_service=indicator,
+        config=cfg or _make_config(),
+        env=env,
+        operating_profile=operating_profile,
+    )
+    return svc
+
+
+def test_position_sizing_canary_profile_uses_canary_overrides():
+    """real 모드 + profile=canary → canary_overrides 적용 (0.25%, 1.5%)."""
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="canary"
+    )
+    assert svc._effective_per_trade_risk_pct() == 0.25
+    assert svc._effective_max_per_position_pct() == 1.5
+
+
+def test_position_sizing_real_limited_profile_uses_real_mode_overrides():
+    """real 모드 + profile=real_limited → real_mode_overrides 적용 (0.5%, 3.0%)."""
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="real_limited"
+    )
+    assert svc._effective_per_trade_risk_pct() == 0.5
+    assert svc._effective_max_per_position_pct() == 3.0
+
+
+def test_position_sizing_real_full_profile_uses_base_values():
+    """real 모드 + profile=real_full → overlay 미적용, base 사용."""
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="real_full"
+    )
+    assert svc._effective_per_trade_risk_pct() == 1.5
+    assert svc._effective_max_per_position_pct() == 5.0
+
+
+def test_position_sizing_paper_mode_ignores_profile():
+    """paper 모드: profile 무시, base 사용."""
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_profile(
+        env=_env(is_paper_trading=True), cfg=cfg, operating_profile="canary"
+    )
+    assert svc._effective_per_trade_risk_pct() == 1.5
+    assert svc._effective_max_per_position_pct() == 5.0
+
+
+def test_position_sizing_default_profile_is_canary():
+    """operating_profile 미지정 시 canary 기본값."""
+    cfg = _make_config(per_trade_risk_pct=1.5, max_per_position_pct=5.0)
+    svc = _make_service_with_profile(env=_env(is_paper_trading=False), cfg=cfg)
+    assert svc._effective_per_trade_risk_pct() == 0.25
+    assert svc._effective_max_per_position_pct() == 1.5
+
+
+def test_position_sizing_canary_overrides_user_yaml():
+    """yaml 에서 canary_overrides 명시 시 default 보다 우선."""
+    cfg = PositionSizingConfig(
+        per_trade_risk_pct=1.5,
+        max_per_position_pct=5.0,
+        canary_overrides={"per_trade_risk_pct": 0.1, "max_per_position_pct": 0.5},
+    )
+    svc = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="canary"
+    )
+    assert svc._effective_per_trade_risk_pct() == 0.1
+    assert svc._effective_max_per_position_pct() == 0.5

--- a/tests/unit_test/services/test_predeploy_check_service.py
+++ b/tests/unit_test/services/test_predeploy_check_service.py
@@ -394,7 +394,7 @@ async def test_run_all_offline_skips_live_checks():
 
     summary = await svc.run_all(offline=True)
     assert isinstance(summary, PreDeployCheckSummary)
-    assert len(summary.results) == 8
+    assert len(summary.results) == 9
     probe.assert_not_awaited()
     broker.get_account_balance.assert_not_awaited()
 
@@ -402,6 +402,7 @@ async def test_run_all_offline_skips_live_checks():
     assert names == [
         "config_validation",
         "broker_env_consistency",
+        "operating_profile",
         "latest_trading_date",
         "event_shadow_status",
         "websocket_subscription_health",
@@ -453,22 +454,40 @@ def _policy_cfg(
     ps_overrides: dict | None = None,
     rg_overrides: dict | None = None,
     op_overrides: dict | None = None,
+    operating_profile: str = "real_limited",
+    canary_ps_overrides: dict | None = None,
+    canary_rg_overrides: dict | None = None,
 ):
-    """real_mode_overrides 만 다르게 채워서 cfg 생성."""
+    """real_mode_overrides 또는 canary_overrides 를 채워서 cfg 생성.
+
+    operating_profile 기본값은 "real_limited" — 기존 테스트가 real_mode_overrides 를 통해
+    검증하는 동작을 유지한다. profile=canary 테스트는 canary_*_overrides 를 사용한다.
+    """
     from config.config_loader import (
         OrderPolicyConfig,
         OrderPolicyRealOverrides,
         PositionSizingConfig,
-        PositionSizingRealOverrides,
         RiskGateConfig,
-        RiskGateRealOverrides,
     )
 
-    ps = PositionSizingConfig(real_mode_overrides=PositionSizingRealOverrides(**(ps_overrides or {})))
-    rg = RiskGateConfig(real_mode_overrides=RiskGateRealOverrides(**(rg_overrides or {})))
+    ps_kwargs: dict = {}
+    if ps_overrides:
+        ps_kwargs["real_mode_overrides"] = ps_overrides
+    if canary_ps_overrides:
+        ps_kwargs["canary_overrides"] = canary_ps_overrides
+
+    rg_kwargs: dict = {}
+    if rg_overrides:
+        rg_kwargs["real_mode_overrides"] = rg_overrides
+    if canary_rg_overrides:
+        rg_kwargs["canary_overrides"] = canary_rg_overrides
+
+    ps = PositionSizingConfig(**ps_kwargs)
+    rg = RiskGateConfig(**rg_kwargs)
     op = OrderPolicyConfig(real_mode_overrides=OrderPolicyRealOverrides(**(op_overrides or {})))
     return SimpleNamespace(
         is_paper_trading=is_paper_trading,
+        operating_profile=operating_profile,
         position_sizing=ps,
         risk_gate=rg,
         order_policy=op,
@@ -539,3 +558,81 @@ async def test_real_mode_policy_strictness_fail_takes_priority_over_warn():
     assert result.status == CheckStatus.FAIL
     assert "allow_market_buy" in result.detail
     assert "per_trade_risk_pct" in result.detail
+
+
+# ── P0 0-7: check_operating_profile + profile-aware strictness ───────────
+
+
+async def test_check_operating_profile_pass_canary_real():
+    """real + canary profile → PASS."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=False, operating_profile="canary"
+    ))
+    result = await svc.check_operating_profile()
+    assert result.status == CheckStatus.PASS
+    assert "canary" in result.detail
+    assert result.name == "operating_profile"
+
+
+async def test_check_operating_profile_warn_real_limited_real():
+    """real + real_limited profile → WARN (운영자 ack 필요)."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=False, operating_profile="real_limited"
+    ))
+    result = await svc.check_operating_profile()
+    assert result.status == CheckStatus.WARN
+    assert "real_limited" in result.detail
+
+
+async def test_check_operating_profile_warn_real_full_real():
+    """real + real_full profile → WARN."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=False, operating_profile="real_full"
+    ))
+    result = await svc.check_operating_profile()
+    assert result.status == CheckStatus.WARN
+    assert "real_full" in result.detail
+
+
+async def test_check_operating_profile_pass_canary_paper():
+    """paper + canary → PASS (canary 가 paper 에서도 안전한 기본값)."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=True, operating_profile="canary"
+    ))
+    result = await svc.check_operating_profile()
+    assert result.status == CheckStatus.PASS
+
+
+async def test_check_operating_profile_warn_non_canary_paper():
+    """paper + non-canary profile → WARN (운영자 의도 불명확)."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=True, operating_profile="real_limited"
+    ))
+    result = await svc.check_operating_profile()
+    assert result.status == CheckStatus.WARN
+
+
+async def test_real_mode_policy_strictness_uses_canary_thresholds_when_profile_canary():
+    """profile=canary 일 때 strictness 임계 = canary_overrides 기본값 (5%/2/0.25/1.5)."""
+    # canary_overrides default: per_trade_risk_pct=0.25, max_per_position_pct=1.5,
+    #                          max_total_exposure_pct=5.0, max_pending_orders=2
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=False, operating_profile="canary",
+        # canary 임계 동등 → PASS
+    ))
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.PASS, result.detail
+
+
+async def test_real_mode_policy_strictness_canary_fails_with_real_limited_values():
+    """profile=canary + canary_overrides 가 real_limited 수준이면 FAIL."""
+    svc = _service(config_loader=lambda: _policy_cfg(
+        is_paper_trading=False, operating_profile="canary",
+        # canary_overrides 를 의도적으로 느슨하게(real_limited 수준) → FAIL
+        canary_rg_overrides={"max_total_exposure_pct": 30.0, "max_pending_orders": 5},
+        canary_ps_overrides={"per_trade_risk_pct": 0.5, "max_per_position_pct": 3.0},
+    ))
+    result = await svc.check_real_mode_policy_strictness()
+    assert result.status == CheckStatus.FAIL
+    # 30% > 5% * 1.5 = 7.5 → FAIL
+    assert "max_total_exposure_pct" in result.detail

--- a/tests/unit_test/services/test_risk_gate_service.py
+++ b/tests/unit_test/services/test_risk_gate_service.py
@@ -18,7 +18,11 @@ def _service(
     logger=None,
     env=None,
     market_buy_reference_price_provider=None,
+    operating_profile: str = "real_limited",
 ):
+    # NOTE: P0 0-7 — 기존 테스트 대다수가 real_mode_overrides (real_limited overlay)
+    # 동작을 검증하므로 helper default 를 "real_limited" 로 둔다. canary 분기 테스트는
+    # 별도 헬퍼 `_profile_service` 또는 명시적 operating_profile 인자를 사용한다.
     if kill_switch is None:
         kill_switch = AsyncMock()
         kill_switch.check_orders_allowed = AsyncMock(return_value=(True, None))
@@ -37,6 +41,7 @@ def _service(
         logger=logger or MagicMock(),
         env=env,
         market_buy_reference_price_provider=market_buy_reference_price_provider,
+        operating_profile=operating_profile,
     ), kill_switch, cache
 
 
@@ -1100,3 +1105,109 @@ async def test_risk_gate_real_mode_blocks_pending_orders_under_canary_threshold(
     assert real_result is not None
     assert real_result.data["rule"] == "max_pending_orders"
     assert real_result.data["max_pending_orders"] == 5
+
+
+# ── P0 0-7: operating_profile 분기 ────────────────────────────────────
+
+
+def _profile_service(*, config=None, env=None, operating_profile="canary"):
+    """operating_profile 키워드를 받는 RiskGateService 헬퍼."""
+    kill_switch = AsyncMock()
+    kill_switch.check_orders_allowed = AsyncMock(return_value=(True, None))
+    kill_switch.is_strategy_tripped = MagicMock(return_value=None)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=AccountSnapshot(
+        total_equity=100_000_000,
+        available_cash=50_000_000,
+        positions={"000660": 10_000_000},
+    ))
+    return RiskGateService(
+        config=config or RiskGateConfig(),
+        kill_switch_service=kill_switch,
+        account_snapshot_cache=cache,
+        strategy_risk_provider=None,
+        logger=MagicMock(),
+        env=env,
+        operating_profile=operating_profile,
+    )
+
+
+def test_risk_gate_canary_profile_uses_canary_overrides():
+    """real + profile=canary → canary_overrides 적용 (5%, 2 pending)."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0, max_pending_orders=10)
+    svc = _profile_service(config=cfg, env=_RealEnv(), operating_profile="canary")
+    assert svc._effective_max_total_exposure_pct() == 5.0
+    assert svc._effective_max_pending_orders() == 2
+
+
+def test_risk_gate_real_limited_profile_uses_real_mode_overrides():
+    """real + profile=real_limited → real_mode_overrides 적용 (30%, 5 pending)."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0, max_pending_orders=10)
+    svc = _profile_service(config=cfg, env=_RealEnv(), operating_profile="real_limited")
+    assert svc._effective_max_total_exposure_pct() == 30.0
+    assert svc._effective_max_pending_orders() == 5
+
+
+def test_risk_gate_real_full_profile_uses_base_values():
+    """real + profile=real_full → overlay 미적용, base 사용."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0, max_pending_orders=10)
+    svc = _profile_service(config=cfg, env=_RealEnv(), operating_profile="real_full")
+    assert svc._effective_max_total_exposure_pct() == 95.0
+    assert svc._effective_max_pending_orders() == 10
+
+
+def test_risk_gate_paper_mode_ignores_profile():
+    """paper 모드: profile 무시, base 사용."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0, max_pending_orders=10)
+    svc = _profile_service(config=cfg, env=_PaperEnv(), operating_profile="canary")
+    assert svc._effective_max_total_exposure_pct() == 95.0
+    assert svc._effective_max_pending_orders() == 10
+
+
+def test_risk_gate_default_profile_is_canary():
+    """operating_profile 미지정 시 canary 기본값."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0, max_pending_orders=10)
+    svc = _profile_service(config=cfg, env=_RealEnv())
+    assert svc._effective_max_total_exposure_pct() == 5.0
+    assert svc._effective_max_pending_orders() == 2
+
+
+def test_risk_gate_canary_overrides_user_yaml():
+    """yaml 에서 canary_overrides 명시 시 default 보다 우선."""
+    cfg = RiskGateConfig(
+        max_total_exposure_pct=95.0,
+        max_pending_orders=10,
+        canary_overrides={"max_total_exposure_pct": 3.0, "max_pending_orders": 1},
+    )
+    svc = _profile_service(config=cfg, env=_RealEnv(), operating_profile="canary")
+    assert svc._effective_max_total_exposure_pct() == 3.0
+    assert svc._effective_max_pending_orders() == 1
+
+
+@pytest.mark.asyncio
+async def test_risk_gate_canary_profile_blocks_exposure_above_5pct():
+    """canary profile: 10% 노출 시도 → 5% 한도로 차단."""
+    cfg = RiskGateConfig(max_total_exposure_pct=95.0)
+    # 10M positions on 100M equity → 10% exposure
+    snapshot = AccountSnapshot(
+        total_equity=100_000_000,
+        available_cash=80_000_000,
+        positions={"000660": 10_000_000},
+    )
+    kill_switch = AsyncMock()
+    kill_switch.check_orders_allowed = AsyncMock(return_value=(True, None))
+    kill_switch.is_strategy_tripped = MagicMock(return_value=None)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=snapshot)
+    svc = RiskGateService(
+        config=cfg, kill_switch_service=kill_switch,
+        account_snapshot_cache=cache, strategy_risk_provider=None,
+        logger=MagicMock(), env=_RealEnv(),
+        operating_profile="canary",
+    )
+    result = await svc.validate_order(
+        "005930", 70_000, 1, OrderSide.BUY, Exchange.KRX, active_order_count=0
+    )
+    assert result is not None
+    assert result.data["rule"] == "max_total_exposure"
+    assert result.data["max_total_exposure_pct"] == 5.0

--- a/todo_list.md
+++ b/todo_list.md
@@ -15,7 +15,7 @@
 남은 실행 영역 요약:
 
 - P0 0-1: 실전 체결 이력 확보 후 broker order mapper 분리 + fixture 회귀 잠금.
-- P0 0-7: canary 5% 노출 제한을 코드/config profile로 분리하고 real 기본 30%와 운영 혼동을 제거.
+- P0 0-7: ~~canary 5% 노출 제한을 코드/config profile로 분리하고 real 기본 30%와 운영 혼동을 제거.~~ ✅ 완료 (2026-05-27).
 - P1 1-5: 한국장 microstructure fixture 로 체결 모델 보수성 검증.
 - P1 1-6: 실전 journal/shadow/paper/live 성과 데이터로 profitability gate의 실제 통과 근거 확보.
 - P1 1-7: multiple testing proxy를 formal walk-forward / purged validation / PBO·Deflated Sharpe급 검증으로 확장할지 결정.
@@ -53,12 +53,13 @@
 
 ### 0-7. Canary profile과 real exposure 한도 분리
 
-- [ ] canary 운영용 profile을 코드/config에 명시적으로 추가한다.
-  - 배경: `docs/canary_procedure.md`는 canary 총 노출 5%를 전제로 하지만, 실전 override config는 총 노출 30%를 허용한다. 운영자가 30% 노출 상태를 canary로 오해하지 않도록 profile을 분리한다.
-  - canary 기본값 후보: `max_total_exposure_pct=5`, `max_positions=2`, `max_pending_orders=2`, `max_order_amount=1_000_000`, active strategy 1~2개.
-  - position sizing 후보: `max_per_position_pct=1~2`, `per_trade_risk_pct=0.25~0.5`.
-- [ ] predeploy / pre-market health check / runbook에서 현재 profile이 `canary`인지 표시하고, canary 단계에서 `real_limited` 또는 `real_full` 설정이면 경고 또는 차단한다.
-- [ ] `real_limited`(예: 총 노출 30%)와 `real_full`은 canary 성과 데이터와 별도 승인 후에만 사용할 수 있도록 운영 문서에 명시한다.
+- [x] canary 운영용 profile을 코드/config에 명시적으로 추가한다.
+  - 적용 완료: `AppConfig.operating_profile` (`canary` | `real_limited` | `real_full`, default `canary`). `RiskGateCanaryOverrides`(5% / 2 pending / 1M order), `PositionSizingCanaryOverrides`(0.25% / 1.5%) 신규 dataclass. 기존 `real_mode_overrides`는 의미상 `real_limited` overlay로 재정의 (값/동작 변경 없음).
+- [x] predeploy / pre-market health check / runbook에서 현재 profile이 `canary`인지 표시하고, canary 단계에서 `real_limited` 또는 `real_full` 설정이면 경고 또는 차단한다.
+  - 적용 완료: `PreDeployCheckService.check_operating_profile` 신규 (canary=PASS, 그 외=WARN). `check_real_mode_policy_strictness`는 profile 별 임계 분기 (canary=5%/2/0.25%/1.5%, real_limited=30%/5/0.5%/3.0%, real_full=SKIPPED).
+  - 후속 (선택): `pre_market_health_check_task` 별도 surfacing은 미반영. 현재 PredeployCheckService 경로로만 표시.
+- [x] `real_limited`(예: 총 노출 30%)와 `real_full`은 canary 성과 데이터와 별도 승인 후에만 사용할 수 있도록 운영 문서에 명시한다.
+  - 적용 완료: `docs/canary_procedure.md` 운영 한도 표를 3-tier (canary/real_limited/real_full) 로 확장. `config/config.yaml.example` 에 `operating_profile`, `risk_gate.canary_overrides`, `position_sizing.canary_overrides` 명시.
 
 주요 파일:
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -423,6 +423,7 @@ class ServiceContainer:
                 logger=ctx.logger,
                 ttl_sec=_ps_cfg.snapshot_ttl_sec if _ps_cfg else 60,
             )
+            _operating_profile = str(getattr(ctx.full_config, "operating_profile", "canary"))
             ctx.position_sizing_service = PositionSizingService(
                 account_snapshot_cache=ctx.account_snapshot_cache,
                 indicator_service=ctx.indicator_service,
@@ -432,6 +433,7 @@ class ServiceContainer:
                 quote_provider=ctx.broker,
                 order_policy_config=_op_cfg,
                 env=getattr(ctx.broker, "env", None),
+                operating_profile=_operating_profile,
             )
             ctx.risk_gate_service = RiskGateService(
                 config=_rg_cfg,
@@ -444,6 +446,7 @@ class ServiceContainer:
                 market_buy_reference_price_provider=lambda code, exchange: _resolve_market_buy_reference_price(
                     ctx.broker, ctx.logger, code, exchange
                 ),
+                operating_profile=_operating_profile,
             )
             ctx.execution_flow_service = ExecutionFlowService(
                 data_provider=ctx.broker,


### PR DESCRIPTION
변경 요약:

config_loader.py: AppConfig.operating_profile 신규 (canary | real_limited | real_full, default canary). RiskGateCanaryOverrides(5%/2/1M), PositionSizingCanaryOverrides(0.25%/1.5%) 추가.
risk_gate_service.py, position_sizing_service.py: operating_profile 파라미터 + profile별 effective value 분기. _effective_max_order_amount_won 신규.
predeploy_check_service.py: check_operating_profile 신규 (canary=PASS, 그 외=WARN). check_real_mode_policy_strictness는 profile별 임계 분기.
service_container.py: AppConfig.operating_profile → 두 서비스에 와이어링.
config.yaml.example, docs/canary_procedure.md: profile 설명/3-tier 한도 표 추가.
테스트: 단위 5647개 + 통합 235개 모두 통과 (신규 22개 포함). 기존 real_mode_overrides 동작은 backward-compat 유지 (default → real_limited overlay).