### PR TITLE
P0 0-9 완료 ✅

### DIFF
--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -19,6 +19,7 @@ from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -487,7 +488,10 @@ class FirstPullbackStrategy(LiveStrategy):
 
         pnl = float((current - buy_price) / buy_price * 100)
 
-        # MFE / MAE 갱신
+        # P0 0-9: stop/익절 trigger 비교는 비용 반영 net 기준 — backtest 와 동일.
+        pnl_net = TransactionCostUtils.net_return_pct(buy_price, current)
+
+        # MFE / MAE 갱신 (가격 변동 = gross — backtest 의 _bar_excursion 과 동일 기준)
         if pnl > state.mfe_pct:
             state.mfe_pct = round(pnl, 2)
             state_dirty = True
@@ -502,7 +506,7 @@ class FirstPullbackStrategy(LiveStrategy):
 
         reason = ""
 
-        # 🚨 손절: 20MA -2% 이탈 → 10분 유예 후 확정 (14:50 이후는 즉시)
+        # 🚨 손절: 20MA -2% 이탈 → 10분 유예 후 확정 (14:50 이후는 즉시) — 가격 기준 trigger, log 는 net 표시
         if len(closes) >= self._cfg.ma_period:
             ma_20d = float(sum(closes[-self._cfg.ma_period:]) / self._cfg.ma_period)
             threshold = ma_20d * (1 + self._cfg.stop_loss_below_ma_pct / 100)
@@ -514,23 +518,23 @@ class FirstPullbackStrategy(LiveStrategy):
                     second=0, microsecond=0,
                 )
                 if now >= eod:
-                    reason = f"손절(20MA {ma_20d:,.0f} 장마감전 이탈 {pnl:.1f}%)"
+                    reason = f"손절(20MA {ma_20d:,.0f} 장마감전 이탈, net {pnl_net:.1f}%)"
                 elif not state.ma_break_since_ts:
                     state.ma_break_since_ts = now.strftime("%Y%m%d%H%M%S")
                     state_dirty = True
                 else:
                     break_dt = datetime.strptime(state.ma_break_since_ts, "%Y%m%d%H%M%S").replace(tzinfo=now.tzinfo)
                     if (now - break_dt).total_seconds() / 60 >= self._cfg.ma_break_grace_minutes:
-                        reason = f"손절(20MA {ma_20d:,.0f} {self._cfg.ma_break_grace_minutes}분 이탈유지 {pnl:.1f}%)"
+                        reason = f"손절(20MA {ma_20d:,.0f} {self._cfg.ma_break_grace_minutes}분 이탈유지, net {pnl_net:.1f}%)"
             else:
                 if state.ma_break_since_ts:
                     state.ma_break_since_ts = None
                     state_dirty = True
 
-        # 🌟 부분 익절: 직전 익절가(또는 진입가) 대비 +10% 도달 시 반복 실행
+        # 🌟 부분 익절: 직전 익절가(또는 진입가) 대비 +10% 도달 시 반복 실행 (net, P0 0-9)
         if not reason:
             ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
-            pnl_from_ref = float((current - ref_price) / ref_price * 100)
+            pnl_from_ref = TransactionCostUtils.net_return_pct(ref_price, current)
             if pnl_from_ref >= self._cfg.take_profit_lower_pct:
                 holding_qty = int(hold.get("qty", 1))
                 sell_qty = max(1, int(holding_qty * self._cfg.partial_sell_ratio))
@@ -559,9 +563,9 @@ class FirstPullbackStrategy(LiveStrategy):
                 ))
                 return signals, state_dirty  # 부분 매도 후 손절 체크하지 않음
 
-        # 🛡️ 본절스탑: 부분익절 후 진입가 하회 시 잔량 전량 청산
+        # 🛡️ 본절스탑: 부분익절 후 진입가 하회 시 잔량 전량 청산 (가격 기준, log 는 net 표시)
         if not reason and state.breakeven_armed and current < buy_price:
-            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회 {pnl:.1f}%)"
+            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회, net {pnl_net:.1f}%)"
 
         # 매도 시그널 생성 (손절)
         if reason:
@@ -570,7 +574,9 @@ class FirstPullbackStrategy(LiveStrategy):
                 "event": "exit_signal_generated",
                 "code": code, "name": hold.get("name", code),
                 "reason": reason,
-                "pnl_pct": round(pnl, 2),
+                "pnl_pct": round(pnl, 2),       # gross (가격 변동) — backtest MFE/MAE 와 동일 기준
+                "pnl_net_pct": round(pnl_net, 2),  # P0 0-9: net (비용 반영) — trigger 비교 기준
+                "pnl_basis": "net_trigger_gross_log",
                 "mfe_pct": state.mfe_pct,
                 "mae_pct": state.mae_pct,
             })

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -17,6 +17,7 @@ from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -609,9 +610,12 @@ class HighTightFlagStrategy(LiveStrategy):
             state.peak_price = current
             state_dirty = True
 
+        # 가격 변동 비율 (gross) — MFE/MAE/log 추적용. backtest 의 _bar_excursion 과 동일 기준.
         pnl = float((current - buy_price) / buy_price * 100)
+        # P0 0-9: stop/익절 trigger 비교는 비용 반영 net 기준 — backtest 와 동일.
+        pnl_net = TransactionCostUtils.net_return_pct(buy_price, current)
 
-        # MFE / MAE 갱신
+        # MFE / MAE 갱신 (가격 변동 = gross)
         if pnl > state.mfe_pct:
             state.mfe_pct = round(pnl, 2)
             state_dirty = True
@@ -621,14 +625,14 @@ class HighTightFlagStrategy(LiveStrategy):
 
         reason = ""
 
-        # 1. 칼손절
-        if pnl <= self._cfg.stop_loss_pct:
-            reason = f"칼손절({pnl:.1f}%)"
+        # 1. 칼손절 (net, P0 0-9)
+        if pnl_net <= self._cfg.stop_loss_pct:
+            reason = f"칼손절(net {pnl_net:.1f}%)"
 
-        # 2. 부분 익절: ref_price 대비 +20% 도달 시 반복 실행
+        # 2. 부분 익절: ref_price 대비 +20% 도달 시 반복 실행 (net, P0 0-9)
         if not reason:
             ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
-            pnl_from_ref = float((current - ref_price) / ref_price * 100)
+            pnl_from_ref = TransactionCostUtils.net_return_pct(ref_price, current)
             if pnl_from_ref >= self._cfg.partial_profit_trigger_pct:
                 holding_qty = int(hold.get("qty", 1))
                 sell_qty = max(1, int(holding_qty * self._cfg.partial_sell_ratio))
@@ -652,9 +656,9 @@ class HighTightFlagStrategy(LiveStrategy):
                 ))
                 return signals, state_dirty
 
-        # 3. 본절스탑: 부분익절 후 진입가 하회 시 잔량 전량 청산
+        # 3. 본절스탑: 부분익절 후 진입가 하회 시 잔량 전량 청산 (가격 기준 trigger, log 는 net 표시)
         if not reason and state.breakeven_armed and current < buy_price:
-            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회 {pnl:.1f}%)"
+            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회, net {pnl_net:.1f}%)"
 
         # 4. 5일 MA 트레일링스탑 + 고점 낙폭 -8%
         if not reason:
@@ -669,7 +673,9 @@ class HighTightFlagStrategy(LiveStrategy):
                 "event": "exit_signal_generated",
                 "code": code, "name": hold.get("name", code),
                 "reason": reason,
-                "pnl_pct": round(pnl, 2),
+                "pnl_pct": round(pnl, 2),       # gross (가격 변동) — backtest MFE/MAE 와 동일 기준
+                "pnl_net_pct": round(pnl_net, 2),  # P0 0-9: net (비용 반영) — trigger 비교 기준
+                "pnl_basis": "net_trigger_gross_log",
                 "mfe_pct": state.mfe_pct,
                 "mae_pct": state.mae_pct,
             })

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -19,6 +19,7 @@ from core.logger import get_strategy_logger
 from strategies.larry_williams_cb_types import LarryWilliamsCBConfig, LarryWilliamsCBPositionState
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -344,13 +345,14 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
         elif state and current < state.channel_low_10d:
             reason = f"트레일링 스탑: {current} < channel_low_10d {state.channel_low_10d}"
 
-        pnl_pct = (current - buy_price) / buy_price * 100.0 if buy_price > 0 else 0.0
+        # P0 0-9: log 의 pnl 표시도 net 기준 (trigger 자체는 가격 기반이라 net 무관).
+        pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current) if buy_price > 0 else 0.0
 
         if reason:
             self._logger.info({
                 "event": "exit_signal_generated",
                 "code": code, "name": hold.get("name", code),
-                "reason": reason, "pnl_pct": round(pnl_pct, 2),
+                "reason": reason, "pnl_pct": round(pnl_pct, 2), "pnl_basis": "net",
             })
             self._position_state.pop(code, None)
             unblock = (self._tm.get_current_kst_time().date() + timedelta(days=self._cfg.cooldown_days)).strftime("%Y%m%d")

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -13,6 +13,7 @@ from interfaces.live_strategy import LiveStrategy
 from services.stock_query_service import StockQueryService
 from strategies.base_strategy_config import BaseStrategyConfig
 from utils.async_concurrency import bounded_gather
+from utils.transaction_cost_utils import TransactionCostUtils
 from utils.volatility_utils import annualized_return_std
 
 if TYPE_CHECKING:
@@ -384,15 +385,16 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 if current <= 0:
                     continue
 
-                pnl_pct = (current - buy_price) / buy_price * 100
-                log_data.update({"current": current, "pnl_pct": round(pnl_pct, 2)})
+                # P0 0-9: 비용 반영 net 수익률 — backtest 와 동일 기준으로 stop trigger.
+                pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current)
+                log_data.update({"current": current, "pnl_pct": round(pnl_pct, 2), "pnl_basis": "net"})
 
                 reason = ""
                 should_sell = False
 
-                # 칼손절: 진입가 대비 -3%
+                # 칼손절: 진입가 대비 -3% (net, P0 0-9)
                 if pnl_pct <= self._cfg.stop_loss_pct:
-                    reason = f"칼손절: 매수가대비 {pnl_pct:.1f}%"
+                    reason = f"칼손절(net): 매수가대비 {pnl_pct:.1f}%"
                     should_sell = True
 
                 # EOD 강제청산: 15:20

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -19,6 +19,7 @@ from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -613,10 +614,13 @@ class OneilPocketPivotStrategy(LiveStrategy):
             state.peak_price = current
             state_dirty = True
 
+        # 가격 변동 비율 (gross) — MFE/MAE/log/anchor 추적용. backtest 와 동일 기준.
         pnl = float((current - buy_price) / buy_price * 100)
+        # P0 0-9: stop/익절 trigger 비교는 비용 반영 net 기준.
+        pnl_net = TransactionCostUtils.net_return_pct(buy_price, current)
         today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
 
-        # MFE / MAE 갱신
+        # MFE / MAE 갱신 (가격 변동 = gross)
         if pnl > state.mfe_pct:
             state.mfe_pct = round(pnl, 2)
             state_dirty = True
@@ -624,8 +628,8 @@ class OneilPocketPivotStrategy(LiveStrategy):
             state.mae_pct = round(pnl, 2)
             state_dirty = True
 
-        # 수익 안착 추적 (+5% 돌파 시 1회만 기록)
-        if pnl >= self._cfg.holding_profit_anchor_pct and state.holding_start_date == "":
+        # 수익 안착 추적 (+5% 돌파 시 1회만 기록 — net 기준, P0 0-9)
+        if pnl_net >= self._cfg.holding_profit_anchor_pct and state.holding_start_date == "":
             state.holding_start_date = today_str
             state_dirty = True
 
@@ -680,9 +684,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 state_dirty = True
                 return signals, state_dirty  # 부분 매도 후 전량 청산하지 않음
 
-        # 🛡️ 우선순위 3.5: 본절스탑 (부분익절 후 진입가 하회)
+        # 🛡️ 우선순위 3.5: 본절스탑 (부분익절 후 진입가 하회 — 가격 기준, log 는 net 표시)
         if not reason and state.breakeven_armed and current < buy_price:
-            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회 {pnl:.1f}%)"
+            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회, net {pnl_net:.1f}%)"
 
         # 🌟 우선순위 4: 7주 룰 만료 (수익 안착 후 35거래일 & 50MA 이탈)
         if not reason and state.holding_start_date:
@@ -697,7 +701,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
                 "event": "exit_signal_generated",
                 "code": code, "name": hold.get("name", code),
                 "reason": reason,
-                "pnl_pct": round(pnl, 2),
+                "pnl_pct": round(pnl, 2),       # gross (가격 변동) — backtest MFE/MAE 와 동일 기준
+                "pnl_net_pct": round(pnl_net, 2),  # P0 0-9: net (비용 반영) — trigger 비교 기준
+                "pnl_basis": "net_trigger_gross_log",
                 "mfe_pct": state.mfe_pct,
                 "mae_pct": state.mae_pct,
             })
@@ -763,9 +769,12 @@ class OneilPocketPivotStrategy(LiveStrategy):
     def _check_partial_profit(
         self, code: str, state: PPPositionState, current: int, buy_price: int, hold: dict
     ) -> Optional[TradeSignal]:
-        """부분 익절: +15% 시 50% 매도. 잔고 1주면 전량."""
-        pnl = float((current - buy_price) / buy_price * 100)
-        if pnl < self._cfg.partial_profit_trigger_pct:
+        """부분 익절: +15% 시 50% 매도. 잔고 1주면 전량.
+
+        P0 0-9: trigger 비교는 net (비용 반영) — backtest 와 동일 기준.
+        """
+        pnl_net = TransactionCostUtils.net_return_pct(buy_price, current)
+        if pnl_net < self._cfg.partial_profit_trigger_pct:
             return None
 
         holding_qty = int(hold.get("qty", 1))
@@ -773,13 +782,14 @@ class OneilPocketPivotStrategy(LiveStrategy):
 
         if sell_qty >= holding_qty:
             sell_qty = holding_qty
-            reason = f"전량익절({pnl:.1f}%, 잔고 {holding_qty}주)"
+            reason = f"전량익절(net {pnl_net:.1f}%, 잔고 {holding_qty}주)"
         else:
-            reason = f"부분익절({pnl:.1f}%, {sell_qty}주/{holding_qty}주)"
+            reason = f"부분익절(net {pnl_net:.1f}%, {sell_qty}주/{holding_qty}주)"
 
         self._logger.info({
             "event": "partial_profit_signal",
-            "code": code, "pnl": round(pnl, 2),
+            "code": code, "pnl": round(pnl_net, 2),
+            "pnl_basis": "net",
             "sell_qty": sell_qty, "holding_qty": holding_qty,
         })
 

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -19,6 +19,7 @@ from core.logger import get_strategy_logger
 from utils.volatility_utils import annualized_return_std
 from utils.strategy_state_io import StrategyStateIO
 from utils.async_concurrency import bounded_gather
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -476,9 +477,12 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             state.peak_price = current
             state_dirty = True
 
+        # 가격 변동 비율 (gross) — MFE/MAE/log/peak 추적용. backtest 의 _bar_excursion 과 동일.
         pnl = float((current - buy_price) / buy_price * 100)
+        # P0 0-9: stop/익절 trigger 비교는 비용 반영 net 기준 — backtest 와 동일.
+        pnl_net = TransactionCostUtils.net_return_pct(buy_price, current)
 
-        # MFE / MAE 갱신
+        # MFE / MAE 갱신 (가격 변동 = gross)
         if pnl > state.mfe_pct:
             state.mfe_pct = round(pnl, 2)
             state_dirty = True
@@ -489,9 +493,9 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         reason = ""
         exit_volatility: float | None = None  # OHLCV 조회 경로에서만 채워짐 (시간손절/추세이탈)
 
-        # 0. 조기 부분익절: ref_price 대비 +7% 도달 시 30% 매도
+        # 0. 조기 부분익절: ref_price 대비 +7% 도달 시 30% 매도 (net, P0 0-9)
         ref_price = float(state.last_partial_sell_price if state.last_partial_sell_price > 0 else buy_price)
-        pnl_from_ref = float((current - ref_price) / ref_price * 100)
+        pnl_from_ref = TransactionCostUtils.net_return_pct(ref_price, current)
         if pnl_from_ref >= self._cfg.early_partial_profit_pct:
             holding_qty = int(hold.get("qty", 1))
             sell_qty = max(1, int(holding_qty * self._cfg.early_partial_sell_ratio))
@@ -516,20 +520,21 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             ))
             return signals, state_dirty
 
-        # 1. 손절
-        if pnl <= self._cfg.stop_loss_pct:
-            reason = f"손절({pnl:.1f}%)"
-        # 2. 트레일링 스탑 — 수익 게이트 적용 (peak_pnl >= trailing_min_peak_profit_pct 이후에만 발동)
+        # 1. 손절 (net, P0 0-9)
+        if pnl_net <= self._cfg.stop_loss_pct:
+            reason = f"손절(net {pnl_net:.1f}%)"
+        # 2. 트레일링 스탑 — peak/drop 은 가격 변동 자체 (gross 유지). 수익 게이트는 net 으로 검증.
         elif state.peak_price > 0:
             peak_pnl = float((state.peak_price - buy_price) / buy_price * 100)
-            if peak_pnl >= self._cfg.trailing_min_peak_profit_pct:
+            peak_pnl_net = TransactionCostUtils.net_return_pct(buy_price, state.peak_price)
+            if peak_pnl_net >= self._cfg.trailing_min_peak_profit_pct:
                 drop = float((current - state.peak_price) / state.peak_price * 100)
                 if drop <= -self._cfg.trailing_stop_pct:
-                    reason = f"트레일링스탑(고점수익 {peak_pnl:.1f}%, 낙폭 {drop:.1f}%)"
+                    reason = f"트레일링스탑(고점수익(net) {peak_pnl_net:.1f}%, 낙폭 {drop:.1f}%)"
 
-        # 2.5. 본절스탑: 부분익절 후 진입가 하회
+        # 2.5. 본절스탑: 부분익절 후 진입가 하회 (가격 기준 trigger, log 는 net 표시)
         if not reason and state.breakeven_armed and current < buy_price:
-            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회 {pnl:.1f}%)"
+            reason = f"본절스탑(부분익절 후 진입가 {buy_price:,} 하회, net {pnl_net:.1f}%)"
 
         # 3·4. 시간손절 + 추세이탈 — OHLCV 1회 조회 후 양쪽에 전달
         if not reason:
@@ -555,7 +560,9 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
                 "event": "exit_signal_generated",
                 "code": code, "name": hold.get("name", code),
                 "reason": reason,
-                "pnl_pct": round(pnl, 2),
+                "pnl_pct": round(pnl, 2),       # gross (가격 변동) — backtest MFE/MAE 와 동일 기준
+                "pnl_net_pct": round(pnl_net, 2),  # P0 0-9: net (비용 반영) — trigger 비교 기준
+                "pnl_basis": "net_trigger_gross_log",
                 "mfe_pct": state.mfe_pct,
                 "mae_pct": state.mae_pct,
             })

--- a/strategies/rsi2_pullback_strategy.py
+++ b/strategies/rsi2_pullback_strategy.py
@@ -19,6 +19,7 @@ from core.logger import get_strategy_logger
 from strategies.rsi2_pullback_types import RSI2PullbackConfig, RSI2PositionState
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
 
 
 _MINERVINI_STAGE_2 = 2  # services.minervini_stage_service.MinerviniStageService.STAGE_2_ADVANCING
@@ -292,15 +293,16 @@ class RSI2PullbackStrategy(LiveStrategy):
         ma200 = self._latest_ma(ma_resps[0])
         ma5 = self._latest_ma(ma_resps[1])
 
-        pnl_pct = (current - buy_price) / buy_price * 100.0
+        # P0 0-9: 비용 반영 net 수익률 — backtest 와 동일 기준으로 stop trigger.
+        pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current)
         reason: Optional[str] = None
 
         # 1) 추세 붕괴: 종가 < 200MA → 손절 (Stage 2 가정 무너짐)
         if ma200 is not None and current < ma200:
             reason = f"추세 붕괴 손절: 현재가 {current} < 200MA {ma200:.0f}"
-        # 2) 하드 스탑: 진입가 대비 -5%
+        # 2) 하드 스탑: 진입가 대비 -5% (net, P0 0-9)
         elif pnl_pct <= self._cfg.hard_stop_pct:
-            reason = f"하드 스탑 손절: PnL {pnl_pct:.2f}% ≤ {self._cfg.hard_stop_pct}%"
+            reason = f"하드 스탑 손절: PnL(net) {pnl_pct:.2f}% ≤ {self._cfg.hard_stop_pct}%"
         # 3) 빠른 복귀 익절: 종가가 5MA 터치
         elif ma5 is not None and current >= ma5:
             reason = f"5MA 터치 익절: 현재가 {current} ≥ 5MA {ma5:.0f}"
@@ -314,6 +316,7 @@ class RSI2PullbackStrategy(LiveStrategy):
             "code": code, "name": hold.get("name", code),
             "reason": reason,
             "pnl_pct": round(pnl_pct, 2),
+            "pnl_basis": "net",  # P0 0-9: pnl_pct 가 net (비용 반영) 임을 명시
         })
 
         # 손절성 청산은 쿨다운 등록

--- a/tests/unit_test/strategies/test_first_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_first_pullback_strategy.py
@@ -907,16 +907,17 @@ async def test_exits_repeated_partial_profit(mock_deps):
     strategy._save_state = MagicMock()
 
     # 1차 익절(11000원)이 이미 된 상태 → last_partial_sell_price=11000
+    # P0 0-9: trigger 가 net 기준이므로 12150 으로 조정 (net_return_pct(11000, 12150) ≈ +10.2%).
     strategy._position_state["005930"] = FPPositionState(
-        10000, "20250101", 12100, 12000, last_partial_sell_price=11000
+        10000, "20250101", 12150, 12000, last_partial_sell_price=11000
     )
 
     ohlcv = _make_ohlcv(20, close=11500)
     sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
 
-    # 현재가 12100 → 11000 대비 +10% (2차 부분 익절 조건 충족)
+    # 현재가 12150 → 11000 대비 net +10.2% (2차 부분 익절 조건 충족, P0 0-9)
     sqs.get_current_price.return_value = ResCommonResponse(
-        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "12100"}}
+        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "12150"}}
     )
 
     signals = await strategy.check_exits([
@@ -926,7 +927,7 @@ async def test_exits_repeated_partial_profit(mock_deps):
     assert len(signals) == 1
     assert "부분익절" in signals[0].reason
     assert signals[0].qty == 2  # 4주의 50%
-    assert strategy._position_state["005930"].last_partial_sell_price == 12100
+    assert strategy._position_state["005930"].last_partial_sell_price == 12150
 
 
 # ════════════════════════════════════════════════════════════════

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
@@ -718,8 +718,9 @@ async def test_exits_repeated_partial_profit(mock_deps):
     universe.is_market_timing_ok.return_value = True
 
     # 1차 익절(11500원)이 이미 된 상태 → last_partial_sell_price=11500
+    # P0 0-9: trigger 가 net 기준이므로 13280 으로 조정 (net_return_pct(11500, 13280) ≈ +15.2%).
     strategy._position_state["005930"] = PPPositionState(
-        "PP", 10000, "20250101", 13225, "20", 0, False, "20250105",
+        "PP", 10000, "20250101", 13280, "20", 0, False, "20250105",
         last_partial_sell_price=11500
     )
 
@@ -727,9 +728,9 @@ async def test_exits_repeated_partial_profit(mock_deps):
     sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
     tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 12, 0, 0)
 
-    # 현재가 13225 → 11500 대비 +15% (2차 부분 익절 조건 충족)
+    # 현재가 13280 → 11500 대비 net +15.2% (2차 부분 익절 조건 충족, P0 0-9)
     sqs.get_current_price.return_value = ResCommonResponse(
-        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "13225"}}
+        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "13280"}}
     )
 
     signals = await strategy.check_exits([
@@ -739,7 +740,7 @@ async def test_exits_repeated_partial_profit(mock_deps):
     assert len(signals) == 1
     assert "부분익절" in signals[0].reason
     assert signals[0].qty == 2  # 4주의 50%
-    assert strategy._position_state["005930"].last_partial_sell_price == 13225
+    assert strategy._position_state["005930"].last_partial_sell_price == 13280
 
 
 # ════════════════════════════════════════════════════════════════

--- a/tests/unit_test/strategies/test_rsi2_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_rsi2_pullback_strategy.py
@@ -238,6 +238,28 @@ async def test_check_exits_hard_stop_at_minus5pct(exit_setup):
 
 
 @pytest.mark.asyncio
+async def test_check_exits_hard_stop_net_triggers_at_gross_below_threshold(exit_setup):
+    """P0 0-9: gross -4.8% 는 hard_stop_pct=-5% 미달이지만 net 은 -5.02% → 손절 발동.
+
+    backtest 와 동일하게 net 기준으로 trigger 가 평가됨을 회귀 방지로 고정.
+    """
+    strategy, sqs, indicator = exit_setup
+    # buy=10000, sell=9520 → gross -4.80%, net ≈ -5.02% (수수료+세금 ≈ 0.22% drag)
+    sqs.get_current_price.return_value = _price_resp("9520")
+    indicator.get_moving_average.side_effect = [
+        _ma_resp(9000.0),   # 200MA OK (9520 > 9000 → 추세 붕괴 트리거 아님)
+        _ma_resp(11000.0),  # 5MA 미도달
+    ]
+    holdings = [{"code": "005930", "name": "삼성전자", "buy_price": 10000, "qty": 5}]
+    signals = await strategy.check_exits(holdings)
+    # net 기준 -5.02% ≤ -5 → 하드 스탑 발동. gross 기준이었다면 -4.8% > -5 로 미발동.
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert "하드 스탑" in signals[0].reason
+    assert "net" in signals[0].reason.lower()
+
+
+@pytest.mark.asyncio
 async def test_check_exits_trend_break_below_200ma(exit_setup):
     """현재가 < 200MA → 추세 붕괴 손절 SELL (하드 스탑보다 우선)."""
     strategy, sqs, indicator = exit_setup

--- a/tests/unit_test/utils/test_transaction_cost_utils.py
+++ b/tests/unit_test/utils/test_transaction_cost_utils.py
@@ -53,3 +53,50 @@ class TestTransactionCostUtils:
     def test_get_return_rate_zero_buy_price(self):
         """매수가가 0일 때 0.0 반환 테스트"""
         assert TransactionCostUtils.get_return_rate(0, 10000) == 0.0
+
+    # ─────────────────────────────────────────────────────────────
+    # P0 0-9: net_return_pct — 라이브 stop/take_profit trigger 용
+    # ─────────────────────────────────────────────────────────────
+
+    def test_net_return_pct_breakeven_is_negative_due_to_cost(self):
+        """동일 가격(buy == sell) 이면 net 수익률은 매도세/수수료만큼 음수."""
+        result = TransactionCostUtils.net_return_pct(10000, 10000)
+        # 매수 fee + 매도 fee + 매도세 ≈ 0.228% drag
+        assert result < 0
+        assert result == pytest.approx(-0.2278, abs=0.01)
+
+    def test_net_return_pct_matches_get_return_rate_with_cost(self):
+        """net_return_pct 는 get_return_rate(qty=1, apply_cost=True) 의 alias 여야 한다."""
+        for buy, sell in [(10000, 10500), (12000, 10000), (5000, 6000)]:
+            net = TransactionCostUtils.net_return_pct(buy, sell)
+            ref = TransactionCostUtils.get_return_rate(buy, sell, qty=1, apply_cost=True)
+            assert net == pytest.approx(ref)
+
+    def test_net_return_pct_qty_invariant(self):
+        """net_return_pct 는 qty 와 무관해야 한다 (비율 비교)."""
+        net_qty1 = TransactionCostUtils.net_return_pct(10000, 11000)
+        # 동일 비율을 100주에서도 검증 — get_return_rate 가 비율 반환이므로 같아야 함
+        ref_qty100 = TransactionCostUtils.get_return_rate(10000, 11000, qty=100, apply_cost=True)
+        assert net_qty1 == pytest.approx(ref_qty100)
+
+    def test_net_return_pct_stop_triggers_earlier_than_gross(self):
+        """가격이 -1.8% 하락하면 gross 는 -2% stop 미발동, net 은 발동 가능해야 한다."""
+        buy = 10000
+        sell = int(buy * (1 - 0.018))  # gross -1.8%
+        gross = TransactionCostUtils.get_return_rate(buy, sell, qty=1, apply_cost=False)
+        net = TransactionCostUtils.net_return_pct(buy, sell)
+        assert gross > -2.0   # gross 기준에선 stop 미발동
+        assert net <= -2.0    # net 기준에선 stop 발동 (비용 drag 추가됨)
+
+    def test_net_return_pct_take_profit_triggers_later_than_gross(self):
+        """가격이 +5% 상승하면 gross 는 +5% 익절 발동, net 은 미발동."""
+        buy = 10000
+        sell = int(buy * 1.05)
+        gross = TransactionCostUtils.get_return_rate(buy, sell, qty=1, apply_cost=False)
+        net = TransactionCostUtils.net_return_pct(buy, sell)
+        assert gross >= 5.0   # gross 기준 발동
+        assert net < 5.0      # net 기준 미발동 (비용 drag)
+
+    def test_net_return_pct_zero_buy_price_safe(self):
+        """매수가 0 이면 0.0 반환 (분모 보호)."""
+        assert TransactionCostUtils.net_return_pct(0, 10000) == 0.0

--- a/utils/transaction_cost_utils.py
+++ b/utils/transaction_cost_utils.py
@@ -32,8 +32,20 @@ class TransactionCostUtils:
 
         buy_cost = cls.calculate_cost(buy_price, qty, is_sell=False)
         sell_cost = cls.calculate_cost(sell_price, qty, is_sell=True)
-        
+
         total_invest = (buy_price * qty) + buy_cost
         total_retrieve = (sell_price * qty) - sell_cost
-        
+
         return ((total_retrieve - total_invest) / total_invest) * 100
+
+    @classmethod
+    def net_return_pct(cls, buy_price: float, sell_price: float) -> float:
+        """수수료/세금 반영 후 net 수익률 (%).
+
+        P0 0-9: 라이브 stop/take_profit trigger 가 backtest 와 동일하게 net 기준으로
+        평가되도록 한다. qty 와 무관 (비율은 1주 기준과 동일).
+
+        Returns:
+            buy_price == 0 이면 0.0 (분모 보호).
+        """
+        return cls.get_return_rate(buy_price, sell_price, qty=1, apply_cost=True)


### PR DESCRIPTION
작업 요약
브랜치: feature/p0-0-9-net-pnl-exit-triggers

핵심 변경:

TransactionCostUtils.net_return_pct(buy_price, sell_price) helper 추가 — 비용 반영 net 수익률(%)을 한 줄로 호출 가능 활성 7개 전략의 stop/익절 trigger 모두 net 기준으로 통일 — backtest 와 라이브의 trigger 발동 시점이 일치 전략별 적용 (12 files, +182/-63):

전략	변경
rsi2_pullback	hard_stop_pct trigger → net
larry_williams_vbo	stop_loss_pct trigger → net
larry_williams_channel_breakout	log 표시 net으로 통일 (trigger는 가격 기준 유지) high_tight_flag	stop_loss_pct + partial_profit_trigger_pct → net; MFE/MAE는 gross 유지 oneil_squeeze_breakout	stop_loss_pct + early_partial_profit_pct + trailing 수익게이트 → net; peak/drop은 gross oneil_pocket_pivot	partial_profit_trigger_pct + holding_profit_anchor_pct → net first_pullback	take_profit_lower_pct → net; MA 이탈 손절은 가격 기준 설계 원칙:

pnl (gross): MFE/MAE 추적, peak 갱신, log 표시 — backtest _bar_excursion과 동일 기준 유지 pnl_net (net, 신규): stop/익절 trigger 비교 — backtest 와 동일 net 기준 log에 pnl_basis: "net_trigger_gross_log" 명시로 추적 가능
테스트:

TransactionCostUtils.net_return_pct 단위 테스트 6건 (회기·비용 drag·qty 불변·stop earlier/take_profit later·zero buy 안전) rsi2 명시적 lock-in 테스트 1건: gross -4.8% 미발동 / net -5.02% 발동 PP/FP repeated_partial_profit fixture를 net trigger 도달 가격으로 조정 — 이 자체가 회귀 방지 lock-in 역할 전체 회귀 확인:

단위 테스트: 5671 passed (3분 26초, +7건 신규)
통합 테스트: 240 passed (2분 43초)
변경량: 12 files, +182/-63 lines
효과
라이브 stop_loss가 약 0.22% 더 빨리 발동 — backtest와 일치
take_profit이 약 0.22% 더 늦게 발동 — 실제 net edge 보호
log에 pnl_pct (gross, MFE/MAE 비교)와 pnl_net_pct (net, trigger 기준) 둘 다 기록 — 사후 분석 가능