### PR TITLE
feat(R-3): 포트폴리오 총위험(heat) 한도를 PositionSizing에 도입

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -198,6 +198,10 @@ position_sizing:
   enabled: true
   per_trade_risk_pct: 1.5          # 1주당 리스크 한도 (총자산 대비 %)
   max_per_position_pct: 10.0       # 단일 종목 비중 상한 (%)
+  # R-3: 전 포지션 합산 open-risk(heat) 한도 (%). 0 이면 비활성.
+  # 종목별 stop 부재로 기존 보유 risk 는 Σ(평가금 × |default_stop_loss_pct|) proxy 로 추정.
+  # 초과 시 신규 BUY 수량을 잔여 budget 에 맞춰 축소(소진 시 차단)한다.
+  max_portfolio_open_risk_pct: 6.0
   default_stop_loss_pct: -5.0      # 시그널 미전달 시 폴백 손절폭 (음수)
   atr_period: 14
   atr_multiplier: 2.0
@@ -208,7 +212,9 @@ position_sizing:
   canary_overrides:
     per_trade_risk_pct: 0.25
     max_per_position_pct: 1.5
+    max_portfolio_open_risk_pct: 1.0
   # operating_profile=real_limited 시 적용되는 overlay (canary 통과 후 중간 단계).
   real_mode_overrides:
     per_trade_risk_pct: 0.5
     max_per_position_pct: 3.0
+    max_portfolio_open_risk_pct: 3.0

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -42,6 +42,7 @@ class PositionSizingRealOverrides(BaseModel):
     """
     per_trade_risk_pct: float = 0.5
     max_per_position_pct: float = 3.0
+    max_portfolio_open_risk_pct: float = 3.0   # R-3: 전 포지션 합산 open-risk(heat) 한도 (%)
 
     model_config = {"extra": "allow"}
 
@@ -53,6 +54,7 @@ class PositionSizingCanaryOverrides(BaseModel):
     """
     per_trade_risk_pct: float = 0.25       # 1주당 리스크 0.25%
     max_per_position_pct: float = 1.5      # 단일 포지션 1.5%
+    max_portfolio_open_risk_pct: float = 1.0   # R-3: heat 한도 1.0%
 
     model_config = {"extra": "allow"}
 
@@ -61,6 +63,7 @@ class PositionSizingConfig(BaseModel):
     enabled: bool = True
     per_trade_risk_pct: float = 1.5        # 1주당 리스크 한도 (총자산 대비 %)
     max_per_position_pct: float = 5.0      # 단일 종목 비중 상한 (%)
+    max_portfolio_open_risk_pct: float = 6.0   # R-3: 전 포지션 합산 open-risk(heat) 한도 (%, 0 이면 비활성)
     default_stop_loss_pct: float = -5.0    # 시그널 미전달 시 폴백 손절폭 (음수)
     atr_period: int = 14
     atr_multiplier: float = 2.0

--- a/services/position_sizing_service.py
+++ b/services/position_sizing_service.py
@@ -102,6 +102,17 @@ class PositionSizingService:
             return self._cfg.max_per_position_pct
         return self._cfg.real_mode_overrides.max_per_position_pct
 
+    def _effective_max_portfolio_open_risk_pct(self) -> float:
+        """R-3: 전 포지션 합산 open-risk(heat) 한도 (%). 0 이면 비활성."""
+        base = getattr(self._cfg, "max_portfolio_open_risk_pct", 0.0)
+        if not self._is_real_mode():
+            return base
+        if self._operating_profile == "canary":
+            return getattr(self._cfg.canary_overrides, "max_portfolio_open_risk_pct", base)
+        if self._operating_profile == "real_full":
+            return base
+        return getattr(self._cfg.real_mode_overrides, "max_portfolio_open_risk_pct", base)
+
     # ── 공개 API ──────────────────────────────────────────────────
 
     async def adjust_buy_qty(
@@ -187,12 +198,21 @@ class PositionSizingService:
         max_order_amount_qty = self._calc_max_order_amount_qty(price)
         top_of_book_qty = await self._calc_top_of_book_qty(signal, price, exchange)
 
+        # 7-1. R-3: 포트폴리오 총위험(heat) 한도. 스냅샷에 종목별 stop 이 없으므로
+        # 기존 보유 open-risk 를 Σ(평가금 × |default_stop|) proxy 로 추정하고(보수적),
+        # 신규 후보는 정확한 per_share_risk×qty 로 잔여 budget 에 맞춰 축소한다.
+        heat_qty = self._calc_portfolio_heat_qty(
+            snapshot=snapshot, total_equity=total_equity, per_share_risk=per_share_risk
+        )
+
         # 8. 후보 목록 구성 — signal.qty / alloc_qty 는 None 이면 제외 (제약 없음)
         candidates = {
             "risk_limited": risk_qty,
             "cap_limited": cap_qty,
             "cash_limited": cash_qty,
         }
+        if heat_qty is not None:
+            candidates["heat_limited"] = heat_qty
         if alloc_qty is not None:
             candidates["strategy_capital_cap"] = alloc_qty
         if max_order_amount_qty is not None:
@@ -215,6 +235,8 @@ class PositionSizingService:
                 reason = "order_amount_cap"
             elif top_of_book_qty is not None and top_of_book_qty == 0:
                 reason = "top_of_book_limited"
+            elif heat_qty is not None and heat_qty == 0:
+                reason = "portfolio_heat_exhausted"
             else:
                 reason = "cash_short"
         elif signal.qty is not None and final_qty == signal.qty:
@@ -225,6 +247,7 @@ class PositionSizingService:
                 "strategy_capital_cap",
                 "max_order_amount_limited",
                 "top_of_book_limited",
+                "heat_limited",
                 "cash_limited",
                 "cap_limited",
                 "risk_limited",
@@ -244,7 +267,7 @@ class PositionSizingService:
             f"[PositionSizing] {signal.code} price={price:,} "
             f"equity={total_equity:,} risk/share={per_share_risk:.0f} "
             f"risk_qty={risk_qty} cap_qty={cap_qty} cash_qty={cash_qty} alloc_qty={alloc_qty} "
-            f"pending_buy_exposure={pending_buy_exposure:,} "
+            f"pending_buy_exposure={pending_buy_exposure:,} heat_qty={heat_qty} "
             f"max_order_amount_qty={max_order_amount_qty} top_of_book_qty={top_of_book_qty} "
             f"signal_qty={signal.qty} → final={final_qty} ({reason})"
         )
@@ -276,6 +299,32 @@ class PositionSizingService:
         if max_amount <= 0:
             return None
         return math.floor(max_amount / price)
+
+    def _calc_portfolio_heat_qty(
+        self,
+        snapshot: Any,
+        total_equity: int,
+        per_share_risk: float,
+    ) -> Optional[int]:
+        """R-3: 전 포지션 합산 open-risk(heat) budget 잔여분에 맞춘 신규 BUY 최대 수량.
+
+        한도 미설정(<=0)이거나 per_share_risk<=0 이면 None(제약 없음).
+        기존 보유 open-risk 는 종목별 stop 부재로 Σ(평가금 × |default_stop|) proxy 로 추정한다.
+        reservation overlay 활성 시 같은 사이클 accepted BUY 예약도 합산한다.
+        """
+        max_heat_pct = self._effective_max_portfolio_open_risk_pct()
+        if max_heat_pct <= 0 or per_share_risk <= 0 or total_equity <= 0:
+            return None
+
+        assumed_stop = abs(self._cfg.default_stop_loss_pct) / 100
+        existing_notional = sum(max(value, 0) for value in snapshot.positions.values())
+        if self._enable_intracycle_reservations:
+            existing_notional += sum(max(value, 0) for value in self._reservations.values())
+        existing_open_risk = existing_notional * assumed_stop
+
+        heat_budget = total_equity * max_heat_pct / 100
+        remaining_heat = max(heat_budget - existing_open_risk, 0)
+        return math.floor(remaining_heat / per_share_risk)
 
     async def _get_pending_buy_exposure_won(
         self,

--- a/tests/unit_test/services/test_position_sizing_service.py
+++ b/tests/unit_test/services/test_position_sizing_service.py
@@ -795,3 +795,132 @@ async def test_reservation_default_is_disabled():
                     reason="r", strategy_name="s2")
     )
     assert qty_a == 5 and qty_b == 5
+
+
+# ─────────────────────────────────────────────────────────────────────
+# R-3: 포트폴리오 총위험(heat) 한도 — Σ(평가금 × |default_stop|) proxy
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_portfolio_heat_scales_down_qty():
+    """기존 보유 open-risk proxy 가 budget 대부분을 소진하면 신규 BUY 가 잔여 budget 으로 축소된다.
+
+    대상 종목(005930)의 기존 보유분도 heat proxy 에 포함된다(모델 A 가정).
+    """
+    # equity 100M, heat 1% → budget 1,000,000.
+    # 기존 보유 10M(005930 5M + AAAAAA 5M) × stop 5% = 500,000 open-risk.
+    # 잔여 budget 500,000 / per_share_risk 500 = heat_qty 1000.
+    snap = _make_snapshot(
+        total_equity=100_000_000,
+        available_cash=100_000_000,
+        positions={"005930": 5_000_000, "AAAAAA": 5_000_000},
+    )
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+        max_portfolio_open_risk_pct=1.0,
+    )
+    svc, _, _ = _make_service(snap, cfg=cfg)
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=10_000, qty=10_000))
+    assert qty == 1000
+    assert reason == "heat_limited"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_heat_exhausted_blocks():
+    """기존 보유 open-risk proxy 가 budget 을 초과하면 신규 BUY 가 0 으로 차단된다."""
+    # equity 100M, heat 1% → budget 1,000,000.
+    # 기존 보유 30M × stop 5% = 1,500,000 > budget → 잔여 0 → heat_qty 0.
+    snap = _make_snapshot(
+        total_equity=100_000_000,
+        available_cash=100_000_000,
+        positions={"AAAAAA": 30_000_000},
+    )
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+        max_portfolio_open_risk_pct=1.0,
+    )
+    svc, _, _ = _make_service(snap, cfg=cfg)
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=10_000, qty=10_000))
+    assert qty == 0
+    assert reason == "portfolio_heat_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_heat_disabled_when_zero():
+    """max_portfolio_open_risk_pct=0 이면 heat 한도 비활성 → 기존 동작 유지."""
+    snap = _make_snapshot(
+        total_equity=100_000_000,
+        available_cash=100_000_000,
+        positions={"AAAAAA": 30_000_000},
+    )
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+        max_portfolio_open_risk_pct=0.0,
+    )
+    svc, _, _ = _make_service(snap, cfg=cfg)
+    # heat 비활성 → risk/cap/cash 모두 여유, signal.qty=100 가 자발적 상한
+    qty, reason = await svc.adjust_buy_qty(_buy_signal(price=10_000, qty=100))
+    assert qty == 100
+    assert reason == "ok"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_heat_includes_reservations():
+    """reservation overlay 활성 시 같은 사이클 예약이 heat proxy 에 합산되어 후속 BUY 를 축소한다."""
+    # equity 100M, heat 1% → budget 1,000,000. per_share_risk 500.
+    snap = _make_snapshot(
+        total_equity=100_000_000,
+        available_cash=100_000_000,
+        positions={},
+    )
+    cfg = _make_config(
+        per_trade_risk_pct=100.0,
+        max_per_position_pct=100.0,
+        default_stop_loss_pct=-5.0,
+        min_stop_distance_pct=0.0,
+        max_portfolio_open_risk_pct=1.0,
+    )
+    svc, _, _ = _make_service(snap, cfg=cfg, enable_intracycle_reservations=True)
+    # 첫 BUY: signal.qty=50 자발적 상한 → 50주, 예약 50×10,000 = 500,000.
+    qty1, _ = await svc.adjust_buy_qty(
+        TradeSignal(code="AAAAAA", name="A", action="BUY", price=10_000, qty=50,
+                    reason="r", strategy_name="s1")
+    )
+    assert qty1 == 50
+    # 두 번째 BUY(다른 종목): 예약 500,000 × stop 5% = 25,000 open-risk.
+    # 잔여 budget 975,000 / 500 = heat_qty 1950 (예약 없으면 2000).
+    qty2, reason2 = await svc.adjust_buy_qty(
+        TradeSignal(code="BBBBBB", name="B", action="BUY", price=10_000, qty=None,
+                    reason="r", strategy_name="s2")
+    )
+    assert qty2 == 1950
+    assert reason2 == "heat_limited"
+
+
+def test_effective_max_portfolio_open_risk_pct_profile_branches():
+    """profile 별 heat 한도: paper/real_full=base(6.0), canary=1.0, real_limited=3.0."""
+    cfg = _make_config()  # base 6.0, canary 1.0, real 3.0 (config 기본값)
+    paper = _make_service_with_profile(env=_env(is_paper_trading=True), cfg=cfg)
+    canary = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="canary"
+    )
+    real_limited = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="real_limited"
+    )
+    real_full = _make_service_with_profile(
+        env=_env(is_paper_trading=False), cfg=cfg, operating_profile="real_full"
+    )
+    assert paper._effective_max_portfolio_open_risk_pct() == 6.0
+    assert canary._effective_max_portfolio_open_risk_pct() == 1.0
+    assert real_limited._effective_max_portfolio_open_risk_pct() == 3.0
+    assert real_full._effective_max_portfolio_open_risk_pct() == 6.0

--- a/todo_list.md
+++ b/todo_list.md
@@ -505,7 +505,7 @@
 
 - 증거: `PositionSizingService`는 per-trade `risk_qty = total_equity × per_trade_risk_pct / 주당리스크`로 종목별 사이징하지만(L170), **전 전략·전 포지션 합산 open-risk(heat) 한도가 없다**. RiskGate의 `max_total_exposure_pct`는 notional(노출금액) cap이지 risk cap이 아니다(L504-505, positions 합산은 금액 기준).
 - 왜 위험한가: R-2의 고상관 7전략이 각자 per-trade risk를 소진하면, 상관 drawdown 시 **합산 open-risk가 per-trade의 배수**로 누적된다. 개별 종목은 "1% 리스크"여도 동시 10포지션이 같이 무너지면 포트폴리오는 10% 리스크. notional cap만으로는 이 위험을 막지 못한다.
-- [ ] 전 포지션 합산 open-risk(Σ 진입가–stop 거리 × 수량 / total_equity) 한도를 RiskGate 또는 PositionSizing에 도입하고, 초과 시 신규 진입 차단/축소한다.
+- [x] 전 포지션 합산 open-risk(Σ 진입가–stop 거리 × 수량 / total_equity) 한도를 RiskGate 또는 PositionSizing에 도입하고, 초과 시 신규 진입 차단/축소한다. (2026-06-09) `PositionSizingService`에 도입(수량 축소 우선, 소진 시 차단). 스냅샷에 종목별 stop이 없어 기존 보유 open-risk를 `Σ(평가금 × |default_stop_loss_pct|)` proxy로 추정(모델 A), 신규 후보는 정확한 `per_share_risk×qty`. reservation overlay 활성 시 같은 사이클 예약도 합산. `_calc_portfolio_heat_qty`가 `heat_limited` 후보로 기존 `min()` 사이징에 합류, budget 소진 시 reason `portfolio_heat_exhausted`. profile별 한도 `max_portfolio_open_risk_pct`(canary 1% / real_limited 3% / paper·real_full 6%, 0이면 비활성). 테스트: `test_position_sizing_service.py` 5종(scale-down/exhausted/disabled/reservation 합산/profile 분기). 단위 5839 / 통합 240 passed.
 - [ ] 상관 가중 heat(고상관 클러스터는 위험 합산)을 검토한다. (R-2 상관행렬과 연계)
 - 관련: `services/position_sizing_service.py`, `services/risk_gate_service.py`
 


### PR DESCRIPTION
전 포지션 합산 open-risk가 profile별 한도를 넘지 않도록 신규 BUY 수량을 잔여 heat budget에 맞춰 축소(소진 시 차단)한다. 고상관 long-only 전략들이 각자 per-trade risk를 소진해 합산 open-risk가 배수로 누적되는 구멍을 막는다.

- 스냅샷에 종목별 stop이 없어 기존 보유 open-risk를 Σ(평가금 × |default_stop_loss_pct|) proxy로 추정(모델 A), 신규 후보는 정확한 per_share_risk×qty.
- _calc_portfolio_heat_qty가 heat_limited 후보로 기존 min() 사이징에 합류. budget 소진 시 reason=portfolio_heat_exhausted.
- reservation overlay 활성 시 같은 사이클 예약도 heat에 합산.
- max_portfolio_open_risk_pct: canary 1% / real_limited 3% / paper·real_full 6% (0이면 비활성). 기존 tiered override 패턴 준수.
- RiskGate 무변경(수량 축소 단독).

테스트: test_position_sizing_service.py 5종. 단위 5839 / 통합 240 passed.