### PR TITLE
구현 완료했습니다. 장마감 배치 post_market_replay_audit를 추가했고, 실제 라이브 후보군과 scan 시각…

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -13,10 +13,11 @@ always_on_tasks:
 after_market_tasks:
   after_market_delay_min:
     after_market_reconcile: 0       # AfterMarketReconcileTask — 장 마감 직후 주문/브로커 상태 검증
-    strategy_log_report: 3          # strategy_log_report — 장 마감 3분 후
+    strategy_log_report: 40         # strategy_log_report — replay audit 이후 리포트 생성
     ranking_refresh: 5          # RankingTask — 장 마감 5분 후
     daily_price_collector: 10      # DailyPriceCollectorTask — 장 마감 10분 후
     ohlcv_update: 20             # OhlcvUpdateTask — 장 마감 20분 후
+    post_market_replay_audit: 30  # PostMarketReplayAuditTask — live 후보군 missed-signal 감사
     newhigh: 21                  # NewHighTask — daily_price_collector 완료(21분) + 여유
     minervini_update: 21        # MinerviniUpdateTask — 장 마감 21분 후
     전일기준주도주_생성: 50        # PremiumWatchlistGeneratorTask — 장 마감 50분 후

--- a/scheduler/strategy_scheduler_store.py
+++ b/scheduler/strategy_scheduler_store.py
@@ -115,6 +115,32 @@ class StrategySchedulerStore:
             for r in reversed(rows)
         ]
 
+    def load_signal_history_for_date(self, target_date: str) -> list:
+        """target_date(YYYYMMDD)의 시그널 이력을 오래된 순 dict list 로 반환."""
+        digits = "".join(ch for ch in str(target_date or "") if ch.isdigit())
+        if len(digits) < 8:
+            return []
+        date_prefix = f"{digits[:4]}-{digits[4:6]}-{digits[6:8]}"
+        with self._lock:
+            cur = self._conn.execute(
+                """SELECT strategy_name, code, name, action, price, qty,
+                          return_rate, reason, timestamp, api_success
+                   FROM signal_history
+                   WHERE timestamp LIKE ?
+                   ORDER BY timestamp ASC, id ASC""",
+                (f"{date_prefix}%",),
+            )
+            rows = cur.fetchall()
+        return [
+            {
+                "strategy_name": r[0], "code": r[1], "name": r[2],
+                "action": r[3], "price": r[4], "qty": r[5],
+                "return_rate": r[6], "reason": r[7],
+                "timestamp": r[8], "api_success": bool(r[9]),
+            }
+            for r in rows
+        ]
+
     # ── Scheduler State ──
 
     def save_state(self, state: dict) -> None:

--- a/services/backtest_replay_adapter.py
+++ b/services/backtest_replay_adapter.py
@@ -25,13 +25,15 @@ class StockQueryBacktestReplayService:
         stock_query_service: Any,
         *,
         program_provider: Any | None = None,
+        market_clock: Any | None = None,
         session: str = "REGULAR",
     ) -> None:
         self._stock_query_service = stock_query_service
         self._program_provider = program_provider
+        self._market_clock = market_clock
         self._session = session
         self._backtest_date: str | None = None
-        self._row_cache: dict[tuple[str, str, str], list[dict]] = {}
+        self._row_cache: dict[tuple[str, str, str, str], list[dict]] = {}
         self._program_cache: dict[tuple[str, str], dict] = {}
 
     def set_backtest_date(self, date_ymd: str) -> None:
@@ -95,7 +97,14 @@ class StockQueryBacktestReplayService:
             kwargs["date_ymd"] = self._backtest_date
         if "session" not in kwargs:
             kwargs["session"] = self._session
-        return await self._stock_query_service.get_day_intraday_minutes_list(stock_code, **kwargs)
+        rows = await self._stock_query_service.get_day_intraday_minutes_list(stock_code, **kwargs)
+        if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+            return []
+        date_ymd = str(kwargs.get("date_ymd") or self._backtest_date or "")
+        return self._normalize_and_cutoff_rows(
+            [dict(row) for row in rows if isinstance(row, dict)],
+            date_ymd=date_ymd,
+        )
 
     def get_market_snapshot(
         self,
@@ -111,7 +120,7 @@ class StockQueryBacktestReplayService:
         if force_fresh or not self._backtest_date:
             return None, DataQualityService.REASON_SNAPSHOT_MISSING
 
-        key = (code, self._backtest_date, self._session)
+        key = (code, self._backtest_date, self._session, self._cutoff_hhmmss())
         rows = self._row_cache.get(key)
         if not rows:
             return None, DataQualityService.REASON_SNAPSHOT_MISSING
@@ -155,7 +164,7 @@ class StockQueryBacktestReplayService:
         if not self._backtest_date:
             return None, DataQualityService.REASON_CONCLUSION_MISSING
 
-        key = (code, self._backtest_date, self._session)
+        key = (code, self._backtest_date, self._session, self._cutoff_hhmmss())
         rows = self._row_cache.get(key)
         if rows:
             latest = rows[-1]
@@ -258,7 +267,7 @@ class StockQueryBacktestReplayService:
         }
 
     async def _get_intraday_rows(self, stock_code: str, date_ymd: str) -> list[dict]:
-        key = (stock_code, date_ymd, self._session)
+        key = (stock_code, date_ymd, self._session, self._cutoff_hhmmss())
         if key in self._row_cache:
             return self._row_cache[key]
 
@@ -269,10 +278,33 @@ class StockQueryBacktestReplayService:
         )
         if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
             rows = []
-        normalized = [dict(row) for row in rows if isinstance(row, dict)]
+        normalized = self._normalize_and_cutoff_rows(
+            [dict(row) for row in rows if isinstance(row, dict)],
+            date_ymd=date_ymd,
+        )
         normalized.sort(key=lambda row: str(self._first(row, "stck_bsop_date", "date") or date_ymd) + str(self._first(row, "stck_cntg_hour", "time") or ""))
         self._row_cache[key] = normalized
         return normalized
+
+    def _normalize_and_cutoff_rows(self, rows: list[dict], *, date_ymd: str) -> list[dict]:
+        cutoff = self._cutoff_hhmmss()
+        if not cutoff:
+            return rows
+        result: list[dict] = []
+        for row in rows:
+            row_time = str(self._first(row, "stck_cntg_hour", "cntg_hour", "time") or "").zfill(6)
+            if not row_time or row_time > cutoff:
+                continue
+            result.append(row)
+        return result
+
+    def _cutoff_hhmmss(self) -> str:
+        if self._market_clock is None:
+            return ""
+        try:
+            return self._market_clock.get_current_kst_time().strftime("%H%M%S")
+        except Exception:
+            return ""
 
     async def _get_program_net_buy_qty(self, stock_code: str, date_ymd: str) -> int | None:
         if self._program_provider is None:

--- a/services/post_market_replay_audit_service.py
+++ b/services/post_market_replay_audit_service.py
@@ -1,0 +1,421 @@
+"""Post-market replay audit for scheduler missed-signal diagnosis."""
+from __future__ import annotations
+
+import gzip
+import glob
+import json
+import logging
+import os
+import re
+import tempfile
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable
+
+from common.trade_journal_schema import normalize_backtest_decision
+from scheduler.strategy_scheduler_store import StrategySchedulerStore
+from services.backtest_replay_adapter import StockQueryBacktestReplayService
+from services.backtest_replay_context import BacktestMarketClock
+from strategies.debug.strategy_debug_runner import StrategyDebugRunner
+
+
+_STRATEGY_NAME_RE = re.compile(r"^\d{8}_(?:\d{6}_)?(.+?)(?:_\d+)?\.log\.json.*$")
+
+_STRATEGY_KEY_BY_NAME = {
+    "OneilPocketPivot": "oneil_pocket_pivot",
+    "OneilSqueezeBreakout": "oneil_squeeze_breakout",
+    "HighTightFlag": "high_tight_flag",
+    "FirstPullback": "first_pullback",
+    "LarryWilliamsVBO": "larry_williams_vbo",
+    "RSI2Pullback": "rsi2_pullback",
+    "LarryWilliamsCB": "larry_williams_channel_breakout",
+    "LarryWilliamsChannelBreakout": "larry_williams_channel_breakout",
+}
+
+
+@dataclass
+class _AuditInput:
+    candidates: set[str] = field(default_factory=set)
+    scan_times: set[str] = field(default_factory=set)
+    live_buy_times: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PostMarketReplayAuditResult:
+    target_date: str
+    skipped: bool = False
+    skip_reason: str = ""
+    strategy_count: int = 0
+    saved_runs: list[dict[str, Any]] = field(default_factory=list)
+    missed_count: int = 0
+    late_count: int = 0
+    missing_from_universe_count: int = 0
+    replayed_rejected_count: int = 0
+    data_unavailable_count: int = 0
+
+
+class PostMarketReplayAuditService:
+    """Replay the day's live candidate set at actual scheduler scan times."""
+
+    def __init__(
+        self,
+        *,
+        stock_query_service: Any,
+        universe_service: Any,
+        indicator_service: Any,
+        market_clock: Any,
+        backtest_journal_repository: Any,
+        scheduler_store: Any | None = None,
+        virtual_trade_service: Any | None = None,
+        log_dir: str = "logs/strategies",
+        program_provider: Any | None = None,
+        strategy_factory: Callable[..., Any] | None = None,
+        env: Any | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._sqs = stock_query_service
+        self._universe_service = universe_service
+        self._indicator_service = indicator_service
+        self._market_clock = market_clock
+        self._repo = backtest_journal_repository
+        self._scheduler_store = scheduler_store or StrategySchedulerStore(logger=logger)
+        self._virtual_trade_service = virtual_trade_service
+        self._log_dir = log_dir
+        self._program_provider = program_provider
+        self._strategy_factory = strategy_factory or self._default_strategy_factory
+        self._env = env
+        self._logger = logger or logging.getLogger(__name__)
+        self._debug_logger = logger if isinstance(logger, logging.Logger) else logging.getLogger(__name__)
+
+    async def run(self, target_date: str) -> PostMarketReplayAuditResult:
+        result = PostMarketReplayAuditResult(target_date=str(target_date))
+        if self._is_paper_mode():
+            result.skipped = True
+            result.skip_reason = "historical_intraday_unavailable_in_paper"
+            self._logger.info(f"post-market replay audit skipped: {result.skip_reason}")
+            return result
+
+        inputs = self._collect_audit_inputs(str(target_date))
+        if not inputs:
+            result.skipped = True
+            result.skip_reason = "no_live_candidates"
+            return result
+
+        backtest_clock = BacktestMarketClock.from_clock(self._market_clock)
+        replay_sqs = StockQueryBacktestReplayService(
+            self._sqs,
+            program_provider=self._program_provider,
+            market_clock=backtest_clock,
+        )
+        replay_sqs.set_backtest_date(str(target_date))
+
+        with tempfile.TemporaryDirectory(prefix="post_market_replay_audit_") as tmp_dir:
+            for strategy_name, audit_input in sorted(inputs.items()):
+                if not audit_input.candidates or not audit_input.scan_times:
+                    continue
+                strategy_result = await self._run_strategy_audit(
+                    strategy_name=strategy_name,
+                    audit_input=audit_input,
+                    target_date=str(target_date),
+                    replay_sqs=replay_sqs,
+                    backtest_clock=backtest_clock,
+                    state_dir=tmp_dir,
+                )
+                result.strategy_count += 1
+                result.saved_runs.extend(strategy_result.saved_runs)
+                result.missed_count += strategy_result.missed_count
+                result.late_count += strategy_result.late_count
+                result.missing_from_universe_count += strategy_result.missing_from_universe_count
+                result.replayed_rejected_count += strategy_result.replayed_rejected_count
+                result.data_unavailable_count += strategy_result.data_unavailable_count
+        return result
+
+    async def _run_strategy_audit(
+        self,
+        *,
+        strategy_name: str,
+        audit_input: _AuditInput,
+        target_date: str,
+        replay_sqs: StockQueryBacktestReplayService,
+        backtest_clock: BacktestMarketClock,
+        state_dir: str,
+    ) -> PostMarketReplayAuditResult:
+        result = PostMarketReplayAuditResult(target_date=target_date)
+        signal_by_code: dict[str, dict] = {}
+        rejected_by_code: dict[str, dict] = {}
+        missing_by_code: dict[str, dict] = {}
+        data_unavailable_by_code: dict[str, dict] = {}
+
+        for scan_time in sorted(audit_input.scan_times):
+            try:
+                backtest_clock.set_backtest_datetime(_parse_signal_time(scan_time))
+                replay_sqs.set_backtest_date(target_date)
+                strategy = self._strategy_factory(
+                    strategy_name=strategy_name,
+                    replay_sqs=replay_sqs,
+                    universe_service=self._universe_service,
+                    indicator_service=self._indicator_service,
+                    backtest_clock=backtest_clock,
+                    state_dir=state_dir,
+                    logger=self._debug_logger,
+                )
+                report = await StrategyDebugRunner(
+                    strategy,
+                    self._debug_logger,
+                    target_date=target_date,
+                    target_signal_time=_canonical_signal_time(scan_time),
+                ).run(candidate_codes=sorted(audit_input.candidates))
+            except Exception as exc:
+                self._logger.warning(
+                    "post-market replay audit scan failed: strategy=%s time=%s error=%s",
+                    strategy_name,
+                    scan_time,
+                    exc,
+                    exc_info=True,
+                )
+                for code in audit_input.candidates:
+                    data_unavailable_by_code.setdefault(
+                        code,
+                        self._audit_record(
+                            strategy=strategy_name,
+                            code=code,
+                            signal_time=scan_time,
+                            status="data_unavailable",
+                            rejected_reason=f"data_unavailable:{exc}",
+                        ),
+                    )
+                continue
+
+            for record in report.journal_records:
+                code = str(record.get("code") or "")
+                if not code:
+                    continue
+                audit_status = self._classify_record(record, audit_input)
+                annotated = self._with_audit_metadata(
+                    record,
+                    audit_status=audit_status,
+                    live_signal_time=audit_input.live_buy_times.get(code, ""),
+                )
+                if audit_status in {"missed_by_scheduler", "late_signal", "replay_matched"}:
+                    signal_by_code.setdefault(code, annotated)
+                elif audit_status == "missing_from_universe":
+                    missing_by_code.setdefault(code, annotated)
+                elif audit_status == "data_unavailable":
+                    data_unavailable_by_code.setdefault(code, annotated)
+                else:
+                    rejected_by_code[code] = annotated
+
+        records: list[dict] = []
+        records.extend(signal_by_code.values())
+        for code, record in missing_by_code.items():
+            if code not in signal_by_code:
+                records.append(record)
+        for code, record in data_unavailable_by_code.items():
+            if code not in signal_by_code and code not in missing_by_code:
+                records.append(record)
+        for code, record in rejected_by_code.items():
+            if code not in signal_by_code and code not in missing_by_code and code not in data_unavailable_by_code:
+                records.append(record)
+
+        counts = Counter((record.get("metadata") or {}).get("audit_status") for record in records)
+        result.missed_count = counts.get("missed_by_scheduler", 0)
+        result.late_count = counts.get("late_signal", 0)
+        result.missing_from_universe_count = counts.get("missing_from_universe", 0)
+        result.replayed_rejected_count = counts.get("replayed_rejected", 0)
+        result.data_unavailable_count = counts.get("data_unavailable", 0)
+
+        saved = self._repo.save_run(
+            records,
+            run_id=f"audit_{strategy_name}_{target_date}",
+            strategy=strategy_name,
+            target_date=target_date,
+            metadata={
+                "audit_type": "missed_signal",
+                "candidate_count": len(audit_input.candidates),
+                "scan_time_count": len(audit_input.scan_times),
+                "missed_count": result.missed_count,
+                "late_count": result.late_count,
+                "missing_from_universe_count": result.missing_from_universe_count,
+                "replayed_rejected_count": result.replayed_rejected_count,
+                "data_unavailable_count": result.data_unavailable_count,
+            },
+        )
+        result.saved_runs.append(saved)
+        return result
+
+    def _collect_audit_inputs(self, target_date: str) -> dict[str, _AuditInput]:
+        inputs = self._collect_inputs_from_logs(target_date)
+        self._merge_scheduler_signals(inputs, target_date)
+        self._merge_virtual_trades(inputs, target_date)
+        return {name: item for name, item in inputs.items() if item.candidates}
+
+    def _collect_inputs_from_logs(self, target_date: str) -> dict[str, _AuditInput]:
+        date_prefix = f"{target_date[:4]}-{target_date[4:6]}-{target_date[6:8]}"
+        inputs: dict[str, _AuditInput] = {}
+        for path in glob.glob(os.path.join(self._log_dir, "**", "*.log.json*"), recursive=True):
+            strategy_name = _strategy_name_from_path(path)
+            if not strategy_name:
+                continue
+            audit_input = inputs.setdefault(strategy_name, _AuditInput())
+            open_fn = gzip.open if path.endswith(".gz") else open
+            try:
+                with open_fn(path, "rb") as fp:
+                    for raw in fp:
+                        try:
+                            entry = json.loads(raw.decode("utf-8").strip())
+                        except Exception:
+                            continue
+                        ts = str(entry.get("timestamp") or "")
+                        if not ts.startswith(date_prefix):
+                            continue
+                        data = entry.get("data")
+                        if not isinstance(data, dict):
+                            continue
+                        event = str(data.get("event") or "")
+                        if event == "scan_with_watchlist":
+                            audit_input.scan_times.add(_canonical_signal_time(ts))
+                        code = str(data.get("code") or "").strip()
+                        if code:
+                            audit_input.candidates.add(code)
+                            if event == "buy_signal_generated":
+                                audit_input.live_buy_times.setdefault(code, _canonical_signal_time(ts))
+            except OSError:
+                continue
+        return inputs
+
+    def _merge_scheduler_signals(self, inputs: dict[str, _AuditInput], target_date: str) -> None:
+        loader = getattr(self._scheduler_store, "load_signal_history_for_date", None)
+        if not callable(loader):
+            return
+        try:
+            rows = loader(target_date)
+        except Exception:
+            return
+        for row in rows or []:
+            strategy_name = str(row.get("strategy_name") or "").strip()
+            code = str(row.get("code") or "").strip()
+            if not strategy_name or not code:
+                continue
+            audit_input = inputs.setdefault(strategy_name, _AuditInput())
+            audit_input.candidates.add(code)
+            if str(row.get("action") or "").upper() == "BUY" and bool(row.get("api_success", True)):
+                audit_input.live_buy_times.setdefault(code, _canonical_signal_time(str(row.get("timestamp") or "")))
+
+    def _merge_virtual_trades(self, inputs: dict[str, _AuditInput], target_date: str) -> None:
+        if self._virtual_trade_service is None:
+            return
+        getter = getattr(self._virtual_trade_service, "get_all_trades", None)
+        if not callable(getter):
+            return
+        date_prefix = f"{target_date[:4]}-{target_date[4:6]}-{target_date[6:8]}"
+        try:
+            trades = getter()
+        except Exception:
+            return
+        for trade in trades or []:
+            buy_date = str(trade.get("buy_date") or "")
+            if not buy_date.startswith(date_prefix):
+                continue
+            strategy_name = str(trade.get("strategy") or "").strip()
+            code = str(trade.get("code") or "").strip()
+            if not strategy_name or not code:
+                continue
+            audit_input = inputs.setdefault(strategy_name, _AuditInput())
+            audit_input.candidates.add(code)
+            audit_input.live_buy_times.setdefault(code, _canonical_signal_time(buy_date))
+
+    def _classify_record(self, record: dict, audit_input: _AuditInput) -> str:
+        code = str(record.get("code") or "")
+        status = str(record.get("status") or "").upper()
+        rejected_reason = str(record.get("rejected_reason") or "")
+        if rejected_reason.startswith("data_unavailable"):
+            return "data_unavailable"
+        if rejected_reason == "missing_from_universe":
+            return "missing_from_universe"
+        if status == "SIGNAL":
+            live_time = audit_input.live_buy_times.get(code, "")
+            if not live_time:
+                return "missed_by_scheduler"
+            if _parse_signal_time(live_time) > _parse_signal_time(str(record.get("signal_time") or "")):
+                return "late_signal"
+            return "replay_matched"
+        return "replayed_rejected"
+
+    @staticmethod
+    def _with_audit_metadata(record: dict, *, audit_status: str, live_signal_time: str) -> dict:
+        copied = dict(record)
+        metadata = dict(copied.get("metadata") or {})
+        metadata["audit_status"] = audit_status
+        metadata["live_signal_time"] = live_signal_time
+        copied["metadata"] = metadata
+        return copied
+
+    @staticmethod
+    def _audit_record(
+        *,
+        strategy: str,
+        code: str,
+        signal_time: str,
+        status: str,
+        rejected_reason: str,
+    ) -> dict:
+        record = normalize_backtest_decision(
+            {
+                "signal_time": _canonical_signal_time(signal_time),
+                "rejected_reason": rejected_reason,
+                "strategy": strategy,
+            },
+            stock_code=code,
+            strategy=strategy,
+            accepted=False,
+        )
+        metadata = dict(record.get("metadata") or {})
+        metadata["audit_status"] = status
+        record["metadata"] = metadata
+        return record
+
+    def _default_strategy_factory(self, **kwargs):
+        from scripts.run_backtest import _build_backtest_strategy
+
+        strategy_name = kwargs["strategy_name"]
+        strategy_key = _STRATEGY_KEY_BY_NAME.get(strategy_name)
+        if not strategy_key:
+            raise ValueError(f"unsupported audit strategy: {strategy_name}")
+        return _build_backtest_strategy(
+            strategy_key=strategy_key,
+            replay_sqs=kwargs["replay_sqs"],
+            universe_service=kwargs["universe_service"],
+            indicator_service=kwargs.get("indicator_service"),
+            backtest_clock=kwargs["backtest_clock"],
+            state_dir=kwargs["state_dir"],
+            logger=kwargs.get("logger"),
+        )
+
+    def _is_paper_mode(self) -> bool:
+        return bool(getattr(self._env, "is_paper_trading", False))
+
+
+def _strategy_name_from_path(path: str) -> str | None:
+    match = _STRATEGY_NAME_RE.match(os.path.basename(path))
+    return match.group(1) if match else None
+
+
+def _canonical_signal_time(value: str) -> str:
+    text = str(value or "").strip()
+    if len(text) >= 19 and text[4] == "-" and text[7] == "-":
+        return text[:19]
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if len(digits) >= 14:
+        return f"{digits[:4]}-{digits[4:6]}-{digits[6:8]} {digits[8:10]}:{digits[10:12]}:{digits[12:14]}"
+    if len(digits) >= 8:
+        return f"{digits[:4]}-{digits[4:6]}-{digits[6:8]} 00:00:00"
+    return text
+
+
+def _parse_signal_time(value: str) -> datetime:
+    canonical = _canonical_signal_time(value)
+    try:
+        return datetime.strptime(canonical, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return datetime.min

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -606,6 +606,10 @@ class StrategyLogReportService:
             f"• 매칭: {matched}건, 백테스트만 {unmatched_backtest}건, 실거래만 {unmatched_live}건",
         ]
 
+        audit_lines = self._build_replay_audit_lines(backtest_records)
+        if audit_lines:
+            lines.extend(audit_lines)
+
         avg_diff = summary.get("avg_net_return_diff")
         avg_abs_diff = summary.get("avg_abs_net_return_diff")
         if avg_diff is not None:
@@ -752,6 +756,45 @@ class StrategyLogReportService:
         if rest_count > 0:
             lines.append(f"  …외 {rest_count}개 전략")
         return "\n".join(lines)
+
+    def _build_replay_audit_lines(self, backtest_records: List[dict]) -> List[str]:
+        counts = Counter()
+        examples: List[dict] = []
+        for record in backtest_records:
+            metadata = record.get("metadata") if isinstance(record, dict) else None
+            if not isinstance(metadata, dict):
+                continue
+            status = str(metadata.get("audit_status") or "")
+            if not status:
+                continue
+            counts[status] += 1
+            if status in {"missed_by_scheduler", "late_signal"} and len(examples) < 3:
+                examples.append(record)
+        if not counts:
+            return []
+
+        labels = [
+            ("missed_by_scheduler", "missed"),
+            ("late_signal", "late"),
+            ("missing_from_universe", "universe 누락"),
+            ("replayed_rejected", "replay 거절"),
+            ("data_unavailable", "데이터 부족"),
+        ]
+        parts = [
+            f"{label} {counts[key]}건"
+            for key, label in labels
+            if counts.get(key)
+        ]
+        lines = [f"• Replay audit: {', '.join(parts)}"]
+        for record in examples:
+            metadata = record.get("metadata") or {}
+            strategy = _esc(record.get("strategy") or "")
+            code = _esc(record.get("code") or "")
+            status = _esc(metadata.get("audit_status") or "")
+            live_time = metadata.get("live_signal_time")
+            suffix = f" (live {live_time[11:16]})" if isinstance(live_time, str) and len(live_time) >= 16 else ""
+            lines.append(f"  - {strategy}/{code}: {status}{suffix}")
+        return lines
 
     def _candidate_with_backtest_live_divergence(
         self,

--- a/strategies/debug/strategy_debug_runner.py
+++ b/strategies/debug/strategy_debug_runner.py
@@ -87,6 +87,7 @@ class StrategyDebugRunner:
         allowed_stages: tuple = (0, 2),
         backtest_journal_repository=None,
         target_date: str = "",
+        target_signal_time: str = "",
         backtest_portfolio_ledger: BacktestPortfolioLedger | None = None,
         max_positions_per_strategy: dict[str, int] | None = None,
     ) -> None:
@@ -96,6 +97,7 @@ class StrategyDebugRunner:
         self._allowed_stages = allowed_stages
         self._backtest_journal_repository = backtest_journal_repository
         self._target_date = target_date
+        self._target_signal_time = target_signal_time
         self._backtest_portfolio_ledger = backtest_portfolio_ledger
         self._max_positions_per_strategy = max_positions_per_strategy
 
@@ -167,7 +169,11 @@ class StrategyDebugRunner:
             limitations=list(self.LIMITATIONS),
         )
         report.portfolio_decisions = self._reserve_signal_orders(signals)
-        report.journal_records = _build_debug_journal_records(report, target_date=self._target_date)
+        report.journal_records = _build_debug_journal_records(
+            report,
+            target_date=self._target_date,
+            target_signal_time=self._target_signal_time,
+        )
 
         if self._backtest_journal_repository is not None and report.journal_records:
             target_date = self._target_date or _target_date_from_records(report.journal_records)
@@ -204,9 +210,14 @@ class StrategyDebugRunner:
         )
 
 
-def _build_debug_journal_records(report: DebugReport, *, target_date: str = "") -> List[dict]:
+def _build_debug_journal_records(
+    report: DebugReport,
+    *,
+    target_date: str = "",
+    target_signal_time: str = "",
+) -> List[dict]:
     records: List[dict] = []
-    default_time = _signal_time_from_target_date(target_date)
+    default_time = target_signal_time or _signal_time_from_target_date(target_date)
     portfolio_decisions_by_code: dict[str, List[PortfolioDecision]] = {}
     for decision in report.portfolio_decisions:
         portfolio_decisions_by_code.setdefault(decision.order.code, []).append(decision)
@@ -267,7 +278,7 @@ def _build_debug_journal_records(report: DebugReport, *, target_date: str = "") 
             normalize_backtest_decision(
                 {
                     **event.details,
-                    "signal_time": _event_signal_time(event, target_date),
+                    "signal_time": target_signal_time or _event_signal_time(event, target_date),
                     "current": _event_price(event),
                     "rejected_reason": event.reason,
                 },

--- a/task/background/after_market/post_market_replay_audit_task.py
+++ b/task/background/after_market/post_market_replay_audit_task.py
@@ -1,0 +1,81 @@
+"""장 마감 후 live 후보군 replay로 missed signal을 감사하는 태스크."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+    from scheduler.worker.worker_pool import WorkerPool
+
+
+class PostMarketReplayAuditTask(AfterMarketTask):
+    def __init__(
+        self,
+        audit_service,
+        mcs: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        logger=None,
+        worker_pool: Optional["WorkerPool"] = None,
+    ) -> None:
+        super().__init__(
+            mcs=mcs,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._audit_service = audit_service
+        self._last_result = None
+
+    @property
+    def task_name(self) -> str:
+        return "post_market_replay_audit"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "PostMarketReplayAuditTask"
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        self._logger.info(f"post-market replay audit 시작: {latest_trading_date}")
+        try:
+            self._last_result = await self._audit_service.run(latest_trading_date)
+        except Exception as e:
+            self._logger.error(f"post-market replay audit 실패: {e}", exc_info=True)
+            return
+        self._logger.info(f"post-market replay audit 완료: {latest_trading_date}")
+
+    async def force_run(self) -> None:
+        self._logger.info("PostMarketReplayAuditTask 강제 실행 요청")
+        async with self._running_state():
+            target_date: Optional[str] = None
+            if self._mcs:
+                try:
+                    target_date = await self._mcs.get_latest_trading_date()
+                except Exception as e:
+                    self._logger.warning(f"최근 거래일 조회 실패 — 오늘 날짜로 대체: {e}")
+            if not target_date:
+                target_date = datetime.now().strftime("%Y%m%d")
+            await self._on_market_closed(target_date)
+
+    def get_progress(self) -> dict:
+        last_result = None
+        if self._last_result is not None:
+            last_result = {
+                "target_date": getattr(self._last_result, "target_date", ""),
+                "skipped": bool(getattr(self._last_result, "skipped", False)),
+                "skip_reason": getattr(self._last_result, "skip_reason", ""),
+                "strategy_count": int(getattr(self._last_result, "strategy_count", 0)),
+                "missed_count": int(getattr(self._last_result, "missed_count", 0)),
+                "late_count": int(getattr(self._last_result, "late_count", 0)),
+                "missing_from_universe_count": int(
+                    getattr(self._last_result, "missing_from_universe_count", 0)
+                ),
+            }
+        return {
+            "running": self._state.value == "running",
+            "last_result": last_result,
+        }

--- a/tests/integration_test/test_it_post_market_replay_audit.py
+++ b/tests/integration_test/test_it_post_market_replay_audit.py
@@ -1,0 +1,183 @@
+import json
+import logging
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from common.types import TradeSignal
+from core.market_clock import MarketClock
+from interfaces.schedulable_task import TaskPriority
+from repositories.backtest_journal_repository import BacktestJournalRepository
+from services.post_market_replay_audit_service import PostMarketReplayAuditService
+from services.strategy_log_report_service import StrategyLogReportService
+from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
+from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
+from view.web.bootstrap.runtime_mode import RuntimeMode
+
+
+def _write_strategy_log(log_dir: str, strategy: str = "OneilPocketPivot") -> None:
+    os.makedirs(log_dir, exist_ok=True)
+    path = os.path.join(log_dir, f"20260505_090300_{strategy}.log.json")
+    rows = [
+        {
+            "timestamp": "2026-05-05 09:03:00,000",
+            "level": "INFO",
+            "data": {"event": "scan_with_watchlist", "count": 2},
+        },
+        {
+            "timestamp": "2026-05-05 09:03:10,000",
+            "level": "DEBUG",
+            "data": {"event": "entry_rejected", "code": "005930", "name": "삼성전자", "reason": "near_signal"},
+        },
+        {
+            "timestamp": "2026-05-05 09:03:11,000",
+            "level": "DEBUG",
+            "data": {"event": "entry_rejected", "code": "000660", "name": "SK하이닉스", "reason": "near_signal"},
+        },
+    ]
+    with open(path, "w", encoding="utf-8") as fp:
+        for row in rows:
+            fp.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _strategy_factory(**_kwargs):
+    universe = MagicMock()
+    universe.get_watchlist = AsyncMock(return_value={"005930": object()})
+
+    class FakeStrategy:
+        name = "OneilPocketPivot"
+        _universe = universe
+
+        async def scan(self):
+            await self._universe.get_watchlist()
+            return [
+                TradeSignal(
+                    code="005930",
+                    name="삼성전자",
+                    action="BUY",
+                    price=70_000,
+                    qty=1,
+                    reason="replay_signal",
+                    strategy_name="OneilPocketPivot",
+                )
+            ]
+
+    return FakeStrategy()
+
+
+@pytest.mark.asyncio
+async def test_it_post_market_replay_audit_task_saves_backtest_journal_run(tmp_path):
+    log_dir = str(tmp_path / "strategies")
+    _write_strategy_log(log_dir)
+    repo = BacktestJournalRepository(tmp_path / "backtest_journals")
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = []
+    service = PostMarketReplayAuditService(
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=repo,
+        scheduler_store=store,
+        log_dir=log_dir,
+        strategy_factory=_strategy_factory,
+        env=SimpleNamespace(is_paper_trading=False),
+        logger=logging.getLogger("test_it_post_market_replay_audit"),
+    )
+    task = PostMarketReplayAuditTask(
+        audit_service=service,
+        mcs=None,
+        market_clock=MarketClock(),
+        logger=logging.getLogger("test_it_post_market_replay_audit.task"),
+    )
+
+    await task.execute({"date": "20260505"})
+
+    records = repo.load_records_for_date("20260505")
+    by_code = {record["code"]: record for record in records}
+    assert by_code["005930"]["metadata"]["audit_status"] == "missed_by_scheduler"
+    assert by_code["000660"]["metadata"]["audit_status"] == "missing_from_universe"
+    runs = repo.list_runs(limit=None)
+    assert runs[0]["run_id"] == "audit_OneilPocketPivot_20260505"
+    assert runs[0]["metadata"]["audit_type"] == "missed_signal"
+
+
+@pytest.mark.asyncio
+async def test_it_strategy_report_reads_replay_audit_journal(tmp_path):
+    log_dir = str(tmp_path / "strategies")
+    _write_strategy_log(log_dir)
+    repo = BacktestJournalRepository(tmp_path / "backtest_journals")
+    repo.save_run(
+        [
+            {
+                "source": "backtest",
+                "strategy": "OneilPocketPivot",
+                "code": "005930",
+                "signal_time": "2026-05-05 09:03:00",
+                "status": "SIGNAL",
+                "metadata": {"audit_status": "missed_by_scheduler", "live_signal_time": ""},
+            }
+        ],
+        run_id="audit_OneilPocketPivot_20260505",
+        strategy="OneilPocketPivot",
+        target_date="20260505",
+        metadata={"audit_type": "missed_signal"},
+    )
+    virtual_trade_service = MagicMock()
+    virtual_trade_service.get_all_trades.return_value = []
+    virtual_trade_service.compare_with_backtest_journal.return_value = {
+        "summary": {"matched_count": 0, "unmatched_backtest_count": 1, "unmatched_live_count": 0},
+        "matches": [],
+    }
+    service = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=virtual_trade_service,
+        backtest_journal_provider=repo.load_records_for_date,
+    )
+
+    report = await service.generate_report("20260505")
+
+    assert "백테스트-실거래 괴리" in report
+    assert "Replay audit: missed 1건" in report
+    assert "OneilPocketPivot/005930: missed_by_scheduler" in report
+
+
+def test_it_scheduler_bootstrap_registers_replay_audit_batch_task_with_delay():
+    ctx = MagicMock()
+    ctx.runtime_mode = RuntimeMode.BATCH
+    ctx.logger = MagicMock()
+    ctx.pm = MagicMock()
+    ctx.worker_pool = MagicMock()
+    ctx.time_dispatcher = MagicMock()
+    ctx.post_market_replay_audit_task = SimpleNamespace(task_name="post_market_replay_audit")
+
+    for name in (
+        "ranking_task",
+        "minervini_update_task",
+        "daily_price_collector_task",
+        "ohlcv_update_task",
+        "premium_watchlist_generator_task",
+        "newhigh_task",
+        "log_cleanup_task",
+        "strategy_log_report_task",
+        "after_market_reconcile_task",
+    ):
+        setattr(ctx, name, None)
+
+    with patch("view.web.bootstrap.scheduler_bootstrap.BackgroundScheduler") as MockBackground, \
+         patch("view.web.bootstrap.scheduler_bootstrap.ForegroundScheduler"), \
+         patch(
+             "view.web.bootstrap.scheduler_bootstrap.load_after_market_delays",
+             return_value={"post_market_replay_audit": 30},
+         ):
+        ctx.background_scheduler = MockBackground.return_value
+        SchedulerBootstrap(ctx).run()
+
+    ctx.time_dispatcher.register_task.assert_called_once_with(
+        "post_market_replay_audit",
+        TaskPriority.LOW,
+        delay_sec=30,
+    )
+    MockBackground.return_value.register.assert_called_once_with(ctx.post_market_replay_audit_task)

--- a/tests/unit_test/services/test_backtest_replay_adapter.py
+++ b/tests/unit_test/services/test_backtest_replay_adapter.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
+from datetime import datetime
 
 import pytest
 
 from common.types import ResCommonResponse, TradeSignal
+from services.backtest_replay_context import BacktestMarketClock
 from services.backtest_period_runner import BacktestExecutionBarPolicy, BacktestPeriodRunner
 from services.backtest_execution_simulator import BacktestPortfolioLedger
 from services.backtest_replay_adapter import (
@@ -278,6 +280,28 @@ async def test_stock_query_backtest_replay_service_replays_execution_strength_fr
     assert response.rt_cd == "0"
     assert response.data["output"] == [{"tday_rltv": "132.4"}]
     sqs.get_stock_conclusion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stock_query_backtest_replay_service_cuts_rows_at_replay_clock_time():
+    sqs = AsyncMock()
+    sqs.get_day_intraday_minutes_list.return_value = [
+        {"stck_bsop_date": "20260501", "stck_cntg_hour": "090000", "stck_prpr": "70000"},
+        {"stck_bsop_date": "20260501", "stck_cntg_hour": "090300", "stck_prpr": "70300", "tday_rltv": "110.0"},
+        {"stck_bsop_date": "20260501", "stck_cntg_hour": "090400", "stck_prpr": "70400", "tday_rltv": "150.0"},
+    ]
+    clock = BacktestMarketClock()
+    clock.set_backtest_datetime(datetime(2026, 5, 1, 9, 3, 0))
+    replay = StockQueryBacktestReplayService(sqs, market_clock=clock)
+    replay.set_backtest_date("20260501")
+
+    price_resp = await replay.get_current_price("005930")
+    conclusion_resp = await replay.get_stock_conclusion("005930")
+    rows = await replay.get_day_intraday_minutes_list("005930", date_ymd="20260501")
+
+    assert price_resp.data["output"]["stck_prpr"] == "70300"
+    assert conclusion_resp.data["output"] == [{"tday_rltv": "110.0"}]
+    assert [row["stck_cntg_hour"] for row in rows] == ["090000", "090300"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_post_market_replay_audit_service.py
+++ b/tests/unit_test/services/test_post_market_replay_audit_service.py
@@ -1,0 +1,154 @@
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import TradeSignal
+from core.market_clock import MarketClock
+from services.post_market_replay_audit_service import PostMarketReplayAuditService
+
+
+def _write_strategy_log(log_dir: str, strategy: str = "OneilPocketPivot") -> None:
+    path = os.path.join(log_dir, f"20260505_090300_{strategy}.log.json")
+    rows = [
+        {
+            "timestamp": "2026-05-05 09:03:00,000",
+            "level": "INFO",
+            "data": {"event": "scan_with_watchlist", "count": 2},
+        },
+        {
+            "timestamp": "2026-05-05 09:03:10,000",
+            "level": "DEBUG",
+            "data": {"event": "entry_rejected", "code": "005930", "name": "삼성전자", "reason": "near_signal"},
+        },
+        {
+            "timestamp": "2026-05-05 09:03:11,000",
+            "level": "DEBUG",
+            "data": {"event": "entry_rejected", "code": "000660", "name": "SK하이닉스", "reason": "near_signal"},
+        },
+    ]
+    with open(path, "w", encoding="utf-8") as fp:
+        for row in rows:
+            fp.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _strategy_factory(**_kwargs):
+    universe = MagicMock()
+    universe.get_watchlist = AsyncMock(return_value={"005930": object()})
+
+    class FakeStrategy:
+        name = "OneilPocketPivot"
+        _universe = universe
+
+        async def scan(self):
+            watchlist = await self._universe.get_watchlist()
+            if "005930" not in watchlist:
+                return []
+            return [
+                TradeSignal(
+                    code="005930",
+                    name="삼성전자",
+                    action="BUY",
+                    price=70_000,
+                    qty=1,
+                    reason="replay_signal",
+                    strategy_name="OneilPocketPivot",
+                )
+            ]
+
+    return FakeStrategy()
+
+
+@pytest.mark.asyncio
+async def test_audit_service_marks_late_signal_and_missing_from_universe(tmp_path):
+    _write_strategy_log(str(tmp_path))
+    repo = MagicMock()
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = [
+        {
+            "strategy_name": "OneilPocketPivot",
+            "code": "005930",
+            "action": "BUY",
+            "timestamp": "2026-05-05 09:05:00",
+            "api_success": True,
+        }
+    ]
+    service = PostMarketReplayAuditService(
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=repo,
+        scheduler_store=store,
+        log_dir=str(tmp_path),
+        strategy_factory=_strategy_factory,
+        env=SimpleNamespace(is_paper_trading=False),
+        logger=MagicMock(),
+    )
+
+    result = await service.run("20260505")
+
+    assert result.strategy_count == 1
+    assert result.late_count == 1
+    assert result.missing_from_universe_count == 1
+    records = repo.save_run.call_args.args[0]
+    by_code = {record["code"]: record for record in records}
+    assert by_code["005930"]["metadata"]["audit_status"] == "late_signal"
+    assert by_code["005930"]["metadata"]["live_signal_time"] == "2026-05-05 09:05:00"
+    assert by_code["000660"]["rejected_reason"] == "missing_from_universe"
+    assert by_code["000660"]["metadata"]["audit_status"] == "missing_from_universe"
+    assert repo.save_run.call_args.kwargs["run_id"] == "audit_OneilPocketPivot_20260505"
+    assert repo.save_run.call_args.kwargs["metadata"]["audit_type"] == "missed_signal"
+
+
+@pytest.mark.asyncio
+async def test_audit_service_marks_replay_signal_missing_when_live_has_no_buy(tmp_path):
+    _write_strategy_log(str(tmp_path))
+    repo = MagicMock()
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = []
+    service = PostMarketReplayAuditService(
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=repo,
+        scheduler_store=store,
+        log_dir=str(tmp_path),
+        strategy_factory=_strategy_factory,
+        env=SimpleNamespace(is_paper_trading=False),
+        logger=MagicMock(),
+    )
+
+    result = await service.run("20260505")
+
+    assert result.missed_count == 1
+    records = repo.save_run.call_args.args[0]
+    missed = [record for record in records if record["code"] == "005930"][0]
+    assert missed["metadata"]["audit_status"] == "missed_by_scheduler"
+
+
+@pytest.mark.asyncio
+async def test_audit_service_skips_paper_mode_without_failing(tmp_path):
+    _write_strategy_log(str(tmp_path))
+    repo = MagicMock()
+    service = PostMarketReplayAuditService(
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=repo,
+        scheduler_store=MagicMock(),
+        log_dir=str(tmp_path),
+        strategy_factory=_strategy_factory,
+        env=SimpleNamespace(is_paper_trading=True),
+        logger=MagicMock(),
+    )
+
+    result = await service.run("20260505")
+
+    assert result.skipped is True
+    assert result.skip_reason == "historical_intraday_unavailable_in_paper"
+    repo.save_run.assert_not_called()

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -262,6 +262,52 @@ def test_backtest_live_divergence_section_from_provider():
     assert "S1/005930: 순수익률 -1.50%p, 체결가 -1.9048%, 순손익 -1,500원" in section
 
 
+def test_backtest_live_divergence_section_includes_replay_audit_summary():
+    backtest_records = [
+        {
+            "source": "backtest",
+            "strategy": "S1",
+            "code": "005930",
+            "signal_time": "2026-04-18 09:03:00",
+            "status": "SIGNAL",
+            "metadata": {"audit_status": "missed_by_scheduler"},
+        },
+        {
+            "source": "backtest",
+            "strategy": "S1",
+            "code": "000660",
+            "signal_time": "2026-04-18 09:03:00",
+            "status": "REJECTED",
+            "rejected_reason": "missing_from_universe",
+            "metadata": {"audit_status": "missing_from_universe"},
+        },
+    ]
+
+    class DummyVirtualTradeService:
+        def compare_with_backtest_journal(self, _records):
+            return {
+                "summary": {
+                    "matched_count": 0,
+                    "unmatched_backtest_count": 2,
+                    "unmatched_live_count": 0,
+                },
+                "matches": [],
+                "unmatched_backtest": backtest_records,
+                "unmatched_live": [],
+            }
+
+    svc = StrategyLogReportService(
+        log_dir=".",
+        virtual_trade_service=DummyVirtualTradeService(),
+        backtest_journal_provider=lambda _target_date: backtest_records,
+    )
+
+    section = svc._build_backtest_live_divergence_section("20260418")
+
+    assert "Replay audit: missed 1건, universe 누락 1건" in section
+    assert "S1/005930: missed_by_scheduler" in section
+
+
 @pytest.mark.asyncio
 async def test_report_includes_strategy_degradation_candidates(log_dir):
     """표준 journal 기반 성과 저하 후보를 리포트에 포함하고 getter로 노출한다."""

--- a/tests/unit_test/strategies/debug/test_strategy_debug_runner.py
+++ b/tests/unit_test/strategies/debug/test_strategy_debug_runner.py
@@ -288,6 +288,32 @@ class TestStrategyDebugRunner:
         assert kwargs["strategy"] == "OneilPocketPivot"
         assert kwargs["target_date"] == "20260505"
 
+    async def test_debug_runner_uses_target_signal_time_in_journal(self):
+        signal = TradeSignal(
+            code="005930",
+            name="삼성전자",
+            action="BUY",
+            price=70_000,
+            qty=1,
+            reason="pocket_pivot",
+            strategy_name="OneilPocketPivot",
+        )
+        strategy = _make_strategy(
+            watchlist={"005930": _make_watchlist_item("005930")},
+            signals=[signal],
+        )
+        strategy.name = "OneilPocketPivot"
+        runner = StrategyDebugRunner(
+            strategy,
+            _make_debug_logger(),
+            target_date="20260505",
+            target_signal_time="2026-05-05 09:03:00",
+        )
+
+        report = await runner.run(candidate_codes=["005930"])
+
+        assert report.journal_records[0]["signal_time"] == "2026-05-05 09:03:00"
+
     async def test_debug_runner_marks_signal_rejected_when_portfolio_cash_is_short(self):
         signal = TradeSignal(
             code="005930",

--- a/tests/unit_test/task/background/after_market/test_post_market_replay_audit_task.py
+++ b/tests/unit_test/task/background/after_market/test_post_market_replay_audit_task.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from interfaces.schedulable_task import TaskState
+from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
+
+
+def _make_task(service=None, mcs=None):
+    service = service or MagicMock()
+    service.run = AsyncMock()
+    return PostMarketReplayAuditTask(
+        audit_service=service,
+        mcs=mcs,
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+async def test_on_market_closed_runs_audit_service():
+    service = MagicMock()
+    service.run = AsyncMock()
+    task = _make_task(service=service)
+
+    await task._on_market_closed("20260505")
+
+    service.run.assert_awaited_once_with("20260505")
+
+
+async def test_force_run_uses_market_calendar_date():
+    service = MagicMock()
+    service.run = AsyncMock()
+    mcs = MagicMock()
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260502")
+    task = _make_task(service=service, mcs=mcs)
+
+    await task.force_run()
+
+    service.run.assert_awaited_once_with("20260502")
+    assert task.state == TaskState.IDLE
+
+
+async def test_force_run_falls_back_to_today_when_calendar_fails():
+    service = MagicMock()
+    service.run = AsyncMock()
+    mcs = MagicMock()
+    mcs.get_latest_trading_date = AsyncMock(side_effect=RuntimeError("calendar down"))
+    task = _make_task(service=service, mcs=mcs)
+
+    with patch("task.background.after_market.post_market_replay_audit_task.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "20260505"
+        await task.force_run()
+
+    service.run.assert_awaited_once_with("20260505")
+    task._logger.warning.assert_called_once()

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -6,7 +6,7 @@ TimeDispatcher 태스크 등록, BackgroundScheduler / ForegroundScheduler 생�
 
 또한 `WebAppContext.runtime_mode` 별로 task 등록이 그룹 단위로 분기되는지
 검증한다. StrategySchedulerTaskAdapter 는 StrategyFactory 책임이라 여기서
-다루지 않는다 (총 14개 = SchedulerBootstrap 등록 분, 15번째 adapter 는 별도).
+다루지 않는다 (총 15개 = SchedulerBootstrap 등록 분, 16번째 adapter 는 별도).
 """
 import contextlib
 from types import SimpleNamespace
@@ -46,6 +46,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
         "log_cleanup_task", "strategy_log_report_task",
         "opening_position_reconcile_task", "after_market_reconcile_task",
+        "post_market_replay_audit_task",
         "websocket_watchdog_task", "pre_market_health_check_task",
         "cache_warmup_task", "notification_queue_task",
     ]:
@@ -88,17 +89,17 @@ def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
 
 # ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
 
-def test_all_mode_registers_14_tasks_to_background(patched_scheduler_deps):
+def test_all_mode_registers_15_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 14
+    assert bg.register.call_count == 15
 
 
-def test_all_mode_registers_10_tasks_to_time_dispatcher(patched_scheduler_deps):
+def test_all_mode_registers_11_tasks_to_time_dispatcher(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
-    assert ctx.time_dispatcher.register_task.call_count == 10
+    assert ctx.time_dispatcher.register_task.call_count == 11
 
 
 # ---------- mode 별 task 등록 ----------
@@ -134,7 +135,8 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
     expected = {
         "ranking_task", "minervini_update_task", "daily_price_collector_task",
         "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
-        "log_cleanup_task", "strategy_log_report_task", "after_market_reconcile_task",
+        "log_cleanup_task", "post_market_replay_audit_task",
+        "strategy_log_report_task", "after_market_reconcile_task",
     }
     assert names == expected
     assert "websocket_watchdog_task" not in names
@@ -174,6 +176,6 @@ def test_skips_none_tasks(patched_scheduler_deps):
     _run(ctx)
     # opening_position_reconcile_task 는 TRADING 그룹 + TimeDispatcher 등록 대상이었으므로
     # 둘 다 -1 감소한다.
-    assert ctx.time_dispatcher.register_task.call_count == 9
+    assert ctx.time_dispatcher.register_task.call_count == 10
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 13
+    assert bg.register.call_count == 14

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -32,6 +32,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "StrategyLogReportService", "NotificationQueueTask",
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
     "OpeningPositionReconcileService", "PerformanceProfiler",
+    "PostMarketReplayAuditService", "PostMarketReplayAuditTask",
 ]
 
 
@@ -190,6 +191,7 @@ def test_service_container_batch_mode_skips_streaming_and_intraday_web_tasks(pat
     assert ctx.opening_position_reconcile_task is None
     assert ctx.notification_queue_task is None
     assert ctx.after_market_reconcile_task is patched_service_container_deps["AfterMarketReconcileTask"].return_value
+    assert ctx.post_market_replay_audit_task is patched_service_container_deps["PostMarketReplayAuditTask"].return_value
     assert ctx.daily_price_collector_task is patched_service_container_deps["DailyPriceCollectorTask"].return_value
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
 
@@ -214,6 +216,7 @@ def test_service_container_web_mode_keeps_realtime_and_skips_trading_batch_tasks
     patched_service_container_deps["DailyPriceCollectorTask"].assert_not_called()
     patched_service_container_deps["OhlcvUpdateTask"].assert_not_called()
     patched_service_container_deps["AfterMarketReconcileTask"].assert_not_called()
+    patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
 
     assert ctx.pre_market_health_check_task is None
     assert ctx.opening_position_reconcile_task is None
@@ -246,6 +249,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     patched_service_container_deps["OhlcvUpdateTask"].assert_not_called()
     patched_service_container_deps["AfterMarketReconcileTask"].assert_not_called()
     patched_service_container_deps["StrategyLogReportTask"].assert_not_called()
+    patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
 
     assert ctx.notification_queue_task is None
     assert ctx.minervini_update_task is None
@@ -253,6 +257,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     assert ctx.ohlcv_update_task is None
     assert ctx.after_market_reconcile_task is None
     assert ctx.strategy_log_report_task is None
+    assert ctx.post_market_replay_audit_task is None
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
     assert ctx.oneil_universe_service is patched_service_container_deps["OneilUniverseService"].return_value
 

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -104,6 +104,7 @@ class SchedulerBootstrap:
         self._register(ctx.premium_watchlist_generator_task, TaskPriority.LOW)
         self._register(ctx.newhigh_task, TaskPriority.LOW)
         self._register(ctx.log_cleanup_task, TaskPriority.MAINTENANCE)
+        self._register(ctx.post_market_replay_audit_task, TaskPriority.LOW)
         self._register(ctx.strategy_log_report_task, TaskPriority.LOW)
         self._register(ctx.after_market_reconcile_task, TaskPriority.LOW)
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -49,6 +49,7 @@ from services.stock_query_service import StockQueryService
 from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
 from services.event_shadow_journal_service import EventShadowJournalService
+from services.post_market_replay_audit_service import PostMarketReplayAuditService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
@@ -60,6 +61,7 @@ from task.background.after_market.ohlcv_update_task import OhlcvUpdateTask
 from task.background.after_market.premium_watchlist_generator_task import PremiumWatchlistGeneratorTask
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
+from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
@@ -587,6 +589,24 @@ class ServiceContainer:
                     worker_pool=ctx.worker_pool,
                     rejection_distribution_service=ctx.rejection_distribution_service,
                 )
+                ctx.post_market_replay_audit_task = PostMarketReplayAuditTask(
+                    audit_service=PostMarketReplayAuditService(
+                        stock_query_service=ctx.stock_query_service,
+                        universe_service=ctx.oneil_universe_service,
+                        indicator_service=ctx.indicator_service,
+                        market_clock=ctx.market_clock,
+                        backtest_journal_repository=ctx.backtest_journal_repository,
+                        virtual_trade_service=ctx.virtual_trade_service,
+                        log_dir=os.path.join(ctx.logger.log_dir, "strategies"),
+                        program_provider=getattr(ctx.broker, "_client", ctx.broker),
+                        env=ctx.env,
+                        logger=ctx.logger,
+                    ),
+                    mcs=ctx._mcs,
+                    market_clock=ctx.market_clock,
+                    logger=ctx.logger,
+                    worker_pool=ctx.worker_pool,
+                )
                 ctx.after_market_reconcile_task = AfterMarketReconcileTask(
                     order_execution_service=ctx.order_execution_service,
                     notification_service=ctx.notification_service,
@@ -601,6 +621,7 @@ class ServiceContainer:
                 ctx.newhigh_task = None
                 ctx.newhigh_service = None
                 ctx.strategy_log_report_task = None
+                ctx.post_market_replay_audit_task = None
                 ctx.after_market_reconcile_task = None
 
             if needs_web:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -46,6 +46,7 @@ from task.background.after_market.log_cleanup_task import LogCleanupTask
 from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
+from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
 from services.strategy_log_report_service import StrategyLogReportService, _REASON_KR
 from services.rejection_distribution_service import RejectionDistributionService
 from task.background.always_on.notification_queue_task import NotificationQueueTask
@@ -137,6 +138,7 @@ class WebAppContext:
         self.log_cleanup_task: LogCleanupTask = None
         self.newhigh_task: NewHighTask = None
         self.strategy_log_report_task: StrategyLogReportTask = None
+        self.post_market_replay_audit_task: PostMarketReplayAuditTask = None
         self.stock_repository: StockRepository = None
         self.background_scheduler: BackgroundScheduler = None
         self.foreground_scheduler: ForegroundScheduler = None


### PR DESCRIPTION
… 기준으로 replay audit을 돌려 BacktestJournalRepository에 audit_{strategy}_{YYYYMMDD} run으로 저장하게 했습니다. 주문 실행은 없고, missed_by_scheduler, late_signal, missing_from_universe, replayed_rejected, data_unavailable 상태만 남깁니다.

핵심 변경은 services/post_market_replay_audit_service.py, task/background/after_market/post_market_replay_audit_task.py, services/backtest_replay_adapter.py, strategies/debug/strategy_debug_runner.py, services/strategy_log_report_service.py, view/web/bootstrap/service_container.py, view/web/bootstrap/scheduler_bootstrap.py, config/task_config.yaml입니다.

검증도 완료했습니다.

pytest tests/unit_test -v -n0: 5659 passed
pytest tests/integration_test -v -n0: 240 passed
테스트는 py310 환경의 C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe로 실행했습니다.