### PR TITLE
perf(P2 2-6): 라이브 핫패스 follow-up — WS 틱 루프 / 장마감 iterrows / HTTP·token 정합성

### DIFF
--- a/brokers/korea_investment/korea_invest_api_base.py
+++ b/brokers/korea_investment/korea_invest_api_base.py
@@ -11,6 +11,7 @@ except ImportError:
 import certifi
 import logging
 import asyncio  # 비동기 처리를 위해 추가
+import random  # 재시도 백오프 jitter
 import httpx  # 비동기 처리를 위해 requests 대신 httpx 사용
 import ssl
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv  # TokenProvider를 import
@@ -34,6 +35,9 @@ class ApiFatalError(Exception):
     def __init__(self, message, rt_cd=None):
         super().__init__(message)
         self.rt_cd = rt_cd
+
+# 재시도 지수 백오프에 더하는 bounded jitter 비율 (base 대비 0~25%)
+_RETRY_JITTER_FRACTION = 0.25
 
 class KoreaInvestApiBase:
     """
@@ -61,7 +65,11 @@ class KoreaInvestApiBase:
             self._async_session = async_client
         else:
             ssl_context = ssl.create_default_context(cafile=certifi.where())
-            self._async_session = httpx.AsyncClient(verify=ssl_context)
+            # shared client(korea_invest_client)와 동일한 Limits/Timeout 적용 —
+            # fallback 경로에서 연결 풀/타임아웃이 무제한이 되는 것을 방지.
+            limits = httpx.Limits(max_keepalive_connections=50, max_connections=100, keepalive_expiry=30.0)
+            timeout = httpx.Timeout(10.0, connect=5.0)  # connect 5s, read/write/pool 10s
+            self._async_session = httpx.AsyncClient(verify=ssl_context, limits=limits, timeout=timeout)
 
         # urllib3 로거의 DEBUG 레벨을 비활성화하여 call_api의 DEBUG 로그와 분리
         logging.getLogger('urllib3.connectionpool').setLevel(logging.WARNING)
@@ -111,9 +119,12 @@ class KoreaInvestApiBase:
             except ApiRetryError as e:
                 # 지수 백오프 적용: 기본 delay * 2^(attempt-1)
                 if e.delay > 0:
+                    # 명시 delay(예: 토큰 Rate Limit)는 그대로 사용 — jitter 미적용
                     wait_time = e.delay
                 else:
-                    wait_time = delay * (2 ** (attempt - 1))
+                    base = delay * (2 ** (attempt - 1))
+                    # bounded jitter — 다전략 동시 재시도(thundering herd) 분산
+                    wait_time = base + random.uniform(0, base * _RETRY_JITTER_FRACTION)
                 self._logger.warning(f"재시도 필요: {attempt}/{retry_count}, 사유: {e}, 지연 {wait_time}초")
                 await self.market_clock.async_sleep(wait_time)
                 continue

--- a/brokers/korea_investment/korea_invest_token_provider.py
+++ b/brokers/korea_investment/korea_invest_token_provider.py
@@ -1,5 +1,6 @@
 import os
 import json
+import asyncio
 import httpx  # 비동기 HTTP 클라이언트
 from datetime import datetime, timedelta
 import logging
@@ -33,31 +34,39 @@ class TokenProvider:
         self._access_token = None
         self._token_expired_at = None
         self._logger = logger if logger else logging.getLogger(__name__)
+        # 동시 토큰 요청 singleflight — 발급 경로를 직렬화해 중복 발급(EGW00133 유발)을 막는다.
+        self._issue_lock = asyncio.Lock()
 
     async def get_access_token(self, base_url: str, app_key: str, app_secret: str) -> str: # env 인자 대신 필요한 정보만 받음
         """유효한 액세스 토큰을 반환합니다. 필요 시 파일에서 로드하거나 새로 발급합니다."""
-        # 1. 메모리에 토큰이 있고 유효한지 먼저 확인
+        # 1. 메모리에 토큰이 있고 유효하면 락 없이 즉시 반환 (fast path)
         if self._access_token and self._is_token_valid():
             return self._access_token
 
-        # 2. 파일에서 토큰을 로드하고 유효한지 확인
-        self._load_token_from_file()
-        if self._access_token and self._is_token_valid():
-            # 파일에서 로드한 토큰이 현재 환경의 base_url과 일치하는지 확인
-            loaded_token_base_url = self._get_token_base_url_from_file()
-            if loaded_token_base_url == base_url: # 전달받은 base_url과 비교
-                self._logger.info("파일에서 유효한 토큰을 로드했습니다.")
+        # 2. 발급/로드 경로는 singleflight 락으로 직렬화 — 동시 호출이 중복 발급하지 않도록.
+        async with self._issue_lock:
+            # double-check: 락 대기 중 다른 코루틴이 이미 유효 토큰을 확보했을 수 있음
+            if self._access_token and self._is_token_valid():
                 return self._access_token
-            else:
-                self._logger.warning(f"파일에서 로드한 토큰의 base_url이 현재 환경과 다릅니다. 저장된: {loaded_token_base_url}, 현재: {base_url}. 새 토큰 발급 필요.")
-                self._access_token = None # base_url이 다르면 토큰 무효화
-                self._token_expired_at = None
 
-        # 3. 위 모든 경우에 해당하지 않으면 새로 발급
-        self._logger.info("새로운 액세스 토큰을 발급합니다.")
-        await self._issue_new_token(base_url, app_key, app_secret) # 필요한 정보 전달
+            # 3. 파일에서 토큰을 로드하고 유효한지 확인
+            self._load_token_from_file()
+            if self._access_token and self._is_token_valid():
+                # 파일에서 로드한 토큰이 현재 환경의 base_url과 일치하는지 확인
+                loaded_token_base_url = self._get_token_base_url_from_file()
+                if loaded_token_base_url == base_url: # 전달받은 base_url과 비교
+                    self._logger.info("파일에서 유효한 토큰을 로드했습니다.")
+                    return self._access_token
+                else:
+                    self._logger.warning(f"파일에서 로드한 토큰의 base_url이 현재 환경과 다릅니다. 저장된: {loaded_token_base_url}, 현재: {base_url}. 새 토큰 발급 필요.")
+                    self._access_token = None # base_url이 다르면 토큰 무효화
+                    self._token_expired_at = None
 
-        return self._access_token
+            # 4. 위 모든 경우에 해당하지 않으면 새로 발급
+            self._logger.info("새로운 액세스 토큰을 발급합니다.")
+            await self._issue_new_token(base_url, app_key, app_secret) # 필요한 정보 전달
+
+            return self._access_token
 
     def _is_token_valid(self):
         """토큰이 존재하고, 만료되지 않았는지 확인합니다. (5분 여유시간)"""

--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -74,6 +74,14 @@ class KoreaInvestWebSocketAPI:
         # 서버가 appkey 중복 사용을 거부한 경우 True → 다음 재연결 시 긴 대기 적용
         self._appkey_collision = False
 
+        # 실시간 수신 핫패스 TR_ID 캐시 (연결 수립/첫 메시지 시 active_config에서 1회 해석).
+        # 매 틱 active_config 깊은 dict 조회를 피한다. 환경 전환은 연결 재수립에서 갱신.
+        self._rt_tr_cached = False
+        self._rt_tr_realtime_price = None
+        self._rt_tr_unified_realtime_price = None
+        self._rt_tr_realtime_quote = None
+        self._rt_program_trading_tr_ids = set()
+
     def _aes_cbc_base64_dec(self, key, iv, cipher_text):
         """
         AES256 DECODE (Base64 인코딩된 암호문을 복호화)
@@ -140,6 +148,8 @@ class KoreaInvestWebSocketAPI:
     async def _establish_connection(self):
         """웹소켓 연결을 수립하는 내부 메서드 (재연결 로직에서 재사용)."""
         self._websocket_url = self._env.get_websocket_url()
+        # 환경 전환(paper/real) 후 재연결 시 핫패스 TR_ID 캐시를 무효화 → 다음 메시지에서 새 active_config로 재해석
+        self._rt_tr_cached = False
         
         # 1. approval_key 발급 (없으면 발급)
         if not self.approval_key:
@@ -266,10 +276,9 @@ class KoreaInvestWebSocketAPI:
 
     def _handle_websocket_message(self, message: str):
         """수신된 웹소켓 메시지를 파싱하고 등록된 콜백으로 전달."""
-        self._websocket_url = self._env.active_config['websocket_url']
-        self._base_rest_url = self._env.active_config['base_url']
-        self._rest_api_key= self._env.active_config['api_key']
-        self._rest_api_secret= self._env.active_config['api_secret_key']
+        # 핫패스 TR_ID 캐시 (첫 메시지 시 1회 해석; 환경 전환 시 연결 재수립에서 갱신).
+        if not self._rt_tr_cached:
+            self._cache_realtime_tr_ids()
 
         # 한국투자증권 실시간 데이터는 '|'로 구분된 문자열 또는 JSON 객체로 수신됨
         if message and (message.startswith('0|') or message.startswith('1|')):  # 실시간 데이터 (0: 일반, 1: 체결통보)
@@ -277,20 +286,20 @@ class KoreaInvestWebSocketAPI:
             tr_id = recvstr[1]  # 두 번째 요소가 TR_ID
             data_body = recvstr[3]  # 네 번째 요소가 실제 데이터 본문
 
-            self._logger.debug(f"받은 TR_ID: {tr_id}")
-            self._logger.debug(f"비교 대상: {self._env.active_config['tr_ids']['websocket']['realtime_price']}")
+            self._logger.debug("받은 TR_ID: %s", tr_id)
+            self._logger.debug("비교 대상: %s", self._rt_tr_realtime_price)
 
             parsed_data = {}
             message_type = 'unknown'
 
             # --- 주식 관련 실시간 데이터 파싱 ---
-            if tr_id == self._env.active_config['tr_ids']['websocket']['realtime_price']:  # H0STCNT0 (주식 체결)
+            if tr_id == self._rt_tr_realtime_price:  # H0STCNT0 (주식 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)
                 message_type = 'realtime_price'
-            elif tr_id == self._env.active_config['tr_ids']['websocket'].get('unified_realtime_price', 'H0UNCNT0'):  # H0UNCNT0 (KRX+NXT 통합 체결)
+            elif tr_id == self._rt_tr_unified_realtime_price:  # H0UNCNT0 (KRX+NXT 통합 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)  # H0STCNT0와 동일 포맷
                 message_type = 'realtime_price'
-            elif tr_id == self._env.active_config['tr_ids']['websocket']['realtime_quote']:  # H0STASP0 (주식 호가)
+            elif tr_id == self._rt_tr_realtime_quote:  # H0STASP0 (주식 호가)
                 parsed_data = self._parse_stock_quote_data(data_body)
                 message_type = 'realtime_quote'
 
@@ -347,12 +356,12 @@ class KoreaInvestWebSocketAPI:
                     self._logger.warning(f"체결통보 암호화 해제 실패: AES 키/IV 없음. TR_ID: {tr_id}, 메시지: {message[:50]}...")
                     return
 
-            elif tr_id in self._get_program_trading_tr_ids():
+            elif tr_id in self._rt_program_trading_tr_ids:
                 parsed_data = self._parse_program_trading_data(data_body)
                 message_type = 'realtime_program_trading'
 
-            # [추가] 파싱된 데이터 디버그 로그 (데이터 내용 확인용)
-            self._logger.debug(f"WS 수신 데이터 파싱: Type={message_type}, TR_ID={tr_id}, Data={parsed_data}")
+            # [추가] 파싱된 데이터 디버그 로그 (데이터 내용 확인용) — lazy 포맷팅으로 매 틱 repr 생성 방지
+            self._logger.debug("WS 수신 데이터 파싱: Type=%s, TR_ID=%s, Data=%s", message_type, tr_id, parsed_data)
 
             # 외부 콜백 함수로 파싱된 데이터 전달
             if self.on_realtime_message_callback:
@@ -662,6 +671,17 @@ class KoreaInvestWebSocketAPI:
             websocket_config.get('realtime_program_trading', 'H0STPGM0'),
             websocket_config.get('nxt_realtime_program_trading', 'H0NXPGM0'),
         }
+
+    def _cache_realtime_tr_ids(self) -> None:
+        """실시간 수신 핫패스에서 매 틱 깊은 dict 조회를 피하기 위해 TR_ID를 1회 캐싱한다.
+        첫 메시지 수신 시 호출된다. realtime_price/realtime_quote는 필수 키이므로 bracket 접근으로
+        누락 시 KeyError를 그대로 전파한다(상위 _receive_messages에서 잡아 재연결)."""
+        ws_cfg = self._env.active_config['tr_ids']['websocket']
+        self._rt_tr_realtime_price = ws_cfg['realtime_price']
+        self._rt_tr_unified_realtime_price = ws_cfg.get('unified_realtime_price', 'H0UNCNT0')
+        self._rt_tr_realtime_quote = ws_cfg['realtime_quote']
+        self._rt_program_trading_tr_ids = self._get_program_trading_tr_ids()
+        self._rt_tr_cached = True
 
     async def subscribe_program_trading(self, stock_code: str):
         """국내주식 실시간 프로그램매매 동향 (H0STPGM0) 구독."""

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -634,13 +634,18 @@ class OneilUniverseService:
         start_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
         
         # 1. 전체 종목 로드
-        all_stocks = []
-        for _, row in self.stock_code_repository.df.iterrows():
-            code = row.get("종목코드", "")
-            name = row.get("종목명", "")
-            market = row.get("시장구분", "")
-            if code and market in ("KOSPI", "KOSDAQ"):
-                all_stocks.append((code, name, market))
+        # 성능: iterrows()는 행마다 Series를 생성해 느리다. 컬럼을 리스트로 한 번 추출해
+        # zip 순회한다. row.get(col, "") 시맨틱(컬럼 부재 시 "") 보존.
+        df = self.stock_code_repository.df
+        n = len(df)
+        codes = df["종목코드"].tolist() if "종목코드" in df.columns else [""] * n
+        names = df["종목명"].tolist() if "종목명" in df.columns else [""] * n
+        markets = df["시장구분"].tolist() if "시장구분" in df.columns else [""] * n
+        all_stocks = [
+            (code, name, market)
+            for code, name, market in zip(codes, names, markets)
+            if code and market in ("KOSPI", "KOSDAQ")
+        ]
 
         total_stocks = len(all_stocks)
         print(f"[전일 기준 우량주 생성] 시작시간: {start_time_str} | 전체 종목 수: {total_stocks}개. 1차 필터링(시총) 시작...")

--- a/task/background/after_market/minervini_update_task.py
+++ b/task/background/after_market/minervini_update_task.py
@@ -107,11 +107,16 @@ class MinerviniUpdateTask(AfterMarketTask):
             await self.refresh_minervini_stage2()
 
     def _load_all_stocks(self) -> List[tuple]:
+        # 성능: iterrows()는 행마다 Series를 생성해 느리다. 컬럼을 리스트로 한 번 추출해
+        # zip 순회한다. row.get(col, "") 시맨틱(컬럼 부재 시 "") 보존.
+        df = self.stock_code_repository.df
+        n = len(df)
+        codes = df["종목코드"].tolist() if "종목코드" in df.columns else [""] * n
+        names = df["종목명"].tolist() if "종목명" in df.columns else [""] * n
+        markets = df["시장구분"].tolist() if "시장구분" in df.columns else [""] * n
+
         all_stocks = []
-        for _, row in self.stock_code_repository.df.iterrows():
-            code = row.get("종목코드", "")
-            name = row.get("종목명", "")
-            market = row.get("시장구분", "")
+        for code, name, market in zip(codes, names, markets):
             if not code:
                 continue
             all_stocks.append((code, name, market))

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -589,12 +589,16 @@ class RankingTask(AfterMarketTask):
 
     def _load_all_stocks(self) -> List[tuple]:
         """StockCodeRepository에서 KOSPI/KOSDAQ 전체 종목 로드."""
-        all_stocks = []
-        for _, row in self.stock_code_repository.df.iterrows():
-            code = row.get("종목코드", "")
-            name = row.get("종목명", "")
-            market = row.get("시장구분", "")
+        # 성능: iterrows()는 행마다 Series를 생성해 느리다. 컬럼을 리스트로 한 번 추출해
+        # zip 순회한다. row.get(col, "") 시맨틱(컬럼 부재 시 "") 보존.
+        df = self.stock_code_repository.df
+        n = len(df)
+        codes = df["종목코드"].tolist() if "종목코드" in df.columns else [""] * n
+        names = df["종목명"].tolist() if "종목명" in df.columns else [""] * n
+        markets = df["시장구분"].tolist() if "시장구분" in df.columns else [""] * n
 
+        all_stocks = []
+        for code, name, market in zip(codes, names, markets):
             if not code:
                 continue
 

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
@@ -310,6 +310,28 @@ def get_api():
 
     return DummyAPI(mock_env, mock_logger, mock_market_clock, trid_provider=mock_trid_provider)
 
+
+@pytest.mark.asyncio
+async def test_fallback_async_client_uses_shared_limits_and_timeout():
+    """async_client 미주입 시 fallback httpx.AsyncClient가 shared client(korea_invest_client)와
+    동일한 Limits/Timeout을 사용해 연결 풀/타임아웃이 무제한이 되지 않도록 한다."""
+    with patch("brokers.korea_investment.korea_invest_api_base.httpx.AsyncClient") as mock_client_cls:
+        get_api()  # DummyAPI → super().__init__ (async_client 미주입) → fallback 경로
+
+        mock_client_cls.assert_called_once()
+        _, kwargs = mock_client_cls.call_args
+        assert "limits" in kwargs, "fallback client에 limits가 지정되어야 한다"
+        assert "timeout" in kwargs, "fallback client에 timeout이 지정되어야 한다"
+
+        limits = kwargs["limits"]
+        assert limits.max_connections == 100
+        assert limits.max_keepalive_connections == 50
+
+        timeout = kwargs["timeout"]
+        assert timeout.connect == 5.0
+        assert timeout.read == 10.0
+
+
 @pytest.mark.asyncio
 async def testcall_api_retry_exceed_failure(caplog):
     logger = get_test_logger()
@@ -486,8 +508,10 @@ async def testcall_api_retry_on_429(caplog):
     # asyncio.sleep이 호출되었는지, 적절한 인자로 호출되었는지 확인
     # 429 에러가 2번 발생했으므로, 2번의 sleep 호출 예상 (첫 실패 후, 두 번째 실패 후)
     assert api.market_clock.async_sleep.await_count == 2
-    # 지수 백오프 적용: 1회차 0.01, 2회차 0.02
-    api.market_clock.async_sleep.assert_has_awaits([call(0.01), call(0.02)])
+    # 지수 백오프 + bounded jitter: base ≤ wait ≤ base*(1+0.25), 1회차 base 0.01 / 2회차 base 0.02
+    _sleeps = [c.args[0] for c in api.market_clock.async_sleep.await_args_list]
+    assert 0.01 <= _sleeps[0] <= 0.01 * 1.25
+    assert 0.02 <= _sleeps[1] <= 0.02 * 1.25
 
 
 @pytest.mark.asyncio
@@ -536,8 +560,10 @@ async def testcall_api_retry_on_500_rate_limit(mock_sleep):
     assert len(responses_list) == 3
     assert api._async_session.get.call_count == 3
     assert api.market_clock.async_sleep.await_count == 2
-    # 지수 백오프 적용: 1회차 0.01, 2회차 0.02
-    api.market_clock.async_sleep.assert_has_awaits([call(0.01), call(0.02)])
+    # 지수 백오프 + bounded jitter: base ≤ wait ≤ base*(1+0.25), 1회차 base 0.01 / 2회차 base 0.02
+    _sleeps = [c.args[0] for c in api.market_clock.async_sleep.await_args_list]
+    assert 0.01 <= _sleeps[0] <= 0.01 * 1.25
+    assert 0.02 <= _sleeps[1] <= 0.02 * 1.25
 
 
     # _log_request_exception은 예외가 call_api에서 잡힐 때만 호출됩니다.
@@ -553,6 +579,45 @@ async def testcall_api_retry_on_500_rate_limit(mock_sleep):
 
     # 디버그 로그는 성공 응답 시에만 호출되어야 합니다.
     api._logger.debug.assert_any_call(f"API 응답 성공: {responses_list[2].text}")
+
+
+@pytest.mark.asyncio
+async def test_call_api_retry_backoff_applies_bounded_jitter():
+    """지수 백오프(e.delay 미지정 ApiRetryError)에 bounded jitter가 더해진다.
+
+    random.uniform을 고정 patch해 wait_time = base + jitter 임을 결정적으로 검증한다.
+    명시 delay(e.delay>0) 경로에는 jitter를 적용하지 않는다.
+    """
+    api = get_api()
+
+    responses = []
+
+    async def mock_get(*a, **k):
+        resp = MagicMock(spec=httpx.Response)
+        if len(responses) < 2:
+            resp.status_code = 500
+            resp.text = '{"msg1":"초당 거래건수를 초과하였습니다."}'
+            resp.json.return_value = {"msg1": "초당 거래건수를 초과하였습니다."}
+        else:
+            resp.status_code = 200
+            resp.text = '{"rt_cd":"0","msg1":"정상","output":{}}'
+            resp.json.return_value = {"rt_cd": "0", "msg1": "정상", "output": {}}
+        resp.raise_for_status.return_value = None
+        resp.raise_for_status.side_effect = None
+        responses.append(resp)
+        return resp
+
+    api._async_session.get.side_effect = mock_get
+
+    with patch("brokers.korea_investment.korea_invest_api_base.random.uniform", return_value=0.001):
+        result = await api.call_api('GET', '/jitter', retry_count=5, delay=0.01)
+
+    assert result.rt_cd == "0"
+    sleeps = [c.args[0] for c in api.market_clock.async_sleep.await_args_list]
+    assert len(sleeps) == 2
+    # base(0.01, 0.02) + 고정 jitter(0.001)
+    assert sleeps[0] == pytest.approx(0.011)
+    assert sleeps[1] == pytest.approx(0.021)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_token_provider.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_token_provider.py
@@ -499,3 +499,48 @@ async def test_refresh_token_success(monkeypatch, tmp_path):
             assert data["access_token"] == mock_access_token
             assert data["base_url"] == mock_base_url
 
+
+class _RealYield:
+    """이벤트 루프에 실제로 1회 양보하는 awaitable.
+
+    conftest가 asyncio.sleep을 AsyncMock으로 패치해 await 시 yield가 일어나지 않으므로,
+    동시성 테스트에서 실제 suspension을 만들기 위해 패치되지 않은 raw yield를 사용한다.
+    """
+    def __await__(self):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_singleflight_under_concurrency(tmp_path):
+    """동시에 여러 코루틴이 토큰을 요청해도 _issue_new_token은 1회만 호출된다(singleflight).
+
+    double-checked asyncio.Lock 이 없으면 동시 호출이 모두 발급 경로로 진입해
+    토큰 발급 API를 N회 호출하고 EGW00133(1분 Rate Limit)을 유발할 수 있다.
+    """
+    import asyncio
+
+    token_file = tmp_path / "sf_token.json"
+    token_provider = TokenProvider(token_file_path=str(token_file))
+
+    call_count = 0
+
+    async def fake_issue(base_url, app_key, app_secret):
+        nonlocal call_count
+        call_count += 1
+        # 실제 suspension — 락이 없으면 이 사이에 다른 코루틴이 발급 경로로 진입한다
+        await _RealYield()
+        await _RealYield()
+        token_provider._access_token = "ISSUED"
+        token_provider._token_expired_at = (
+            datetime.now(pytz.timezone("Asia/Seoul")) + timedelta(hours=10)
+        )
+
+    token_provider._issue_new_token = fake_issue
+
+    results = await asyncio.gather(*[
+        token_provider.get_access_token("https://x", "k", "s") for _ in range(10)
+    ])
+
+    assert call_count == 1
+    assert all(r == "ISSUED" for r in results)
+

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -439,6 +439,87 @@ def test_handle_websocket_message_realtime_price_success(websocket_api_instance)
     assert called_args['data']["주식현재가"] == '10000'
 
 
+def _make_realtime_price_message(tr_id="H0STCNT0"):
+    data_parts = [''] * 60
+    data_parts[0] = '0001'
+    data_parts[2] = '10000'
+    return f"0|{tr_id}|some_key|{'^'.join(data_parts)}"
+
+
+def test_handle_message_does_not_reassign_rest_attrs_per_tick(websocket_api_instance):
+    """핫패스 최적화: 메시지 핸들러는 더 이상 매 틱 URL/api key/secret을 재대입하지 않는다.
+    이 값들은 연결 수립 경로(_get_approval_key/_establish_connection)에서만 설정된다."""
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+
+    api._handle_websocket_message(_make_realtime_price_message())
+
+    assert api._websocket_url is None
+    assert api._base_rest_url is None
+    assert api._rest_api_key is None
+    assert api._rest_api_secret is None
+
+
+def test_handle_message_caches_realtime_tr_ids(websocket_api_instance):
+    """핫패스 최적화: 실시간 TR_ID를 1회 캐싱해 매 틱 깊은 dict 조회를 제거한다."""
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+
+    api._handle_websocket_message(_make_realtime_price_message())
+
+    assert api._rt_tr_realtime_price == "H0STCNT0"
+    assert api._rt_tr_realtime_quote == "H0STASP0"
+    assert api._rt_tr_unified_realtime_price == "H0UNCNT0"
+    assert "H0STPGM0" in api._rt_program_trading_tr_ids
+
+
+def test_handle_message_uses_cached_tr_ids_after_config_mutation(websocket_api_instance):
+    """캐시 이후 active_config가 바뀌어도 같은 연결에서는 재조회하지 않는다(깊은 조회 제거 증거)."""
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+
+    api._handle_websocket_message(_make_realtime_price_message())
+    # 같은 연결 중 config가 바뀌어도 캐시는 유지된다
+    api._env.active_config['tr_ids']['websocket']['realtime_price'] = "H0XXXXX0"
+
+    api._handle_websocket_message(_make_realtime_price_message("H0STCNT0"))
+
+    # 여전히 캐시된 H0STCNT0 으로 realtime_price 분기를 탄다
+    assert api.on_realtime_message_callback.call_args[0][0]['type'] == 'realtime_price'
+    assert api._rt_tr_realtime_price == "H0STCNT0"
+
+
+def test_cache_realtime_tr_ids_refreshes_on_reconnect(websocket_api_instance):
+    """연결 재수립 시 환경 전환을 반영하도록 캐시를 강제 갱신한다."""
+    api = websocket_api_instance
+    api._cache_realtime_tr_ids()
+    assert api._rt_tr_realtime_quote == "H0STASP0"
+
+    api._env.active_config['tr_ids']['websocket']['realtime_quote'] = "H0NEWASP0"
+    api._cache_realtime_tr_ids()
+
+    assert api._rt_tr_realtime_quote == "H0NEWASP0"
+
+
+def test_handle_message_debug_logging_is_lazy(websocket_api_instance):
+    """debug 로그는 %s 파라미터화로 지연 포맷팅한다(큰 parsed_data repr을 매 틱 만들지 않는다)."""
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+
+    api._handle_websocket_message(_make_realtime_price_message())
+
+    parse_log_calls = [
+        c for c in api._logger.debug.call_args_list
+        if c.args and isinstance(c.args[0], str) and "WS 수신 데이터 파싱" in c.args[0]
+    ]
+    assert parse_log_calls, "파싱 debug 로그가 호출되어야 한다"
+    call = parse_log_calls[0]
+    # f-string(단일 인자)이 아니라 %s 파라미터 형태여야 한다
+    assert "%s" in call.args[0]
+    assert len(call.args) > 1
+    assert any(isinstance(a, dict) for a in call.args[1:])
+
+
 # _handle_websocket_message: 성공적인 주식 호가(H0STASP0) 파싱 테스트
 def test_handle_websocket_message_realtime_quote_success(websocket_api_instance):
     api = websocket_api_instance

--- a/tests/unit_test/task/background/after_market/test_minervini_update_task.py
+++ b/tests/unit_test/task/background/after_market/test_minervini_update_task.py
@@ -447,6 +447,27 @@ async def test_load_all_stocks_skips_empty_code():
 
 
 @pytest.mark.asyncio
+async def test_load_all_stocks_preserves_order_and_all_markets():
+    """벡터화(zip) 후에도 df 순서를 보존하고 시장 구분에 무관하게 빈 코드만 제외한다."""
+    rows = [
+        {"종목코드": "0001", "종목명": "A", "시장구분": "KOSPI"},
+        {"종목코드": "", "종목명": "빈코드", "시장구분": "KOSDAQ"},
+        {"종목코드": "0003", "종목명": "C", "시장구분": "KONEX"},
+        {"종목코드": "0002", "종목명": "B", "시장구분": "KOSDAQ"},
+    ]
+    task = MinerviniUpdateTask(
+        minervini_service=DummyMinerviniSvc({}),
+        stock_code_repository=DummyStockCodeRepo(rows),
+    )
+    # KONEX도 포함(_load_all_stocks는 시장 필터링하지 않음), 빈 코드만 제외, 순서 보존
+    assert task._load_all_stocks() == [
+        ("0001", "A", "KOSPI"),
+        ("0003", "C", "KONEX"),
+        ("0002", "B", "KOSDAQ"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_refresh_skips_when_already_refreshing():
     """_is_refreshing=True 이면 refresh 즉시 리턴 (L130-L131)"""
     task = MinerviniUpdateTask(

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -657,6 +657,32 @@ def test_load_all_stocks_skips_blank_and_non_target_market(bg_service, mock_deps
     assert bg_service._load_all_stocks() == [("000660", "SK하이닉스", "KOSPI")]
 
 
+def test_load_all_stocks_preserves_df_order_after_filtering(bg_service, mock_deps):
+    """벡터화(zip) 후에도 결과 tuple 목록이 df 순서를 보존하고 모든 제외 조건이 유지된다."""
+    _, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([
+        ("000660", "SK하이닉스", "KOSPI"),
+        ("005935", "삼성전자우", "KOSPI"),   # 우선주(끝자리 0 아님) 제외
+        ("069500", "KODEX 200", "KOSPI"),    # ETF 접두사 제외
+        ("035420", "NAVER", "KOSPI"),
+        ("123456", "케이스팩", "KOSDAQ"),    # 스팩 제외
+        ("005930", "삼성전자", "KONEX"),     # 비대상 시장 제외
+        ("000270", "기아", "KOSDAQ"),
+    ])
+    assert bg_service._load_all_stocks() == [
+        ("000660", "SK하이닉스", "KOSPI"),
+        ("035420", "NAVER", "KOSPI"),
+        ("000270", "기아", "KOSDAQ"),
+    ]
+
+
+def test_load_all_stocks_empty_df_returns_empty(bg_service, mock_deps):
+    """행이 없는 df(컬럼만 존재)에서도 안전하게 빈 목록을 반환한다."""
+    _, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([])
+    assert bg_service._load_all_stocks() == []
+
+
 @pytest.mark.asyncio
 async def test_on_start_hook_and_suspend_resume_noop_states(bg_service):
     """시작 hook은 suspend event를 세팅하고, 상태가 맞지 않으면 suspend/resume은 no-op이다."""

--- a/todo_list.md
+++ b/todo_list.md
@@ -26,7 +26,7 @@
 - P2 2-2: ~~실제 KIS 계정별 REST/WebSocket 유량 한도 재확인 후 budget 기본값 보정.~~ 전역 normal 8/s + emergency 2/s 기본값 보정 완료. 계정별 공식 한도 재확인은 운영 전 외부 확인으로 유지.
 - P2 2-4: VBO shadow 5거래일 jsonl 수집 → polling parity 비교. event-driven live order는 별도 승인 전 No-Go.
 - P2 2-5: ~~전략 scan의 종목별 현재가 REST 호출을 batch quote / WebSocket snapshot 중심으로 줄인다.~~ helper(`StockQueryService.prefetch_prices`) + rsi2 포함 활성 전략 7개 scan 배선 + 테스트 완료.
-- P2 2-6: 라이브 핫패스 성능 follow-up. WebSocket 틱 루프 상수 캐싱/로그 lazy 처리, 활성 전략 scan/check_exits 순차 후보 처리 개선, 장마감 배치 `iterrows()` 축소, HTTP/token 미세 정합성 개선.
+- P2 2-6: 라이브 핫패스 성능 follow-up. ~~WebSocket 틱 루프 상수 캐싱/로그 lazy 처리~~ ✅, ~~장마감 배치 `iterrows()` 축소~~ ✅, ~~HTTP/token 미세 정합성 개선(fallback Limits·Timeout / token singleflight / retry jitter)~~ ✅ (2026-05-31). 남은 것: 활성 전략 `scan()`/`check_exits()` 순차 후보 처리 bounded 전환 — 실전 진입/청산 경로라 별도 승인 후 진행(VBO scan은 실익 marginal로 보류 결정).
 - P3 3-4: active strategy lifecycle contract 최소 공통 단계 강제 여부 재설계(현재 보류).
 - P3 3-5: backtest/live 호가단위 tick-size 로직을 단일 utility로 통일한다.
 - P3 3-6: ~~IndicatorService 계산 경로의 광범위 `except Exception` silent skip에 ERROR log/metric/alert hook을 붙인다.~~ ✅ 완료. 전략 레이어 per-code fail-rate metric도 `scan_metrics`/`exit_metrics`에 반영 완료.
@@ -331,8 +331,9 @@
   - 적용 완료: `_handle_websocket_message()`에서 (1) 미사용 REST 속성(`_websocket_url`/`_base_rest_url`/`_rest_api_key`/`_rest_api_secret`) 틱당 재대입 제거, (2) `realtime_price`/`unified_realtime_price`/`realtime_quote`/program trading TR_ID를 `_cache_realtime_tr_ids()`로 1회 캐싱(첫 메시지 lazy + 재연결 시 무효화→재해석), (3) debug 로그를 `%s` 파라미터화로 전환해 매 틱 `parsed_data` repr/깊은 dict 조회 제거.
   - 보존: `realtime_price`/`realtime_quote` 필수 키 누락 시 KeyError fail-fast 그대로 유지(상위 재연결 경로). 캐시 속성 bracket 접근으로 회귀 테스트 통과.
   - 테스트 고정: `test_handle_message_does_not_reassign_rest_attrs_per_tick`, `test_handle_message_caches_realtime_tr_ids`, `test_handle_message_uses_cached_tr_ids_after_config_mutation`, `test_cache_realtime_tr_ids_refreshes_on_reconnect`, `test_handle_message_debug_logging_is_lazy`. 단위 5729 passed / 통합 240 passed.
-- [ ] 활성 라이브 전략의 `scan()` 후보 처리 중 남은 순차 REST/보강 호출을 전략별로 재분류하고, 필요한 곳만 `bounded_gather`로 전환한다.
+- [~] 활성 라이브 전략의 `scan()` 후보 처리 중 남은 순차 REST/보강 호출을 전략별로 재분류하고, 필요한 곳만 `bounded_gather`로 전환한다.
   - 우선 대상: `LarryWilliamsVBOStrategy.scan()` 후보 루프. 이미 `prefetch_prices()`와 range cache `bounded_gather()`는 적용되어 있지만, 후보별 현재가/체결강도/변동성 보강 호출은 순차 흐름이 남아 있다.
+  - 검토 결과(2026-05-31, 보류): 저비용 단계(현재가는 `prefetch_prices` 덕에 대부분 snapshot hit)에서 대다수 후보가 탈락하고, 고비용 REST(`_get_execution_strength`)는 가격 게이트 통과한 돌파 후보(소수)에만 발생. 게다가 전역 `ApiBudgetLimiter`가 모든 REST를 8/s로 직렬화하므로 bounded 전환의 실익은 "동시 돌파 후보 多"일 때의 직렬 RTT 누적 감소뿐(marginal). 실전 진입 경로 동등성(순서/시그널 수/`_bought_today`) 검증 부담 대비 이득이 작아 보류. 재개 시 2-pass(돌파 후보만 `execution_strength` bounded)가 가장 외과적.
   - 주의: `MomentumStrategy.run()`과 `GapUpPullbackStrategy.run()`도 순차 N+1이 맞지만 현재 웹 라이브 스케줄러 등록 대상이 아니므로, 라이브 핫패스 최우선 항목으로 일반화하지 않는다.
   - 검증 기준: 결과 순서/시그널 수/거절 사유/`_bought_today` state 변화가 기존과 동등하고, 동시성 limit은 KIS budget limiter 기본값과 충돌하지 않는다.
 - [ ] 활성 전략 `check_exits()` 순차 루프를 계산 경로별로 점검하고, 보유 종목 수가 늘어나는 경로는 bounded 처리로 통일한다.
@@ -460,8 +461,8 @@
 
 2. **코드 수정으로 바로 진행 가능**
    - ~~WebSocket 틱 루프 TR_ID 캐싱 + debug lazy logging 적용 (P2 2-6)~~ ✅ 완료 (2026-05-31)
-   - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 여부 검증 후 적용 (P2 2-6)
-   - 활성 전략 `check_exits()` 순차 holdings 루프를 bounded 처리로 통일할지 전략별 적용 (P2 2-6)
+   - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 (P2 2-6) — 2026-05-31 검토 후 **보류**(실익 marginal·실전 진입 경로). 재개 시 2-pass 권장.
+   - 활성 전략 `check_exits()` 순차 holdings 루프 bounded 통일 (P2 2-6) — 실전 청산 경로라 별도 승인 후 진행.
    - ~~장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)~~ ✅ 완료 (2026-05-31, zip 순회). FDR/RS line 변환 경로는 영향 작아 보류.
    - ~~`KoreaInvestApiBase` fallback client Limits/Timeout + retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)~~ ✅ 완료 (2026-05-31). JSON 이중 파싱 제거는 MagicMock 충돌/이득 미미로 보류.
    - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 — 나머지 전략 MA/RSI rollout 후속

--- a/todo_list.md
+++ b/todo_list.md
@@ -339,10 +339,11 @@
   - 확인: `sell_all_stocks()`에는 이미 `SAFE_SEQUENTIAL` / `BOUNDED_PARALLEL` / `EMERGENCY` 모드가 있으며, `EMERGENCY` unbounded gather는 `emergency_scope()`를 사용하는 의도적 경로다. 리뷰의 "exit unbounded gather"는 이 경로보다 전략별 `check_exits()` 순차 계산 개선으로 재정의한다.
   - 우선 대상: `LarryWilliamsVBOStrategy`, `ProgramBuyFollowStrategy`, `VolumeBreakoutLiveStrategy`, `TraditionalVolumeBreakoutStrategy`의 순차 holdings 루프. 단, 현재 웹 등록 활성 전략은 VBO 중심으로 먼저 적용한다.
   - 검증 기준: 손절/익절/시간청산 신호 생성 결과가 기존과 동등하고, per-code 예외가 다른 보유 종목 exit 판단을 막지 않는다.
-- [ ] 장마감 배치의 `iterrows()` 사용처를 API 호출 전처리와 단순 포맷 변환으로 나눠 낮은 위험부터 개선한다.
-  - 우선 대상: `OneilUniverseService._generate_premium_watchlist()`, `RankingTask._load_all_stocks()`, `MinerviniUpdateTask._load_all_stocks()`의 전체 종목 필터링 루프.
-  - 낮은 우선순위: FDR OHLCV 포맷 변환(`DailyPriceCollectorTask`, `OhlcvUpdateTask`)과 RS line 결과 변환(`RSRatingService`)은 장마감/소규모 변환 경로라 성능 영향이 작다.
-  - 검증 기준: 필터링 결과 tuple 목록이 기존과 동일하고 ETF/우선주/스팩 제외 조건이 유지된다.
+- [~] 장마감 배치의 `iterrows()` 사용처를 API 호출 전처리와 단순 포맷 변환으로 나눠 낮은 위험부터 개선한다.
+  - 적용 완료(2026-05-31): 전체 종목 필터링 루프 3곳(`OneilUniverseService._generate_premium_watchlist()`, `RankingTask._load_all_stocks()`, `MinerviniUpdateTask._load_all_stocks()`)의 `iterrows()`를 컬럼 리스트 추출 후 `zip` 순회로 전환. 행마다 Series 생성하던 비용 제거. `row.get(col, "")` 시맨틱(컬럼 부재→"") 보존, 필터 순서/조건 불변.
+  - 테스트 고정: ranking `test_load_all_stocks_preserves_df_order_after_filtering`/`test_load_all_stocks_empty_df_returns_empty`, minervini `test_load_all_stocks_preserves_order_and_all_markets`. 기존 ETF/우선주/스팩/빈코드/비대상시장 테스트 회귀 통과. 단위 5732 passed / 통합 240 passed.
+  - 낮은 우선순위(미적용): FDR OHLCV 포맷 변환(`DailyPriceCollectorTask`, `OhlcvUpdateTask`)과 RS line 결과 변환(`RSRatingService`)은 장마감/소규모 변환 경로라 성능 영향이 작아 보류.
+  - 검증 기준: 필터링 결과 tuple 목록이 기존과 동일하고 ETF/우선주/스팩 제외 조건이 유지된다. (충족)
 - [ ] HTTP/token 미세 정합성 개선은 별도 작은 PR로 묶는다.
   - 대상: `KoreaInvestApiBase._execute_request()` / `_handle_response()`의 JSON 이중 파싱 제거, fallback `httpx.AsyncClient`에 shared client와 같은 `Limits`/`Timeout` 적용, `TokenProvider.get_access_token()` double-checked `asyncio.Lock` 추가, retry jitter 추가.
   - 주의: `http2=True`는 KIS 지원 여부가 불확실하므로 측정/공식 확인 전 적용하지 않는다.
@@ -459,7 +460,7 @@
    - ~~WebSocket 틱 루프 TR_ID 캐싱 + debug lazy logging 적용 (P2 2-6)~~ ✅ 완료 (2026-05-31)
    - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 여부 검증 후 적용 (P2 2-6)
    - 활성 전략 `check_exits()` 순차 holdings 루프를 bounded 처리로 통일할지 전략별 적용 (P2 2-6)
-   - 장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)
+   - ~~장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)~~ ✅ 완료 (2026-05-31, zip 순회). FDR/RS line 변환 경로는 영향 작아 보류.
    - `KoreaInvestApiBase` JSON 파싱/fallback client/retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)
    - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 — 나머지 전략 MA/RSI rollout 후속
    - ~~라이브 exit net PnL 통일 (P0 0-9)~~ ✅ #479

--- a/todo_list.md
+++ b/todo_list.md
@@ -344,10 +344,12 @@
   - 테스트 고정: ranking `test_load_all_stocks_preserves_df_order_after_filtering`/`test_load_all_stocks_empty_df_returns_empty`, minervini `test_load_all_stocks_preserves_order_and_all_markets`. 기존 ETF/우선주/스팩/빈코드/비대상시장 테스트 회귀 통과. 단위 5732 passed / 통합 240 passed.
   - 낮은 우선순위(미적용): FDR OHLCV 포맷 변환(`DailyPriceCollectorTask`, `OhlcvUpdateTask`)과 RS line 결과 변환(`RSRatingService`)은 장마감/소규모 변환 경로라 성능 영향이 작아 보류.
   - 검증 기준: 필터링 결과 tuple 목록이 기존과 동일하고 ETF/우선주/스팩 제외 조건이 유지된다. (충족)
-- [ ] HTTP/token 미세 정합성 개선은 별도 작은 PR로 묶는다.
-  - 대상: `KoreaInvestApiBase._execute_request()` / `_handle_response()`의 JSON 이중 파싱 제거, fallback `httpx.AsyncClient`에 shared client와 같은 `Limits`/`Timeout` 적용, `TokenProvider.get_access_token()` double-checked `asyncio.Lock` 추가, retry jitter 추가.
+- [~] HTTP/token 미세 정합성 개선은 별도 작은 PR로 묶는다.
+  - 적용 완료(2026-05-31): (a) fallback `httpx.AsyncClient`에 shared client(`korea_invest_client`)와 동일한 `Limits(max_keepalive=50, max_conn=100, keepalive_expiry=30)`/`Timeout(10.0, connect=5.0)` 적용. (b) `TokenProvider.get_access_token()` double-checked `asyncio.Lock`(`_issue_lock`) singleflight — 동시 호출 중복 발급(EGW00133) 방지. (c) `call_api` 지수 백오프에 bounded jitter(`_RETRY_JITTER_FRACTION=0.25`) 추가 — 명시 delay(`e.delay>0`) 경로는 불변.
+  - 보류(근거): JSON 이중 파싱(`_execute_request` + `_handle_response`의 `response.json()` 2회) 제거는 MagicMock 응답 테스트와 충돌(MagicMock이 임의 속성 자동 생성 → 응답 객체 속성 캐싱 불가)하고, 이중 EGW00123 처리 경로를 건드릴 위험 대비 이득이 미미(작은 JSON 2회 파싱=마이크로초)해 단순성 원칙상 보류. weakref 캐시 도입은 과한 복잡도.
+  - 테스트 고정: `test_fallback_async_client_uses_shared_limits_and_timeout`, `test_get_access_token_singleflight_under_concurrency`(conftest의 `asyncio.sleep` 패치를 우회하는 raw yield로 실제 동시성 검증), `test_call_api_retry_backoff_applies_bounded_jitter`(`random.uniform` 고정 patch). 기존 429/500 retry 테스트는 jitter 범위 단언으로 갱신. 단위 5735 passed / 통합 240 passed.
   - 주의: `http2=True`는 KIS 지원 여부가 불확실하므로 측정/공식 확인 전 적용하지 않는다.
-  - 검증 기준: token refresh, EGW00123 재시도, 429 retry, JSON parsing error 테스트가 기존 contract를 유지한다.
+  - 검증 기준: token refresh, EGW00123 재시도, 429 retry, JSON parsing error 테스트가 기존 contract를 유지한다. (충족)
 
 판단:
 
@@ -461,7 +463,7 @@
    - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 여부 검증 후 적용 (P2 2-6)
    - 활성 전략 `check_exits()` 순차 holdings 루프를 bounded 처리로 통일할지 전략별 적용 (P2 2-6)
    - ~~장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)~~ ✅ 완료 (2026-05-31, zip 순회). FDR/RS line 변환 경로는 영향 작아 보류.
-   - `KoreaInvestApiBase` JSON 파싱/fallback client/retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)
+   - ~~`KoreaInvestApiBase` fallback client Limits/Timeout + retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)~~ ✅ 완료 (2026-05-31). JSON 이중 파싱 제거는 MagicMock 충돌/이득 미미로 보류.
    - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 — 나머지 전략 MA/RSI rollout 후속
    - ~~라이브 exit net PnL 통일 (P0 0-9)~~ ✅ #479
    - ~~pending/reserved cash + 전 전략 same-symbol qty cap 반영 (P0 0-10)~~ ✅ 완료

--- a/todo_list.md
+++ b/todo_list.md
@@ -327,10 +327,10 @@
 
 ### 2-6. 라이브 핫패스 성능 리뷰 follow-up
 
-- [ ] WebSocket 수신 루프의 틱당 고정 비용을 줄인다.
-  - 확인된 병목: `KoreaInvestWebSocketApi._parse_message()`가 매 틱마다 TR_ID debug f-string을 즉시 평가하고, `active_config['tr_ids']['websocket']` 깊은 조회를 반복한다.
-  - 개선 방향: `realtime_price` / `unified_realtime_price` / `realtime_quote` / program trading TR_ID를 연결 또는 초기화 시 인스턴스 속성으로 캐싱한다. debug 로그는 `%s` lazy formatting 또는 `isEnabledFor(DEBUG)` guard를 사용한다.
-  - 검증 기준: 동일 메시지 입력에서 기존 `message_type`/parsed payload/콜백 contract가 유지되고, debug disabled 상태에서 불필요한 문자열 생성이 사라진다.
+- [x] WebSocket 수신 루프의 틱당 고정 비용을 줄인다. (2026-05-31 완료)
+  - 적용 완료: `_handle_websocket_message()`에서 (1) 미사용 REST 속성(`_websocket_url`/`_base_rest_url`/`_rest_api_key`/`_rest_api_secret`) 틱당 재대입 제거, (2) `realtime_price`/`unified_realtime_price`/`realtime_quote`/program trading TR_ID를 `_cache_realtime_tr_ids()`로 1회 캐싱(첫 메시지 lazy + 재연결 시 무효화→재해석), (3) debug 로그를 `%s` 파라미터화로 전환해 매 틱 `parsed_data` repr/깊은 dict 조회 제거.
+  - 보존: `realtime_price`/`realtime_quote` 필수 키 누락 시 KeyError fail-fast 그대로 유지(상위 재연결 경로). 캐시 속성 bracket 접근으로 회귀 테스트 통과.
+  - 테스트 고정: `test_handle_message_does_not_reassign_rest_attrs_per_tick`, `test_handle_message_caches_realtime_tr_ids`, `test_handle_message_uses_cached_tr_ids_after_config_mutation`, `test_cache_realtime_tr_ids_refreshes_on_reconnect`, `test_handle_message_debug_logging_is_lazy`. 단위 5729 passed / 통합 240 passed.
 - [ ] 활성 라이브 전략의 `scan()` 후보 처리 중 남은 순차 REST/보강 호출을 전략별로 재분류하고, 필요한 곳만 `bounded_gather`로 전환한다.
   - 우선 대상: `LarryWilliamsVBOStrategy.scan()` 후보 루프. 이미 `prefetch_prices()`와 range cache `bounded_gather()`는 적용되어 있지만, 후보별 현재가/체결강도/변동성 보강 호출은 순차 흐름이 남아 있다.
   - 주의: `MomentumStrategy.run()`과 `GapUpPullbackStrategy.run()`도 순차 N+1이 맞지만 현재 웹 라이브 스케줄러 등록 대상이 아니므로, 라이브 핫패스 최우선 항목으로 일반화하지 않는다.
@@ -456,7 +456,7 @@
    - 실제 KIS 계정별 REST/WebSocket 유량 한도 재확인 → 필요 시 `_global` 8/s + `_global.emergency` 2/s 운영값 조정 (P2 2-2; 공통 HTTP 경로 강제 주입과 보수 기본값은 적용 완료)
 
 2. **코드 수정으로 바로 진행 가능**
-   - WebSocket 틱 루프 TR_ID 캐싱 + debug lazy logging 적용 (P2 2-6)
+   - ~~WebSocket 틱 루프 TR_ID 캐싱 + debug lazy logging 적용 (P2 2-6)~~ ✅ 완료 (2026-05-31)
    - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 여부 검증 후 적용 (P2 2-6)
    - 활성 전략 `check_exits()` 순차 holdings 루프를 bounded 처리로 통일할지 전략별 적용 (P2 2-6)
    - 장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)


### PR DESCRIPTION
@
## 개요

P2 2-6(라이브 핫패스 성능 follow-up) 중 **실전 주문/청산 경로를 건드리지 않는** 외과적 성능·정합성 개선 3건. 각 항목 TDD로 contract 고정.

## 변경 (4 commits)

### 1. WebSocket 틱 루프 상수 캐싱 + debug lazy logging
`_handle_websocket_message()` 핫패스에서:
- 미사용 REST 속성(`_websocket_url`/`_base_rest_url`/`_rest_api_key`/`_rest_api_secret`) 틱당 재대입 제거
- `realtime_price`/`unified_realtime_price`/`realtime_quote`/program TR_ID를 `_cache_realtime_tr_ids()`로 1회 캐싱(첫 메시지 lazy + 재연결 시 무효화→재해석)
- debug 로그 `%s` 파라미터화 → 매 틱 `parsed_data` repr/깊은 dict 조회 제거
- 필수 키 누락 시 KeyError fail-fast 보존

### 2. 장마감 배치 `iterrows()` → `zip` 순회 벡터화
`RankingTask`/`MinerviniUpdateTask._load_all_stocks`, `OneilUniverseService._generate_premium_watchlist`의 전체 종목 필터링에서 행당 Series 생성 비용 제거. `row.get(col, "")` 시맨틱·필터 조건·결과 순서 불변.

### 3. HTTP/token 미세 정합성
- fallback `httpx.AsyncClient`에 shared client와 동일한 `Limits`/`Timeout` 적용
- `TokenProvider.get_access_token` double-checked `asyncio.Lock`(singleflight) — 동시 호출 중복 발급(EGW00133) 방지
- `call_api` 지수 백오프에 bounded jitter(0~25%) — thundering herd 분산. 명시 delay 경로는 불변
- JSON 이중 파싱 제거는 MagicMock 충돌 + 이득 미미로 **보류**(근거 todo 기록)

### 4. todo_list 현황 정확 반영

## 보류한 잔여 2-6 항목 (실전 경로, 별도 승인 필요)
- VBO `scan()` bounded 전환 — 검토 결과 실익 marginal(budget limiter가 이미 8/s 직렬화), 보류
- 활성 전략 `check_exits()` bounded — 실전 청산 경로

## 테스트
신규 테스트 9종 + 기존 retry 테스트 jitter 범위 단언 갱신. **단위 5735 passed / 통합 240 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@