### PR TITLE
P0 0-1 후속 개선을 codex/p0-1-broker-order-mapper 브랜치에서 진행했습니다.

### DIFF
--- a/common/broker_order_response_mapper.py
+++ b/common/broker_order_response_mapper.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from common.types import Exchange, OrderExecutionReport, OrderSide, OrderState, ResCommonResponse
+
+
+class BrokerOrderResponseMapper:
+    """KIS order submit/query/signing payloads를 내부 주문 이벤트로 정규화한다."""
+
+    _ORDER_NO_KEYS = (
+        "ordno",
+        "order_no",
+        "odno",
+        "ORDNO",
+        "ORDER_NO",
+        "ODNO",
+        "ODER_NO",
+        "주문번호",
+    )
+
+    @classmethod
+    def extract_broker_order_no(cls, result: Optional[ResCommonResponse]) -> Optional[str]:
+        if not result or not result.data:
+            return None
+        if hasattr(result.data, "ordno"):
+            value = getattr(result.data, "ordno")
+            return str(value).strip() if value else None
+        if isinstance(result.data, dict):
+            return cls.extract_broker_order_no_from_dict(result.data)
+        return None
+
+    @classmethod
+    def extract_broker_order_no_from_dict(cls, data: dict) -> Optional[str]:
+        for key in cls._ORDER_NO_KEYS:
+            value = data.get(key)
+            if value:
+                return str(value).strip()
+        output = data.get("output")
+        if isinstance(output, dict):
+            return cls.extract_broker_order_no_from_dict(output)
+        return None
+
+    @classmethod
+    def from_signing_notice(cls, data: dict, *, tr_id: str = "") -> OrderExecutionReport:
+        side = cls._parse_side(data.get("매도매수구분") or data.get("SELN_BYOV_CLS"))
+        fill_qty = cls._to_int(data.get("체결수량") or data.get("CNTG_QTY"))
+        order_qty = cls._to_int(data.get("주문수량") or data.get("ODER_QTY")) or None
+        rejected = str(data.get("거부여부") or data.get("RFUS_YN") or "").upper() == "Y"
+        accepted = str(data.get("접수여부") or data.get("ACPT_YN") or "").upper() == "Y"
+        concluded = str(data.get("체결여부") or data.get("CNTG_YN") or "") == "2"
+
+        if rejected:
+            event_state = OrderState.REJECTED
+        elif concluded and order_qty and fill_qty >= order_qty:
+            event_state = OrderState.FILLED
+        elif concluded and fill_qty > 0:
+            event_state = OrderState.PARTIAL_FILLED
+        elif accepted:
+            event_state = OrderState.SUBMITTED
+        else:
+            event_state = OrderState.SUBMITTED
+
+        return OrderExecutionReport(
+            broker_order_no=str(data.get("주문번호") or data.get("ODER_NO") or "").strip(),
+            original_order_no=str(data.get("원주문번호") or data.get("OODER_NO") or "").strip() or None,
+            stock_code=str(data.get("주식단축종목코드") or data.get("STCK_SHRN_ISCD") or "").strip(),
+            side=side,
+            exchange=cls._parse_exchange(data.get("주문거래소구분") or data.get("ORD_EXG_GB")),
+            event_state=event_state,
+            order_qty=order_qty,
+            fill_qty=fill_qty,
+            fill_price=cls._to_int(data.get("체결단가") or data.get("CNTG_UNPR")),
+            event_time=str(data.get("주식체결시간") or data.get("STCK_CNTG_HOUR") or ""),
+            source=f"websocket:{tr_id}" if tr_id else "websocket",
+            message="거부" if rejected else ("체결" if concluded else "접수"),
+            raw=data,
+        )
+
+    @classmethod
+    def from_order_query(cls, data: dict, *, tr_id: str = "") -> OrderExecutionReport:
+        order_qty = cls._to_int(data.get("ord_qty") or data.get("ORD_QTY") or data.get("주문수량")) or None
+        filled_qty = cls._to_int(data.get("tot_ccld_qty") or data.get("TOT_CCLD_QTY") or data.get("체결수량"))
+        raw_remaining_qty = data.get("rmn_qty") or data.get("RMN_QTY") or data.get("잔여수량")
+        remaining_qty = cls._to_int(raw_remaining_qty) if raw_remaining_qty not in (None, "") else None
+        rejected_qty = cls._to_int(data.get("rjct_qty") or data.get("RJCT_QTY") or data.get("거부수량"))
+        canceled_qty = cls._to_int(data.get("cncl_cfrm_qty") or data.get("CNCL_CFRM_QTY") or data.get("취소확인수량"))
+        canceled = str(data.get("cncl_yn") or data.get("CNCL_YN") or "").upper() == "Y"
+
+        if rejected_qty and filled_qty == 0 and (order_qty is None or rejected_qty >= order_qty):
+            event_state = OrderState.REJECTED
+        elif canceled or (
+            canceled_qty
+            and (
+                remaining_qty == 0
+                or order_qty is None
+                or filled_qty + canceled_qty >= order_qty
+            )
+        ):
+            event_state = OrderState.CANCELED
+        elif order_qty and filled_qty >= order_qty:
+            event_state = OrderState.FILLED
+        elif remaining_qty is not None and remaining_qty == 0 and filled_qty > 0:
+            event_state = OrderState.FILLED
+        elif filled_qty > 0:
+            event_state = OrderState.PARTIAL_FILLED
+        else:
+            event_state = OrderState.SUBMITTED
+
+        event_time = str(
+            data.get("ord_dt")
+            or data.get("ORD_DT")
+            or data.get("주문일자")
+            or ""
+        ) + str(data.get("ord_tmd") or data.get("ORD_TMD") or data.get("주문시각") or "")
+
+        return OrderExecutionReport(
+            broker_order_no=str(data.get("odno") or data.get("ODNO") or data.get("주문번호") or "").strip(),
+            original_order_no=str(data.get("orgn_odno") or data.get("ORGN_ODNO") or data.get("원주문번호") or "").strip() or None,
+            stock_code=str(data.get("pdno") or data.get("PDNO") or data.get("종목코드") or "").strip(),
+            side=cls._parse_side(data.get("sll_buy_dvsn_cd") or data.get("SLL_BUY_DVSN_CD") or data.get("매도매수구분")),
+            exchange=cls._parse_exchange(
+                data.get("excg_id_dvsn_cd")
+                or data.get("EXCG_ID_DVSN_CD")
+                or data.get("excg_dvsn_cd")
+                or data.get("EXCG_DVSN_CD")
+                or data.get("거래소구분")
+            ),
+            event_state=event_state,
+            order_qty=order_qty,
+            fill_qty=filled_qty,
+            fill_price=cls._to_int(data.get("avg_prvs") or data.get("AVG_PRVS") or data.get("평균가")),
+            cumulative_filled_qty=filled_qty,
+            remaining_qty=remaining_qty,
+            event_time=event_time,
+            source=f"polling:{tr_id}" if tr_id else "polling",
+            message="주문조회",
+            raw=data,
+        )
+
+    @staticmethod
+    def _to_int(value: Any, default: int = 0) -> int:
+        try:
+            text = str(value or "").replace(",", "").strip()
+            return int(float(text)) if text else default
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _parse_side(value: Any) -> Optional[OrderSide]:
+        side_value = str(value or "").strip().upper()
+        if side_value in ("01", "1", "매도", "SELL"):
+            return OrderSide.SELL
+        if side_value in ("02", "2", "매수", "BUY"):
+            return OrderSide.BUY
+        return None
+
+    @staticmethod
+    def _parse_exchange(value: Any) -> Exchange:
+        exchange_value = str(value or "").upper()
+        if exchange_value in (Exchange.NXT.value, "NX"):
+            return Exchange.NXT
+        return Exchange.KRX

--- a/common/types.py
+++ b/common/types.py
@@ -282,97 +282,16 @@ class OrderExecutionReport(BaseModel):
 
     @classmethod
     def from_signing_notice(cls, data: dict, *, tr_id: str = "") -> "OrderExecutionReport":
-        side = cls._parse_side(data.get("매도매수구분") or data.get("SELN_BYOV_CLS"))
-        fill_qty = cls._to_int(data.get("체결수량") or data.get("CNTG_QTY"))
-        order_qty = cls._to_int(data.get("주문수량") or data.get("ODER_QTY")) or None
-        rejected = str(data.get("거부여부") or data.get("RFUS_YN") or "").upper() == "Y"
-        accepted = str(data.get("접수여부") or data.get("ACPT_YN") or "").upper() == "Y"
-        concluded = str(data.get("체결여부") or data.get("CNTG_YN") or "") == "2"
+        from common.broker_order_response_mapper import BrokerOrderResponseMapper
 
-        if rejected:
-            event_state = OrderState.REJECTED
-        elif concluded and order_qty and fill_qty >= order_qty:
-            event_state = OrderState.FILLED
-        elif concluded and fill_qty > 0:
-            event_state = OrderState.PARTIAL_FILLED
-        elif accepted:
-            event_state = OrderState.SUBMITTED
-        else:
-            event_state = OrderState.SUBMITTED
-
-        exchange = cls._parse_exchange(data.get("주문거래소구분") or data.get("ORD_EXG_GB"))
-
-        return cls(
-            broker_order_no=str(data.get("주문번호") or data.get("ODER_NO") or "").strip(),
-            original_order_no=str(data.get("원주문번호") or data.get("OODER_NO") or "").strip() or None,
-            stock_code=str(data.get("주식단축종목코드") or data.get("STCK_SHRN_ISCD") or "").strip(),
-            side=side,
-            exchange=exchange,
-            event_state=event_state,
-            order_qty=order_qty,
-            fill_qty=fill_qty,
-            fill_price=cls._to_int(data.get("체결단가") or data.get("CNTG_UNPR")),
-            event_time=str(data.get("주식체결시간") or data.get("STCK_CNTG_HOUR") or ""),
-            source=f"websocket:{tr_id}" if tr_id else "websocket",
-            message="거부" if rejected else ("체결" if concluded else "접수"),
-            raw=data,
-        )
+        return BrokerOrderResponseMapper.from_signing_notice(data, tr_id=tr_id)
 
     @classmethod
     def from_order_query(cls, data: dict, *, tr_id: str = "") -> "OrderExecutionReport":
         """주문체결내역 조회(inquire-daily-ccld) row를 공통 체결 이벤트로 변환합니다."""
-        order_qty = cls._to_int(data.get("ord_qty") or data.get("ORD_QTY") or data.get("주문수량")) or None
-        filled_qty = cls._to_int(data.get("tot_ccld_qty") or data.get("TOT_CCLD_QTY") or data.get("체결수량"))
-        raw_remaining_qty = data.get("rmn_qty") or data.get("RMN_QTY") or data.get("잔여수량")
-        remaining_qty = cls._to_int(raw_remaining_qty) if raw_remaining_qty not in (None, "") else None
-        rejected_qty = cls._to_int(data.get("rjct_qty") or data.get("RJCT_QTY") or data.get("거부수량"))
-        canceled_qty = cls._to_int(data.get("cncl_cfrm_qty") or data.get("CNCL_CFRM_QTY") or data.get("취소확인수량"))
-        canceled = str(data.get("cncl_yn") or data.get("CNCL_YN") or "").upper() == "Y"
+        from common.broker_order_response_mapper import BrokerOrderResponseMapper
 
-        if rejected_qty and filled_qty == 0 and (order_qty is None or rejected_qty >= order_qty):
-            event_state = OrderState.REJECTED
-        elif canceled or (
-            canceled_qty
-            and (
-                remaining_qty == 0
-                or order_qty is None
-                or filled_qty + canceled_qty >= order_qty
-            )
-        ):
-            event_state = OrderState.CANCELED
-        elif order_qty and filled_qty >= order_qty:
-            event_state = OrderState.FILLED
-        elif remaining_qty is not None and remaining_qty == 0 and filled_qty > 0:
-            event_state = OrderState.FILLED
-        elif filled_qty > 0:
-            event_state = OrderState.PARTIAL_FILLED
-        else:
-            event_state = OrderState.SUBMITTED
-
-        event_time = str(
-            data.get("ord_dt")
-            or data.get("ORD_DT")
-            or data.get("주문일자")
-            or ""
-        ) + str(data.get("ord_tmd") or data.get("ORD_TMD") or data.get("주문시각") or "")
-
-        return cls(
-            broker_order_no=str(data.get("odno") or data.get("ODNO") or data.get("주문번호") or "").strip(),
-            original_order_no=str(data.get("orgn_odno") or data.get("ORGN_ODNO") or data.get("원주문번호") or "").strip() or None,
-            stock_code=str(data.get("pdno") or data.get("PDNO") or data.get("종목코드") or "").strip(),
-            side=cls._parse_side(data.get("sll_buy_dvsn_cd") or data.get("SLL_BUY_DVSN_CD") or data.get("매도매수구분")),
-            exchange=cls._parse_exchange(data.get("excg_dvsn_cd") or data.get("EXCG_DVSN_CD") or data.get("거래소구분")),
-            event_state=event_state,
-            order_qty=order_qty,
-            fill_qty=filled_qty,
-            fill_price=cls._to_int(data.get("avg_prvs") or data.get("AVG_PRVS") or data.get("평균가")),
-            cumulative_filled_qty=filled_qty,
-            remaining_qty=remaining_qty,
-            event_time=event_time,
-            source=f"polling:{tr_id}" if tr_id else "polling",
-            message="주문조회",
-            raw=data,
-        )
+        return BrokerOrderResponseMapper.from_order_query(data, tr_id=tr_id)
 
 
 # --- 공통적으로 사용되는 데이터 응답 구조 ---

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -19,6 +19,7 @@ from services.risk_gate_service import RiskGateService
 from services.order_policy_service import OrderPolicyDecision, OrderPolicyService
 from core.account_snapshot import AccountSnapshotCache
 from config.config_loader import ExecutionQualityReportConfig
+from common.broker_order_response_mapper import BrokerOrderResponseMapper
 from services.execution_quality_reporter import ExecutionQualityReporter
 from services.broker_order_submitter import BrokerOrderSubmitter
 from services.order_state_machine import OrderStateMachine
@@ -126,7 +127,7 @@ class OrderExecutionService:
             market_clock=market_clock,
             state_provider=lambda: self._fsm._order_states,
             transition_fn=self._fsm.transition,
-            extract_broker_order_no_fn=OrderStateMachine.extract_broker_order_no,
+            extract_broker_order_no_fn=BrokerOrderResponseMapper.extract_broker_order_no,
             on_missing_broker_order_no_fn=self._fill_reconciliation.on_broker_order_no_missing,
             max_retries=self._order_max_retries,
             retry_delay_sec=self._order_retry_delay_sec,
@@ -259,7 +260,7 @@ class OrderExecutionService:
         return self._fsm.has_active(stock_code, exchange)
 
     def _extract_broker_order_no(self, result: ResCommonResponse) -> Optional[str]:
-        return OrderStateMachine.extract_broker_order_no(result)
+        return BrokerOrderResponseMapper.extract_broker_order_no(result)
 
     def _set_order_context(self, context: OrderContext) -> OrderContext:
         return self._fsm.register(context)

--- a/services/order_state_machine.py
+++ b/services/order_state_machine.py
@@ -11,6 +11,7 @@ from common.types import (
     OrderState,
     ResCommonResponse,
 )
+from common.broker_order_response_mapper import BrokerOrderResponseMapper
 
 
 class OrderStateMachine:
@@ -118,24 +119,11 @@ class OrderStateMachine:
 
     @staticmethod
     def extract_broker_order_no(result: ResCommonResponse) -> Optional[str]:
-        if not result or not result.data:
-            return None
-        if hasattr(result.data, "ordno"):
-            return result.data.ordno
-        if isinstance(result.data, dict):
-            return OrderStateMachine._extract_broker_order_no_from_dict(result.data)
-        return None
+        return BrokerOrderResponseMapper.extract_broker_order_no(result)
 
     @staticmethod
     def _extract_broker_order_no_from_dict(data: dict) -> Optional[str]:
-        for key in ("ordno", "order_no", "odno", "ORDNO", "ORDER_NO", "ODNO"):
-            value = data.get(key)
-            if value:
-                return str(value).strip()
-        output = data.get("output")
-        if isinstance(output, dict):
-            return OrderStateMachine._extract_broker_order_no_from_dict(output)
-        return None
+        return BrokerOrderResponseMapper.extract_broker_order_no_from_dict(data)
 
     # ── register / transition ─────────────────────────────────────────
     def register(self, context: OrderContext) -> OrderContext:

--- a/tests/unit_test/common/test_broker_order_response_mapper.py
+++ b/tests/unit_test/common/test_broker_order_response_mapper.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from common.broker_order_response_mapper import BrokerOrderResponseMapper
+from common.types import ErrorCode, OrderSide, OrderState, ResCommonResponse
+from utils.kis_inquire_daily_ccld_fixture_utils import load_fixture_document
+
+
+def test_extract_broker_order_no_from_submit_response_variants():
+    mapper = BrokerOrderResponseMapper()
+
+    assert mapper.extract_broker_order_no(None) is None
+    assert mapper.extract_broker_order_no(ResCommonResponse(rt_cd="0", msg1="", data=None)) is None
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(rt_cd="0", msg1="", data={"ordno": "A0001"})
+    ) == "A0001"
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(rt_cd="0", msg1="", data={"ODNO": "A0002"})
+    ) == "A0002"
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(rt_cd="0", msg1="", data={"ODER_NO": "A0003"})
+    ) == "A0003"
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(rt_cd="0", msg1="", data={"주문번호": "A0004"})
+    ) == "A0004"
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="",
+            data={"output": {"KRX_FWDG_ORD_ORGNO": "00950", "ODNO": "A0005"}},
+        )
+    ) == "A0005"
+
+
+def test_extract_broker_order_no_from_object_payload():
+    class Payload:
+        ordno = "OBJ001"
+
+    mapper = BrokerOrderResponseMapper()
+
+    assert mapper.extract_broker_order_no(
+        ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="", data=Payload())
+    ) == "OBJ001"
+
+
+def test_from_order_query_uses_real_kis_fixture_row():
+    fixture_path = (
+        Path(__file__).resolve().parents[2]
+        / "fixtures"
+        / "kis"
+        / "inquire_daily_ccld_output1_real_20260601_001510.json"
+    )
+    document = load_fixture_document(fixture_path)
+    sell_case = document["rows"][0]
+
+    report = BrokerOrderResponseMapper.from_order_query(
+        sell_case["row"],
+        tr_id=document["tr_id"],
+    )
+
+    assert report.broker_order_no == sell_case["expected"]["broker_order_no"]
+    assert report.stock_code == "001510"
+    assert report.side == OrderSide.SELL
+    assert report.event_state == OrderState.FILLED
+    assert report.order_qty == 1
+    assert report.fill_qty == 1
+    assert report.remaining_qty == 0
+    assert report.fill_price == 3330
+    assert report.source == "polling:TTTC0081R"
+
+
+def test_from_signing_notice_normalizes_kis_notice_payload():
+    report = BrokerOrderResponseMapper.from_signing_notice(
+        {
+            "ODER_NO": "N0001",
+            "OODER_NO": "",
+            "STCK_SHRN_ISCD": "001510",
+            "SELN_BYOV_CLS": "02",
+            "ODER_QTY": "2",
+            "CNTG_QTY": "1",
+            "CNTG_UNPR": "3330",
+            "CNTG_YN": "2",
+            "ORD_EXG_GB": "KRX",
+            "STCK_CNTG_HOUR": "141904",
+        },
+        tr_id="H0STCNI0",
+    )
+
+    assert report.broker_order_no == "N0001"
+    assert report.stock_code == "001510"
+    assert report.side == OrderSide.BUY
+    assert report.event_state == OrderState.PARTIAL_FILLED
+    assert report.order_qty == 2
+    assert report.fill_qty == 1
+    assert report.fill_price == 3330
+    assert report.source == "websocket:H0STCNI0"
+

--- a/todo_list.md
+++ b/todo_list.md
@@ -46,9 +46,10 @@
 - [x] 실전 KRX 조회에서 `EXCG_ID_DVSN_CD=KRX`를 보내도록 계좌 체결/미체결 조회 파라미터를 고정한다.
 - [~] 주문 접수 응답의 broker order number mapper를 실전/모의 fixture 기반으로 확장한다.
   - 적용 완료: 주문번호 추출 실패 시 raw payload 보존 + `FillReconciliationService.on_broker_order_no_missing` → 운영자 CRITICAL 알림 + 다음 reconcile 사이클까지 신규 주문 차단.
-  - 후속: 별도 `BrokerOrderResponseMapper` 클래스로 분리하고 submit response / order query / signing notice / real response / paper response를 각각 normalize한다. 실전 order query fixture는 확보 완료, 실전 submit response/signing notice fixture는 추가 확보 필요.
-  - 테스트 고정 대상: `ordno`, `order_no`, `odno`, `ORDNO`, `ORDER_NO`, `ODNO`, `ODER_NO`, `주문번호`, 중첩 `output` payload, 체결통보 payload 키.
-  - 리뷰 판단: 현재 구조는 추출 실패 시 신규 주문을 막는 방어는 충분하지만, submit response mapper가 `OrderStateMachine` 내부 helper에 가까워 독립 mapper와 raw fixture 회귀 테스트가 아직 필요하다.
+  - 적용 완료: `BrokerOrderResponseMapper` 별도 클래스로 분리하고 submit response / order query / signing notice normalize 경로를 이 클래스로 통일했다. 기존 `OrderExecutionReport.from_order_query()` / `from_signing_notice()`와 `OrderStateMachine.extract_broker_order_no()`는 호환 wrapper로 유지한다.
+  - 테스트 고정: `ordno`, `order_no`, `odno`, `ORDNO`, `ORDER_NO`, `ODNO`, `ODER_NO`, `주문번호`, 중첩 `output` payload, 실전 `inquire-daily-ccld` fixture row, 체결통보 payload 키.
+  - 후속: 실전 submit response/signing notice raw fixture는 추가 확보 필요. 현재 submit/signing normalize는 대표 KIS shape 단위 테스트와 실전 order query fixture로 고정했다.
+  - 리뷰 판단: 추출 실패 시 신규 주문을 막는 방어와 독립 mapper 구조는 확보했다. 남은 리스크는 실전 submit/signing payload 원본 표본 부족이다.
 
 주요 파일:
 
@@ -57,6 +58,7 @@
 - `brokers/broker_api_wrapper.py`
 - `services/order_execution_service.py`
 - `services/fill_reconciliation_service.py`
+- `common/broker_order_response_mapper.py`
 - `utils/kis_inquire_daily_ccld_fixture_utils.py`
 - `tests/fixtures/kis/inquire_daily_ccld_output1_real_20260601_001510.json`
 


### PR DESCRIPTION
BrokerOrderResponseMapper를 새로 분리해서 submit response 주문번호 추출, inquire-daily-ccld order query row 변환, WebSocket signing notice 변환을 한 곳으로 모았습니다. 기존 호환성은 유지해서 common/types.py (line 284)의 OrderExecutionReport.from_order_query() / from_signing_notice()는 새 mapper로 위임하고, services/order_state_machine.py (line 120)의 기존 extract_broker_order_no()도 wrapper로 남겨뒀습니다. 주문 제출 경로는 services/order_execution_service.py (line 23)에서 새 mapper를 직접 주입하도록 바꿨습니다. 추가한 핵심 파일은 common/broker_order_response_mapper.py (line 1)와 test_broker_order_response_mapper.py (line 1)입니다. todo_list.md도 0-1 상태를 갱신해서 “독립 mapper 분리 완료, 실전 submit/signing raw fixture는 추가 확보 필요”로 정리했습니다. 검증:
관련 테스트: 83 passed
전체 단위 테스트: 5774 passed
전체 통합 테스트: 240 passed
통합 테스트 warning 2건은 기존성 경고로 보이며 실패는 없습니다.