### PR TITLE
P0 0-11 완료 ✅

### DIFF
--- a/services/kill_switch_service.py
+++ b/services/kill_switch_service.py
@@ -11,6 +11,7 @@ from common.operator_alert_types import AlertSource
 from common.strategy_identity import STRATEGY_IDENTITY_RESOLVER
 from config.config_loader import KillSwitchConfig
 from services.notification_service import NotificationCategory, NotificationLevel, NotificationService
+from utils.atomic_json import write_json_atomic
 
 if TYPE_CHECKING:
     from config.config_loader import RiskGateConfig
@@ -493,7 +494,9 @@ class KillSwitchService:
                 "strategy_consecutive_losses": self._strategy_consecutive_losses,
                 "strategy_daily_loss_won": self._strategy_daily_loss_won,
             }
-            self._state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+            # P0 0-11: atomic write (tempfile → fsync → os.replace) — 강제 종료/쓰기 실패 시
+            # 기존 상태 파일 truncate 방지. 기존 truncate-write(write_text) 대체.
+            write_json_atomic(str(self._state_path), state, indent=2, ensure_ascii=False)
         except Exception as e:
             self._logger.error("[KillSwitch] 상태 저장 실패: %s", e)
 

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -20,6 +20,7 @@ from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
 from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -651,10 +652,9 @@ class FirstPullbackStrategy(LiveStrategy):
         except RuntimeError:
             # 이벤트 루프 없음 → 동기 저장
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, data, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -18,6 +18,7 @@ from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
 from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -808,10 +809,9 @@ class HighTightFlagStrategy(LiveStrategy):
         except RuntimeError:
             # 이벤트 루프 없음 → 동기 저장
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, data, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -20,6 +20,7 @@ from strategies.larry_williams_cb_types import LarryWilliamsCBConfig, LarryWilli
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
 from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -471,13 +472,12 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
             asyncio.get_running_loop()
         except RuntimeError:
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 payload = {
                     "positions": {k: asdict(v) for k, v in self._position_state.items()},
                     "cooldown": dict(self._cooldown),
                 }
-                with open(self.STATE_FILE, "w", encoding="utf-8") as f:
-                    json.dump(payload, f, ensure_ascii=False, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, payload, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -20,6 +20,7 @@ from core.logger import get_strategy_logger
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
 from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
 
 
 # 청산/exit 동시성 상한. entry chunk_size(10)보다 높게 두어 손절/청산이 entry scan 보다
@@ -901,10 +902,9 @@ class OneilPocketPivotStrategy(LiveStrategy):
         except RuntimeError:
             # 이벤트 루프 없음 → 동기 저장
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, data, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -18,6 +18,7 @@ from services.oneil_universe_service import OneilUniverseService
 from core.logger import get_strategy_logger
 from utils.volatility_utils import annualized_return_std
 from utils.strategy_state_io import StrategyStateIO
+from utils.atomic_json import write_json_atomic
 from utils.async_concurrency import bounded_gather
 from utils.transaction_cost_utils import TransactionCostUtils
 
@@ -690,10 +691,9 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
         except RuntimeError:
             # 이벤트 루프 없음 → 동기 저장
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 data = {"positions": {k: asdict(v) for k, v in self._position_state.items()}, "cooldown": self._cooldown}
-                with open(self.STATE_FILE, "w") as f:
-                    json.dump(data, f, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, data, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/strategies/rsi2_pullback_strategy.py
+++ b/strategies/rsi2_pullback_strategy.py
@@ -20,6 +20,7 @@ from strategies.rsi2_pullback_types import RSI2PullbackConfig, RSI2PositionState
 from utils.async_concurrency import bounded_gather
 from utils.strategy_state_io import StrategyStateIO
 from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
 
 
 _MINERVINI_STAGE_2 = 2  # services.minervini_stage_service.MinerviniStageService.STAGE_2_ADVANCING
@@ -426,13 +427,12 @@ class RSI2PullbackStrategy(LiveStrategy):
             asyncio.get_running_loop()
         except RuntimeError:
             try:
-                os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
                 payload = {
                     "positions": {k: asdict(v) for k, v in self._position_state.items()},
                     "cooldown": dict(self._cooldown),
                 }
-                with open(self.STATE_FILE, "w", encoding="utf-8") as f:
-                    json.dump(payload, f, ensure_ascii=False, indent=2)
+                # P0 0-11: atomic write (truncate-write 대체)
+                write_json_atomic(self.STATE_FILE, payload, indent=2, ensure_ascii=False)
             except Exception as e:
                 self._logger.error(f"Failed to save state for {self.name}: {e}")
             return

--- a/tests/unit_test/services/test_kill_switch_service.py
+++ b/tests/unit_test/services/test_kill_switch_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -414,3 +415,22 @@ async def test_state_load_missing_file_is_noop(cfg, mock_notif, logger, tmp_path
     cfg2 = cfg.model_copy(update={"state_file_path": str(tmp_path / "nonexistent.json")})
     ks = KillSwitchService(cfg2, mock_notif, logger)
     assert ks._is_tripped is False
+
+
+async def test_save_state_atomic_preserves_file_on_write_failure(cfg, mock_notif, logger, tmp_path):
+    """P0 0-11: 저장 중 예외가 나도 기존 상태 파일이 truncate 되지 않고 temp 도 남지 않는다."""
+    state_file = tmp_path / "ks_state.json"
+    cfg2 = cfg.model_copy(update={"state_file_path": str(state_file)})
+    ks = KillSwitchService(cfg2, mock_notif, logger)
+
+    ks._save_state()  # 정상 저장 1회 → 파일 생성
+    original = state_file.read_text(encoding="utf-8")
+    assert original.strip()
+
+    # 실제 atomic util 의 json.dump 단계에서 예외 강제 → temp 생성 후 실패 → 정리 + 원본 보존
+    with patch("utils.atomic_json.json.dump", side_effect=RuntimeError("boom")):
+        ks._save_state()  # _save_state 가 예외를 흡수(log)
+
+    assert state_file.read_text(encoding="utf-8") == original
+    leftover = [p for p in os.listdir(tmp_path) if p.endswith(".tmp")]
+    assert leftover == []

--- a/tests/unit_test/utils/test_atomic_json.py
+++ b/tests/unit_test/utils/test_atomic_json.py
@@ -1,0 +1,81 @@
+"""P0 0-11: write_json_atomic 원자성 회귀 테스트."""
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from utils.atomic_json import write_json_atomic
+
+
+def test_writes_json_roundtrip(tmp_path):
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"a": 1, "b": [1, 2, 3]})
+    with open(path, "r", encoding="utf-8") as f:
+        assert json.load(f) == {"a": 1, "b": [1, 2, 3]}
+
+
+def test_creates_parent_directory(tmp_path):
+    path = str(tmp_path / "nested" / "deep" / "state.json")
+    write_json_atomic(path, {"ok": True})
+    assert os.path.exists(path)
+
+
+def test_korean_preserved_with_ensure_ascii_false(tmp_path):
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"name": "삼성전자"}, ensure_ascii=False)
+    raw = open(path, "r", encoding="utf-8").read()
+    assert "삼성전자" in raw  # escape 되지 않고 원문 보존
+
+
+def test_overwrite_replaces_existing(tmp_path):
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"v": 1})
+    write_json_atomic(path, {"v": 2})
+    with open(path, "r", encoding="utf-8") as f:
+        assert json.load(f) == {"v": 2}
+
+
+def test_existing_file_not_truncated_on_write_failure(tmp_path):
+    """쓰기 도중 예외 발생 시 기존 파일이 truncate/손상되지 않는다 (atomic 보장)."""
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"good": "original"})
+
+    # json.dump 도중 예외를 강제 → temp 파일만 영향, 원본은 os.replace 전이라 보존
+    with patch("utils.atomic_json.json.dump", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            write_json_atomic(path, {"bad": "should_not_persist"})
+
+    # 원본 그대로 유지
+    with open(path, "r", encoding="utf-8") as f:
+        assert json.load(f) == {"good": "original"}
+
+
+def test_no_temp_files_left_after_failure(tmp_path):
+    """쓰기 실패 시 temp 파일이 남지 않는다."""
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"good": "original"})
+
+    with patch("utils.atomic_json.json.dump", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            write_json_atomic(path, {"bad": "x"})
+
+    leftover = [p for p in os.listdir(tmp_path) if p.endswith(".tmp")]
+    assert leftover == []
+
+
+def test_unserializable_data_preserves_existing(tmp_path):
+    """직렬화 불가 데이터 → 예외 발생하되 기존 파일 보존."""
+    path = str(tmp_path / "state.json")
+    write_json_atomic(path, {"v": 1})
+
+    class _NotSerializable:
+        pass
+
+    with pytest.raises(TypeError):
+        write_json_atomic(path, {"bad": _NotSerializable()})
+
+    with open(path, "r", encoding="utf-8") as f:
+        assert json.load(f) == {"v": 1}
+    leftover = [p for p in os.listdir(tmp_path) if p.endswith(".tmp")]
+    assert leftover == []

--- a/utils/atomic_json.py
+++ b/utils/atomic_json.py
@@ -1,0 +1,48 @@
+"""원자적 JSON 파일 쓰기 유틸 (P0 0-11).
+
+temp 파일에 기록 → ``fsync`` → ``os.replace`` 로 원자 교체한다. 저장 중 프로세스가
+강제 종료되거나 쓰기 도중 예외가 발생해도 기존 파일이 truncate 되지 않는다.
+
+직접 ``open(path, "w")`` 후 ``json.dump`` 하는 truncate-write 패턴(부분 쓰기/빈 파일
+잔존 위험)을 대체한다. 비동기 직렬화·per-file lock 이 필요하면
+``utils.strategy_state_io.StrategyStateIO`` 를 사용한다.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any
+
+
+def write_json_atomic(
+    file_path: str,
+    data: Any,
+    *,
+    indent: int = 2,
+    ensure_ascii: bool = False,
+) -> None:
+    """``data`` 를 ``file_path`` 에 원자적으로 JSON 저장한다.
+
+    부모 디렉터리는 없으면 생성한다. temp 파일 쓰기 실패 시 temp 를 정리하고
+    예외를 그대로 전파한다(기존 파일은 보존).
+    """
+    directory = os.path.dirname(file_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=os.path.basename(file_path) + ".",
+        suffix=".tmp",
+        dir=directory,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=indent, ensure_ascii=ensure_ascii)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, file_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/utils/strategy_state_io.py
+++ b/utils/strategy_state_io.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import tempfile
 from typing import Any, Dict, Optional, Set
+
+from utils.atomic_json import write_json_atomic
 
 
 class StrategyStateIO:
@@ -69,25 +70,8 @@ class StrategyStateIO:
 
     @staticmethod
     def _write_atomic(file_path: str, data: Any) -> None:
-        directory = os.path.dirname(file_path) or "."
-        os.makedirs(directory, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=os.path.basename(file_path) + ".",
-            suffix=".tmp",
-            dir=directory,
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, file_path)
-        except Exception:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+        # P0 0-11: 공통 atomic util 에 위임 (tempfile → fsync → os.replace).
+        write_json_atomic(file_path, data, indent=2, ensure_ascii=False)
 
     @classmethod
     async def load(cls, file_path: str) -> Optional[Any]:


### PR DESCRIPTION
작업 요약
브랜치: feature/p0-0-11-atomic-state-write

핵심 변경:

신규 utils/atomic_json.py: write_json_atomic(path, data, *, indent, ensure_ascii) — tempfile → fsync → os.replace 원자 교체, 부모 디렉터리 자동 생성, 실패 시 temp 정리 + 예외 전파(원본 보존) StrategyStateIO._write_atomic → 공통 util에 위임 (중복 제거, tempfile import 삭제) KillSwitchService._save_state: write_text(json.dumps(...)) truncate-write → write_json_atomic 교체 6개 활성 전략 sync fallback _save_state: with open(...) as f: json.dump(...) → write_json_atomic 교체 (FP/HTF/OSB/PP/RSI2/CB) + 중복 os.makedirs 제거 (util이 처리) 테스트 (신규):

test_atomic_json.py 7건: roundtrip / 부모 디렉터리 생성 / 한글 보존 / 덮어쓰기 / 쓰기 실패 시 원본 truncate 안됨 / temp 잔존 없음 / 직렬화 불가 데이터 시 원본 보존 test_kill_switch_service.py +1건: json.dump 단계 강제 실패 시 kill switch 상태 파일이 보존되고 temp도 안 남음 (실제 atomic util 통합 검증) 전체 회귀:

단위 5672 passed (3분 27초, +8건 신규)
통합 240 passed (2분 58초)
변경량: 9 files modified + 2 new, +46/-39 lines
효과
프로세스 강제 종료(SIGKILL)나 디스크 쓰기 실패가 저장 중 발생해도 kill switch trip 카운트·전략 포지션 state가 손상되지 않음 모든 JSON state 저장 경로(async StrategyStateIO + kill switch + 전략 sync fallback)가 단일 atomic util로 통일 — 향후 한 곳만 유지보수 P0 전체 진행 현황
todo_list.md의 코드 수정으로 바로 진행 가능 P0 항목 4건이 모두 완료되었습니다:

✅ 0-8 (당일 미확정 봉 제외) — 머지됨 (#478)
✅ 0-9 (net PnL exit trigger) — 브랜치 커밋
✅ 0-10 (reserved cash + cross-strategy 노출) — 브랜치 커밋 ✅ 0-11 (atomic state write) — 이 브랜치 (커밋 대기)