### PR TITLE
[codex] Bound VBO check exits concurrency

### DIFF
--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -36,6 +36,7 @@ _ENTRY_CUTOFF = time(14, 0)
 _EOD_FLATTEN = time(15, 20)
 
 _RANGE_CACHE_CONCURRENCY = 10
+_EXIT_CONCURRENCY = 15
 
 
 @dataclass
@@ -416,83 +417,100 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
     # ------------------------------------------------------------------
 
     async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
-        signals: List[TradeSignal] = []
         now = self._tm.get_current_kst_time()
         today = now.strftime("%Y%m%d")
         is_eod = now.time() >= _EOD_FLATTEN
         self._logger.info({"event": "check_exits_started", "holdings_count": len(holdings), "is_eod": is_eod})
 
-        for hold in holdings:
-            code = str(hold.get("code", ""))
-            buy_price_raw = hold.get("buy_price", 0)
-            buy_date_raw = hold.get("buy_date", "")
-            buy_date = normalize_yyyymmdd(buy_date_raw)
-            stock_name = hold.get("name", code)
+        results = await bounded_gather(
+            [self._check_single_exit(hold, today, is_eod) for hold in holdings],
+            limit=_EXIT_CONCURRENCY,
+            return_exceptions=True,
+        )
 
-            if not code or not buy_price_raw:
-                continue
-
-            buy_price = float(buy_price_raw)
-            log_data = {"code": code, "name": stock_name, "buy_price": buy_price}
-
-            try:
-                # 오버나이트 방어: 매수일 ≠ 오늘이면 즉시 시장가 청산
-                if buy_date and buy_date != today:
-                    qty = int(hold.get("qty", 1))
-                    reason = f"오버나이트방어: 매수일({buy_date}) ≠ 오늘({today})"
-                    signals.append(TradeSignal(
-                        code=code, name=stock_name, action="SELL", price=0, qty=qty,
-                        reason=reason, strategy_name=self.name,
-                    ))
-                    self._logger.info({"event": "sell_signal_generated", "strategy_name": self.name,
-                                       "code": code, "reason": reason})
-                    continue
-
-                price_resp = await self._sqs.handle_get_current_stock_price(code, caller=self.name)
-                if not price_resp or price_resp.rt_cd != ErrorCode.SUCCESS.value:
-                    self._logger.warning({"event": "check_exits_price_fail", **log_data})
-                    continue
-
-                data = price_resp.data or {}
-                current = int(data.get("price", "0") or "0")
-                if current <= 0:
-                    continue
-
-                # P0 0-9: 비용 반영 net 수익률 — backtest 와 동일 기준으로 stop trigger.
-                pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current)
-                log_data.update({"current": current, "pnl_pct": round(pnl_pct, 2), "pnl_basis": "net"})
-
-                reason = ""
-                should_sell = False
-
-                # 칼손절: 진입가 대비 -3% (net, P0 0-9)
-                if pnl_pct <= self._cfg.stop_loss_pct:
-                    reason = f"칼손절(net): 매수가대비 {pnl_pct:.1f}%"
-                    should_sell = True
-
-                # EOD 강제청산: 15:20
-                if not should_sell and is_eod:
-                    reason = f"EOD청산: {_EOD_FLATTEN.strftime('%H:%M')} 전량 시장가"
-                    should_sell = True
-
-                if should_sell:
-                    qty = int(hold.get("qty", 1))
-                    signals.append(TradeSignal(
-                        code=code, name=stock_name, action="SELL", price=current, qty=qty,
-                        reason=reason, strategy_name=self.name,
-                    ))
-                    self._logger.info({"event": "sell_signal_generated", "strategy_name": self.name,
-                                       "code": code, "reason": reason, "data": log_data})
-                else:
-                    self._logger.info({"event": "hold_checked", "code": code,
-                                       "reason": "청산 조건 미충족", "data": log_data})
-
-            except Exception as e:
+        signals: List[TradeSignal] = []
+        for result in results:
+            if isinstance(result, Exception):
                 self._logger.error({"event": "check_exits_error", "strategy_name": self.name,
-                                    "code": code, "error": str(e)}, exc_info=True)
+                                    "error": str(result)}, exc_info=True)
+                continue
+            if result is not None:
+                signals.append(result)
 
         self._logger.info({"event": "check_exits_finished", "signals_found": len(signals)})
         return signals
+
+    async def _check_single_exit(self, hold: dict, today: str, is_eod: bool) -> Optional[TradeSignal]:
+        code = str(hold.get("code", ""))
+        buy_price_raw = hold.get("buy_price", 0)
+        buy_date_raw = hold.get("buy_date", "")
+        buy_date = normalize_yyyymmdd(buy_date_raw)
+        stock_name = hold.get("name", code)
+
+        if not code or not buy_price_raw:
+            return None
+
+        buy_price = float(buy_price_raw)
+        log_data = {"code": code, "name": stock_name, "buy_price": buy_price}
+
+        try:
+            # 오버나이트 방어: 매수일 ≠ 오늘이면 즉시 시장가 청산
+            if buy_date and buy_date != today:
+                qty = int(hold.get("qty", 1))
+                reason = f"오버나이트방어: 매수일({buy_date}) ≠ 오늘({today})"
+                signal = TradeSignal(
+                    code=code, name=stock_name, action="SELL", price=0, qty=qty,
+                    reason=reason, strategy_name=self.name,
+                )
+                self._logger.info({"event": "sell_signal_generated", "strategy_name": self.name,
+                                   "code": code, "reason": reason})
+                return signal
+
+            price_resp = await self._sqs.handle_get_current_stock_price(code, caller=self.name)
+            if not price_resp or price_resp.rt_cd != ErrorCode.SUCCESS.value:
+                self._logger.warning({"event": "check_exits_price_fail", **log_data})
+                return None
+
+            data = price_resp.data or {}
+            current = int(data.get("price", "0") or "0")
+            if current <= 0:
+                return None
+
+            # P0 0-9: 비용 반영 net 수익률 — backtest 와 동일 기준으로 stop trigger.
+            pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current)
+            log_data.update({"current": current, "pnl_pct": round(pnl_pct, 2), "pnl_basis": "net"})
+
+            reason = ""
+            should_sell = False
+
+            # 칼손절: 진입가 대비 -3% (net, P0 0-9)
+            if pnl_pct <= self._cfg.stop_loss_pct:
+                reason = f"칼손절(net): 매수가대비 {pnl_pct:.1f}%"
+                should_sell = True
+
+            # EOD 강제청산: 15:20
+            if not should_sell and is_eod:
+                reason = f"EOD청산: {_EOD_FLATTEN.strftime('%H:%M')} 전량 시장가"
+                should_sell = True
+
+            if should_sell:
+                qty = int(hold.get("qty", 1))
+                signal = TradeSignal(
+                    code=code, name=stock_name, action="SELL", price=current, qty=qty,
+                    reason=reason, strategy_name=self.name,
+                )
+                self._logger.info({"event": "sell_signal_generated", "strategy_name": self.name,
+                                   "code": code, "reason": reason, "data": log_data})
+                return signal
+
+            self._logger.info({"event": "hold_checked", "code": code,
+                               "reason": "청산 조건 미충족", "data": log_data})
+            return None
+
+        except Exception as e:
+            self._logger.error({"event": "check_exits_error", "strategy_name": self.name,
+                                "code": code, "error": str(e)}, exc_info=True)
+            return None
 
     # ------------------------------------------------------------------
     # 내부 헬퍼

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -716,6 +716,43 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(signals, [])
 
+    async def test_check_exits_respects_concurrency_limit(self):
+        """현재가 조회는 _EXIT_CONCURRENCY를 초과해 동시에 in-flight 되지 않는다."""
+        import asyncio
+
+        from strategies import larry_williams_vbo_strategy as vbo_mod
+
+        strategy, sqs, tm = self._make_strategy(now_time=_kst(11, 0))
+        today = tm.get_current_kst_time().strftime("%Y%m%d")
+
+        concurrency_limit = vbo_mod._EXIT_CONCURRENCY
+        in_flight = 0
+        peak = 0
+        gate = asyncio.Event()
+
+        async def _tracked(code, caller=None):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            if in_flight >= concurrency_limit:
+                gate.set()
+            try:
+                await gate.wait()
+                return _price_resp(current=70500, open_price=70000)
+            finally:
+                in_flight -= 1
+
+        sqs.handle_get_current_stock_price = _tracked
+        holdings = [
+            {"code": f"C{i:04d}", "name": f"종목{i}", "buy_price": 70000, "buy_date": today, "qty": 1}
+            for i in range(concurrency_limit * 2)
+        ]
+
+        signals = await strategy.check_exits(holdings)
+
+        self.assertEqual(signals, [])
+        self.assertEqual(peak, concurrency_limit)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/todo_list.md
+++ b/todo_list.md
@@ -26,7 +26,7 @@
 - P2 2-2: ~~실제 KIS 계정별 REST/WebSocket 유량 한도 재확인 후 budget 기본값 보정.~~ 전역 normal 8/s + emergency 2/s 기본값 보정 완료. 계정별 공식 한도 재확인은 운영 전 외부 확인으로 유지.
 - P2 2-4: VBO shadow 5거래일 jsonl 수집 → polling parity 비교. event-driven live order는 별도 승인 전 No-Go.
 - P2 2-5: ~~전략 scan의 종목별 현재가 REST 호출을 batch quote / WebSocket snapshot 중심으로 줄인다.~~ helper(`StockQueryService.prefetch_prices`) + rsi2 포함 활성 전략 7개 scan 배선 + 테스트 완료.
-- P2 2-6: 라이브 핫패스 성능 follow-up. ~~WebSocket 틱 루프 상수 캐싱/로그 lazy 처리~~ ✅, ~~장마감 배치 `iterrows()` 축소~~ ✅, ~~HTTP/token 미세 정합성 개선(fallback Limits·Timeout / token singleflight / retry jitter)~~ ✅ (2026-05-31). 남은 것: 활성 전략 `scan()`/`check_exits()` 순차 후보 처리 bounded 전환 — 실전 진입/청산 경로라 별도 승인 후 진행(VBO scan은 실익 marginal로 보류 결정).
+- P2 2-6: 라이브 핫패스 성능 follow-up. ~~WebSocket 틱 루프 상수 캐싱/로그 lazy 처리~~ ✅, ~~장마감 배치 `iterrows()` 축소~~ ✅, ~~HTTP/token 미세 정합성 개선(fallback Limits·Timeout / token singleflight / retry jitter)~~ ✅, ~~VBO `check_exits()` bounded 전환~~ ✅ (2026-06-11). 남은 것: 활성 전략 `scan()` 순차 후보 처리 bounded 전환 — 실전 진입 경로라 별도 승인 후 진행(VBO scan은 실익 marginal로 보류 결정).
 - P3 3-4: active strategy lifecycle contract 최소 공통 단계 강제 여부 재설계(현재 보류).
 - P3 3-5: backtest/live 호가단위 tick-size 로직을 단일 utility로 통일한다.
 - P3 3-6: ~~IndicatorService 계산 경로의 광범위 `except Exception` silent skip에 ERROR log/metric/alert hook을 붙인다.~~ ✅ 완료. 전략 레이어 per-code fail-rate metric도 `scan_metrics`/`exit_metrics`에 반영 완료.
@@ -361,10 +361,11 @@
   - 검토 결과(2026-05-31, 보류): 저비용 단계(현재가는 `prefetch_prices` 덕에 대부분 snapshot hit)에서 대다수 후보가 탈락하고, 고비용 REST(`_get_execution_strength`)는 가격 게이트 통과한 돌파 후보(소수)에만 발생. 게다가 전역 `ApiBudgetLimiter`가 모든 REST를 8/s로 직렬화하므로 bounded 전환의 실익은 "동시 돌파 후보 多"일 때의 직렬 RTT 누적 감소뿐(marginal). 실전 진입 경로 동등성(순서/시그널 수/`_bought_today`) 검증 부담 대비 이득이 작아 보류. 재개 시 2-pass(돌파 후보만 `execution_strength` bounded)가 가장 외과적.
   - 주의: `MomentumStrategy.run()`과 `GapUpPullbackStrategy.run()`도 순차 N+1이 맞지만 현재 웹 라이브 스케줄러 등록 대상이 아니므로, 라이브 핫패스 최우선 항목으로 일반화하지 않는다.
   - 검증 기준: 결과 순서/시그널 수/거절 사유/`_bought_today` state 변화가 기존과 동등하고, 동시성 limit은 KIS budget limiter 기본값과 충돌하지 않는다.
-- [ ] 활성 전략 `check_exits()` 순차 루프를 계산 경로별로 점검하고, 보유 종목 수가 늘어나는 경로는 bounded 처리로 통일한다.
+- [x] 활성 전략 `check_exits()` 순차 루프를 계산 경로별로 점검하고, 보유 종목 수가 늘어나는 경로는 bounded 처리로 통일한다. (2026-06-11)
   - 확인: `sell_all_stocks()`에는 이미 `SAFE_SEQUENTIAL` / `BOUNDED_PARALLEL` / `EMERGENCY` 모드가 있으며, `EMERGENCY` unbounded gather는 `emergency_scope()`를 사용하는 의도적 경로다. 리뷰의 "exit unbounded gather"는 이 경로보다 전략별 `check_exits()` 순차 계산 개선으로 재정의한다.
   - 우선 대상: `LarryWilliamsVBOStrategy`, `ProgramBuyFollowStrategy`, `VolumeBreakoutLiveStrategy`, `TraditionalVolumeBreakoutStrategy`의 순차 holdings 루프. 단, 현재 웹 등록 활성 전략은 VBO 중심으로 먼저 적용한다.
-  - 검증 기준: 손절/익절/시간청산 신호 생성 결과가 기존과 동등하고, per-code 예외가 다른 보유 종목 exit 판단을 막지 않는다.
+  - 적용 완료: `LarryWilliamsVBOStrategy.check_exits()`에 `_EXIT_CONCURRENCY=15` + `bounded_gather()` 적용. 기존 오버나이트/EOD/net 손절 판정은 `_check_single_exit()`로 분리해 동등성 유지.
+  - 검증 기준: 손절/익절/시간청산 신호 생성 결과가 기존과 동등하고, per-code 예외가 다른 보유 종목 exit 판단을 막지 않는다. (충족: VBO 전략 단위 39 passed / 단위 5876 passed / 통합 240 passed)
 - [~] 장마감 배치의 `iterrows()` 사용처를 API 호출 전처리와 단순 포맷 변환으로 나눠 낮은 위험부터 개선한다.
   - 적용 완료(2026-05-31): 전체 종목 필터링 루프 3곳(`OneilUniverseService._generate_premium_watchlist()`, `RankingTask._load_all_stocks()`, `MinerviniUpdateTask._load_all_stocks()`)의 `iterrows()`를 컬럼 리스트 추출 후 `zip` 순회로 전환. 행마다 Series 생성하던 비용 제거. `row.get(col, "")` 시맨틱(컬럼 부재→"") 보존, 필터 순서/조건 불변.
   - 테스트 고정: ranking `test_load_all_stocks_preserves_df_order_after_filtering`/`test_load_all_stocks_empty_df_returns_empty`, minervini `test_load_all_stocks_preserves_order_and_all_markets`. 기존 ETF/우선주/스팩/빈코드/비대상시장 테스트 회귀 통과. 단위 5732 passed / 통합 240 passed.
@@ -562,7 +563,7 @@
 2. **코드 수정으로 바로 진행 가능**
    - ~~WebSocket 틱 루프 TR_ID 캐싱 + debug lazy logging 적용 (P2 2-6)~~ ✅ 완료 (2026-05-31)
    - `LarryWilliamsVBOStrategy.scan()` 잔여 순차 후보 처리 bounded 전환 (P2 2-6) — 2026-05-31 검토 후 **보류**(실익 marginal·실전 진입 경로). 재개 시 2-pass 권장.
-   - 활성 전략 `check_exits()` 순차 holdings 루프 bounded 통일 (P2 2-6) — 실전 청산 경로라 별도 승인 후 진행.
+   - ~~활성 전략 `check_exits()` 순차 holdings 루프 bounded 통일 (P2 2-6)~~ ✅ 완료 (2026-06-11, VBO 중심 적용)
    - ~~장마감 배치 `iterrows()` 중 전체 종목 필터링 경로부터 벡터화/`itertuples()` 전환 (P2 2-6)~~ ✅ 완료 (2026-05-31, zip 순회). FDR/RS line 변환 경로는 영향 작아 보류.
    - ~~`KoreaInvestApiBase` fallback client Limits/Timeout + retry jitter + `TokenProvider` singleflight 정합성 개선 (P2 2-6)~~ ✅ 완료 (2026-05-31). JSON 이중 파싱 제거는 MagicMock 충돌/이득 미미로 보류.
    - ~~라이브 일봉 지표 당일 미완성 봉 제외 (P0 0-8)~~ ✅ #478 + rollout 조사 완료 (추가 오염은 `LarryWilliamsChannelBreakout` ADX/채널뿐 → `_confirmed_bars()`로 마감)


### PR DESCRIPTION
## What changed
- Added a bounded `_EXIT_CONCURRENCY` path for `LarryWilliamsVBOStrategy.check_exits()`.
- Moved per-holding exit evaluation into `_check_single_exit()` while preserving overnight, EOD, and net stop-loss behavior.
- Added a concurrency regression test and updated `todo_list.md` to mark the VBO exit follow-up complete.

## Why
The VBO live exit path still processed holdings sequentially, while the other active strategies already used bounded exit concurrency. This closes that remaining hot-path gap without making exit checks unbounded.

## Validation
- `python -m pytest tests/unit_test/strategies/test_larry_williams_vbo_strategy.py -v` -> 39 passed
- `python -m pytest tests/unit_test -v` -> 5876 passed
- `python -m pytest tests/integration_test -v` -> 240 passed, 1 warning
- `git diff --check` -> passed