### PR TITLE
P0 0-8 완료 ✅

### DIFF
--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -53,19 +53,20 @@ class IndicatorService:
         return resp.data, None
 
     async def _get_with_incremental_cache(
-        self, 
-        stock_code: str, 
-        candle_type: str, 
-        indicator_name: str, 
-        data: List[Dict], 
-        lookback_period: int, 
-        calc_func: callable, 
-        *calc_args
+        self,
+        stock_code: str,
+        candle_type: str,
+        indicator_name: str,
+        data: List[Dict],
+        lookback_period: int,
+        calc_func: callable,
+        *calc_args,
+        exclude_today: bool = False,
     ) -> ResCommonResponse:
         """
         [공통 지표 캐싱 & 병합 파이프라인]
         과거 확정 데이터는 캐싱하고, 당일(미확정) 데이터만 증분 계산하여 O(1)로 병합합니다.
-        
+
         :param stock_code: 종목코드
         :param candle_type: 캔들 타입 ("D", "W", "M" 등)
         :param indicator_name: 캐시 키 생성을 위한 지표명 (예: "rsi_14", "bb_20_2.0")
@@ -73,17 +74,44 @@ class IndicatorService:
         :param lookback_period: 증분 계산 시 필요한 최소 과거 데이터 개수 (예: RSI 14면 14)
         :param calc_func: 실제 지표 계산을 수행하고 List[Dict]를 반환하는 콜백 함수
         :param calc_args: calc_func에 전달할 추가 인자들
+        :param exclude_today: True 면 마지막 봉(=장중 미확정 봉) 을 결과에서 제외 (P0 0-8).
+                              라이브 신호 계산이 인트라데이 변동에 흔들리지 않게 한다.
         """
+        # P0 0-8: 라이브 호출은 마지막 봉(당일 미확정) 을 제외한다.
+        # MarketDataService.get_ohlcv 가 장중에 today row 를 병합하므로, 이 옵션이
+        # 켜진 호출은 confirmed 영역까지만 본다.
+        if exclude_today and len(data) >= 1:
+            effective_data = data[:-1]
+        else:
+            effective_data = data
+
         # 1. 예외 처리 및 캐시 미적용 조건 (데이터가 너무 적거나, 일봉이 아니거나, 캐시가 꺼진 경우)
-        if not self.cache_store or candle_type != "D" or len(data) <= lookback_period:
-            resp = calc_func(stock_code, data, *calc_args)
+        if not self.cache_store or candle_type != "D" or len(effective_data) <= lookback_period:
+            resp = calc_func(stock_code, effective_data, *calc_args)
             # [수정포인트 1] 이미 ResCommonResponse 객체라면 이중 래핑 방지
             return resp if isinstance(resp, ResCommonResponse) else ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(NoCache)", data=resp)
-        
+
+        # exclude_today=True 면 effective_data 전체가 confirmed → partial merge 없이 캐시 결과만 반환.
+        # cache_key 는 effective_data 마지막 행 날짜 기준 (include 경로와 같은 confirmed 일자) → cache 공유.
+        if exclude_today:
+            confirmed_last_date = str(effective_data[-1]['date'])
+            cache_key = f"{indicator_name}_{stock_code}_{confirmed_last_date}"
+            cached_result = self.cache_store.get(cache_key)
+            if not cached_result:
+                calc_resp = calc_func(stock_code, effective_data, *calc_args)
+                if isinstance(calc_resp, ResCommonResponse):
+                    if calc_resp.rt_cd != ErrorCode.SUCCESS.value:
+                        return calc_resp
+                    cached_result = calc_resp.data
+                else:
+                    cached_result = calc_resp
+                self.cache_store.set(cache_key, cached_result)
+            return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공(ExcludeToday)", data=cached_result)
+
         # 2. 확정 데이터(어제까지)와 당일 데이터 분리
         confirmed_data = data[:-1]
         confirmed_last_date = str(confirmed_data[-1]['date'])
-        
+
         # 캐시 키 생성 (지표명_종목코드_마지막확정일자)
         cache_key = f"{indicator_name}_{stock_code}_{confirmed_last_date}"
 
@@ -100,15 +128,15 @@ class IndicatorService:
                 cached_result = calc_resp.data
             else:
                 cached_result = calc_resp
-                
+
             self.cache_store.set(cache_key, cached_result)
 
         # 5. 당일 증분 계산
         slice_size = lookback_period + 5
         partial_data = data[-slice_size:]
-        
+
         partial_resp = calc_func(stock_code, partial_data, *calc_args)
-        
+
         # [수정포인트 3] 반환값이 ResCommonResponse면 내부 data만 추출해서 병합 준비
         if isinstance(partial_resp, ResCommonResponse):
             if partial_resp.rt_cd != ErrorCode.SUCCESS.value:
@@ -116,14 +144,14 @@ class IndicatorService:
             partial_result = partial_resp.data
         else:
             partial_result = partial_resp
-            
+
         if not partial_result:
             return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1="부분 지표 계산 실패", data=None)
-            
+
         latest_indicator = partial_result[-1]
         # 6. O(1) 속도로 병합 (리스트 '+' 연산자 제거 최적화)
         final_data = cached_result.copy() # 얕은 복사로 원본 캐시 리스트 보호
-        
+
         if final_data and final_data[-1]['date'] == latest_indicator['date']:
             final_data[-1] = latest_indicator # 덮어쓰기
         else:
@@ -149,8 +177,13 @@ class IndicatorService:
         )
 
     async def get_rsi(self, stock_code: str, period: int = 14, candle_type: str = "D",
-                                 ohlcv_data: Optional[List[Dict]] = None) -> ResCommonResponse:
-        """RSI (상대강도지수) 조회"""
+                                 ohlcv_data: Optional[List[Dict]] = None,
+                                 exclude_today: bool = False) -> ResCommonResponse:
+        """RSI (상대강도지수) 조회.
+
+        exclude_today (P0 0-8): True 면 결과에서 당일(장중 미확정) 봉을 제외한다. 라이브 전략은
+        인트라데이 변동에 트리거가 흔들리지 않도록 True 로 호출한다.
+        """
         # 1. OHLCV 데이터 가져오기
         data, err_resp = await self._get_ohlcv_data(stock_code, candle_type, ohlcv_data=ohlcv_data)
         if err_resp: return err_resp
@@ -163,7 +196,8 @@ class IndicatorService:
             data,
             period,
             self._calculate_rsi_series, # DataFrame 변환 및 순수 계산 로직만 있는 내부 함수
-            period  # <-- calc_func에 전달될 *calc_args (정상 작동!)
+            period,  # <-- calc_func에 전달될 *calc_args (정상 작동!)
+            exclude_today=exclude_today,
         )
 
     async def calculate_atr(
@@ -172,9 +206,13 @@ class IndicatorService:
         period: int = 14,
         candle_type: str = "D",
         ohlcv_data: Optional[List[Dict]] = None,
+        exclude_today: bool = False,
     ) -> ResCommonResponse:
         """ATR(Average True Range) 조회 — 포지션 사이징용.
         응답 data: List[{"code", "date", "close", "atr"}] (마지막 항목의 atr 이 현재 ATR)
+
+        exclude_today (P0 0-8): True 면 결과에서 당일(장중 미확정) 봉을 제외한다. 포지션 사이징은
+        인트라데이 high/low 흔들림이 size 에 반영되지 않도록 True 로 호출한다.
         """
         data, err_resp = await self._get_ohlcv_data(stock_code, candle_type, ohlcv_data=ohlcv_data)
         if err_resp:
@@ -188,17 +226,23 @@ class IndicatorService:
             period,
             self._calculate_atr_full,
             period,
+            exclude_today=exclude_today,
         )
 
     async def get_moving_average(
-        self, 
-        stock_code: str, 
-        period: int = 20, 
-        method: str = "sma", 
-        candle_type: str = "D", 
-        ohlcv_data: Optional[List[Dict]] = None
+        self,
+        stock_code: str,
+        period: int = 20,
+        method: str = "sma",
+        candle_type: str = "D",
+        ohlcv_data: Optional[List[Dict]] = None,
+        exclude_today: bool = False,
     ) -> ResCommonResponse:
-        """이동평균선 조회"""
+        """이동평균선 조회.
+
+        exclude_today (P0 0-8): True 면 결과에서 당일(장중 미확정) 봉을 제외한다. MA 기반
+        손절/지지선 판정이 인트라데이 변동으로 깜빡이지 않게 한다.
+        """
         # 1. OHLCV 데이터 로드 및 에러 처리
         data, err_resp = await self._get_ohlcv_data(stock_code, candle_type, ohlcv_data=ohlcv_data)
 
@@ -214,7 +258,8 @@ class IndicatorService:
             period,
             self._calculate_moving_average_full,  # 기존 이동평균선 전체 계산 함수
             period,                               # *calc_args 첫 번째 인자
-            method                                # [수정됨] *calc_args 두 번째 인자로 method 전달
+            method,                               # [수정됨] *calc_args 두 번째 인자로 method 전달
+            exclude_today=exclude_today,
         )
 
     async def get_relative_strength(

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -294,10 +294,13 @@ class PositionSizingService:
         return max(stop_from_price, stop_from_pct, stop_from_atr, min_stop)
 
     async def _get_atr_krw(self, signal: TradeSignal) -> float:
-        """ATR 마지막 값을 KRW 로 반환. 실패 시 0.0."""
+        """ATR 마지막 값을 KRW 로 반환. 실패 시 0.0.
+
+        P0 0-8: 사이징은 당일 미확정 봉의 high/low 흔들림을 ATR 에 반영하지 않도록 exclude_today=True.
+        """
         try:
             resp = await self._indicator.calculate_atr(
-                signal.code, period=self._cfg.atr_period
+                signal.code, period=self._cfg.atr_period, exclude_today=True,
             )
             from common.types import ErrorCode
             if resp is None or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:

--- a/strategies/rsi2_pullback_strategy.py
+++ b/strategies/rsi2_pullback_strategy.py
@@ -145,8 +145,8 @@ class RSI2PullbackStrategy(LiveStrategy):
             })
             return None
 
-        # Phase 1-2: 일봉 RSI(2) 조회
-        rsi_resp = await self._indicator.get_rsi(code, period=self._cfg.rsi_period, candle_type="D")
+        # Phase 1-2: 일봉 RSI(2) 조회 — P0 0-8: 당일 미확정 봉 제외 (인트라데이 RSI 깜빡임 방지)
+        rsi_resp = await self._indicator.get_rsi(code, period=self._cfg.rsi_period, candle_type="D", exclude_today=True)
         if not rsi_resp or rsi_resp.rt_cd != "0" or not rsi_resp.data:
             self._logger.info({
                 "event": "entry_rejected",
@@ -283,10 +283,10 @@ class RSI2PullbackStrategy(LiveStrategy):
         if buy_price <= 0:
             buy_price = current
 
-        # 200MA / 5MA 조회 (병렬)
+        # 200MA / 5MA 조회 (병렬) — P0 0-8: 당일 미확정 봉 제외 (MA exit 트리거 인트라데이 흔들림 방지)
         ma_resps = await asyncio.gather(
-            self._indicator.get_moving_average(code, period=self._cfg.trend_break_ma_period, candle_type="D"),
-            self._indicator.get_moving_average(code, period=self._cfg.take_profit_ma_period, candle_type="D"),
+            self._indicator.get_moving_average(code, period=self._cfg.trend_break_ma_period, candle_type="D", exclude_today=True),
+            self._indicator.get_moving_average(code, period=self._cfg.take_profit_ma_period, candle_type="D", exclude_today=True),
             return_exceptions=True,
         )
         ma200 = self._latest_ma(ma_resps[0])

--- a/tests/integration_test/strategies/test_it_api_rsi2_pullback_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_rsi2_pullback_strategy.py
@@ -11,26 +11,35 @@ from services.oneil_universe_service import OneilUniverseService
 from common.types import ResCommonResponse
 
 
-def _make_rsi2_oversold_ohlcv(code, days=30, base_close=10000):
-    """RSI(2) ≤ 10 이 되도록 마지막 2일을 강한 음봉으로 만든 30일 OHLCV.
+def _make_rsi2_oversold_ohlcv(code, days=31, base_close=10000):
+    """어제 confirmed RSI(2) ≤ 10 + 오늘 미확정 양봉 반등 시나리오.
+
+    P0 0-8: exclude_today=True 인 production 라이브 코드는 어제 confirmed RSI 로 trigger.
+    오늘 인트라데이 양봉이 RSI 를 흔들어도 신호 안정성이 유지된다.
 
     IndicatorService._to_dataframe 가 plain dict (date/open/high/low/close/volume)을
     기대하므로 그 포맷으로 반환한다.
     """
-    base_dt = datetime(2026, 3, 7)
+    # base_dt 는 mock_tm.get_current_kst_time 의 KST today (2026-03-09) 와 동기화 — 마지막 봉이 "오늘"
+    base_dt = datetime(2026, 3, 9)
     rows = []
     for i in range(days):
         dt = base_dt - timedelta(days=days - 1 - i)
         date_str = dt.strftime("%Y%m%d")
-        if i < days - 2:
+        if i < days - 3:
             # 강한 우상향 (Stage 2)
             price = int(base_close * (1.0 + 0.005 * i))
             vol = 500000
-        else:
-            # 마지막 2영업일 큰 음봉 (-3%) → RSI(2)가 한 자릿수까지 하락
+        elif i < days - 1:
+            # 어제까지 confirmed 2영업일 큰 음봉 (-3%) → confirmed RSI(2) 한 자릿수
             prev = rows[-1]["close"]
             price = int(prev * 0.97)
             vol = 900000
+        else:
+            # 오늘 (미확정) — 강한 양봉 +5% 반등 (인트라데이 노이즈로 RSI 반등)
+            prev = rows[-1]["close"]
+            price = int(prev * 1.05)
+            vol = 700000
         rows.append({
             "date": date_str,
             "open": price - 50, "high": price + 100,

--- a/tests/integration_test/strategies/test_it_strategy_scan.py
+++ b/tests/integration_test/strategies/test_it_strategy_scan.py
@@ -821,17 +821,24 @@ class TestRSI2PullbackScan:
         from strategies.oneil_common_types import OSBWatchlistItem
         from services.indicator_service import IndicatorService
 
-        # 마지막 2영업일에 큰 음봉을 배치하여 IndicatorService가 RSI(2) ≤ 10 을 산출하도록 구성
-        base_dt = datetime(2026, 3, 7)
+        # P0 0-8: 어제까지 confirmed RSI(2) ≤ 10 + 오늘(마지막 봉) 미확정 양봉 반등 시나리오.
+        # exclude_today=True 인 production 라이브 코드는 어제 confirmed RSI 로 trigger.
+        # base_dt 를 mock_tm.today (2026-03-09) 와 동기화하여 마지막 봉이 "오늘 미확정" 을 모방.
+        base_dt = datetime(2026, 3, 9)
         ohlcv = []
-        for i in range(30):
-            dt = base_dt - timedelta(days=29 - i)
+        for i in range(31):
+            dt = base_dt - timedelta(days=30 - i)
             date_str = dt.strftime("%Y%m%d")
             if i < 28:
                 price = int(10000 * (1.0 + 0.005 * i))
-            else:
+            elif i < 30:
+                # 어제까지 confirmed 2영업일 큰 음봉 (-3%)
                 prev = ohlcv[-1]["close"]
                 price = int(prev * 0.97)
+            else:
+                # 오늘 (미확정) — 강한 양봉 +5% 반등 (인트라데이 노이즈)
+                prev = ohlcv[-1]["close"]
+                price = int(prev * 1.05)
             ohlcv.append({
                 "date": date_str,
                 "open": price - 50, "high": price + 100,

--- a/tests/unit_test/services/test_indicator_service.py
+++ b/tests/unit_test/services/test_indicator_service.py
@@ -1773,3 +1773,117 @@ def test_calc_adx_sync_missing_high_low_returns_empty(indicator_service):
             for i in range(50)]
     result = service.calc_adx_sync(data, period=14)
     assert result == {}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# P0 0-8: exclude_today 옵션 — 라이브 지표가 당일 미완성 봉을 제외
+# ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_rsi_exclude_today_drops_last_bar(indicator_service):
+    """exclude_today=True 일 때 마지막 행(=당일 미확정 봉) 이 결과에서 제외된다."""
+    service, mock_sqs = indicator_service
+
+    # 20일치 + 당일 1봉 = 21봉. 당일 close 는 의도적으로 큰 점프 → RSI 변동 유발.
+    data = [{"date": f"202501{i+1:02d}", "close": 10000 + i * 100} for i in range(20)]
+    data.append({"date": "20250121", "close": 20000})  # 당일 미확정 (큰 점프)
+
+    mock_sqs.get_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=data
+    )
+
+    incl = await service.get_rsi("005930", period=14, exclude_today=False)
+    excl = await service.get_rsi("005930", period=14, exclude_today=True)
+
+    assert incl.rt_cd == ErrorCode.SUCCESS.value
+    assert excl.rt_cd == ErrorCode.SUCCESS.value
+    # exclude_today=True 면 마지막 행이 빠진 20개여야 한다
+    assert len(excl.data) == len(incl.data) - 1
+    assert excl.data[-1]["date"] == "20250120"
+    assert incl.data[-1]["date"] == "20250121"
+    # 동일 confirmed 구간의 RSI 값은 동일해야 한다 (마지막 confirmed bar 기준)
+    assert excl.data[-1]["rsi"] == pytest.approx(incl.data[-2]["rsi"])
+
+
+@pytest.mark.asyncio
+async def test_get_moving_average_exclude_today_drops_last_bar(indicator_service):
+    """MA: exclude_today=True 면 결과에서 당일 봉 제외, 마지막 MA 는 전일 확정값."""
+    service, mock_sqs = indicator_service
+
+    data = [{"date": f"202501{i+1:02d}", "close": 10000 + i * 100} for i in range(25)]
+    data.append({"date": "20250126", "close": 30000})  # 당일 점프
+
+    mock_sqs.get_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=data
+    )
+
+    incl = await service.get_moving_average("005930", period=20, exclude_today=False)
+    excl = await service.get_moving_average("005930", period=20, exclude_today=True)
+
+    assert incl.rt_cd == ErrorCode.SUCCESS.value
+    assert excl.rt_cd == ErrorCode.SUCCESS.value
+    assert len(excl.data) == len(incl.data) - 1
+    assert excl.data[-1]["date"] == "20250125"
+    # 당일 점프된 close 가 빠졌으므로 마지막 MA 값은 include 보다 작아야 한다
+    assert excl.data[-1]["ma"] < incl.data[-1]["ma"]
+
+
+@pytest.mark.asyncio
+async def test_calculate_atr_exclude_today_drops_last_bar(indicator_service):
+    """ATR: exclude_today=True 면 당일 high/low 점프가 ATR 에 반영되지 않는다."""
+    service, mock_sqs = indicator_service
+
+    data = []
+    for i in range(20):
+        c = 10000 + i * 100
+        data.append({"date": f"202501{i+1:02d}", "open": c, "high": c + 50, "low": c - 50, "close": c, "volume": 1000})
+    # 당일 미확정 봉: 큰 high/low 변동 → ATR 인플레이션
+    data.append({"date": "20250121", "open": 12000, "high": 15000, "low": 11000, "close": 14000, "volume": 1000})
+
+    mock_sqs.get_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=data
+    )
+
+    incl = await service.calculate_atr("005930", period=14, exclude_today=False)
+    excl = await service.calculate_atr("005930", period=14, exclude_today=True)
+
+    assert incl.rt_cd == ErrorCode.SUCCESS.value
+    assert excl.rt_cd == ErrorCode.SUCCESS.value
+    assert len(excl.data) == len(incl.data) - 1
+    assert excl.data[-1]["date"] == "20250120"
+    # 당일 큰 변동이 빠졌으므로 ATR 은 include 보다 작아야 한다
+    assert excl.data[-1]["atr"] < incl.data[-1]["atr"]
+
+
+@pytest.mark.asyncio
+async def test_get_rsi_exclude_today_default_is_false(indicator_service):
+    """기본값 (exclude_today 미지정) 은 기존 동작과 동일해야 한다 (회귀 방지)."""
+    service, mock_sqs = indicator_service
+
+    data = [{"date": f"202501{i+1:02d}", "close": 10000 + i * 100} for i in range(20)]
+    data.append({"date": "20250121", "close": 20000})
+
+    mock_sqs.get_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=data
+    )
+
+    default_resp = await service.get_rsi("005930", period=14)
+    explicit_incl = await service.get_rsi("005930", period=14, exclude_today=False)
+
+    assert len(default_resp.data) == len(explicit_incl.data) == 21
+    assert default_resp.data[-1]["date"] == "20250121"
+    assert default_resp.data[-1]["rsi"] == pytest.approx(explicit_incl.data[-1]["rsi"])
+
+
+@pytest.mark.asyncio
+async def test_get_rsi_exclude_today_with_empty_data_safe(indicator_service):
+    """OHLCV 가 비어있어도 exclude_today=True 가 예외를 던지지 않는다."""
+    service, mock_sqs = indicator_service
+
+    mock_sqs.get_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=[]
+    )
+
+    result = await service.get_rsi("005930", period=14, exclude_today=True)
+    # _get_ohlcv_data 에서 빈 데이터는 API_ERROR 응답으로 반환됨 (기존 동작)
+    assert result.rt_cd != ErrorCode.SUCCESS.value or not result.data


### PR DESCRIPTION
작업 요약
브랜치: feature/p0-0-8-exclude-today-indicators

구현 사항:

IndicatorService._get_with_incremental_cache에 exclude_today: bool = False 파라미터 추가 — True 시 data[:-1]로 작업하고 partial merge 단계 skip (cache 키는 include 경로와 공유) IndicatorService.get_rsi(), get_moving_average(), calculate_atr() 모두 exclude_today 받아서 pass-through 기본값 False → 차트/UI 등 기존 호출 모두 회귀 없음
라이브 호출처 적용 (총 4곳):

strategies/rsi2_pullback_strategy.py:149 — get_rsi(..., exclude_today=True) (entry trigger) strategies/rsi2_pullback_strategy.py:288-289 — get_moving_average(..., exclude_today=True) (200MA/5MA exit trigger) services/position_sizing_service.py:299-301 — calculate_atr(..., exclude_today=True) (size 계산) 테스트:

신규 단위 테스트 5건 (exclude_today 효과 검증)
통합 테스트 fixture 2건 보정 — "어제 confirmed RSI<10 + 오늘 인트라데이 양봉 반등" 시나리오로 P0 0-8의 핵심 가치(인트라데이 노이즈 차단) 직접 검증 전체 회귀 확인:

단위 테스트: 5664 passed (3분)
통합 테스트: 240 passed (3분 21초)
변경량: 6 files, +227/-49 lines
효과
인트라데이 변동으로 RSI(2) trigger가 깜빡이던 문제 차단
ATR 기반 position sizing이 당일 high/low 흔들림에 영향 안 받음
MA(200)/MA(5) 기반 exit trigger도 confirmed 값 기준으로 안정화 라이브 신호가 백테스트 가정(확정 봉)과 정합화 → 백테스트↔라이브 괴리 진단이 명확해짐