### PR TITLE
[codex] Add overseas manual web surface

### DIFF
--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -18,6 +18,7 @@ PAGE_PATHS = [
     "/favorite",
     "/balance",
     "/order",
+    "/overseas",
     "/ranking",
     "/marketcap",
     "/virtual",

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -8,6 +8,7 @@ PAGES = [
     ("/stock", "stock"),
     ("/balance", "balance"),
     ("/order", "order"),
+    ("/overseas", "overseas"),
     ("/ranking", "ranking"),
     ("/marketcap", "marketcap"),
     ("/virtual", "virtual"),
@@ -40,6 +41,10 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert "계좌 잔고" in response.text
         elif path == "/order":
             assert "주식 주문" in response.text
+        elif path == "/overseas":
+            assert "해외주식" in response.text
+            assert 'id="overseas-symbol"' in response.text
+            assert "/static/js/overseas.js" in response.text
         elif path == "/ranking":
             assert "상위 종목 랭킹" in response.text
         elif path == "/marketcap":
@@ -76,6 +81,17 @@ def test_virtual_static_js_exposes_divergence_workflow():
     assert "compareVirtualDivergence" in script
     assert "filled_qty" in script
     assert "slippage_pct" in script
+
+
+def test_overseas_static_js_exposes_manual_workflow():
+    """overseas.js가 해외 조회/잔고/수동 주문 API를 호출할 수 있어야 한다."""
+    script = Path("view/web/static/js/overseas.js").read_text(encoding="utf-8")
+
+    assert "/api/overseas/stock/" in script
+    assert "/api/overseas/balance" in script
+    assert "/api/overseas/order" in script
+    assert "loadOverseasQuote" in script
+    assert "placeOverseasOrder" in script
 
 def test_pages_show_login_page_when_unauthorized(web_client, mock_web_ctx):
     """로그인 기능 활성화 시 토큰 없이 접근하면 로그인 페이지가 렌더링되는지 테스트"""

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-06-13 (해외주식 Mode V1 완료 및 V2 병행 운영 범위 추가)
+최종 업데이트: 2026-06-13 (해외주식 Mode V1 완료, V2 병행 운영 + Web 수동 surface 추가)
 
 이 문서는 현재 남은 실행 항목만 추린 목록이다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거한다. 100% 종료된 섹션(`[x]` only, follow-up 없음)은 git history 로 추적하고 본 문서에서 삭제한다.
 
@@ -34,7 +34,7 @@
 - 완료 기준의 전략 성과 `[~]`: `MomentumStrategy` 등 비활성 백테스트 경로의 표준 journal 통합 여부 결정.
 - 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. 자금 확대 전 R-1~R-3 우선 해소 권장. (R-5 거래세율은 검토 결과 0.20% 정확 → 해소, 변경 없음. 하단 "시스템 트레이더 관점 리뷰" 섹션)
 - StrategyScheduler 코드 리뷰(S-1~S-10, 2026-06-12): `stop()` 강제청산 데드 패스, 매도 병렬 에러 처리 비대칭, 이력 트림 vs 복구 충돌 등 버그 + 수명/구조 개선. S-1/S-2/S-4~S-8 수정 완료, S-3/S-10은 의도된 설계 확인 후 주석 명시로 종결. S-9는 부분 진행(prune 통합/trace_id 영속화/import 정리) — getter 부수효과는 의도된 계약으로 판명되어 철회, god class 분리는 P2 2-4 parity 판정 후 재평가로 보류. (하단 "StrategyScheduler 코드 리뷰" 섹션)
-- 해외주식 Mode: V1은 main merge 완료(2026-06-13) — 미국 3시장 조회 + 수동 USD 지정가 주문 + 실전 fail-close + 해외 mode 자동전략 차단. V2는 **국내 run을 유지하면서 해외 수동 조회/주문 surface를 병행 활성화**하는 `enabled_market_modes` 축 추가로 진행한다. 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 계속 제외.
+- 해외주식 Mode: V1은 main merge 완료(2026-06-13) — 미국 3시장 조회 + 수동 USD 지정가 주문 + 실전 fail-close + 해외 mode 자동전략 차단. V2는 **국내 run을 유지하면서 해외 수동 조회/주문 surface를 병행 활성화**하는 `enabled_market_modes` 축과 Web 수동 화면 연결까지 진행한다. 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 계속 제외.
 
 ---
 
@@ -63,6 +63,14 @@
 - [x] 해외 route fail-close: `overseas_us`가 enabled가 아니면 차단.
 - [x] bootstrap: `market_mode=domestic`, `enabled_market_modes`에 해외 포함 시 국내 전략/배치 생성 경로를 유지한다.
 
+### Web 수동 surface
+
+- [x] `/overseas` 화면을 추가해 미국 3시장 심볼 현재가/일봉/잔고 조회를 노출한다.
+- [x] 해외 주문 화면은 USD 지정가 수동 매수/매도만 노출한다.
+- [x] 실전 모드에서는 기존 실전 배지 감지 + confirm + `REAL` 재확인을 요구한다.
+- [x] `enabled_market_modes`에 `overseas_us`가 없으면 화면 JS가 조회/주문 호출 전에 fail-close 메시지를 표시한다.
+- [x] 페이지 렌더링/정적 자산/JS API 호출 문자열을 테스트로 고정한다.
+
 주요 파일:
 
 - `config/config_loader.py`
@@ -70,6 +78,8 @@
 - `view/web/routes/stock.py`
 - `view/web/routes/balance.py`
 - `view/web/routes/order.py`
+- `view/web/templates/overseas.html`
+- `view/web/static/js/overseas.js`
 - `view/web/bootstrap/service_container.py`
 - `view/web/bootstrap/strategy_factory.py`
 

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -1,0 +1,259 @@
+/* view/web/static/js/overseas.js — 해외주식 수동 조회/주문 */
+
+function _overseasIsRealMode() {
+    const badge = document.getElementById('status-env');
+    return !!(badge && (
+        badge.dataset.mode === 'real' || badge.classList.contains('real')
+    ));
+}
+
+function _overseasSymbolValue(inputId) {
+    const input = document.getElementById(inputId);
+    return input ? input.value.trim().toUpperCase() : '';
+}
+
+function _overseasExchangeValue(selectId) {
+    const select = document.getElementById(selectId);
+    return select ? select.value : 'NASD';
+}
+
+function _formatUsd(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return value === undefined || value === null ? '-' : String(value);
+    return '$' + n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function _formatNumber(value) {
+    const n = Number(String(value ?? '').replace(/,/g, ''));
+    if (!Number.isFinite(n)) return value === undefined || value === null || value === '' ? '-' : String(value);
+    return n.toLocaleString();
+}
+
+function _setOverseasOrderSymbol(symbol, exchange) {
+    const symbolInput = document.getElementById('overseas-order-symbol');
+    const exchangeSelect = document.getElementById('overseas-order-exchange');
+    if (symbolInput && symbol) symbolInput.value = symbol;
+    if (exchangeSelect && exchange) exchangeSelect.value = exchange;
+}
+
+function _refreshOverseasRealBanner() {
+    const isReal = _overseasIsRealMode();
+    const banner = document.getElementById('overseas-real-banner');
+    const label = document.getElementById('overseas-order-mode-label');
+    if (banner) banner.style.display = isReal ? 'block' : 'none';
+    if (label) {
+        label.innerText = isReal ? '[실전]' : '';
+        label.style.color = isReal ? '#ff4d4d' : '#aaa';
+    }
+}
+
+async function _ensureOverseasEnabled() {
+    const res = await fetchWithTimeout('/api/market-mode', {}, 5000);
+    if (!res.ok) return false;
+    const json = await res.json();
+    return Array.isArray(json.enabled_market_modes) && json.enabled_market_modes.includes('overseas_us');
+}
+
+async function loadOverseasQuote() {
+    const symbol = _overseasSymbolValue('overseas-symbol');
+    const exchange = _overseasExchangeValue('overseas-exchange');
+    const resultDiv = document.getElementById('overseas-quote-result');
+    if (!symbol) {
+        alert('심볼을 입력하세요.');
+        return;
+    }
+    _setOverseasOrderSymbol(symbol, exchange);
+    showLoading(resultDiv, '조회 중...');
+
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout(`/api/overseas/stock/${encodeURIComponent(symbol)}?exchange=${exchange}`, {}, 12000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">조회 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const data = json.data || {};
+        const rate = Number(data.change_rate || 0);
+        const rateClass = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
+        resultDiv.innerHTML = `
+            <div class="card">
+                <h3>${data.symbol || symbol} <span style="color:#aaa;font-size:0.85rem;">${data.exchange || exchange} ${data.currency || 'USD'}</span></h3>
+                <p class="price ${rateClass}">${_formatUsd(data.price)}</p>
+                <p>등락률: <span class="${rateClass}">${Number.isFinite(rate) ? rate.toFixed(2) + '%' : '-'}</span></p>
+                <p>거래량: ${_formatNumber(data.volume)}</p>
+                <p>시각: ${data.timestamp || '-'}</p>
+            </div>
+        `;
+    } catch (e) {
+        resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+    }
+}
+
+async function loadOverseasChart() {
+    const symbol = _overseasSymbolValue('overseas-symbol');
+    const exchange = _overseasExchangeValue('overseas-exchange');
+    const resultDiv = document.getElementById('overseas-chart-result');
+    if (!symbol) {
+        alert('심볼을 입력하세요.');
+        return;
+    }
+    showLoading(resultDiv, '일봉 조회 중...');
+
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout(`/api/overseas/chart/${encodeURIComponent(symbol)}?exchange=${exchange}&period=D`, {}, 12000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">일봉 조회 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const rows = Array.isArray(json.data) ? json.data.slice(-10).reverse() : [];
+        const body = rows.map((row) => `
+            <tr>
+                <td>${row.date || row.xymd || row.stck_bsop_date || '-'}</td>
+                <td>${_formatUsd(row.close || row.clpr || row.ovrs_nmix_prpr)}</td>
+                <td>${_formatNumber(row.volume || row.acml_vol)}</td>
+            </tr>
+        `).join('');
+        resultDiv.innerHTML = `
+            <div class="card">
+                <h3>${symbol} 일봉</h3>
+                <table>
+                    <thead><tr><th>일자</th><th>종가</th><th>거래량</th></tr></thead>
+                    <tbody>${body || '<tr><td colspan="3">데이터 없음</td></tr>'}</tbody>
+                </table>
+            </div>
+        `;
+    } catch (e) {
+        resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+    }
+}
+
+async function loadOverseasBalance() {
+    const exchange = _overseasExchangeValue('overseas-exchange');
+    const resultDiv = document.getElementById('overseas-balance-result');
+    showLoading(resultDiv, '잔고 조회 중...');
+
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout(`/api/overseas/balance?exchange=${exchange}&currency=USD`, {}, 12000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">잔고 조회 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const data = json.data || {};
+        const rows = Array.isArray(data.output1) ? data.output1 : (Array.isArray(data) ? data : []);
+        const body = rows.map((row) => `
+            <tr>
+                <td>${row.ovrs_pdno || row.pdno || row.symbol || '-'}</td>
+                <td>${row.ovrs_item_name || row.prdt_name || row.name || '-'}</td>
+                <td>${_formatNumber(row.ovrs_cblc_qty || row.hldg_qty || row.qty)}</td>
+                <td>${_formatUsd(row.now_pric2 || row.price || row.ovrs_now_pric1)}</td>
+            </tr>
+        `).join('');
+        resultDiv.innerHTML = `
+            <div class="card">
+                <h3>해외 잔고 <span style="color:#aaa;font-size:0.85rem;">${exchange} USD</span></h3>
+                <table>
+                    <thead><tr><th>심볼</th><th>이름</th><th>수량</th><th>현재가</th></tr></thead>
+                    <tbody>${body || '<tr><td colspan="4">보유 없음</td></tr>'}</tbody>
+                </table>
+            </div>
+        `;
+    } catch (e) {
+        resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+    }
+}
+
+async function placeOverseasOrder(side) {
+    const symbol = _overseasSymbolValue('overseas-order-symbol');
+    const exchange = _overseasExchangeValue('overseas-order-exchange');
+    const qty = Number(document.getElementById('overseas-order-qty')?.value || 0);
+    const limitPrice = Number(document.getElementById('overseas-order-price')?.value || 0);
+    const resultDiv = document.getElementById('overseas-order-result');
+
+    if (!symbol || qty <= 0 || limitPrice <= 0) {
+        alert('심볼, 수량, 지정가를 확인하세요.');
+        return;
+    }
+
+    const sideKr = side === 'buy' ? '매수' : '매도';
+    let realOrderConfirmation = null;
+    if (_overseasIsRealMode()) {
+        const step1 = confirm(
+            `[실전투자] 해외 ${sideKr} 주문\n\n` +
+            `심볼: ${symbol}\n거래소: ${exchange}\n수량: ${qty}\n지정가: ${limitPrice}\n\n` +
+            `계속하시겠습니까?`
+        );
+        if (!step1) return;
+        realOrderConfirmation = prompt('최종 확인을 위해 "REAL"을 입력하세요:');
+        if (realOrderConfirmation !== 'REAL') {
+            alert('확인 문자열이 일치하지 않아 주문이 취소되었습니다.');
+            return;
+        }
+    } else if (!confirm(`해외 ${sideKr} 주문\n심볼: ${symbol}\n수량: ${qty}\n지정가: ${limitPrice}`)) {
+        return;
+    }
+
+    showLoading(resultDiv, '주문 전송 중...');
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout('/api/overseas/order', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                symbol,
+                exchange,
+                side,
+                qty,
+                limit_price: limitPrice,
+                currency: 'USD',
+                real_order_confirmation: realOrderConfirmation
+            })
+        }, 15000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">주문 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const orderNo = json.data && (json.data.broker_order_no || json.data.ord_no || json.data.ODNO);
+        resultDiv.innerHTML = `<p class="success">주문 접수: ${orderNo || '-'}</p>`;
+    } catch (e) {
+        resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+    }
+}
+
+function initOverseasPage() {
+    _refreshOverseasRealBanner();
+    if (!window.__overseasRealBannerTimer) {
+        window.__overseasRealBannerTimer = setInterval(_refreshOverseasRealBanner, 3000);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.location.pathname !== '/overseas') return;
+    initOverseasPage();
+});
+
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/overseas') return;
+    initOverseasPage();
+});

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -79,6 +79,7 @@
     <a href="/favorite" class="{% if active_page == 'favorite' %}active{% endif %}">즐겨찾기</a>
     <a href="/balance" class="{% if active_page == 'balance' %}active{% endif %}">계좌 잔고</a>
     <a href="/order" class="{% if active_page == 'order' %}active{% endif %}">매수/매도</a>
+    <a href="/overseas" class="{% if active_page == 'overseas' %}active{% endif %}">해외주식</a>
     <a href="/ranking" class="{% if active_page == 'ranking' %}active{% endif %}">랭킹</a>
     <a href="/marketcap" class="{% if active_page == 'marketcap' %}active{% endif %}">시가총액</a>
     <a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div id="section-overseas" class="section">
+    <div id="overseas-real-banner" style="display:none; padding:10px 14px; margin-bottom:12px; background:#7a1f1f; color:#fff; border:2px solid #ff4d4d; border-radius:6px; font-weight:bold;">
+        실전투자 모드
+    </div>
+
+    <div class="card">
+        <h2>해외주식</h2>
+        <div class="form-row">
+            <label>심볼</label>
+            <input type="text" id="overseas-symbol" placeholder="AAPL" maxlength="12" autocomplete="off">
+        </div>
+        <div class="form-row">
+            <label>거래소</label>
+            <select id="overseas-exchange">
+                <option value="NASD">NASDAQ</option>
+                <option value="NYSE">NYSE</option>
+                <option value="AMEX">AMEX</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <button class="btn" onclick="loadOverseasQuote()">현재가</button>
+            <button class="btn" onclick="loadOverseasChart()">일봉</button>
+            <button class="btn" onclick="loadOverseasBalance()">잔고</button>
+        </div>
+    </div>
+
+    <div id="overseas-quote-result"></div>
+    <div id="overseas-chart-result"></div>
+    <div id="overseas-balance-result"></div>
+
+    <div class="card">
+        <h2>해외 지정가 주문 <span id="overseas-order-mode-label" style="font-size:0.7em; color:#aaa;"></span></h2>
+        <div class="form-row">
+            <label>심볼</label>
+            <input type="text" id="overseas-order-symbol" placeholder="AAPL" maxlength="12" autocomplete="off">
+        </div>
+        <div class="form-row">
+            <label>거래소</label>
+            <select id="overseas-order-exchange">
+                <option value="NASD">NASDAQ</option>
+                <option value="NYSE">NYSE</option>
+                <option value="AMEX">AMEX</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <label>수량</label>
+            <input type="number" id="overseas-order-qty" min="1" step="1" placeholder="1">
+        </div>
+        <div class="form-row">
+            <label>지정가</label>
+            <input type="number" id="overseas-order-price" min="0.01" step="0.01" placeholder="190.00">
+        </div>
+        <div class="form-row">
+            <button class="btn btn-buy" onclick="placeOverseasOrder('buy')">매수</button>
+            <button class="btn btn-sell" onclick="placeOverseasOrder('sell')">매도</button>
+        </div>
+    </div>
+
+    <div id="overseas-order-result"></div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/overseas.js?v=1"></script>
+{% endblock %}

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -208,6 +208,7 @@ _FOREGROUND_PATHS = frozenset({
     "/api/balance",
     # order.py
     "/api/order",
+    "/api/overseas/",
     # ranking.py
     "/api/ranking/",
     "/api/top-market-cap",
@@ -321,6 +322,10 @@ async def balance(request: Request):
 @page_router.get("/order")
 async def order(request: Request):
     return await render_page(request, "order.html", "order")
+
+@page_router.get("/overseas")
+async def overseas(request: Request):
+    return await render_page(request, "overseas.html", "overseas")
 
 @page_router.get("/ranking")
 async def ranking(request: Request):


### PR DESCRIPTION
## Summary
- Added a dedicated `/overseas` Web page for overseas US manual workflows.
- Wired navigation, foreground API path handling, and page-specific JS for quote, daily chart, balance, and USD limit order calls.
- Updated `todo_list.md` to mark the V2 Web manual surface work and remaining exclusions.

## Safety
- The UI checks `/api/market-mode` before overseas quote/balance/order calls and fail-closes when `overseas_us` is not enabled.
- Real mode overseas orders keep a confirm step plus `REAL` prompt before submitting.

## Validation
- Browser check: opened `http://127.0.0.1:8010/overseas`, confirmed the page/nav/form render, and verified the quote action fail-closes with `overseas_us가 enabled되어 있지 않습니다.` when only domestic mode is enabled.
- `python -m pytest tests/unit_test -v` — passed (`5995 items`).
- `python -m pytest tests/integration_test -v` — passed (`240 passed, 1 warning`).

## Note
- The remaining integration warning is the pre-existing urllib3 `SystemTimeWarning` in `test_it_api_traditional_volume_breakout_strategy.py`.