### PR TITLE
fix(web): 해외 일봉 차트 빈 테이블 회귀 수정 + jsdom 회귀 TC

### DIFF
--- a/tests/frontend/run_overseas_dom_tests.mjs
+++ b/tests/frontend/run_overseas_dom_tests.mjs
@@ -1,0 +1,114 @@
+/*
+ * jsdom 기반 /overseas 화면 JS 회귀 테스트.
+ *
+ * 대표 회귀: get_overseas_dailyprice 는 KIS 원본 body(dict: output1/output2)를
+ * 그대로 반환하므로 json.data 는 배열이 아니다. loadOverseasChart 가 이를
+ * 배열로 가정하면 일봉 테이블이 항상 빈다. 또한 output2 행 키는 KIS 해외
+ * 스키마(xymd/clos/tvol)라 국내 키 매핑으로는 종가/거래량이 표시되지 않는다.
+ *
+ * 실행: node run_overseas_dom_tests.mjs  (exit 0 = 전부 통과)
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+const OVERSEAS_JS = process.env.OVERSEAS_JS_PATH
+  ? resolve(process.env.OVERSEAS_JS_PATH)
+  : resolve(import.meta.dirname, "../../view/web/static/js/overseas.js");
+
+const SCAFFOLD = `
+<span id="status-env" data-mode="paper"></span>
+<input id="overseas-symbol" type="text">
+<select id="overseas-exchange"><option value="NASD">NASDAQ</option></select>
+<div id="overseas-quote-result"></div>
+<div id="overseas-chart-result"></div>
+<div id="overseas-balance-result"></div>
+`;
+
+function makeWindow() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/overseas",
+    runScripts: "dangerously",
+  });
+  const { window } = dom;
+  window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
+  window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
+  window.alert = () => {};
+
+  const script = window.document.createElement("script");
+  script.textContent = readFileSync(OVERSEAS_JS, "utf8");
+  window.document.body.appendChild(script);
+  return window;
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("loadOverseasChart 가 KIS body(dict의 output2)에서 일봉 행을 렌더한다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["domestic", "overseas_us"] }) };
+    }
+    if (url.includes("/api/overseas/chart/")) {
+      return { ok: true, json: async () => ({
+        rt_cd: "0",
+        // KIS 해외 일봉 원본 형태: 전체 body dict(output1 + output2 배열)
+        data: {
+          output1: { rsym: "DNASAAPL" },
+          output2: [
+            { xymd: "20260101", clos: "190.50", tvol: "1000" },
+            { xymd: "20260102", clos: "192.00", tvol: "2000" },
+          ],
+        },
+      }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  window.document.getElementById("overseas-symbol").value = "AAPL";
+
+  await window.loadOverseasChart();
+
+  const html = window.document.getElementById("overseas-chart-result").innerHTML;
+  assert(html.includes("20260102"), "회귀: 일봉 일자 행이 렌더되지 않음(output2 미추출)");
+  assert(html.includes("$192.00"), "회귀: 종가(clos) 매핑 실패");
+  assert(html.includes("2,000"), "회귀: 거래량(tvol) 매핑 실패");
+  assert(!html.includes("데이터 없음"), "회귀: 데이터 있는데 빈 테이블 표시");
+});
+
+test("loadOverseasChart 가 이미 배열인 data 도 처리한다(하위호환)", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (url.includes("/api/overseas/chart/")) {
+      return { ok: true, json: async () => ({
+        rt_cd: "0",
+        data: [{ xymd: "20260103", clos: "195.00", tvol: "3000" }],
+      }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  window.document.getElementById("overseas-symbol").value = "AAPL";
+
+  await window.loadOverseasChart();
+
+  const html = window.document.getElementById("overseas-chart-result").innerHTML;
+  assert(html.includes("20260103"), "배열 형태 data 미처리");
+  assert(html.includes("$195.00"), "배열 형태 종가 미표시");
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/integration_test/view/web/test_it_stock_js_dom_regression.py
+++ b/tests/integration_test/view/web/test_it_stock_js_dom_regression.py
@@ -1,8 +1,8 @@
-"""/stock 화면 JS 의 런타임 DOM 회귀를 jsdom 으로 검증한다 (pytest gate 편입).
+"""웹 화면 JS 의 런타임 DOM 회귀를 jsdom 으로 검증한다 (pytest gate 편입).
 
-해외(overseas) 기능이 기존 국내 차트/조회 경로를 깨는 회귀는 소스 문자열
-검사로는 못 잡으므로, tests/frontend/run_stock_dom_tests.mjs 를 node 서브프로세스로
-실행해 실제 DOM 행위를 확인한다.
+해외(overseas) 기능이 기존 국내 차트/조회 경로를 깨거나, 해외 화면 자체가
+KIS 응답 형태를 잘못 가정하는 회귀는 소스 문자열 검사로는 못 잡으므로,
+tests/frontend/run_*_dom_tests.mjs 를 node 서브프로세스로 실행해 실제 DOM 행위를 확인한다.
 
 node 또는 jsdom 미설치 시에는 skip 한다(설치: `cd tests/frontend && npm install`).
 """
@@ -14,17 +14,22 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _FRONTEND_DIR = _REPO_ROOT / "tests" / "frontend"
-_RUNNER = _FRONTEND_DIR / "run_stock_dom_tests.mjs"
+_RUNNERS = sorted(_FRONTEND_DIR.glob("run_*_dom_tests.mjs"))
 
 
-def test_stock_js_dom_regression_suite():
+def _skip_if_unavailable():
     if shutil.which("node") is None:
         pytest.skip("node 미설치 — JS DOM 회귀 테스트 skip")
     if not (_FRONTEND_DIR / "node_modules" / "jsdom").exists():
         pytest.skip("jsdom 미설치 — `cd tests/frontend && npm install` 후 실행")
 
+
+@pytest.mark.parametrize("runner", _RUNNERS, ids=lambda p: p.name)
+def test_js_dom_regression_suite(runner):
+    _skip_if_unavailable()
+
     result = subprocess.run(
-        ["node", str(_RUNNER)],
+        ["node", str(runner)],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
@@ -33,5 +38,6 @@ def test_stock_js_dom_regression_suite():
         timeout=120,
     )
     assert result.returncode == 0, (
-        f"jsdom 회귀 테스트 실패\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        f"jsdom 회귀 테스트 실패 ({runner.name})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -116,12 +116,18 @@ async function loadOverseasChart() {
             resultDiv.innerHTML = `<p class="error">일봉 조회 실패: ${json.msg1 || res.status}</p>`;
             return;
         }
-        const rows = Array.isArray(json.data) ? json.data.slice(-10).reverse() : [];
+        // KIS 해외 일봉은 원본 body(dict)를 그대로 반환하므로 output2 배열을 꺼낸다.
+        // (이미 배열로 정규화된 형태도 하위호환으로 허용)
+        const data = json.data || {};
+        const list = Array.isArray(data)
+            ? data
+            : (Array.isArray(data.output2) ? data.output2 : []);
+        const rows = list.slice(-10).reverse();
         const body = rows.map((row) => `
             <tr>
                 <td>${row.date || row.xymd || row.stck_bsop_date || '-'}</td>
-                <td>${_formatUsd(row.close || row.clpr || row.ovrs_nmix_prpr)}</td>
-                <td>${_formatNumber(row.volume || row.acml_vol)}</td>
+                <td>${_formatUsd(row.close || row.clos || row.clpr || row.ovrs_nmix_prpr)}</td>
+                <td>${_formatNumber(row.volume || row.tvol || row.acml_vol)}</td>
             </tr>
         `).join('');
         resultDiv.innerHTML = `

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -64,5 +64,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/overseas.js?v=1"></script>
+<script src="/static/js/overseas.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## 배경
해외 기능 추가 검토 중 발견. 표준 `/overseas` 화면의 **일봉 버튼이 항상 "데이터 없음"** 으로 표시되던 V2 버그.

## 버그
- `get_overseas_dailyprice` 는 `call_api` 원본 결과를 그대로 반환 → `resp.data` 는 **KIS body dict**(`{output1, output2:[…]}`)이다([api_base.py:105-108](brokers/korea_investment/korea_invest_api_base.py#L105) `data=result_data`).
- 그러나 [overseas.js:119](view/web/static/js/overseas.js#L119) `loadOverseasChart` 는 `Array.isArray(json.data) ? … : []` 로 **배열을 가정** → 항상 `rows=[]` → 빈 테이블.
- 부가: `output2` 행 키가 KIS 해외 스키마(`clos`/`tvol`)라 국내 키 매핑(`close`/`acml_vol`)으로는 종가·거래량 미표시(일자는 `xymd` 로 우연히 동작).
- 잔고 경로는 `data.output1` 을 올바르게 읽어 정상 — 영향 없음.

## 수정
`data.output2` 배열 추출(이미 배열인 형태도 하위호환 허용) + `clos`/`tvol` 키 fallback 추가. `overseas.js?v=2` 캐시버스트.

## 회귀 TC
- `tests/frontend/run_overseas_dom_tests.mjs` 신설(jsdom) — KIS dict 형태 응답을 먹여 일자/종가/거래량 렌더 검증. **수정 전 코드 대비 2/2 실패**로 포착 입증.
- pytest gate(`test_it_stock_js_dom_regression.py`)를 `run_*_dom_tests.mjs` 전체 parametrize 실행으로 일반화 → stock + overseas 2 스위트 in-gate.

## 테스트
- 단위 **6000 passed**, 통합 **242 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)