### PR TITLE
fix(virtual-trade): pykrx 종가 조회를 FinanceDataReader로 전환

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -862,14 +862,12 @@ class VirtualTradeRepository:
                 )
 
     def _fetch_close_prices(self, codes: list[str], start_date: str, end_date: str) -> dict:
-        """pykrx로 종가 조회 후 캐시에 병합. 캐시에 이미 있으면 API 스킵.
+        """FinanceDataReader로 종가 조회 후 캐시에 병합. 캐시에 이미 있으면 API 스킵.
         Returns: { code: { "YYYY-MM-DD": close_price, ... }, ... }
         """
-        from pykrx import stock as pykrx_stock
+        import FinanceDataReader as fdr
 
         cache = self._load_price_cache()
-        start_fmt = start_date.replace('-', '')
-        end_fmt = end_date.replace('-', '')
         fetched = 0
 
         for code in codes:
@@ -885,7 +883,7 @@ class VirtualTradeRepository:
                     continue
 
             try:
-                df = pykrx_stock.get_market_ohlcv_by_date(start_fmt, end_fmt, code)
+                df = fdr.DataReader(code, start_date, end_date)
                 if df.empty:
                     continue
 
@@ -894,11 +892,11 @@ class VirtualTradeRepository:
 
                 for date_idx, row in df.iterrows():
                     day_str = date_idx.strftime('%Y-%m-%d')
-                    cache[code][day_str] = int(row['종가'])
+                    cache[code][day_str] = int(row['Close'])
 
                 fetched += 1
             except Exception as e:
-                logger.warning(f"[가상매매] pykrx 종가 조회 실패 {code}: {e}")
+                logger.warning(f"[가상매매] FDR 종가 조회 실패 {code}: {e}")
                 continue
 
         if fetched > 0:
@@ -916,7 +914,7 @@ class VirtualTradeRepository:
         계산 방식 (web_api.py의 save_daily_snapshot과 동일):
         - 해당 날짜 기준 '활성 거래' = 매수일 <= day인 모든 거래
           - SOLD: sell_day <= day → 확정 return_rate 사용
-          - HOLD(당시 기준): 당일 종가 기준 수익률 (pykrx 조회, SQLite 캐시)
+          - HOLD(당시 기준): 당일 종가 기준 수익률 (FinanceDataReader 조회, SQLite 캐시)
         - 전략별 평균 return_rate 저장
         """
         df = self._read()

--- a/services/stock_sync_service.py
+++ b/services/stock_sync_service.py
@@ -4,7 +4,6 @@ import pandas as pd
 import json
 import os
 import sqlite3
-from pykrx import stock
 from datetime import datetime
 import FinanceDataReader as fdr
 

--- a/task/background/after_market/daily_price_collector_task.py
+++ b/task/background/after_market/daily_price_collector_task.py
@@ -8,7 +8,6 @@ import logging
 import time
 import pandas as pd
 import FinanceDataReader as fdr
-import pykrx
 
 from typing import Dict, List, Optional, TYPE_CHECKING
 from common.types import ErrorCode

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -541,57 +541,36 @@ def test_fetch_close_prices_cache_hit(virutal_trade_repository):
     cache_data = {"005930": {"2025-01-01": 70000, "2025-01-02": 71000, "2025-01-03": 72000}}
     virutal_trade_repository._save_price_cache(cache_data)
 
-    mock_pykrx_stock = MagicMock()
-    mock_pykrx = MagicMock()
-    mock_pykrx.stock = mock_pykrx_stock
-
-    with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
+    with patch("FinanceDataReader.DataReader") as mock_fdr:
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-03")
         assert result == cache_data
-        mock_pykrx_stock.get_market_ohlcv_by_date.assert_not_called()
+        mock_fdr.assert_not_called()
 
 def test_fetch_close_prices_api_call(virutal_trade_repository):
     """캐시가 없으면 API 호출 후 저장"""
-    mock_pykrx_stock = MagicMock()
-    mock_df = pd.DataFrame({'종가': [70000, 71000]}, index=pd.to_datetime(['2025-01-01', '2025-01-02']))
-    mock_pykrx_stock.get_market_ohlcv_by_date.return_value = mock_df
+    mock_df = pd.DataFrame({'Close': [70000, 71000]}, index=pd.to_datetime(['2025-01-01', '2025-01-02']))
 
-    mock_pykrx = MagicMock()
-    mock_pykrx.stock = mock_pykrx_stock
-
-    with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
+    with patch("FinanceDataReader.DataReader", return_value=mock_df) as mock_fdr:
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-02")
 
         assert "005930" in result
         assert result["005930"]["2025-01-01"] == 70000
         assert result["005930"]["2025-01-02"] == 71000
-        mock_pykrx_stock.get_market_ohlcv_by_date.assert_called_once()
+        mock_fdr.assert_called_once()
 
         loaded = virutal_trade_repository._load_price_cache()
         assert loaded["005930"]["2025-01-01"] == 70000
 
 def test_fetch_close_prices_api_empty(virutal_trade_repository):
     """API 응답이 비어있을 때 처리"""
-    mock_pykrx_stock = MagicMock()
-    mock_pykrx_stock.get_market_ohlcv_by_date.return_value = pd.DataFrame()
-
-    mock_pykrx = MagicMock()
-    mock_pykrx.stock = mock_pykrx_stock
-
-    with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
+    with patch("FinanceDataReader.DataReader", return_value=pd.DataFrame()) as mock_fdr:
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-01")
         assert "005930" not in result
-        mock_pykrx_stock.get_market_ohlcv_by_date.assert_called_once()
+        mock_fdr.assert_called_once()
 
 def test_fetch_close_prices_api_exception(virutal_trade_repository):
     """API 호출 중 예외 발생 시 처리"""
-    mock_pykrx_stock = MagicMock()
-    mock_pykrx_stock.get_market_ohlcv_by_date.side_effect = Exception("API Error")
-
-    mock_pykrx = MagicMock()
-    mock_pykrx.stock = mock_pykrx_stock
-
-    with patch.dict("sys.modules", {"pykrx": mock_pykrx, "pykrx.stock": mock_pykrx_stock}):
+    with patch("FinanceDataReader.DataReader", side_effect=Exception("API Error")):
         with patch("repositories.virtual_trade_repository.logger") as mock_logger:
             result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-01")
             assert "005930" not in result
@@ -1196,17 +1175,17 @@ def test_find_prev_close_and_change_empty_edges(virutal_trade_repository):
     assert virutal_trade_repository.get_weekly_change("S1", 1.0, _data={"daily": {}}) == (None, None)
 
 
-def test_fetch_close_prices_uses_cache_and_handles_pykrx_error(virutal_trade_repository):
+def test_fetch_close_prices_uses_cache_and_handles_fdr_error(virutal_trade_repository):
     """종가 캐시가 충분하면 조회를 건너뛰고, 조회 실패 종목은 스킵한다."""
     cached = {"005930": {"2025-01-01": 70000, "2025-01-02": 71000, "2025-01-03": 72000}}
     with patch.object(virutal_trade_repository, "_load_price_cache", return_value=cached), \
-         patch("pykrx.stock.get_market_ohlcv_by_date") as mock_pykrx:
+         patch("FinanceDataReader.DataReader") as mock_fdr:
         result = virutal_trade_repository._fetch_close_prices(["005930"], "2025-01-01", "2025-01-03")
     assert result is cached
-    mock_pykrx.assert_not_called()
+    mock_fdr.assert_not_called()
 
     with patch.object(virutal_trade_repository, "_load_price_cache", return_value={}), \
-         patch("pykrx.stock.get_market_ohlcv_by_date", side_effect=RuntimeError("boom")), \
+         patch("FinanceDataReader.DataReader", side_effect=RuntimeError("boom")), \
          patch("repositories.virtual_trade_repository.logger") as mock_logger:
         assert virutal_trade_repository._fetch_close_prices(["000660"], "2025-01-01", "2025-01-03") == {}
     mock_logger.warning.assert_called_once()


### PR DESCRIPTION
pykrx 비정상 동작 대응. _fetch_close_prices의 get_market_ohlcv_by_date 호출을 fdr.DataReader로 교체하고 컬럼명을 종가->Close로 변경한다.
또한 stock_sync_service / daily_price_collector_task에 남아 있던 미사용 pykrx import를 제거한다.

테스트: 관련 단위 테스트 5건 FDR mock으로 갱신, 단위/통합 전체 통과.