### PR TITLE
[codex] Add delisting universe audit

### DIFF
--- a/scripts/audit_delisting_universe.py
+++ b/scripts/audit_delisting_universe.py
@@ -1,0 +1,376 @@
+"""Audit KRX delisting universe inputs for survivorship-bias work.
+
+This script is intentionally one step before backtest integration. It builds a
+filtered delisting snapshot from FinanceDataReader and can cross-check recent
+rows against KIND's official delisting status page.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import pandas as pd
+
+
+_DEFAULT_MARKETS = ("KOSPI", "KOSDAQ")
+_DEFAULT_SECU_GROUPS = ("주권",)
+_KIND_URL = "https://kind.krx.co.kr/investwarn/delcompany.do"
+_KIND_MARKET_TYPES = {"KOSPI": "1", "KOSDAQ": "2", "KONEX": "6"}
+
+
+def _normalize_date(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    ts = pd.to_datetime(value, errors="coerce")
+    if pd.isna(ts):
+        text = str(value).strip()
+        digits = re.sub(r"\D", "", text)
+        if len(digits) == 8:
+            return f"{digits[:4]}-{digits[4:6]}-{digits[6:8]}"
+        return text
+    return ts.strftime("%Y-%m-%d")
+
+
+def _compact_date(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    digits = re.sub(r"\D", "", str(value))
+    return digits[:8] if len(digits) >= 8 else digits
+
+
+def _as_text(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _is_spac(record: Dict[str, Any]) -> bool:
+    name = record.get("name", "")
+    reason = record.get("reason", "")
+    return "스팩" in name or "스팩" in reason
+
+
+def fetch_fdr_delisting_listing() -> pd.DataFrame:
+    import FinanceDataReader as fdr
+
+    return fdr.StockListing("KRX-DELISTING")
+
+
+def normalize_fdr_delistings(
+    df: pd.DataFrame,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    markets: Sequence[str] = _DEFAULT_MARKETS,
+    secu_groups: Sequence[str] = _DEFAULT_SECU_GROUPS,
+    exclude_spac: bool = False,
+) -> List[Dict[str, Any]]:
+    start = _compact_date(date_from)
+    end = _compact_date(date_to)
+    market_set = set(markets or [])
+    secu_group_set = set(secu_groups or [])
+
+    records: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        delisting_date = _normalize_date(row.get("DelistingDate"))
+        delisting_compact = _compact_date(delisting_date)
+        if start and delisting_compact < start:
+            continue
+        if end and delisting_compact > end:
+            continue
+
+        record = {
+            "symbol": _as_text(row.get("Symbol")),
+            "name": _as_text(row.get("Name")),
+            "market": _as_text(row.get("Market")),
+            "secu_group": _as_text(row.get("SecuGroup")),
+            "kind": _as_text(row.get("Kind")),
+            "listing_date": _normalize_date(row.get("ListingDate")),
+            "delisting_date": delisting_date,
+            "reason": _as_text(row.get("Reason")),
+            "to_symbol": _as_text(row.get("ToSymbol")),
+            "to_name": _as_text(row.get("ToName")),
+        }
+        if market_set and record["market"] not in market_set:
+            continue
+        if secu_group_set and record["secu_group"] not in secu_group_set:
+            continue
+        if exclude_spac and _is_spac(record):
+            continue
+        records.append(record)
+
+    records.sort(key=lambda r: (r["delisting_date"], r["symbol"]), reverse=True)
+    return records
+
+
+def parse_kind_delisting_rows(html: str) -> List[Dict[str, str]]:
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    rows: List[Dict[str, str]] = []
+    for tr in soup.find_all("tr"):
+        cells = [c.get_text(" ", strip=True) for c in tr.find_all("td")]
+        if len(cells) < 4:
+            continue
+        if not cells[2] or not re.match(r"\d{4}[-./]?\d{2}[-./]?\d{2}", cells[2]):
+            continue
+        rows.append({
+            "name": cells[1],
+            "delisting_date": _normalize_date(cells[2]),
+            "reason": cells[3],
+            "note": cells[4] if len(cells) > 4 else "",
+        })
+    return rows
+
+
+def fetch_kind_delisting_rows(
+    date_from: str,
+    date_to: str,
+    market_type: str = "",
+) -> List[Dict[str, str]]:
+    import requests
+
+    market_types = _split_csv_arg(market_type) or ("",)
+    rows_by_key: Dict[tuple[str, str], Dict[str, str]] = {}
+    for mt in market_types:
+        payload = {
+            "method": "searchDelCompanySub",
+            "currentPageSize": "3000",
+            "pageIndex": "1",
+            "orderMode": "2",
+            "orderStat": "D",
+            "tabType": "1",
+            "searchMode": "",
+            "searchCodeType": "",
+            "searchCorpName": "",
+            "repIsuSrtCd": "",
+            "forward": "delcompany_sub",
+            "searchType": "",
+            "marketType": mt,
+            "searchCorpNameTmp": "",
+            "fromDate": _compact_date(date_from),
+            "toDate": _compact_date(date_to),
+        }
+        resp = requests.post(
+            _KIND_URL,
+            data=payload,
+            timeout=30,
+            headers={"Referer": f"{_KIND_URL}?method=searchDelCompanyMain"},
+        )
+        resp.raise_for_status()
+        for row in parse_kind_delisting_rows(resp.text):
+            rows_by_key[_kind_key(row)] = row
+    return list(rows_by_key.values())
+
+
+def _kind_key(row: Dict[str, Any]) -> tuple[str, str]:
+    return (_as_text(row.get("name")), _normalize_date(row.get("delisting_date")))
+
+
+def compare_with_kind(
+    fdr_records: List[Dict[str, Any]],
+    kind_rows: List[Dict[str, str]],
+) -> Dict[str, Any]:
+    kind_by_key = {_kind_key(row): row for row in kind_rows}
+    fdr_by_key = {_kind_key(row): row for row in fdr_records}
+
+    matched = []
+    fdr_only = []
+    for key, record in fdr_by_key.items():
+        if key in kind_by_key:
+            matched.append({"fdr": record, "kind": kind_by_key[key]})
+        else:
+            fdr_only.append(record)
+
+    kind_only = []
+    for key, row in kind_by_key.items():
+        if key not in fdr_by_key:
+            kind_only.append(row)
+
+    fdr_only.sort(key=lambda r: (r["delisting_date"], r["symbol"]), reverse=True)
+    kind_only.sort(key=lambda r: (r["delisting_date"], r["name"]), reverse=True)
+    return {
+        "matched_count": len(matched),
+        "fdr_only_count": len(fdr_only),
+        "kind_only_count": len(kind_only),
+        "fdr_only": fdr_only,
+        "kind_only": kind_only,
+    }
+
+
+def _count(records: Iterable[Dict[str, Any]], key: str) -> Dict[str, int]:
+    return dict(Counter(_as_text(r.get(key)) for r in records))
+
+
+def build_report(
+    fdr_records: List[Dict[str, Any]],
+    *,
+    date_from: str,
+    date_to: str,
+    kind_rows: Optional[List[Dict[str, str]]] = None,
+    markets: Sequence[str] = _DEFAULT_MARKETS,
+    secu_groups: Sequence[str] = _DEFAULT_SECU_GROUPS,
+    exclude_spac: bool = False,
+) -> Dict[str, Any]:
+    report = {
+        "config": {
+            "date_from": _normalize_date(date_from),
+            "date_to": _normalize_date(date_to),
+            "markets": list(markets),
+            "secu_groups": list(secu_groups),
+            "exclude_spac": exclude_spac,
+        },
+        "totals": {
+            "fdr_filtered": len(fdr_records),
+            "kind_rows": len(kind_rows or []),
+        },
+        "market_counts": _count(fdr_records, "market"),
+        "secu_group_counts": _count(fdr_records, "secu_group"),
+        "reason_counts": dict(Counter(r.get("reason", "") for r in fdr_records).most_common(20)),
+        "records": fdr_records,
+    }
+    if kind_rows is not None:
+        report["kind_comparison"] = compare_with_kind(fdr_records, kind_rows)
+    return report
+
+
+def write_csv(records: List[Dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "symbol", "name", "market", "secu_group", "kind",
+        "listing_date", "delisting_date", "reason", "to_symbol", "to_name",
+    ]
+    with path.open("w", encoding="utf-8-sig", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(records)
+
+
+def format_markdown_report(report: Dict[str, Any]) -> str:
+    cfg = report["config"]
+    totals = report["totals"]
+    lines = [
+        "# Delisting Universe Audit",
+        "",
+        f"- date: `{cfg['date_from']} ~ {cfg['date_to']}`",
+        f"- markets: `{', '.join(cfg['markets'])}`",
+        f"- secu_groups: `{', '.join(cfg['secu_groups'])}`",
+        f"- exclude_spac: `{cfg['exclude_spac']}`",
+        "",
+        "## Summary",
+        "",
+        f"- FDR filtered rows: {totals['fdr_filtered']}",
+        f"- KIND rows: {totals['kind_rows']}",
+        "",
+        "## Market Counts",
+        "",
+    ]
+    for market, count in report["market_counts"].items():
+        lines.append(f"- {market}: {count}")
+    lines.extend(["", "## KIND Comparison", ""])
+    comparison = report.get("kind_comparison")
+    if comparison:
+        lines.append(f"- matched: {comparison['matched_count']}")
+        lines.append(f"- FDR only: {comparison['fdr_only_count']}")
+        lines.append(f"- KIND only: {comparison['kind_only_count']}")
+    else:
+        lines.append("- KIND check not requested.")
+    lines.extend(["", "## First Records", ""])
+    for row in report["records"][:20]:
+        lines.append(
+            f"- `{row['symbol']}` {row['name']} {row['market']} "
+            f"{row['delisting_date']} {row['reason']}"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit FDR KRX-DELISTING rows and optionally cross-check KIND.",
+    )
+    parser.add_argument("--date-from", required=True, help="YYYYMMDD or YYYY-MM-DD")
+    parser.add_argument("--date-to", required=True, help="YYYYMMDD or YYYY-MM-DD")
+    parser.add_argument("--markets", default="KOSPI,KOSDAQ")
+    parser.add_argument("--secu-groups", default="주권")
+    parser.add_argument("--exclude-spac", action="store_true")
+    parser.add_argument("--kind-check", action="store_true")
+    parser.add_argument("--kind-market-type", default="")
+    parser.add_argument("--output-json")
+    parser.add_argument("--output-csv")
+    parser.add_argument("--output-markdown")
+    return parser
+
+
+def _split_csv_arg(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def kind_market_type_arg(markets: Sequence[str], explicit: str = "") -> str:
+    if explicit.strip():
+        return explicit
+    return ",".join(_KIND_MARKET_TYPES[m] for m in markets if m in _KIND_MARKET_TYPES)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    markets = _split_csv_arg(args.markets)
+    secu_groups = _split_csv_arg(args.secu_groups)
+
+    fdr_df = fetch_fdr_delisting_listing()
+    fdr_records = normalize_fdr_delistings(
+        fdr_df,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        markets=markets,
+        secu_groups=secu_groups,
+        exclude_spac=args.exclude_spac,
+    )
+    kind_rows = (
+        fetch_kind_delisting_rows(
+            args.date_from,
+            args.date_to,
+            kind_market_type_arg(markets, args.kind_market_type),
+        )
+        if args.kind_check
+        else None
+    )
+    report = build_report(
+        fdr_records,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        kind_rows=kind_rows,
+        markets=markets,
+        secu_groups=secu_groups,
+        exclude_spac=args.exclude_spac,
+    )
+
+    wrote = False
+    if args.output_json:
+        path = Path(args.output_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"[INFO] JSON report: {path}")
+        wrote = True
+    if args.output_csv:
+        path = Path(args.output_csv)
+        write_csv(fdr_records, path)
+        print(f"[INFO] CSV snapshot: {path}")
+        wrote = True
+    if args.output_markdown:
+        path = Path(args.output_markdown)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(format_markdown_report(report), encoding="utf-8")
+        print(f"[INFO] Markdown report: {path}")
+        wrote = True
+    if not wrote:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit_test/scripts/test_audit_delisting_universe.py
+++ b/tests/unit_test/scripts/test_audit_delisting_universe.py
@@ -1,0 +1,181 @@
+import json
+
+import pandas as pd
+
+from scripts import audit_delisting_universe as mod
+
+
+def _fdr_df():
+    return pd.DataFrame([
+        {
+            "Symbol": "230980",
+            "Name": "비유테크놀러지",
+            "Market": "KOSDAQ",
+            "SecuGroup": "주권",
+            "Kind": "보통주",
+            "ListingDate": "2016-03-02",
+            "DelistingDate": "2026-06-05",
+            "Reason": "감사의견 거절",
+        },
+        {
+            "Symbol": "008110",
+            "Name": "대동전자",
+            "Market": "KOSPI",
+            "SecuGroup": "주권",
+            "Kind": "보통주",
+            "ListingDate": "1990-06-05",
+            "DelistingDate": "2026-03-30",
+            "Reason": "감사의견 한정",
+        },
+        {
+            "Symbol": "257990",
+            "Name": "나우코스",
+            "Market": "KONEX",
+            "SecuGroup": "주권",
+            "Kind": "보통주",
+            "ListingDate": "2020-12-30",
+            "DelistingDate": "2026-06-01",
+            "Reason": "타법인의 완전자회사로 편입",
+        },
+        {
+            "Symbol": "1477601G",
+            "Name": "피엠티 5R",
+            "Market": "KOSDAQ",
+            "SecuGroup": "신주인수권증서",
+            "Kind": "보통주",
+            "ListingDate": "2026-06-04",
+            "DelistingDate": "2026-06-11",
+            "Reason": "",
+        },
+        {
+            "Symbol": "451700",
+            "Name": "엔에이치스팩29호",
+            "Market": "KOSDAQ",
+            "SecuGroup": "주권",
+            "Kind": "보통주",
+            "ListingDate": "2023-06-23",
+            "DelistingDate": "2026-06-10",
+            "Reason": "피흡수합병(스팩소멸합병)",
+        },
+    ])
+
+
+def test_normalize_fdr_delistings_filters_backtest_universe():
+    records = mod.normalize_fdr_delistings(
+        _fdr_df(),
+        date_from="20260301",
+        date_to="20260611",
+        markets=("KOSPI", "KOSDAQ"),
+        secu_groups=("주권",),
+    )
+
+    assert [r["symbol"] for r in records] == ["451700", "230980", "008110"]
+    assert {r["market"] for r in records} == {"KOSPI", "KOSDAQ"}
+    assert {r["secu_group"] for r in records} == {"주권"}
+
+
+def test_normalize_fdr_delistings_can_exclude_spacs():
+    records = mod.normalize_fdr_delistings(
+        _fdr_df(),
+        date_from="20260301",
+        date_to="20260611",
+        exclude_spac=True,
+    )
+
+    assert [r["symbol"] for r in records] == ["230980", "008110"]
+
+
+def test_parse_kind_delisting_rows_from_html_table():
+    html = """
+    <table>
+      <tr><td>2</td><td>비유테크놀러지</td><td>2026-06-05</td><td>감사의견 거절</td><td></td></tr>
+      <tr><td>1</td><td>대동전자</td><td>2026-03-30</td><td>감사의견 한정</td><td>비고</td></tr>
+    </table>
+    """
+
+    rows = mod.parse_kind_delisting_rows(html)
+
+    assert rows == [
+        {
+            "name": "비유테크놀러지",
+            "delisting_date": "2026-06-05",
+            "reason": "감사의견 거절",
+            "note": "",
+        },
+        {
+            "name": "대동전자",
+            "delisting_date": "2026-03-30",
+            "reason": "감사의견 한정",
+            "note": "비고",
+        },
+    ]
+
+
+def test_compare_with_kind_uses_name_and_delisting_date():
+    fdr_records = mod.normalize_fdr_delistings(_fdr_df(), date_from="20260301", date_to="20260611")
+    kind_rows = [
+        {"name": "비유테크놀러지", "delisting_date": "2026-06-05", "reason": "감사의견 거절", "note": ""},
+        {"name": "대동전자", "delisting_date": "2026-03-30", "reason": "감사의견 한정", "note": ""},
+        {"name": "KIND에만있는종목", "delisting_date": "2026-04-01", "reason": "x", "note": ""},
+    ]
+
+    comparison = mod.compare_with_kind(fdr_records, kind_rows)
+
+    assert comparison["matched_count"] == 2
+    assert [r["symbol"] for r in comparison["fdr_only"]] == ["451700"]
+    assert comparison["kind_only"] == [
+        {"name": "KIND에만있는종목", "delisting_date": "2026-04-01", "reason": "x", "note": ""}
+    ]
+
+
+def test_kind_market_type_arg_defaults_to_requested_markets():
+    assert mod.kind_market_type_arg(("KOSPI", "KOSDAQ"), "") == "1,2"
+    assert mod.kind_market_type_arg(("KONEX",), "") == "6"
+    assert mod.kind_market_type_arg(("KOSPI",), "1,2,6") == "1,2,6"
+
+
+def test_build_report_counts_and_records():
+    fdr_records = mod.normalize_fdr_delistings(_fdr_df(), date_from="20260301", date_to="20260611")
+    report = mod.build_report(
+        fdr_records,
+        date_from="20260301",
+        date_to="20260611",
+        kind_rows=None,
+    )
+
+    assert report["totals"]["fdr_filtered"] == 3
+    assert report["market_counts"] == {"KOSDAQ": 2, "KOSPI": 1}
+    assert report["secu_group_counts"] == {"주권": 3}
+    assert report["records"][0]["symbol"] == "451700"
+
+
+def test_main_writes_json_csv_and_markdown(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(mod, "fetch_fdr_delisting_listing", lambda: _fdr_df())
+    monkeypatch.setattr(
+        mod,
+        "fetch_kind_delisting_rows",
+        lambda date_from, date_to, market_type="": [
+            {"name": "비유테크놀러지", "delisting_date": "2026-06-05", "reason": "감사의견 거절", "note": ""},
+            {"name": "대동전자", "delisting_date": "2026-03-30", "reason": "감사의견 한정", "note": ""},
+        ],
+    )
+
+    json_out = tmp_path / "report.json"
+    csv_out = tmp_path / "snapshot.csv"
+    md_out = tmp_path / "report.md"
+    exit_code = mod.main([
+        "--date-from", "20260301",
+        "--date-to", "20260611",
+        "--kind-check",
+        "--output-json", str(json_out),
+        "--output-csv", str(csv_out),
+        "--output-markdown", str(md_out),
+    ])
+
+    assert exit_code == 0
+    report = json.loads(json_out.read_text(encoding="utf-8"))
+    assert report["totals"]["fdr_filtered"] == 3
+    assert report["kind_comparison"]["matched_count"] == 2
+    assert "451700" in csv_out.read_text(encoding="utf-8")
+    assert "Delisting Universe Audit" in md_out.read_text(encoding="utf-8")
+    assert str(json_out) in capsys.readouterr().out

--- a/todo_list.md
+++ b/todo_list.md
@@ -492,6 +492,7 @@
   - `fdr.DataReader(code, start, end)` OHLCV 조회 **정상**(005930 41행, 장기 이력 1233행). → 상폐 코드 목록만 있으면 OHLCV 백필은 FDR로 가능.
   - `fdr.StockListing('KRX')` **HTTP 404**, `StockListing('KRX-DELISTING')` **0행** → 일자별 상장 구성·상폐 목록을 FDR로 못 가져옴(스크레이퍼 깨짐). pykrx도 불안정.
   - **진짜 병목**: "어느 종목이 언제 상장/상폐됐는가" 신뢰 소스 부재. 이게 없으면 백필 대상 코드도, 편향 정량화도 불가. → 1순위 sub-task = **상폐 종목+상폐일+일자별 구성 신뢰 소스 확보**(예: KRX data.krx.co.kr 상장폐지 목록 수동 export, 또는 대체 소스). 외부 데이터 의사결정 필요.
+- 적용 완료(2026-06-11, 데이터 소스 재검증/감사 스크립트): `scripts/audit_delisting_universe.py` 추가. 현재 환경의 FDR 0.9.110에서는 `StockListing('KRX-DELISTING')`가 다시 정상 동작(전체 4,139행)하고, `DataReader(code, exchange='KRX-DELISTING')` 상폐 종목 OHLCV도 조회 가능하다. 스크립트는 FDR 상폐 목록을 `Market in {KOSPI,KOSDAQ}` + `SecuGroup == 주권`으로 필터하고, KIND `상장폐지현황` POST 결과(시장별 1/2)와 이름+상폐일 기준 대조한다. 2026-01-01~2026-06-11 실측: FDR filtered 44건, KIND 45건, matched 40건, FDR-only 4건, KIND-only 5건. 불일치 대부분은 표기 차이(`에스케이` vs `SK`, `IHQ` vs `아이에이치큐`)와 필터 제외 대상(리츠/투자회사)로 보이며, 다음 단계는 이 audit 결과를 기반으로 point-in-time universe snapshot schema/백필 파이프라인을 설계하는 것.
 - 관련: `services/oneil_universe_service.py`, `services/generic_liquidity_universe_service.py`, `services/stock_sync_service.py`, `task/background/after_market/daily_price_collector_task.py`, `task/background/after_market/ohlcv_update_task.py`, `data/stock_code_list.csv`, `data/ohlcv_extracted.csv`, `scripts/run_backtest.py`
 
 ### R-2. 전략 상관 / 단일 regime 집중 — "7전략 분산"의 착시 [심각]


### PR DESCRIPTION
## What changed
- Added `scripts/audit_delisting_universe.py` to build an audit snapshot from FDR `KRX-DELISTING` rows.
- Added filtering for KOSPI/KOSDAQ common-stock rows, optional SPAC exclusion, and optional KIND delisting-status cross-checks.
- Added JSON/CSV/Markdown report output support.
- Added unit coverage for FDR normalization, KIND HTML parsing, comparison logic, market mapping, and CLI outputs.
- Recorded the 2026-01-01 through 2026-06-11 audit result in `todo_list.md`.

## Why
R-1 survivorship-bias work needs a reliable source for delisted symbols and delisting dates before point-in-time universe and OHLCV backfill work can start. This adds the audit layer first, without wiring delisted names into backtests yet.

## Findings
For 2026-01-01 through 2026-06-11:
- FDR filtered rows: 44
- KIND KOSPI/KOSDAQ rows: 45
- matched: 40
- FDR-only: 4
- KIND-only: 5

Most mismatches appear to be name-display differences such as `에스케이` vs `SK` and `IHQ` vs `아이에이치큐`, plus rows intentionally filtered out by security type such as REIT/investment-company style instruments.

## Validation
- `python -m pytest tests/unit_test/scripts/test_audit_delisting_universe.py -v` -> 7 passed
- `python -m pytest tests/unit_test -v` -> 5883 passed
- `python -m pytest tests/integration_test -v` -> 240 passed, 1 warning
- `git diff --cached --check` -> passed