### PR TITLE
fix(websocket): 재연결 후 stale 구독 멤버십 유령 구독 차단 (VBO no-tick 근본원인)

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -413,11 +413,16 @@ class KoreaInvestWebSocketAPI:
                     elif 'ALREADY IN USE' in msg1:
                         self._logger.warning("서버가 appkey 중복 사용을 거부했습니다. 재연결 시 대기 시간을 늘립니다.")
                         self._appkey_collision = True
-                    elif self._streaming_logger:
-                        if tr_type == "2":
-                            self._streaming_logger.log_unsubscribe_failure(tr_key or tr_id, msg1 or "ACK error")
-                        else:
-                            self._streaming_logger.log_subscribe_failure(tr_key or tr_id, msg1 or "ACK error")
+                    else:
+                        # 현재 연결에서 구독이 거부됨 → 재연결 후 남아있을 수 있는 stale 등록 정보를
+                        # 제거해 유령 구독(active 인데 tick 0)을 방지한다. (P2 2-4 no-tick 근본원인)
+                        if tr_type == "1":
+                            self._subscribed_items.discard((tr_id, tr_key))
+                        if self._streaming_logger:
+                            if tr_type == "2":
+                                self._streaming_logger.log_unsubscribe_failure(tr_key or tr_id, msg1 or "ACK error")
+                            else:
+                                self._streaming_logger.log_subscribe_failure(tr_key or tr_id, msg1 or "ACK error")
                     # ALREADY IN SUBSCRIBE 외 모든 오류 응답은 구독 확정 실패(no-op if 이미 해소).
                     self._resolve_subscription_ack(pending, False)
             except json.JSONDecodeError:
@@ -863,14 +868,15 @@ class KoreaInvestWebSocketAPI:
     async def wait_for_subscription_ack(self, tr_id, tr_key, timeout: float = None) -> bool:
         """구독 요청에 대한 KIS 등록 응답(ACK)을 기다린다.
 
-        - 이미 확정된(`_subscribed_items`) 구독이면 즉시 True.
-        - send_realtime_request(tr_type="1") 가 만든 pending future 를 timeout 까지 await.
-        - timeout 내 ACK 미수신 시 False (구독 미확정 → 상위에서 재구독).
+        - send_realtime_request(tr_type="1") 가 만든 fresh pending future 가 있으면 그것을
+          우선 await 한다. timeout 내 ACK 미수신 시 False (구독 미확정 → 상위에서 재구독).
+        - pending future 가 없을 때만 `_subscribed_items` 멤버십을 신뢰한다.
+          (`_subscribed_items` 는 disconnect 시 정리되지 않으므로 — 내부 `_resubscribe_all`
+           이 의존 — 멤버십을 먼저 보면 재연결 후 현재 연결에 등록 안 된 구독을 가짜로
+           통과시킨다. fresh frame 을 보냈다면 반드시 그 ACK 로 확정한다.)
 
         send_realtime_request 자체의 반환 의미(프레임 전송 성공)는 바꾸지 않는다.
         """
-        if (tr_id, tr_key) in self._subscribed_items:
-            return True
         if timeout is None:
             timeout = self.SUBSCRIBE_ACK_TIMEOUT_SEC
         pending = self._pending_requests.get((tr_id, tr_key))

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -2901,3 +2901,41 @@ async def test_wait_for_subscription_ack_false_on_hard_error(websocket_api_insta
     confirmed = await api.wait_for_subscription_ack("H0UNCNT0", "005930", timeout=1.0)
     assert confirmed is False
     assert ("H0UNCNT0", "005930") not in api._subscribed_items
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ack_awaits_fresh_frame_despite_stale_membership(websocket_api_instance):
+    """재연결 후 stale _subscribed_items 멤버십이 남아있어도, 새로 전송한 구독 프레임의
+    ACK 가 안 오면(유령 구독) False 여야 한다. (P2 2-4 no-tick 근본원인 #1)
+
+    disconnect 시 _subscribed_items 는 정리되지 않으므로(내부 _resubscribe_all 이 의존),
+    멤버십만 보고 즉시 True 를 반환하면 현재 연결에 등록 안 된 구독을 가짜 통과시킨다.
+    """
+    api = websocket_api_instance
+    _arm_connected(api)
+    # 이전 연결에서 ACK 됐던 stale 멤버십
+    api._subscribed_items.add(("H0UNCNT0", "005930"))
+    # 재연결 후 새 프레임 전송(fresh pending) — KIS 응답 없음(유령)
+    await api.send_realtime_request("H0UNCNT0", "005930", tr_type="1")
+
+    confirmed = await api.wait_for_subscription_ack("H0UNCNT0", "005930", timeout=0.05)
+    assert confirmed is False
+
+
+@pytest.mark.asyncio
+async def test_hard_error_discards_stale_subscription_membership(websocket_api_instance):
+    """현재 연결에서 구독이 거부되면(레이트리밋/한도) stale 멤버십을 제거해야 한다.
+    (P2 2-4 no-tick 근본원인 #2)
+    """
+    api = websocket_api_instance
+    _arm_connected(api)
+    api._subscribed_items.add(("H0UNCNT0", "005930"))  # 이전 연결의 stale 멤버십
+    await api.send_realtime_request("H0UNCNT0", "005930", tr_type="1")
+
+    api._handle_websocket_message(
+        _ack_message("H0UNCNT0", "005930", rt_cd="1", msg1="SUBSCRIBE ERROR")
+    )
+
+    assert ("H0UNCNT0", "005930") not in api._subscribed_items
+    confirmed = await api.wait_for_subscription_ack("H0UNCNT0", "005930", timeout=0.05)
+    assert confirmed is False


### PR DESCRIPTION
## 배경 — VBO event-shadow no-tick 근본원인 추적

P2 2-4 VBO event-shadow가 후보 구독에도 신호 0건인 원인을 streaming 로그(6/9~6/12)로 추적한 결과:

- **연결·가격 피드는 종일 정상**: 접속매매(09:00~15:00) 중 `price_data_gap` max 0.2~3.8s. (15:23~15:30의 gap 급증은 종가단일가 구간 tick 자연공백 오탐, 무해.)
- 그런데 **구독 종목의 ~55%가 종일 tick 0건**(`subscribed_no_tick`): 6/9 30개 중 18개, 6/12 34개 중 21개.
- 폴링이 **실제 매수한 liquid 종목도 포함**: 403870(6/12 12:02 @71500 매수)은 09:14~15:21 내내 no-tick, 5분마다 재구독(61회)에도 미복구. 200470도 동일. → no-trade가 아니라 **재연결 후 KIS에 실제 등록되지 않은 "유령 구독"이 로컬 active로 고착**.

## 근본 원인 — #509 ACK 확정이 무력화된 2가지 결함

1. **`wait_for_subscription_ack`의 잘못된 우선순위**: 새로 보낸 구독 프레임의 ACK future보다 `_subscribed_items` 멤버십을 먼저 확인해 즉시 `True` 반환. `_subscribed_items`는 disconnect 시 정리되지 않으므로(내부 `_resubscribe_all`이 복구 의도로 의존), 재연결 후 fresh frame을 보내도 **stale 멤버십으로 ACK를 가짜 통과** → 현재 연결에 미등록인 구독이 active로 고착.
2. **하드 에러 시 stale 멤버십 미제거**: 구독이 거부되면(레이트리밋/한도) `_subscribed_items`에서 제거하지 않아 stale 멤버십 잔존. (재연결 직후 `_restore_all_subscriptions`는 0.2s 간격으로 전 종목을 재구독하는 burst라 레이트리밋 거부가 발생하기 쉬움.)

## 변경

- `wait_for_subscription_ack`: fresh pending ACK future가 있으면 그것을 우선 await. `_subscribed_items` 멤버십은 pending future가 없을 때만 신뢰.
- 수신 핸들러: 구독(`tr_type=="1"`) 하드 에러 응답 시 `_subscribed_items.discard()`.

내부 `_resubscribe_all`(자동재연결)은 `_subscribed_items`를 그대로 읽어 복구하므로 clear-on-disconnect가 아닌 위 2개 수정으로 **양쪽 재연결 경로를 모두 보존**한다.

## 테스트
- `test_wait_for_ack_awaits_fresh_frame_despite_stale_membership` (timeout 유령 구독)
- `test_hard_error_discards_stale_subscription_membership` (하드 에러 stale 제거)
- 기존 ACK 계약 테스트 5종 회귀 없음. 단위 5938(websocket 154) / 통합 240 passed.

## 관련
진단 계측 PR(#533, tick-ingest 카운터)과 분리. 본 PR은 라이브 WebSocket 구독 경로 **동작 변경**이라 별도 리뷰 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)