### PR TITLE
수정했습니다. 원인은 shadow 신호가 없으면 event_shadow jsonl 자체가 안 생기는 구조라서, “수집이 안 …

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -1132,7 +1132,14 @@ class StrategyScheduler:
         """
         if not cfg.event_driven_shadow:
             return
-        if self._event_router is None or self._event_shadow_journal is None:
+        if self._event_shadow_journal is None:
+            return
+        if self._event_router is None:
+            self._record_event_shadow_status(
+                strategy_name=getattr(cfg.strategy, "name", ""),
+                event="subscriptions_skipped",
+                details={"reason": "event_router_missing"},
+            )
             return
 
         strategy = cfg.strategy
@@ -1142,6 +1149,11 @@ class StrategyScheduler:
         except Exception as e:
             self._logger.warning(
                 f"[Scheduler] {name} current_candidate_codes() 호출 오류: {e}"
+            )
+            self._record_event_shadow_status(
+                strategy_name=name,
+                event="subscriptions_skipped",
+                details={"reason": "candidate_codes_error", "error": str(e)},
             )
             return
 
@@ -1171,6 +1183,18 @@ class StrategyScheduler:
 
         self._event_shadow_subscriptions[name] = new_codes
         await self._sync_event_shadow_price_subscriptions(name, new_codes)
+        self._record_event_shadow_status(
+            strategy_name=name,
+            event="subscriptions_refreshed",
+            details={
+                "candidate_count": len(new_codes),
+                "added_count": len(to_add),
+                "removed_count": len(to_remove),
+                "candidate_codes": sorted(new_codes),
+                "added_codes": sorted(to_add),
+                "removed_codes": sorted(to_remove),
+            },
+        )
 
     async def _sync_event_shadow_price_subscriptions(self, strategy_name: str, codes: set[str],
                                                       category_key: Optional[str] = None) -> None:
@@ -1271,6 +1295,28 @@ class StrategyScheduler:
             signal=signal,
             snapshot=snapshot,
             signal_source=signal_source,
+        )
+        flush_fn = getattr(journal, "flush_to_file", None)
+        if callable(flush_fn):
+            flush_fn(self._event_shadow_date_str())
+
+    def _record_event_shadow_status(
+        self,
+        *,
+        strategy_name: str,
+        event: str,
+        details: Optional[dict] = None,
+    ) -> None:
+        journal = self._event_shadow_journal
+        if journal is None:
+            return
+        record_status_fn = getattr(journal, "record_status", None)
+        if not callable(record_status_fn):
+            return
+        record_status_fn(
+            strategy_name=strategy_name,
+            event=event,
+            details=details or {},
         )
         flush_fn = getattr(journal, "flush_to_file", None)
         if callable(flush_fn):

--- a/services/event_shadow_journal_service.py
+++ b/services/event_shadow_journal_service.py
@@ -27,7 +27,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 class EventShadowJournalService:
@@ -66,6 +66,24 @@ class EventShadowJournalService:
 
     def get_records(self) -> List[Dict]:
         return list(self._buffer)
+
+    def record_status(
+        self,
+        *,
+        strategy_name: str,
+        event: str,
+        details: Optional[Dict[str, Any]] = None,
+        signal_source: str = "event_shadow_status",
+    ) -> None:
+        if not strategy_name or not event:
+            return
+        self._buffer.append({
+            "recorded_at": time.time(),
+            "strategy": strategy_name,
+            "signal_source": signal_source,
+            "event": event,
+            "details": details or {},
+        })
 
     def flush_to_file(self, date_str: str) -> Optional[Path]:
         if not self._buffer:

--- a/tests/unit_test/scheduler/test_event_shadow_pipeline_e2e.py
+++ b/tests/unit_test/scheduler/test_event_shadow_pipeline_e2e.py
@@ -138,9 +138,10 @@ async def test_live_tick_flows_to_entry_shadow_jsonl(tmp_path):
 
     path = tmp_path / "event_shadow" / "20260520.jsonl"
     assert path.exists(), "라이브 틱이 event_shadow jsonl 까지 도달하지 못했다"
-    lines = path.read_text(encoding="utf-8").strip().splitlines()
-    assert len(lines) == 1
-    rec = json.loads(lines[0])
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").strip().splitlines()]
+    signal_records = [r for r in records if r.get("signal_source") == "event_shadow"]
+    assert len(signal_records) == 1
+    rec = signal_records[0]
     assert rec["signal_source"] == "event_shadow"
     assert rec["code"] == "005930"
     assert rec["strategy"] == "래리윌리엄스VBO"
@@ -174,7 +175,9 @@ async def test_below_target_tick_writes_no_entry_record(tmp_path):
     await _drain_pending()
 
     path = tmp_path / "event_shadow" / "20260520.jsonl"
-    assert not path.exists()
+    assert path.exists()
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert [r for r in records if r.get("signal_source") == "event_shadow"] == []
     assert journal.get_records() == []
 
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
@@ -8,6 +8,7 @@ scheduler 가 cfg.event_driven_shadow=True 인 전략에 대해:
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -135,6 +136,28 @@ async def test_refresh_subscriptions_syncs_price_subscription_category():
 
 
 @pytest.mark.asyncio
+async def test_refresh_subscriptions_writes_status_record_to_daily_jsonl(tmp_path):
+    router = MagicMock()
+    router.subscribe = MagicMock()
+    router.unsubscribe = MagicMock()
+    journal = EventShadowJournalService(log_root=tmp_path)
+    scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
+
+    cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930", "000660"])
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
+
+    path = tmp_path / "event_shadow" / "20260520.jsonl"
+    assert path.exists()
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert records[-1]["signal_source"] == "event_shadow_status"
+    assert records[-1]["event"] == "subscriptions_refreshed"
+    assert records[-1]["strategy"] == "래리윌리엄스VBO"
+    assert records[-1]["details"]["candidate_count"] == 2
+    assert records[-1]["details"]["added_count"] == 2
+    assert sorted(records[-1]["details"]["candidate_codes"]) == ["000660", "005930"]
+
+
+@pytest.mark.asyncio
 async def test_shadow_evaluator_records_signal_and_returns_none():
     router = MagicMock()
     router.subscribe = MagicMock()
@@ -150,6 +173,8 @@ async def test_shadow_evaluator_records_signal_and_returns_none():
     cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
 
     await scheduler._refresh_event_shadow_subscriptions(cfg)
+    journal.record.reset_mock()
+    journal.flush_to_file.reset_mock()
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
 
     snapshot = {"price": "75000", "open": 74000.0}
@@ -177,6 +202,8 @@ async def test_shadow_evaluator_does_not_record_when_no_signal():
     cfg.strategy.evaluate_single = AsyncMock(return_value=None)
 
     await scheduler._refresh_event_shadow_subscriptions(cfg)
+    journal.record.reset_mock()
+    journal.flush_to_file.reset_mock()
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
 
     result = await evaluator("005930", {"price": "70000"})

--- a/tests/unit_test/services/test_event_shadow_journal_service.py
+++ b/tests/unit_test/services/test_event_shadow_journal_service.py
@@ -61,6 +61,24 @@ def test_record_exit_signal_source_override(tmp_path, logger):
     assert rec["signal"]["action"] == "SELL"
 
 
+def test_record_status_appends_diagnostic_record(tmp_path, logger):
+    svc = EventShadowJournalService(log_root=tmp_path, logger=logger)
+    svc.record_status(
+        strategy_name="래리윌리엄스VBO",
+        event="subscriptions_refreshed",
+        details={"candidate_count": 2, "added_count": 1},
+    )
+
+    records = svc.get_records()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["strategy"] == "래리윌리엄스VBO"
+    assert rec["signal_source"] == "event_shadow_status"
+    assert rec["event"] == "subscriptions_refreshed"
+    assert rec["details"] == {"candidate_count": 2, "added_count": 1}
+    assert "recorded_at" in rec
+
+
 def test_flush_writes_jsonl_and_clears_buffer(tmp_path, logger):
     svc = EventShadowJournalService(log_root=tmp_path, logger=logger)
     svc.record(strategy_name="VBO", code="005930", signal={"a": 1}, snapshot={})


### PR DESCRIPTION
…된 건지, 수집은 됐는데 신호가 없던 건지” 구분이 안 됐던 겁니다.

변경 내용:

event_shadow_journal_service.py에 record_status() 추가 strategy_scheduler.py에서 VBO shadow 구독 갱신 시 event_shadow_status 레코드를 logs/strategies/event_shadow/YYYYMMDD.jsonl에 flush parity 분석은 기존처럼 event_shadow / event_shadow_exit 신호만 보므로 status 레코드가 분석 결과를 오염시키지 않음 관련 테스트를 status 레코드가 공존하는 새 contract에 맞게 보강
이제 장중에 shadow 신호가 0건이어도 jsonl 파일이 생기고, 그 안에 subscriptions_refreshed, 후보 수, 추가/제거 후보 코드가 남습니다. 다음부터는 5거래일 수집 여부를 파일 존재와 status 레코드로 확인할 수 있고, 신호 parity는 별도로 계산할 수 있습니다.