### PR TITLE
fix(web): /stock 국내 차트 회귀 수정 + 해외 회귀 TC(jsdom+소스계약) 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+# Node / frontend test toolchain (jsdom regression harness)
+node_modules/
+tests/frontend/package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/tests/frontend/package.json
+++ b/tests/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "investment-frontend-tests",
+  "private": true,
+  "version": "0.0.0",
+  "description": "jsdom regression harness for /stock screen JS (domestic regression guard for overseas features)",
+  "type": "module",
+  "scripts": {
+    "test": "node run_stock_dom_tests.mjs"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -1,0 +1,162 @@
+/*
+ * jsdom 기반 /stock 화면 회귀 테스트.
+ *
+ * 목적: 해외(overseas) 기능이 기존 국내 경로를 깨는 런타임 DOM 회귀를
+ * "함수 이름 문자열 존재" 수준이 아니라 실제 DOM 행위로 잡는다.
+ *
+ * 대표 회귀: 국내 조회 후 차트 카드(#stock-chart-card)는 #stock-result 안으로
+ * 이동된다. 모드 토글/해외 조회가 #stock-result 를 비울 때 차트 카드를 먼저
+ * 대피시키지 않으면 카드가 영구 파괴되어 이후 국내 차트가 깨진다.
+ *
+ * 실행: node run_stock_dom_tests.mjs  (exit 0 = 전부 통과)
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+// 기본은 실제 stock.js. STOCK_JS_PATH 로 다른 사본(예: 회귀 검증용 buggy 사본)을 지정 가능.
+const STOCK_JS = process.env.STOCK_JS_PATH
+  ? resolve(process.env.STOCK_JS_PATH)
+  : resolve(import.meta.dirname, "../../view/web/static/js/stock.js");
+
+// stock.html 의 #section-stock 구조를 회귀 검증에 필요한 만큼만 재현.
+const SCAFFOLD = `
+<div id="section-stock" class="section">
+  <div class="card">
+    <button id="stock-mode-domestic" class="exchange-btn active">국내</button>
+    <button id="stock-mode-overseas" class="exchange-btn">해외</button>
+    <div id="domestic-stock-row">
+      <input id="stock-code-input" type="text">
+      <ul id="stock-autocomplete-list"></ul>
+    </div>
+    <div id="overseas-stock-row" style="display:none;">
+      <input id="overseas-stock-symbol" type="text">
+      <select id="overseas-stock-exchange"><option value="NASD">NASDAQ</option></select>
+    </div>
+  </div>
+  <div id="stock-result"></div>
+  <div class="card" id="stock-chart-card" style="display:none;">
+    <canvas id="stockChart"></canvas>
+  </div>
+</div>
+`;
+
+function makeWindow() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/stock",
+    runScripts: "dangerously",
+  });
+  const { window } = dom;
+  // stock.js 가 로드 시점에 호출/참조하는 전역 스텁
+  window.StockAutocomplete = () => {};
+  window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
+  window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
+  window.loadAndRenderStockChart = () => {};
+  window.formatTradingValue = () => "";
+  window.ALL_STOCKS = [];
+  window._matchMixed = () => false;
+
+  const script = window.document.createElement("script");
+  script.textContent = readFileSync(STOCK_JS, "utf8");
+  window.document.body.appendChild(script);
+  return window;
+}
+
+/* 국내 조회 직후 상태 재현: 차트 카드를 #stock-result 안(#chart-placeholder)으로 이동 */
+function simulateDomesticSearchRendered(window) {
+  const result = window.document.getElementById("stock-result");
+  result.innerHTML = '<div class="card stock-info-box"><div id="chart-placeholder"></div></div>';
+  const placeholder = window.document.getElementById("chart-placeholder");
+  placeholder.appendChild(window.document.getElementById("stock-chart-card"));
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("setStockMarketMode('overseas') 가 stock-result 안의 차트 카드를 파괴하지 않는다", async () => {
+  const window = makeWindow();
+  simulateDomesticSearchRendered(window);
+  assert(window.document.getElementById("stock-chart-card"), "사전조건: 차트 카드 존재");
+
+  window.setStockMarketMode("overseas");
+
+  assert(window.document.getElementById("stock-chart-card"),
+    "회귀: 국내→해외 전환 시 차트 카드가 DOM에서 사라짐");
+  const card = window.document.getElementById("stock-chart-card");
+  assert(card.parentElement.id === "section-stock", "차트 카드는 section-stock 으로 대피되어야 함");
+  assert(window.document.getElementById("stock-result").innerHTML === "", "결과 영역은 비워져야 함");
+  assert(window.document.getElementById("overseas-stock-row").style.display !== "none", "해외 입력행이 보여야 함");
+  assert(window.document.getElementById("domestic-stock-row").style.display === "none", "국내 입력행은 숨겨져야 함");
+});
+
+test("국내→해외→국내 왕복 후에도 차트 카드와 캔버스가 보존된다", async () => {
+  const window = makeWindow();
+  simulateDomesticSearchRendered(window);
+  window.setStockMarketMode("overseas");
+  window.setStockMarketMode("domestic");
+  assert(window.document.getElementById("stock-chart-card"), "왕복 후 차트 카드 소실");
+  assert(window.document.getElementById("stockChart"), "왕복 후 차트 캔버스 소실");
+});
+
+test("searchOverseasStock 가 차트 카드를 보존하고 최소 view model 을 렌더한다", async () => {
+  const window = makeWindow();
+  simulateDomesticSearchRendered(window);
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["domestic", "overseas_us"] }) };
+    }
+    if (url.includes("/api/overseas/stock/")) {
+      return { ok: true, json: async () => ({
+        rt_cd: "0",
+        data: { symbol: "AAPL", exchange: "NASD", currency: "USD", price: 190.5, change_rate: 1.23, volume: 1000, timestamp: "20260614" },
+      }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  window.document.getElementById("overseas-stock-symbol").value = "aapl";
+
+  await window.searchOverseasStock();
+
+  assert(window.document.getElementById("stock-chart-card"), "회귀: 해외 조회가 차트 카드를 파괴함");
+  const html = window.document.getElementById("stock-result").innerHTML;
+  assert(html.includes("AAPL"), "심볼 표시 누락");
+  assert(html.includes("$190.50"), "가격(USD) 표시 누락");
+  // 해외 렌더는 국내 전용 SSE 타깃 id 를 만들면 안 된다(틱 핸들러 오작동 방지)
+  assert(!html.includes('id="rt-price"'), "해외 렌더가 국내 전용 rt-price id 를 생성함");
+});
+
+test("overseas_us 미enabled 시 searchOverseasStock 가 fail-close 하고 시세 API 를 호출하지 않는다", async () => {
+  const window = makeWindow();
+  let priceCalled = false;
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["domestic"] }) };
+    }
+    if (url.includes("/api/overseas/stock/")) {
+      priceCalled = true;
+      return { ok: true, json: async () => ({ rt_cd: "0", data: {} }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  window.document.getElementById("overseas-stock-symbol").value = "AAPL";
+
+  await window.searchOverseasStock();
+
+  assert(priceCalled === false, "fail-close 인데 해외 시세 API 가 호출됨");
+  const html = window.document.getElementById("stock-result").innerHTML;
+  assert(html.includes("overseas_us"), "fail-close 메시지 누락");
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/integration_test/view/web/test_it_stock_js_dom_regression.py
+++ b/tests/integration_test/view/web/test_it_stock_js_dom_regression.py
@@ -1,0 +1,37 @@
+"""/stock 화면 JS 의 런타임 DOM 회귀를 jsdom 으로 검증한다 (pytest gate 편입).
+
+해외(overseas) 기능이 기존 국내 차트/조회 경로를 깨는 회귀는 소스 문자열
+검사로는 못 잡으므로, tests/frontend/run_stock_dom_tests.mjs 를 node 서브프로세스로
+실행해 실제 DOM 행위를 확인한다.
+
+node 또는 jsdom 미설치 시에는 skip 한다(설치: `cd tests/frontend && npm install`).
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FRONTEND_DIR = _REPO_ROOT / "tests" / "frontend"
+_RUNNER = _FRONTEND_DIR / "run_stock_dom_tests.mjs"
+
+
+def test_stock_js_dom_regression_suite():
+    if shutil.which("node") is None:
+        pytest.skip("node 미설치 — JS DOM 회귀 테스트 skip")
+    if not (_FRONTEND_DIR / "node_modules" / "jsdom").exists():
+        pytest.skip("jsdom 미설치 — `cd tests/frontend && npm install` 후 실행")
+
+    result = subprocess.run(
+        ["node", str(_RUNNER)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"jsdom 회귀 테스트 실패\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )

--- a/tests/unit_test/view/web/test_stock_js_contracts.py
+++ b/tests/unit_test/view/web/test_stock_js_contracts.py
@@ -1,0 +1,61 @@
+"""stock.js 소스 계약(회귀 잠금) — 해외 기능이 국내 차트 경로를 깨지 않도록 강제.
+
+런타임 DOM 행위는 tests/integration_test/.../test_it_stock_js_dom_regression.py(jsdom)가
+검증한다. 본 모듈은 node toolchain 없이도 항상 도는 in-gate 정적 계약으로,
+"차트 카드 대피가 stock-result 비우기보다 먼저 온다"는 핵심 순서를 잠근다.
+"""
+from pathlib import Path
+
+import pytest
+
+_STOCK_JS = Path("view/web/static/js/stock.js")
+
+
+@pytest.fixture(scope="module")
+def stock_js() -> str:
+    return _STOCK_JS.read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    """`function name(` 부터 다음 top-level `\\nfunction ` 직전까지를 반환(근사)."""
+    start = src.index(f"function {name}(")
+    rest = src[start + 1:]
+    nxt = rest.find("\nfunction ")
+    return rest if nxt == -1 else rest[:nxt]
+
+
+def test_detach_helper_defined(stock_js):
+    assert "function _detachStockChartCard(" in stock_js
+
+
+def test_set_market_mode_detaches_chart_before_clearing_result(stock_js):
+    """회귀 잠금: setStockMarketMode 는 stock-result 를 비우기 전에 차트 카드를 대피해야 한다.
+
+    순서가 뒤바뀌면 stock-result 안으로 이동돼 있던 차트 카드가 innerHTML 초기화로 파괴된다.
+    """
+    body = _function_body(stock_js, "setStockMarketMode")
+    detach_at = body.find("_detachStockChartCard()")
+    clear_at = body.find("innerHTML = ''")
+    assert detach_at != -1, "setStockMarketMode 가 _detachStockChartCard 를 호출하지 않음"
+    assert clear_at != -1, "setStockMarketMode 가 stock-result 를 비우지 않음"
+    assert detach_at < clear_at, "차트 카드 대피가 stock-result 비우기보다 먼저 와야 함"
+
+
+def test_search_overseas_detaches_chart_before_overwriting_result(stock_js):
+    """회귀 잠금: searchOverseasStock 도 결과를 덮어쓰기(showLoading) 전에 차트 카드를 대피."""
+    body = _function_body(stock_js, "searchOverseasStock")
+    detach_at = body.find("_detachStockChartCard()")
+    loading_at = body.find("showLoading(")
+    assert detach_at != -1, "searchOverseasStock 가 _detachStockChartCard 를 호출하지 않음"
+    assert loading_at != -1, "searchOverseasStock 가 showLoading 으로 결과를 덮어쓰지 않음"
+    assert detach_at < loading_at, "차트 카드 대피가 결과 덮어쓰기보다 먼저 와야 함"
+
+
+def test_overseas_render_does_not_reuse_domestic_sse_ids(stock_js):
+    """해외 렌더는 국내 전용 SSE 타깃 id(rt-price/rt-change-rate/rt-high/rt-low)를 만들면 안 된다.
+
+    재사용 시 stock-price-tick 핸들러가 해외 결과 DOM 을 국내 틱으로 덮어쓸 수 있다.
+    """
+    body = _function_body(stock_js, "searchOverseasStock")
+    for forbidden in ('id="rt-price"', 'id="rt-change-rate"', 'id="rt-high"', 'id="rt-low"'):
+        assert forbidden not in body, f"해외 렌더가 국내 전용 {forbidden} 를 생성함"

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -32,6 +32,19 @@ document.addEventListener('stock-price-tick', function (e) {
 });
 
 /* ── 국내/해외 조회 모드 토글 (V2.1) ── */
+
+/* 차트 카드를 stock-result 밖(section-stock)으로 대피시키고 숨긴다.
+ * searchStock가 차트 카드를 stock-result 안으로 옮기므로, stock-result를
+ * 비우기 전에 먼저 대피시키지 않으면 innerHTML 초기화 시 카드가 파괴된다. */
+function _detachStockChartCard() {
+    const chartCard = document.getElementById('stock-chart-card');
+    const sectionStock = document.getElementById('section-stock');
+    if (chartCard && sectionStock && chartCard.parentElement !== sectionStock) {
+        sectionStock.appendChild(chartCard);
+    }
+    if (chartCard) chartCard.style.display = 'none';
+}
+
 function setStockMarketMode(mode) {
     const domesticRow = document.getElementById('domestic-stock-row');
     const overseasRow = document.getElementById('overseas-stock-row');
@@ -45,14 +58,10 @@ function setStockMarketMode(mode) {
     if (overseasBtn) overseasBtn.classList.toggle('active', isOverseas);
 
     // 모드 전환 시 결과/차트 영역 초기화 (국내↔해외 잔여 UI 방지)
+    // 차트 카드를 먼저 대피시킨 뒤 결과를 비운다.
+    _detachStockChartCard();
     const resultDiv = document.getElementById('stock-result');
     if (resultDiv) resultDiv.innerHTML = '';
-    const chartCard = document.getElementById('stock-chart-card');
-    const sectionStock = document.getElementById('section-stock');
-    if (chartCard && sectionStock && chartCard.parentElement !== sectionStock) {
-        sectionStock.appendChild(chartCard);
-    }
-    if (chartCard) chartCard.style.display = 'none';
 }
 
 /* overseas_us가 enabled된 run에서만 해외 조회 허용 (fail-close) */
@@ -80,9 +89,8 @@ async function searchOverseasStock() {
     if (symbolInput) symbolInput.value = symbol;
     if (!resultDiv) return;
 
-    // 해외 모드에서는 국내 전용 차트 카드를 숨긴다.
-    const chartCard = document.getElementById('stock-chart-card');
-    if (chartCard) chartCard.style.display = 'none';
+    // 해외 모드는 국내 전용 차트 카드를 미표시. 결과를 덮어쓰기 전에 먼저 대피시킨다.
+    _detachStockChartCard();
 
     showLoading(resultDiv, '해외 종목 조회 중...');
     try {

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -70,7 +70,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/stock.js?v=9"></script>
+<script src="/static/js/stock.js?v=10"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 배경
해외(overseas) 검토 중 **V2.1에서 유입된 국내 경로 회귀**를 발견. 기존 `/stock` 테스트는 "함수 이름 문자열 존재" 수준이라 런타임 DOM 회귀를 못 잡았다. 사용자 요청에 따라 회귀를 더 엄격히 잡는 TC를 먼저 구축하고 버그를 수정한다.

## 버그
`setStockMarketMode` / `searchOverseasStock` 가 `#stock-result` 를 비우기 **전에** 차트 카드를 대피시키지 않았다. 국내 조회 시 차트 카드(`#stock-chart-card`, `#stockChart` 캔버스)는 `searchStock` 에 의해 `#stock-result` **안**으로 이동되는데, 모드 전환/해외 조회가 `innerHTML` 을 먼저 비워 카드를 **영구 파괴** → 이후 국내 차트가 깨짐(새로고침 전까지).

**수정**: `_detachStockChartCard()` 헬퍼로 `section-stock` 으로 대피를 먼저 수행.

## 회귀 TC (둘 다)
1. **jsdom 행위 테스트** `tests/frontend/run_stock_dom_tests.mjs` — 국내→해외 전환/왕복/해외 렌더 시 차트 카드 보존 + 최소 view model + overseas_us 미enabled fail-close 검증. **buggy 사본 대비 3/4 실패**로 실제 회귀 포착 입증.
2. **pytest gate 편입** `test_it_stock_js_dom_regression.py` — node 서브프로세스로 jsdom 스위트 실행, node/jsdom 미설치 시 graceful skip(`cd tests/frontend && npm install`).
3. **소스 계약 테스트** `test_stock_js_contracts.py` — "대피가 clear보다 먼저" 순서 + 해외 렌더가 국내 SSE id(`rt-price` 등) 미재사용을 in-gate 정적 잠금.

## 인프라
- `tests/frontend/`: jsdom devDependency. `node_modules`/`package-lock.json` 은 `.gitignore`.

## 테스트
- 단위 **6000 passed**, 통합 **241 passed**(jsdom gate 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)