### PR TITLE
진행 완료했습니다.

### DIFF
--- a/core/scan_rejection_counter.py
+++ b/core/scan_rejection_counter.py
@@ -20,7 +20,7 @@ counter 에 도달하지 않는다. INFO 이상으로 emit 되는 entry_rejected
 from __future__ import annotations
 
 import logging
-from typing import Dict
+from typing import Dict, Set
 
 
 class EntryRejectionCounter(logging.Handler):
@@ -53,3 +53,61 @@ class EntryRejectionCounter(logging.Handler):
 
     def reset(self) -> None:
         self._counts.clear()
+
+
+class StrategyCalcFailureCounter(logging.Handler):
+    """전략 scan/check_exits 동안 per-code 계산 실패 이벤트를 누적한다.
+
+    `event` 이름에 error/failed/exception 이 포함되고 `code` 가 있는 구조화 로그만
+    카운트한다. 전략 단위 장애나 state load/save 같은 code-less 이벤트는 실패율
+    분모와 맞지 않으므로 제외한다.
+    """
+
+    _FAILURE_MARKERS = ("error", "failed", "exception")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._counts: Dict[str, int] = {}
+        self._failed_codes: Set[str] = set()
+
+    def record(self, event: str, code: str) -> None:
+        if not event or not code:
+            return
+        self._counts[event] = self._counts.get(event, 0) + 1
+        self._failed_codes.add(code)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = record.msg
+        if not isinstance(msg, dict):
+            return
+        event = msg.get("event")
+        if not isinstance(event, str) or not event:
+            return
+        event_key = event.casefold()
+        if not any(marker in event_key for marker in self._FAILURE_MARKERS):
+            return
+        code = msg.get("code")
+        if not isinstance(code, str):
+            return
+        code = code.strip()
+        if not code:
+            return
+        self.record(event, code)
+
+    def snapshot(self) -> Dict[str, int]:
+        return dict(self._counts)
+
+    def total_count(self) -> int:
+        return sum(self._counts.values())
+
+    def failed_code_count(self) -> int:
+        return len(self._failed_codes)
+
+    def failure_rate_pct(self, denominator: int) -> float:
+        if denominator <= 0:
+            return 0.0
+        return round(self.failed_code_count() / denominator * 100.0, 4)
+
+    def reset(self) -> None:
+        self._counts.clear()
+        self._failed_codes.clear()

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -31,7 +31,7 @@ from repositories.stock_code_repository import StockCodeRepository
 from services.stock_query_service import StockQueryService
 from core.market_clock import MarketClock
 from core.performance_profiler import PerformanceProfiler
-from core.scan_rejection_counter import EntryRejectionCounter
+from core.scan_rejection_counter import EntryRejectionCounter, StrategyCalcFailureCounter
 
 from scheduler.strategy_scheduler_store import StrategySchedulerStore, SCHEDULER_DB_FILE
 from services.price_subscription_service import SubscriptionPriority
@@ -437,8 +437,31 @@ class StrategyScheduler:
         holdings = self._get_strategy_holdings(cfg)
         if holdings:
             t_exit = self._pm.start_timer()
-            sell_signals = await cfg.strategy.check_exits(holdings)
+            strategy_logger = getattr(cfg.strategy, "_logger", None)
+            exit_failure_counter = StrategyCalcFailureCounter() if strategy_logger is not None else None
+            if exit_failure_counter is not None:
+                strategy_logger.addHandler(exit_failure_counter)
+            t_exit_metric = time.monotonic()
+            try:
+                sell_signals = await cfg.strategy.check_exits(holdings)
+            finally:
+                if exit_failure_counter is not None:
+                    strategy_logger.removeHandler(exit_failure_counter)
             self._pm.log_timer(f"{name}.check_exits({len(holdings)}건)", t_exit)
+            self._logger.info({
+                "event": "exit_metrics",
+                "strategy_name": name,
+                "latency_ms": round((time.monotonic() - t_exit_metric) * 1000.0, 3),
+                "holding_count": len(holdings),
+                "signal_count": len(sell_signals or []),
+                "calc_failures": exit_failure_counter.snapshot() if exit_failure_counter is not None else {},
+                "calc_failure_count": exit_failure_counter.total_count() if exit_failure_counter is not None else 0,
+                "calc_failure_code_count": exit_failure_counter.failed_code_count() if exit_failure_counter is not None else 0,
+                "calc_failure_rate_pct": (
+                    exit_failure_counter.failure_rate_pct(len(holdings))
+                    if exit_failure_counter is not None else 0.0
+                ),
+            })
             # P2 2-2 후속: signal-to-order latency 측정용 — 미stamp 신호에만 현재 시각 부여.
             # P3-4 Phase 2c: signal_id / strategy_id 도 동일 시점에 자동 stamp.
             _exit_stamp = time.time()
@@ -500,8 +523,11 @@ class StrategyScheduler:
         # strategy logger 에 EntryRejectionCounter 를 일시 attach. 예외에도 detach 보장.
         strategy_logger = getattr(cfg.strategy, "_logger", None)
         rejection_counter = EntryRejectionCounter() if strategy_logger is not None else None
+        scan_failure_counter = StrategyCalcFailureCounter() if strategy_logger is not None else None
         if rejection_counter is not None:
             strategy_logger.addHandler(rejection_counter)
+        if scan_failure_counter is not None:
+            strategy_logger.addHandler(scan_failure_counter)
         # P2 2-2 2차: scan cycle 동안의 현재가/캐시 조회 지표 delta 산출
         sqs_snapshot_before = {}
         sqs_snapshot_fn = getattr(self._sqs, "price_lookup_stats_snapshot", None) if self._sqs is not None else None
@@ -516,6 +542,8 @@ class StrategyScheduler:
         finally:
             if rejection_counter is not None:
                 strategy_logger.removeHandler(rejection_counter)
+            if scan_failure_counter is not None:
+                strategy_logger.removeHandler(scan_failure_counter)
         # P2 2-2 후속: signal-to-order latency 측정용 — scan 직후 stamp.
         # P3-4 Phase 2c: signal_id / strategy_id 도 동일 시점에 자동 stamp.
         _scan_stamp = time.time()
@@ -560,6 +588,13 @@ class StrategyScheduler:
             "candidate_count": candidate_count,
             "signal_count": len(buy_signals),
             "rejected_reasons": rejection_counter.snapshot() if rejection_counter is not None else {},
+            "calc_failures": scan_failure_counter.snapshot() if scan_failure_counter is not None else {},
+            "calc_failure_count": scan_failure_counter.total_count() if scan_failure_counter is not None else 0,
+            "calc_failure_code_count": scan_failure_counter.failed_code_count() if scan_failure_counter is not None else 0,
+            "calc_failure_rate_pct": (
+                scan_failure_counter.failure_rate_pct(candidate_count)
+                if scan_failure_counter is not None else 0.0
+            ),
             "lookup_stats_delta": lookup_stats_delta,
         })
 

--- a/tests/unit_test/core/test_scan_rejection_counter.py
+++ b/tests/unit_test/core/test_scan_rejection_counter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from core.scan_rejection_counter import EntryRejectionCounter
+from core.scan_rejection_counter import EntryRejectionCounter, StrategyCalcFailureCounter
 
 
 def _record(msg) -> logging.LogRecord:
@@ -86,3 +86,39 @@ def test_record_helper_ignores_empty_reason():
     counter.record("")
 
     assert counter.snapshot() == {}
+
+
+def test_calc_failure_counter_counts_per_code_failure_events():
+    counter = StrategyCalcFailureCounter()
+    counter.emit(_record({"event": "scan_error", "code": "005930", "error": "boom"}))
+    counter.emit(_record({"event": "cgld_check_failed", "code": "005930", "error": "timeout"}))
+    counter.emit(_record({"event": "program_filter_error", "code": "000660", "error": "bad data"}))
+
+    assert counter.snapshot() == {
+        "scan_error": 1,
+        "cgld_check_failed": 1,
+        "program_filter_error": 1,
+    }
+    assert counter.total_count() == 3
+    assert counter.failed_code_count() == 2
+    assert counter.failure_rate_pct(denominator=4) == 50.0
+
+
+def test_calc_failure_counter_ignores_non_failure_or_code_less_events():
+    counter = StrategyCalcFailureCounter()
+    counter.emit(_record({"event": "entry_rejected", "code": "005930", "reason": "low_volume"}))
+    counter.emit(_record({"event": "scan_error", "error": "strategy wide"}))
+    counter.emit(_record({"event": "pool_b_load_failed"}))
+    counter.emit(_record("plain log"))
+
+    assert counter.snapshot() == {}
+    assert counter.total_count() == 0
+    assert counter.failed_code_count() == 0
+    assert counter.failure_rate_pct(denominator=10) == 0.0
+
+
+def test_calc_failure_counter_zero_denominator_rate_is_zero():
+    counter = StrategyCalcFailureCounter()
+    counter.emit(_record({"event": "scan_error", "code": "005930", "error": "boom"}))
+
+    assert counter.failure_rate_pct(denominator=0) == 0.0

--- a/tests/unit_test/scheduler/test_strategy_scheduler_scan_metrics.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_scan_metrics.py
@@ -25,12 +25,16 @@ class _StubStrategy(LiveStrategy):
         self,
         name: str = "테스트전략",
         rejections=None,  # List[str] of reason values
+        failures=None,  # List[dict] of per-code failure log payloads
+        exit_failures=None,  # List[dict] of per-code failure log payloads
         signals: List[TradeSignal] = None,
         candidates: List[str] = None,
         raise_in_scan: bool = False,
     ):
         self._name = name
         self._rejections = rejections or []
+        self._failures = failures or []
+        self._exit_failures = exit_failures or []
         self._signals = signals or []
         self._candidates = candidates or []
         self._raise_in_scan = raise_in_scan
@@ -46,11 +50,15 @@ class _StubStrategy(LiveStrategy):
     async def scan(self):
         for reason in self._rejections:
             self._logger.info({"event": "entry_rejected", "code": "X", "reason": reason})
+        for payload in self._failures:
+            self._logger.warning(payload)
         if self._raise_in_scan:
             raise RuntimeError("scan boom")
         return list(self._signals)
 
     async def check_exits(self, holdings):
+        for payload in self._exit_failures:
+            self._logger.error(payload)
         return []
 
     def current_candidate_codes(self):
@@ -120,6 +128,17 @@ class TestStrategySchedulerScanMetrics(unittest.IsolatedAsyncioTestCase):
                 events.append(arg)
         return events
 
+    @staticmethod
+    def _exit_metrics_records(mock_logger):
+        events = []
+        for call in mock_logger.info.call_args_list:
+            if not call.args:
+                continue
+            arg = call.args[0]
+            if isinstance(arg, dict) and arg.get("event") == "exit_metrics":
+                events.append(arg)
+        return events
+
     async def test_scan_metrics_logged_after_scan(self):
         scheduler, mock_logger = self._make_scheduler()
         sig = TradeSignal(
@@ -181,6 +200,70 @@ class TestStrategySchedulerScanMetrics(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(records[0]["rejected_reasons"], {})
         # sqs MagicMock 이므로 price_lookup_stats_snapshot 미연동 → 빈 dict
         self.assertEqual(records[0]["lookup_stats_delta"], {})
+
+    async def test_scan_metrics_includes_per_code_calc_failure_rate(self):
+        scheduler, mock_logger = self._make_scheduler()
+        strategy = _StubStrategy(
+            name="failure전략",
+            candidates=["005930", "000660", "035720", "051910"],
+            failures=[
+                {"event": "scan_error", "code": "005930", "error": "ohlcv timeout"},
+                {"event": "cgld_check_failed", "code": "005930", "error": "conclusion timeout"},
+                {"event": "program_filter_error", "code": "000660", "error": "bad payload"},
+                {"event": "scan_error", "error": "strategy-wide without code"},
+            ],
+        )
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=10)
+        scheduler.register(config)
+
+        await scheduler._run_strategy(config)
+
+        records = self._scan_metrics_records(mock_logger)
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["calc_failures"], {
+            "scan_error": 1,
+            "cgld_check_failed": 1,
+            "program_filter_error": 1,
+        })
+        self.assertEqual(rec["calc_failure_count"], 3)
+        self.assertEqual(rec["calc_failure_code_count"], 2)
+        self.assertEqual(rec["calc_failure_rate_pct"], 50.0)
+
+    async def test_exit_metrics_includes_per_code_calc_failure_rate(self):
+        scheduler, mock_logger = self._make_scheduler()
+        vm = scheduler._virtual_trade_service
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "buy_price": 70000},
+            {"code": "000660", "buy_price": 120000},
+            {"code": "035720", "buy_price": 50000},
+        ]
+        strategy = _StubStrategy(
+            name="exitFailure전략",
+            exit_failures=[
+                {"event": "exit_check_error", "code": "005930", "error": "price timeout"},
+                {"event": "check_exits_error", "code": "000660", "error": "state error"},
+                {"event": "exit_check_error", "error": "missing code"},
+            ],
+        )
+        config = StrategySchedulerConfig(strategy=strategy, max_positions=10)
+        scheduler.register(config)
+
+        await scheduler._run_strategy(config)
+
+        records = self._exit_metrics_records(mock_logger)
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["strategy_name"], "exitFailure전략")
+        self.assertEqual(rec["holding_count"], 3)
+        self.assertEqual(rec["signal_count"], 0)
+        self.assertEqual(rec["calc_failures"], {
+            "exit_check_error": 1,
+            "check_exits_error": 1,
+        })
+        self.assertEqual(rec["calc_failure_count"], 2)
+        self.assertEqual(rec["calc_failure_code_count"], 2)
+        self.assertEqual(rec["calc_failure_rate_pct"], 66.6667)
 
     async def test_scan_metrics_includes_lookup_stats_delta(self):
         scheduler, mock_logger = self._make_scheduler()


### PR DESCRIPTION
per-code fail-rate metric을 스케줄러 관측성에 붙였습니다. core/scan_rejection_counter.py에 StrategyCalcFailureCounter를 추가했고, scheduler/strategy_scheduler.py에서 scan_metrics와 신규 exit_metrics에 아래 필드를 남기도록 했습니다. calc_failures
calc_failure_count
calc_failure_code_count
calc_failure_rate_pct
집계 대상은 구조화 로그에서 event 이름에 error/failed/exception이 포함되고 code가 있는 per-code 실패만입니다. code 없는 전략 전체 장애는 실패율 분모와 맞지 않아 제외했습니다. 테스트도 추가했습니다:
test_scan_rejection_counter.py
test_strategy_scheduler_scan_metrics.py
검증:
pytest tests/unit_test/scheduler -q → 311 passed
pytest tests/unit_test -v → 5719 passed
pytest tests/integration_test -v → 240 passed, 2 warnings 통합 테스트 warnings는 SystemTimeWarning 1건과 기존 StrategyStateIO.save_atomic unraisable warning 1건이고, 결과는 모두 통과입니다.