### PR TITLE
P0 0-10 완료 ✅

### DIFF
--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -9,10 +9,12 @@
   final_qty = max(0, min([risk_qty, cap_qty, cash_qty, (alloc_qty), (signal.qty)]))
 """
 
+import asyncio
 import math
 import inspect
 import logging
-from typing import Any, Optional, Protocol, Tuple, TYPE_CHECKING
+from datetime import datetime
+from typing import Any, Dict, Optional, Protocol, Tuple, TYPE_CHECKING
 
 from common.types import ErrorCode, Exchange, ResCommonResponse, TradeSignal
 from core.account_snapshot import AccountSnapshotCache
@@ -45,6 +47,7 @@ class PositionSizingService:
         order_policy_config: Optional["OrderPolicyConfig"] = None,
         env: Optional[Any] = None,
         operating_profile: str = "canary",
+        enable_intracycle_reservations: bool = False,
     ):
         self._cache = account_snapshot_cache
         self._indicator = indicator_service
@@ -55,6 +58,16 @@ class PositionSizingService:
         self._order_policy_config = order_policy_config
         self._env = env
         self._operating_profile = operating_profile
+
+        # P0 0-10: 같은 scheduler 사이클의 미체결 BUY 를 현금/종목 노출에 선반영하는 overlay.
+        # live 에서만 활성화한다. backtest 는 BacktestPortfolioLedger 가 예약을 처리하므로
+        # 기본 False (이중 차감 방지). 예약은 snapshot.fetched_at 이 바뀌면 자동 초기화한다
+        # (체결 → 캐시 invalidate → 새 snapshot, 또는 TTL 만료). 주문 실패 시 별도 release 는
+        # 하지 않으며, 다음 snapshot 까지 보수적으로 유지된다.
+        self._enable_intracycle_reservations = enable_intracycle_reservations
+        self._reservations: Dict[str, int] = {}      # {code: 예약 현금(KRW)}
+        self._reservation_baseline_ts: Optional[datetime] = None
+        self._reservation_lock = asyncio.Lock()
 
     def _is_real_mode(self) -> bool:
         """env 미주입이면 paper 로 간주 (보수적 default)."""
@@ -104,6 +117,18 @@ class PositionSizingService:
         if signal.qty is not None and signal.qty <= 0:
             return signal.qty, "bypass"
 
+        # P0 0-10: 예약 overlay 활성 시, snapshot 읽기~예약 기록을 직렬화해
+        # 병렬 BUY 간 cash/종목 cap 이중 사용을 막는다.
+        if self._enable_intracycle_reservations:
+            async with self._reservation_lock:
+                return await self._compute_buy_qty(signal, exchange)
+        return await self._compute_buy_qty(signal, exchange)
+
+    async def _compute_buy_qty(
+        self,
+        signal: TradeSignal,
+        exchange: "Exchange | None",
+    ) -> Tuple[int, str]:
         price = signal.price
 
         # 1. 잔고 스냅샷 (API 비호출, 캐시에서 읽기)
@@ -111,6 +136,16 @@ class PositionSizingService:
         total_equity = snapshot.total_equity
         available_cash = snapshot.available_cash
         current_position_value = snapshot.positions.get(signal.code, 0)
+
+        # P0 0-10: 같은 사이클 미체결 BUY 예약을 현금/종목 노출에 선반영.
+        # snapshot.fetched_at 이 바뀌면(체결 invalidate/TTL) 예약 초기화 → 새 baseline.
+        if self._enable_intracycle_reservations:
+            if self._reservation_baseline_ts != snapshot.fetched_at:
+                self._reservations.clear()
+                self._reservation_baseline_ts = snapshot.fetched_at
+            reserved_total = sum(self._reservations.values())
+            available_cash = max(available_cash - reserved_total, 0)
+            current_position_value = current_position_value + self._reservations.get(signal.code, 0)
 
         if total_equity <= 0:
             self._logger.warning(
@@ -187,6 +222,12 @@ class PositionSizingService:
             reason = next(
                 key for key in reason_priority
                 if candidates.get(key) == final_qty
+            )
+
+        # P0 0-10: 매수 확정분을 예약에 누적 → 같은 사이클 후속 BUY 가 차감된 현금/cap 을 본다.
+        if self._enable_intracycle_reservations and final_qty > 0:
+            self._reservations[signal.code] = (
+                self._reservations.get(signal.code, 0) + final_qty * price
             )
 
         self._logger.info(

--- a/tests/unit_test/services/test_position_sizing_service.py
+++ b/tests/unit_test/services/test_position_sizing_service.py
@@ -50,6 +50,7 @@ def _make_service(
     risk_gate_config=None,
     quote_provider=None,
     order_policy_config=None,
+    enable_intracycle_reservations=False,
 ):
     cache = AsyncMock()
     cache.get.return_value = snapshot
@@ -70,6 +71,7 @@ def _make_service(
         risk_gate_config=risk_gate_config,
         quote_provider=quote_provider,
         order_policy_config=order_policy_config,
+        enable_intracycle_reservations=enable_intracycle_reservations,
     )
     return svc, cache, indicator
 
@@ -626,3 +628,120 @@ def test_position_sizing_canary_overrides_user_yaml():
     )
     assert svc._effective_per_trade_risk_pct() == 0.1
     assert svc._effective_max_per_position_pct() == 0.5
+
+
+# ─────────────────────────────────────────────────────────────────────
+# P0 0-10: intra-cycle reservation overlay (reserved cash + same-symbol)
+# ─────────────────────────────────────────────────────────────────────
+
+def _no_constraint_cfg():
+    """risk/cap 이 binding 되지 않게 큰 값 — cash/cap overlay 만 격리 검증."""
+    return _make_config(per_trade_risk_pct=100.0, max_per_position_pct=100.0)
+
+
+@pytest.mark.asyncio
+async def test_reservation_reduces_cash_for_second_buy_different_code():
+    """같은 사이클: 첫 BUY 가 예약한 현금이 두 번째 BUY 의 cash_qty 에서 차감된다."""
+    snap = _make_snapshot(total_equity=100_000_000, available_cash=500_000)
+    svc, _, _ = _make_service(
+        snap, cfg=_no_constraint_cfg(), enable_intracycle_reservations=True
+    )
+    # 첫 매수: 코드 A, price 100k → cash 500k / 100k = 5주, 500k 예약
+    qty_a, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="AAAAAA", name="A", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s1")
+    )
+    assert qty_a == 5
+    # 두 번째 매수: 코드 B (다른 종목) → 가용현금 500k-500k=0 → 0주
+    qty_b, reason_b = await svc.adjust_buy_qty(
+        TradeSignal(code="BBBBBB", name="B", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    assert qty_b == 0
+    assert reason_b == "cash_short"
+
+
+@pytest.mark.asyncio
+async def test_reservation_same_symbol_reduces_position_cap():
+    """같은 사이클: 같은 종목을 여러 전략이 사면 종목별 비중 cap 이 누적 반영된다."""
+    # total_equity=10M, max_per_position_pct=10% → 종목당 1M cap. cash 는 충분.
+    snap = _make_snapshot(total_equity=10_000_000, available_cash=100_000_000)
+    cfg = _make_config(per_trade_risk_pct=100.0, max_per_position_pct=10.0)
+    svc, _, _ = _make_service(snap, cfg=cfg, enable_intracycle_reservations=True)
+    # 첫 매수: 코드 X, price 100k → cap 1M / 100k = 10주, 1M 예약
+    qty1, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="XXXXXX", name="X", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s1")
+    )
+    assert qty1 == 10
+    # 두 번째 매수: 같은 코드 X (다른 전략) → 종목 cap 소진 → 0주
+    qty2, reason2 = await svc.adjust_buy_qty(
+        TradeSignal(code="XXXXXX", name="X", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    assert qty2 == 0
+    assert reason2 == "cap_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_reservation_resets_on_new_snapshot():
+    """새 snapshot(fetched_at 변경) 도착 시 예약이 초기화된다 (fill→invalidate 모방)."""
+    from datetime import datetime, timedelta
+    snap1 = _make_snapshot(total_equity=100_000_000, available_cash=500_000)
+    svc, cache, _ = _make_service(
+        snap1, cfg=_no_constraint_cfg(), enable_intracycle_reservations=True
+    )
+    qty1, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="AAAAAA", name="A", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s1")
+    )
+    assert qty1 == 5  # 500k 예약됨
+
+    # 체결 → 캐시 invalidate → 다음 사이클 새 snapshot (fetched_at 다름)
+    snap2 = AccountSnapshot(
+        total_equity=100_000_000, available_cash=500_000, positions={},
+        fetched_at=datetime.now() + timedelta(seconds=120),
+    )
+    cache.get.return_value = snap2
+    qty2, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="BBBBBB", name="B", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    # 예약 초기화되어 새 snapshot 의 500k 전부 사용 가능 → 다시 5주
+    assert qty2 == 5
+
+
+@pytest.mark.asyncio
+async def test_no_reservation_overlay_when_flag_disabled():
+    """flag=False(기본, backtest) 면 overlay 미적용 — 두 번째 BUY 도 동일 수량."""
+    snap = _make_snapshot(total_equity=100_000_000, available_cash=500_000)
+    svc, _, _ = _make_service(
+        snap, cfg=_no_constraint_cfg(), enable_intracycle_reservations=False
+    )
+    qty_a, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="AAAAAA", name="A", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s1")
+    )
+    qty_b, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="BBBBBB", name="B", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    # overlay 없으므로 같은 stale snapshot 으로 둘 다 5주 (= 기존 over-allocation 동작)
+    assert qty_a == 5
+    assert qty_b == 5
+
+
+@pytest.mark.asyncio
+async def test_reservation_default_is_disabled():
+    """enable_intracycle_reservations 미지정 시 기본 False (backtest 안전)."""
+    snap = _make_snapshot(total_equity=100_000_000, available_cash=500_000)
+    svc, _, _ = _make_service(snap, cfg=_no_constraint_cfg())
+    qty_a, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="AAAAAA", name="A", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s1")
+    )
+    qty_b, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="BBBBBB", name="B", action="BUY", price=100_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    assert qty_a == 5 and qty_b == 5

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -436,6 +436,9 @@ class ServiceContainer:
                 order_policy_config=_op_cfg,
                 env=getattr(ctx.broker, "env", None),
                 operating_profile=_operating_profile,
+                # P0 0-10: live 는 같은 사이클 미체결 BUY 예약 overlay 활성화.
+                # backtest 는 BacktestPortfolioLedger 가 예약을 처리하므로 wiring 하지 않는다.
+                enable_intracycle_reservations=True,
             )
             ctx.risk_gate_service = RiskGateService(
                 config=_rg_cfg,


### PR DESCRIPTION
작업 요약
브랜치: feature/p0-0-10-reserved-cash-cross-strategy-exposure

선택된 설계 (둘 다 Recommended):

PositionSizing overlay + opt-in flag
snapshot 변경 시 자동 reset (실패 시 명시적 release 없음 — 보수적) 핵심 구현 (position_sizing_service.py):

생성자에 enable_intracycle_reservations: bool = False 추가 + _reservations dict / _reservation_baseline_ts / _reservation_lock adjust_buy_qty → overlay 활성 시 asyncio.Lock으로 직렬화 후 _compute_buy_qty 위임 (병렬 BUY 간 이중 사용 방지) overlay 로직:
snapshot.fetched_at이 바뀌면 예약 자동 초기화 (체결→invalidate / TTL→refresh가 새 baseline) available_cash ← 예약 총액 차감
current_position_value ← 해당 종목 예약 가산 → cap_qty(종목 비중)에 cross-strategy same-symbol 노출 반영 final_qty > 0 시 final_qty * price를 예약에 누적
Wiring:

live (service_container.py:429): enable_intracycle_reservations=True backtest (run_backtest.py:369): 미지정 → 기본 False → BacktestPortfolioLedger가 단독 예약 처리 → 이중 차감 없음 테스트 (신규 5건):

다른 종목 두 번째 BUY가 예약된 현금만큼 차감 (cash_short)
같은 종목 다중 전략 BUY가 종목 비중 cap 누적 소진 (cap_exhausted) — cross-strategy same-symbol 새 snapshot 도착 시 예약 reset (fill→invalidate 모방)
flag=False면 overlay 미적용 (기존 over-allocation 동작 유지 = backtest 안전) 기본값 False 확인
전체 회귀:

단위 5669 passed (3분), 통합 240 passed (3분 22초)
변경량: 3 files, +164/-1 lines
설계 결정 (todo checkbox 3 답변)
"전 전략 합산 동일 종목 노출 상한을 별도 hard-block으로 추가하지 않음" — 기존 max_per_position_pct cap이 예약 overlay를 통해 같은 snapshot 수명 동안 자동으로 cross-strategy same-symbol 인식. 새 차단 규칙 불필요.