### PR TITLE
VBO 시가/현재가 0: 단순히 스냅샷 우회만 한 게 아니라, 상세 현재가의 open/stck_oprc가 0이면 당일 정규장…

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -358,7 +358,11 @@ class OneilUniverseService:
         if logger: logger.debug({"event": "pass_trend", "code": code, "reason": "uptrend_and_volume_ok"})
 
         # 필터: 52주 고가 근접
-        full_resp = await self._sqs.get_current_price(code, caller="OneilUniverseService")
+        full_resp = await self._sqs.get_current_price(
+            code,
+            caller="OneilUniverseService",
+            allow_snapshot=False,
+        )
         if not full_resp or full_resp.rt_cd != ErrorCode.SUCCESS.value:
             if logger: logger.debug({"event": "drop", "code": code, "reason": "current_price_api_fail"})
             return None
@@ -472,7 +476,11 @@ class OneilUniverseService:
             return None
 
         # 3. 실시간 현재가/거래량 조회 (어차피 스캔 시 필요한 데이터)
-        full_resp = await self._sqs.get_current_price(code, caller="OneilUniverseService")
+        full_resp = await self._sqs.get_current_price(
+            code,
+            caller="OneilUniverseService",
+            allow_snapshot=False,
+        )
         if not full_resp or full_resp.rt_cd != ErrorCode.SUCCESS.value:
             return None
         output = full_resp.data.get("output")
@@ -559,7 +567,11 @@ class OneilUniverseService:
             return None
 
         # 필터: 52주 고가 근접
-        full_resp = await self._sqs.get_current_price(code, caller="OneilUniverseService")
+        full_resp = await self._sqs.get_current_price(
+            code,
+            caller="OneilUniverseService",
+            allow_snapshot=False,
+        )
         if not full_resp or full_resp.rt_cd != ErrorCode.SUCCESS.value:
             if logger: logger.debug({"event": "drop", "code": code, "reason": "current_price_api_fail"})
             return None
@@ -660,7 +672,14 @@ class OneilUniverseService:
         passed_first = []
         processed_count = 0
         for chunk in _chunked(all_stocks, self._cfg.api_chunk_size):
-            tasks = [self._sqs.get_current_price(c, caller="OneilUniverseService") for c, _, _ in chunk]
+            tasks = [
+                self._sqs.get_current_price(
+                    c,
+                    caller="OneilUniverseService",
+                    allow_snapshot=False,
+                )
+                for c, _, _ in chunk
+            ]
             results = await asyncio.gather(*tasks, return_exceptions=True)
             for (code, name, market), resp in zip(chunk, results):
                 if isinstance(resp, Exception) or not resp or resp.rt_cd != ErrorCode.SUCCESS.value:

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -177,6 +177,7 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 price_resp = await self._sqs.handle_get_current_stock_price(
                     code,
                     caller=self.name,
+                    allow_snapshot=False,
                 )
                 if not price_resp or price_resp.rt_cd != ErrorCode.SUCCESS.value:
                     self._log_entry_rejected(log_data, "price_unavailable", "현재가 조회 실패")
@@ -185,7 +186,12 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 data = price_resp.data or {}
                 current = int(data.get("price", "0") or "0")
                 open_price = int(data.get("open", "0") or "0")
+                if current > 0 and open_price <= 0:
+                    open_price = await self._fetch_intraday_open_price(code, now)
+                    if open_price > 0:
+                        log_data["open_price_source"] = "intraday_minutes"
                 if current <= 0 or open_price <= 0:
+                    log_data.update({"current": current, "open": open_price})
                     self._log_entry_rejected(log_data, "invalid_price", "시가/현재가 0")
                     continue
 
@@ -571,6 +577,31 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
             return False
 
         return True
+
+    async def _fetch_intraday_open_price(self, code: str, now) -> int:
+        """상세 현재가 시가가 비어 있을 때 당일 첫 분봉 시가로 보강한다."""
+        try:
+            rows = await self._sqs.get_day_intraday_minutes_list(
+                code,
+                session="REGULAR",
+                start_hhmmss="090000",
+                end_hhmmss=now.strftime("%H%M%S"),
+            )
+        except Exception as e:
+            self._logger.debug({"event": "intraday_open_fallback_failed", "code": code, "error": str(e)})
+            return 0
+
+        for row in rows or []:
+            if not isinstance(row, dict):
+                continue
+            for key in ("stck_oprc", "open", "oprc", "stck_prpr", "price"):
+                try:
+                    value = int(float(row.get(key) or 0))
+                except (TypeError, ValueError):
+                    value = 0
+                if value > 0:
+                    return value
+        return 0
 
     async def _get_execution_strength(self, code: str) -> float:
         """체결강도(%) 스냅샷 1회 조회.

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1513,6 +1513,10 @@ async def test_analyze_surge_candidate_success_with_dict_output(mock_deps):
     item = await service._analyze_surge_candidate("005930", "Samsung", logger=logger)
 
     assert item is not None
+    assert sqs.get_current_price.await_args_list == [
+        call("005930", caller="OneilUniverseService", allow_snapshot=False),
+        call("005930", caller="OneilUniverseService", allow_snapshot=False),
+    ]
     assert item.market == "KOSPI"
     assert item.market_cap == 80000000000000
     assert item.w52_hgpr == 1500

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -61,6 +61,7 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         sqs.handle_get_current_stock_price = AsyncMock()
         sqs.prefetch_prices = AsyncMock(return_value=0)
         sqs.get_stock_conclusion = AsyncMock()
+        sqs.get_day_intraday_minutes_list = AsyncMock(return_value=[])
 
         tm = MagicMock()
         tm.get_current_kst_time.return_value = now_time or _kst(10, 0)
@@ -146,7 +147,7 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertIn("VBO돌파", signals[0].reason)
         sqs.prefetch_prices.assert_awaited_once_with(["005930"])
         sqs.handle_get_current_stock_price.assert_awaited_once_with(
-            "005930", caller=strategy.name
+            "005930", caller=strategy.name, allow_snapshot=False
         )
 
     # ── Target 미달 → 거절 ────────────────────────────────────────────
@@ -163,6 +164,36 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
 
         signals = await strategy.scan()
         self.assertEqual(signals, [])
+
+    async def test_scan_uses_intraday_open_fallback_when_current_price_open_is_zero(self):
+        """상세 현재가의 시가가 0이면 당일 첫 분봉 시가로 VBO 타깃을 계산한다."""
+        strategy, sqs, _ = self._make_strategy(now_time=_kst(10, 0), k_value=0.5)
+        sqs.get_top_trading_value_stocks.return_value = self._pool_b()
+        strategy._load_pool_b = AsyncMock(return_value=[{
+            "code": "005930", "name": "삼성전자", "market": "",
+            "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+        }])
+        sqs.get_recent_daily_ohlcv.return_value = _ohlcv_resp(high=72000, low=70000)
+        sqs.handle_get_current_stock_price.return_value = _price_resp(
+            current=72000, open_price=0,
+            pgtr_ntby_qty=700_000, acml_tr_pbmn=50_000_000_000,
+        )
+        sqs.get_day_intraday_minutes_list.return_value = [
+            {"stck_cntg_hour": "090000", "stck_oprc": "70000", "stck_prpr": "70100"},
+            {"stck_cntg_hour": "090100", "stck_oprc": "70100", "stck_prpr": "70200"},
+        ]
+        sqs.get_stock_conclusion.return_value = _conclusion_resp(130.0)
+
+        signals = await strategy.scan()
+
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(signals[0].code, "005930")
+        sqs.get_day_intraday_minutes_list.assert_awaited_once_with(
+            "005930",
+            session="REGULAR",
+            start_hhmmss="090000",
+            end_hhmmss="100000",
+        )
 
     # ── 체결강도 필터 ────────────────────────────────────────────────
 


### PR DESCRIPTION
… 분봉 09:00부터 조회해서 첫 유효 시가로 보강하도록 추가했습니다. larry_williams_vbo_strategy.py (line 187)

market_cap cap=0: 오닐 유니버스의 시총/52주고가/상태값처럼 상세 필드가 필요한 조회는 WebSocket snapshot을 쓰지 않고 REST 상세 응답을 강제하도록 막았습니다. oneil_universe_service.py (line 358) 검증도 완료했습니다.
관련 테스트: 100 passed
전체 단위 테스트: 5765 passed
통합 테스트: 240 passed, 기존 경고 2개만 있음