### PR TITLE
Add enabled market modes for overseas V2

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -31,6 +31,9 @@ operating_profile: "canary"
 # domestic    : 기존 국내주식 모드
 # overseas_us : 미국 3시장(NASDAQ/NYSE/AMEX) 조회 + 수동 지정가 주문 v1
 market_mode: "domestic"
+# V2: 한 프로세스에서 국내 전략/배치를 유지하면서 해외 수동 조회/주문 surface를 열려면
+# ["domestic", "overseas_us"] 로 설정한다. overseas_us active mode는 국내 전략/배치를 fail-close한다.
+enabled_market_modes: ["domestic"]
 
 overseas_stock:
   enabled_exchanges: ["NASD", "NYSE", "AMEX"]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -3,7 +3,7 @@ import yaml
 import os
 import json
 from typing import Dict, Any, Literal, Optional, List
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 # config.yaml 및 tr_ids_config.yaml 파일 경로 설정
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -388,6 +388,7 @@ class AppConfig(BaseModel):
 
     # Product/market surface. This is orthogonal to paper/real and runtime mode.
     market_mode: Literal["domestic", "overseas_us"] = "domestic"
+    enabled_market_modes: Optional[List[Literal["domestic", "overseas_us"]]] = None
 
     # Sub-configs
     web: WebConfig
@@ -426,6 +427,20 @@ class AppConfig(BaseModel):
         if v and not (v.startswith("http://") or v.startswith("https://")):
             raise ValueError("base_url은 'http://' 또는 'https://'로 시작해야 합니다.")
         return v
+
+    @model_validator(mode="after")
+    def normalize_enabled_market_modes(self):
+        modes = self.enabled_market_modes
+        if modes is None:
+            modes = [self.market_mode]
+        normalized = []
+        for mode in modes:
+            if mode not in normalized:
+                normalized.append(mode)
+        if self.market_mode not in normalized:
+            normalized.append(self.market_mode)
+        self.enabled_market_modes = normalized
+        return self
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -199,6 +199,7 @@ def test_real_app_status_api_uses_initialized_context(client_with_fake_lifespan,
         "env_type": "모의투자",
         "is_paper_trading": True,
         "market_mode": "domestic",
+        "enabled_market_modes": ["domestic"],
         "current_time": "2026-03-08 10:30:00",
         "initialized": True,
     }

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -133,6 +133,7 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.order_execution.order_max_retries == 3
     assert config.order_execution.order_retry_delay_sec == 3
     assert config.market_mode == "domestic"
+    assert config.enabled_market_modes == ["domestic"]
     assert config.overseas_stock.enabled_exchanges == ["NASD", "NYSE", "AMEX"]
     assert config.overseas_stock.default_exchange == "NASD"
     assert config.overseas_stock.currency == "USD"
@@ -154,6 +155,7 @@ def test_app_config_accepts_overseas_us_market_mode():
     )
 
     assert config.market_mode == "overseas_us"
+    assert config.enabled_market_modes == ["overseas_us"]
     assert config.overseas_stock.enabled_exchanges == ["NASD", "NYSE"]
     assert config.overseas_stock.default_exchange == "NYSE"
     assert config.overseas_stock.allow_live_trading is True
@@ -164,6 +166,25 @@ def test_app_config_rejects_invalid_market_mode():
         AppConfig(
             web={"host": "localhost", "port": 8080},
             market_mode="global",
+        )
+
+
+def test_app_config_accepts_domestic_and_overseas_enabled_market_modes():
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="domestic",
+        enabled_market_modes=["domestic", "overseas_us"],
+    )
+
+    assert config.market_mode == "domestic"
+    assert config.enabled_market_modes == ["domestic", "overseas_us"]
+
+
+def test_app_config_rejects_invalid_enabled_market_mode():
+    with pytest.raises(ValidationError):
+        AppConfig(
+            web={"host": "localhost", "port": 8080},
+            enabled_market_modes=["domestic", "crypto"],
         )
 
 

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -141,6 +141,7 @@ def mock_web_ctx():
     ctx.get_current_time_str.return_value = "2025-01-01 12:00:00"
     ctx.initialized = True
     ctx.market_mode = "domestic"
+    ctx.enabled_market_modes = ["domestic"]
     
     # 하위 서비스 Mocking
     ctx.stock_query_service = AsyncMock()

--- a/tests/unit_test/view/web/routes/test_web_routes_balance.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_balance.py
@@ -118,6 +118,26 @@ async def test_get_overseas_balance_calls_service(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_overseas_balance_allowed_when_domestic_active_but_overseas_enabled(web_client, mock_web_ctx):
+    """국내 active run에서도 overseas_us가 enabled이면 해외 잔고 조회를 허용한다."""
+    mock_web_ctx.market_mode = "domestic"
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    mock_web_ctx.stock_query_service.get_overseas_balance.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data={"output1": []}
+    )
+
+    response = web_client.get("/api/overseas/balance?exchange=NASD")
+
+    assert response.status_code == 200
+    assert response.json()["account_info"]["market_mode"] == "domestic"
+    assert response.json()["account_info"]["enabled_market_modes"] == ["domestic", "overseas_us"]
+    mock_web_ctx.stock_query_service.get_overseas_balance.assert_awaited_once_with(
+        exchange=OverseasExchange.NASD,
+        currency="USD",
+    )
+
+
+@pytest.mark.asyncio
 async def test_post_balance_sell_all_success(web_client, mock_web_ctx):
     """POST /api/balance/sell_all 성공 테스트"""
     mock_results = {"message": "일괄 매도가 완료되었습니다.", "results": [{"stock_code": "005930", "success": True}]}

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -168,7 +168,7 @@ async def test_place_overseas_limit_order_calls_broker(web_client, mock_web_ctx)
 
 @pytest.mark.asyncio
 async def test_place_overseas_order_requires_overseas_mode(web_client, mock_web_ctx):
-    """국내 mode에서는 해외 주문 endpoint가 닫혀 있어야 한다."""
+    """overseas_us가 enabled되지 않은 run에서는 해외 주문 endpoint가 닫혀 있어야 한다."""
     payload = {
         "symbol": "AAPL",
         "exchange": "NASD",
@@ -181,6 +181,35 @@ async def test_place_overseas_order_requires_overseas_mode(web_client, mock_web_
 
     assert response.status_code == 400
     mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_allowed_when_domestic_active_but_overseas_enabled(web_client, mock_web_ctx):
+    """국내 active run에서도 overseas_us가 enabled이면 해외 수동 지정가 주문을 허용한다."""
+    mock_web_ctx.market_mode = "domestic"
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    mock_web_ctx.broker.place_overseas_limit_order.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"}
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    mock_web_ctx.broker.place_overseas_limit_order.assert_awaited_once_with(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        side="buy",
+        qty=1,
+        limit_price=190.0,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -19,6 +19,7 @@ def test_get_status(web_client, mock_web_ctx):
         "current_time": "2025-01-01 12:00:00",
         "initialized": True,
         "market_mode": "domestic",
+        "enabled_market_modes": ["domestic"],
     }
 
 
@@ -235,6 +236,7 @@ async def test_get_status_ctx_none(web_client, monkeypatch):
         "current_time": "",
         "initialized": False,
         "market_mode": "domestic",
+        "enabled_market_modes": ["domestic"],
     }
 
 
@@ -262,6 +264,7 @@ async def test_get_status_cached(web_client, mock_web_ctx):
     # 캐시를 반환하되 시간은 갱신되었는지 확인
     assert json_resp["current_time"] == "new_time"
     assert json_resp["market_mode"] == "domestic"
+    assert json_resp["enabled_market_modes"] == ["domestic"]
 
 
 @pytest.mark.asyncio
@@ -275,6 +278,7 @@ async def test_get_market_mode(web_client, mock_web_ctx):
     assert response.json() == {
         "success": True,
         "market_mode": "overseas_us",
+        "enabled_market_modes": ["domestic", "overseas_us"],
         "requires_reinitialize": False,
     }
 
@@ -287,8 +291,22 @@ async def test_change_market_mode_marks_reinitialize(web_client, mock_web_ctx):
     assert response.status_code == 200
     assert response.json()["success"] is True
     assert response.json()["market_mode"] == "overseas_us"
+    assert response.json()["enabled_market_modes"] == ["domestic", "overseas_us"]
     assert response.json()["requires_reinitialize"] is True
     assert mock_web_ctx.market_mode == "overseas_us"
+
+
+@pytest.mark.asyncio
+async def test_get_market_mode_reports_enabled_markets(web_client, mock_web_ctx):
+    """GET /api/market-mode는 active mode와 enabled market 목록을 함께 반환한다."""
+    mock_web_ctx.market_mode = "domestic"
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+
+    response = web_client.get("/api/market-mode")
+
+    assert response.status_code == 200
+    assert response.json()["market_mode"] == "domestic"
+    assert response.json()["enabled_market_modes"] == ["domestic", "overseas_us"]
 
 
 @pytest.mark.asyncio
@@ -303,6 +321,7 @@ async def test_change_market_mode_invalid(web_client, mock_web_ctx):
 @pytest.mark.asyncio
 async def test_get_overseas_stock_price_calls_service(web_client, mock_web_ctx):
     """GET /api/overseas/stock/{symbol}은 해외 조회 서비스를 호출한다."""
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
     mock_web_ctx.stock_query_service.get_overseas_price.return_value = ResCommonResponse(
         rt_cd="0", msg1="Success", data={"symbol": "AAPL", "price": 190.0}
     )
@@ -319,6 +338,7 @@ async def test_get_overseas_stock_price_calls_service(web_client, mock_web_ctx):
 @pytest.mark.asyncio
 async def test_get_overseas_stock_chart_calls_service(web_client, mock_web_ctx):
     """GET /api/overseas/chart/{symbol}은 해외 일봉 조회 서비스를 호출한다."""
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
     mock_web_ctx.stock_query_service.get_overseas_dailyprice.return_value = ResCommonResponse(
         rt_cd="0", msg1="Success", data=[{"date": "20250101", "close": 190.0}]
     )

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-06-12 (StrategyScheduler 코드 리뷰 S-1~S-10 추가)
+최종 업데이트: 2026-06-13 (해외주식 Mode V1 완료 및 V2 병행 운영 범위 추가)
 
 이 문서는 현재 남은 실행 항목만 추린 목록이다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거한다. 100% 종료된 섹션(`[x]` only, follow-up 없음)은 git history 로 추적하고 본 문서에서 삭제한다.
 
@@ -34,6 +34,44 @@
 - 완료 기준의 전략 성과 `[~]`: `MomentumStrategy` 등 비활성 백테스트 경로의 표준 journal 통합 여부 결정.
 - 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. 자금 확대 전 R-1~R-3 우선 해소 권장. (R-5 거래세율은 검토 결과 0.20% 정확 → 해소, 변경 없음. 하단 "시스템 트레이더 관점 리뷰" 섹션)
 - StrategyScheduler 코드 리뷰(S-1~S-10, 2026-06-12): `stop()` 강제청산 데드 패스, 매도 병렬 에러 처리 비대칭, 이력 트림 vs 복구 충돌 등 버그 + 수명/구조 개선. S-1/S-2/S-4~S-8 수정 완료, S-3/S-10은 의도된 설계 확인 후 주석 명시로 종결. S-9는 부분 진행(prune 통합/trace_id 영속화/import 정리) — getter 부수효과는 의도된 계약으로 판명되어 철회, god class 분리는 P2 2-4 parity 판정 후 재평가로 보류. (하단 "StrategyScheduler 코드 리뷰" 섹션)
+- 해외주식 Mode: V1은 main merge 완료(2026-06-13) — 미국 3시장 조회 + 수동 USD 지정가 주문 + 실전 fail-close + 해외 mode 자동전략 차단. V2는 **국내 run을 유지하면서 해외 수동 조회/주문 surface를 병행 활성화**하는 `enabled_market_modes` 축 추가로 진행한다. 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 계속 제외.
+
+---
+
+## 해외주식 Mode V2. 국내/해외 수동 surface 병행 운영
+
+### 목표
+
+- [x] `market_mode`는 active/default 화면·부트스트랩 mode로 유지한다.
+- [x] `enabled_market_modes: ["domestic"] | ["domestic", "overseas_us"]`를 추가해 한 프로세스에서 국내 전략/배치를 유지하면서 해외 수동 조회/주문 API를 사용할 수 있게 한다.
+- [x] `domestic` active mode + `overseas_us` enabled 상태에서는 국내 `StrategyFactory`/batch/realtime은 기존처럼 동작하고, 해외 endpoint는 mode 전환 없이 허용한다.
+- [x] `overseas_us` active mode는 V1처럼 국내 전략/배치/실시간을 fail-close한다.
+- [x] 해외 주문은 계속 수동 USD 지정가만 허용한다. 실전 해외주문은 `allow_live_trading=True` + 기존 real 확인 gate를 모두 통과해야 한다.
+
+### 제외
+
+- [ ] 해외 자동전략 BUY/SELL 지원.
+- [ ] 국내/해외 주문 FSM과 reconciliation의 단일 장부 통합.
+- [ ] 해외 WebSocket 실시간 시세/체결통보.
+- [ ] 다국가/다통화, 프리/애프터마켓 자동 운영.
+
+### 테스트 계획
+
+- [x] config loader: 기본값 `enabled_market_modes=["domestic"]`, 국내+해외 허용, 잘못된 mode 거부.
+- [x] Web status/market-mode API: active `market_mode`와 enabled modes를 함께 반환.
+- [x] 해외 balance/order route: active mode가 `domestic`이어도 `overseas_us`가 enabled면 허용.
+- [x] 해외 route fail-close: `overseas_us`가 enabled가 아니면 차단.
+- [x] bootstrap: `market_mode=domestic`, `enabled_market_modes`에 해외 포함 시 국내 전략/배치 생성 경로를 유지한다.
+
+주요 파일:
+
+- `config/config_loader.py`
+- `config/config.yaml.example`
+- `view/web/routes/stock.py`
+- `view/web/routes/balance.py`
+- `view/web/routes/order.py`
+- `view/web/bootstrap/service_container.py`
+- `view/web/bootstrap/strategy_factory.py`
 
 ---
 

--- a/view/web/bootstrap/config_bootstrap.py
+++ b/view/web/bootstrap/config_bootstrap.py
@@ -36,6 +36,7 @@ class ConfigBootstrap:
         config_data = load_configs()
         ctx.full_config = config_data
         ctx.market_mode = getattr(config_data, "market_mode", "domestic")
+        ctx.enabled_market_modes = list(getattr(config_data, "enabled_market_modes", [ctx.market_mode]))
 
         config_dict = config_data
         if hasattr(config_data, "model_dump"):
@@ -72,7 +73,10 @@ class ConfigBootstrap:
         self._register_telegram(ctx, config_dict)
 
         ctx._load_position_sizing_state()
-        ctx.logger.info(f"웹 앱: 환경 설정 로드 완료. market_mode={ctx.market_mode}")
+        ctx.logger.info(
+            f"웹 앱: 환경 설정 로드 완료. market_mode={ctx.market_mode}, "
+            f"enabled_market_modes={ctx.enabled_market_modes}"
+        )
 
         ctx._mcs = MarketCalendarService(
             ctx.market_clock, ctx.logger, performance_profiler=ctx.pm

--- a/view/web/market_mode_utils.py
+++ b/view/web/market_mode_utils.py
@@ -1,0 +1,28 @@
+VALID_MARKET_MODES = ("domestic", "overseas_us")
+
+
+def market_mode_of(ctx) -> str:
+    mode = getattr(ctx, "market_mode", "domestic")
+    return mode if mode in VALID_MARKET_MODES else "domestic"
+
+
+def enabled_market_modes_of(ctx) -> list[str]:
+    active_mode = market_mode_of(ctx)
+    raw_modes = getattr(ctx, "enabled_market_modes", None)
+    if not isinstance(raw_modes, (list, tuple, set)):
+        raw_modes = []
+
+    modes: list[str] = []
+    for mode in raw_modes:
+        if mode in VALID_MARKET_MODES and mode not in modes:
+            modes.append(mode)
+
+    if active_mode not in modes:
+        modes.append(active_mode)
+    if not modes:
+        modes.append("domestic")
+    return modes
+
+
+def is_market_enabled(ctx, market_mode: str) -> bool:
+    return market_mode in enabled_market_modes_of(ctx)

--- a/view/web/routes/balance.py
+++ b/view/web/routes/balance.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Query, HTTPException
 from common.overseas_types import OverseasExchange
 from common.types import Exchange
 from view.web.api_common import _get_ctx, _serialize_response
+from view.web.market_mode_utils import enabled_market_modes_of, is_market_enabled, market_mode_of
 
 router = APIRouter()
 
@@ -75,6 +76,8 @@ async def get_balance(exchange: str = Query("KRX")):
 async def get_overseas_balance(exchange: str = Query("NASD"), currency: str = Query("USD")):
     """해외주식 잔고 조회. v1은 미국 3시장 + USD만 지원한다."""
     ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 잔고 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
     try:
         exchange_enum = OverseasExchange(exchange.upper())
     except ValueError:
@@ -88,7 +91,8 @@ async def get_overseas_balance(exchange: str = Query("NASD"), currency: str = Qu
         "type": ctx.get_env_type(),
         "exchange": exchange_enum.value,
         "currency": "USD",
-        "market_mode": getattr(ctx, "market_mode", "domestic"),
+        "market_mode": market_mode_of(ctx),
+        "enabled_market_modes": enabled_market_modes_of(ctx),
     }
     return result
 

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -6,6 +6,7 @@ from fastapi import Query
 from common.overseas_types import OverseasOrderRequest
 from common.types import ErrorCode, ResCommonResponse
 from view.web.api_common import _get_ctx, _serialize_response, OrderRequest
+from view.web.market_mode_utils import is_market_enabled
 
 router = APIRouter()
 
@@ -52,8 +53,8 @@ async def place_order(req: OrderRequest):
 async def place_overseas_order(req: OverseasOrderRequest):
     """해외주식 수동 지정가 주문. v1은 미국 3시장 + USD 지정가만 지원한다."""
     ctx = _get_ctx()
-    if getattr(ctx, "market_mode", "domestic") != "overseas_us":
-        raise HTTPException(status_code=400, detail="해외주식 주문은 overseas_us mode에서만 사용할 수 있습니다.")
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 주문은 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
 
     cfg = getattr(getattr(ctx, "full_config", None), "overseas_stock", None)
     enabled_exchanges = set(getattr(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
@@ -93,8 +94,8 @@ async def get_overseas_orders(
     ccld_nccs_dvsn: str = Query("00"),
 ):
     ctx = _get_ctx()
-    if getattr(ctx, "market_mode", "domestic") != "overseas_us":
-        raise HTTPException(status_code=400, detail="해외주식 주문 조회는 overseas_us mode에서만 사용할 수 있습니다.")
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 주문 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
     if not start_date or not end_date:
         today = ctx.market_clock.get_current_kst_time().strftime("%Y%m%d")
         start_date = start_date or today

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -12,6 +12,7 @@ from repositories.streaming_stock_repo import StreamingType
 from services.price_subscription_service import SubscriptionPriority
 from view.web.api_common import _get_ctx, _serialize_response, EnvironmentRequest
 import view.web.api_common as api_common
+from view.web.market_mode_utils import enabled_market_modes_of, is_market_enabled, market_mode_of
 
 router = APIRouter()
 
@@ -23,11 +24,6 @@ _STATUS_CACHE_TTL = 5.0
 
 class MarketModeRequest(BaseModel):
     market_mode: str
-
-
-def _market_mode_of(ctx) -> str:
-    mode = getattr(ctx, "market_mode", "domestic")
-    return mode if mode in ("domestic", "overseas_us") else "domestic"
 
 
 @router.get("/status")
@@ -42,6 +38,7 @@ async def get_status():
             "env_type": "미설정",
             "is_paper_trading": True,
             "market_mode": "domestic",
+            "enabled_market_modes": ["domestic"],
             "current_time": "",
             "initialized": False,
         }
@@ -50,14 +47,16 @@ async def get_status():
     if _status_cache is not None and (now - _status_cache_ts) < _STATUS_CACHE_TTL:
         # 캐시된 결과 반환 (현재 시각만 갱신)
         _status_cache["current_time"] = ctx.get_current_time_str()
-        _status_cache["market_mode"] = _market_mode_of(ctx)
+        _status_cache["market_mode"] = market_mode_of(ctx)
+        _status_cache["enabled_market_modes"] = enabled_market_modes_of(ctx)
         return _status_cache
 
     result = {
         "market_open": await ctx.is_market_open_now(),
         "env_type": ctx.get_env_type(),
         "is_paper_trading": bool(getattr(getattr(ctx, "env", None), "is_paper_trading", True)),
-        "market_mode": _market_mode_of(ctx),
+        "market_mode": market_mode_of(ctx),
+        "enabled_market_modes": enabled_market_modes_of(ctx),
         "current_time": ctx.get_current_time_str(),
         "initialized": ctx.initialized
     }
@@ -69,10 +68,11 @@ async def get_status():
 @router.get("/market-mode")
 def get_market_mode():
     ctx = _get_ctx()
-    mode = _market_mode_of(ctx)
+    mode = market_mode_of(ctx)
     return {
         "success": True,
         "market_mode": mode,
+        "enabled_market_modes": enabled_market_modes_of(ctx),
         "requires_reinitialize": False,
     }
 
@@ -85,17 +85,24 @@ def change_market_mode(req: MarketModeRequest):
     if mode not in ("domestic", "overseas_us"):
         raise HTTPException(status_code=400, detail="market_mode는 domestic 또는 overseas_us만 지원합니다.")
 
-    current = _market_mode_of(ctx)
+    current = market_mode_of(ctx)
     ctx.market_mode = mode
+    enabled_modes = enabled_market_modes_of(ctx)
+    if mode not in enabled_modes:
+        enabled_modes.append(mode)
+    ctx.enabled_market_modes = enabled_modes
     full_config = getattr(ctx, "full_config", None)
     if full_config is not None and hasattr(full_config, "market_mode"):
         full_config.market_mode = mode
+    if full_config is not None and hasattr(full_config, "enabled_market_modes"):
+        full_config.enabled_market_modes = enabled_modes
 
     _status_cache = None
     _status_cache_ts = 0.0
     return {
         "success": True,
         "market_mode": mode,
+        "enabled_market_modes": enabled_modes,
         "previous_market_mode": current,
         "requires_reinitialize": current != mode,
     }
@@ -215,6 +222,8 @@ async def get_stock_price(code: str, exchange: str = Query("KRX")):
 @router.get("/overseas/stock/{symbol}")
 async def get_overseas_stock_price(symbol: str, exchange: str = Query("NASD")):
     ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
     try:
         exchange_enum = OverseasExchange(exchange.upper())
     except ValueError:
@@ -232,6 +241,8 @@ async def get_overseas_stock_chart(
     end_date: str = Query(""),
 ):
     ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 차트 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
     try:
         exchange_enum = OverseasExchange(exchange.upper())
     except ValueError:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -96,6 +96,7 @@ class WebAppContext:
         self.logger = Logger()
         self.runtime_mode: RuntimeMode = runtime_mode if runtime_mode is not None else RuntimeMode.ALL
         self.market_mode: str = "domestic"
+        self.enabled_market_modes: list[str] = ["domestic"]
         self.env = app_context.env if app_context else None
         self.full_config = {}  # [추가] 전체 설정을 담을 그릇
         self.market_clock: MarketClock = None


### PR DESCRIPTION
## Summary
- update todo_list with overseas mode V1 completion and V2 scope
- add enabled_market_modes config so domestic active runs can expose overseas manual surfaces
- report active/enabled market modes in status and market-mode APIs
- gate overseas quote/chart/balance/order routes on overseas_us being enabled, not necessarily active

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v