### PR TITLE
NewHighService 정리: 포매터 통합·중복 트리거 제거·결과 개수 대칭·0.0 등락률 보존

### DIFF
--- a/services/newhigh_service.py
+++ b/services/newhigh_service.py
@@ -14,6 +14,9 @@ class NewHighService:
     DB 및 NewHighTask 캐시 연동을 담당한다.
     """
 
+    # DB/캐시 양쪽 경로의 최대 반환 개수 (NewHighTask.get_newhigh_cache 기본값과 일치)
+    _MAX_ITEMS = 200
+
     def __init__(
         self,
         stock_repository: Optional["StockRepository"] = None,
@@ -38,7 +41,10 @@ class NewHighService:
                         return ResCommonResponse(
                             rt_cd="0",
                             msg1="성공",
-                            data=[self._format_db_item(it) for it in db_items],
+                            data=[
+                                self._format_item(it, "is_historical_newhigh")
+                                for it in db_items[: self._MAX_ITEMS]
+                            ],
                         )
             except Exception as e:
                 self._logger.warning(f"NewHighService DB 조회 오류: {e}")
@@ -56,50 +62,35 @@ class NewHighService:
         ):
             return ResCommonResponse(rt_cd="0", msg1="성공", data=[])
 
-        # 2차: In-Memory 캐시
-        cache = await task.get_newhigh_cache()
+        # 2차: In-Memory 캐시 (비어 있으면 get_newhigh_cache가 갱신을 트리거한다)
+        cache = await task.get_newhigh_cache(self._MAX_ITEMS)
         if cache:
             return ResCommonResponse(
                 rt_cd="0",
                 msg1="성공",
-                data=[self._format_cache_item(it) for it in cache],
+                data=[self._format_item(it, "is_historical_new_high") for it in cache],
             )
 
-        # 3차: 갱신 트리거 후 수집 대기
-        progress = task.get_progress()
-        if not progress.get("running"):
-            trigger_refresh = getattr(task, "trigger_refresh", None)
-            if callable(trigger_refresh):
-                trigger_refresh()
-
+        # 캐시가 비어 수집이 진행/예약된 상태 — 빈 목록으로 응답
         return ResCommonResponse(rt_cd="0", msg1="수집 중", data=[])
 
     @staticmethod
-    def _format_db_item(item: dict) -> dict:
-        return {
-            "code": item.get("code", ""),
-            "name": item.get("name", ""),
-            "stck_prpr": str(item.get("current_price") or 0),
-            "prdy_ctrt": str(item.get("change_rate") or 0),
-            "rs_rating": item.get("rs_rating") or 0,
-            "market_cap": item.get("market_cap") or 0,
-            "trading_value": item.get("trading_value") or 0,
-            "w52_high": item.get("w52_high") or 0,
-            "is_historical_new_high": bool(item.get("is_historical_newhigh")),
-            "minervini_stage": item.get("minervini_stage") or 0,
-        }
+    def _format_item(item: dict, hist_key: str) -> dict:
+        """DB row / 캐시 dict를 웹 응답 형식으로 변환한다.
 
-    @staticmethod
-    def _format_cache_item(item: dict) -> dict:
+        DB와 캐시는 역사적 신고가 키 이름이 다르므로(hist_key) 인자로 받는다.
+        """
+        price = item.get("current_price")
+        rate = item.get("change_rate")
         return {
             "code": item.get("code", ""),
             "name": item.get("name", ""),
-            "stck_prpr": str(item.get("current_price") or 0),
-            "prdy_ctrt": str(item.get("change_rate") or 0),
+            "stck_prpr": str(price if price is not None else 0),
+            "prdy_ctrt": str(rate if rate is not None else 0),
             "rs_rating": item.get("rs_rating") or 0,
             "market_cap": item.get("market_cap") or 0,
             "trading_value": item.get("trading_value") or 0,
             "w52_high": item.get("w52_high") or 0,
-            "is_historical_new_high": item.get("is_historical_new_high", False),
+            "is_historical_new_high": bool(item.get(hist_key)),
             "minervini_stage": item.get("minervini_stage") or 0,
         }

--- a/tests/unit_test/services/test_newhigh_service.py
+++ b/tests/unit_test/services/test_newhigh_service.py
@@ -218,8 +218,8 @@ async def test_get_newhigh_list_cache_null_fields(mock_task):
 
 # ── force_run 트리거 ──────────────────────────────────────────────────────
 
-async def test_get_newhigh_list_no_cache_triggers_collect(mock_task):
-    """캐시가 없고 task가 실행 중이 아닐 때 갱신을 트리거하고 빈 목록을 반환한다."""
+async def test_get_newhigh_list_no_cache_returns_collecting(mock_task):
+    """캐시가 비면 수집을 get_newhigh_cache에 위임하고 빈 목록('수집 중')을 반환한다."""
     mock_task.get_newhigh_cache.return_value = []
     mock_task.get_progress.return_value = {"running": False}
 
@@ -229,11 +229,12 @@ async def test_get_newhigh_list_no_cache_triggers_collect(mock_task):
     assert result.rt_cd == "0"
     assert result.msg1 == "수집 중"
     assert result.data == []
-    mock_task.trigger_refresh.assert_called_once()
+    mock_task.get_newhigh_cache.assert_awaited_once()
+    mock_task.trigger_refresh.assert_not_called()
 
 
-async def test_get_newhigh_list_no_cache_already_running_no_duplicate_trigger(mock_task):
-    """캐시가 없고 task가 이미 실행 중이면 force_run을 중복 트리거하지 않는다."""
+async def test_get_newhigh_list_no_cache_running_service_does_not_trigger(mock_task):
+    """실행 중 여부와 무관하게 서비스는 직접 트리거하지 않고 '수집 중'을 반환한다."""
     mock_task.get_newhigh_cache.return_value = []
     mock_task.get_progress.return_value = {"running": True}
 
@@ -243,6 +244,32 @@ async def test_get_newhigh_list_no_cache_already_running_no_duplicate_trigger(mo
     assert result.rt_cd == "0"
     assert result.msg1 == "수집 중"
     mock_task.trigger_refresh.assert_not_called()
+
+
+# ── 결과 개수 제한 / 0.0 등락률 보존 ─────────────────────────────────────────────
+
+async def test_get_newhigh_list_db_truncates_to_max_items(mock_repo):
+    """DB 경로도 캐시 경로와 동일하게 _MAX_ITEMS 개수로 잘린다."""
+    base = mock_repo.get_newhigh_stocks.return_value[0]
+    mock_repo.get_newhigh_stocks.return_value = [
+        dict(base) for _ in range(NewHighService._MAX_ITEMS + 5)
+    ]
+    service = make_service(repo=mock_repo)
+    result = await service.get_newhigh_list()
+
+    assert result.rt_cd == "0"
+    assert len(result.data) == NewHighService._MAX_ITEMS
+
+
+async def test_get_newhigh_list_zero_change_rate_preserved(mock_repo):
+    """change_rate가 정확히 0.0이면 '0.0'으로 보존되어 None(미수집, '0')과 구분된다."""
+    item0 = dict(mock_repo.get_newhigh_stocks.return_value[0])
+    item0["change_rate"] = 0.0
+    mock_repo.get_newhigh_stocks.return_value = [item0]
+    service = make_service(repo=mock_repo)
+    result = await service.get_newhigh_list()
+
+    assert result.data[0]["prdy_ctrt"] == "0.0"
 
 
 # ── task 미설정 ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 요약
`services/newhigh_service.py`의 개선 포인트 4건을 순서대로 정리.

## 변경 내용
1. **포매터 통합** — `_format_db_item` / `_format_cache_item`은 역사적 신고가 키 이름(`is_historical_newhigh` vs `is_historical_new_high`)만 달랐음. `_format_item(item, hist_key)` 단일 헬퍼로 통합하고 키만 인자로 분기. 나머지 9개 필드 동일.
2. **중복 트리거 제거** — `get_newhigh_cache()`가 캐시가 비고 not running일 때 내부적으로 `trigger_refresh()`를 호출하므로, 서비스의 명시적 3차 트리거 블록과 2차 `get_progress()` 호출은 running 가드 때문에 이중 발사되지 않아 프로덕션에서 무해한 dead path였음. 제거하고 수집 트리거를 `get_newhigh_cache`에 위임.
3. **결과 개수 대칭** — 캐시 경로는 `limit=200`으로 잘리는데 DB 경로(`get_newhigh_stocks`)는 전체 반환이었음. `_MAX_ITEMS=200` 상수로 양쪽을 동일하게 제한.
4. **0.0 등락률 보존** — `str(change_rate or 0)`은 실제 0.0%(보합)를 `"0"`으로 뭉갰음. `None`(미수집)과 구분해 `"0.0"`으로 보존. (영향은 표시 형식 수준)

## 테스트
- 단위(서비스) 14건, NewHighTask 59건 통과
- 통합 240건 통과 (회귀 없음)
- `_format_*` 통합에 따라 기존 트리거 단언 2건을 새 위임 계약에 맞게 갱신, `_MAX_ITEMS` 절단 / 0.0 보존 테스트 2건 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)
