### PR TITLE
StrategyScheduler 성능 개선 3건 (컷오프 로그 1회화, 보유 조회 중복 제거, shadow flush 오프로드)

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -164,6 +164,7 @@ class StrategyScheduler:
         self._last_order_poll_time: Optional[datetime] = None
         self._force_exit_done: set = set()  # 당일 강제 청산 완료된 전략
         self._force_exit_done_date: Optional[str] = None
+        self._order_cutoff_logged = False  # 컷오프 스킵 로그 1회화 (매초 반복 방지)
         self._reconciled_dates: set = set()  # 원장 대사 완료된 날짜 (YYYY-MM-DD)
         self.MAX_HISTORY = 200  # 최대 보관 이력 수
         self._signal_history: List[SignalRecord] = self._load_signal_history()
@@ -252,11 +253,13 @@ class StrategyScheduler:
                 self._sync_force_exit_done_date(now)
 
                 if self._is_after_order_cutoff(now, close_time):
-                    self._logger.info(
-                        f"[Scheduler] 주문 컷오프 이후 전략 실행 스킵 "
-                        f"(now={now.strftime('%H:%M:%S')}, cutoff="
-                        f"{self._get_order_cutoff_time(close_time).strftime('%H:%M:%S')})"
-                    )
+                    if not self._order_cutoff_logged:
+                        self._order_cutoff_logged = True
+                        self._logger.info(
+                            f"[Scheduler] 주문 컷오프 이후 전략 실행 스킵 "
+                            f"(now={now.strftime('%H:%M:%S')}, cutoff="
+                            f"{self._get_order_cutoff_time(close_time).strftime('%H:%M:%S')})"
+                        )
                     await asyncio.sleep(self.LOOP_INTERVAL_SEC)
                     continue
 
@@ -349,6 +352,7 @@ class StrategyScheduler:
             return
         self._force_exit_done.clear()
         self._force_exit_done_date = today
+        self._order_cutoff_logged = False
         # 날짜 키를 포함하는 set 의 과거 항목 purge (장기 구동 시 무한 증가 방지)
         today_compact = now.strftime("%Y%m%d")
         self._strategy_failure_alert_keys = {
@@ -450,6 +454,7 @@ class StrategyScheduler:
 
         # 1) 보유 종목 청산 조건 체크
         holdings = self._get_strategy_holdings(cfg)
+        sells_dispatched = False
         if holdings:
             t_exit = self._pm.start_timer()
             strategy_logger = getattr(cfg.strategy, "strategy_logger", None)
@@ -483,9 +488,13 @@ class StrategyScheduler:
             self._stamp_signals(sell_signals, cfg.strategy)
             if sell_signals:
                 await self._execute_signals_concurrently(sell_signals)
+                sells_dispatched = True
+
+        # 매도 미발생 사이클은 위 조회 결과를 재사용해 중복 조회/prune 패스를 줄인다.
+        post_exit_holdings = holdings if not sells_dispatched else None
 
         # P2 2-4 exit: 보유 종목 손절 shadow 구독 갱신 (entry gate 와 무관하게 매 사이클 실행).
-        await self._refresh_exit_shadow_subscriptions(cfg)
+        await self._refresh_exit_shadow_subscriptions(cfg, holdings=post_exit_holdings)
 
         # 2) 새 매수 스캔
         entry_gate = self._check_live_expansion_gate(name)
@@ -500,7 +509,10 @@ class StrategyScheduler:
             self._pm.log_timer(f"{name}.run_strategy", t_run)
             return
 
-        current_holdings = self._get_strategy_holdings(cfg)
+        current_holdings = (
+            post_exit_holdings if post_exit_holdings is not None
+            else self._get_strategy_holdings(cfg)
+        )
         current_holds_count = len(current_holdings)
 
         position_full = current_holds_count >= cfg.max_positions
@@ -1172,7 +1184,7 @@ class StrategyScheduler:
         if self._event_shadow_journal is None:
             return
         if self._event_router is None:
-            self._record_event_shadow_status(
+            await self._record_event_shadow_status(
                 strategy_name=getattr(cfg.strategy, "name", ""),
                 event="subscriptions_skipped",
                 details={"reason": "event_router_missing"},
@@ -1187,7 +1199,7 @@ class StrategyScheduler:
             self._logger.warning(
                 f"[Scheduler] {name} current_candidate_codes() 호출 오류: {e}"
             )
-            self._record_event_shadow_status(
+            await self._record_event_shadow_status(
                 strategy_name=name,
                 event="subscriptions_skipped",
                 details={"reason": "candidate_codes_error", "error": str(e)},
@@ -1220,7 +1232,7 @@ class StrategyScheduler:
 
         self._event_shadow_subscriptions[name] = new_codes
         await self._sync_event_shadow_price_subscriptions(name, new_codes)
-        self._record_event_shadow_status(
+        await self._record_event_shadow_status(
             strategy_name=name,
             event="subscriptions_refreshed",
             details={
@@ -1293,7 +1305,7 @@ class StrategyScheduler:
             except Exception:
                 payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
             try:
-                self._record_event_shadow_signal(
+                await self._record_event_shadow_signal(
                     strategy_name=strategy.name,
                     code=code,
                     signal=payload,
@@ -1314,7 +1326,7 @@ class StrategyScheduler:
         except Exception:
             return time.strftime("%Y%m%d")
 
-    def _record_event_shadow_signal(
+    async def _record_event_shadow_signal(
         self,
         *,
         strategy_name: str,
@@ -1333,11 +1345,9 @@ class StrategyScheduler:
             snapshot=snapshot,
             signal_source=signal_source,
         )
-        flush_fn = getattr(journal, "flush_to_file", None)
-        if callable(flush_fn):
-            flush_fn(self._event_shadow_date_str())
+        await self._flush_event_shadow_journal()
 
-    def _record_event_shadow_status(
+    async def _record_event_shadow_status(
         self,
         *,
         strategy_name: str,
@@ -1355,9 +1365,13 @@ class StrategyScheduler:
             event=event,
             details=details or {},
         )
-        flush_fn = getattr(journal, "flush_to_file", None)
+        await self._flush_event_shadow_journal()
+
+    async def _flush_event_shadow_journal(self) -> None:
+        """journal flush 를 worker thread 로 오프로드 (틱 경로 이벤트 루프 blocking 방지)."""
+        flush_fn = getattr(self._event_shadow_journal, "flush_to_file", None)
         if callable(flush_fn):
-            flush_fn(self._event_shadow_date_str())
+            await asyncio.to_thread(flush_fn, self._event_shadow_date_str())
 
     @staticmethod
     def _exit_shadow_category_key(strategy_name: str) -> str:
@@ -1368,7 +1382,11 @@ class StrategyScheduler:
         # entry shadow 와 같은 종목을 구독해도 router 키가 겹치지 않도록 접미사를 붙인다.
         return f"{strategy_name}__exit"
 
-    async def _refresh_exit_shadow_subscriptions(self, cfg: StrategySchedulerConfig) -> None:
+    async def _refresh_exit_shadow_subscriptions(
+        self,
+        cfg: StrategySchedulerConfig,
+        holdings: Optional[List[dict]] = None,
+    ) -> None:
         """P2 2-4 exit: event_driven_shadow 전략의 보유 종목을 손절 shadow 로 router 구독.
 
         - flag False / router·journal 미주입 시 no-op.
@@ -1384,11 +1402,12 @@ class StrategyScheduler:
 
         strategy = cfg.strategy
         name = strategy.name
-        try:
-            holdings = self._get_strategy_holdings(cfg) or []
-        except Exception as e:
-            self._logger.warning(f"[Scheduler] {name} exit shadow 보유 조회 오류: {e}")
-            return
+        if holdings is None:
+            try:
+                holdings = self._get_strategy_holdings(cfg) or []
+            except Exception as e:
+                self._logger.warning(f"[Scheduler] {name} exit shadow 보유 조회 오류: {e}")
+                return
 
         holdings_by_code: Dict[str, dict] = {}
         for hold in holdings:
@@ -1443,7 +1462,7 @@ class StrategyScheduler:
             except Exception:
                 payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
             try:
-                self._record_event_shadow_signal(
+                await self._record_event_shadow_signal(
                     strategy_name=strategy.name,
                     code=code,
                     signal=payload,

--- a/services/event_shadow_journal_service.py
+++ b/services/event_shadow_journal_service.py
@@ -88,15 +88,18 @@ class EventShadowJournalService:
     def flush_to_file(self, date_str: str) -> Optional[Path]:
         if not self._buffer:
             return None
-        self._log_dir.mkdir(parents=True, exist_ok=True)
+        # flush 가 worker thread 로 오프로드될 수 있으므로(이벤트 루프의 record 와 경합),
+        # 버퍼를 통째로 교체한 뒤 쓰고, 실패 시 되돌려 유실을 막는다.
+        records, self._buffer = self._buffer, []
         path = self._log_dir / f"{date_str}.jsonl"
         try:
+            self._log_dir.mkdir(parents=True, exist_ok=True)
             with path.open("a", encoding="utf-8") as f:
-                for rec in self._buffer:
+                for rec in records:
                     f.write(json.dumps(rec, ensure_ascii=False))
                     f.write("\n")
-            self._buffer.clear()
             return path
         except OSError as e:
+            self._buffer = records + self._buffer
             self._logger.warning(f"[EventShadowJournal] flush 실패: {e}")
             return None

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1727,6 +1727,75 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         mock_run.assert_not_awaited()
 
+    async def test_loop_logs_order_cutoff_skip_only_once(self):
+        """주문 컷오프 스킵 INFO 로그는 컷오프 진입 시 1회만 남긴다 (매초 반복 금지)."""
+        from datetime import datetime
+
+        scheduler, _, _, tm, mcs = self._make_scheduler()
+        now_dt = datetime(2026, 5, 19, 15, 25, 0)
+        close_dt = datetime(2026, 5, 19, 15, 40, 0)
+        tm.get_current_kst_time.return_value = now_dt
+        tm.get_market_close_time.return_value = close_dt
+
+        strategy = MockStrategy(name="전략A")
+        scheduler.register(StrategySchedulerConfig(strategy=strategy, interval_minutes=0))
+        scheduler._running = True
+        # 컷오프 이후 시간대에서 루프 2회 반복 후 종료
+        mcs.is_market_open_now.side_effect = [True, True, asyncio.CancelledError()]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            try:
+                await scheduler._loop()
+            except asyncio.CancelledError:
+                pass
+
+        cutoff_logs = [
+            c for c in scheduler._logger.info.call_args_list
+            if c.args and isinstance(c.args[0], str) and "주문 컷오프" in c.args[0]
+        ]
+        self.assertEqual(len(cutoff_logs), 1)
+
+    def test_sync_force_exit_done_date_resets_cutoff_log_flag(self):
+        """날짜가 바뀌면 컷오프 로그 1회화 플래그가 초기화된다."""
+        from datetime import datetime
+
+        scheduler, _, _, _, _ = self._make_scheduler()
+        scheduler._sync_force_exit_done_date(datetime(2026, 5, 19, 15, 25, 0))
+        scheduler._order_cutoff_logged = True
+
+        scheduler._sync_force_exit_done_date(datetime(2026, 5, 20, 9, 0, 0))
+
+        self.assertFalse(scheduler._order_cutoff_logged)
+
+    async def test_run_strategy_fetches_holdings_once_when_no_sells(self):
+        """매도 신호가 없는 사이클은 보유 목록을 1회만 조회한다 (중복 조회 제거)."""
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        strategy = MockStrategy(name="전략A")
+        config = StrategySchedulerConfig(strategy=strategy)
+        scheduler.register(config)
+
+        await scheduler._run_strategy(config)
+
+        self.assertEqual(vm.get_holds_by_strategy.call_count, 1)
+
+    async def test_run_strategy_refetches_holdings_after_sell_signals(self):
+        """매도 신호를 실행한 사이클은 매수 스캔 전에 보유 목록을 재조회한다."""
+        sell = TradeSignal(
+            code="005930", name="삼성전자", action="SELL",
+            price=70000, qty=1, reason="청산", strategy_name="전략A",
+        )
+        strategy = MockStrategy(name="전략A", exit_signals=[sell])
+        scheduler, vm, _, _, _ = self._make_scheduler()
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "name": "삼성전자", "buy_price": 60000, "qty": 1, "status": "HOLD"}
+        ]
+        config = StrategySchedulerConfig(strategy=strategy)
+        scheduler.register(config)
+
+        await scheduler._run_strategy(config)
+
+        self.assertEqual(vm.get_holds_by_strategy.call_count, 2)
+
     async def test_loop_exception_handling(self):
         """루프 내 예외 발생 시 계속 실행되는지 테스트."""
         scheduler, _, _, tm, _ = self._make_scheduler()

--- a/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -188,6 +188,31 @@ async def test_shadow_evaluator_records_signal_and_returns_none():
     assert call_kwargs["signal"]["action"] == "BUY"
     assert call_kwargs["snapshot"] == snapshot
     journal.flush_to_file.assert_called_once_with("20260520")
+
+
+@pytest.mark.asyncio
+async def test_shadow_record_flush_offloaded_to_thread():
+    """flush_to_file 은 이벤트 루프를 막지 않도록 asyncio.to_thread 로 오프로드된다."""
+    router = MagicMock()
+    router.subscribe = MagicMock()
+    journal = MagicMock()
+    journal.record = MagicMock()
+    scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
+
+    sig = TradeSignal(
+        code="005930", name="삼성전자", action="BUY", price=75000,
+        qty=1, reason="test", strategy_name="VBO",
+    )
+    cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
+    cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
+
+    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    evaluator = router.subscribe.call_args.kwargs["evaluator"]
+
+    with patch("asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+        await evaluator("005930", {"price": "75000"})
+
+    to_thread.assert_awaited_once_with(journal.flush_to_file, "20260520")
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_event_shadow_journal_service.py
+++ b/tests/unit_test/services/test_event_shadow_journal_service.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -113,6 +113,19 @@ def test_flush_appends_to_existing_file(tmp_path, logger):
 
     lines = path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 2  # 첫 flush 1줄 + 두 번째 flush 1줄
+
+
+def test_flush_to_file_keeps_records_on_write_failure(tmp_path, logger):
+    """flush 쓰기 실패 시 레코드가 유실되지 않고 버퍼에 보존된다."""
+    svc = EventShadowJournalService(log_root=tmp_path, logger=logger)
+    svc.record(strategy_name="VBO", code="005930", signal={"a": 1}, snapshot={})
+
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        result = svc.flush_to_file(date_str="20260518")
+
+    assert result is None
+    assert len(svc.get_records()) == 1
+    logger.warning.assert_called_once()
 
 
 def test_record_ignores_missing_required_fields(tmp_path, logger):


### PR DESCRIPTION
## 배경

`scheduler/strategy_scheduler.py` 성능 검토에서 발견된 3가지 개선 포인트를 적용합니다.

## 변경 내용

### 1. 주문 컷오프 스킵 INFO 로그 1회화
- 컷오프(마감 20분 전) 이후 메인 루프가 1초마다 동일한 "주문 컷오프 이후 전략 실행 스킵" INFO를 남겨 하루 ~1,200줄의 로그 스팸이 발생하던 것을 컷오프 진입 시 1회만 기록하도록 변경.
- `_sync_force_exit_done_date`의 일일 리셋 경로에서 플래그를 초기화해 다음 거래일에 다시 1회 기록.

### 2. `_run_strategy` 보유 목록 중복 조회 제거
- 기존: 사이클당 `_get_strategy_holdings()` 3회 호출 (청산 체크 → exit shadow 갱신 → 매수 스캔). 조회마다 prune 2패스(`signal_history` 역순 풀스캔 포함)가 동반.
- 변경: 매도 신호 미발생 사이클(대부분)은 첫 조회 결과를 재사용 — 조회 3→1회(shadow on) / 2→1회(shadow off). 매도 실행 시에는 기존대로 재조회.
- `_refresh_exit_shadow_subscriptions`에 optional `holdings` 파라미터 추가 (미전달 시 기존 동작 유지).

### 3. event-shadow journal flush 이벤트 루프 오프로드
- 틱 evaluator 경로에서 레코드마다 동기 파일 flush(mkdir + open/append)가 이벤트 루프를 막던 것을 `asyncio.to_thread`로 오프로드.
- **per-record flush 계약(#498, e2e 테스트)은 유지** — flush 빈도는 동일하고 blocking만 제거.
- `EventShadowJournalService.flush_to_file`: worker thread와 이벤트 루프(record) 경합 방지를 위해 버퍼 swap 후 쓰기, 실패 시 복원. (부수 변경: mkdir 실패 시 예외 전파 대신 버퍼 보존 + warning — 기존 flush 실패 처리와 일관.)

## 테스트 (TDD)
- 신규 6건: 컷오프 로그 1회 / 플래그 일일 리셋 / 무매도 사이클 조회 1회 / 매도 후 재조회(회귀 가드) / flush to_thread 경유 / flush 실패 시 버퍼 보존(회귀 가드)
- 검증: 단위 테스트 5,919건 + 통합 테스트 240건 전체 통과
- 기존 계약 보존 확인: `test_event_shadow_pipeline_e2e.py`(per-record flush), `test_get_status_prunes_*`(prune 계약 — get_status 경로 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)