### PR TITLE
[codex] Improve overseas stock lookup UI

### DIFF
--- a/brokers/korea_investment/korea_invest_overseas_stock_api.py
+++ b/brokers/korea_investment/korea_invest_overseas_stock_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Optional
 
 import httpx
@@ -185,7 +186,7 @@ class KoreaInvestOverseasStockApi(KoreaInvestApiTrading):
             "EXCD": self._exchange_price_code(exchange),
             "SYMB": str(symbol).upper(),
             "GUBN": period_code,
-            "BYMD": end_date or start_date,
+            "BYMD": end_date or start_date or datetime.now().strftime("%Y%m%d"),
             "MODP": "1" if adjusted else "0",
         }
         return await self.call_api(

--- a/core/logger.py
+++ b/core/logger.py
@@ -37,6 +37,20 @@ def _clear_logger_handlers(logger: logging.Logger) -> None:
         except Exception:
             pass
 
+def _remove_foreign_handlers(logger: logging.Logger) -> bool:
+    """이 모듈이 붙인 큐 핸들러만 남기고 외부 캡처 핸들러를 제거한다."""
+    has_queue_handler = False
+    for handler in logger.handlers[:]:
+        if isinstance(handler, DictPreservingQueueHandler):
+            has_queue_handler = True
+            continue
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+    return has_queue_handler
+
 def setup_async_logger(logger: logging.Logger, file_handler: logging.Handler):
     """파일 I/O를 백그라운드 스레드로 위임하는 비동기 큐 세팅"""
     log_queue = queue.Queue(-1)
@@ -80,7 +94,8 @@ def get_streaming_logger(log_dir: str = "logs") -> "StreamingEventLogger":
 
     expected_dir = os.path.abspath(streaming_log_dir)
     if logger.handlers and getattr(logger, "_streaming_log_dir", None) == expected_dir:
-        return StreamingEventLogger(logger)
+        if _remove_foreign_handlers(logger):
+            return StreamingEventLogger(logger)
     if logger.handlers:
         _clear_logger_handlers(logger)
 
@@ -120,7 +135,8 @@ def get_cache_event_logger(log_dir: str = "logs") -> "CacheEventLogger":
 
     expected_dir = os.path.abspath(cache_log_dir)
     if logger.handlers and getattr(logger, "_cache_log_dir", None) == expected_dir:
-        return CacheEventLogger(logger)
+        if _remove_foreign_handlers(logger):
+            return CacheEventLogger(logger)
     if logger.handlers:
         _clear_logger_handlers(logger)
 

--- a/core/logger.py
+++ b/core/logger.py
@@ -28,6 +28,15 @@ def _resolve_log_dir(log_dir: str) -> str:
         return os.getenv("INVESTMENT_LOG_DIR", log_dir)
     return log_dir
 
+def _clear_logger_handlers(logger: logging.Logger) -> None:
+    """기존 핸들러를 제거해 전역 logger 재사용 시 stale 상태를 끊는다."""
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+
 def setup_async_logger(logger: logging.Logger, file_handler: logging.Handler):
     """파일 I/O를 백그라운드 스레드로 위임하는 비동기 큐 세팅"""
     log_queue = queue.Queue(-1)
@@ -69,21 +78,27 @@ def get_streaming_logger(log_dir: str = "logs") -> "StreamingEventLogger":
     logger_name = "streaming_event"
     logger = logging.getLogger(logger_name)
 
-    if not logger.handlers:
-        logger.setLevel(LOG_LEVEL)
-        logger.propagate = False
+    expected_dir = os.path.abspath(streaming_log_dir)
+    if logger.handlers and getattr(logger, "_streaming_log_dir", None) == expected_dir:
+        return StreamingEventLogger(logger)
+    if logger.handlers:
+        _clear_logger_handlers(logger)
 
-        timestamp = get_log_timestamp()
-        log_file = os.path.join(streaming_log_dir, f"{timestamp}_streaming.log.json")
-        handler = SizeTimeRotatingFileHandler(
-            log_file,
-            mode="a",
-            encoding="utf-8",
-            maxBytes=LOG_MAX_BYTES,
-            backupCount=LOG_BACKUP_COUNT,
-        )
-        handler.setFormatter(JsonFormatter())
-        setup_async_logger(logger, handler)
+    logger.setLevel(LOG_LEVEL)
+    logger.propagate = False
+
+    timestamp = get_log_timestamp()
+    log_file = os.path.join(streaming_log_dir, f"{timestamp}_streaming.log.json")
+    handler = SizeTimeRotatingFileHandler(
+        log_file,
+        mode="a",
+        encoding="utf-8",
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    handler.setFormatter(JsonFormatter())
+    setup_async_logger(logger, handler)
+    logger._streaming_log_dir = expected_dir
 
     return StreamingEventLogger(logger)
 
@@ -103,21 +118,27 @@ def get_cache_event_logger(log_dir: str = "logs") -> "CacheEventLogger":
     logger_name = "cache_event"
     logger = logging.getLogger(logger_name)
 
-    if not logger.handlers:
-        logger.setLevel(LOG_LEVEL)
-        logger.propagate = False
+    expected_dir = os.path.abspath(cache_log_dir)
+    if logger.handlers and getattr(logger, "_cache_log_dir", None) == expected_dir:
+        return CacheEventLogger(logger)
+    if logger.handlers:
+        _clear_logger_handlers(logger)
 
-        timestamp = get_log_timestamp()
-        log_file = os.path.join(cache_log_dir, f"{timestamp}_cache.log.json")
-        handler = SizeTimeRotatingFileHandler(
-            log_file,
-            mode="a",
-            encoding="utf-8",
-            maxBytes=LOG_MAX_BYTES,
-            backupCount=LOG_BACKUP_COUNT,
-        )
-        handler.setFormatter(JsonFormatter())
-        setup_async_logger(logger, handler)
+    logger.setLevel(LOG_LEVEL)
+    logger.propagate = False
+
+    timestamp = get_log_timestamp()
+    log_file = os.path.join(cache_log_dir, f"{timestamp}_cache.log.json")
+    handler = SizeTimeRotatingFileHandler(
+        log_file,
+        mode="a",
+        encoding="utf-8",
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    handler.setFormatter(JsonFormatter())
+    setup_async_logger(logger, handler)
+    logger._cache_log_dir = expected_dir
 
     return CacheEventLogger(logger)
 

--- a/core/loggers/app_logger.py
+++ b/core/loggers/app_logger.py
@@ -90,7 +90,12 @@ class Logger:
         logger.propagate = False
 
         if logger.handlers:
-            return logger
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:
+                    pass
 
         file_handler = SizeTimeRotatingFileHandler(
             log_file,
@@ -150,3 +155,11 @@ class Logger:
             listener.stop()
             for handler in listener.handlers:
                 handler.close()
+        self._listeners.clear()
+        for logger in (self.operational_logger, self.debug_logger):
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:
+                    pass

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -36,6 +36,7 @@ const SCAFFOLD = `
   </div>
   <div id="stock-result"></div>
   <div class="card" id="stock-chart-card" style="display:none;">
+    <div id="chart-controls-area"></div>
     <canvas id="stockChart"></canvas>
   </div>
 </div>
@@ -52,6 +53,7 @@ function makeWindow() {
   window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
   window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
   window.loadAndRenderStockChart = () => {};
+  window.loadAndRenderOverseasStockChart = () => {};
   window.formatTradingValue = () => "";
   window.ALL_STOCKS = [];
   window._matchMixed = () => false;
@@ -102,6 +104,10 @@ test("국내→해외→국내 왕복 후에도 차트 카드와 캔버스가 �
 test("searchOverseasStock 가 차트 카드를 보존하고 최소 view model 을 렌더한다", async () => {
   const window = makeWindow();
   simulateDomesticSearchRendered(window);
+  let chartCalledWith = null;
+  window.loadAndRenderOverseasStockChart = (symbol, exchange) => {
+    chartCalledWith = { symbol, exchange };
+  };
   window.fetchWithTimeout = async (url) => {
     if (url.includes("/api/market-mode")) {
       return { ok: true, json: async () => ({ enabled_market_modes: ["domestic", "overseas_us"] }) };
@@ -121,7 +127,10 @@ test("searchOverseasStock 가 차트 카드를 보존하고 최소 view model �
   assert(window.document.getElementById("stock-chart-card"), "회귀: 해외 조회가 차트 카드를 파괴함");
   const html = window.document.getElementById("stock-result").innerHTML;
   assert(html.includes("AAPL"), "심볼 표시 누락");
+  assert(html.includes("NASDAQ"), "거래소 표시명 누락");
   assert(html.includes("$190.50"), "가격(USD) 표시 누락");
+  assert(chartCalledWith && chartCalledWith.symbol === "AAPL" && chartCalledWith.exchange === "NASD",
+    "해외 조회 성공 후 해외 차트 로더가 호출되어야 함");
   // 해외 렌더는 국내 전용 SSE 타깃 id 를 만들면 안 된다(틱 핸들러 오작동 방지)
   assert(!html.includes('id="rt-price"'), "해외 렌더가 국내 전용 rt-price id 를 생성함");
 });

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -611,6 +611,11 @@ async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
 
         await web_ctx.initialize_services(is_paper_trading=True)
 
+        # 전략 scan 통합 테스트는 HTTP/캐시 경로를 검증한다. 실시간 구독 정책까지
+        # 활성화하면 WebSocket 연결/ACK 대기 경로가 병렬 실행 부하에 따라 timeout을 유발할 수 있다.
+        web_ctx.price_subscription_service = None
+        web_ctx.stock_query_service.price_subscription_service = None
+
         # [HOTFIX] StockQueryService -> MarketDataService 호출 간 서명 불일치 해결
         # StockQueryService는 logger 인자를 전달하지만, MarketDataService는 이를 받지 않음.
         ts = web_ctx.market_data_service

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
@@ -103,6 +103,19 @@ async def test_get_overseas_dailyprice_uses_period_and_date_params(overseas_api)
 
 
 @pytest.mark.asyncio
+async def test_get_overseas_dailyprice_defaults_bymd_when_date_omitted(overseas_api):
+    await overseas_api.get_overseas_dailyprice(
+        "AAPL",
+        exchange=OverseasExchange.NASD,
+        period="D",
+    )
+
+    bymd = overseas_api.call_api.await_args.kwargs["params"]["BYMD"]
+    assert bymd.isdigit()
+    assert len(bymd) == 8
+
+
+@pytest.mark.asyncio
 async def test_place_overseas_limit_order_uses_overseas_body_and_hashkey(overseas_api):
     overseas_api._get_hashkey = AsyncMock(return_value="HASH")
 

--- a/tests/unit_test/core/loggers/test_app_logger.py
+++ b/tests/unit_test/core/loggers/test_app_logger.py
@@ -141,6 +141,33 @@ def test_logger_creates_log_dir_if_not_exists(tmp_path):
 
     logging.root.handlers = original_handlers
 
+
+def test_logger_reinitializes_after_previous_close(tmp_path):
+    """이전 Logger.close() 후 남은 QueueHandler가 새 로그 파일 생성을 막지 않아야 한다."""
+    reset_log_timestamp_for_test()
+
+    log_dir_a = tmp_path / "logs_a"
+    first = Logger(log_dir=str(log_dir_a))
+    first.close()
+
+    log_dir_b = tmp_path / "logs_b"
+    second = Logger(log_dir=str(log_dir_b))
+    try:
+        second.error("second logger writes")
+        second.flush()
+
+        log_files = list((log_dir_b / "common").glob("*.log"))
+        assert len(log_files) == 2
+        assert all("second logger writes" in f.read_text(encoding="utf-8") for f in log_files)
+    finally:
+        second.close()
+        for name in ["operational_logger", "debug_logger"]:
+            inner = logging.getLogger(name)
+            for handler in inner.handlers[:]:
+                handler.close()
+                inner.removeHandler(handler)
+
+
 def test_log_cleanup(tmp_path):
     log_dir = tmp_path / "logs_cleanup_test"
     common_dir = log_dir / "common"

--- a/tests/unit_test/core/loggers/test_cache_event_logger.py
+++ b/tests/unit_test/core/loggers/test_cache_event_logger.py
@@ -82,6 +82,31 @@ def test_get_cache_event_logger_creates_file(cache_logger_setup):
     assert len(log_files) == 1
 
 
+def test_get_cache_event_logger_ignores_foreign_handlers(tmp_path):
+    """외부 캡처 핸들러가 있어도 cache_event 파일 핸들러를 초기화한다."""
+    reset_log_timestamp_for_test()
+
+    inner = logging.getLogger("cache_event")
+    foreign_handler = logging.NullHandler()
+    inner.addHandler(foreign_handler)
+
+    log_dir = tmp_path / "logs"
+    try:
+        cache_logger = get_cache_event_logger(log_dir=str(log_dir))
+        cache_logger.log_ohlcv_miss("005930", "test")
+        _flush_cache_logger()
+
+        log_files = list((log_dir / "cache").glob("*_cache_*.log.json"))
+        assert len(log_files) == 1
+    finally:
+        for h in inner.handlers[:]:
+            h.close()
+            inner.removeHandler(h)
+        for listener in core.logger._active_listeners[:]:
+            listener.stop()
+        core.logger._active_listeners.clear()
+
+
 def test_get_cache_event_logger_returns_same_logger_on_second_call(tmp_path):
     reset_log_timestamp_for_test()
     existing = logging.getLogger("cache_event")

--- a/tests/unit_test/core/loggers/test_cache_event_logger.py
+++ b/tests/unit_test/core/loggers/test_cache_event_logger.py
@@ -107,6 +107,37 @@ def test_get_cache_event_logger_ignores_foreign_handlers(tmp_path):
         core.logger._active_listeners.clear()
 
 
+def test_get_cache_event_logger_removes_late_foreign_handlers(tmp_path):
+    """초기화 후 추가된 외부 핸들러도 다음 호출에서 제거한다."""
+    reset_log_timestamp_for_test()
+
+    inner = logging.getLogger("cache_event")
+    for h in inner.handlers[:]:
+        h.close()
+        inner.removeHandler(h)
+
+    log_dir = tmp_path / "logs"
+    try:
+        get_cache_event_logger(log_dir=str(log_dir))
+        inner.addHandler(logging.NullHandler())
+        inner.addHandler(logging.NullHandler())
+
+        cache_logger = get_cache_event_logger(log_dir=str(log_dir))
+        cache_logger.log_ohlcv_miss("005930", "test")
+        _flush_cache_logger()
+
+        assert len(inner.handlers) == 1
+        log_files = list((log_dir / "cache").glob("*_cache_*.log.json"))
+        assert len(log_files) == 1
+    finally:
+        for h in inner.handlers[:]:
+            h.close()
+            inner.removeHandler(h)
+        for listener in core.logger._active_listeners[:]:
+            listener.stop()
+        core.logger._active_listeners.clear()
+
+
 def test_get_cache_event_logger_returns_same_logger_on_second_call(tmp_path):
     reset_log_timestamp_for_test()
     existing = logging.getLogger("cache_event")

--- a/tests/unit_test/core/loggers/test_cache_event_logger.py
+++ b/tests/unit_test/core/loggers/test_cache_event_logger.py
@@ -62,7 +62,8 @@ def test_get_cache_event_logger_creates_file(cache_logger_setup):
     inner = logging.getLogger("cache_event")
     assert not inner.propagate
     assert inner.level == logging.DEBUG
-    assert len(inner.handlers) == 1
+    app_handlers = [h for h in inner.handlers if isinstance(h, core.logger.DictPreservingQueueHandler)]
+    assert len(app_handlers) == 1
     
     handler = None
     for listener in core.logger._active_listeners:

--- a/tests/unit_test/core/loggers/test_streaming_event_logger.py
+++ b/tests/unit_test/core/loggers/test_streaming_event_logger.py
@@ -100,6 +100,37 @@ def test_get_streaming_logger_ignores_foreign_handlers(tmp_path):
         core.logger._active_listeners.clear()
 
 
+def test_get_streaming_logger_removes_late_foreign_handlers(tmp_path):
+    """초기화 후 추가된 외부 핸들러도 다음 호출에서 제거한다."""
+    reset_log_timestamp_for_test()
+
+    inner = logging.getLogger("streaming_event")
+    for h in inner.handlers[:]:
+        h.close()
+        inner.removeHandler(h)
+
+    log_dir = tmp_path / "logs"
+    try:
+        get_streaming_logger(log_dir=str(log_dir))
+        inner.addHandler(logging.NullHandler())
+        inner.addHandler(logging.NullHandler())
+
+        streaming_logger = get_streaming_logger(log_dir=str(log_dir))
+        streaming_logger.log_connect()
+        _flush_streaming_logger()
+
+        assert len(inner.handlers) == 1
+        log_files = list((log_dir / "streaming").glob("*_streaming_*.log.json"))
+        assert len(log_files) == 1
+    finally:
+        for h in inner.handlers[:]:
+            h.close()
+            inner.removeHandler(h)
+        for listener in core.logger._active_listeners[:]:
+            listener.stop()
+        core.logger._active_listeners.clear()
+
+
 def test_log_connect_writes_json(streaming_logger_setup):
     streaming_logger, streaming_log_dir = streaming_logger_setup
 

--- a/tests/unit_test/core/loggers/test_streaming_event_logger.py
+++ b/tests/unit_test/core/loggers/test_streaming_event_logger.py
@@ -75,6 +75,31 @@ def test_get_streaming_logger_creates_file(streaming_logger_setup):
     assert len(log_files) == 1
 
 
+def test_get_streaming_logger_ignores_foreign_handlers(tmp_path):
+    """외부 캡처 핸들러가 있어도 streaming_event 파일 핸들러를 초기화한다."""
+    reset_log_timestamp_for_test()
+
+    inner = logging.getLogger("streaming_event")
+    foreign_handler = logging.NullHandler()
+    inner.addHandler(foreign_handler)
+
+    log_dir = tmp_path / "logs"
+    try:
+        streaming_logger = get_streaming_logger(log_dir=str(log_dir))
+        streaming_logger.log_connect()
+        _flush_streaming_logger()
+
+        log_files = list((log_dir / "streaming").glob("*_streaming_*.log.json"))
+        assert len(log_files) == 1
+    finally:
+        for h in inner.handlers[:]:
+            h.close()
+            inner.removeHandler(h)
+        for listener in core.logger._active_listeners[:]:
+            listener.stop()
+        core.logger._active_listeners.clear()
+
+
 def test_log_connect_writes_json(streaming_logger_setup):
     streaming_logger, streaming_log_dir = streaming_logger_setup
 

--- a/tests/unit_test/core/loggers/test_streaming_event_logger.py
+++ b/tests/unit_test/core/loggers/test_streaming_event_logger.py
@@ -55,7 +55,8 @@ def test_get_streaming_logger_creates_file(streaming_logger_setup):
 
     inner = logging.getLogger("streaming_event")
     assert not inner.propagate
-    assert len(inner.handlers) == 1
+    app_handlers = [h for h in inner.handlers if isinstance(h, core.logger.DictPreservingQueueHandler)]
+    assert len(app_handlers) == 1
     
     handler = None
     for listener in core.logger._active_listeners:

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -336,6 +336,22 @@ async def test_get_overseas_stock_price_calls_service(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_overseas_stock_price_timeout(web_client, mock_web_ctx):
+    """GET /api/overseas/stock/{symbol}은 타임아웃 시 에러 응답을 반환한다."""
+    import asyncio
+
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    mock_web_ctx.stock_query_service.get_overseas_price.side_effect = asyncio.TimeoutError()
+
+    response = web_client.get("/api/overseas/stock/AAPL?exchange=NASD")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "1"
+    assert "초과" in json_resp["msg1"]
+
+
+@pytest.mark.asyncio
 async def test_get_overseas_stock_chart_calls_service(web_client, mock_web_ctx):
     """GET /api/overseas/chart/{symbol}은 해외 일봉 조회 서비스를 호출한다."""
     mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
@@ -354,6 +370,22 @@ async def test_get_overseas_stock_chart_calls_service(web_client, mock_web_ctx):
         start_date="",
         end_date="",
     )
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_stock_chart_timeout(web_client, mock_web_ctx):
+    """GET /api/overseas/chart/{symbol}은 타임아웃 시 에러 응답을 반환한다."""
+    import asyncio
+
+    mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    mock_web_ctx.stock_query_service.get_overseas_dailyprice.side_effect = asyncio.TimeoutError()
+
+    response = web_client.get("/api/overseas/chart/AAPL?exchange=NASD")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "1"
+    assert "초과" in json_resp["msg1"]
 
 
 @pytest.mark.asyncio

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -228,7 +228,14 @@ async def get_overseas_stock_price(symbol: str, exchange: str = Query("NASD")):
         exchange_enum = OverseasExchange(exchange.upper())
     except ValueError:
         raise HTTPException(status_code=400, detail="exchange는 NASD, NYSE, AMEX 중 하나여야 합니다.")
-    resp = await ctx.stock_query_service.get_overseas_price(symbol, exchange=exchange_enum)
+    try:
+        resp = await asyncio.wait_for(
+            ctx.stock_query_service.get_overseas_price(symbol, exchange=exchange_enum),
+            timeout=10.0,
+        )
+    except asyncio.TimeoutError:
+        ctx.logger.warning(f"[stock] 해외 현재가 조회 타임아웃 ({symbol}, 10s 초과)")
+        return {"rt_cd": "1", "msg1": "해외주식 API 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.", "data": None}
     return _serialize_response(resp)
 
 
@@ -247,13 +254,20 @@ async def get_overseas_stock_chart(
         exchange_enum = OverseasExchange(exchange.upper())
     except ValueError:
         raise HTTPException(status_code=400, detail="exchange는 NASD, NYSE, AMEX 중 하나여야 합니다.")
-    resp = await ctx.stock_query_service.get_overseas_dailyprice(
-        symbol,
-        exchange=exchange_enum,
-        start_date=start_date,
-        end_date=end_date,
-        period=period,
-    )
+    try:
+        resp = await asyncio.wait_for(
+            ctx.stock_query_service.get_overseas_dailyprice(
+                symbol,
+                exchange=exchange_enum,
+                start_date=start_date,
+                end_date=end_date,
+                period=period,
+            ),
+            timeout=12.0,
+        )
+    except asyncio.TimeoutError:
+        ctx.logger.warning(f"[stock] 해외 차트 조회 타임아웃 ({symbol}, 12s 초과)")
+        return {"rt_cd": "1", "msg1": "해외주식 차트 API 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.", "data": None}
     return _serialize_response(resp)
 
 

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -109,6 +109,156 @@ async function loadAndRenderStockChart(code) {
     }
 }
 
+function _ensureChartControls() {
+    const controlsArea = document.getElementById('chart-controls-area');
+    if (document.getElementById('chart-controls')) return;
+
+    const controls = document.createElement('div');
+    controls.id = 'chart-controls';
+    controls.className = 'chart-controls';
+    controls.innerHTML = `
+        <button class="btn-xs active" onclick="changeChartPeriod('3M', this)">3개월</button>
+        <button class="btn-xs" onclick="changeChartPeriod('6M', this)">6개월</button>
+        <button class="btn-xs" onclick="changeChartPeriod('1Y', this)">1년</button>
+    `;
+    if (controlsArea) {
+        controlsArea.appendChild(controls);
+    } else {
+        const canvas = document.getElementById('stockChart');
+        if (canvas) canvas.parentNode.insertBefore(controls, canvas);
+    }
+
+    if (!document.getElementById('chart-btn-style')) {
+        const style = document.createElement('style');
+        style.id = 'chart-btn-style';
+        style.innerHTML = `
+            .btn-xs { padding: 4px 8px; font-size: 12px; margin-left: 4px; background: var(--bg-primary); border: 1px solid var(--border); color: var(--text-secondary); border-radius: 4px; cursor: pointer; }
+            .btn-xs.active { background: var(--accent); color: white; border-color: var(--accent); }
+            .btn-xs:hover { background: var(--bg-card); }
+        `;
+        document.head.appendChild(style);
+    }
+}
+
+function _toChartNumber(value) {
+    const n = Number(String(value ?? '').replace(/,/g, ''));
+    return Number.isFinite(n) ? n : 0;
+}
+
+function _readOverseasChartRows(data) {
+    if (Array.isArray(data)) return data;
+    if (data && Array.isArray(data.output2)) return data.output2;
+    return [];
+}
+
+function _overseasRowDate(row) {
+    return String(row.date || row.xymd || row.stck_bsop_date || '').replace(/-/g, '');
+}
+
+function _normalizeOverseasOhlcv(rows) {
+    return rows
+        .map((row) => {
+            const date = _overseasRowDate(row);
+            const close = _toChartNumber(row.close || row.clos || row.clpr || row.ovrs_nmix_prpr);
+            const open = _toChartNumber(row.open || row.open_pric || row.ovrs_nmix_oprc || row.ovrs_nmix_prdy_vrss);
+            const high = _toChartNumber(row.high || row.high_pric || row.ovrs_nmix_hgpr);
+            const low = _toChartNumber(row.low || row.low_pric || row.ovrs_nmix_lwpr);
+            return {
+                date,
+                open: open || close,
+                high: high || close,
+                low: low || close,
+                close,
+                volume: _toChartNumber(row.volume || row.tvol || row.acml_vol),
+            };
+        })
+        .filter((row) => row.date && row.close > 0)
+        .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function _movingAverageRows(rows, period) {
+    return rows.map((row, idx) => {
+        if (idx + 1 < period) return null;
+        let sum = 0;
+        for (let i = idx - period + 1; i <= idx; i++) sum += rows[i].close;
+        return { date: row.date, ma: sum / period };
+    });
+}
+
+function _volumeMovingAverageRows(rows, period) {
+    return rows.map((row, idx) => {
+        if (idx + 1 < period) return null;
+        let sum = 0;
+        for (let i = idx - period + 1; i <= idx; i++) sum += rows[i].volume;
+        return { date: row.date, ma: sum / period };
+    });
+}
+
+function _bollingerRows(rows, period = 20, multiplier = 2) {
+    return rows.map((row, idx) => {
+        if (idx + 1 < period) return null;
+        const values = rows.slice(idx - period + 1, idx + 1).map((r) => r.close);
+        const mean = values.reduce((acc, v) => acc + v, 0) / period;
+        const variance = values.reduce((acc, v) => acc + Math.pow(v - mean, 2), 0) / period;
+        const std = Math.sqrt(variance);
+        return {
+            date: row.date,
+            upper: mean + std * multiplier,
+            middle: mean,
+            lower: mean - std * multiplier,
+        };
+    });
+}
+
+function _buildOverseasIndicators(rows) {
+    return {
+        ma5: _movingAverageRows(rows, 5),
+        ma10: _movingAverageRows(rows, 10),
+        ma20: _movingAverageRows(rows, 20),
+        ma50: _movingAverageRows(rows, 50),
+        ma60: _movingAverageRows(rows, 60),
+        ma120: _movingAverageRows(rows, 120),
+        ma150: _movingAverageRows(rows, 150),
+        ma200: _movingAverageRows(rows, 200),
+        bb: _bollingerRows(rows),
+        vol_ma5: _volumeMovingAverageRows(rows, 5),
+        vol_ma20: _volumeMovingAverageRows(rows, 20),
+        vol_ma60: _volumeMovingAverageRows(rows, 60),
+    };
+}
+
+async function loadAndRenderOverseasStockChart(symbol, exchange) {
+    const chartCard = document.getElementById('stock-chart-card');
+    if (!chartCard) return;
+    _ensureChartControls();
+
+    try {
+        const res = await fetchWithTimeout(
+            `/api/overseas/chart/${encodeURIComponent(symbol)}?exchange=${exchange}&period=D`,
+            {},
+            12000
+        );
+        const json = await res.json();
+        const rows = _normalizeOverseasOhlcv(_readOverseasChartRows(json.data));
+        if (!res.ok || json.rt_cd !== "0" || rows.length === 0) {
+            chartCard.style.display = 'none';
+            return;
+        }
+
+        const formatYYYYMMDD = (str) => str.substring(0, 4) + '-' + str.substring(4, 6) + '-' + str.substring(6, 8);
+        rows.forEach(d => { d.formattedDate = formatYYYYMMDD(d.date); });
+        g_chartRawData = rows;
+        g_chartIndicators = _buildOverseasIndicators(rows);
+        g_chartCode = symbol;
+
+        chartCard.style.display = 'block';
+        renderStockChart('3M');
+    } catch (e) {
+        console.error("Overseas chart rendering failed:", e);
+        chartCard.style.display = 'none';
+    }
+}
+
 function changeChartPeriod(period, btn) {
     if (btn) {
         document.querySelectorAll('#chart-controls .btn-xs').forEach(b => b.classList.remove('active'));
@@ -186,6 +336,7 @@ function renderStockChart(period) {
     // [최적화 3] 고가/저가 레이블 문자열을 플러그인 외부에서 1회 생성
     const highLabel = `${highestPrice.toLocaleString()} (${labels[highIdx]}) ${highPct > 0 ? '+' : ''}${highPct}%`;
     const lowLabel  = `${lowestPrice.toLocaleString()} (${labels[lowIdx]}) ${lowPct > 0 ? '+' : ''}${lowPct}%`;
+    const compactPoints = (points) => points.filter(Boolean);
 
     const highLowPlugin = {
         id: 'highLowMarker',
@@ -263,21 +414,21 @@ function renderStockChart(period) {
                     borderColors: { up: '#ff0000', down: '#0000ff', unchanged: '#777777' },
                     order: 1
                 },
-                { label: 'MA5', data: ma5, type: 'line', borderColor: '#ff6b6b', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'MA10', data: ma10, type: 'line', borderColor: '#51cf66', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 }, // [추가] Green
-                { label: 'MA20', data: ma20, type: 'line', borderColor: '#feca57', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'MA50', data: ma50, type: 'line', borderColor: '#ff8a00', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'MA60', data: ma60, type: 'line', borderColor: '#54a0ff', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'MA120', data: ma120, type: 'line', borderColor: '#a29bfe', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 }, // [추가] 보라색 계열
-                { label: 'MA150', data: ma150, type: 'line', borderColor: '#6f42c1', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'MA200', data: ma200, type: 'line', borderColor: '#2ecc71', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
-                { label: 'BB Upper', data: bbUpper, type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: false, order: 3 },
-                { label: 'BB Lower', data: bbLower, type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: '-1', backgroundColor: 'rgba(200,200,200,0.1)', order: 3 },
-                { label: 'BB Middle', data: bbMiddle, type: 'line', borderColor: 'rgba(255, 215, 0, 0.8)', borderWidth: 1.5, borderDash: [3, 3], pointRadius: 0, yAxisID: 'y', fill: false, order: 3, hidden: true }, // [수정] MA20과 중복되므로 기본 숨김
+                { label: 'MA5', data: compactPoints(ma5), type: 'line', borderColor: '#ff6b6b', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'MA10', data: compactPoints(ma10), type: 'line', borderColor: '#51cf66', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 }, // [추가] Green
+                { label: 'MA20', data: compactPoints(ma20), type: 'line', borderColor: '#feca57', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'MA50', data: compactPoints(ma50), type: 'line', borderColor: '#ff8a00', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'MA60', data: compactPoints(ma60), type: 'line', borderColor: '#54a0ff', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'MA120', data: compactPoints(ma120), type: 'line', borderColor: '#a29bfe', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 }, // [추가] 보라색 계열
+                { label: 'MA150', data: compactPoints(ma150), type: 'line', borderColor: '#6f42c1', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'MA200', data: compactPoints(ma200), type: 'line', borderColor: '#2ecc71', borderWidth: 1, pointRadius: 0, yAxisID: 'y', order: 2 },
+                { label: 'BB Upper', data: compactPoints(bbUpper), type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: false, order: 3 },
+                { label: 'BB Lower', data: compactPoints(bbLower), type: 'line', borderColor: 'rgba(78, 76, 76, 0.8)', borderWidth: 3, pointRadius: 0, yAxisID: 'y', fill: '-1', backgroundColor: 'rgba(200,200,200,0.1)', order: 3 },
+                { label: 'BB Middle', data: compactPoints(bbMiddle), type: 'line', borderColor: 'rgba(255, 215, 0, 0.8)', borderWidth: 1.5, borderDash: [3, 3], pointRadius: 0, yAxisID: 'y', fill: false, order: 3, hidden: true }, // [수정] MA20과 중복되므로 기본 숨김
                 { label: '거래량', data: volumes, type: 'bar', yAxisID: 'y1', backgroundColor: volumeColors, order: 4 },
-                { label: 'Vol MA5',  data: volMa5,  type: 'line', borderColor: '#ff6b6b', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
-                { label: 'Vol MA20', data: volMa20, type: 'line', borderColor: '#feca57', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
-                { label: 'Vol MA60', data: volMa60, type: 'line', borderColor: '#54a0ff', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 }
+                { label: 'Vol MA5',  data: compactPoints(volMa5),  type: 'line', borderColor: '#ff6b6b', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
+                { label: 'Vol MA20', data: compactPoints(volMa20), type: 'line', borderColor: '#feca57', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 },
+                { label: 'Vol MA60', data: compactPoints(volMa60), type: 'line', borderColor: '#54a0ff', borderWidth: 1, pointRadius: 0, yAxisID: 'y1', order: 5 }
             ]
         },
         options: {

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -76,6 +76,18 @@ async function _ensureOverseasEnabledForStock() {
     }
 }
 
+function _overseasExchangeLabel(exchange) {
+    return ({ NASD: 'NASDAQ', NYSE: 'NYSE', AMEX: 'AMEX' })[exchange] || exchange || '-';
+}
+
+function _formatOverseasTimestamp(value) {
+    const text = String(value || '').trim();
+    if (/^\d{8}$/.test(text)) {
+        return `${text.substring(0, 4)}-${text.substring(4, 6)}-${text.substring(6, 8)}`;
+    }
+    return text || '-';
+}
+
 async function searchOverseasStock() {
     const symbolInput = document.getElementById('overseas-stock-symbol');
     const exchangeSel = document.getElementById('overseas-stock-exchange');
@@ -89,7 +101,10 @@ async function searchOverseasStock() {
     if (symbolInput) symbolInput.value = symbol;
     if (!resultDiv) return;
 
-    // 해외 모드는 국내 전용 차트 카드를 미표시. 결과를 덮어쓰기 전에 먼저 대피시킨다.
+    // 해외 모드는 국내 실시간 구독을 끊고 차트 카드를 대피시킨 뒤 다시 배치한다.
+    if (typeof unsubscribeRealtimePrice === 'function') {
+        unsubscribeRealtimePrice();
+    }
     _detachStockChartCard();
 
     showLoading(resultDiv, '해외 종목 조회 중...');
@@ -108,6 +123,7 @@ async function searchOverseasStock() {
         const data = json.data || {};
         const rate = Number(data.change_rate || 0);
         const rateClass = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
+        const exchangeLabel = _overseasExchangeLabel(data.exchange || exchange);
         const usd = (v) => {
             const n = Number(v);
             return Number.isFinite(n) ? '$' + n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
@@ -117,14 +133,46 @@ async function searchOverseasStock() {
             return Number.isFinite(n) ? n.toLocaleString() : '-';
         };
         resultDiv.innerHTML = `
-            <div class="card stock-info-box">
-                <h3 style="margin:0;">${data.symbol || symbol} <span style="color:#aaa;font-size:0.85rem;">${data.exchange || exchange} ${data.currency || 'USD'}</span></h3>
+            <div class="card stock-info-box" style="position: relative;">
+                <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
+                    <h3 class="stock-title" style="margin:0;">
+                        ${data.symbol || symbol}
+                        <span style="color:#aaa;font-size:0.85rem;">${exchangeLabel} ${data.currency || 'USD'}</span>
+                    </h3>
+                    <span class="badge" style="background:var(--bg-primary,#f5f5f5); border:1px solid var(--border,#ccc); border-radius:8px; padding:8px 10px; font-weight:bold;">
+                        해외
+                    </span>
+                </div>
                 <p class="price ${rateClass}">${usd(data.price)}</p>
                 <p class="change-rate">등락률: <span class="${rateClass}">${Number.isFinite(rate) ? (rate > 0 ? '+' : '') + rate.toFixed(2) + '%' : '-'}</span></p>
-                <p>거래량: ${num(data.volume)}</p>
-                <p>시각: ${data.timestamp || '-'}</p>
+                <div id="chart-placeholder" style="margin: 16px 0;"></div>
+                <div class="stock-details">
+                    <div class="detail-group">
+                        <h4>기본 정보</h4>
+                        <p><strong>거래소:</strong> <span>${exchangeLabel}</span></p>
+                        <p><strong>통화:</strong> <span>${data.currency || 'USD'}</span></p>
+                    </div>
+                    <div class="detail-group">
+                        <h4>시세</h4>
+                        <p><strong>현재가:</strong> <span>${usd(data.price)}</span></p>
+                        <p><strong>등락률:</strong> <span class="${rateClass}">${Number.isFinite(rate) ? (rate > 0 ? '+' : '') + rate.toFixed(2) + '%' : '-'}</span></p>
+                    </div>
+                    <div class="detail-group">
+                        <h4>거래</h4>
+                        <p><strong>거래량:</strong> <span>${num(data.volume)}</span></p>
+                        <p><strong>시각:</strong> <span>${_formatOverseasTimestamp(data.timestamp)}</span></p>
+                    </div>
+                </div>
             </div>
         `;
+        const chartCard = document.getElementById('stock-chart-card');
+        const placeholder = document.getElementById('chart-placeholder');
+        if (chartCard && placeholder) {
+            placeholder.appendChild(chartCard);
+        }
+        if (typeof loadAndRenderOverseasStockChart === 'function') {
+            loadAndRenderOverseasStockChart(data.symbol || symbol, data.exchange || exchange);
+        }
     } catch (e) {
         if (e.name === 'AbortError') {
             resultDiv.innerHTML = `<p class="error">요청 시간이 초과되었습니다. 다시 시도해주세요.</p>`;

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -114,7 +114,7 @@ async function searchOverseasStock() {
             resultDiv.innerHTML = '<p class="error">해외주식 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.</p>';
             return;
         }
-        const res = await fetchWithTimeout(`/api/overseas/stock/${encodeURIComponent(symbol)}?exchange=${exchange}`, {}, 12000);
+        const res = await fetchWithTimeout(`/api/overseas/stock/${encodeURIComponent(symbol)}?exchange=${exchange}`, {}, 20000);
         const json = await res.json();
         if (!res.ok || json.rt_cd !== '0') {
             resultDiv.innerHTML = `<p class="error">조회 실패: ${json.msg1 || res.status}</p>`;
@@ -175,7 +175,7 @@ async function searchOverseasStock() {
         }
     } catch (e) {
         if (e.name === 'AbortError') {
-            resultDiv.innerHTML = `<p class="error">요청 시간이 초과되었습니다. 다시 시도해주세요.</p>`;
+            resultDiv.innerHTML = `<p class="error">해외주식 조회 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.</p>`;
         } else {
             resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
         }

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -70,7 +70,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/stock.js?v=11"></script>
+<script src="/static/js/stock.js?v=12"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/candle_chart.js?v=2"></script>
+<script src="/static/js/candle_chart.js?v=4"></script>
 <script>
     // 종목 리스트: localStorage에서 즉시 복원, 없으면 API 로드 후 저장
     var ALL_STOCKS = (function() {
@@ -70,7 +70,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/stock.js?v=10"></script>
+<script src="/static/js/stock.js?v=11"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
﻿## Summary
- Improve the /stock overseas quote card so exchange codes render as user-facing labels and the card uses the richer stock info layout.
- Wire overseas quote success to the shared candlestick chart card by normalizing overseas daily-price output into OHLCV and derived MA/BB/volume indicators.
- Default overseas daily-price BYMD when omitted so KIS returns period rows instead of an empty/current-price-shaped response.

## Validation
- node tests/frontend/run_stock_dom_tests.mjs
- node tests/frontend/run_overseas_dom_tests.mjs
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_test -v

## Notes
Browser verification found the Chart.js sparse-line-data issue and the missing BYMD issue; both were fixed before the final full test run. A live browser re-check was blocked by the local web startup path repeatedly hitting KIS token/holiday-call retry loops before opening port 8000.
