### PR TITLE
Add overseas US stock mode v1

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -311,6 +311,49 @@ class BrokerAPIWrapper:
         """주식 주문 취소를 실행합니다 (KoreaInvestApiTrading 위임)."""
         return await self._client.cancel_stock_order(**kwargs)
 
+    # --- KoreaInvestApiClient / Overseas stock API delegation ---
+    async def get_overseas_price(self, symbol: str, **kwargs) -> ResCommonResponse:
+        return await self._client.get_overseas_price(symbol, **kwargs)
+
+    async def get_overseas_dailyprice(self, symbol: str, **kwargs) -> ResCommonResponse:
+        return await self._client.get_overseas_dailyprice(symbol, **kwargs)
+
+    async def get_overseas_balance(self, **kwargs) -> ResCommonResponse:
+        return await self._client.get_overseas_balance(**kwargs)
+
+    async def inquire_overseas_ccnl(self, **kwargs) -> ResCommonResponse:
+        return await self._client.inquire_overseas_ccnl(**kwargs)
+
+    async def inquire_overseas_unfilled(self, **kwargs) -> ResCommonResponse:
+        return await self._client.inquire_overseas_unfilled(**kwargs)
+
+    async def place_overseas_limit_order(self, **kwargs) -> ResCommonResponse:
+        if self._cb_is_open():
+            remaining = (self._cb_open_until - datetime.now()).seconds // 60
+            if self._logger:
+                self._logger.warning(
+                    f"[CircuitBreaker] 해외주식 주문 차단됨 ({remaining}분 남음): {kwargs.get('symbol')}"
+                )
+            return ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1=f"서킷 브레이커 개방 — {remaining}분 후 재시도",
+            )
+        resp = await self._client.place_overseas_limit_order(**kwargs)
+        rt_cd = getattr(resp, "rt_cd", None) if resp else None
+        if rt_cd == ErrorCode.SUCCESS.value:
+            self._cb_record_success()
+        elif is_non_retriable_business_error(resp):
+            if self._logger:
+                self._logger.warning(
+                    f"[CircuitBreaker] 해외주식 비즈니스 거부는 실패 카운트 제외: {kwargs.get('symbol')}"
+                )
+        else:
+            self._cb_record_failure()
+        return resp
+
+    async def cancel_overseas_order(self, **kwargs) -> ResCommonResponse:
+        return await self._client.cancel_overseas_order(**kwargs)
+
     # --- KoreaInvestApiClient / WebSocket API delegation ---
     def is_websocket_receive_alive(self) -> bool:
         """웹소켓 수신 태스크가 살아있는지 확인."""

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -5,6 +5,7 @@ from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
 from brokers.korea_investment.korea_invest_quotations_api import KoreaInvestApiQuotations
 from brokers.korea_investment.korea_invest_account_api import KoreaInvestApiAccount
 from brokers.korea_investment.korea_invest_trading_api import KoreaInvestApiTrading
+from brokers.korea_investment.korea_invest_overseas_stock_api import KoreaInvestOverseasStockApi
 from brokers.korea_investment.korea_invest_websocket_api import KoreaInvestWebSocketAPI
 from brokers.korea_investment.korea_invest_header_provider import build_header_provider_from_env
 from brokers.korea_investment.korea_invest_url_provider import KoreaInvestUrlProvider
@@ -78,6 +79,15 @@ class KoreaInvestApiClient:
             url_provider=url_provider,
             trid_provider=trid_provider,
         )
+        self._overseas_stock = KoreaInvestOverseasStockApi(
+            self._env,
+            self._logger,
+            self.market_clock,
+            async_client=shared_client,
+            header_provider=header_provider.fork(),
+            url_provider=url_provider,
+            trid_provider=trid_provider,
+        )
         self._websocketAPI = KoreaInvestWebSocketAPI(
             self._env, self._logger,
             market_clock=self.market_clock,
@@ -105,6 +115,28 @@ class KoreaInvestApiClient:
 
     async def cancel_stock_order(self, **kwargs) -> ResCommonResponse:
         return await self._trading.cancel_stock_order(**kwargs)
+
+    # --- Overseas stock API delegation ---
+    async def get_overseas_price(self, symbol: str, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.get_overseas_price(symbol, **kwargs)
+
+    async def get_overseas_dailyprice(self, symbol: str, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.get_overseas_dailyprice(symbol, **kwargs)
+
+    async def get_overseas_balance(self, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.get_overseas_balance(**kwargs)
+
+    async def inquire_overseas_ccnl(self, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.inquire_overseas_ccnl(**kwargs)
+
+    async def inquire_overseas_unfilled(self, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.inquire_overseas_unfilled(**kwargs)
+
+    async def place_overseas_limit_order(self, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.place_overseas_limit_order(**kwargs)
+
+    async def cancel_overseas_order(self, **kwargs) -> ResCommonResponse:
+        return await self._overseas_stock.cancel_overseas_order(**kwargs)
 
     # --- Quotations API delegation (Updated) ---
     # KoreaInvestApiQuotations의 모든 메서드가 ResCommonResponse를 반환하도록 이미 수정되었으므로, 해당 반환 타입을 반영

--- a/brokers/korea_investment/korea_invest_overseas_stock_api.py
+++ b/brokers/korea_investment/korea_invest_overseas_stock_api.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
+from brokers.korea_investment.korea_invest_header_provider import KoreaInvestHeaderProvider
+from brokers.korea_investment.korea_invest_trading_api import KoreaInvestApiTrading
+from brokers.korea_investment.korea_invest_trid_provider import KoreaInvestTrIdProvider
+from brokers.korea_investment.korea_invest_url_keys import EndpointKey
+from brokers.korea_investment.korea_invest_url_provider import KoreaInvestUrlProvider
+from common.overseas_types import OverseasExchange, OverseasOrderReport, OverseasPriceSummary
+from common.types import ErrorCode, ResCommonResponse
+
+
+_PRICE_EXCHANGE_CODES = {
+    OverseasExchange.NASD: "NAS",
+    OverseasExchange.NYSE: "NYS",
+    OverseasExchange.AMEX: "AMS",
+}
+_PERIOD_CODES = {"D": "0", "W": "1", "M": "2"}
+
+
+class KoreaInvestOverseasStockApi(KoreaInvestApiTrading):
+    """KIS 해외주식 REST API v1 surface.
+
+    국내 주식 API 클래스의 응답 모델과 파라미터가 많이 달라서 별도 클래스로 둔다.
+    v1은 미국 3시장 조회 + 수동 지정가 주문만 지원한다.
+    """
+
+    def __init__(
+        self,
+        env: KoreaInvestApiEnv,
+        logger=None,
+        market_clock=None,
+        async_client: Optional[httpx.AsyncClient] = None,
+        header_provider: Optional[KoreaInvestHeaderProvider] = None,
+        url_provider: Optional[KoreaInvestUrlProvider] = None,
+        trid_provider: Optional[KoreaInvestTrIdProvider] = None,
+    ):
+        super().__init__(
+            env,
+            logger,
+            market_clock,
+            async_client=async_client,
+            header_provider=header_provider,
+            url_provider=url_provider,
+            trid_provider=trid_provider,
+        )
+
+    @staticmethod
+    def _split_account(full_account_number: str) -> tuple[str, str]:
+        text = str(full_account_number or "").strip()
+        if "-" in text and len(text.split("-", 1)[1]) == 2:
+            cano, acnt_prdt_cd = text.split("-", 1)
+            return cano, acnt_prdt_cd
+        return text, "01"
+
+    @staticmethod
+    def _exchange_price_code(exchange: OverseasExchange) -> str:
+        return _PRICE_EXCHANGE_CODES[exchange]
+
+    @staticmethod
+    def _as_exchange(value: OverseasExchange | str) -> OverseasExchange:
+        if isinstance(value, OverseasExchange):
+            return value
+        return OverseasExchange(str(value).upper())
+
+    @staticmethod
+    def _to_float(value, default: float = 0.0) -> float:
+        try:
+            text = str(value or "").replace(",", "").strip()
+            return float(text) if text else default
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _to_int(value, default: int = 0) -> int:
+        try:
+            text = str(value or "").replace(",", "").strip()
+            return int(float(text)) if text else default
+        except (TypeError, ValueError):
+            return default
+
+    def _account_parts(self) -> tuple[str, str]:
+        full_config = self._env.active_config or {}
+        return self._split_account(full_config.get("stock_account_number", ""))
+
+    def _set_tr_header(self, tr_id: str) -> None:
+        full_config = self._env.active_config or {}
+        self._headers.set_tr_id(tr_id)
+        self._headers.set_custtype(full_config.get("custtype", "P"))
+
+    def _normalize_price_summary(
+        self,
+        *,
+        symbol: str,
+        exchange: OverseasExchange,
+        output: dict,
+    ) -> OverseasPriceSummary:
+        price = self._to_float(
+            output.get("last")
+            or output.get("ovrs_nmix_prpr")
+            or output.get("base")
+            or output.get("clos")
+        )
+        change_rate = self._to_float(
+            output.get("rate")
+            or output.get("prdy_ctrt")
+            or output.get("diff_rate")
+        )
+        volume = self._to_int(output.get("tvol") or output.get("acml_vol"))
+        timestamp = str(
+            output.get("xymd")
+            or output.get("trdt")
+            or output.get("stck_bsop_date")
+            or ""
+        )
+        return OverseasPriceSummary(
+            symbol=symbol,
+            exchange=exchange,
+            currency="USD",
+            price=price,
+            change_rate=change_rate,
+            volume=volume,
+            timestamp=timestamp,
+            raw=output,
+        )
+
+    async def get_overseas_price(
+        self,
+        symbol: str,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        tr_id = self._trid_provider.overseas_stock("price")
+        self._set_tr_header(tr_id)
+        params = {
+            "AUTH": "",
+            "EXCD": self._exchange_price_code(exchange),
+            "SYMB": str(symbol).upper(),
+        }
+        resp = await self.call_api(
+            "GET",
+            EndpointKey.OVERSEAS_STOCK_PRICE,
+            params=params,
+            retry_count=1,
+        )
+        if resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp
+        raw = resp.data if isinstance(resp.data, dict) else {}
+        output = raw.get("output") or raw
+        if not isinstance(output, dict):
+            output = {}
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1=resp.msg1,
+            data=self._normalize_price_summary(symbol=str(symbol).upper(), exchange=exchange, output=output),
+        )
+
+    async def get_overseas_dailyprice(
+        self,
+        symbol: str,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        start_date: str = "",
+        end_date: str = "",
+        period: str = "D",
+        adjusted: bool = True,
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        period_code = _PERIOD_CODES.get(str(period).upper())
+        if period_code is None:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1=f"지원하지 않는 해외주식 기간 구분: {period}",
+                data=[],
+            )
+        tr_id = self._trid_provider.overseas_stock("dailyprice")
+        self._set_tr_header(tr_id)
+        params = {
+            "AUTH": "",
+            "EXCD": self._exchange_price_code(exchange),
+            "SYMB": str(symbol).upper(),
+            "GUBN": period_code,
+            "BYMD": end_date or start_date,
+            "MODP": "1" if adjusted else "0",
+        }
+        return await self.call_api(
+            "GET",
+            EndpointKey.OVERSEAS_STOCK_DAILYPRICE,
+            params=params,
+            retry_count=1,
+        )
+
+    async def get_overseas_balance(
+        self,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        currency: str = "USD",
+        ctx_area_fk200: str = "",
+        ctx_area_nk200: str = "",
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        cano, acnt_prdt_cd = self._account_parts()
+        self._set_tr_header(self._trid_provider.overseas_stock_inquire_balance())
+        params = {
+            "CANO": cano,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
+            "OVRS_EXCG_CD": exchange.value,
+            "TR_CRCY_CD": currency,
+            "CTX_AREA_FK200": ctx_area_fk200,
+            "CTX_AREA_NK200": ctx_area_nk200,
+        }
+        return await self.call_api(
+            "GET",
+            EndpointKey.OVERSEAS_STOCK_INQUIRE_BALANCE,
+            params=params,
+            retry_count=1,
+        )
+
+    async def inquire_overseas_ccnl(
+        self,
+        *,
+        symbol: str = "%",
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        start_date: str,
+        end_date: str,
+        side_code: str = "00",
+        ccld_nccs_dvsn: str = "00",
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        cano, acnt_prdt_cd = self._account_parts()
+        self._set_tr_header(self._trid_provider.overseas_stock_inquire_ccnl())
+        params = {
+            "CANO": cano,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
+            "PDNO": symbol,
+            "ORD_STRT_DT": start_date,
+            "ORD_END_DT": end_date,
+            "SLL_BUY_DVSN": side_code,
+            "CCLD_NCCS_DVSN": ccld_nccs_dvsn,
+            "OVRS_EXCG_CD": exchange.value,
+            "SORT_SQN": "DS",
+            "ORD_DT": "",
+            "ORD_GNO_BRNO": "",
+            "ODNO": "",
+            "CTX_AREA_NK200": "",
+            "CTX_AREA_FK200": "",
+        }
+        return await self.call_api(
+            "GET",
+            EndpointKey.OVERSEAS_STOCK_INQUIRE_CCNL,
+            params=params,
+            retry_count=1,
+        )
+
+    async def inquire_overseas_unfilled(
+        self,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        cano, acnt_prdt_cd = self._account_parts()
+        self._set_tr_header(self._trid_provider.overseas_stock_inquire_nccs())
+        params = {
+            "CANO": cano,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
+            "OVRS_EXCG_CD": exchange.value,
+            "SORT_SQN": "DS",
+            "CTX_AREA_FK200": "",
+            "CTX_AREA_NK200": "",
+        }
+        return await self.call_api(
+            "GET",
+            EndpointKey.OVERSEAS_STOCK_INQUIRE_NCCS,
+            params=params,
+            retry_count=1,
+        )
+
+    async def place_overseas_limit_order(
+        self,
+        *,
+        symbol: str,
+        exchange: OverseasExchange | str,
+        side: str,
+        qty: int,
+        limit_price: str,
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        side_value = str(side).lower()
+        if side_value not in ("buy", "sell"):
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="side는 buy 또는 sell이어야 합니다.",
+                data=None,
+            )
+        if qty <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="주문수량은 0보다 커야 합니다.",
+                data=None,
+            )
+        if self._to_float(limit_price) <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+                msg1="해외주식 v1은 지정가 주문만 지원합니다.",
+                data={"rule": "overseas_market_order_not_supported"},
+            )
+
+        cano, acnt_prdt_cd = self._account_parts()
+        body = {
+            "CANO": cano,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
+            "OVRS_EXCG_CD": exchange.value,
+            "PDNO": str(symbol).upper(),
+            "ORD_QTY": str(qty),
+            "OVRS_ORD_UNPR": str(limit_price),
+            "ORD_SVR_DVSN_CD": "0",
+            "ORD_DVSN": "00",
+        }
+        hashkey = await self._get_hashkey(body)
+        if not hashkey or isinstance(hashkey, ResCommonResponse):
+            return ResCommonResponse(
+                rt_cd=ErrorCode.MISSING_KEY.value,
+                msg1=f"hashkey 계산 실패 - {hashkey}",
+                data=None,
+            )
+
+        tr_id = self._trid_provider.overseas_stock_order(is_buy=side_value == "buy")
+        self._set_tr_header(tr_id)
+        self._headers.set_hashkey(hashkey)
+        self._headers.set_gt_uid()
+        resp = await self.call_api(
+            "POST",
+            EndpointKey.OVERSEAS_STOCK_ORDER,
+            data=body,
+            retry_count=3,
+        )
+        if resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp
+        raw = resp.data if isinstance(resp.data, dict) else {}
+        output = raw.get("output") if isinstance(raw, dict) else {}
+        output = output if isinstance(output, dict) else {}
+        report = OverseasOrderReport(
+            symbol=str(symbol).upper(),
+            exchange=exchange,
+            side=side_value,
+            qty=qty,
+            limit_price=str(limit_price),
+            broker_order_no=str(output.get("ODNO") or output.get("odno") or ""),
+            raw=raw,
+        )
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1=resp.msg1, data=report)
+
+    async def cancel_overseas_order(
+        self,
+        *,
+        symbol: str,
+        exchange: OverseasExchange | str,
+        original_order_no: str,
+        qty: int,
+        limit_price: str,
+        rvse_cncl_dvsn_cd: str = "02",
+    ) -> ResCommonResponse:
+        exchange = self._as_exchange(exchange)
+        cano, acnt_prdt_cd = self._account_parts()
+        body = {
+            "CANO": cano,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
+            "OVRS_EXCG_CD": exchange.value,
+            "PDNO": str(symbol).upper(),
+            "ORGN_ODNO": original_order_no,
+            "RVSE_CNCL_DVSN_CD": rvse_cncl_dvsn_cd,
+            "ORD_QTY": str(qty),
+            "OVRS_ORD_UNPR": str(limit_price),
+            "ORD_SVR_DVSN_CD": "0",
+        }
+        hashkey = await self._get_hashkey(body)
+        if not hashkey or isinstance(hashkey, ResCommonResponse):
+            return ResCommonResponse(
+                rt_cd=ErrorCode.MISSING_KEY.value,
+                msg1=f"hashkey 계산 실패 - {hashkey}",
+                data=None,
+            )
+        self._set_tr_header(self._trid_provider.overseas_stock_order_rvsecncl())
+        self._headers.set_hashkey(hashkey)
+        self._headers.set_gt_uid()
+        return await self.call_api(
+            "POST",
+            EndpointKey.OVERSEAS_STOCK_ORDER_RVSECNCL,
+            data=body,
+            retry_count=3,
+        )

--- a/brokers/korea_investment/korea_invest_trid_provider.py
+++ b/brokers/korea_investment/korea_invest_trid_provider.py
@@ -6,7 +6,7 @@ from config.config_loader import load_configs, load_config, TR_IDS_CONFIG_PATH
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
 from brokers.korea_investment.korea_invest_trid_keys import TrIdLeaf, TrId
 
-_DOMAINS = ("quotations", "account", "trading")
+_DOMAINS = ("quotations", "account", "trading", "overseas_stock")
 
 class KoreaInvestTrIdProvider:
     """
@@ -109,3 +109,37 @@ class KoreaInvestTrIdProvider:
     def time_daily_itemchartprice(self) -> str:
         leaf = TrIdLeaf.TIME_DAILY_ITEMCHARTPRICE
         return self.get_by_leaf(leaf)
+
+    # ── 해외주식 v1 ───────────────────────────────────────────────
+    def overseas_stock(self, leaf_key: str) -> str:
+        dom = self._tr_ids.get("overseas_stock", {})
+        if leaf_key not in dom:
+            raise KeyError(f"tr_ids.overseas_stock에 '{leaf_key}'를 찾을 수 없습니다.")
+        return dom[leaf_key]
+
+    def _overseas_mode_leaf(self, base: str) -> str:
+        return f"{base}_{'paper' if bool(self._env.is_paper_trading) else 'real'}"
+
+    def overseas_stock_inquire_balance(self) -> str:
+        return self.overseas_stock(self._overseas_mode_leaf("inquire_balance"))
+
+    def overseas_stock_inquire_ccnl(self) -> str:
+        return self.overseas_stock(self._overseas_mode_leaf("inquire_ccnl"))
+
+    def overseas_stock_inquire_nccs(self) -> str:
+        return self.overseas_stock(self._overseas_mode_leaf("inquire_nccs"))
+
+    def overseas_stock_order(self, is_buy: bool) -> str:
+        if self._env.is_paper_trading:
+            key = "order_buy_paper" if is_buy else "order_sell_paper"
+            dom = self._tr_ids.get("overseas_stock", {})
+            if key in dom:
+                return dom[key]
+        return self.overseas_stock("order_buy_real" if is_buy else "order_sell_real")
+
+    def overseas_stock_order_rvsecncl(self) -> str:
+        if self._env.is_paper_trading:
+            dom = self._tr_ids.get("overseas_stock", {})
+            if "order_rvsecncl_paper" in dom:
+                return dom["order_rvsecncl_paper"]
+        return self.overseas_stock("order_rvsecncl_real")

--- a/brokers/korea_investment/korea_invest_url_keys.py
+++ b/brokers/korea_investment/korea_invest_url_keys.py
@@ -28,3 +28,12 @@ class EndpointKey(str, Enum):
     ORDER_CASH = "order_cash"
     ORDER_RVSECNCL = "order_rvsecncl"
     HASHKEY = "hashkey"                       # YAML에 없으면 리터럴(/uapi/hashkey) 써도 됨
+
+    # ── 해외주식 v1 ─────────────────────
+    OVERSEAS_STOCK_PRICE = "overseas_stock_price"
+    OVERSEAS_STOCK_DAILYPRICE = "overseas_stock_dailyprice"
+    OVERSEAS_STOCK_INQUIRE_BALANCE = "overseas_stock_inquire_balance"
+    OVERSEAS_STOCK_INQUIRE_CCNL = "overseas_stock_inquire_ccnl"
+    OVERSEAS_STOCK_INQUIRE_NCCS = "overseas_stock_inquire_nccs"
+    OVERSEAS_STOCK_ORDER = "overseas_stock_order"
+    OVERSEAS_STOCK_ORDER_RVSECNCL = "overseas_stock_order_rvsecncl"

--- a/common/overseas_types.py
+++ b/common/overseas_types.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+MarketMode = Literal["domestic", "overseas_us"]
+
+
+class OverseasExchange(str, Enum):
+    NASD = "NASD"
+    NYSE = "NYSE"
+    AMEX = "AMEX"
+
+
+class OverseasPriceSummary(BaseModel):
+    symbol: str
+    exchange: OverseasExchange
+    currency: str = "USD"
+    price: float = 0.0
+    change_rate: float = 0.0
+    volume: int = 0
+    timestamp: str = ""
+    raw: dict = Field(default_factory=dict)
+
+    def to_dict(self):
+        return self.model_dump()
+
+
+class OverseasOrderRequest(BaseModel):
+    symbol: str
+    exchange: OverseasExchange
+    side: Literal["buy", "sell"]
+    qty: int
+    limit_price: float
+    currency: Literal["USD"] = "USD"
+    real_order_confirmation: str | None = None
+
+    def to_dict(self):
+        return self.model_dump()
+
+
+class OverseasOrderReport(BaseModel):
+    symbol: str
+    exchange: OverseasExchange
+    side: Literal["buy", "sell"]
+    qty: int
+    limit_price: str
+    broker_order_no: str = ""
+    raw: dict = Field(default_factory=dict)
+
+    def to_dict(self):
+        return self.model_dump()

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -27,6 +27,19 @@ is_paper_trading: true
 # canary 외 profile 은 WARN 으로 보고된다.
 operating_profile: "canary"
 
+# 시장 mode. paper/real 및 RUNTIME_MODE 와 독립 축이다.
+# domestic    : 기존 국내주식 모드
+# overseas_us : 미국 3시장(NASDAQ/NYSE/AMEX) 조회 + 수동 지정가 주문 v1
+market_mode: "domestic"
+
+overseas_stock:
+  enabled_exchanges: ["NASD", "NYSE", "AMEX"]
+  default_exchange: "NASD"
+  currency: "USD"
+  manual_order_only: true
+  # 실전 해외 주문은 기본 차단. 운영 검증 후 별도 승인으로만 true 전환.
+  allow_live_trading: false
+
 # 선택
 htsid: ""
 custtype: "P"

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -355,6 +355,18 @@ class OpeningPositionReconcileConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class OverseasStockConfig(BaseModel):
+    enabled_exchanges: List[Literal["NASD", "NYSE", "AMEX"]] = Field(
+        default_factory=lambda: ["NASD", "NYSE", "AMEX"]
+    )
+    default_exchange: Literal["NASD", "NYSE", "AMEX"] = "NASD"
+    currency: Literal["USD"] = "USD"
+    manual_order_only: bool = True
+    allow_live_trading: bool = False
+
+    model_config = {"extra": "allow"}
+
+
 class AppConfig(BaseModel):
     # Core API keys
     api_key: Optional[str] = None
@@ -374,6 +386,9 @@ class AppConfig(BaseModel):
     # paper 모드에서는 base 값을 사용하므로 profile 무관. real 모드에서 overlay 선택.
     operating_profile: Literal["canary", "real_limited", "real_full"] = "canary"
 
+    # Product/market surface. This is orthogonal to paper/real and runtime mode.
+    market_mode: Literal["domestic", "overseas_us"] = "domestic"
+
     # Sub-configs
     web: WebConfig
     cache: CacheConfig = Field(default_factory=CacheConfig)
@@ -392,6 +407,7 @@ class AppConfig(BaseModel):
         default_factory=StrategyProfitabilityGateConfig
     )
     opening_position_reconcile: OpeningPositionReconcileConfig = Field(default_factory=OpeningPositionReconcileConfig)
+    overseas_stock: OverseasStockConfig = Field(default_factory=OverseasStockConfig)
     
     # Dynamic/Merged configs
     tr_ids: Dict[str, Any] = Field(default_factory=dict)

--- a/config/kis_config.yaml
+++ b/config/kis_config.yaml
@@ -27,6 +27,15 @@ paths:
   order_rvsecncl: /uapi/domestic-stock/v1/trading/order-rvsecncl
   hashkey: /uapi/hashkey   # 선택: 없으면 코드에서 리터럴로 써도 됨
 
+  # 해외주식 v1 (미국 3시장 조회 + 수동 지정가 주문)
+  overseas_stock_price: /uapi/overseas-price/v1/quotations/price
+  overseas_stock_dailyprice: /uapi/overseas-price/v1/quotations/dailyprice
+  overseas_stock_inquire_balance: /uapi/overseas-stock/v1/trading/inquire-balance
+  overseas_stock_inquire_ccnl: /uapi/overseas-stock/v1/trading/inquire-ccnl
+  overseas_stock_inquire_nccs: /uapi/overseas-stock/v1/trading/inquire-nccs
+  overseas_stock_order: /uapi/overseas-stock/v1/trading/order
+  overseas_stock_order_rvsecncl: /uapi/overseas-stock/v1/trading/order-rvsecncl
+
   # websocket
   approval_key: /oauth2/Approval
   real_time_price: /tryitout/H0STCNT0

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -36,6 +36,18 @@ tr_ids:
     order_cash_sell_paper: VTTC0011U # 모의 주식 현금 매도
     order_rvsecncl_real: TTTC0803U # 실전 주식 정정취소
     order_rvsecncl_paper: VTTC0803U # 모의 주식 정정취소
+  overseas_stock:
+    price: HHDFS00000300 # 해외주식 현재체결가
+    dailyprice: HHDFS76240000 # 해외주식 기간별 시세
+    inquire_balance_real: TTTS3012R # 해외주식 잔고 (실전)
+    inquire_balance_paper: VTTS3012R # 해외주식 잔고 (모의)
+    inquire_ccnl_real: TTTS3035R # 해외주식 주문체결내역 (실전)
+    inquire_ccnl_paper: VTTS3035R # 해외주식 주문체결내역 (모의)
+    inquire_nccs_real: TTTS3018R # 해외주식 미체결내역 (실전)
+    inquire_nccs_paper: VTTS3018R # 해외주식 미체결내역 (모의)
+    order_buy_real: TTTS6036U # 해외주식 미국주간 지정가 매수
+    order_sell_real: TTTS6037U # 해외주식 미국주간 지정가 매도
+    order_rvsecncl_real: TTTS6038U # 해외주식 미국주간 정정취소
   # --- 웹소켓 TR ID 추가 ---
   websocket:
     approval_key: 실시간-000 # 웹소켓 접속키 발급 TR ID (문서에 명시된 값)

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -70,7 +70,8 @@ class OrderExecutionService:
                  execution_quality_config: Optional[ExecutionQualityReportConfig] = None,
                  deferred_order_queue=None,
                  order_max_retries: int = _ORDER_MAX_RETRIES,
-                 order_retry_delay_sec: int = _ORDER_RETRY_DELAY_SEC):
+                 order_retry_delay_sec: int = _ORDER_RETRY_DELAY_SEC,
+                 market_mode: str = "domestic"):
         self.broker_api_wrapper = broker_api_wrapper
         self.logger = logger
         self.market_clock = market_clock
@@ -85,6 +86,7 @@ class OrderExecutionService:
         self._order_policy = order_policy_service
         self._data_quality = data_quality_service
         self._execution_quality_config = execution_quality_config or ExecutionQualityReportConfig()
+        self._market_mode = str(market_mode or "domestic")
         self._order_max_retries = self._validate_order_max_retries(order_max_retries)
         self._order_retry_delay_sec = self._validate_order_retry_delay_sec(order_retry_delay_sec)
         self._exec_quality_reporter = ExecutionQualityReporter(
@@ -229,6 +231,9 @@ class OrderExecutionService:
     def _is_strategy_source(source: str) -> bool:
         text = str(source or "")
         return text.startswith("strategy:") or text.startswith("strategy_force_exit:")
+
+    def _is_overseas_mode(self) -> bool:
+        return self._market_mode == "overseas_us"
 
     def _log_real_order_preview(self, **kwargs) -> None:
         return self._submission_coordinator._log_real_order_preview(**kwargs)
@@ -472,6 +477,16 @@ class OrderExecutionService:
         current_trace = trace_id or get_trace_id() or new_trace_id("MANUAL")
         with trace_scope(current_trace):
             t_start = self.pm.start_timer()
+            if self._is_overseas_mode() and self._is_strategy_source(source):
+                msg = "해외주식 mode v1에서는 자동전략 매수 주문을 지원하지 않습니다."
+                self.logger.warning(
+                    f"[OrderPolicy] overseas_us strategy BUY blocked: stock_code={stock_code}, source={source}"
+                )
+                return ResCommonResponse(
+                    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+                    msg1=msg,
+                    data={"rule": "overseas_strategy_buy_blocked"},
+                )
             if self.market_calendar_service and not await self.market_calendar_service.is_market_open_now():
                 self.logger.warning("시장이 닫혀 있어 매수 주문을 제출하지 못했습니다.")
                 return ResCommonResponse(rt_cd=ErrorCode.MARKET_CLOSED.value, msg1="장 마감 시간에는 주문할 수 없습니다.", data=None)

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import time
 from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
+from common.overseas_types import OverseasExchange
 from common.types import ErrorCode, ResCommonResponse, ResTopMarketCapApiItem, ResBasicStockInfo, \
     ResStockFullInfoApiOutput, Exchange
 from config.DynamicConfig import DynamicConfig
@@ -1093,6 +1094,66 @@ class StockQueryService:
         특정 기간의 OHLCV 데이터를 조회합니다.
         """
         return await self.market_data_service.get_ohlcv_range(stock_code, period, start_date, end_date, exchange=exchange)
+
+    async def get_overseas_price(
+        self,
+        symbol: str,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+    ) -> ResCommonResponse:
+        if not self.broker:
+            return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1="broker 미설정", data=None)
+        return await self.broker.get_overseas_price(symbol, exchange=exchange)
+
+    async def get_overseas_dailyprice(
+        self,
+        symbol: str,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        start_date: str = "",
+        end_date: str = "",
+        period: str = "D",
+    ) -> ResCommonResponse:
+        if not self.broker:
+            return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1="broker 미설정", data=[])
+        return await self.broker.get_overseas_dailyprice(
+            symbol,
+            exchange=exchange,
+            start_date=start_date,
+            end_date=end_date,
+            period=period,
+        )
+
+    async def get_overseas_balance(
+        self,
+        *,
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        currency: str = "USD",
+    ) -> ResCommonResponse:
+        if not self.broker:
+            return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1="broker 미설정", data=None)
+        return await self.broker.get_overseas_balance(exchange=exchange, currency=currency)
+
+    async def get_overseas_order_history(
+        self,
+        *,
+        symbol: str = "%",
+        exchange: OverseasExchange | str = OverseasExchange.NASD,
+        start_date: str,
+        end_date: str,
+        side_code: str = "00",
+        ccld_nccs_dvsn: str = "00",
+    ) -> ResCommonResponse:
+        if not self.broker:
+            return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1="broker 미설정", data=None)
+        return await self.broker.inquire_overseas_ccnl(
+            symbol=symbol,
+            exchange=exchange,
+            start_date=start_date,
+            end_date=end_date,
+            side_code=side_code,
+            ccld_nccs_dvsn=ccld_nccs_dvsn,
+        )
 
     async def get_ohlcv_with_indicators(self, stock_code: str, period: str = "D", caller: str = "unknown") -> ResCommonResponse:
         """

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -198,6 +198,7 @@ def test_real_app_status_api_uses_initialized_context(client_with_fake_lifespan,
         "market_open": True,
         "env_type": "모의투자",
         "is_paper_trading": True,
+        "market_mode": "domestic",
         "current_time": "2026-03-08 10:30:00",
         "initialized": True,
     }

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
@@ -1,0 +1,146 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from brokers.korea_investment.korea_invest_header_provider import KoreaInvestHeaderProvider
+from brokers.korea_investment.korea_invest_overseas_stock_api import KoreaInvestOverseasStockApi
+from brokers.korea_investment.korea_invest_trid_provider import KoreaInvestTrIdProvider
+from brokers.korea_investment.korea_invest_url_keys import EndpointKey
+from brokers.korea_investment.korea_invest_url_provider import KoreaInvestUrlProvider
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+
+
+@pytest.fixture
+def overseas_env():
+    env = MagicMock()
+    env.is_paper_trading = True
+    env.my_agent = "pytest-agent"
+    env.active_config = {
+        "api_key": "app",
+        "api_secret_key": "secret",
+        "stock_account_number": "12345678-01",
+        "custtype": "P",
+    }
+    return env
+
+
+@pytest.fixture
+def overseas_api(overseas_env):
+    paths = {
+        "hashkey": "/uapi/hashkey",
+        "overseas_stock_price": "/uapi/overseas-price/v1/quotations/price",
+        "overseas_stock_dailyprice": "/uapi/overseas-price/v1/quotations/dailyprice",
+        "overseas_stock_inquire_balance": "/uapi/overseas-stock/v1/trading/inquire-balance",
+        "overseas_stock_inquire_ccnl": "/uapi/overseas-stock/v1/trading/inquire-ccnl",
+        "overseas_stock_inquire_nccs": "/uapi/overseas-stock/v1/trading/inquire-nccs",
+        "overseas_stock_order": "/uapi/overseas-stock/v1/trading/order",
+        "overseas_stock_order_rvsecncl": "/uapi/overseas-stock/v1/trading/order-rvsecncl",
+    }
+    tr_ids = {
+        "overseas_stock": {
+            "price": "HHDFS00000300",
+            "dailyprice": "HHDFS76240000",
+            "inquire_balance_real": "TTTS3012R",
+            "inquire_balance_paper": "VTTS3012R",
+            "inquire_ccnl_real": "TTTS3035R",
+            "inquire_ccnl_paper": "VTTS3035R",
+            "inquire_nccs_real": "TTTS3018R",
+            "inquire_nccs_paper": "VTTS3018R",
+            "order_buy_real": "TTTS6036U",
+            "order_sell_real": "TTTS6037U",
+            "order_rvsecncl_real": "TTTS6038U",
+        }
+    }
+    api = KoreaInvestOverseasStockApi(
+        overseas_env,
+        logger=MagicMock(),
+        market_clock=MagicMock(),
+        header_provider=KoreaInvestHeaderProvider(my_agent="pytest-agent"),
+        url_provider=KoreaInvestUrlProvider(lambda: "https://mock.kis", paths),
+        trid_provider=KoreaInvestTrIdProvider(overseas_env, tr_ids),
+    )
+    api.call_api = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {}})
+    )
+    return api
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_price_uses_overseas_endpoint_trid_and_params(overseas_api):
+    await overseas_api.get_overseas_price("AAPL", exchange=OverseasExchange.NASD)
+
+    overseas_api.call_api.assert_awaited_once()
+    _, key = overseas_api.call_api.await_args.args[:2]
+    assert key == EndpointKey.OVERSEAS_STOCK_PRICE
+    assert overseas_api.call_api.await_args.kwargs["params"] == {
+        "AUTH": "",
+        "EXCD": "NAS",
+        "SYMB": "AAPL",
+    }
+    assert overseas_api._headers.build()["tr_id"] == "HHDFS00000300"
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_dailyprice_uses_period_and_date_params(overseas_api):
+    await overseas_api.get_overseas_dailyprice(
+        "MSFT",
+        exchange=OverseasExchange.NYSE,
+        start_date="20260101",
+        end_date="20260131",
+        period="D",
+    )
+
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_DAILYPRICE
+    assert overseas_api.call_api.await_args.kwargs["params"] == {
+        "AUTH": "",
+        "EXCD": "NYS",
+        "SYMB": "MSFT",
+        "GUBN": "0",
+        "BYMD": "20260131",
+        "MODP": "1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_limit_order_uses_overseas_body_and_hashkey(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value="HASH")
+
+    await overseas_api.place_overseas_limit_order(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        side="buy",
+        qty=3,
+        limit_price="150.25",
+    )
+
+    overseas_api._get_hashkey.assert_awaited_once()
+    body = overseas_api._get_hashkey.await_args.args[0]
+    assert body == {
+        "CANO": "12345678",
+        "ACNT_PRDT_CD": "01",
+        "OVRS_EXCG_CD": "NASD",
+        "PDNO": "AAPL",
+        "ORD_QTY": "3",
+        "OVRS_ORD_UNPR": "150.25",
+        "ORD_SVR_DVSN_CD": "0",
+        "ORD_DVSN": "00",
+    }
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_ORDER
+    assert overseas_api.call_api.await_args.kwargs["data"] == body
+    assert overseas_api._headers.build()["tr_id"] == "TTTS6036U"
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_blocks_market_order(overseas_api):
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        side="buy",
+        qty=1,
+        limit_price="0",
+    )
+
+    assert resp.rt_cd == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert "지정가" in resp.msg1
+    overseas_api.call_api.assert_not_awaited()

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_trid_provider.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_trid_provider.py
@@ -32,6 +32,19 @@ def mock_tr_ids():
             "order_rvsecncl_real": "TR_CANCEL_REAL",
             "inquire_psbl_rvsecncl_paper": "TR_PSBL_CANCEL_PAPER",
             "inquire_psbl_rvsecncl_real": "TR_PSBL_CANCEL_REAL"
+        },
+        "overseas_stock": {
+            "price": "TR_OVRS_PRICE",
+            "dailyprice": "TR_OVRS_DAILY",
+            "inquire_balance_real": "TR_OVRS_BALANCE_REAL",
+            "inquire_balance_paper": "TR_OVRS_BALANCE_PAPER",
+            "inquire_ccnl_real": "TR_OVRS_CCLD_REAL",
+            "inquire_ccnl_paper": "TR_OVRS_CCLD_PAPER",
+            "inquire_nccs_real": "TR_OVRS_NCCS_REAL",
+            "inquire_nccs_paper": "TR_OVRS_NCCS_PAPER",
+            "order_buy_real": "TR_OVRS_BUY_REAL",
+            "order_sell_real": "TR_OVRS_SELL_REAL",
+            "order_rvsecncl_real": "TR_OVRS_CANCEL_REAL"
         }
     }
 
@@ -130,3 +143,18 @@ def test_get_leaf_string_delegates_to_leaf_lookup(mock_env, mock_tr_ids):
     provider = KoreaInvestTrIdProvider(mock_env, mock_tr_ids)
 
     assert provider.get("inquire_daily_itemchartprice") == "TR_DAILY_CHART"
+
+
+def test_overseas_stock_convenience_methods_respect_paper_and_real(mock_env, mock_tr_ids):
+    provider = KoreaInvestTrIdProvider(mock_env, mock_tr_ids)
+
+    assert provider.overseas_stock("price") == "TR_OVRS_PRICE"
+    assert provider.overseas_stock_inquire_balance() == "TR_OVRS_BALANCE_PAPER"
+    assert provider.overseas_stock_inquire_ccnl() == "TR_OVRS_CCLD_PAPER"
+    assert provider.overseas_stock_inquire_nccs() == "TR_OVRS_NCCS_PAPER"
+
+    mock_env.is_paper_trading = False
+    assert provider.overseas_stock_inquire_balance() == "TR_OVRS_BALANCE_REAL"
+    assert provider.overseas_stock_order(is_buy=True) == "TR_OVRS_BUY_REAL"
+    assert provider.overseas_stock_order(is_buy=False) == "TR_OVRS_SELL_REAL"
+    assert provider.overseas_stock_order_rvsecncl() == "TR_OVRS_CANCEL_REAL"

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_url_provider.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_url_provider.py
@@ -98,6 +98,25 @@ def test_url_with_enum(url_provider):
     """url: Enum 멤버를 사용하여 전체 URL을 생성하는지 테스트."""
     assert url_provider.url(DummyEnum.GET_PRICE) == "https://mock.api.com/api/v1/price"
 
+
+def test_url_with_overseas_stock_paths(mock_env):
+    provider = KoreaInvestUrlProvider(
+        get_base_url=mock_env.get_base_url,
+        paths={
+            "overseas_stock_price": "/uapi/overseas-price/v1/quotations/price",
+            "overseas_stock_order": "/uapi/overseas-stock/v1/trading/order",
+        },
+    )
+
+    assert (
+        provider.url("overseas_stock_price")
+        == "https://mock.api.com/uapi/overseas-price/v1/quotations/price"
+    )
+    assert (
+        provider.url("overseas_stock_order")
+        == "https://mock.api.com/uapi/overseas-stock/v1/trading/order"
+    )
+
 def test_url_with_slashes(mock_paths):
     """url: base_url과 path의 슬래시 처리가 올바른지 테스트."""
     # Case 1: base_url에 trailing slash

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -132,6 +132,39 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.data_quality.violation_alert_window_sec == 60.0
     assert config.order_execution.order_max_retries == 3
     assert config.order_execution.order_retry_delay_sec == 3
+    assert config.market_mode == "domestic"
+    assert config.overseas_stock.enabled_exchanges == ["NASD", "NYSE", "AMEX"]
+    assert config.overseas_stock.default_exchange == "NASD"
+    assert config.overseas_stock.currency == "USD"
+    assert config.overseas_stock.manual_order_only is True
+    assert config.overseas_stock.allow_live_trading is False
+
+
+def test_app_config_accepts_overseas_us_market_mode():
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="overseas_us",
+        overseas_stock={
+            "enabled_exchanges": ["NASD", "NYSE"],
+            "default_exchange": "NYSE",
+            "currency": "USD",
+            "manual_order_only": True,
+            "allow_live_trading": True,
+        },
+    )
+
+    assert config.market_mode == "overseas_us"
+    assert config.overseas_stock.enabled_exchanges == ["NASD", "NYSE"]
+    assert config.overseas_stock.default_exchange == "NYSE"
+    assert config.overseas_stock.allow_live_trading is True
+
+
+def test_app_config_rejects_invalid_market_mode():
+    with pytest.raises(ValidationError):
+        AppConfig(
+            web={"host": "localhost", "port": 8080},
+            market_mode="global",
+        )
 
 
 def test_position_sizing_real_mode_overrides_defaults_are_canary_friendly():

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -140,6 +140,7 @@ def mock_web_ctx():
     ctx.get_env_type.return_value = "모의투자"
     ctx.get_current_time_str.return_value = "2025-01-01 12:00:00"
     ctx.initialized = True
+    ctx.market_mode = "domestic"
     
     # 하위 서비스 Mocking
     ctx.stock_query_service = AsyncMock()

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -345,6 +345,34 @@ async def test_strategy_sell_failure_does_not_emit_duplicate_system_notification
     assert result.rt_cd == ErrorCode.API_ERROR.value
     mock_notification_service.emit.assert_not_awaited()
 
+
+@pytest.mark.asyncio
+async def test_overseas_mode_blocks_strategy_buy_before_broker_call(
+    mock_broker_api_wrapper,
+    mock_logger,
+    mock_market_clock,
+    mock_market_calendar_service,
+):
+    handler_instance = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        market_mode="overseas_us",
+    )
+
+    result = await handler_instance.handle_place_buy_order(
+        "AAPL",
+        190,
+        1,
+        source="strategy:OneilSqueezeBreakout",
+    )
+
+    assert result.rt_cd == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert result.data == {"rule": "overseas_strategy_buy_blocked"}
+    mock_broker_api_wrapper.place_stock_order.assert_not_awaited()
+    mock_logger.warning.assert_called_once()
+
 @pytest.mark.asyncio # This test is not directly related to the market open check, but it's good to ensure it still works.
 async def test_handle_realtime_price_quote_stream_success(handler, mock_broker_api_wrapper, mock_logger, mock_market_calendar_service):
     """실시간 스트림이 성공적으로 연결, 구독, 종료되는지 테스트합니다."""

--- a/tests/unit_test/view/web/routes/test_web_routes_balance.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_balance.py
@@ -3,6 +3,7 @@
 """
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
+from common.overseas_types import OverseasExchange
 from common.types import ResCommonResponse
 
 @pytest.fixture(autouse=True)
@@ -95,6 +96,25 @@ async def test_get_balance_full_config_exception(web_client, mock_web_ctx):
     response = web_client.get("/api/balance")
     assert response.status_code == 200
     assert response.json()["account_info"]["number"] == "번호없음"
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_balance_calls_service(web_client, mock_web_ctx):
+    """GET /api/overseas/balance는 해외 잔고 조회 서비스를 호출한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.stock_query_service.get_overseas_balance.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data={"output1": []}
+    )
+
+    response = web_client.get("/api/overseas/balance?exchange=AMEX&currency=USD")
+
+    assert response.status_code == 200
+    assert response.json()["account_info"]["market_mode"] == "overseas_us"
+    assert response.json()["account_info"]["exchange"] == "AMEX"
+    mock_web_ctx.stock_query_service.get_overseas_balance.assert_awaited_once_with(
+        exchange=OverseasExchange.AMEX,
+        currency="USD",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -2,7 +2,8 @@
 주문 관련 테스트 (order.html).
 """
 import pytest
-from common.types import ResCommonResponse
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
 
 
 @pytest.mark.asyncio
@@ -134,3 +135,72 @@ async def test_place_order_market_price_lookup_exception(web_client, mock_web_ct
     assert response.status_code == 200
     
     mock_web_ctx.virtual_trade_service.log_buy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_limit_order_calls_broker(web_client, mock_web_ctx):
+    """POST /api/overseas/order는 해외 mode에서 수동 지정가 주문만 브로커에 위임한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.broker.place_overseas_limit_order.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"}
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 3,
+        "limit_price": 190.25,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["data"]["ord_no"] == "A12345"
+    mock_web_ctx.broker.place_overseas_limit_order.assert_awaited_once_with(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        side="buy",
+        qty=3,
+        limit_price=190.25,
+    )
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_requires_overseas_mode(web_client, mock_web_ctx):
+    """국내 mode에서는 해외 주문 endpoint가 닫혀 있어야 한다."""
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 400
+    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_real_order_requires_allow_live_trading(web_client, mock_web_ctx):
+    """실전 해외주문은 allow_live_trading=False이면 정책 차단 응답을 반환한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.env.is_paper_trading = False
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+        "real_order_confirmation": "REAL",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert response.json()["data"]["rule"] == "overseas_live_trading_disabled"
+    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -3,6 +3,7 @@
 """
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from common.overseas_types import OverseasExchange
 from common.types import ResCommonResponse
 
 
@@ -16,7 +17,8 @@ def test_get_status(web_client, mock_web_ctx):
         "is_paper_trading": True,
         "env_type": "모의투자",
         "current_time": "2025-01-01 12:00:00",
-        "initialized": True
+        "initialized": True,
+        "market_mode": "domestic",
     }
 
 
@@ -231,7 +233,8 @@ async def test_get_status_ctx_none(web_client, monkeypatch):
         "env_type": "미설정",
         "is_paper_trading": True,
         "current_time": "",
-        "initialized": False
+        "initialized": False,
+        "market_mode": "domestic",
     }
 
 
@@ -258,6 +261,79 @@ async def test_get_status_cached(web_client, mock_web_ctx):
     assert json_resp["env_type"] == "테스트"
     # 캐시를 반환하되 시간은 갱신되었는지 확인
     assert json_resp["current_time"] == "new_time"
+    assert json_resp["market_mode"] == "domestic"
+
+
+@pytest.mark.asyncio
+async def test_get_market_mode(web_client, mock_web_ctx):
+    """GET /api/market-mode는 현재 market_mode를 반환한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+
+    response = web_client.get("/api/market-mode")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "market_mode": "overseas_us",
+        "requires_reinitialize": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_market_mode_marks_reinitialize(web_client, mock_web_ctx):
+    """POST /api/market-mode는 허용된 mode만 반영하고 재초기화 필요 여부를 반환한다."""
+    response = web_client.post("/api/market-mode", json={"market_mode": "overseas_us"})
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["market_mode"] == "overseas_us"
+    assert response.json()["requires_reinitialize"] is True
+    assert mock_web_ctx.market_mode == "overseas_us"
+
+
+@pytest.mark.asyncio
+async def test_change_market_mode_invalid(web_client, mock_web_ctx):
+    """POST /api/market-mode는 domestic/overseas_us 외 값을 거부한다."""
+    response = web_client.post("/api/market-mode", json={"market_mode": "crypto"})
+
+    assert response.status_code == 400
+    assert mock_web_ctx.market_mode == "domestic"
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_stock_price_calls_service(web_client, mock_web_ctx):
+    """GET /api/overseas/stock/{symbol}은 해외 조회 서비스를 호출한다."""
+    mock_web_ctx.stock_query_service.get_overseas_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data={"symbol": "AAPL", "price": 190.0}
+    )
+
+    response = web_client.get("/api/overseas/stock/AAPL?exchange=NASD")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["symbol"] == "AAPL"
+    mock_web_ctx.stock_query_service.get_overseas_price.assert_awaited_once_with(
+        "AAPL", exchange=OverseasExchange.NASD
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_stock_chart_calls_service(web_client, mock_web_ctx):
+    """GET /api/overseas/chart/{symbol}은 해외 일봉 조회 서비스를 호출한다."""
+    mock_web_ctx.stock_query_service.get_overseas_dailyprice.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data=[{"date": "20250101", "close": 190.0}]
+    )
+
+    response = web_client.get("/api/overseas/chart/AAPL?exchange=NYSE&period=W")
+
+    assert response.status_code == 200
+    assert response.json()["data"][0]["close"] == 190.0
+    mock_web_ctx.stock_query_service.get_overseas_dailyprice.assert_awaited_once_with(
+        "AAPL",
+        exchange=OverseasExchange.NYSE,
+        period="W",
+        start_date="",
+        end_date="",
+    )
 
 
 @pytest.mark.asyncio

--- a/view/web/bootstrap/config_bootstrap.py
+++ b/view/web/bootstrap/config_bootstrap.py
@@ -35,6 +35,7 @@ class ConfigBootstrap:
 
         config_data = load_configs()
         ctx.full_config = config_data
+        ctx.market_mode = getattr(config_data, "market_mode", "domestic")
 
         config_dict = config_data
         if hasattr(config_data, "model_dump"):
@@ -71,7 +72,7 @@ class ConfigBootstrap:
         self._register_telegram(ctx, config_dict)
 
         ctx._load_position_sizing_state()
-        ctx.logger.info("웹 앱: 환경 설정 로드 완료.")
+        ctx.logger.info(f"웹 앱: 환경 설정 로드 완료. market_mode={ctx.market_mode}")
 
         ctx._mcs = MarketCalendarService(
             ctx.market_clock, ctx.logger, performance_profiler=ctx.pm

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -164,6 +164,12 @@ class ServiceContainer:
         needs_trading = bool(mode & RuntimeMode.TRADING)
         needs_batch = bool(mode & RuntimeMode.BATCH)
         needs_realtime = bool(mode & (RuntimeMode.WEB | RuntimeMode.TRADING))
+        is_overseas_us = getattr(ctx, "market_mode", "domestic") == "overseas_us"
+        if is_overseas_us:
+            # 해외주식 v1은 조회 + 수동 지정가 주문만 지원한다.
+            needs_trading = False
+            needs_batch = False
+            needs_realtime = False
 
         config_dict = ctx.full_config
         if hasattr(config_dict, "model_dump"):
@@ -235,19 +241,22 @@ class ServiceContainer:
             raise
 
         try:
-            ctx.ranking_task = RankingTask(
-                broker_api_wrapper=ctx.broker,
-                stock_code_repository=ctx.stock_code_repository,
-                env=ctx.env,
-                logger=ctx.logger,
-                market_clock=ctx.market_clock,
-                performance_profiler=ctx.pm,
-                notification_service=ctx.notification_service,
-                telegram_reporter=getattr(ctx, 'telegram_reporter', None),
-                market_calendar_service=ctx._mcs,
-                market_data_service=ctx.market_data_service,
-                worker_pool=ctx.worker_pool,
-            )
+            if is_overseas_us:
+                ctx.ranking_task = None
+            else:
+                ctx.ranking_task = RankingTask(
+                    broker_api_wrapper=ctx.broker,
+                    stock_code_repository=ctx.stock_code_repository,
+                    env=ctx.env,
+                    logger=ctx.logger,
+                    market_clock=ctx.market_clock,
+                    performance_profiler=ctx.pm,
+                    notification_service=ctx.notification_service,
+                    telegram_reporter=getattr(ctx, 'telegram_reporter', None),
+                    market_calendar_service=ctx._mcs,
+                    market_data_service=ctx.market_data_service,
+                    worker_pool=ctx.worker_pool,
+                )
             ctx.stock_query_service = StockQueryService(
                 market_data_service=ctx.market_data_service, logger=ctx.logger, market_clock=ctx.market_clock,
                 indicator_service=ctx.indicator_service,
@@ -263,12 +272,15 @@ class ServiceContainer:
             raise
 
         try:
-            ctx.minervini_stage_service = MinerviniStageService(
-                stock_query_service=ctx.stock_query_service,
-                rs_rating_service=getattr(ctx, "rs_rating_service", None),
-                stock_repository=ctx.stock_repository,
-                logger=ctx.logger,
-            )
+            if is_overseas_us:
+                ctx.minervini_stage_service = None
+            else:
+                ctx.minervini_stage_service = MinerviniStageService(
+                    stock_query_service=ctx.stock_query_service,
+                    rs_rating_service=getattr(ctx, "rs_rating_service", None),
+                    stock_repository=ctx.stock_repository,
+                    logger=ctx.logger,
+                )
             # NOTE: favorite_service.minervini_stage_service wiring is performed by WiringPhase.
         except Exception as e:
             ctx.logger.warning(f"[ServiceBootstrap:MinerviniStage] 초기화 실패: {e}")
@@ -504,6 +516,7 @@ class ServiceContainer:
                     "order_retry_delay_sec",
                     OrderExecutionService._ORDER_RETRY_DELAY_SEC,
                 ),
+                market_mode=getattr(ctx, "market_mode", "domestic"),
             )
             # NOTE: streaming_service.register_handler("signing_notice", ...) is performed by WiringPhase.
         except Exception as e:
@@ -511,6 +524,28 @@ class ServiceContainer:
             raise
 
         try:
+            if is_overseas_us:
+                ctx.oneil_universe_service = None
+                ctx.premium_watchlist_generator_task = None
+                ctx.cache_warmup_task = None
+                ctx.log_cleanup_task = None
+                ctx.newhigh_task = None
+                ctx.newhigh_service = None
+                ctx.strategy_log_report_task = None
+                ctx.post_market_replay_audit_task = None
+                ctx.after_market_reconcile_task = None
+                ctx.opening_position_reconcile_task = None
+                if needs_web:
+                    ctx.notification_queue_task = NotificationQueueTask(
+                        notification_service=ctx.notification_service,
+                        poll_interval=config_dict.get("notification_queue_poll_interval", 1.0),
+                        telegram_config=getattr(getattr(ctx.full_config, "notifications", None), "telegram", None),
+                        logger=ctx.logger,
+                    )
+                else:
+                    ctx.notification_queue_task = None
+                return
+
             ctx.oneil_universe_service = OneilUniverseService(
                 stock_query_service=ctx.stock_query_service,
                 indicator_service=ctx.indicator_service,

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -32,6 +32,12 @@ class StrategyFactory:
 
     def build(self) -> None:
         ctx = self._ctx
+        if getattr(ctx, "market_mode", "domestic") == "overseas_us":
+            ctx.logger.info(
+                "[StrategyFactory] market_mode=overseas_us — 해외주식 v1은 자동전략을 비활성화합니다."
+            )
+            ctx.scheduler = None
+            return
         if not (ctx.runtime_mode & RuntimeMode.TRADING):
             ctx.logger.info(
                 "[StrategyFactory] runtime_mode=%s — TRADING 비활성, StrategyScheduler 미생성.",

--- a/view/web/routes/balance.py
+++ b/view/web/routes/balance.py
@@ -2,6 +2,7 @@
 계좌 잔고 관련 API 엔드포인트 (balance.html).
 """
 from fastapi import APIRouter, Query, HTTPException
+from common.overseas_types import OverseasExchange
 from common.types import Exchange
 from view.web.api_common import _get_ctx, _serialize_response
 
@@ -67,6 +68,28 @@ async def get_balance(exchange: str = Query("KRX")):
         }
 
     ctx.pm.log_timer("get_balance", t_start)
+    return result
+
+
+@router.get("/overseas/balance")
+async def get_overseas_balance(exchange: str = Query("NASD"), currency: str = Query("USD")):
+    """해외주식 잔고 조회. v1은 미국 3시장 + USD만 지원한다."""
+    ctx = _get_ctx()
+    try:
+        exchange_enum = OverseasExchange(exchange.upper())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="exchange는 NASD, NYSE, AMEX 중 하나여야 합니다.")
+    if currency.upper() != "USD":
+        raise HTTPException(status_code=400, detail="v1은 USD만 지원합니다.")
+
+    resp = await ctx.stock_query_service.get_overseas_balance(exchange=exchange_enum, currency="USD")
+    result = _serialize_response(resp)
+    result["account_info"] = {
+        "type": ctx.get_env_type(),
+        "exchange": exchange_enum.value,
+        "currency": "USD",
+        "market_mode": getattr(ctx, "market_mode", "domestic"),
+    }
     return result
 
 @router.post("/balance/sell_all")

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -2,6 +2,9 @@
 주문 관련 API 엔드포인트 (order.html).
 """
 from fastapi import APIRouter, HTTPException
+from fastapi import Query
+from common.overseas_types import OverseasOrderRequest
+from common.types import ErrorCode, ResCommonResponse
 from view.web.api_common import _get_ctx, _serialize_response, OrderRequest
 
 router = APIRouter()
@@ -42,4 +45,66 @@ async def place_order(req: OrderRequest):
         raise HTTPException(status_code=400, detail="side는 'buy' 또는 'sell'이어야 합니다.")
 
     ctx.pm.log_timer("place_order", t_start)
+    return _serialize_response(resp)
+
+
+@router.post("/overseas/order")
+async def place_overseas_order(req: OverseasOrderRequest):
+    """해외주식 수동 지정가 주문. v1은 미국 3시장 + USD 지정가만 지원한다."""
+    ctx = _get_ctx()
+    if getattr(ctx, "market_mode", "domestic") != "overseas_us":
+        raise HTTPException(status_code=400, detail="해외주식 주문은 overseas_us mode에서만 사용할 수 있습니다.")
+
+    cfg = getattr(getattr(ctx, "full_config", None), "overseas_stock", None)
+    enabled_exchanges = set(getattr(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
+    if req.exchange.value not in enabled_exchanges:
+        raise HTTPException(status_code=400, detail="활성화되지 않은 해외 거래소입니다.")
+    if req.currency != "USD":
+        raise HTTPException(status_code=400, detail="v1은 USD 주문만 지원합니다.")
+    if _is_real_trading_mode(ctx):
+        if not bool(getattr(cfg, "allow_live_trading", False)):
+            return _serialize_response(
+                ResCommonResponse(
+                    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+                    msg1="실전 해외주식 주문은 overseas_stock.allow_live_trading=true 설정 전까지 차단됩니다.",
+                    data={"rule": "overseas_live_trading_disabled"},
+                )
+            )
+        if req.real_order_confirmation != "REAL":
+            raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
+
+    resp = await ctx.broker.place_overseas_limit_order(
+        symbol=req.symbol,
+        exchange=req.exchange,
+        side=req.side,
+        qty=req.qty,
+        limit_price=req.limit_price,
+    )
+    return _serialize_response(resp)
+
+
+@router.get("/overseas/orders")
+async def get_overseas_orders(
+    symbol: str = Query("%"),
+    exchange: str = Query("NASD"),
+    start_date: str = Query(""),
+    end_date: str = Query(""),
+    side_code: str = Query("00"),
+    ccld_nccs_dvsn: str = Query("00"),
+):
+    ctx = _get_ctx()
+    if getattr(ctx, "market_mode", "domestic") != "overseas_us":
+        raise HTTPException(status_code=400, detail="해외주식 주문 조회는 overseas_us mode에서만 사용할 수 있습니다.")
+    if not start_date or not end_date:
+        today = ctx.market_clock.get_current_kst_time().strftime("%Y%m%d")
+        start_date = start_date or today
+        end_date = end_date or today
+    resp = await ctx.stock_query_service.get_overseas_order_history(
+        symbol=symbol,
+        exchange=exchange,
+        start_date=start_date,
+        end_date=end_date,
+        side_code=side_code,
+        ccld_nccs_dvsn=ccld_nccs_dvsn,
+    )
     return _serialize_response(resp)

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -5,6 +5,8 @@
 import asyncio
 import time
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+from common.overseas_types import OverseasExchange
 from common.types import Exchange
 from repositories.streaming_stock_repo import StreamingType
 from services.price_subscription_service import SubscriptionPriority
@@ -19,6 +21,15 @@ _status_cache_ts = 0.0
 _STATUS_CACHE_TTL = 5.0
 
 
+class MarketModeRequest(BaseModel):
+    market_mode: str
+
+
+def _market_mode_of(ctx) -> str:
+    mode = getattr(ctx, "market_mode", "domestic")
+    return mode if mode in ("domestic", "overseas_us") else "domestic"
+
+
 @router.get("/status")
 async def get_status():
     """시장 상태 및 환경 정보."""
@@ -30,6 +41,7 @@ async def get_status():
             "market_open": False,
             "env_type": "미설정",
             "is_paper_trading": True,
+            "market_mode": "domestic",
             "current_time": "",
             "initialized": False,
         }
@@ -38,18 +50,55 @@ async def get_status():
     if _status_cache is not None and (now - _status_cache_ts) < _STATUS_CACHE_TTL:
         # 캐시된 결과 반환 (현재 시각만 갱신)
         _status_cache["current_time"] = ctx.get_current_time_str()
+        _status_cache["market_mode"] = _market_mode_of(ctx)
         return _status_cache
 
     result = {
         "market_open": await ctx.is_market_open_now(),
         "env_type": ctx.get_env_type(),
         "is_paper_trading": bool(getattr(getattr(ctx, "env", None), "is_paper_trading", True)),
+        "market_mode": _market_mode_of(ctx),
         "current_time": ctx.get_current_time_str(),
         "initialized": ctx.initialized
     }
     _status_cache = result
     _status_cache_ts = now
     return result
+
+
+@router.get("/market-mode")
+def get_market_mode():
+    ctx = _get_ctx()
+    mode = _market_mode_of(ctx)
+    return {
+        "success": True,
+        "market_mode": mode,
+        "requires_reinitialize": False,
+    }
+
+
+@router.post("/market-mode")
+def change_market_mode(req: MarketModeRequest):
+    global _status_cache, _status_cache_ts
+    ctx = _get_ctx()
+    mode = str(req.market_mode or "").strip().lower()
+    if mode not in ("domestic", "overseas_us"):
+        raise HTTPException(status_code=400, detail="market_mode는 domestic 또는 overseas_us만 지원합니다.")
+
+    current = _market_mode_of(ctx)
+    ctx.market_mode = mode
+    full_config = getattr(ctx, "full_config", None)
+    if full_config is not None and hasattr(full_config, "market_mode"):
+        full_config.market_mode = mode
+
+    _status_cache = None
+    _status_cache_ts = 0.0
+    return {
+        "success": True,
+        "market_mode": mode,
+        "previous_market_mode": current,
+        "requires_reinitialize": current != mode,
+    }
 
 
 @router.get("/stocks/list")
@@ -161,6 +210,40 @@ async def get_stock_price(code: str, exchange: str = Query("KRX")):
     asyncio.create_task(_preload_ohlcv())
 
     return result
+
+
+@router.get("/overseas/stock/{symbol}")
+async def get_overseas_stock_price(symbol: str, exchange: str = Query("NASD")):
+    ctx = _get_ctx()
+    try:
+        exchange_enum = OverseasExchange(exchange.upper())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="exchange는 NASD, NYSE, AMEX 중 하나여야 합니다.")
+    resp = await ctx.stock_query_service.get_overseas_price(symbol, exchange=exchange_enum)
+    return _serialize_response(resp)
+
+
+@router.get("/overseas/chart/{symbol}")
+async def get_overseas_stock_chart(
+    symbol: str,
+    exchange: str = Query("NASD"),
+    period: str = Query("D"),
+    start_date: str = Query(""),
+    end_date: str = Query(""),
+):
+    ctx = _get_ctx()
+    try:
+        exchange_enum = OverseasExchange(exchange.upper())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="exchange는 NASD, NYSE, AMEX 중 하나여야 합니다.")
+    resp = await ctx.stock_query_service.get_overseas_dailyprice(
+        symbol,
+        exchange=exchange_enum,
+        start_date=start_date,
+        end_date=end_date,
+        period=period,
+    )
+    return _serialize_response(resp)
 
 
 @router.get("/chart/{code}")

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -95,6 +95,7 @@ class WebAppContext:
         from view.web.bootstrap.runtime_mode import RuntimeMode
         self.logger = Logger()
         self.runtime_mode: RuntimeMode = runtime_mode if runtime_mode is not None else RuntimeMode.ALL
+        self.market_mode: str = "domestic"
         self.env = app_context.env if app_context else None
         self.full_config = {}  # [추가] 전체 설정을 담을 그릇
         self.market_clock: MarketClock = None


### PR DESCRIPTION
## Summary
- add market_mode=domestic|overseas_us config and overseas_stock safety defaults
- add KIS overseas stock REST client for US quote/daily/balance/orders with v1 limit-order-only behavior
- expose web APIs for market mode, overseas quote/chart/balance/manual orders and disable domestic strategy/batch surfaces in overseas mode
- block strategy BUY orders in overseas_us mode with ORDER_POLICY_BLOCKED

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v