### PR TITLE
MinerviniStage 정확성 개선: MA200 시리즈 기울기 + 입력 방어

### DIFF
--- a/services/minervini_stage_service.py
+++ b/services/minervini_stage_service.py
@@ -58,6 +58,7 @@ class MinerviniStageService:
         self._rs_rating_svc = rs_rating_service
         self._stock_repository = stock_repository
         self._minervini_update_task: Optional["MinerviniUpdateTask"] = None
+        self._refresh_task: Optional[asyncio.Task] = None
         self._slope_lookback = slope_lookback
         self._vol_threshold = volatility_threshold
         self._logger = logger or logging.getLogger(__name__)
@@ -101,8 +102,8 @@ class MinerviniStageService:
                             for it in db_items
                         ]
                         return ResCommonResponse(rt_cd="0", msg1="성공", data=data)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.debug(f"[MinerviniStage] Stage2 DB 조회 실패 — 캐시로 폴백: {e}")
 
         # 2차: in-memory 캐시
         task = self._minervini_update_task
@@ -116,7 +117,8 @@ class MinerviniStageService:
         # 3차: 갱신 트리거 후 수집 대기
         progress = task.get_progress()
         if not progress.get("running"):
-            asyncio.create_task(task.refresh_minervini_stage2())
+            # 참조를 보관해 실행 중 GC 수거를 방지 (fire-and-forget 안티패턴 회피).
+            self._refresh_task = asyncio.create_task(task.refresh_minervini_stage2())
         return ResCommonResponse(rt_cd="0", msg1="수집 중", data=[])
 
     async def get_stage_for_code(self, code: str) -> tuple[int, str]:
@@ -214,9 +216,11 @@ class MinerviniStageService:
         ma150 = mean(closes[-150:])
         ma200 = mean(closes[-200:])
 
-        # MA200 기울기: numpy 선형회귀 (20일 = 미너비니 "최소 1개월 우상향" 기준)
-        slope_window = closes[-self._slope_lookback:]
-        ma200_slope = self._calculate_slope(slope_window)
+        # MA200 기울기: MA200 시리즈 자체에 numpy 선형회귀
+        # (20일 = 미너비니 "최소 1개월 우상향" 기준). 원시 종가가 아니라
+        # 이동평균선의 추세를 봐야 단기 눌림을 하락 전환으로 오판하지 않는다.
+        ma200_series = self._ma_series(closes, 200, self._slope_lookback)
+        ma200_slope = self._calculate_slope(ma200_series)
 
         # 52주 고가: 종가 기준
         w52_closes = closes[-252:] if len(closes) >= 252 else closes
@@ -270,6 +274,23 @@ class MinerviniStageService:
         return (self.STAGE_1_NEGLECT, reason) if return_reason else self.STAGE_1_NEGLECT
 
     # ── 내부 헬퍼 ──────────────────────────────────────────────────────────
+
+    def _ma_series(self, closes: List[float], window: int, count: int) -> List[float]:
+        """최근 'count'개 거래일에 대한 'window'기간 단순이동평균 시리즈(오래된 순).
+
+        MA200 기울기 산출에 사용. 데이터가 window+1 미만이면 점이 1개 이하라
+        기울기를 낼 수 없어 빈/단일 리스트를 반환하며, 이 경우 _calculate_slope가
+        0.0을 돌려주어 보수적으로 Stage 4(하락)로 분류된다.
+        """
+        n = len(closes)
+        max_points = n - window + 1
+        if max_points < 1:
+            return []
+        points = min(count, max_points)
+        return [
+            mean(closes[i - window + 1: i + 1])
+            for i in range(n - points, n)
+        ]
 
     def _calculate_slope(self, values: List[float]) -> float:
         """numpy 선형회귀로 기울기 산출.
@@ -351,8 +372,11 @@ class MinerviniStageService:
         """OHLCV 행 목록에서 종가/저가 리스트 추출.
 
         KIS API 필드명(stck_clpr, stck_lwpr) 우선, 없으면 'close'/'low' fallback.
-        rows는 오래된 순 또는 최신 순 모두 처리 — DB에서 날짜 오름차순 반환 가정.
+        모든 행에 날짜 키가 있으면 오래된 순으로 정렬해 closes[-1]이 최신가가 되도록
+        보장한다(없으면 입력 순서 유지). 종가 0 이하 행은 거래정지 등 비정상으로
+        보고 제외한다 — 52주 저가 등 계산 오염 방지.
         """
+        rows = self._ensure_ascending(rows)
         closes: List[float] = []
         lows: List[float] = []
         for r in rows:
@@ -367,9 +391,20 @@ class MinerviniStageService:
                     f"close={close_val!r}, low={low_val!r}"
                 )
                 continue
+            if c <= 0:
+                continue
+            if l <= 0:
+                l = c
             closes.append(c)
             lows.append(l)
         return closes, lows
+
+    def _ensure_ascending(self, rows: list) -> list:
+        """모든 행에 동일한 날짜 키가 있으면 오래된 순으로 정렬, 아니면 원본 유지."""
+        for key in ("date", "stck_bsop_date"):
+            if rows and all(isinstance(r, dict) and r.get(key) for r in rows):
+                return sorted(rows, key=lambda r: r[key])
+        return rows
 
     async def _fetch_rs_rating(self, code: str) -> int:
         """RS Rating 서비스에서 최신 RS Rating 조회. 없으면 0 반환."""

--- a/tests/unit_test/services/test_minervini_stage_service.py
+++ b/tests/unit_test/services/test_minervini_stage_service.py
@@ -93,6 +93,16 @@ class TestClassifyStage:
         assert isinstance(reason, str)
         assert reason
 
+    def test_ma200_slope_uses_ma_series_not_raw_closes(self):
+        # 장기 강한 상승(240일) 후 최근 20일 완만한 눌림.
+        # 원시 종가 기울기는 음수지만 MA200 자체는 여전히 우상향이므로
+        # Stage 4(하락/매수금지)로 오판해서는 안 된다.
+        svc = _make_svc()
+        closes = _trending_closes(5000, 14000, 240) + _trending_closes(14000, 13500, 20)
+        lows = [c * 0.97 for c in closes]
+        result = svc.classify_stage(closes, lows, rs_rating=80)
+        assert result != MinerviniStageService.STAGE_4_DECLINING
+
 
 class TestCheckVcpPattern:
 
@@ -173,6 +183,30 @@ class TestHelpers:
         closes, lows = svc._extract_price_series(rows)
         assert closes == [100.0, 200.0, 300.0]
         assert lows == [90.0, 190.0, 300.0]
+
+    def test_extract_price_series_sorts_by_date_ascending(self):
+        # 모든 행에 날짜 키가 있으면 오래된 순으로 정렬해 closes[-1]이 최신가가 되도록 한다.
+        svc = _make_svc()
+        rows = [
+            {"date": "20260103", "stck_clpr": "300", "stck_lwpr": "290"},
+            {"date": "20260101", "stck_clpr": "100", "stck_lwpr": "90"},
+            {"date": "20260102", "stck_clpr": "200", "stck_lwpr": "190"},
+        ]
+        closes, lows = svc._extract_price_series(rows)
+        assert closes == [100.0, 200.0, 300.0]
+        assert lows == [90.0, 190.0, 290.0]
+
+    def test_extract_price_series_skips_zero_prices(self):
+        # 거래정지 등으로 종가 0이 들어오면 52주 저가 등을 오염시키므로 제외한다.
+        svc = _make_svc()
+        rows = [
+            {"stck_clpr": "100", "stck_lwpr": "90"},
+            {"stck_clpr": "0", "stck_lwpr": "0"},
+            {"stck_clpr": "200", "stck_lwpr": "190"},
+        ]
+        closes, lows = svc._extract_price_series(rows)
+        assert closes == [100.0, 200.0]
+        assert 0.0 not in lows
 
     def test_describe_stage_mapping(self):
         svc = _make_svc()
@@ -284,6 +318,42 @@ class TestGetStage2List:
 
         assert resp.rt_cd == "0"
         assert resp.data[0]["code"] == "035720"
+
+    @pytest.mark.asyncio
+    async def test_db_exception_is_logged(self):
+        stock_repo = AsyncMock()
+        stock_repo.get_latest_trade_date.side_effect = RuntimeError("DB 오류")
+        update_task = AsyncMock()
+        update_task.get_minervini_stage2_cache.return_value = [{"code": "035720"}]
+        logger = MagicMock()
+
+        svc = MinerviniStageService(
+            stock_query_service=AsyncMock(), stock_repository=stock_repo, logger=logger
+        )
+        svc._minervini_update_task = update_task
+
+        await svc.get_stage2_list()
+
+        assert logger.debug.called or logger.warning.called
+
+    @pytest.mark.asyncio
+    async def test_refresh_task_reference_is_retained(self):
+        stock_repo = AsyncMock()
+        stock_repo.get_latest_trade_date.return_value = None
+        update_task = AsyncMock()
+        update_task.get_minervini_stage2_cache.return_value = []
+        update_task.get_progress = MagicMock(return_value={"running": False})
+
+        svc = MinerviniStageService(stock_query_service=AsyncMock(), stock_repository=stock_repo)
+        svc._minervini_update_task = update_task
+
+        sentinel = MagicMock()
+        with patch(
+            "services.minervini_stage_service.asyncio.create_task", return_value=sentinel
+        ):
+            await svc.get_stage2_list()
+
+        assert svc._refresh_task is sentinel
 
 
 class TestGetStageForCode:


### PR DESCRIPTION
## 배경
`services/minervini_stage_service.py` 개선 포인트 점검 결과 중, 정확성에 직접 영향을 주는 항목과 저위험 정리를 TDD로 반영했다. (private 속성 침투 제거 #4는 생성자/DI 와이어링까지 건드리는 별도 리팩토링이라 이번 범위에서 제외)

## 변경 내용
1. **MA200 기울기 버그 수정 (핵심)** — `ma200_slope`를 최근 20일 *원시 종가*가 아니라 *MA200 시리즈*에 선형회귀하도록 변경. 기존 구현은 단기 가격 모멘텀이라, MA200 위에서 건강하게 상승 중인 종목이 2~3주 눌림만 와도 `Stage 4(하락/매수금지)`로 오판했다. `_ma_series()` 헬퍼 추가.
2. **입력 정렬 방어** — `_extract_price_series`가 모든 행에 날짜 키(`date`/`stck_bsop_date`)가 있으면 오래된 순으로 정렬(`_ensure_ascending`)해 `closes[-1]`이 항상 최신가가 되도록 보장. 날짜 키가 없으면 입력 순서 유지(기존 동작 호환).
3. **0가 행 제외** — 거래정지 등으로 종가 0이 들어오면 `w52_low`를 0으로 만들어 조건 ⑥을 항상 참으로 만드는 오염을 방지. 종가 ≤ 0 행 skip.
4. **refresh task 참조 보관** — `asyncio.create_task` 반환값을 `self._refresh_task`에 보관(fire-and-forget 시 실행 중 GC 수거 방지).
5. **DB 조회 예외 로깅** — `get_stage2_list`의 침묵하던 `except: pass`를 `logger.debug`로 대체.

## 테스트
- 신규 단위 테스트 5건 추가 (각 변경의 회귀 가드).
- 단위: `test_minervini_stage_service.py` 44 passed + 호출부(oneil/favorite/strategy_executor/minervini_update_task/web routes) 184 passed.
- 통합: `tests/integration_test` 240 passed.

## 후속(별도 PR 권장)
- #4 private 속성 침투 제거: `self._stock_query_svc.market_data_service._stock_repo/_mcs` → 주입된 `stock_repository` + MarketCalendarService 주입으로 전환 (커밋 #524 패턴).

🤖 Generated with [Claude Code](https://claude.com/claude-code)