### PR TITLE
fix(web): PJAX 진입 시 head_scripts CDN 미로드로 차트 안 나오는 문제 수정

### DIFF
--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -113,6 +113,17 @@ function loadScript(src) {
     });
 }
 
+// 새로 가져온 문서의 <head> 외부 스크립트(차트 CDN 등)를 로드 (PJAX 진입 시 head_scripts 누락 방지)
+async function loadHeadScripts(doc) {
+    const scripts = Array.from(doc.querySelectorAll('head script[src]'));
+    for (const headScript of scripts) {
+        const normalizedSrc = new URL(headScript.src, location.href).href;
+        if (_loadedScripts.has(normalizedSrc)) continue;
+        _loadedScripts.add(normalizedSrc);
+        try { await loadScript(headScript.src); } catch (e) { console.error('Head script load failed:', headScript.src, e); }
+    }
+}
+
 async function executePageScripts(container) {
     const scripts = Array.from(container.querySelectorAll('script'));
     for (const oldScript of scripts) {
@@ -168,6 +179,7 @@ async function navigatePjax(href) {
         const pageMain = document.querySelector('#page-main');
         pageMain.innerHTML = newMain.innerHTML;
 
+        await loadHeadScripts(doc);
         await executePageScripts(pageMain);
 
         window.history.pushState({path: href}, '', href);

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -145,7 +145,7 @@
 </div>
 
 <!-- 공통 스크립트 -->
-<script src="/static/js/common.js?v=4"></script>
+<script src="/static/js/common.js?v=5"></script>
 <script src="/static/js/notifications.js?v=1"></script>
 <script src="/static/js/kill_switch.js?v=3"></script>
 <script src="/static/js/pagination.js?v=1"></script>


### PR DESCRIPTION
navigatePjax가 #page-main 내부만 교체/실행해 새 문서 <head>의
Chart.js CDN(defer) 스크립트가 로드되지 않았다. PJAX로 /virtual에 진입하면 window.Chart 미정의 → waitForChartLibrary 5초 타임아웃 → 차트가 그려지지 않음. (주소창 직접 진입/F5는 정상)

loadHeadScripts()를 추가해 가져온 문서 <head>의 외부 스크립트도
_loadedScripts 중복 방지 하에 로드하도록 보완.