### PR TITLE
원인 확인했고 워치독 쪽을 개선했습니다.

### DIFF
--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -72,6 +72,7 @@ class WebSocketWatchdogTask(SchedulableTask):
         self._reconnect_lock = asyncio.Lock()
         self._last_reconnect_started_ts: float = 0.0
         self._reconnect_trigger_counts: Dict[str, int] = {}
+        self._pt_no_initial_data_started_ts: Optional[float] = None
 
     # ── SchedulableTask 인터페이스 구현 ────────────────────────
 
@@ -208,9 +209,22 @@ class WebSocketWatchdogTask(SchedulableTask):
 
                 # 조건 2: PT 데이터 수신 갭 확인 (PT 종목이 있을 때만 — last_data_ts가 PT 기준)
                 data_gap = 0.0
+                pt_no_initial_data_gap = None
                 if pt_codes and self._program_trading_stream_service:
                     last_ts = self._program_trading_stream_service.last_data_ts
-                    data_gap = (time.time() - last_ts) if last_ts > 0 else 0.0
+                    if last_ts > 0:
+                        data_gap = time.time() - last_ts
+                        self._pt_no_initial_data_started_ts = None
+                    elif active_pt_codes:
+                        now_ts = time.time()
+                        if self._pt_no_initial_data_started_ts is None:
+                            self._pt_no_initial_data_started_ts = now_ts
+                        pt_no_initial_data_gap = now_ts - self._pt_no_initial_data_started_ts
+                        data_gap = pt_no_initial_data_gap
+                    else:
+                        self._pt_no_initial_data_started_ts = None
+                else:
+                    self._pt_no_initial_data_started_ts = None
 
                 price_gap = None
                 stale_price_codes = []
@@ -269,6 +283,17 @@ class WebSocketWatchdogTask(SchedulableTask):
                         if self._streaming_logger:
                             self._streaming_logger.log_receive_task_dead()
                         reconnect_trigger = "receive_task_dead"
+                elif (
+                    pt_codes
+                    and pt_no_initial_data_gap is not None
+                    and pt_no_initial_data_gap > self.PT_DATA_GAP_THRESHOLD_SEC
+                ):
+                    if self._streaming_logger:
+                        self._streaming_logger.log_pt_data_gap(
+                            pt_no_initial_data_gap,
+                            self.PT_DATA_GAP_THRESHOLD_SEC,
+                        )
+                    reconnect_trigger = f"pt_no_initial_data_{pt_no_initial_data_gap:.0f}s"
                 elif pt_codes and data_gap > self.PT_DATA_GAP_THRESHOLD_SEC:
                     # 수신 태스크는 살아있지만 PT 데이터가 임계값 이상 안 오는 경우
                     if self._streaming_logger:
@@ -290,6 +315,16 @@ class WebSocketWatchdogTask(SchedulableTask):
                         )
                     await self.force_reconnect(trigger=reconnect_trigger)
                 else:
+                    pending_pt_codes = [
+                        code for code in pt_codes
+                        if code not in active_pt_codes
+                    ]
+                    if pending_pt_codes:
+                        for code in pending_pt_codes:
+                            if self._streaming_logger:
+                                self._streaming_logger.log_missing_reason(code, "pt_not_active")
+                        await self._restore_all_subscriptions()
+                        continue
                     self._reconnect_trigger_counts.clear()
 
             except asyncio.CancelledError:

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -27,6 +27,18 @@ def make_sleep_side_effect(cancel_after_calls=1):
     side_effect.counter = 0
     return side_effect
 
+def make_time_side_effect(*values):
+    """time.time() 모킹용 side_effect — 주어진 값을 순서대로 반환하고,
+    값이 소진되면 마지막 값을 계속 반환한다.
+
+    호출 횟수에 의존하던 list 기반 side_effect와 달리, 구현이 time.time()을
+    한 번 더 호출하더라도 StopIteration으로 깨지지 않는다.
+    """
+    seq = list(values)
+    def side_effect(*args, **kwargs):
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+    return side_effect
+
 def _make_streaming_stock_repo(pt_desired=None):
     """StreamingStockRepo mock 생성 헬퍼."""
     repo = MagicMock()
@@ -257,7 +269,7 @@ async def test_streaming_watchdog_reconnects_when_active_pt_never_receives_data(
     svc.force_reconnect = AsyncMock()
 
     with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(2)), \
-         patch("task.background.intraday.websocket_watchdog_task.time.time", side_effect=[1000.0, 1301.0]):
+         patch("task.background.intraday.websocket_watchdog_task.time.time", side_effect=make_time_side_effect(1000.0, 1301.0)):
         try:
             await svc._streaming_watchdog()
         except asyncio.CancelledError:
@@ -265,6 +277,37 @@ async def test_streaming_watchdog_reconnects_when_active_pt_never_receives_data(
 
     svc.force_reconnect.assert_called_once()
     assert svc.force_reconnect.call_args.kwargs["trigger"] == "pt_no_initial_data_301s"
+
+
+@pytest.mark.asyncio
+async def test_streaming_watchdog_resets_pt_no_initial_timer_when_data_arrives(watchdog_task):
+    """첫 데이터가 도착하면(last_data_ts>0) PT 최초 수신 대기 타이머가 리셋되고
+    재연결/복원을 하지 않는다 — 복구 후 오탐 재연결 방지."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now.return_value = True
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    svc._streaming_stock_repo.get_active.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    # 이전 tick에서 누적 중이던 "최초 수신 대기" 타이머가 있었다고 가정
+    svc._pt_no_initial_data_started_ts = 1000.0
+    svc._program_trading_stream_service.last_data_ts = time.time()  # 데이터 도착
+    svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+
+    svc.force_reconnect = AsyncMock()
+    svc._restore_all_subscriptions = AsyncMock()
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(1)):
+        try:
+            await svc._streaming_watchdog()
+        except asyncio.CancelledError:
+            pass
+
+    assert svc._pt_no_initial_data_started_ts is None
+    svc.force_reconnect.assert_not_called()
+    svc._restore_all_subscriptions.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -379,14 +422,21 @@ async def test_streaming_watchdog_refreshes_subscribed_no_tick_codes(watchdog_ta
 
 @pytest.mark.asyncio
 async def test_streaming_watchdog_no_reconnect_when_never_received(watchdog_task, mock_deps):
-    """_streaming_watchdog: 데이터를 한 번도 받지 않았을 때(last_data_ts=0) 재연결하지 않음."""
+    """_streaming_watchdog: active 구독이 있고 첫 데이터 전(last_data_ts=0)이라도
+    임계값(5분) 이내면 재연결도 복원도 하지 않는다."""
     svc = watchdog_task
     svc.mcs.is_market_open_now.return_value = True
-    svc._streaming_stock_repo.get_desired.return_value = {"005930"}
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    svc._streaming_stock_repo.get_active.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
     svc._program_trading_stream_service.last_data_ts = 0.0
     svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
 
     svc.force_reconnect = AsyncMock()
+    svc._restore_all_subscriptions = AsyncMock()
 
     with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(1)):
         try:
@@ -395,6 +445,7 @@ async def test_streaming_watchdog_no_reconnect_when_never_received(watchdog_task
             pass
 
     svc.force_reconnect.assert_not_called()
+    svc._restore_all_subscriptions.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -220,6 +220,54 @@ async def test_streaming_watchdog_data_gap(watchdog_task, mock_deps):
 
 
 @pytest.mark.asyncio
+async def test_streaming_watchdog_restores_desired_pt_when_not_active(watchdog_task):
+    """desired PT가 있는데 active가 비어 있으면 장중 즉시 PT 복원을 시도한다."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now.return_value = True
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    svc._streaming_stock_repo.get_active.return_value = set()
+    svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+    svc._restore_all_subscriptions = AsyncMock()
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(1)):
+        try:
+            await svc._streaming_watchdog()
+        except asyncio.CancelledError:
+            pass
+
+    svc._streaming_logger.log_missing_reason.assert_called_once_with("005930", "pt_not_active")
+    svc._restore_all_subscriptions.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_watchdog_reconnects_when_active_pt_never_receives_data(watchdog_task):
+    """active PT 구독 후에도 첫 데이터가 계속 없으면 재연결한다."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now.return_value = True
+    svc._streaming_stock_repo.get_desired.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    svc._streaming_stock_repo.get_active.side_effect = (
+        lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+    )
+    svc._program_trading_stream_service.last_data_ts = 0.0
+    svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+    svc.force_reconnect = AsyncMock()
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(2)), \
+         patch("task.background.intraday.websocket_watchdog_task.time.time", side_effect=[1000.0, 1301.0]):
+        try:
+            await svc._streaming_watchdog()
+        except asyncio.CancelledError:
+            pass
+
+    svc.force_reconnect.assert_called_once()
+    assert svc.force_reconnect.call_args.kwargs["trigger"] == "pt_no_initial_data_301s"
+
+
+@pytest.mark.asyncio
 async def test_streaming_watchdog_price_data_gap_triggers_reconnect(watchdog_task):
     """체결가 전역 수신 갭이 임계값을 넘으면 price_data_gap trigger로 재연결한다."""
     svc = watchdog_task


### PR DESCRIPTION
핵심 원인은 PT desired 구독은 복원되어 있었지만, 장중 active 구독이 비어 있는 상태를 워치독이 복구하지 못한 점입니다. 특히 last_data_ts == 0이면 데이터 갭을 0초로 계산해서 “아직 한 번도 수신 못 함”을 정상처럼 지나갔습니다. 그래서 2026-05-29 로그에서도 08:43에 PT desired 3종목은 복원됐지만, 실제 H0STPGM0 구독 전송은 15:28 이후에야 보였습니다. 수정 내용:
websocket_watchdog_task.py (line 75): PT 최초 수신 대기 시간을 추적하는 상태 추가 websocket_watchdog_task.py (line 210): active PT가 있는데 최초 tick이 계속 없으면 5분 후 재연결 websocket_watchdog_task.py (line 317): desired PT가 active에 없으면 pt_not_active로 기록하고 즉시 PT 복원 시도 test_websocket_watchdog_task.py (line 222): 두 재현 테스트 추가 검증:
pytest tests/unit_test -v 통과: 5704 passed
pytest tests/integration_test -v 통과: 240 passed, warnings 2개 통합 테스트 warnings는 기존 테스트 환경성 경고로 보이며 이번 변경 실패는 없었습니다.