### PR TITLE
매도완료 테이블에 미매도 가정 수익률(hold_return_rate) 표시

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_virtual.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_virtual.py
@@ -271,6 +271,41 @@ async def test_get_virtual_history_complex(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_virtual_history_sold_hold_return_rate(web_client, mock_web_ctx):
+    """GET /api/virtual/history SOLD 거래에 미매도 가정 수익률(hold_return_rate) 포함 검증"""
+    web_api._PRICE_CACHE.clear()
+    mock_web_ctx.virtual_trade_service.get_all_trades.return_value = [
+        mock_trade(code="000660", status="SOLD", buy_price=1000, sell_price=1100,
+                   sell_date="2025-01-05 15:00:00", strategy="A")
+    ]
+    mock_web_ctx.virtual_trade_service.calculate_return.side_effect = \
+        lambda bp, sp, qty=1, apply_cost=False: round((sp - bp) / bp * 100, 2)
+
+    mock_web_ctx.stock_code_repository = MagicMock()
+    mock_web_ctx.stock_code_repository.get_name_by_code.return_value = "SK하이닉스"
+
+    async def mock_multi_price(codes):
+        return ResCommonResponse(rt_cd="0", msg1="OK", data=[
+            {"stck_shrn_iscd": "000660", "stck_prpr": "1300", "prdy_ctrt": "2.0"}
+        ])
+    mock_web_ctx.stock_query_service.get_multi_price = mock_multi_price
+
+    mock_web_ctx.virtual_trade_service.save_daily_snapshot = MagicMock()
+    mock_web_ctx.virtual_trade_service._load_data.return_value = {}
+    mock_web_ctx.virtual_trade_service.get_daily_change.return_value = (0.0, None)
+    mock_web_ctx.virtual_trade_service.get_weekly_change.return_value = (0.0, None)
+
+    response = web_client.get("/api/virtual/history")
+    assert response.status_code == 200
+
+    sold = response.json()["trades"][0]
+    assert sold["return_rate"] == 10.0       # 매수가 1000 → 매도가 1100
+    assert sold["hold_return_rate"] == 30.0  # 매수가 1000 → 현재가 1300 (미매도 가정)
+
+    web_api._PRICE_CACHE.clear()
+
+
+@pytest.mark.asyncio
 async def test_get_virtual_history_force_update(web_client, mock_web_ctx):
     """GET /api/virtual/history force_code 테스트"""
     web_api._PRICE_CACHE.clear()

--- a/view/web/routes/virtual.py
+++ b/view/web/routes/virtual.py
@@ -617,6 +617,11 @@ async def _get_virtual_history_impl(ctx, force_code, apply_cost):
                     trade['return_rate'] = vm.calculate_return(bp, sp, qty, apply_cost=apply_cost)
                     trade['sell_price'] = sp
 
+                # 미매도 가정 수익률 (매수가 → 현재가)
+                cur = trade.get('current_price')
+                if cur:
+                    trade['hold_return_rate'] = vm.calculate_return(bp, float(cur), qty, apply_cost=apply_cost)
+
     except Exception as e:
         print(f"[WebAPI] virtual/history enrichment 오류: {e}")
 

--- a/view/web/static/js/virtual.js
+++ b/view/web/static/js/virtual.js
@@ -920,6 +920,11 @@ function renderVirtualSoldTable() {
     pageData.forEach(item => {
         const ror = item.return_rate || 0;
         const rorClass = ror > 0 ? 'text-positive' : (ror < 0 ? 'text-negative' : '');
+        const hrr = item.hold_return_rate;
+        const hrrClass = hrr > 0 ? 'text-positive' : (hrr < 0 ? 'text-negative' : '');
+        const holdRorHtml = (hrr !== null && hrr !== undefined)
+            ? `<div style="font-size:0.8em; color:var(--text-secondary);" title="매도하지 않고 보유했다면 현재가 기준 수익률">미매도 <span class="${hrrClass}">${formatVirtualPct(hrr)}</span></div>`
+            : '';
         const buyDate = item.buy_date ? item.buy_date.split(' ')[0] : '-';
         const sellDate = item.sell_date ? item.sell_date.split(' ')[0] : '-';
         const buyPrice = Number(item.buy_price).toLocaleString();
@@ -955,7 +960,7 @@ function renderVirtualSoldTable() {
                 </td>
                 <td>${buyPrice}</td>
                 <td>${sellPrice}<div style="font-size:0.8em; color:var(--text-secondary);">${curPrice}${cacheLabel}${forceBtn}</div></td>
-                <td class="${rorClass}"><strong>${ror.toFixed(2)}%</strong>${costHtml}</td>
+                <td class="${rorClass}"><strong>${ror.toFixed(2)}%</strong>${costHtml}${holdRorHtml}</td>
                 <td>${days}일<div style="font-size:0.8em; color:var(--text-secondary);">${buyDate} ~ ${sellDate}</div></td>
             </tr>
         `);

--- a/view/web/templates/virtual.html
+++ b/view/web/templates/virtual.html
@@ -118,7 +118,7 @@
 {% block scripts %}
 <script src="/static/js/virtual_chart.js?v=8"></script>
 <script src="/static/js/stock.js?v=1"></script>
-<script src="/static/js/virtual.js?v=3"></script>
+<script src="/static/js/virtual.js?v=4"></script>
 <script>
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', () => loadVirtualHistory(), { once: true });


### PR DESCRIPTION
## 요약
- 모의투자 페이지 매도완료 테이블의 수익률(매수가→매도가) 아래에, **매도하지 않고 보유했다면 현재가 기준 수익률**(`미매도 +x.xx%`)을 함께 표시합니다.

## 변경 내용
- `view/web/routes/virtual.py`: `/api/virtual/history` SOLD 분기에서 `current_price`가 있으면 `hold_return_rate`(매수가→현재가)를 계산해 응답에 포함. `vm.calculate_return`을 그대로 사용하므로 수수료/세금 포함 토글(`apply_cost`)과 일관됩니다. SOLD 종목도 기존 `price_map`으로 현재가를 받고 있어 추가 API 호출 없음.
- `view/web/static/js/virtual.js`: 매도완료 테이블 수익률 셀에 `미매도 +x.xx%` 보조 표시 (상승/하락 색상 + 툴팁). `current_price` 없는 항목은 생략.
- `view/web/templates/virtual.html`: `virtual.js` 캐시 버스팅 `v=3` → `v=4`.

## 테스트
- TDD: SOLD 거래(매수 1000/매도 1100/현재가 1300)에서 `return_rate=10.0`, `hold_return_rate=30.0`을 검증하는 테스트를 선작성, `KeyError`로 실패 확인 후 구현.
- 단위 테스트 5904건 통과, 통합 테스트 240건 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)