### PR TITLE
fix(P0 0-8): 채널 돌파 전략 라이브 ADX/채널에서 당일 미확정 봉 제외

### DIFF
--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -163,7 +163,8 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
                 "reason": "ohlcv_unavailable",
             })
             return None
-        ohlcv = ohlcv_resp.data
+        # P0 0-8: get_ohlcv는 장중 당일 미확정 봉을 붙이므로 ADX/채널 baseline에서 제외한다.
+        ohlcv = self._confirmed_bars(ohlcv_resp.data)
 
         # Phase 1-1: ADX(14) ≥ threshold + 우상향
         adx_result = self._indicator.calc_adx_sync(
@@ -371,7 +372,8 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
         if state:
             ohlcv_resp = await self._sqs.get_ohlcv(code, period="D", caller=self.name)
             if ohlcv_resp and ohlcv_resp.rt_cd == "0" and ohlcv_resp.data:
-                new_low = self._calc_channel_low(ohlcv_resp.data, period=self._cfg.channel_low_period)
+                # P0 0-8: 당일 미확정 봉 저가가 trailing stop 갱신을 막지 않도록 확정봉만 사용.
+                new_low = self._calc_channel_low(self._confirmed_bars(ohlcv_resp.data), period=self._cfg.channel_low_period)
                 if new_low > state.channel_low_10d:
                     state.channel_low_10d = new_low
                     self._logger.debug({
@@ -383,6 +385,16 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
         return (None, False)
 
     # ── helpers ─────────────────────────────────────────────────────
+
+    def _confirmed_bars(self, ohlcv: list) -> list:
+        """P0 0-8: 라이브 호출 시 get_ohlcv가 장중 붙이는 당일 미확정 봉을 제외한다.
+        마지막 행 date가 오늘(KST)이면 그 행을 떼고 확정봉만 반환한다."""
+        if not ohlcv:
+            return ohlcv
+        today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        if str(ohlcv[-1].get("date", "")) == today_str:
+            return ohlcv[:-1]
+        return ohlcv
 
     @staticmethod
     def _extract_current_price(resp) -> int:

--- a/tests/unit_test/strategies/test_larry_williams_channel_breakout_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_channel_breakout_strategy.py
@@ -319,6 +319,62 @@ async def test_check_single_exit_skips_missing_code_and_bad_price(exit_setup):
     assert await strategy._check_single_exit({"code": "005930"}) is None
 
 
+# ── P0 0-8: 당일 미확정 봉 제외 ───────────────────────────────────
+
+def _ohlcv_with_today(today_str, n_confirmed=34, confirmed_low=12500, today_low=50):
+    """확정봉 n개(date < today) + 마지막에 당일(미확정) 봉 1개.
+    get_ohlcv가 장중 붙이는 today 행을 모사한다. today_low는 채널/ADX를 오염시키는 극단값."""
+    data = []
+    for i in range(n_confirmed):
+        data.append({
+            "date": f"2024{(i // 28) + 1:02d}{(i % 28) + 1:02d}",
+            "open": 13000, "high": 13100,
+            "low": confirmed_low, "close": 13000, "volume": 150000,
+        })
+    data.append({
+        "date": today_str,
+        "open": 13000, "high": 14000,
+        "low": today_low, "close": 13500, "volume": 90000,
+    })
+    return ResCommonResponse(rt_cd="0", msg1="OK", data=data)
+
+
+@pytest.mark.asyncio
+async def test_check_entry_excludes_today_bar_from_adx_and_channel(scan_setup):
+    """라이브 진입: get_ohlcv가 붙인 당일 미확정 봉을 ADX/채널 하단 계산에서 제외한다."""
+    strategy, sqs, _, indicator, tm = scan_setup
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 2, 15, 15, 0)  # today=20250102
+    sqs.get_ohlcv.return_value = _ohlcv_with_today("20250102", confirmed_low=12500, today_low=50)
+
+    sig = await strategy._check_entry("005930", _watchlist_item())
+
+    assert sig is not None and sig.action == "BUY"
+    # calc_adx_sync에는 당일 봉이 빠진 확정봉만 전달되어야 한다
+    passed_ohlcv = indicator.calc_adx_sync.call_args.args[0]
+    assert all(row["date"] != "20250102" for row in passed_ohlcv)
+    # 채널 하단/칼손절이 당일 극단 저가(50)에 오염되지 않고 확정봉(12500) 기준으로 계산
+    state = strategy._position_state["005930"]
+    assert state.channel_low_10d == 12500
+    assert state.hard_stop_price >= 12500
+
+
+@pytest.mark.asyncio
+async def test_check_exits_trailing_update_excludes_today_bar(exit_setup):
+    """라이브 청산: trailing stop 상향 갱신도 당일 미확정 봉 저가를 제외한 확정봉 기준."""
+    strategy, sqs = exit_setup
+    strategy._tm.get_current_kst_time.return_value = datetime(2025, 1, 2, 15, 15, 0)
+    sqs.get_current_price.return_value = _price_resp(current="13500")  # 청산 미발동
+    # 확정봉 최근 10일 저가=12500, 당일 봉 저가=12000(오염값)
+    sqs.get_ohlcv.return_value = _ohlcv_with_today("20250102", confirmed_low=12500, today_low=12000)
+
+    holdings = [{"code": "005930", "name": "삼성전자", "buy_price": 12500, "qty": 3}]
+    signals = await strategy.check_exits(holdings)
+
+    assert signals == []
+    # 당일 저가(12000)가 아니라 확정봉 저가(12500)로 상향되어야 한다
+    assert strategy._position_state["005930"].channel_low_10d == 12500
+
+
 # ── 헬퍼 / 인터페이스 ────────────────────────────────────────────
 
 def test_name_property(mock_deps):

--- a/todo_list.md
+++ b/todo_list.md
@@ -16,7 +16,7 @@
 
 - P0 0-1: 실전 체결 이력 확보 후 broker order mapper 분리 + fixture 회귀 잠금.
 - P0 0-7: ~~canary 5% 노출 제한을 코드/config profile로 분리하고 real 기본 30%와 운영 혼동을 제거.~~ ✅ 완료 (2026-05-27).
-- P0 0-8: ~~라이브 전략 일봉 지표에서 당일 미완성 봉 제외 옵션을 도입한다.~~ ✅ 완료 (2026-05-28, #478). 지표 API + RSI2 + ATR sizing 적용. 나머지 전략 MA/RSI 라이브 호출 rollout은 후속.
+- P0 0-8: ~~라이브 전략 일봉 지표에서 당일 미완성 봉 제외 옵션을 도입한다.~~ ✅ 완료 (2026-05-28, #478 + rollout 조사). 지표 API + RSI2 + ATR sizing 적용. rollout 전수 조사 결과 추가 오염 경로는 `LarryWilliamsChannelBreakout`(ADX/채널)뿐이라 `_confirmed_bars()`로 마감.
 - P0 0-9: ~~라이브 손절/익절 판단을 gross PnL이 아닌 비용 반영 net PnL 기준으로 통일한다.~~ ✅ 완료 (2026-05-28, #479).
 - P0 0-10: ~~같은 사이클/이전 사이클의 신규 BUY에 대해 pending/reserved cash와 동일 종목 전 전략 합산 노출을 qty cap에 반영한다.~~ ✅ 완료.
 - P0 0-11: ~~kill switch 및 sync fallback state 저장을 atomic write로 통일한다.~~ ✅ 완료 (2026-05-28, #481).
@@ -83,9 +83,11 @@
 ### 0-8. 라이브 일봉 지표에서 당일 미완성 봉 제외 — ✅ 완료 (#478, 2026-05-28)
 
 - [x] `IndicatorService.get_rsi()`, `get_moving_average()`, `calculate_atr()`에 `exclude_today: bool = False` 옵션을 추가했다.
-- [~] 라이브 전략 호출 경로는 기본적으로 당일 미완성 봉을 제외하도록 변경한다.
+- [x] 라이브 전략 호출 경로는 기본적으로 당일 미완성 봉을 제외하도록 변경한다.
   - 적용 완료: RSI(2) 경로(`RSI2PullbackStrategy`)와 ATR 기반 sizing(`PositionSizingService` `exclude_today=True`).
-  - 후속: 그 외 활성 전략의 MA/RSI 라이브 호출은 아직 `exclude_today`를 전달하지 않는다. 해당 전략이 일봉 지표로 라이브 신호를 내는 경로만 선별 적용 필요.
+  - 적용 완료(rollout 조사 후): 나머지 활성 전략을 전수 조사한 결과, 당일 미확정 봉이 라이브 신호를 오염시키는 곳은 `LarryWilliamsChannelBreakoutStrategy` 하나뿐이었다. 유일하게 `get_ohlcv(period="D")`(장중 당일봉 병합)를 ADX(`calc_adx_sync`)/채널 하단(`_calc_channel_low`) 계산에 그대로 넘기던 경로를 `_confirmed_bars()`(마지막 행 date==오늘이면 제외)로 차단했다. 진입(`_check_entry`)·청산 trailing 갱신(`check_exits`) 양쪽 적용. 돌파 트리거(`current > item.high_20d`, 확정 watchlist 값)는 불변.
+  - 조사 결과(미적용 사유): `RSI2Pullback`=이미 처리, `FirstPullback`=진입 `end_date=어제`/exit `get_recent_daily_ohlcv` DB-first 확정봉, `OneilSqueezeBreakout`=exit DB-first 확정봉, `OneilPocketPivot`=`today_candle` 의도적 병합, `HighTightFlag`=`get_recent_daily_ohlcv` DB-first 확정봉, `LarryWilliamsVBO`=전일 range only. 핵심: `get_recent_daily_ohlcv`는 장중 DB-first라 확정봉만 반환하고, `get_ohlcv`만 당일 미확정 봉을 붙인다.
+  - 테스트 고정: `test_larry_williams_channel_breakout_strategy.py`의 `test_check_entry_excludes_today_bar_from_adx_and_channel`, `test_check_exits_trailing_update_excludes_today_bar`. 단위 5737 passed / 통합 240 passed.
 - [x] 차트/리포트 UI 등 장중 현재 봉 표시가 필요한 경로는 기본값 `exclude_today=False`로 기존 동작을 유지한다.
 - [x] 테스트: 장중 today row 병합 시에도 라이브 지표 호출이 전일 확정 봉까지만 사용함을 `test_indicator_service.py`에 고정했다.
 
@@ -465,7 +467,7 @@
    - 활성 전략 `check_exits()` 순차 holdings 루프 bounded 통일 (P2 2-6) — 실전 청산 경로라 별도 승인 후 진행.
    - ~~장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)~~ ✅ 완료 (2026-05-31, zip 순회). FDR/RS line 변환 경로는 영향 작아 보류.
    - ~~`KoreaInvestApiBase` fallback client Limits/Timeout + retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)~~ ✅ 완료 (2026-05-31). JSON 이중 파싱 제거는 MagicMock 충돌/이득 미미로 보류.
-   - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 — 나머지 전략 MA/RSI rollout 후속
+   - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 + rollout 조사 완료 (추가 오염은 `LarryWilliamsChannelBreakout` ADX/채널뿐 → `_confirmed_bars()`로 마감)
    - ~~라이브 exit net PnL 통일 (P0 0-9)~~ ✅ #479
    - ~~pending/reserved cash + 전 전략 same-symbol qty cap 반영 (P0 0-10)~~ ✅ 완료
    - ~~kill switch/state sync fallback atomic write 통일 (P0 0-11)~~ ✅ #481


### PR DESCRIPTION
라이브 일봉 지표 rollout 전수 조사 결과, 당일 미확정 봉이 신호를
오염시키는 활성 전략은 LarryWilliamsChannelBreakout 하나뿐이었다.
get_ohlcv(period="D")는 장중 _fetch_today_ohlcv로 당일 봉을 붙이는데, 이 전략만 그 결과를 calc_adx_sync(ADX)와 _calc_channel_low(채널 하단, hard_stop/trailing)에 그대로 넘기고 있었다.

_confirmed_bars()(마지막 행 date==오늘(KST)이면 제외)를 추가해
_check_entry와 check_exits trailing 갱신 양쪽에 적용. 돌파 트리거 (current > item.high_20d)는 확정 watchlist 값이라 불변.

나머지 활성 전략은 미적용: RSI2=처리 완료, FirstPullback/
OneilSqueezeBreakout/HighTightFlag=get_recent_daily_ohlcv DB-first 확정봉, OneilPocketPivot=today_candle 의도적 병합, VBO=전일 range only.

테스트: test_check_entry_excludes_today_bar_from_adx_and_channel, test_check_exits_trailing_update_excludes_today_bar. 단위 5737 passed / 통합 240 passed.