### PR TITLE
feat(web): /stock 화면 국내/해외 모드 토글 + 해외 심볼 검색 통합 (V2.1)

### DIFF
--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -37,6 +37,12 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert "Investment" in response.text
         elif path == "/stock":
             assert "종목 현재가 조회" in response.text
+            # V2.1: 국내/해외 조회 모드 토글 + 해외 ticker 입력
+            assert 'id="stock-mode-domestic"' in response.text
+            assert 'id="stock-mode-overseas"' in response.text
+            assert 'id="overseas-stock-symbol"' in response.text
+            assert 'id="overseas-stock-exchange"' in response.text
+            assert 'value="NASD"' in response.text
         elif path == "/balance":
             assert "계좌 잔고" in response.text
         elif path == "/order":
@@ -81,6 +87,16 @@ def test_virtual_static_js_exposes_divergence_workflow():
     assert "compareVirtualDivergence" in script
     assert "filled_qty" in script
     assert "slippage_pct" in script
+
+
+def test_stock_static_js_exposes_overseas_mode():
+    """stock.js가 /stock 화면에서 해외 모드 조회를 fail-close와 함께 지원해야 한다."""
+    script = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
+
+    assert "setStockMarketMode" in script
+    assert "searchOverseasStock" in script
+    assert "/api/overseas/stock/" in script
+    assert "/api/market-mode" in script
 
 
 def test_overseas_static_js_exposes_manual_workflow():

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-06-13 (해외주식 Mode V1/V2 merge 완료, 현재가 조회 해외 검색 통합 계획 추가)
+최종 업데이트: 2026-06-14 (해외주식 Mode V2.1 — /stock 현재가 조회 화면 해외 검색 통합 완료)
 
 이 문서는 현재 남은 실행 항목만 추린 목록이다. 완료된 구현 상세, 완료 체크 항목, 과거 세션 요약은 제거한다. 100% 종료된 섹션(`[x]` only, follow-up 없음)은 git history 로 추적하고 본 문서에서 삭제한다.
 
@@ -34,7 +34,7 @@
 - 완료 기준의 전략 성과 `[~]`: `MomentumStrategy` 등 비활성 백테스트 경로의 표준 journal 통합 여부 결정.
 - 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. 자금 확대 전 R-1~R-3 우선 해소 권장. (R-5 거래세율은 검토 결과 0.20% 정확 → 해소, 변경 없음. 하단 "시스템 트레이더 관점 리뷰" 섹션)
 - StrategyScheduler 코드 리뷰(S-1~S-10, 2026-06-12): `stop()` 강제청산 데드 패스, 매도 병렬 에러 처리 비대칭, 이력 트림 vs 복구 충돌 등 버그 + 수명/구조 개선. S-1/S-2/S-4~S-8 수정 완료, S-3/S-10은 의도된 설계 확인 후 주석 명시로 종결. S-9는 부분 진행(prune 통합/trace_id 영속화/import 정리) — getter 부수효과는 의도된 계약으로 판명되어 철회, god class 분리는 P2 2-4 parity 판정 후 재평가로 보류. (하단 "StrategyScheduler 코드 리뷰" 섹션)
-- 해외주식 Mode: V1/V2는 main merge 완료(2026-06-13) — 미국 3시장 조회 + 수동 USD 지정가 주문 + 실전 fail-close + 해외 mode 자동전략 차단 + 국내 run 유지 상태의 해외 수동 Web surface. 다음은 기존 현재가 조회(`/stock`) 화면에 해외 심볼 직접 검색을 통합한다. 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 계속 제외.
+- 해외주식 Mode: V1/V2는 main merge 완료(2026-06-13) — 미국 3시장 조회 + 수동 USD 지정가 주문 + 실전 fail-close + 해외 mode 자동전략 차단 + 국내 run 유지 상태의 해외 수동 Web surface. V2.1(2026-06-14)로 기존 현재가 조회(`/stock`) 화면에 국내/해외 모드 토글 + 해외 심볼 직접 검색 통합 완료. 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 계속 제외.
 
 ---
 
@@ -71,29 +71,21 @@
 - [x] `enabled_market_modes`에 `overseas_us`가 없으면 화면 JS가 조회/주문 호출 전에 fail-close 메시지를 표시한다.
 - [x] 페이지 렌더링/정적 자산/JS API 호출 문자열을 테스트로 고정한다.
 
-### V2.1 현재가 조회 화면 해외 검색 통합
+### V2.1 현재가 조회 화면 해외 검색 통합 — ✅ 완료 (2026-06-14)
 
-- [ ] `/stock` 현재가 조회 화면에 `국내/해외` 조회 모드 선택 UI를 추가한다.
-- [ ] 국내 모드 기본 동작은 그대로 유지한다. 국내 종목명 자동완성, 국내 코드 조회, 차트/지표 표시 경로는 회귀 없이 보존한다.
-- [ ] 해외 모드에서는 ticker 직접 입력(`AAPL` 등) + 거래소 선택(`NASD`/`NYSE`/`AMEX`)만 허용한다. v1/v2 범위에서는 해외 심볼 자동완성/마스터 검색은 제외한다.
-- [ ] 해외 모드 조회는 `/api/overseas/stock/{symbol}?exchange=...`를 호출하고 `symbol`, `exchange`, `currency`, `price`, `change_rate`, `volume`, `timestamp` 최소 view model만 표시한다.
-- [ ] `enabled_market_modes`에 `overseas_us`가 없으면 `/stock` 화면에서도 해외 조회를 fail-close 메시지로 차단한다.
-- [ ] 해외 모드에서는 국내 전용 보조 액션(국내 차트/국내 지표/랭킹 연결 등)을 숨기거나 비활성화한다.
-- [ ] 테스트는 `/stock` 렌더링, JS 모드 전환 문자열, 해외 API 호출 경로, 해외 disabled fail-close를 우선 고정한다.
+- [x] `/stock` 현재가 조회 화면에 `국내/해외` 조회 모드 선택 UI를 추가한다. (`stock-mode-domestic`/`stock-mode-overseas` 세그먼트 토글 + `setStockMarketMode()`)
+- [x] 국내 모드 기본 동작은 그대로 유지한다. 국내 종목명 자동완성, 국내 코드 조회, 차트/지표 표시 경로는 회귀 없이 보존한다. (기본 모드=국내, 기존 `searchStock` 경로 무변경)
+- [x] 해외 모드에서는 ticker 직접 입력(`AAPL` 등) + 거래소 선택(`NASD`/`NYSE`/`AMEX`)만 허용한다. v1/v2 범위에서는 해외 심볼 자동완성/마스터 검색은 제외한다.
+- [x] 해외 모드 조회는 `/api/overseas/stock/{symbol}?exchange=...`를 호출하고 `symbol`, `exchange`, `currency`, `price`, `change_rate`, `volume`, `timestamp` 최소 view model만 표시한다. (백엔드 엔드포인트는 V2에서 이미 구현 → 프론트만 배선)
+- [x] `enabled_market_modes`에 `overseas_us`가 없으면 `/stock` 화면에서도 해외 조회를 fail-close 메시지로 차단한다. (`_ensureOverseasEnabledForStock()` → `/api/market-mode` 확인)
+- [x] 해외 모드에서는 국내 전용 보조 액션(국내 차트/국내 지표/랭킹 연결 등)을 숨기거나 비활성화한다. (모드 전환/해외 조회 시 차트 카드 detach+hide)
+- [x] 테스트는 `/stock` 렌더링, JS 모드 전환 문자열, 해외 API 호출 경로, 해외 disabled fail-close를 우선 고정한다. (`test_web_pages.py::test_pages_render_success_no_login` /stock 분기 + 신규 `test_stock_static_js_exposes_overseas_mode`)
 
-주요 파일:
+주요 파일(V2.1 실제 수정 범위 — 프론트엔드 한정, 백엔드는 V2에서 완료):
 
-- `config/config_loader.py`
-- `config/config.yaml.example`
-- `view/web/routes/stock.py`
-- `view/web/routes/balance.py`
-- `view/web/routes/order.py`
 - `view/web/templates/stock.html`
 - `view/web/static/js/stock.js`
-- `view/web/templates/overseas.html`
-- `view/web/static/js/overseas.js`
-- `view/web/bootstrap/service_container.py`
-- `view/web/bootstrap/strategy_factory.py`
+- `tests/unit_test/view/web/test_web_pages.py`
 
 ---
 

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -31,6 +31,101 @@ document.addEventListener('stock-price-tick', function (e) {
     if (lowEl  && tick.low  > 0) lowEl.textContent  = fmt(tick.low);
 });
 
+/* ── 국내/해외 조회 모드 토글 (V2.1) ── */
+function setStockMarketMode(mode) {
+    const domesticRow = document.getElementById('domestic-stock-row');
+    const overseasRow = document.getElementById('overseas-stock-row');
+    const domesticBtn = document.getElementById('stock-mode-domestic');
+    const overseasBtn = document.getElementById('stock-mode-overseas');
+    const isOverseas = mode === 'overseas';
+
+    if (domesticRow) domesticRow.style.display = isOverseas ? 'none' : '';
+    if (overseasRow) overseasRow.style.display = isOverseas ? '' : 'none';
+    if (domesticBtn) domesticBtn.classList.toggle('active', !isOverseas);
+    if (overseasBtn) overseasBtn.classList.toggle('active', isOverseas);
+
+    // 모드 전환 시 결과/차트 영역 초기화 (국내↔해외 잔여 UI 방지)
+    const resultDiv = document.getElementById('stock-result');
+    if (resultDiv) resultDiv.innerHTML = '';
+    const chartCard = document.getElementById('stock-chart-card');
+    const sectionStock = document.getElementById('section-stock');
+    if (chartCard && sectionStock && chartCard.parentElement !== sectionStock) {
+        sectionStock.appendChild(chartCard);
+    }
+    if (chartCard) chartCard.style.display = 'none';
+}
+
+/* overseas_us가 enabled된 run에서만 해외 조회 허용 (fail-close) */
+async function _ensureOverseasEnabledForStock() {
+    try {
+        const res = await fetchWithTimeout('/api/market-mode', {}, 5000);
+        if (!res.ok) return false;
+        const json = await res.json();
+        return Array.isArray(json.enabled_market_modes) && json.enabled_market_modes.includes('overseas_us');
+    } catch (_) {
+        return false;
+    }
+}
+
+async function searchOverseasStock() {
+    const symbolInput = document.getElementById('overseas-stock-symbol');
+    const exchangeSel = document.getElementById('overseas-stock-exchange');
+    const symbol = symbolInput ? symbolInput.value.trim().toUpperCase() : '';
+    const exchange = exchangeSel ? exchangeSel.value : 'NASD';
+    const resultDiv = document.getElementById('stock-result');
+    if (!symbol) {
+        alert('심볼을 입력하세요.');
+        return;
+    }
+    if (symbolInput) symbolInput.value = symbol;
+    if (!resultDiv) return;
+
+    // 해외 모드에서는 국내 전용 차트 카드를 숨긴다.
+    const chartCard = document.getElementById('stock-chart-card');
+    if (chartCard) chartCard.style.display = 'none';
+
+    showLoading(resultDiv, '해외 종목 조회 중...');
+    try {
+        const enabled = await _ensureOverseasEnabledForStock();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">해외주식 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout(`/api/overseas/stock/${encodeURIComponent(symbol)}?exchange=${exchange}`, {}, 12000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">조회 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const data = json.data || {};
+        const rate = Number(data.change_rate || 0);
+        const rateClass = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
+        const usd = (v) => {
+            const n = Number(v);
+            return Number.isFinite(n) ? '$' + n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
+        };
+        const num = (v) => {
+            const n = Number(String(v ?? '').replace(/,/g, ''));
+            return Number.isFinite(n) ? n.toLocaleString() : '-';
+        };
+        resultDiv.innerHTML = `
+            <div class="card stock-info-box">
+                <h3 style="margin:0;">${data.symbol || symbol} <span style="color:#aaa;font-size:0.85rem;">${data.exchange || exchange} ${data.currency || 'USD'}</span></h3>
+                <p class="price ${rateClass}">${usd(data.price)}</p>
+                <p class="change-rate">등락률: <span class="${rateClass}">${Number.isFinite(rate) ? (rate > 0 ? '+' : '') + rate.toFixed(2) + '%' : '-'}</span></p>
+                <p>거래량: ${num(data.volume)}</p>
+                <p>시각: ${data.timestamp || '-'}</p>
+            </div>
+        `;
+    } catch (e) {
+        if (e.name === 'AbortError') {
+            resultDiv.innerHTML = `<p class="error">요청 시간이 초과되었습니다. 다시 시도해주세요.</p>`;
+        } else {
+            resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+        }
+    }
+}
+
 function changeExchange(exchange, btn) {
     if (_currentExchange === exchange) return;
     _currentExchange = exchange;

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -8,14 +8,32 @@
 {% endblock %}
 
 {% block content %}
+    <style>
+        .stock-mode-toggle .exchange-btn { padding: 4px 14px; font-size: 13px; background: var(--bg-primary, #f5f5f5); border: 1px solid var(--border, #ccc); color: var(--text-secondary, #555); border-radius: 4px; cursor: pointer; }
+        .stock-mode-toggle .exchange-btn.active { background: var(--accent, #4a90e2); color: #fff; border-color: var(--accent, #4a90e2); font-weight: bold; }
+    </style>
     <div id="section-stock" class="section">
         <div class="card">
             <h2>종목 현재가 조회</h2>
-            <div class="form-row" style="position: relative;">
+            <div class="stock-mode-toggle" style="display:flex; gap:4px; margin-bottom:10px;">
+                <button type="button" id="stock-mode-domestic" class="exchange-btn active" onclick="setStockMarketMode('domestic')">국내</button>
+                <button type="button" id="stock-mode-overseas" class="exchange-btn" onclick="setStockMarketMode('overseas')">해외</button>
+            </div>
+            <div id="domestic-stock-row" class="form-row" style="position: relative;">
                 <label>종목코드/종목명</label>
                 <input type="text" id="stock-code-input" placeholder="예: 005930 / 삼성전자 / ㅅㅅㅈㅈ / 삼성ㅈㅈ" autocomplete="off">
                 <button class="btn" onclick="searchStock()">조회</button>
                 <ul id="stock-autocomplete-list" class="autocomplete-list"></ul>
+            </div>
+            <div id="overseas-stock-row" class="form-row" style="display:none;">
+                <label>심볼</label>
+                <input type="text" id="overseas-stock-symbol" placeholder="예: AAPL" maxlength="12" autocomplete="off">
+                <select id="overseas-stock-exchange">
+                    <option value="NASD">NASDAQ</option>
+                    <option value="NYSE">NYSE</option>
+                    <option value="AMEX">AMEX</option>
+                </select>
+                <button class="btn" onclick="searchOverseasStock()">조회</button>
             </div>
         </div>
         <div id="stock-result"></div>
@@ -52,7 +70,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/stock.js?v=8"></script>
+<script src="/static/js/stock.js?v=9"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 요약
해외주식 Mode **V2.1**: 기존 현재가 조회(`/stock`) 화면에 `국내/해외` 조회 모드 토글을 추가하고 해외 심볼 직접 검색을 통합한다. 백엔드 `/api/overseas/stock/{symbol}` 와 fail-close 게이트는 V2에서 이미 구현되어 있어 **프론트엔드 배선 + 테스트**만 추가했다.

## 변경
- `view/web/templates/stock.html`: 국내/해외 세그먼트 토글, 해외 ticker 입력 행(거래소 `NASD`/`NYSE`/`AMEX`), 토글 스타일, `stock.js?v=9` 캐시버스트.
- `view/web/static/js/stock.js`:
  - `setStockMarketMode(mode)` — 입력 행 토글 + 결과/차트 영역 초기화.
  - `searchOverseasStock()` — `/api/overseas/stock/{symbol}?exchange=` 호출, 최소 view model(symbol/exchange/currency/price/change_rate/volume/timestamp)만 렌더, 국내 전용 차트 카드 숨김.
  - `_ensureOverseasEnabledForStock()` — `/api/market-mode`로 `overseas_us` enabled 확인, 미enabled 시 fail-close 메시지.
- 국내 모드 기본 동작(자동완성/코드조회/차트/RS/Stage)은 무변경.

## 범위 제외 (task 명시)
해외 심볼 자동완성/마스터 검색, 해외 일봉 차트 통합 — V2.1은 차트 없는 최소 표시만.

## 테스트
- `test_web_pages.py::test_pages_render_success_no_login` /stock 분기에 토글/해외 입력 마커 assert 추가.
- 신규 `test_stock_static_js_exposes_overseas_mode` — `setStockMarketMode`/`searchOverseasStock`/`/api/overseas/stock/`/`/api/market-mode` 문자열 고정.
- 단위 **5996 passed**, 통합 **240 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)