### PR TITLE
조치 완료했습니다. 원인은 짚은 대로 VBO shadow 후보가 StrategyEventRouter 내부에만 등록되고, 실제…

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -599,7 +599,7 @@ class StrategyScheduler:
         })
 
         # P2 2-4: event-driven shadow 구독 갱신 (scan 직후 후보군 변화 반영)
-        self._refresh_event_shadow_subscriptions(cfg)
+        await self._refresh_event_shadow_subscriptions(cfg)
 
         # 이미 보유 중인 종목은 추가 매수(불타기) 방지
         if cfg.allow_pyramiding:
@@ -1099,7 +1099,7 @@ class StrategyScheduler:
                 )
             return
 
-    def _refresh_event_shadow_subscriptions(self, cfg: StrategySchedulerConfig) -> None:
+    async def _refresh_event_shadow_subscriptions(self, cfg: StrategySchedulerConfig) -> None:
         """P2 2-4: cfg.event_driven_shadow=True 인 전략의 router 구독을 scan 후 갱신.
 
         - cfg.event_driven_shadow=False / router 미주입 / shadow journal 미주입 시 no-op.
@@ -1147,6 +1147,44 @@ class StrategyScheduler:
                     )
 
         self._event_shadow_subscriptions[name] = new_codes
+        await self._sync_event_shadow_price_subscriptions(name, new_codes)
+
+    async def _sync_event_shadow_price_subscriptions(self, strategy_name: str, codes: set[str]) -> None:
+        if self._price_sub_svc is None:
+            return
+        sync_fn = getattr(self._price_sub_svc, "sync_subscriptions", None)
+        if not callable(sync_fn):
+            return
+        try:
+            result = sync_fn(
+                sorted(codes),
+                self._event_shadow_category_key(strategy_name),
+                SubscriptionPriority.MEDIUM,
+                StreamingType.UNIFIED_PRICE,
+            )
+            if asyncio.iscoroutine(result):
+                await result
+        except TypeError:
+            try:
+                result = sync_fn(
+                    sorted(codes),
+                    self._event_shadow_category_key(strategy_name),
+                    SubscriptionPriority.MEDIUM,
+                )
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                self._logger.warning(
+                    f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
+                )
+        except Exception as e:
+            self._logger.warning(
+                f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
+            )
+
+    @staticmethod
+    def _event_shadow_category_key(strategy_name: str) -> str:
+        return f"event_shadow_{strategy_name}"
 
     def _build_shadow_evaluator(self, strategy):
         """evaluate_single → shadow journal 기록 → None 반환을 수행하는 wrapper.
@@ -1365,6 +1403,10 @@ class StrategyScheduler:
 
                 if self._price_sub_svc:
                     await self._price_sub_svc.remove_category(f"scheduler_{name}")
+                    if cfg.event_driven_shadow:
+                        await self._price_sub_svc.remove_category(
+                            self._event_shadow_category_key(name)
+                        )
 
                 return True
         return False

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -197,6 +197,7 @@ class SubscriptionPolicy:
         codes: List[str],
         category_key: str,
         priority: SubscriptionPriority,
+        stream_type: StreamingType = StreamingType.UNIFIED_PRICE,
     ) -> None:
         """
         카테고리 전체를 새 코드 목록으로 원자적으로 교체합니다.
@@ -216,15 +217,15 @@ class SubscriptionPolicy:
         for code in new_codes:
             self._refs.setdefault(code, {})[category_key] = {
                 "priority": priority,
-                "type": StreamingType.UNIFIED_PRICE  # 전략 워치리스트 동기화이므로 Price로 고정
+                "type": stream_type,
             }
 
         if self._streaming_stock_repo:
             for code in removed_codes:
                 if code not in self._refs:
-                    await self._streaming_stock_repo.unmark_desired(code, StreamingType.UNIFIED_PRICE)
+                    await self._streaming_stock_repo.unmark_desired(code, stream_type)
             for code in added_codes:
-                await self._streaming_stock_repo.mark_desired(code, StreamingType.UNIFIED_PRICE)
+                await self._streaming_stock_repo.mark_desired(code, stream_type)
 
         await self._rebalance()
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
@@ -12,11 +12,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from repositories.streaming_stock_repo import StreamingType
 from common.types import TradeSignal
 from scheduler.strategy_scheduler import StrategyScheduler, StrategySchedulerConfig
+from services.price_subscription_service import SubscriptionPriority
 
 
-def _make_scheduler(event_router=None, event_shadow_journal=None):
+def _make_scheduler(event_router=None, event_shadow_journal=None, price_subscription_service=None):
     return StrategyScheduler(
         virtual_trade_service=MagicMock(),
         order_execution_service=MagicMock(),
@@ -27,6 +29,7 @@ def _make_scheduler(event_router=None, event_shadow_journal=None):
         logger=MagicMock(),
         dry_run=True,
         store=MagicMock(),
+        price_subscription_service=price_subscription_service,
         event_router=event_router,
         event_shadow_journal=event_shadow_journal,
     )
@@ -52,7 +55,7 @@ async def test_refresh_subscriptions_adds_codes_from_candidate_set():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
 
     assert router.subscribe.call_count == 2
     subscribed_codes = sorted(call.args[0] for call in router.subscribe.call_args_list)
@@ -70,12 +73,12 @@ async def test_refresh_subscriptions_diffs_against_previous_set():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=MagicMock())
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
     router.subscribe.reset_mock()
 
     # 다음 scan: 005930 빠지고 035720 추가
     cfg.strategy.current_candidate_codes.return_value = ["000660", "035720"]
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
 
     router.unsubscribe.assert_called_once_with("005930", "VBO")
     router.subscribe.assert_called_once()
@@ -88,7 +91,7 @@ async def test_refresh_subscriptions_noop_when_flag_off():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=MagicMock())
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=False, codes=["005930"])
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
 
     router.subscribe.assert_not_called()
     router.unsubscribe.assert_not_called()
@@ -101,7 +104,30 @@ async def test_refresh_subscriptions_noop_when_router_missing():
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     # router 없이도 예외 없이 종료해야 한다
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
+
+
+@pytest.mark.asyncio
+async def test_refresh_subscriptions_syncs_price_subscription_category():
+    router = MagicMock()
+    router.subscribe = MagicMock()
+    router.unsubscribe = MagicMock()
+    price_sub = AsyncMock()
+    scheduler = _make_scheduler(
+        event_router=router,
+        event_shadow_journal=MagicMock(),
+        price_subscription_service=price_sub,
+    )
+
+    cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930", "000660"])
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
+
+    price_sub.sync_subscriptions.assert_awaited_once_with(
+        ["000660", "005930"],
+        "event_shadow_래리윌리엄스VBO",
+        SubscriptionPriority.MEDIUM,
+        StreamingType.UNIFIED_PRICE,
+    )
 
 
 @pytest.mark.asyncio
@@ -119,7 +145,7 @@ async def test_shadow_evaluator_records_signal_and_returns_none():
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
 
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
 
     snapshot = {"price": "75000", "open": 74000.0}
@@ -145,10 +171,27 @@ async def test_shadow_evaluator_does_not_record_when_no_signal():
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=None)
 
-    scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
 
     result = await evaluator("005930", {"price": "70000"})
 
     assert result is None
     journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stop_strategy_removes_event_shadow_price_subscription_category():
+    price_sub = AsyncMock()
+    scheduler = _make_scheduler(
+        event_router=MagicMock(),
+        event_shadow_journal=MagicMock(),
+        price_subscription_service=price_sub,
+    )
+    cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930"])
+    scheduler.register(cfg)
+
+    assert await scheduler.stop_strategy("래리윌리엄스VBO")
+
+    assert price_sub.remove_category.await_args_list[0].args == ("scheduler_래리윌리엄스VBO",)
+    assert price_sub.remove_category.await_args_list[1].args == ("event_shadow_래리윌리엄스VBO",)

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-05-31 (P0 0-10 same-symbol pending BUY qty cap 완료 반영)
+최종 업데이트: 2026-05-31 (VBO event-shadow 가격 구독 배선 수정 반영)
 
 이 문서는 현재 남은 실행 항목만 추린 목록이다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거한다. 100% 종료된 섹션(`[x]` only, follow-up 없음)은 git history 로 추적하고 본 문서에서 삭제한다.
 
@@ -260,7 +260,9 @@
 - [~] PR-2.5: VBO shadow 운영 관찰 시작.
   - 적용 완료: `StrategyFactory`에서 VBO `StrategySchedulerConfig(..., event_driven_shadow=True)` 활성화 (실주문은 `enabled=False`로 차단).
   - 적용 완료: parity 분석 도구 `scripts/analyze_event_shadow_parity.py` (matched / shadow_only / polling_only / duplicates / lead_time_seconds / price_divergence / missed_pnl / per_date) + `tests/unit_test/scripts/test_analyze_event_shadow_parity.py` 회귀 잠금.
+  - 적용 완료(2026-05-31): event shadow 후보가 `StrategyEventRouter` 내부 구독만 갱신하고 실제 가격 WebSocket 구독을 요청하지 않던 배선 누락을 수정했다. `StrategyScheduler`가 `event_shadow_<strategy>` 카테고리로 `PriceSubscriptionService.sync_subscriptions()`를 호출해 후보 종목 tick을 실제 수신하도록 한다.
   - 남은 작업: 5거래일 동안 `logs/strategies/event_shadow/YYYYMMDD.jsonl` 을 수집한 뒤 위 도구로 리포트 생성.
+  - 수집 현황(2026-05-31 확인): `logs/strategies/event_shadow/` 디렉터리 없음. 기존 기간은 유효 수집일로 계산하지 않고, 배선 수정 후 장중 운영일부터 5거래일을 다시 센다.
   - 검증 기준: shadow 신호와 기존 polling 신호의 시간/종목/가격 괴리를 비교해 실주문 전환 가능 여부를 판정한다.
   - 추가 기준: polling 대비 신호 선행 시간, fast path false positive, false negative, full gate parity, missed trade PnL, duplicate signal rate. (모두 위 스크립트 출력에 포함)
   - VBO 특이점: `evaluate_single()` shadow fast path는 execution strength/program-buy를 의도적으로 생략하므로, fast path 통과(=`shadow_only` + `matched`)와 full gate 최종 통과(=`matched` + `polling_only`)의 분리는 현재 스크립트의 `shadow_only` / `matched` / `polling_only` 분류로 간접 표현된다.
@@ -420,6 +422,7 @@
 
 3. **운영 관찰 진행 중**
    - VBO shadow 5거래일 jsonl 수집 → `scripts/analyze_event_shadow_parity.py` 로 parity 리포트 생성 → PR-3 진입 판정 (P2 2-4 PR-2.5)
+     - 2026-05-31 배선 수정 후 장중 운영일부터 수집일 카운트 재시작.
    - 손절 전용 exit fast-path shadow/latency 측정 설계 (P2 2-4 후속)
    - profitability gate는 우회하지 않고 shadow/paper/canary journal로 전략별 실전 근거를 축적 (P1 1-6)
 


### PR DESCRIPTION
… 가격 WebSocket 구독으로는 이어지지 않던 배선 누락이었습니다.

변경:
scheduler/strategy_scheduler.py (line 1102): event shadow 구독 갱신을 async로 바꾸고, 후보 종목을 event_shadow_<strategy> 카테고리로 PriceSubscriptionService.sync_subscriptions()에 연결 services/subscription_policy.py (line 195): sync_subscriptions()가 stream type을 받을 수 있게 확장 tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py (line 113): shadow 후보가 실제 가격 구독 카테고리로 sync되는지, 전략 정지 시 cleanup되는지 테스트 추가 todo_list.md (line 263): 기존 shadow 수집 0건 및 배선 수정 후 5거래일 재수집 필요로 정리 검증:
Event shadow 테스트: 8 passed
관련 scheduler/subscription 테스트: 341 passed
전체 단위 테스트: 5724 passed
전체 통합 테스트: 240 passed, 2 warnings
통합 테스트 경고 2개와 마지막 pending task 경고는 기존 계열로 보이며, 이번 변경 경로는 모두 통과했습니다. 이제 다음 장중 운영부터 logs/strategies/event_shadow/YYYYMMDD.jsonl 생성 여부를 다시 보면 됩니다. 기존 2026-05-27~29는 유효 수집일로 세면 안 되고, 이번 수정 이후부터 5거래일 카운트 재시작이 맞습니다.