### PR TITLE
[codex] Fix real-auth token refresh during web startup

### DIFF
--- a/brokers/korea_investment/korea_invest_api_base.py
+++ b/brokers/korea_investment/korea_invest_api_base.py
@@ -243,13 +243,20 @@ class KoreaInvestApiBase:
             if isinstance(res_json, dict) and res_json.get("msg_cd") == "EGW00123" and not token_refreshed:
                 self._logger.warning("🔁 토큰 만료 감지 (EGW00123). 재발급 후 1회 재시도")
                 await self.market_clock.async_sleep(3)
-                await self._env.refresh_token()
+                if self._use_real_auth:
+                    await self._env.refresh_real_token()
+                else:
+                    await self._env.refresh_token()
                 token_refreshed = True  # ✅ 재시도 플래그 설정
 
                 # ✅ 강제 delay 삽입
 
                 # ✅ 반드시 새로 가져온 토큰으로 Authorization 헤더 재세팅
-                new_token = await self._env.get_access_token()
+                new_token = (
+                    await self._env.get_real_access_token()
+                    if self._use_real_auth
+                    else await self._env.get_access_token()
+                )
                 self._headers.set_auth_bearer(new_token)  # ✅ 메서드 사용
                 self._logger.debug(f"✅ 재발급 후 토큰 적용 확인: {new_token[:40]}...")
 
@@ -293,7 +300,10 @@ class KoreaInvestApiBase:
         # 4. 토큰 만료 오류 처리 (API 응답 내용 기반)
         if response_json.get('msg_cd') == 'EGW00123':
             self._logger.error("최종 토큰 만료 오류(EGW00123) 감지.")
-            self._env.invalidate_token()
+            if self._use_real_auth:
+                self._env.invalidate_real_token()
+            else:
+                self._env.invalidate_token()
             raise ApiRetryError("Token expired")
 
         if not expect_standard_schema:

--- a/brokers/korea_investment/korea_invest_env.py
+++ b/brokers/korea_investment/korea_invest_env.py
@@ -153,12 +153,27 @@ class KoreaInvestApiEnv:
         if self._token_provider:
             self._token_provider.invalidate_token()
 
+    def invalidate_real_token(self):
+        """조회 API용 실전 토큰을 무효화합니다."""
+        if self._token_provider_real:
+            self._token_provider_real.invalidate_token()
+
     async def refresh_token(self):
         if self._token_provider:
             await self._token_provider.refresh_token(
                 base_url=self.active_config['base_url'],
                 app_key=self.active_config['api_key'],
                 app_secret=self.active_config['api_secret_key']
+            )
+
+    async def refresh_real_token(self):
+        """조회 API용 실전 토큰을 강제로 재발급합니다."""
+        real_cfg = self.get_real_config()
+        if self._token_provider_real:
+            await self._token_provider_real.refresh_token(
+                base_url=real_cfg['base_url'],
+                app_key=real_cfg['api_key'],
+                app_secret=real_cfg['api_secret_key']
             )
 
     def get_base_url(self):

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def run_web():
     host = configs.web.host
     port = configs.web.port
 
-    def _wait_for_port(timeout: float = 10.0) -> bool:
+    def _wait_for_port(timeout: float = 60.0) -> bool:
         import socket, time
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
@@ -177,6 +177,34 @@ class TestKoreaInvestApiBase(unittest.IsolatedAsyncioTestCase):
         # 총 2번의 post 요청이 있었는지 확인
         self.assertEqual(self.api_base._async_session.post.await_count, 2)
 
+    async def test_execute_request_refreshes_real_token_when_real_auth_enabled(self):
+        """
+        TC: 조회 API(_use_real_auth=True)에서 EGW00123 응답 시 실전 토큰을 재발급해야 한다.
+        """
+        self.api_base._use_real_auth = True
+        self.mock_env.get_real_config.return_value = {
+            "api_key": "real_key",
+            "api_secret_key": "real_secret",
+        }
+        self.mock_env.get_real_access_token = AsyncMock(side_effect=["old_real", "new_real", "new_real"])
+        self.mock_env.refresh_real_token = AsyncMock()
+        self.mock_env.refresh_token = AsyncMock()
+
+        resp1 = MagicMock(spec=httpx.Response)
+        resp1.json.return_value = {"msg_cd": "EGW00123", "rt_cd": "1"}
+
+        resp2 = MagicMock(spec=httpx.Response)
+        resp2.json.return_value = {"rt_cd": "0", "msg_cd": "MCA00000"}
+
+        self.api_base._async_session.get = AsyncMock(side_effect=[resp1, resp2])
+
+        response = await self.api_base._execute_request("GET", "http://test-url", None, None)
+
+        self.mock_env.refresh_real_token.assert_awaited_once()
+        self.mock_env.refresh_token.assert_not_awaited()
+        self.assertEqual(response, resp2)
+        self.assertEqual(self.api_base._async_session.get.await_count, 2)
+
     async def test_call_api_custom_retry_delay(self):
         """
         TC: ApiRetryError에 delay가 설정된 경우 해당 시간만큼 대기하는지 검증
@@ -214,6 +242,25 @@ class TestKoreaInvestApiBase(unittest.IsolatedAsyncioTestCase):
 
         # Assert
         self.assertEqual(result, {"some_key": "some_value"})
+
+    async def test_handle_response_invalidates_real_token_when_real_auth_enabled(self):
+        """
+        TC: 조회 API(_use_real_auth=True)의 최종 EGW00123 응답은 실전 토큰을 무효화한다.
+        """
+        self.api_base._use_real_auth = True
+        self.mock_env.invalidate_real_token = MagicMock()
+        self.mock_env.invalidate_token = MagicMock()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rt_cd": "1", "msg_cd": "EGW00123"}
+        mock_response.raise_for_status.return_value = None
+
+        with self.assertRaises(ApiRetryError):
+            await self.api_base._handle_response(mock_response)
+
+        self.mock_env.invalidate_real_token.assert_called_once()
+        self.mock_env.invalidate_token.assert_not_called()
 
     async def test_execute_request_missing_token(self):
         """

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_env.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_env.py
@@ -338,6 +338,21 @@ class TestKoreaInvestApiEnv(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_kwargs['app_key'], self.mock_config_data['api_key'])
         self.assertEqual(call_kwargs['app_secret'], self.mock_config_data['api_secret_key'])
 
+    async def test_refresh_real_token_delegates_to_real_provider(self):
+        """
+        TC: 모의투자 모드에서도 조회 API용 실전 토큰 갱신은 real provider로 위임한다.
+        """
+        self.env.set_trading_mode(True)
+        self.env._token_provider_real = AsyncMock()
+
+        await self.env.refresh_real_token()
+
+        self.env._token_provider_real.refresh_token.assert_awaited_once()
+        call_kwargs = self.env._token_provider_real.refresh_token.call_args.kwargs
+        self.assertEqual(call_kwargs['base_url'], self.mock_config_data['url'])
+        self.assertEqual(call_kwargs['app_key'], self.mock_config_data['api_key'])
+        self.assertEqual(call_kwargs['app_secret'], self.mock_config_data['api_secret_key'])
+
     async def test_refresh_token_no_provider(self):
         """
         TC: TokenProvider가 없을 때 refresh_token 호출 시 에러 없이 넘어가는지 검증


### PR DESCRIPTION
﻿## What changed
- Refresh and invalidate the real-auth token when `_use_real_auth=True` receives EGW00123.
- Keep paper/active token refresh behavior unchanged for normal trading API calls.
- Increase the web auto-open port wait from 10s to 60s to avoid false startup timeout reports during slower app initialization.
- Add unit coverage for real token refresh/invalidation delegation.

## Why
Web startup can initialize real-query services even while paper trading is active. When the real-query API returned EGW00123, the retry path refreshed the active paper token instead of the real query token, leaving startup stuck retrying with the wrong credential path.

## Validation
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v` -> 6011 passed
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v` -> 242 passed
