### PR TITLE
OneilUniverseService 개선 3건 (Pool B 중복 API 제거, 구독 태스크 강참조, refresh 네이밍)

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -93,6 +93,8 @@ class OneilUniverseService:
 
         # 상태 관리
         self._watchlist: Dict[str, OSBWatchlistItem] = {}
+        # 구독 동기화 fire-and-forget 태스크 강참조 보관 (GC 중간 취소 방지)
+        self._subscription_sync_tasks: set = set()
         self._watchlist_date: str = ""
         self._watchlist_refresh_done: set = set()
         self._pool_a_loaded: bool = False
@@ -141,10 +143,10 @@ class OneilUniverseService:
             self._market_timing_date = "" # 마켓타이밍도 재확인 필요
             
             # 초기화 시점에도 현재 시간 기준 이미 지난 갱신 주기는 완료 처리하여 중복 갱신 방지
-            self._should_refresh_watchlist()
-        
+            self._mark_due_refreshes()
+
         # 장중 갱신 주기 체크
-        elif self._should_refresh_watchlist():
+        elif self._mark_due_refreshes():
             await self._build_watchlist(logger=logger)
 
         if self._excluded_codes_today:
@@ -154,11 +156,14 @@ class OneilUniverseService:
             }
 
         if self._price_sub_svc and self._watchlist:
-            asyncio.create_task(self._price_sub_svc.sync_subscriptions(
+            # 강참조 보관: create_task 결과를 잡아두지 않으면 GC가 태스크를 중간 취소할 수 있다.
+            task = asyncio.create_task(self._price_sub_svc.sync_subscriptions(
                 codes=list(self._watchlist.keys()),
                 category_key="strategy_oneil",
                 priority=SubscriptionPriority.MEDIUM,
             ))
+            self._subscription_sync_tasks.add(task)
+            task.add_done_callback(self._subscription_sync_tasks.discard)
         return self._watchlist
 
     async def is_market_timing_ok(self, market: str, caller: str = "", logger: Optional[logging.Logger] = None) -> bool:
@@ -571,20 +576,7 @@ class OneilUniverseService:
             })
             return None
 
-        # 필터: 52주 고가 근접
-        full_resp = await self._sqs.get_current_price(
-            code,
-            caller="OneilUniverseService",
-            allow_snapshot=False,
-        )
-        if not full_resp or full_resp.rt_cd != ErrorCode.SUCCESS.value:
-            if logger: logger.debug({"event": "drop", "code": code, "reason": "current_price_api_fail"})
-            return None
-        output = full_resp.data.get("output") if full_resp.data else None
-        if not output:
-            if logger: logger.debug({"event": "drop", "code": code, "reason": "no_price_output"})
-            return None
-        
+        # 필터: 52주 고가 근접 (위에서 조회한 현재가 output 재사용 — 중복 API 호출 제거)
         if isinstance(output, dict):
             w52_hgpr = int(output.get("w52_hgpr") or 0)
             cap_billion = int(output.get("hts_avls") or output.get("stck_llam") or 0)
@@ -961,11 +953,12 @@ class OneilUniverseService:
 
         return None
 
-    def _should_refresh_watchlist(self) -> bool:
+    def _mark_due_refreshes(self) -> bool:
+        """이미 도래한 갱신 주기를 완료 처리(상태 변이)하고, 이번 호출에서 새로 트리거된 주기가 있으면 True를 반환한다."""
         now = self._tm.get_current_kst_time()
         open_time = self._tm.get_market_open_time()
         elapsed = (now - open_time).total_seconds() / 60
-        
+
         triggered = False
         for t_min in self._cfg.watchlist_refresh_minutes:
             if elapsed >= t_min and t_min not in self._watchlist_refresh_done:

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -399,7 +399,7 @@ class OneilUniverseService:
             cap_billion = int(getattr(output, "hts_avls", 0) or getattr(output, "stck_llam", 0) or 0)
         stck_llam = cap_billion * 100_000_000  # 억 단위 -> 원 단위 변환
 
-        # Pool B 전용 시가총액 필터
+        # 시가총액 필터 (Pool A 우량주 시총 범위)
         if not (self._cfg.premium_stocks_cap_min <= stck_llam <= self._cfg.premium_stocks_cap_max):
             if logger: logger.debug({"event": "drop", "code": code, "reason": "market_cap_out_of_range", "cap": stck_llam})
             return None

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -238,6 +238,36 @@ async def test_get_watchlist_filters_loaded_premium_blocked_security_status(mock
     assert watchlist == {}
     assert service._watchlist == {}
 
+async def test_get_watchlist_retains_subscription_sync_task(mock_deps):
+    """get_watchlist: sync_subscriptions fire-and-forget 태스크를 강참조로 보관한다(GC 방지)."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    price_sub_svc = MagicMock()
+    price_sub_svc.sync_subscriptions = AsyncMock(return_value=None)
+    service = OneilUniverseService(
+        sqs, indicator, mapper, tm, logger=logger,
+        price_subscription_service=price_sub_svc,
+    )
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 10, 0)
+    tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
+
+    item = OSBWatchlistItem(
+        code="005930", name="삼성전자", market="KOSPI",
+        high_20d=1000, ma_20d=900, ma_50d=800, avg_vol_20d=10000,
+        bb_width_min_20d=10, prev_bb_width=11, w52_hgpr=1200,
+        avg_trading_value_5d=20_000_000_000, market_cap=500_000_000_000,
+    )
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": create_mock_stock_info({})},
+    )
+
+    with patch.object(service, "_load_premium_stocks", return_value=[item]), \
+         patch.object(service, "_build_daily_surge_pool", new_callable=AsyncMock, return_value={}):
+        watchlist = await service.get_watchlist(logger=logger)
+
+    assert "005930" in watchlist
+    # 반환 직후 태스크는 아직 실행 전이므로 강참조 집합에 보관되어 있어야 한다.
+    assert len(service._subscription_sync_tasks) == 1
+
 async def test_analyze_premium_candidate_filter_trading_value(mock_deps):
     """_analyze_premium_candidate: 거래대금 부족 시 None 반환 검증."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
@@ -1023,6 +1053,42 @@ async def test_build_daily_surge_pool_partial_api_failure(mock_deps):
         assert "A" in pool_b
         assert len(pool_b) == 1
 
+async def test_analyze_surge_candidate_calls_current_price_once(mock_deps):
+    """_analyze_surge_candidate: 모든 필터를 통과해도 get_current_price를 1회만 호출한다.
+
+    첫 호출 output에 이미 w52_hgpr/시총이 포함되므로 두 번째 조회는 불필요하다(중복 API 제거).
+    """
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 2, 10, 0, 0)
+
+    # 어제까지의 OHLCV (상승 추세 → 정배열 통과)
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data=create_surge_ohlcv(length=90)
+    )
+
+    # 현재가 output: 첫 호출이 현재가/시초가/고저가 + w52_hgpr/시총을 모두 포함
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK",
+        data={"output": create_mock_stock_info({
+            "stck_prpr": "1500", "acml_vol": "100000000",
+            "stck_oprc": "1490", "stck_hgpr": "1510", "stck_lwpr": "1480",
+            "w52_hgpr": "1450", "hts_avls": "5000",  # 5000억 → 시총 범위 내
+        })},
+    )
+
+    indicator.calc_bb_widths_sync.return_value = [20.0] * 30
+    indicator.calc_rs_sync.return_value = 10.0
+    mapper.is_kosdaq.return_value = False
+
+    item = await service._analyze_surge_candidate("005930", "Samsung", logger=logger)
+
+    assert item is not None
+    assert item.code == "005930"
+    assert sqs.get_current_price.call_count == 1
+
+
 async def test_analyze_premium_candidate_price_api_object_access(mock_deps):
     """_analyze_premium_candidate: get_current_price 응답이 객체(속성 접근)일 때 처리 검증."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
@@ -1124,31 +1190,31 @@ async def test_generate_premium_watchlist_fallback_market_cap(mock_deps, tmp_pat
         # passed_first가 1이어야 함 (5000 * 1억 = 5000억 -> 범위 내)
         assert result['passed_first'] == 1
 
-def test_should_refresh_watchlist_logic(mock_deps):
-    """_should_refresh_watchlist: 설정된 시간에 따른 갱신 트리거 검증."""
+def test_mark_due_refreshes_logic(mock_deps):
+    """_mark_due_refreshes: 설정된 시간에 따른 갱신 트리거 + 완료 처리 검증."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
     service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
-    
+
     service._cfg.watchlist_refresh_minutes = [10, 30, 60]
     service._watchlist_refresh_done = set()
-    
+
     tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
-    
+
     # 1. 5분 경과 -> False
     tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 5, 0)
-    assert service._should_refresh_watchlist() is False
-    
+    assert service._mark_due_refreshes() is False
+
     # 2. 10분 경과 -> True
     tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 10, 0)
-    assert service._should_refresh_watchlist() is True
+    assert service._mark_due_refreshes() is True
     assert 10 in service._watchlist_refresh_done
-    
+
     # 3. 10분 경과 (재호출) -> False (이미 수행됨)
-    assert service._should_refresh_watchlist() is False
-    
+    assert service._mark_due_refreshes() is False
+
     # 4. 35분 경과 -> True (30분 트리거)
     tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 35, 0)
-    assert service._should_refresh_watchlist() is True
+    assert service._mark_due_refreshes() is True
     assert 30 in service._watchlist_refresh_done
 
 async def test_build_daily_surge_pool_analyze_exception(mock_deps):
@@ -1451,7 +1517,7 @@ async def test_get_watchlist_syncs_subscriptions(mock_deps):
         coro.close()
         return MagicMock()
 
-    with patch.object(service, "_should_refresh_watchlist", return_value=False), \
+    with patch.object(service, "_mark_due_refreshes", return_value=False), \
          patch("services.oneil_universe_service.asyncio.create_task", side_effect=fake_create_task) as mock_create_task:
         result = await service.get_watchlist()
 
@@ -1503,18 +1569,17 @@ async def test_analyze_surge_candidate_success_with_dict_output(mock_deps):
         "w52_hgpr": "1500",
         "hts_avls": "800000",
     }
-    sqs.get_current_price.side_effect = [
-        ResCommonResponse(rt_cd="0", msg1="OK", data={"output": price_output}),
-        ResCommonResponse(rt_cd="0", msg1="OK", data={"output": price_output}),
-    ]
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": price_output}
+    )
     indicator.calc_bb_widths_sync.return_value = [10.0] * 25
     indicator.calc_rs_sync.return_value = 12.3
 
     item = await service._analyze_surge_candidate("005930", "Samsung", logger=logger)
 
     assert item is not None
+    # 첫 현재가 output 재사용 → get_current_price는 1회만 호출
     assert sqs.get_current_price.await_args_list == [
-        call("005930", caller="OneilUniverseService", allow_snapshot=False),
         call("005930", caller="OneilUniverseService", allow_snapshot=False),
     ]
     assert item.market == "KOSPI"


### PR DESCRIPTION
## 요약
`services/oneil_universe_service.py` 코드 리뷰에서 도출한 개선 포인트 상위 3건을 TDD로 적용했습니다.

## 변경 내용
1. **Pool B 중복 현재가 호출 제거** — `_analyze_surge_candidate`가 같은 종목에 `get_current_price`를 두 번 호출하던 것을 첫 호출 output 재사용으로 1회로 축소. 장중 후보 스캔 API 호출이 후보당 절반으로 감소.
2. **구독 동기화 태스크 강참조 보관** — `get_watchlist`의 `asyncio.create_task(sync_subscriptions(...))`를 변수에 잡지 않아 GC가 태스크를 중간 취소할 수 있던 문제 해결. `_subscription_sync_tasks` 집합에 보관하고 done 콜백으로 정리.
3. **`_should_refresh_watchlist` → `_mark_due_refreshes` rename** — boolean 질의처럼 보이지만 `_watchlist_refresh_done`을 변이하던 메서드의 부수효과를 이름/docstring으로 명시.

## 테스트
- 신규: `test_analyze_surge_candidate_calls_current_price_once`, `test_get_watchlist_retains_subscription_sync_task`
- 갱신: `test_analyze_surge_candidate_success_with_dict_output`(1회 호출 단언), `test_mark_due_refreshes_logic`(rename)
- 단위 5928 passed / 통합 240 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)