### PR TITLE
API budget e2e 통합 테스트 추가했습니다.

### DIFF
--- a/docs/api_budget_coverage_matrix.md
+++ b/docs/api_budget_coverage_matrix.md
@@ -65,5 +65,6 @@ category별 rate limit은 endpoint군 간 burst를 나누기 위한 상한이며
 - `tests/unit_test/core/retry_queue/test_api_budget_limiter.py::test_opening_burst_load_keeps_order_reconcile_and_emergency_lanes_available`가 장초반 조회 burst 중에도 `account_reconciliation`, normal `order_submit`, emergency `order_submit` lane이 독립적으로 진입하는지 검증한다.
 - `tests/unit_test/core/retry_queue/test_api_budget_limiter.py::test_global_rate_limiter_caps_total_rps_across_categories`가 서로 다른 category 호출도 `_global` bucket으로 전체 합산 제한되는지 검증한다.
 - `tests/unit_test/core/retry_queue/test_api_budget_limiter.py::test_emergency_global_rate_bucket_is_independent_from_normal_global_bucket`가 emergency global bucket이 normal global bucket과 분리되는지 검증한다.
+- `tests/integration_test/test_it_api_budget_limiter.py`가 `ClientWithRetryQueue → ApiRequestQueue → ApiBudgetLimiter → fake client` 전체 경로에서 current price/OHLCV/account/reconcile/order/WebSocket/emergency 호출이 shared global budget을 지나는지 검증한다.
 - `services.predeploy_check_service.PreDeployCheckService.check_api_budget_limiter()`는 `_global` 및 `_global.emergency` bucket 누락을 WARN으로 보고한다.
 - `ApiBudgetLimiter.snapshot()`은 `rate_wait_total`과 `rate_wait_seconds_total`을 노출해 사전 throttle이 실제로 작동했는지 운영 상태 API에서 관측할 수 있다.

--- a/tests/integration_test/test_it_api_budget_limiter.py
+++ b/tests/integration_test/test_it_api_budget_limiter.py
@@ -1,0 +1,146 @@
+"""ApiBudgetLimiter end-to-end integration scenarios."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from common.types import ErrorCode, ResCommonResponse
+from core.api_priority import emergency_scope
+from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
+from core.retry_queue.api_request_queue import ApiRequestQueue
+from core.retry_queue.client_with_retry_queue import ClientWithRetryQueue
+
+
+def _success(data=None) -> ResCommonResponse:
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상처리 되었습니다.",
+        data=data or {},
+    )
+
+
+def _make_fake_client() -> MagicMock:
+    client = MagicMock()
+    client.get_current_price = AsyncMock(return_value=_success({"price": "70000"}))
+    client.inquire_daily_itemchartprice = AsyncMock(return_value=_success({"ohlcv": []}))
+    client.get_account_balance = AsyncMock(return_value=_success({"balance": []}))
+    client.inquire_unfilled_orders = AsyncMock(return_value=_success({"orders": []}))
+    client.inquire_daily_ccld = AsyncMock(return_value=_success({"fills": []}))
+    client.place_stock_order = AsyncMock(return_value=_success({"ordno": "1"}))
+    client.cancel_stock_order = AsyncMock(return_value=_success({"ordno": "1"}))
+    client.subscribe_realtime_price = AsyncMock(return_value=True)
+    return client
+
+
+async def test_api_budget_limiter_caps_mixed_live_operation_paths_end_to_end(test_logger):
+    """조회/계좌/주문/WebSocket/emergency 호출을 섞어도 shared global budget을 지난다."""
+    sleeps: list[float] = []
+    now = 100.0
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    limiter = ApiBudgetLimiter(
+        limits={
+            "quotation_price": 8,
+            "quotation_ohlcv": 8,
+            "account_balance": 8,
+            "account_reconciliation": 8,
+            "order_submit": 8,
+            "order_cancel": 8,
+            "websocket_subscribe": 8,
+        },
+        rate_limits_per_sec={
+            "quotation_price": float("inf"),
+            "quotation_ohlcv": float("inf"),
+            "account_balance": float("inf"),
+            "account_reconciliation": float("inf"),
+            "order_submit": float("inf"),
+            "order_cancel": float("inf"),
+            "websocket_subscribe": float("inf"),
+        },
+        emergency_limits={"order_submit": 8, "order_cancel": 8},
+        emergency_rate_limits_per_sec={
+            "order_submit": float("inf"),
+            "order_cancel": float("inf"),
+        },
+        global_rate_limit_per_sec=2.0,
+        emergency_global_rate_limit_per_sec=2.0,
+        sleep=fake_sleep,
+        monotonic=lambda: now,
+    )
+    queue = ApiRequestQueue(logger=test_logger, budget_limiter=limiter)
+    client = _make_fake_client()
+    wrapped = ClientWithRetryQueue(client, queue, budget_limiter=limiter)
+
+    await wrapped.get_current_price("005930")
+    await wrapped.inquire_daily_itemchartprice("005930")
+    await wrapped.get_account_balance()
+    await wrapped.inquire_unfilled_orders()
+    await wrapped.inquire_daily_ccld()
+    await wrapped.place_stock_order("005930", 70000, 1, True)
+    await wrapped.cancel_stock_order(broker_order_no="1", order_qty=1)
+    await wrapped.subscribe_realtime_price("005930")
+    with emergency_scope():
+        await wrapped.place_stock_order("005930", 0, 1, False)
+        await wrapped.cancel_stock_order(broker_order_no="2", order_qty=1)
+
+    snapshot = limiter.snapshot()
+    assert snapshot["_global"]["rate_wait_total"] == 7
+    assert snapshot["_global"]["rate_wait_seconds_total"] == 14.0
+    assert snapshot["_global"]["emergency"]["rate_wait_total"] == 1
+    assert snapshot["_global"]["emergency"]["rate_wait_seconds_total"] == 0.5
+
+    assert snapshot["quotation_price"]["acquired_total"] == 1
+    assert snapshot["quotation_ohlcv"]["acquired_total"] == 1
+    assert snapshot["account_balance"]["acquired_total"] == 1
+    assert snapshot["account_reconciliation"]["acquired_total"] == 2
+    assert snapshot["order_submit"]["acquired_total"] == 1
+    assert snapshot["order_cancel"]["acquired_total"] == 1
+    assert snapshot["websocket_subscribe"]["acquired_total"] == 1
+    assert snapshot["order_submit"]["emergency"]["acquired_total"] == 1
+    assert snapshot["order_cancel"]["emergency"]["acquired_total"] == 1
+
+    assert sleeps == [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 0.5]
+    assert queue.fail_queue.empty()
+    await queue.stop()
+
+
+async def test_api_budget_limiter_keeps_emergency_path_available_during_normal_burst(test_logger):
+    """normal 전역 bucket이 예약된 상태에서도 emergency 전역 bucket은 별도로 진입한다."""
+    sleeps: list[float] = []
+    now = 100.0
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    limiter = ApiBudgetLimiter(
+        limits={"quotation_price": 8, "order_submit": 8},
+        rate_limits_per_sec={
+            "quotation_price": float("inf"),
+            "order_submit": float("inf"),
+        },
+        emergency_limits={"order_submit": 8},
+        emergency_rate_limits_per_sec={"order_submit": float("inf")},
+        global_rate_limit_per_sec=1.0,
+        emergency_global_rate_limit_per_sec=1.0,
+        sleep=fake_sleep,
+        monotonic=lambda: now,
+    )
+    queue = ApiRequestQueue(logger=test_logger, budget_limiter=limiter)
+    client = _make_fake_client()
+    wrapped = ClientWithRetryQueue(client, queue, budget_limiter=limiter)
+
+    await wrapped.get_current_price("005930")
+    await wrapped.get_current_price("000660")
+    await wrapped.get_current_price("035420")
+    with emergency_scope():
+        await wrapped.place_stock_order("005930", 0, 1, False)
+
+    snapshot = limiter.snapshot()
+    assert snapshot["_global"]["rate_wait_total"] == 2
+    assert snapshot["_global"]["emergency"]["rate_wait_total"] == 0
+    assert snapshot["order_submit"]["emergency"]["acquired_total"] == 1
+    assert client.place_stock_order.await_args.kwargs == {}
+    assert sleeps == [1.0, 2.0]
+    await queue.stop()

--- a/todo_list.md
+++ b/todo_list.md
@@ -148,7 +148,7 @@
   - 적용 완료(2026-05-27): `ApiBudgetLimiter`에 `_global` normal bucket(8/s)과 `_global.emergency` bucket(2/s)을 추가해 category가 달라도 전체 합산 RPS를 제한한다. 개인 실전 10/s 가능성에도 맞는 보수 기본값이며, emergency liquidation은 normal traffic과 분리된 2/s bucket을 사용한다.
   - 적용 완료(2026-05-27): predeploy 점검에서 `_global` 및 `_global.emergency` bucket 누락을 WARN으로 보고한다.
   - 남은 작업(외부): 실제 KIS 계정별 REST/WebSocket 유량 한도 숫자는 공식 포털/계정 공지로 운영 직전 재확인한다. 공개 자료는 실전 20/s, 모의 1~2/s, 과거 개인 10/s 등으로 갈리므로 코드 기본값은 보수값 유지.
-  - 남은 작업: current price/OHLCV/account/balance/order submit/order status/reconcile/websocket subscribe/emergency liquidation priority lane을 모두 섞은 end-to-end 통합 시나리오 테스트를 추가한다. (현재는 limiter 단위 전역 RPS 테스트 + endpoint별 category 분리 + 장초반 invariant 테스트로 잠금.)
+  - 적용 완료(2026-05-27): current price/OHLCV/account/balance/order submit/order status/reconcile/websocket subscribe/emergency liquidation priority lane을 모두 섞은 end-to-end 통합 시나리오 테스트 추가. `ClientWithRetryQueue → ApiRequestQueue → ApiBudgetLimiter → fake client` 전체 경로에서 shared `_global` bucket과 `_global.emergency` bucket 동작을 검증한다.
   - 운영 기준: 429 또는 "초당 거래건수를 초과하였습니다" 응답 후 retry하는 사후 대응만으로는 부족하므로, 장초반 다전략 동시 실행 전에 사전 제한이 동작해야 한다.
 
 주요 파일:


### PR DESCRIPTION
추가한 파일:
test_it_api_budget_limiter.py
검증 내용:
ClientWithRetryQueue → ApiRequestQueue → ApiBudgetLimiter → fake client 전체 경로 현재가, OHLCV, 계좌잔고, 미체결/체결 대사, 주문 제출/취소, WebSocket 구독, emergency 주문을 섞어도 shared _global bucket을 지나는지 확인 normal burst 중에도 _global.emergency bucket이 분리되어 emergency path가 막히지 않는지 확인 문서도 갱신했습니다:
docs/api_budget_coverage_matrix.md
todo_list.md
검증:
pytest tests/integration_test/test_it_api_budget_limiter.py -v → 2 passed 이번 변경은 테스트/문서 추가만이라 전체 unit/integration suite는 재실행하지 않았습니다.