### PR TITLE
feat(web): /stock 해외 종목 조회 자동완성 추가 (FDR 전체 상장목록 + 거래소 자동설정)

### DIFF
--- a/repositories/overseas_stock_code_repository.py
+++ b/repositories/overseas_stock_code_repository.py
@@ -1,0 +1,130 @@
+# repositories/overseas_stock_code_repository.py
+
+import os
+import sqlite3
+import pandas as pd
+from services.overseas_stock_sync_service import save_overseas_stock_code_list
+
+TABLE_NAME = "overseas_stocks"
+
+
+def _write_minimal_db(db_path: str, logger=None):
+    """빈/손상된 DB 대신 최소 유효 DB를 써서 앱이 시작되도록 합니다."""
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+        conn.execute(
+            f"CREATE TABLE {TABLE_NAME} (심볼 TEXT, 종목명 TEXT, 거래소 TEXT)"
+        )
+        conn.execute(
+            f"INSERT INTO {TABLE_NAME} VALUES (?, ?, ?)",
+            ("(NONE)", "(종목목록 없음)", "NASD"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    if logger:
+        logger.warning(f"해외 종목코드 DB가 비어 있어 최소 파일로 생성했습니다: {db_path}")
+
+
+class OverseasStockCodeRepository:
+    """
+    해외(미국) 심볼 ↔ 종목명/거래소 조회를 제공하는 SQLite 기반 유틸리티 클래스.
+    국내 StockCodeRepository와 동일한 생성/복구 패턴을 따른다.
+    """
+
+    def __init__(self, db_path=None, logger=None):
+        self.logger = logger
+        if db_path is None:
+            root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+            db_path = os.path.join(root, "data", "overseas_stock_code_list.db")
+        self._db_path = db_path
+
+        if not os.path.exists(db_path):
+            if self.logger:
+                self.logger.info(f"🔍 해외 종목코드 DB 파일 없음. 생성 시작: {db_path}")
+            try:
+                save_overseas_stock_code_list(force_update=True)
+                if self.logger:
+                    self.logger.info("✅ 해외 종목코드 DB 파일 생성 완료.")
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"❌ 해외 종목코드 DB 파일 생성 실패: {e}")
+                raise e
+
+        self._load_data()
+
+    def _load_data(self):
+        try:
+            self.df = self._read_df()
+            if self.df.empty or len(self.df.columns) == 0 or (
+                len(self.df) == 1 and self.df.iloc[0]["심볼"] == "(NONE)"
+            ):
+                raise ValueError("DB 테이블이 비어있거나 최소 DB 상태입니다.")
+            self._build_index()
+            if self.logger:
+                self.logger.info(f"🔄 해외 종목코드 DB 로드 완료: {self._db_path}")
+        except Exception as e:
+            if self.logger:
+                self.logger.warning(f"⚠️ 해외 종목코드 DB 갱신/복구 시도 중 (사유: {e})")
+            try:
+                if os.path.exists(self._db_path):
+                    os.remove(self._db_path)
+            except Exception as remove_err:
+                if self.logger:
+                    self.logger.error(f"❌ 손상된 해외 DB 파일 삭제 실패: {remove_err}")
+            try:
+                save_overseas_stock_code_list(force_update=True)
+                self.df = self._read_df()
+                if self.df.empty or len(self.df.columns) == 0 or (
+                    len(self.df) == 1 and self.df.iloc[0]["심볼"] == "(NONE)"
+                ):
+                    raise ValueError("DB 테이블이 비어있거나 최소 DB 상태입니다.")
+                self._build_index()
+                if self.logger:
+                    self.logger.info(f"🔄 해외 종목코드 DB 로드 완료: {self._db_path}")
+            except Exception:
+                if self.logger:
+                    self.logger.warning("해외 종목 갱신 실패. 최소 DB로 앱을 시작합니다.")
+                _write_minimal_db(self._db_path, self.logger)
+                self.df = self._read_df()
+                self._build_index()
+
+    def _read_df(self):
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            return pd.read_sql(f"SELECT * FROM {TABLE_NAME}", conn, dtype={"심볼": str})
+        finally:
+            conn.close()
+
+    def _build_index(self):
+        self.symbol_to_meta = {
+            str(row["심볼"]): {"name": row["종목명"], "exchange": row["거래소"]}
+            for _, row in self.df.iterrows()
+        }
+
+    def all_symbols(self) -> list:
+        """전 심볼 리스트 반환 (클라이언트 자동완성용)."""
+        return [
+            {"s": symbol, "n": meta["name"], "e": meta["exchange"]}
+            for symbol, meta in self.symbol_to_meta.items()
+        ]
+
+    def search(self, keyword: str, limit: int = 20) -> list:
+        """심볼 prefix(대소문자 무시) 또는 종목명 부분 일치 검색."""
+        kw = keyword.strip()
+        if not kw:
+            return []
+        kw_upper = kw.upper()
+        kw_lower = kw.lower()
+        results = []
+        for symbol, meta in self.symbol_to_meta.items():
+            name = meta["name"] or ""
+            if symbol.upper().startswith(kw_upper) or kw_lower in name.lower():
+                results.append({"s": symbol, "n": name, "e": meta["exchange"]})
+                if len(results) >= limit:
+                    break
+        return results

--- a/services/overseas_stock_sync_service.py
+++ b/services/overseas_stock_sync_service.py
@@ -1,0 +1,96 @@
+# services/overseas_stock_sync_service.py
+#
+# 해외(미국) 종목 심볼 목록 동기화 서비스.
+# FinanceDataReader로 NASDAQ/NYSE/AMEX 상장목록을 받아 SQLite DB로 저장한다.
+# 국내용 stock_sync_service.py와 동일한 메타데이터/캐시 패턴을 따른다.
+
+import json
+import os
+import sqlite3
+from datetime import datetime
+import pandas as pd
+import FinanceDataReader as fdr
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DATA_DIR = os.path.join(ROOT_DIR, "data")
+DB_FILE_PATH = os.path.join(DATA_DIR, "overseas_stock_code_list.db")
+METADATA_PATH = os.path.join(DATA_DIR, "overseas_metadata.json")
+
+TABLE_NAME = "overseas_stocks"
+
+# FDR StockListing 시장명 → OverseasExchange enum 코드 매핑
+_MARKET_TO_EXCHANGE = {
+    "NASDAQ": "NASD",
+    "NYSE": "NYSE",
+    "AMEX": "AMEX",
+}
+
+
+def _save_metadata():
+    metadata = {"last_updated": datetime.today().strftime("%Y-%m-%d")}
+    with open(METADATA_PATH, "w", encoding="utf-8-sig") as f:
+        json.dump(metadata, f)
+
+
+def _load_metadata():
+    if not os.path.exists(METADATA_PATH):
+        return None
+    with open(METADATA_PATH, "r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+
+def _needs_update(max_age_days=7):
+    metadata = _load_metadata()
+    if not metadata:
+        return True
+    last_updated = datetime.strptime(metadata["last_updated"], "%Y-%m-%d")
+    return (datetime.today() - last_updated).days > max_age_days
+
+
+def save_overseas_stock_code_list(force_update=False):
+    """
+    해외(미국) 종목 심볼 리스트 저장 (SQLite + 메타데이터).
+    force_update=True일 경우 날짜와 무관하게 업데이트.
+    """
+    if not force_update and not _needs_update():
+        print("✅ 해외 종목: 최근 7일 이내에 이미 업데이트됨. 업데이트 생략.")
+        return
+
+    try:
+        print("🔄 FinanceDataReader를 통해 해외(NASDAQ/NYSE/AMEX) 종목 목록을 다운로드합니다...")
+        frames = []
+        for market, exchange in _MARKET_TO_EXCHANGE.items():
+            df_market = fdr.StockListing(market)[["Symbol", "Name"]].copy()
+            df_market["거래소"] = exchange
+            frames.append(df_market)
+
+        df = pd.concat(frames, ignore_index=True)
+        df = df.rename(columns={"Symbol": "심볼", "Name": "종목명"})
+        df = df[["심볼", "종목명", "거래소"]]
+        # 심볼 누락/중복 정리 (중복 시 첫 거래소 유지)
+        df = df.dropna(subset=["심볼"])
+        df = df.drop_duplicates(subset=["심볼"], keep="first")
+
+        os.makedirs(DATA_DIR, exist_ok=True)
+        conn = sqlite3.connect(DB_FILE_PATH)
+        try:
+            df.to_sql(TABLE_NAME, conn, if_exists="replace", index=False)
+            conn.execute(f"CREATE INDEX IF NOT EXISTS idx_overseas_symbol ON {TABLE_NAME}(심볼)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        _save_metadata()
+        print(f"🟢 {len(df)}개 해외 종목 저장 완료 (FDR 사용): {DB_FILE_PATH}")
+
+    except Exception as e:
+        print(f"❌ 해외 종목 데이터 업데이트 실패: {e}")
+        raise
+
+
+def load_overseas_stock_code_list():
+    conn = sqlite3.connect(DB_FILE_PATH)
+    try:
+        return pd.read_sql(f"SELECT * FROM {TABLE_NAME}", conn, dtype={"심볼": str})
+    finally:
+        conn.close()

--- a/tests/frontend/package.json
+++ b/tests/frontend/package.json
@@ -5,7 +5,7 @@
   "description": "jsdom regression harness for /stock screen JS (domestic regression guard for overseas features)",
   "type": "module",
   "scripts": {
-    "test": "node run_stock_dom_tests.mjs"
+    "test": "node run_stock_dom_tests.mjs && node run_overseas_dom_tests.mjs && node run_autocomplete_dom_tests.mjs"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/tests/frontend/run_autocomplete_dom_tests.mjs
+++ b/tests/frontend/run_autocomplete_dom_tests.mjs
@@ -1,0 +1,182 @@
+/*
+ * jsdom 기반 종목 자동완성(autocomplete.js + stock.js) 회귀 테스트.
+ *
+ * 목적:
+ *  1) autocomplete.js 일반화(valueKey/searchImpl/formatItem/item 전달)가 기존
+ *     국내 자동완성 동작을 깨지 않는지 행위로 검증.
+ *  2) 해외 심볼 자동완성: 심볼 prefix / 영문명 부분일치 매칭, 선택 시 거래소
+ *     드롭다운 자동설정 + 조회 트리거를 검증.
+ *
+ * 실행: node run_autocomplete_dom_tests.mjs  (exit 0 = 전부 통과)
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+const AUTOCOMPLETE_JS = resolve(import.meta.dirname, "../../view/web/static/js/autocomplete.js");
+const STOCK_JS = resolve(import.meta.dirname, "../../view/web/static/js/stock.js");
+
+const SCAFFOLD = `
+<div id="section-stock" class="section">
+  <div class="card">
+    <button id="stock-mode-domestic" class="exchange-btn active">국내</button>
+    <button id="stock-mode-overseas" class="exchange-btn">해외</button>
+    <div id="domestic-stock-row" style="position:relative;">
+      <input id="stock-code-input" type="text">
+      <ul id="stock-autocomplete-list"></ul>
+    </div>
+    <div id="overseas-stock-row" style="display:none; position:relative;">
+      <input id="overseas-stock-symbol" type="text">
+      <select id="overseas-stock-exchange">
+        <option value="NASD">NASDAQ</option>
+        <option value="NYSE">NYSE</option>
+        <option value="AMEX">AMEX</option>
+      </select>
+      <ul id="overseas-autocomplete-list"></ul>
+    </div>
+  </div>
+  <div id="stock-result"></div>
+  <div class="card" id="stock-chart-card" style="display:none;">
+    <div id="chart-controls-area"></div>
+    <canvas id="stockChart"></canvas>
+  </div>
+</div>
+`;
+
+async function makeWindow() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/stock",
+    runScripts: "dangerously",
+  });
+  const { window } = dom;
+  // stock.js 가 로드/실행 시점에 참조하는 전역 스텁
+  window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
+  window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
+  window.fetch = async () => ({ json: async () => ({ stocks: [] }) });
+  window.loadAndRenderStockChart = () => {};
+  window.loadAndRenderOverseasStockChart = () => {};
+  window.formatTradingValue = () => "";
+  window.alert = () => {};
+  window.ALL_STOCKS = [];
+
+  const a = window.document.createElement("script");
+  a.textContent = readFileSync(AUTOCOMPLETE_JS, "utf8");
+  window.document.body.appendChild(a);
+
+  const s = window.document.createElement("script");
+  s.textContent = readFileSync(STOCK_JS, "utf8");
+  window.document.body.appendChild(s);
+
+  // JSDOM 은 DOMContentLoaded 를 비동기로 발사하므로, 자동완성 init(_initDom)이
+  // 실행될 때까지 한 틱 대기한다.
+  await new Promise((r) => setTimeout(r, 0));
+  return window;
+}
+
+function typeInto(window, id, value) {
+  const el = window.document.getElementById(id);
+  el.value = value;
+  el.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("국내 자동완성: 종목명 입력 시 드롭다운 렌더 + 선택 시 searchStock(code) 호출", async () => {
+  const window = await makeWindow();
+  window.document.dispatchEvent(new window.CustomEvent("all-stocks-ready", {
+    detail: [{ c: "005930", n: "삼성전자" }, { c: "035720", n: "카카오" }],
+  }));
+  let called = null;
+  window.searchStock = (code) => { called = code; };
+
+  typeInto(window, "stock-code-input", "삼성");
+  const list = window.document.getElementById("stock-autocomplete-list");
+  assert(list.style.display === "block", "회귀: 국내 드롭다운이 표시되지 않음");
+  assert(list.querySelectorAll("li").length === 1, "회귀: 국내 검색 결과 수 불일치");
+  assert(list.querySelector("li").textContent === "삼성전자 (005930)", "회귀: 국내 표시 포맷 변경됨");
+
+  list.querySelector("li").click();
+  assert(called === "005930", "회귀: 국내 선택 시 searchStock(code) 미호출");
+});
+
+test("국내 자동완성: 숫자 입력 시 종목코드 prefix 매칭", async () => {
+  const window = await makeWindow();
+  window.document.dispatchEvent(new window.CustomEvent("all-stocks-ready", {
+    detail: [{ c: "005930", n: "삼성전자" }, { c: "035720", n: "카카오" }],
+  }));
+  typeInto(window, "stock-code-input", "0357");
+  const list = window.document.getElementById("stock-autocomplete-list");
+  assert(list.querySelectorAll("li").length === 1, "숫자 prefix 매칭 결과 수 불일치");
+  assert(list.querySelector("li").textContent.includes("카카오"), "숫자 prefix → 코드 매칭 실패");
+});
+
+test("해외 자동완성: 심볼 prefix 입력 시 드롭다운 렌더", async () => {
+  const window = await makeWindow();
+  window.document.dispatchEvent(new window.CustomEvent("all-overseas-stocks-ready", {
+    detail: [
+      { s: "AAPL", n: "Apple Inc", e: "NASD" },
+      { s: "LLY", n: "Eli Lilly and Co", e: "NYSE" },
+    ],
+  }));
+  typeInto(window, "overseas-stock-symbol", "AAP");
+  const list = window.document.getElementById("overseas-autocomplete-list");
+  assert(list.style.display === "block", "해외 드롭다운이 표시되지 않음");
+  assert(list.querySelectorAll("li").length === 1, "해외 심볼 prefix 결과 수 불일치");
+  assert(list.querySelector("li").textContent === "AAPL — Apple Inc (NASD)", "해외 표시 포맷 불일치");
+});
+
+test("해외 자동완성: 영문명 부분일치(대소문자 무시) 매칭", async () => {
+  const window = await makeWindow();
+  window.document.dispatchEvent(new window.CustomEvent("all-overseas-stocks-ready", {
+    detail: [
+      { s: "AAPL", n: "Apple Inc", e: "NASD" },
+      { s: "LLY", n: "Eli Lilly and Co", e: "NYSE" },
+    ],
+  }));
+  typeInto(window, "overseas-stock-symbol", "lilly");
+  const list = window.document.getElementById("overseas-autocomplete-list");
+  assert(list.querySelectorAll("li").length === 1, "영문명 부분일치 결과 수 불일치");
+  assert(list.querySelector("li").textContent.startsWith("LLY"), "영문명 매칭 실패");
+});
+
+test("해외 자동완성: 선택 시 거래소 드롭다운 자동설정 + searchOverseasStock 호출", async () => {
+  const window = await makeWindow();
+  window.document.dispatchEvent(new window.CustomEvent("all-overseas-stocks-ready", {
+    detail: [{ s: "LLY", n: "Eli Lilly and Co", e: "NYSE" }],
+  }));
+  let searched = false;
+  window.searchOverseasStock = () => { searched = true; };
+
+  typeInto(window, "overseas-stock-symbol", "LLY");
+  window.document.getElementById("overseas-autocomplete-list").querySelector("li").click();
+
+  assert(window.document.getElementById("overseas-stock-symbol").value === "LLY", "심볼 input 미설정");
+  assert(window.document.getElementById("overseas-stock-exchange").value === "NYSE",
+    "회귀: 선택한 심볼의 거래소로 드롭다운이 자동설정되지 않음");
+  assert(searched === true, "선택 후 searchOverseasStock 미호출");
+});
+
+test("해외 자동완성: 미선택 Enter 시 onConfirm(searchOverseasStock) 호출", async () => {
+  const window = await makeWindow();
+  let searched = false;
+  window.searchOverseasStock = () => { searched = true; };
+  const input = window.document.getElementById("overseas-stock-symbol");
+  input.value = "TSLA";
+  input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter" }));
+  assert(searched === true, "미선택 Enter 시 직접 입력 조회가 트리거되지 않음");
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -50,8 +50,10 @@ function makeWindow() {
   const { window } = dom;
   // stock.js 가 로드 시점에 호출/참조하는 전역 스텁
   window.StockAutocomplete = () => {};
+  window._overseasStockSearch = () => [];
   window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
   window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
+  window.fetch = async () => ({ json: async () => ({ stocks: [] }) });
   window.loadAndRenderStockChart = () => {};
   window.loadAndRenderOverseasStockChart = () => {};
   window.formatTradingValue = () => "";

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
@@ -157,3 +157,194 @@ async def test_place_overseas_order_blocks_market_order(overseas_api):
     assert resp.rt_cd == ErrorCode.ORDER_POLICY_BLOCKED.value
     assert "지정가" in resp.msg1
     overseas_api.call_api.assert_not_awaited()
+
+
+# --- 정적 헬퍼 ---
+
+def test_split_account_variants():
+    assert KoreaInvestOverseasStockApi._split_account("12345678-99") == ("12345678", "99")
+    # 대시 없음 / 잘못된 형식 → 기본 상품코드 "01"
+    assert KoreaInvestOverseasStockApi._split_account("12345678") == ("12345678", "01")
+    assert KoreaInvestOverseasStockApi._split_account("") == ("", "01")
+
+
+def test_as_exchange_from_string():
+    assert KoreaInvestOverseasStockApi._as_exchange("nasd") == OverseasExchange.NASD
+    assert KoreaInvestOverseasStockApi._as_exchange(OverseasExchange.NYSE) == OverseasExchange.NYSE
+
+
+def test_to_float_and_to_int_invalid_returns_default():
+    assert KoreaInvestOverseasStockApi._to_float("abc") == 0.0
+    assert KoreaInvestOverseasStockApi._to_float("abc", default=-1.0) == -1.0
+    assert KoreaInvestOverseasStockApi._to_float("1,234.5") == 1234.5
+    assert KoreaInvestOverseasStockApi._to_int("abc") == 0
+    assert KoreaInvestOverseasStockApi._to_int("abc", default=7) == 7
+    assert KoreaInvestOverseasStockApi._to_int("1,200") == 1200
+
+
+# --- 조회 응답 처리 ---
+
+@pytest.mark.asyncio
+async def test_get_overseas_price_returns_failure_response(overseas_api):
+    overseas_api.call_api = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="에러", data=None)
+    )
+    resp = await overseas_api.get_overseas_price("AAPL")
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_price_normalizes_output(overseas_api):
+    overseas_api.call_api = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data={"output": {"last": "150.5", "rate": "1.2", "tvol": "1000", "xymd": "20260512"}},
+        )
+    )
+    resp = await overseas_api.get_overseas_price("aapl", exchange="nasd")
+    summary = resp.data
+    assert summary.symbol == "AAPL"
+    assert summary.price == 150.5
+    assert summary.change_rate == 1.2
+    assert summary.volume == 1000
+    assert summary.timestamp == "20260512"
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_price_handles_non_dict_output(overseas_api):
+    overseas_api.call_api = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": "weird"}
+        )
+    )
+    resp = await overseas_api.get_overseas_price("AAPL")
+    assert resp.data.price == 0.0  # output 비-dict → 기본값
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_dailyprice_invalid_period(overseas_api):
+    resp = await overseas_api.get_overseas_dailyprice("AAPL", period="X")
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    overseas_api.call_api.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_balance_params(overseas_api):
+    await overseas_api.get_overseas_balance(exchange=OverseasExchange.NASD, currency="USD")
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_INQUIRE_BALANCE
+    params = overseas_api.call_api.await_args.kwargs["params"]
+    assert params["CANO"] == "12345678"
+    assert params["OVRS_EXCG_CD"] == "NASD"
+    assert params["TR_CRCY_CD"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_inquire_overseas_ccnl_params(overseas_api):
+    await overseas_api.inquire_overseas_ccnl(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        start_date="20260101",
+        end_date="20260131",
+    )
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_INQUIRE_CCNL
+    params = overseas_api.call_api.await_args.kwargs["params"]
+    assert params["PDNO"] == "AAPL"
+    assert params["ORD_STRT_DT"] == "20260101"
+    assert params["ORD_END_DT"] == "20260131"
+
+
+@pytest.mark.asyncio
+async def test_inquire_overseas_unfilled_params(overseas_api):
+    await overseas_api.inquire_overseas_unfilled(exchange=OverseasExchange.NYSE)
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_INQUIRE_NCCS
+    assert overseas_api.call_api.await_args.kwargs["params"]["OVRS_EXCG_CD"] == "NYSE"
+
+
+# --- 주문/취소 분기 ---
+
+@pytest.mark.asyncio
+async def test_place_order_invalid_side(overseas_api):
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="hold", qty=1, limit_price="10"
+    )
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    overseas_api.call_api.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_order_invalid_qty(overseas_api):
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="buy", qty=0, limit_price="10"
+    )
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    overseas_api.call_api.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_order_hashkey_failure(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value=None)
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="buy", qty=1, limit_price="10"
+    )
+    assert resp.rt_cd == ErrorCode.MISSING_KEY.value
+    overseas_api.call_api.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_order_returns_failure_response(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value="HASH")
+    overseas_api.call_api = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="거부", data=None)
+    )
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="sell", qty=1, limit_price="10"
+    )
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.asyncio
+async def test_place_order_builds_report_with_order_no(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value="HASH")
+    overseas_api.call_api = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {"ODNO": "0001234"}}
+        )
+    )
+    resp = await overseas_api.place_overseas_limit_order(
+        symbol="aapl", exchange=OverseasExchange.NASD, side="buy", qty=2, limit_price="150.25"
+    )
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data.broker_order_no == "0001234"
+    assert resp.data.symbol == "AAPL"
+    assert resp.data.qty == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_overseas_order_success(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value="HASH")
+    await overseas_api.cancel_overseas_order(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        original_order_no="0001234",
+        qty=1,
+        limit_price="150.0",
+    )
+    assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_ORDER_RVSECNCL
+    body = overseas_api.call_api.await_args.kwargs["data"]
+    assert body["ORGN_ODNO"] == "0001234"
+    assert body["RVSE_CNCL_DVSN_CD"] == "02"
+
+
+@pytest.mark.asyncio
+async def test_cancel_overseas_order_hashkey_failure(overseas_api):
+    overseas_api._get_hashkey = AsyncMock(return_value=None)
+    resp = await overseas_api.cancel_overseas_order(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        original_order_no="0001234",
+        qty=1,
+        limit_price="150.0",
+    )
+    assert resp.rt_cd == ErrorCode.MISSING_KEY.value
+    overseas_api.call_api.assert_not_awaited()

--- a/tests/unit_test/common/test_config_hashing.py
+++ b/tests/unit_test/common/test_config_hashing.py
@@ -100,3 +100,60 @@ def test_dataclass_and_dict_with_same_data_produce_same_hash():
     dc_hash = compute_config_hash(_ExampleConfig(a=1, b="x", c=[1, 2]))
     dict_hash = compute_config_hash({"a": 1, "b": "x", "c": [1, 2]})
     assert dc_hash == dict_hash
+
+
+def test_nested_none_value_is_normalized():
+    """중첩된 None 값도 정규화 — _normalize 의 None 분기를 탄다."""
+    h1 = compute_config_hash({"a": None, "b": 1})
+    h2 = compute_config_hash({"a": None, "b": 1})
+    assert h1 == h2 and len(h1) == 12
+
+
+def test_model_dump_failure_returns_empty():
+    """model_dump 가 예외를 던지면 (예외 대신) 빈 string."""
+    class _BrokenV2:
+        def model_dump(self):
+            raise RuntimeError("dump failed")
+
+    assert compute_config_hash(_BrokenV2()) == ""
+
+
+def test_pydantic_v1_dict_method_path():
+    """model_dump 가 없고 dict() 메서드만 있는 v1 스타일 객체 지원."""
+    class _V1Model:
+        def dict(self):
+            return {"a": 1, "b": 2}
+
+    assert compute_config_hash(_V1Model()) == compute_config_hash({"a": 1, "b": 2})
+
+
+def test_pydantic_v1_dict_method_failure_falls_through():
+    """dict() 가 예외를 던지면 무시하고 다음 정규화 경로로 폴백."""
+    class _BrokenV1:
+        def dict(self):
+            raise RuntimeError("dict failed")
+
+    # __dict__ 가 비어 있어 최종적으로 빈 string 으로 안전 처리된다.
+    assert compute_config_hash(_BrokenV1()) == ""
+
+
+def test_dataclass_asdict_failure_returns_empty():
+    """asdict 가 실패하는 dataclass(복제 불가 필드)는 빈 string."""
+    @dataclass
+    class _Uncopyable:
+        gen: object
+
+    assert compute_config_hash(_Uncopyable(gen=(i for i in range(3)))) == ""
+
+
+def test_object_without_dict_returns_empty():
+    """__dict__ 조차 없는 객체는 빈 string (최종 None 분기)."""
+    assert compute_config_hash(object()) == ""
+
+
+def test_serialization_failure_returns_empty():
+    """json 직렬화가 실패하면 빈 string 으로 안전 처리."""
+    from unittest.mock import patch
+
+    with patch("common.config_hashing.json.dumps", side_effect=TypeError("boom")):
+        assert compute_config_hash({"x": 1}) == ""

--- a/tests/unit_test/repositories/test_overseas_stock_code_repository.py
+++ b/tests/unit_test/repositories/test_overseas_stock_code_repository.py
@@ -1,0 +1,130 @@
+# tests/unit_test/repositories/test_overseas_stock_code_repository.py
+
+import os
+import sqlite3
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock, patch
+
+from repositories.overseas_stock_code_repository import (
+    OverseasStockCodeRepository,
+    _write_minimal_db,
+    TABLE_NAME,
+)
+
+
+def _create_test_db(db_path, data=None):
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    if data is None:
+        data = {
+            "심볼": ["AAPL", "NVDA", "LLY"],
+            "종목명": ["Apple Inc", "NVIDIA Corp", "Eli Lilly and Co"],
+            "거래소": ["NASD", "NASD", "NYSE"],
+        }
+    pd.DataFrame(data).to_sql(TABLE_NAME, conn, if_exists="replace", index=False)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def test_db(tmp_path):
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+    _create_test_db(db_path)
+    return db_path
+
+
+def test_all_symbols(test_db, mock_logger):
+    repo = OverseasStockCodeRepository(db_path=test_db, logger=mock_logger)
+    items = repo.all_symbols()
+    assert len(items) == 3
+    aapl = next(i for i in items if i["s"] == "AAPL")
+    assert aapl == {"s": "AAPL", "n": "Apple Inc", "e": "NASD"}
+
+
+def test_search_by_symbol_prefix(test_db):
+    repo = OverseasStockCodeRepository(db_path=test_db)
+    results = repo.search("AAP")
+    assert len(results) == 1
+    assert results[0]["s"] == "AAPL"
+    assert results[0]["e"] == "NASD"
+
+    # 소문자 입력도 매칭
+    assert repo.search("aap")[0]["s"] == "AAPL"
+
+
+def test_search_by_name_substring(test_db):
+    repo = OverseasStockCodeRepository(db_path=test_db)
+    results = repo.search("apple")
+    assert len(results) == 1
+    assert results[0]["s"] == "AAPL"
+
+    results_lilly = repo.search("lilly")
+    assert results_lilly[0]["s"] == "LLY"
+
+
+def test_search_empty_and_no_match(test_db):
+    repo = OverseasStockCodeRepository(db_path=test_db)
+    assert repo.search("") == []
+    assert repo.search("   ") == []
+    assert repo.search("ZZZZ") == []
+
+
+def test_search_limit(tmp_path):
+    db_path = str(tmp_path / "ov.db")
+    _create_test_db(db_path, {
+        "심볼": ["A1", "A2", "A3"],
+        "종목명": ["alpha one", "alpha two", "alpha three"],
+        "거래소": ["NASD", "NYSE", "AMEX"],
+    })
+    repo = OverseasStockCodeRepository(db_path=db_path)
+    assert len(repo.search("alpha", limit=2)) == 2
+
+
+def test_write_minimal_db(tmp_path):
+    db_path = str(tmp_path / "minimal.db")
+    logger = MagicMock()
+    _write_minimal_db(db_path, logger)
+    assert os.path.exists(db_path)
+    conn = sqlite3.connect(db_path)
+    df = pd.read_sql(f"SELECT * FROM {TABLE_NAME}", conn)
+    conn.close()
+    assert df.iloc[0]["심볼"] == "(NONE)"
+    logger.warning.assert_called_once()
+
+
+@patch("repositories.overseas_stock_code_repository.save_overseas_stock_code_list")
+def test_init_creates_file_when_missing(mock_save, mock_logger, tmp_path):
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+
+    def side_effect(**kwargs):
+        _create_test_db(db_path)
+
+    mock_save.side_effect = side_effect
+    repo = OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
+    mock_save.assert_called_once_with(force_update=True)
+    assert repo.symbol_to_meta["AAPL"]["name"] == "Apple Inc"
+
+
+@patch("repositories.overseas_stock_code_repository._write_minimal_db")
+@patch("repositories.overseas_stock_code_repository.save_overseas_stock_code_list")
+def test_recovery_falls_back_to_minimal(mock_save, mock_write_minimal, mock_logger, tmp_path):
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+    # 잘못된 스키마 → read 시 에러
+    conn = sqlite3.connect(db_path)
+    conn.execute(f"CREATE TABLE {TABLE_NAME} (wrong_col TEXT)")
+    conn.execute(f"INSERT INTO {TABLE_NAME} VALUES ('x')")
+    conn.commit()
+    conn.close()
+
+    mock_save.side_effect = Exception("Update Failed")
+    mock_write_minimal.side_effect = lambda path, logger=None: _write_minimal_db(path, logger=None)
+
+    repo = OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
+    mock_write_minimal.assert_called_once()
+    assert repo.symbol_to_meta["(NONE)"]["name"] == "(종목목록 없음)"

--- a/tests/unit_test/repositories/test_overseas_stock_code_repository.py
+++ b/tests/unit_test/repositories/test_overseas_stock_code_repository.py
@@ -128,3 +128,47 @@ def test_recovery_falls_back_to_minimal(mock_save, mock_write_minimal, mock_logg
     repo = OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
     mock_write_minimal.assert_called_once()
     assert repo.symbol_to_meta["(NONE)"]["name"] == "(종목목록 없음)"
+
+
+@patch("repositories.overseas_stock_code_repository.save_overseas_stock_code_list")
+def test_init_raises_when_initial_creation_fails(mock_save, mock_logger, tmp_path):
+    """DB 파일 생성 실패 시 예외를 전파하고 에러를 로깅한다."""
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+    mock_save.side_effect = RuntimeError("Create Failed")
+
+    with pytest.raises(RuntimeError, match="Create Failed"):
+        OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
+
+    mock_logger.error.assert_called_once()
+
+
+@patch("repositories.overseas_stock_code_repository.save_overseas_stock_code_list")
+def test_recovery_succeeds_on_second_attempt(mock_save, mock_logger, tmp_path):
+    """최초 로드가 최소 DB라 실패해도, 갱신이 성공하면 정상 데이터로 복구된다."""
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+    _write_minimal_db(db_path)  # 첫 로드는 최소 DB → ValueError 유발
+
+    mock_save.side_effect = lambda **kwargs: _create_test_db(db_path)
+
+    repo = OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
+
+    mock_save.assert_called_once_with(force_update=True)
+    assert repo.symbol_to_meta["AAPL"]["name"] == "Apple Inc"
+
+
+@patch("repositories.overseas_stock_code_repository.os.remove")
+@patch("repositories.overseas_stock_code_repository.save_overseas_stock_code_list")
+def test_recovery_continues_when_remove_fails(mock_save, mock_remove, mock_logger, tmp_path):
+    """복구 중 손상 파일 삭제가 실패해도 갱신 성공 시 정상 복구된다."""
+    db_path = str(tmp_path / "overseas_stock_code_list.db")
+    _write_minimal_db(db_path)  # 첫 로드 실패 유발
+
+    mock_remove.side_effect = OSError("권한 없음")
+    mock_save.side_effect = lambda **kwargs: _create_test_db(db_path)
+
+    repo = OverseasStockCodeRepository(db_path=db_path, logger=mock_logger)
+
+    mock_remove.assert_called_once()
+    assert repo.symbol_to_meta["AAPL"]["name"] == "Apple Inc"
+    # 삭제 실패 에러가 로깅되어야 한다.
+    assert any("삭제 실패" in str(c.args[0]) for c in mock_logger.error.call_args_list)

--- a/tests/unit_test/services/test_backtest_microstructure_capture.py
+++ b/tests/unit_test/services/test_backtest_microstructure_capture.py
@@ -97,3 +97,167 @@ async def test_capture_can_read_latest_program_overlay_from_program_db(tmp_path)
         "000002": {"program_net_buy_qty": -50},
     }
 
+
+def _service(sqs=None, provider=None, db_path="data/program_subscribe/program_trading.db"):
+    return BacktestMicrostructureCaptureService(
+        stock_query_service=sqs or AsyncMock(),
+        program_provider=provider,
+        program_db_path=db_path,
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_program_source_none_returns_all_none():
+    payload = await _service().capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        include_execution_strength=False,
+        program_source="none",
+    )
+    assert payload["program_trades"] == {"000001": None}
+    assert payload["metadata"]["row_counts"]["program_trades"] == 0
+
+
+@pytest.mark.asyncio
+async def test_capture_unsupported_program_source_raises():
+    with pytest.raises(ValueError, match="unsupported program_source"):
+        await _service().capture(
+            codes=["000001"],
+            date_ymd="20260512",
+            include_intraday=False,
+            include_execution_strength=False,
+            program_source="bogus",
+        )
+
+
+@pytest.mark.asyncio
+async def test_capture_daily_rest_without_provider_method_returns_none():
+    # provider 가 None → getter 가 callable 이 아님
+    payload = await _service(provider=None).capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        include_execution_strength=False,
+        program_source="daily_rest",
+    )
+    assert payload["program_trades"] == {"000001": None}
+
+
+@pytest.mark.asyncio
+async def test_capture_daily_rest_getter_exception_and_missing_qty():
+    provider = AsyncMock()
+    provider.get_program_trade_by_stock_daily.side_effect = [
+        Exception("boom"),
+        _response({"unrelated": "1"}),  # qty 추출 불가 → None
+    ]
+    payload = await _service(provider=provider).capture(
+        codes=["A", "B"],
+        date_ymd="20260512",
+        include_intraday=False,
+        include_execution_strength=False,
+        program_source="daily_rest",
+    )
+    assert payload["program_trades"] == {"A": None, "B": None}
+
+
+@pytest.mark.asyncio
+async def test_capture_execution_strength_exception_returns_none():
+    sqs = AsyncMock()
+    sqs.get_stock_conclusion.side_effect = Exception("conclusion down")
+    payload = await _service(sqs=sqs).capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        include_execution_strength=True,
+        program_source="none",
+    )
+    assert payload["execution_strength"] == {"000001": None}
+
+
+@pytest.mark.asyncio
+async def test_capture_program_db_missing_path_returns_none(tmp_path):
+    payload = await _service(db_path=tmp_path / "nope.db").capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        include_execution_strength=False,
+        program_source="program_db",
+    )
+    assert payload["program_trades"] == {"000001": None}
+
+
+@pytest.mark.asyncio
+async def test_capture_program_db_no_matching_row_returns_none(tmp_path):
+    db_path = tmp_path / "program_trading.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE pt_history (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "code TEXT, trade_time TEXT, net_vol INTEGER, created_at REAL)"
+        )
+        # trade_time 이 조회 윈도우(0900~1000) 밖이라 매칭되지 않음
+        conn.execute(
+            "INSERT INTO pt_history (code, trade_time, net_vol, created_at) VALUES (?,?,?,?)",
+            ("000001", "120000", 999, 1.0),
+        )
+    payload = await _service(db_path=db_path).capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        start_hhmmss="090000",
+        end_hhmmss="100000",
+        include_intraday=False,
+        include_execution_strength=False,
+        program_source="program_db",
+    )
+    assert payload["program_trades"] == {"000001": None}
+
+
+# --- 모듈 레벨 헬퍼 단위 테스트 ---
+from services.backtest_microstructure_capture import (  # noqa: E402
+    _extract_execution_strength,
+    _extract_program_net_buy_qty,
+    _first,
+    _first_output_row,
+    _to_float,
+    _to_int,
+)
+
+
+def _fail(data=None):
+    return ResCommonResponse(rt_cd="1", msg1="FAIL", data=data)
+
+
+def test_extract_execution_strength_variants():
+    assert _extract_execution_strength(_fail()) is None  # 비성공
+    assert _extract_execution_strength(_response({"output": []})) is None  # row 없음
+    assert _extract_execution_strength(_response({"output": [{"tday_rltv": "10.5"}]})) == 10.5
+
+
+def test_extract_program_net_buy_qty_variants():
+    assert _extract_program_net_buy_qty(_fail()) is None
+    assert _extract_program_net_buy_qty(_response({"pgtr_ntby_qty": "500"})) == 500
+    assert _extract_program_net_buy_qty(_response({"nothing": "x"})) is None
+
+
+def test_first_output_row_handles_non_dict_and_scalar_output():
+    assert _first_output_row(_response("not-a-dict")) is None
+    # output 이 list 가 아닌 dict → 그대로 반환
+    assert _first_output_row(_response({"output": {"k": 1}})) == {"k": 1}
+
+
+def test_first_handles_none_row_and_object_attr():
+    from types import SimpleNamespace
+
+    assert _first(None, "a") is None
+    assert _first({"a": "", "b": "v"}, "a", "b") == "v"  # 빈 값은 건너뜀
+    assert _first(SimpleNamespace(x=7), "x") == 7  # 객체 속성 경로
+
+
+def test_to_float_and_to_int_edge_cases():
+    assert _to_float(None) is None
+    assert _to_float("abc") is None
+    assert _to_float("3.5") == 3.5
+    assert _to_int("") is None
+    assert _to_int("xyz") is None
+    assert _to_int("42") == 42
+

--- a/tests/unit_test/services/test_backtest_replay_adapter_branches.py
+++ b/tests/unit_test/services/test_backtest_replay_adapter_branches.py
@@ -1,0 +1,198 @@
+"""backtest_replay_adapter 의 분기/헬퍼 경로 커버리지 보강 테스트."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse, TradeSignal
+from services.backtest_execution_simulator import BacktestBar
+from services.data_quality_service import DataQualityService
+from services.backtest_replay_adapter import (
+    StockQueryBacktestReplayService,
+    StockQueryIntradayReplayBarProvider,
+    StockQueryDailyMtmBarProvider,
+)
+
+SESSION = "REGULAR"
+
+
+def _replay(sqs=None, market_clock=None):
+    svc = StockQueryBacktestReplayService(sqs or AsyncMock(), market_clock=market_clock)
+    svc.set_backtest_date("20260505")
+    return svc
+
+
+# --- 정적 헬퍼 ---
+
+def test_response_has_rows_non_rescommon():
+    assert StockQueryBacktestReplayService._response_has_rows([1]) is True
+    assert StockQueryBacktestReplayService._response_has_rows(None) is False
+
+
+def test_to_int_edge_cases():
+    assert StockQueryBacktestReplayService._to_int("abc") is None
+    assert StockQueryBacktestReplayService._to_int(None) is None
+    assert StockQueryBacktestReplayService._to_int("1,234") == 1234
+
+
+def test_require_date_raises_when_unset():
+    svc = StockQueryBacktestReplayService(AsyncMock())
+    with pytest.raises(ValueError, match="backtest date is not set"):
+        svc._require_date()
+
+
+def test_cutoff_hhmmss_handles_clock_error():
+    clock = MagicMock()
+    clock.get_current_kst_time.side_effect = RuntimeError("clock down")
+    svc = _replay(market_clock=clock)
+    assert svc._cutoff_hhmmss() == ""
+
+
+def test_getattr_delegates_to_underlying_service():
+    sqs = MagicMock()
+    sqs.some_custom_attr = "delegated"
+    svc = _replay(sqs=sqs)
+    assert svc.some_custom_attr == "delegated"
+
+
+# --- get_market_snapshot ---
+
+def test_market_snapshot_force_fresh_returns_missing():
+    svc = _replay()
+    snap, reason = svc.get_market_snapshot("005930", force_fresh=True)
+    assert snap is None
+    assert reason == DataQualityService.REASON_SNAPSHOT_MISSING
+
+
+def test_market_snapshot_cache_miss_returns_missing():
+    svc = _replay()
+    snap, reason = svc.get_market_snapshot("005930")
+    assert snap is None
+    assert reason == DataQualityService.REASON_SNAPSHOT_MISSING
+
+
+def test_market_snapshot_cache_hit_builds_snapshot():
+    svc = _replay()  # market_clock None → cutoff ""
+    key = ("005930", "20260505", SESSION, "")
+    svc._row_cache[key] = [
+        {"stck_prpr": "100", "stck_hgpr": "110", "stck_lwpr": "90",
+         "acml_vol": "1000", "acml_tr_pbmn": "5000"},
+    ]
+    snap, reason = svc.get_market_snapshot("005930")
+    assert reason is None
+    assert snap.price == 100.0
+    assert snap.high == 110.0
+    assert snap.low == 90.0
+    assert snap.acml_vol == 1000
+    assert snap.source == "backtest_replay"
+
+
+# --- get_conclusion_snapshot ---
+
+@pytest.mark.asyncio
+async def test_conclusion_snapshot_no_date_returns_missing():
+    svc = StockQueryBacktestReplayService(AsyncMock())
+    snap, reason = await svc.get_conclusion_snapshot("005930")
+    assert snap is None
+    assert reason == DataQualityService.REASON_CONCLUSION_MISSING
+
+
+@pytest.mark.asyncio
+async def test_conclusion_snapshot_from_cache():
+    svc = _replay()
+    key = ("005930", "20260505", SESSION, "")
+    svc._row_cache[key] = [{"tday_rltv": "150.5"}]
+    snap, reason = await svc.get_conclusion_snapshot("005930")
+    assert reason is None
+    assert snap.execution_strength_pct == 150.5
+
+
+@pytest.mark.asyncio
+async def test_conclusion_snapshot_from_cache_invalid_strength_defaults_zero():
+    svc = _replay()
+    key = ("005930", "20260505", SESSION, "")
+    svc._row_cache[key] = [{"tday_rltv": "abc"}]
+    snap, _ = await svc.get_conclusion_snapshot("005930")
+    assert snap.execution_strength_pct == 0.0
+
+
+@pytest.mark.asyncio
+async def test_conclusion_snapshot_fallback_to_get_stock_conclusion():
+    sqs = AsyncMock()
+    sqs.get_day_intraday_minutes_list.return_value = [{"tday_rltv": "133.0"}]
+    svc = _replay(sqs=sqs)
+    snap, reason = await svc.get_conclusion_snapshot("005930")
+    assert reason is None
+    assert snap.execution_strength_pct == 133.0
+
+
+@pytest.mark.asyncio
+async def test_conclusion_snapshot_fallback_missing_returns_reason():
+    sqs = AsyncMock()
+    sqs.get_day_intraday_minutes_list.return_value = []  # 체결강도 없음 → 실패 응답
+    svc = _replay(sqs=sqs)
+    snap, reason = await svc.get_conclusion_snapshot("005930")
+    assert snap is None
+    assert reason == DataQualityService.REASON_CONCLUSION_MISSING
+
+
+# --- StockQueryIntradayReplayBarProvider ---
+
+@pytest.mark.asyncio
+async def test_intraday_bar_provider_raises_when_rows_not_sequence():
+    sqs = AsyncMock()
+    sqs.get_day_intraday_minutes_list.return_value = None  # 비-Sequence → []
+    provider = StockQueryIntradayReplayBarProvider(sqs)
+    signal = TradeSignal(code="005930", name="t", action="BUY", price=100, qty=1,
+                         reason="r", strategy_name="s")
+    with pytest.raises(ValueError, match="intraday rows not found"):
+        await provider.get_bar(signal=signal, date_ymd="20260505", side="BUY")
+
+
+def test_intraday_price_reached_fallback_side():
+    bar = BacktestBar(timestamp="20260505 090000", open=95, high=110, low=90, close=100, volume=1)
+    # side 가 BUY/SELL 이 아니어도 범위 검사로 폴백
+    assert StockQueryIntradayReplayBarProvider._price_reached(bar, 100.0, "OTHER") is True
+    assert StockQueryIntradayReplayBarProvider._price_reached(bar, 0.0, "OTHER") is False
+
+
+# --- StockQueryDailyMtmBarProvider ---
+
+@pytest.mark.asyncio
+async def test_daily_provider_returns_empty_when_start_after_end():
+    provider = StockQueryDailyMtmBarProvider(AsyncMock())
+    assert await provider.get_holding_bars(code="005930", start_ymd="20260510", end_ymd="20260505") == []
+
+
+@pytest.mark.asyncio
+async def test_daily_provider_uses_cache_and_handles_non_sequence_rows():
+    sqs = AsyncMock()
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=None  # 비-Sequence → []
+    )
+    provider = StockQueryDailyMtmBarProvider(sqs)
+    first = await provider.get_holding_bars(code="005930", start_ymd="20260501", end_ymd="20260510")
+    second = await provider.get_holding_bars(code="005930", start_ymd="20260501", end_ymd="20260510")
+    assert first == [] and second == []
+    # 캐시 적중으로 한 번만 조회
+    sqs.get_recent_daily_ohlcv.assert_awaited_once()
+
+
+def test_daily_provider_lookup_limit_handles_invalid_date():
+    provider = StockQueryDailyMtmBarProvider(AsyncMock(), lookback_padding_days=10)
+    assert provider._lookup_limit("bad", "alsobad") == 70
+
+
+def test_daily_provider_row_to_bar_none_branches():
+    provider = StockQueryDailyMtmBarProvider(AsyncMock())
+    assert provider._row_to_bar("not-a-dict") is None       # 비-dict
+    assert provider._row_to_bar({"open": "1"}) is None        # close 없음
+    assert provider._row_to_bar({"close": "100"}) is None     # date 없음
+    bar = provider._row_to_bar({"close": "100", "date": "20260505"})
+    assert bar.close == 100.0
+
+
+def test_daily_provider_first_and_to_float_helpers():
+    assert StockQueryDailyMtmBarProvider._first({"a": "", "b": "-"}, "a", "b") is None
+    assert StockQueryDailyMtmBarProvider._to_float(None) is None
+    assert StockQueryDailyMtmBarProvider._to_float("abc") is None
+    assert StockQueryDailyMtmBarProvider._to_float("1,234.5") == 1234.5

--- a/tests/unit_test/services/test_overseas_stock_sync_service.py
+++ b/tests/unit_test/services/test_overseas_stock_sync_service.py
@@ -1,0 +1,90 @@
+# tests/unit_test/services/test_overseas_stock_sync_service.py
+
+import json
+import sqlite3
+import os
+from datetime import datetime, timedelta
+import pandas as pd
+import pytest
+from services import overseas_stock_sync_service as svc
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def setup_and_teardown(tmp_path, mocker):
+    """각 테스트 전후로 임시 데이터 경로로 모킹."""
+    temp_data_dir = tmp_path / "data"
+    temp_db_file_path = temp_data_dir / "overseas_stock_code_list.db"
+    temp_metadata_path = temp_data_dir / "overseas_metadata.json"
+    temp_data_dir.mkdir(parents=True, exist_ok=True)
+
+    mocker.patch.object(svc, "ROOT_DIR", new=str(tmp_path))
+    mocker.patch.object(svc, "DATA_DIR", new=str(temp_data_dir))
+    mocker.patch.object(svc, "DB_FILE_PATH", new=str(temp_db_file_path))
+    mocker.patch.object(svc, "METADATA_PATH", new=str(temp_metadata_path))
+    yield
+
+
+def _fake_listing(market):
+    data = {
+        "NASDAQ": {"Symbol": ["AAPL", "NVDA"], "Name": ["Apple Inc", "NVIDIA Corp"]},
+        "NYSE": {"Symbol": ["LLY"], "Name": ["Eli Lilly and Co"]},
+        "AMEX": {"Symbol": ["IMO"], "Name": ["Imperial Oil Ltd"]},
+    }[market]
+    df = pd.DataFrame(data)
+    df["IndustryCode"] = "0"
+    df["Industry"] = "x"
+    return df
+
+
+@patch("FinanceDataReader.StockListing", side_effect=_fake_listing)
+def test_force_update_saves_files(mock_listing):
+    """force_update=True이면 3개 거래소 합산 DB와 메타데이터가 저장된다."""
+    svc.save_overseas_stock_code_list(force_update=True)
+
+    assert os.path.exists(svc.DB_FILE_PATH)
+    assert os.path.exists(svc.METADATA_PATH)
+
+    conn = sqlite3.connect(svc.DB_FILE_PATH)
+    df = pd.read_sql(f"SELECT * FROM {svc.TABLE_NAME}", conn)
+    conn.close()
+
+    assert list(df.columns) == ["심볼", "종목명", "거래소"]
+    assert len(df) == 4  # 2 + 1 + 1
+    aapl = df[df["심볼"] == "AAPL"].iloc[0]
+    assert aapl["종목명"] == "Apple Inc"
+    assert aapl["거래소"] == "NASD"
+    assert df[df["심볼"] == "LLY"].iloc[0]["거래소"] == "NYSE"
+    assert df[df["심볼"] == "IMO"].iloc[0]["거래소"] == "AMEX"
+
+
+@patch("FinanceDataReader.StockListing", side_effect=_fake_listing)
+def test_metadata_blocks_update_within_7_days(mock_listing, capfd):
+    svc.save_overseas_stock_code_list(force_update=True)
+    svc.save_overseas_stock_code_list(force_update=False)
+    captured = capfd.readouterr()
+    assert "이미 업데이트됨" in captured.out
+
+
+def test_needs_update_logic():
+    old_date = (datetime.today() - timedelta(days=8)).strftime("%Y-%m-%d")
+    with open(svc.METADATA_PATH, "w", encoding="utf-8") as f:
+        json.dump({"last_updated": old_date}, f)
+    assert svc._needs_update() is True
+
+    recent_date = (datetime.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    with open(svc.METADATA_PATH, "w", encoding="utf-8") as f:
+        json.dump({"last_updated": recent_date}, f)
+    assert svc._needs_update() is False
+
+
+def test_needs_update_when_metadata_missing():
+    assert svc._needs_update() is True
+
+
+@patch("FinanceDataReader.StockListing", side_effect=_fake_listing)
+def test_load_overseas_stock_code_list(mock_listing):
+    svc.save_overseas_stock_code_list(force_update=True)
+    df = svc.load_overseas_stock_code_list()
+    assert len(df) == 4
+    assert set(df["심볼"]) == {"AAPL", "NVDA", "LLY", "IMO"}

--- a/tests/unit_test/services/test_post_market_replay_audit_service.py
+++ b/tests/unit_test/services/test_post_market_replay_audit_service.py
@@ -152,3 +152,186 @@ async def test_audit_service_skips_paper_mode_without_failing(tmp_path):
     assert result.skipped is True
     assert result.skip_reason == "historical_intraday_unavailable_in_paper"
     repo.save_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 모듈 레벨 헬퍼
+# ---------------------------------------------------------------------------
+from datetime import datetime  # noqa: E402
+from services.post_market_replay_audit_service import (  # noqa: E402
+    _canonical_signal_time,
+    _parse_signal_time,
+    _strategy_name_from_path,
+)
+
+
+def test_strategy_name_from_path():
+    assert _strategy_name_from_path("20260505_090300_OneilPocketPivot.log.json") == "OneilPocketPivot"
+    assert _strategy_name_from_path("20260505_OneilSqueezeBreakout.log.json.gz") == "OneilSqueezeBreakout"
+    assert _strategy_name_from_path("not-a-strategy-file.txt") is None
+
+
+def test_canonical_signal_time_variants():
+    assert _canonical_signal_time("2026-05-05 09:03:00,123") == "2026-05-05 09:03:00"
+    assert _canonical_signal_time("20260505090300") == "2026-05-05 09:03:00"
+    assert _canonical_signal_time("20260505") == "2026-05-05 00:00:00"
+    assert _canonical_signal_time("xyz") == "xyz"
+
+
+def test_parse_signal_time_valid_and_invalid():
+    assert _parse_signal_time("2026-05-05 09:03:00") == datetime(2026, 5, 5, 9, 3, 0)
+    assert _parse_signal_time("garbage") == datetime.min
+
+
+# ---------------------------------------------------------------------------
+# 입력 수집 / 보조 분기
+# ---------------------------------------------------------------------------
+def _make_service(tmp_path, **overrides):
+    kwargs = dict(
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=MagicMock(),
+        scheduler_store=MagicMock(),
+        log_dir=str(tmp_path),
+        strategy_factory=_strategy_factory,
+        env=SimpleNamespace(is_paper_trading=False),
+        logger=MagicMock(),
+    )
+    kwargs.update(overrides)
+    return PostMarketReplayAuditService(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_no_live_candidates(tmp_path):
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = []
+    service = _make_service(tmp_path, scheduler_store=store)  # 로그 디렉터리 비어 있음
+
+    result = await service.run("20260505")
+
+    assert result.skipped is True
+    assert result.skip_reason == "no_live_candidates"
+
+
+def test_collect_inputs_from_logs_reads_gzip_and_buy_signal(tmp_path):
+    import gzip
+
+    path = os.path.join(str(tmp_path), "20260505_090300_OneilPocketPivot.log.json.gz")
+    rows = [
+        json.dumps({"timestamp": "2026-05-05 09:03:00", "data": {"event": "scan_with_watchlist"}}),
+        json.dumps({"timestamp": "2026-05-05 09:03:05", "data": {"event": "buy_signal_generated", "code": "005930"}}),
+        "this-is-not-json",  # decode/JSON 오류 → 건너뜀
+        json.dumps({"timestamp": "2026-05-05 09:03:06", "data": "not-a-dict"}),  # data 비-dict → 건너뜀
+        json.dumps({"timestamp": "2025-01-01 00:00:00", "data": {"event": "scan_with_watchlist"}}),  # 날짜 불일치
+    ]
+    with gzip.open(path, "wb") as fp:
+        for row in rows:
+            fp.write((row + "\n").encode("utf-8"))
+
+    service = _make_service(tmp_path)
+    inputs = service._collect_inputs_from_logs("20260505")
+
+    audit = inputs["OneilPocketPivot"]
+    assert "005930" in audit.candidates
+    assert audit.scan_times == {"2026-05-05 09:03:00"}
+    assert audit.live_buy_times["005930"] == "2026-05-05 09:03:05"
+
+
+def test_merge_scheduler_signals_handles_non_buy_and_errors(tmp_path):
+    from services.post_market_replay_audit_service import _AuditInput
+
+    # 1) loader 가 없는 store → 조용히 반환
+    service = _make_service(tmp_path, scheduler_store=SimpleNamespace())
+    inputs = {}
+    service._merge_scheduler_signals(inputs, "20260505")
+    assert inputs == {}
+
+    # 2) loader 가 예외 → 조용히 반환
+    store = MagicMock()
+    store.load_signal_history_for_date.side_effect = RuntimeError("db down")
+    service = _make_service(tmp_path, scheduler_store=store)
+    service._merge_scheduler_signals(inputs, "20260505")
+    assert inputs == {}
+
+    # 3) SELL 액션 → candidate 만 추가, live_buy_times 없음
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = [
+        {"strategy_name": "OneilPocketPivot", "code": "005930", "action": "SELL", "timestamp": "2026-05-05 09:05:00"},
+        {"strategy_name": "", "code": "x"},  # strategy 누락 → skip
+    ]
+    service = _make_service(tmp_path, scheduler_store=store)
+    inputs = {}
+    service._merge_scheduler_signals(inputs, "20260505")
+    assert inputs["OneilPocketPivot"].candidates == {"005930"}
+    assert inputs["OneilPocketPivot"].live_buy_times == {}
+
+
+def test_merge_virtual_trades_variants(tmp_path):
+    # 1) virtual_trade_service None → no-op
+    service = _make_service(tmp_path, virtual_trade_service=None)
+    inputs = {}
+    service._merge_virtual_trades(inputs, "20260505")
+    assert inputs == {}
+
+    # 2) get_all_trades 없음 → no-op
+    service = _make_service(tmp_path, virtual_trade_service=SimpleNamespace())
+    service._merge_virtual_trades(inputs, "20260505")
+    assert inputs == {}
+
+    # 3) get_all_trades 예외 → no-op
+    vts = MagicMock()
+    vts.get_all_trades.side_effect = RuntimeError("csv down")
+    service = _make_service(tmp_path, virtual_trade_service=vts)
+    service._merge_virtual_trades(inputs, "20260505")
+    assert inputs == {}
+
+    # 4) 정상 trade + 날짜 불일치/필드 누락 trade
+    vts = MagicMock()
+    vts.get_all_trades.return_value = [
+        {"buy_date": "2026-05-05 09:00:00", "strategy": "OneilPocketPivot", "code": "005930"},
+        {"buy_date": "2025-01-01 09:00:00", "strategy": "OneilPocketPivot", "code": "000660"},  # 날짜 불일치
+        {"buy_date": "2026-05-05 09:00:00", "strategy": "", "code": "000999"},  # strategy 누락
+    ]
+    service = _make_service(tmp_path, virtual_trade_service=vts)
+    inputs = {}
+    service._merge_virtual_trades(inputs, "20260505")
+    assert inputs["OneilPocketPivot"].candidates == {"005930"}
+    assert inputs["OneilPocketPivot"].live_buy_times["005930"] == "2026-05-05 09:00:00"
+
+
+@pytest.mark.asyncio
+async def test_run_strategy_audit_marks_data_unavailable_on_factory_error(tmp_path):
+    _write_strategy_log(str(tmp_path))
+    repo = MagicMock()
+    store = MagicMock()
+    store.load_signal_history_for_date.return_value = []
+
+    def _raising_factory(**_kwargs):
+        raise RuntimeError("replay data missing")
+
+    service = _make_service(
+        tmp_path, backtest_journal_repository=repo, scheduler_store=store,
+        strategy_factory=_raising_factory,
+    )
+
+    result = await service.run("20260505")
+
+    assert result.data_unavailable_count >= 1
+    records = repo.save_run.call_args.args[0]
+    assert any(r["metadata"]["audit_status"] == "data_unavailable" for r in records)
+
+
+def test_default_strategy_factory_rejects_unknown_strategy(tmp_path):
+    service = _make_service(tmp_path, strategy_factory=None)
+    with pytest.raises(ValueError, match="unsupported audit strategy"):
+        service._default_strategy_factory(
+            strategy_name="UnknownStrategy",
+            replay_sqs=MagicMock(),
+            universe_service=MagicMock(),
+            indicator_service=MagicMock(),
+            backtest_clock=MagicMock(),
+            state_dir="/tmp",
+            logger=MagicMock(),
+        )

--- a/tests/unit_test/services/test_program_trading_stream_service_branches.py
+++ b/tests/unit_test/services/test_program_trading_stream_service_branches.py
@@ -1,0 +1,286 @@
+"""ProgramTradingStreamService 의 분기/헬퍼/생명주기 경로 커버리지 보강."""
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.program_trading_stream_service import ProgramTradingStreamService
+
+MODULE = "services.program_trading_stream_service"
+
+
+@pytest.fixture
+def svc(tmp_path):
+    base = str(tmp_path / "program_subscribe")
+    with patch.object(ProgramTradingStreamService, "_get_base_dir", return_value=base):
+        s = ProgramTradingStreamService(logger=MagicMock())
+    yield s
+    if s._flush_task and not s._flush_task.done():
+        s._flush_task.cancel()
+    try:
+        if s._conn:
+            s._conn.close()
+    except Exception:
+        pass
+    s._executor.shutdown(wait=False)
+
+
+# --- 포워딩 / 정적 헬퍼 ---
+
+def test_property_forwards(svc):
+    assert svc._buffer_lock is svc._repo._buffer_lock
+    assert svc._lock is svc._repo._lock
+
+
+def test_bulk_insert_forwards(svc):
+    svc._repo._bulk_insert_to_db = MagicMock()
+    svc._bulk_insert_to_db([{"a": 1}])
+    svc._repo._bulk_insert_to_db.assert_called_once_with([{"a": 1}])
+
+
+@pytest.mark.asyncio
+async def test_flush_loop_forwards(svc):
+    svc._repo._flush_loop = AsyncMock()
+    await svc._flush_loop()
+    svc._repo._flush_loop.assert_awaited_once()
+
+
+def test_safe_int_and_float_invalid(svc):
+    assert ProgramTradingStreamService._safe_int("x") == 0
+    assert ProgramTradingStreamService._safe_int(None) == 0
+    assert ProgramTradingStreamService._safe_float("x") == 0.0
+    assert ProgramTradingStreamService._safe_float(None) == 0.0
+
+
+def test_on_data_received_queue_inner_exception(svc):
+    q = MagicMock()
+    q.put_nowait.side_effect = asyncio.QueueFull()
+    q.get_nowait.side_effect = Exception("empty")
+    svc._pt_queues.append(q)
+    svc.on_data_received({"유가증권단축종목코드": "005930"})
+    # 내부 예외를 삼키고 큐는 그대로 유지된다.
+    assert q in svc._pt_queues
+
+
+# --- 포맷터 ---
+
+def test_format_helpers_invalid_inputs():
+    assert ProgramTradingStreamService._format_int(None) == "0"
+    assert ProgramTradingStreamService._format_int("12,345") == "12,345"
+    assert ProgramTradingStreamService._format_rate("abc") == "0.00%"
+    assert ProgramTradingStreamService._format_rate("1.5") == "+1.50%"
+    assert ProgramTradingStreamService._format_eok("abc") == "0.0억"
+    assert ProgramTradingStreamService._format_eok("100000000") == "1.0억"
+
+
+def test_format_stock_label_variants(svc):
+    # repo 없음 → code 그대로
+    assert svc._format_stock_label("005930") == "005930"
+    # repo 정상
+    repo = MagicMock()
+    repo.get_name_by_code.return_value = "삼성전자"
+    svc._stock_code_repository = repo
+    assert svc._format_stock_label("005930") == "삼성전자"
+    # repo 예외 → code 폴백
+    repo.get_name_by_code.side_effect = RuntimeError("boom")
+    assert svc._format_stock_label("005930") == "005930"
+
+
+# --- 구독 코드 / 스냅샷 ---
+
+def test_get_subscribed_program_codes_variants(svc):
+    assert svc._get_subscribed_program_codes() == []  # streaming repo 없음
+    repo = MagicMock()
+    repo.get_desired.return_value = {"000660", "005930"}
+    svc._streaming_stock_repo = repo
+    assert svc._get_subscribed_program_codes() == ["000660", "005930"]
+    repo.get_desired.side_effect = RuntimeError("db down")
+    assert svc._get_subscribed_program_codes() == []
+
+
+def test_extract_latest_program_snapshot(svc):
+    assert svc._extract_latest_program_snapshot("not-dict") is None
+    assert svc._extract_latest_program_snapshot({"순매수거래대금": 0}) is None
+    snap = svc._extract_latest_program_snapshot(
+        {"순매수거래대금": "5000", "price": "100", "prdy_ctrt": "1.2"}
+    )
+    assert snap == {"순매수거래대금": "5000", "price": "100", "rate": "1.2"}
+
+
+@pytest.mark.asyncio
+async def test_get_latest_program_snapshot_variants(svc):
+    assert await svc._get_latest_program_snapshot("005930") is None  # provider 없음
+
+    provider = MagicMock(spec=[])  # getter 없음
+    svc._program_trade_provider = provider
+    assert await svc._get_latest_program_snapshot("005930") is None
+
+    # rt_cd != "0"
+    provider = MagicMock()
+    provider.get_program_trade_by_stock_daily = AsyncMock(return_value=MagicMock(rt_cd="1"))
+    svc._program_trade_provider = provider
+    assert await svc._get_latest_program_snapshot("005930") is None
+
+    # 성공
+    resp = MagicMock(rt_cd="0", data={"순매수거래대금": "5000"})
+    provider.get_program_trade_by_stock_daily = AsyncMock(return_value=resp)
+    snap = await svc._get_latest_program_snapshot("005930")
+    assert snap["순매수거래대금"] == "5000"
+
+    # 예외
+    provider.get_program_trade_by_stock_daily = AsyncMock(side_effect=RuntimeError("rest down"))
+    assert await svc._get_latest_program_snapshot("005930") is None
+
+
+# --- tick 리포트 포맷 ---
+
+@pytest.mark.asyncio
+async def test_format_last_tick_report_async_with_and_without_history(svc):
+    svc._pt_history = {"005930": [{"주식체결시간": "090000", "price": "100", "rate": "1.0"}]}
+    svc._last_tick_ts_by_code = {"005930": time.time()}
+    svc._get_latest_program_snapshot = AsyncMock(return_value={"순매수거래대금": "100000000"})
+    report = await svc._format_last_tick_report_async(["005930", "000660"])
+    assert "REST보정" in report
+    assert "수신 없음" in report  # 000660 은 history 없음
+
+
+def test_format_last_tick_report_sync(svc):
+    svc._pt_history = {"005930": [{"주식체결시간": "090000", "price": "100"}]}
+    svc._last_tick_ts_by_code = {"005930": time.time()}
+    report = svc._format_last_tick_report(["005930", "000660"])
+    assert "원" in report
+    assert "수신 없음" in report
+
+
+# --- 텔레그램 전송 ---
+
+@pytest.mark.asyncio
+async def test_send_telegram_message_variants(svc):
+    assert await svc._send_telegram_message("hi") is False  # reporter 없음
+
+    reporter = MagicMock(spec=[])  # _send_message 없음
+    svc._telegram_reporter = reporter
+    assert await svc._send_telegram_message("hi") is False
+
+    reporter = MagicMock()
+    reporter._send_message = AsyncMock(return_value=True)
+    svc._telegram_reporter = reporter
+    assert await svc._send_telegram_message("hi") is True
+
+    reporter._send_message = AsyncMock(side_effect=RuntimeError("net down"))
+    assert await svc._send_telegram_message("hi") is False
+
+
+@pytest.mark.asyncio
+async def test_send_subscribed_last_tick_alert_no_codes(svc):
+    assert await svc.send_subscribed_last_tick_alert() is False
+
+
+@pytest.mark.asyncio
+async def test_send_db_persistence_report_no_codes(svc):
+    assert await svc.send_db_persistence_report("20260505") is False
+
+
+# --- 윈도우 / 분 파싱 ---
+
+def test_build_trading_window_defaults_to_today_for_short_date(svc):
+    start_dt, end_dt, minutes, tz = svc._build_trading_window("abc")
+    assert tz is None
+    assert minutes[0] == "09:00"
+    assert minutes[-1] == "15:40"
+
+
+def test_minute_from_trade_time_invalid(svc):
+    assert svc._minute_from_trade_time("0900") == "09:00"
+    assert svc._minute_from_trade_time("99") is None       # 자릿수 부족
+    assert svc._minute_from_trade_time("9999") is None       # 시/분 범위 초과
+
+
+# --- 상태/장중 여부 ---
+
+def test_get_background_task_status_with_last_received(svc):
+    svc.last_data_ts = time.time()
+    status = svc.get_background_task_status()
+    assert status["last_received_at"] is not None
+    assert status["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_is_market_open_for_tick_alert_variants(svc):
+    assert await svc._is_market_open_for_tick_alert() is True  # mcs 없음
+
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    svc._market_calendar_service = mcs
+    assert await svc._is_market_open_for_tick_alert() is False
+
+    mcs.is_market_open_now = AsyncMock(side_effect=RuntimeError("cal down"))
+    assert await svc._is_market_open_for_tick_alert() is False
+
+
+# --- 백그라운드 루프 ---
+
+@pytest.mark.asyncio
+async def test_hourly_tick_alert_loop_iterates_then_cancels(svc):
+    svc._is_market_open_for_tick_alert = AsyncMock(side_effect=[True, False])
+    svc.send_subscribed_last_tick_alert = AsyncMock(return_value=True)
+    with patch(f"{MODULE}.asyncio.sleep",
+               new=AsyncMock(side_effect=[None, None, asyncio.CancelledError()])):
+        with pytest.raises(asyncio.CancelledError):
+            await svc._hourly_tick_alert_loop()
+    svc.send_subscribed_last_tick_alert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_hourly_tick_alert_loop_swallows_generic_error(svc):
+    with patch(f"{MODULE}.asyncio.sleep", new=AsyncMock(side_effect=RuntimeError("boom"))):
+        await svc._hourly_tick_alert_loop()
+    svc.logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_after_market_db_check_loop_reports_once_per_date(svc):
+    svc._market_calendar_service = MagicMock()
+    svc._market_clock = MagicMock()
+    svc.send_db_persistence_report = AsyncMock(return_value=True)
+
+    async def fake_loop(**kwargs):
+        cb = kwargs["on_market_closed"]
+        await cb("20260505")
+        await cb("20260505")  # 같은 날짜 → 조기 반환
+
+    with patch("scheduler.after_market_loop.run_after_market_loop",
+               new=AsyncMock(side_effect=fake_loop)):
+        await svc._after_market_db_check_loop()
+
+    assert svc._last_db_check_report_date == "20260505"
+    svc.send_db_persistence_report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_alert_tasks_creates_loops(svc):
+    svc._hourly_tick_alert_loop = AsyncMock()
+    svc._after_market_db_check_loop = AsyncMock()
+    svc._telegram_reporter = MagicMock()
+    svc._market_calendar_service = MagicMock()
+    svc._market_clock = MagicMock()
+
+    svc._start_alert_tasks()
+    try:
+        assert len(svc._alert_tasks) == 2
+    finally:
+        await asyncio.gather(*svc._alert_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_pending_alert_tasks(svc):
+    pending = asyncio.create_task(asyncio.Event().wait())
+    svc._alert_tasks = [pending]
+    svc._repo.shutdown = AsyncMock()
+
+    await svc.shutdown()
+
+    assert pending.cancelled()
+    assert svc._alert_tasks == []
+    svc._repo.shutdown.assert_awaited_once()

--- a/tests/unit_test/task/background/after_market/test_post_market_replay_audit_task.py
+++ b/tests/unit_test/task/background/after_market/test_post_market_replay_audit_task.py
@@ -51,3 +51,53 @@ async def test_force_run_falls_back_to_today_when_calendar_fails():
 
     service.run.assert_awaited_once_with("20260505")
     task._logger.warning.assert_called_once()
+
+
+def test_task_name_and_scheduler_label():
+    task = _make_task()
+    assert task.task_name == "post_market_replay_audit"
+    assert task._scheduler_label == "PostMarketReplayAuditTask"
+
+
+async def test_on_market_closed_swallows_audit_exception():
+    task = _make_task()
+    task._audit_service.run = AsyncMock(side_effect=RuntimeError("audit boom"))
+
+    await task._on_market_closed("20260505")
+
+    task._logger.error.assert_called_once()
+    assert task._last_result is None
+
+
+def test_get_progress_without_result():
+    task = _make_task()
+    progress = task.get_progress()
+    assert progress["running"] is False
+    assert progress["last_result"] is None
+
+
+def test_get_progress_with_result():
+    from types import SimpleNamespace
+
+    task = _make_task()
+    task._last_result = SimpleNamespace(
+        target_date="20260505",
+        skipped=False,
+        skip_reason="",
+        strategy_count=3,
+        missed_count=1,
+        late_count=2,
+        missing_from_universe_count=4,
+    )
+
+    progress = task.get_progress()
+
+    assert progress["last_result"] == {
+        "target_date": "20260505",
+        "skipped": False,
+        "skip_reason": "",
+        "strategy_count": 3,
+        "missed_count": 1,
+        "late_count": 2,
+        "missing_from_universe_count": 4,
+    }

--- a/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
+++ b/tests/unit_test/task/background/intraday/test_opening_position_reconcile_task.py
@@ -133,3 +133,127 @@ async def test_opening_position_reconcile_loop_runs_once_and_recovers_errors():
 
     task.run_once.assert_awaited_once()
     task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_false_without_clock_or_calendar():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_false_on_non_business_day():
+    clock = MagicMock()
+    open_time = datetime(2026, 4, 30, 9, 0)
+    clock.get_market_open_time.return_value = open_time
+    clock.get_current_kst_time.return_value = open_time + timedelta(seconds=61)
+    mcs = AsyncMock()
+    mcs.is_business_day.return_value = False
+    task = OpeningPositionReconcileTask(
+        reconcile_service=AsyncMock(), market_calendar_service=mcs, market_clock=clock
+    )
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_false_when_business_day_check_raises():
+    clock = MagicMock()
+    open_time = datetime(2026, 4, 30, 9, 0)
+    clock.get_market_open_time.return_value = open_time
+    clock.get_current_kst_time.return_value = open_time + timedelta(seconds=61)
+    mcs = AsyncMock()
+    mcs.is_business_day.side_effect = RuntimeError("calendar down")
+    task = OpeningPositionReconcileTask(
+        reconcile_service=AsyncMock(), market_calendar_service=mcs, market_clock=clock
+    )
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_suspend_resume_and_progress():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+
+    task._state = TaskState.RUNNING
+    await task.suspend()
+    assert task.state == TaskState.SUSPENDED
+
+    progress = task.get_progress()
+    assert progress["running"] is False
+    assert progress["last_result"] == {"mismatch_count": None, "error": None}
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_start_resets_state_after_stop():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+    try:
+        await task.start()
+        await task.stop()
+        assert task.state == TaskState.STOPPED
+
+        # STOPPED 상태에서 재시작하면 IDLE로 복귀해야 한다.
+        await task.start()
+        assert task.state == TaskState.IDLE
+    finally:
+        await task.stop()
+
+
+@pytest.mark.asyncio
+async def test_loop_continues_when_suspended():
+    task = OpeningPositionReconcileTask(reconcile_service=AsyncMock(), logger=MagicMock())
+    task._state = TaskState.SUSPENDED
+    task._should_run_now = AsyncMock()
+
+    with patch(
+        "task.background.intraday.opening_position_reconcile_task.asyncio.sleep",
+        new=AsyncMock(side_effect=[None, asyncio.CancelledError()]),
+    ):
+        await task._loop()
+
+    # SUSPENDED 동안에는 실행 여부 판단 자체를 건너뛴다.
+    task._should_run_now.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_once_reports_to_operator_alert_on_mismatch():
+    oas = AsyncMock()
+    service = AsyncMock()
+    service.reconcile_once.return_value = {"mismatch_count": 2, "force_closed": ["A"]}
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service, operator_alert_service=oas, logger=MagicMock()
+    )
+
+    await task.run_once()
+
+    oas.report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_once_resolves_operator_alert_when_ok():
+    oas = AsyncMock()
+    service = AsyncMock()
+    service.reconcile_once.return_value = {"mismatch_count": 0}
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service, operator_alert_service=oas, logger=MagicMock()
+    )
+
+    await task.run_once()
+
+    oas.resolve.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_once_reports_to_operator_alert_on_failure():
+    oas = AsyncMock()
+    service = AsyncMock()
+    service.reconcile_once.side_effect = RuntimeError("boom")
+    task = OpeningPositionReconcileTask(
+        reconcile_service=service, operator_alert_service=oas, logger=MagicMock()
+    )
+
+    result = await task.run_once()
+
+    assert result["error"] == "boom"
+    oas.report.assert_awaited_once()

--- a/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
@@ -1,0 +1,42 @@
+"""Kill Switch 라우트 단위 테스트 (reset-strategy 경로 중심)."""
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_reset_strategy_kill_switch_success(web_client, mock_web_ctx):
+    """단일 전략 Kill Switch 해제 — 200 + reset_strategy 위임."""
+    mock_web_ctx.kill_switch_service.reset_strategy = AsyncMock()
+    web_client.cookies.set("access_token", "secret")
+
+    resp = web_client.post("/api/kill-switch/reset-strategy/momentum")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "momentum" in body["message"]
+    mock_web_ctx.kill_switch_service.reset_strategy.assert_awaited_once()
+    await_args = mock_web_ctx.kill_switch_service.reset_strategy.await_args
+    assert await_args.args[0] == "momentum"
+    assert await_args.args[1] == "secret"  # operator = access_token 쿠키
+
+
+@pytest.mark.asyncio
+async def test_reset_strategy_kill_switch_service_unavailable(web_client, mock_web_ctx):
+    """Kill Switch 서비스 미초기화 시 503."""
+    mock_web_ctx.kill_switch_service = None
+    web_client.cookies.set("access_token", "secret")
+
+    resp = web_client.post("/api/kill-switch/reset-strategy/momentum")
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_reset_strategy_kill_switch_requires_auth(web_client, mock_web_ctx):
+    """인증 쿠키가 없으면 401."""
+    web_client.cookies.clear()
+
+    resp = web_client.post("/api/kill-switch/reset-strategy/momentum")
+
+    assert resp.status_code == 401

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -233,3 +233,87 @@ async def test_place_overseas_real_order_requires_allow_live_trading(web_client,
     assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
     assert response.json()["data"]["rule"] == "overseas_live_trading_disabled"
     mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_rejects_disabled_exchange(web_client, mock_web_ctx):
+    """overseas_stock.enabled_exchanges 밖의 거래소는 400으로 차단된다."""
+    from types import SimpleNamespace
+
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.full_config = SimpleNamespace(
+        overseas_stock=SimpleNamespace(enabled_exchanges=["NYSE"])
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",  # NYSE만 활성화 → NASD는 차단
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 400
+    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_real_order_requires_confirmation_when_live_allowed(web_client, mock_web_ctx):
+    """allow_live_trading=True 라도 확인 문자열이 없으면 400."""
+    from types import SimpleNamespace
+
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config = SimpleNamespace(
+        overseas_stock=SimpleNamespace(
+            allow_live_trading=True,
+            enabled_exchanges=["NASD", "NYSE", "AMEX"],
+        )
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+        # real_order_confirmation 누락
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 400
+    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_orders_requires_overseas_mode(web_client, mock_web_ctx):
+    """overseas_us가 enabled되지 않은 run에서는 해외 주문 조회가 닫혀 있다."""
+    response = web_client.get("/api/overseas/orders")
+    assert response.status_code == 400
+    mock_web_ctx.stock_query_service.get_overseas_order_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_orders_defaults_dates_to_today(web_client, mock_web_ctx):
+    """날짜 미지정 시 market_clock 기준 오늘 날짜로 채워 조회한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.market_clock.get_current_kst_time.return_value.strftime.return_value = "20260614"
+    mock_web_ctx.stock_query_service.get_overseas_order_history.return_value = ResCommonResponse(
+        rt_cd="0", msg1="ok", data={"orders": []}
+    )
+
+    response = web_client.get("/api/overseas/orders")
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == "0"
+    mock_web_ctx.stock_query_service.get_overseas_order_history.assert_awaited_once_with(
+        symbol="%",
+        exchange="NASD",
+        start_date="20260614",
+        end_date="20260614",
+        side_code="00",
+        ccld_nccs_dvsn="00",
+    )

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -400,6 +400,29 @@ async def test_get_stocks_list(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_overseas_stocks_list(web_client, mock_web_ctx):
+    """GET /api/overseas/stocks/list 엔드포인트 테스트"""
+    mock_web_ctx.overseas_stock_code_repository.all_symbols.return_value = [
+        {"s": "AAPL", "n": "Apple Inc", "e": "NASD"},
+        {"s": "LLY", "n": "Eli Lilly and Co", "e": "NYSE"},
+    ]
+    response = web_client.get("/api/overseas/stocks/list")
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["count"] == 2
+    assert {"s": "AAPL", "n": "Apple Inc", "e": "NASD"} in json_resp["stocks"]
+
+
+@pytest.mark.asyncio
+async def test_get_overseas_stocks_list_no_repo(web_client, mock_web_ctx):
+    """리포지토리가 None이면 빈 목록을 반환한다."""
+    mock_web_ctx.overseas_stock_code_repository = None
+    response = web_client.get("/api/overseas/stocks/list")
+    assert response.status_code == 200
+    assert response.json() == {"stocks": [], "count": 0}
+
+
+@pytest.mark.asyncio
 async def test_search_stock_by_name(web_client, mock_web_ctx):
     """GET /api/stock/search 엔드포인트 테스트 (빈 쿼리 및 정상 쿼리)"""
     # 빈 문자열 검색

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -119,6 +119,17 @@ async def get_stocks_list():
     return {"stocks": stock_list, "count": len(stock_list)}
 
 
+@router.get("/overseas/stocks/list")
+async def get_overseas_stocks_list():
+    """해외(미국) 전 심볼 리스트 반환 (클라이언트 자동완성용, localStorage 캐싱 대상)."""
+    ctx = _get_ctx()
+    repo = getattr(ctx, "overseas_stock_code_repository", None)
+    if repo is None:
+        return {"stocks": [], "count": 0}
+    stock_list = repo.all_symbols()
+    return {"stocks": stock_list, "count": len(stock_list)}
+
+
 @router.get("/stock/search")
 async def search_stock_by_name(q: str = ""):
     """종목명 부분 일치 검색 (자동완성용)."""

--- a/view/web/static/js/autocomplete.js
+++ b/view/web/static/js/autocomplete.js
@@ -47,38 +47,79 @@ function _matchMixed(query, name) {
 }
 
 /**
+ * 국내 종목 기본 검색: 숫자 → 종목코드 prefix, 그 외 → 종목명 혼합(초성+텍스트) 매칭.
+ */
+function _defaultStockSearch(q, stocks) {
+    const results = [];
+    const isDigit = /^\d+$/.test(q);
+    for (let i = 0; i < stocks.length && results.length < 20; i++) {
+        const s = stocks[i];
+        if (isDigit) {
+            if (s.c.startsWith(q)) results.push(s);
+        } else {
+            if (_matchMixed(q, s.n)) results.push(s);
+        }
+    }
+    return results;
+}
+
+/**
+ * 해외 심볼 검색: 심볼 prefix(대소문자 무시) 또는 영문명 부분 일치.
+ * 항목 형태: { s: 심볼, n: 종목명, e: 거래소 }
+ */
+function _overseasStockSearch(q, stocks) {
+    const upper = q.toUpperCase();
+    const lower = q.toLowerCase();
+    const results = [];
+    for (let i = 0; i < stocks.length && results.length < 20; i++) {
+        const s = stocks[i];
+        const sym = String(s.s || '');
+        const name = String(s.n || '');
+        if (sym.toUpperCase().startsWith(upper) || name.toLowerCase().includes(lower)) {
+            results.push(s);
+        }
+    }
+    return results;
+}
+
+/**
  * 종목 자동완성 초기화.
  *
  * @param {object} config
  * @param {string}   config.inputId    - 검색 input 요소 ID
  * @param {string}   config.listId     - 드롭다운 목록 요소 ID
- * @param {function} config.onSelect   - 항목 선택 시 콜백: (code, name) => void
+ * @param {function} config.onSelect   - 항목 선택 시 콜백: (value, name, item) => void
  * @param {function} [config.onConfirm] - 드롭다운 미선택 상태에서 Enter 시 콜백 (기본: noop)
+ * @param {string}   [config.valueKey='c'] - onSelect 첫 인자로 넘길 항목 필드 (국내 'c' / 해외 's')
+ * @param {function} [config.getInitial] - 초기 데이터 배열 반환 (기본: 전역 ALL_STOCKS)
+ * @param {string}   [config.readyEvent='all-stocks-ready'] - 데이터 준비 완료 이벤트명
+ * @param {function} [config.searchImpl] - 검색 구현 (q, stocks) => item[] (기본: 국내 검색)
+ * @param {function} [config.formatItem] - 항목 표시 문자열 (기본: "name (value)")
  */
-function StockAutocomplete({ inputId, listId, onSelect, onConfirm }) {
+function StockAutocomplete(config) {
+    const { inputId, listId, onSelect, onConfirm } = config;
+    const valueKey = config.valueKey || 'c';
+    const readyEvent = config.readyEvent || 'all-stocks-ready';
+    const searchImpl = config.searchImpl || _defaultStockSearch;
+    const formatItem = config.formatItem || function (s) { return s.n + ' (' + s[valueKey] + ')'; };
+    const getInitial = config.getInitial || function () {
+        return (typeof ALL_STOCKS !== 'undefined' && ALL_STOCKS) ? ALL_STOCKS : null;
+    };
+
     let _stocks = [];
     let _activeIndex = -1;
+    let _rendered = [];
 
     function _setupStocks(raw) {
         _stocks = raw || [];
         for (let i = 0; i < _stocks.length; i++) {
-            if (!_stocks[i].ch) _stocks[i].ch = _getChosung(_stocks[i].n);
+            if (!_stocks[i].ch) _stocks[i].ch = _getChosung(_stocks[i].n || '');
         }
     }
 
     function _search(q) {
         if (!q) return [];
-        const results = [];
-        const isDigit = /^\d+$/.test(q);
-        for (let i = 0; i < _stocks.length && results.length < 20; i++) {
-            const s = _stocks[i];
-            if (isDigit) {
-                if (s.c.startsWith(q)) results.push(s);
-            } else {
-                if (_matchMixed(q, s.n)) results.push(s);
-            }
-        }
-        return results;
+        return searchImpl(q, _stocks);
     }
 
     function _initDom() {
@@ -86,29 +127,30 @@ function StockAutocomplete({ inputId, listId, onSelect, onConfirm }) {
         const list = document.getElementById(listId);
         if (!input || !list) return;
 
-        if (typeof ALL_STOCKS !== 'undefined' && ALL_STOCKS) _setupStocks(ALL_STOCKS);
-        document.addEventListener('all-stocks-ready', function (e) { _setupStocks(e.detail); });
+        const initial = getInitial();
+        if (initial) _setupStocks(initial);
+        document.addEventListener(readyEvent, function (e) { _setupStocks(e.detail); });
 
         function _close() {
             list.innerHTML = '';
             list.style.display = 'none';
             _activeIndex = -1;
+            _rendered = [];
         }
 
-        function _select(code, name) {
+        function _select(item) {
             _close();
-            onSelect(code, name);
+            onSelect(item[valueKey], item.n, item);
         }
 
         function _render(results) {
             list.innerHTML = '';
+            _rendered = results;
             if (!results.length) { list.style.display = 'none'; return; }
             results.forEach(function (s) {
                 const li = document.createElement('li');
-                li.textContent = s.n + ' (' + s.c + ')';
-                li.dataset.code = s.c;
-                li.dataset.name = s.n;
-                li.addEventListener('click', function () { _select(s.c, s.n); });
+                li.textContent = formatItem(s);
+                li.addEventListener('click', function () { _select(s); });
                 list.appendChild(li);
             });
             list.style.display = 'block';
@@ -138,9 +180,8 @@ function StockAutocomplete({ inputId, listId, onSelect, onConfirm }) {
                 _updateActive();
             } else if (e.key === 'Enter') {
                 e.preventDefault();
-                if (_activeIndex >= 0 && items[_activeIndex]) {
-                    const item = items[_activeIndex];
-                    _select(item.dataset.code, item.dataset.name);
+                if (_activeIndex >= 0 && _rendered[_activeIndex]) {
+                    _select(_rendered[_activeIndex]);
                 } else if (typeof onConfirm === 'function') {
                     _close();
                     onConfirm();

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -3,6 +3,31 @@
 let _currentExchange = 'KRX';
 let _currentStockCode = null;
 
+/* 해외 심볼 리스트: localStorage 즉시 복원, 없으면 해외 모드 진입 시 지연 로드.
+ * 국내(ALL_STOCKS)와 달리 대부분의 방문자가 국내만 쓰므로 ~7천 심볼을
+ * 매 방문마다 받지 않도록 lazy 로드한다. */
+window.ALL_OVERSEAS_STOCKS = (function () {
+    try {
+        var cached = localStorage.getItem('all_overseas_stocks_v1');
+        if (cached) return JSON.parse(cached);
+    } catch (e) {}
+    return null;
+})();
+let _overseasStocksLoading = false;
+function _ensureOverseasStocksLoaded() {
+    if (window.ALL_OVERSEAS_STOCKS || _overseasStocksLoading) return;
+    _overseasStocksLoading = true;
+    fetch('/api/overseas/stocks/list')
+        .then(function (r) { return r.json(); })
+        .then(function (json) {
+            window.ALL_OVERSEAS_STOCKS = json.stocks || [];
+            try { localStorage.setItem('all_overseas_stocks_v1', JSON.stringify(window.ALL_OVERSEAS_STOCKS)); } catch (e) {}
+            document.dispatchEvent(new CustomEvent('all-overseas-stocks-ready', { detail: window.ALL_OVERSEAS_STOCKS }));
+        })
+        .catch(function () { window.ALL_OVERSEAS_STOCKS = []; })
+        .finally(function () { _overseasStocksLoading = false; });
+}
+
 // SSE 실시간 틱 수신 → 가격·전일대비·당일시세(고가·저가) UI 업데이트
 document.addEventListener('stock-price-tick', function (e) {
     const tick = e.detail;
@@ -56,6 +81,9 @@ function setStockMarketMode(mode) {
     if (overseasRow) overseasRow.style.display = isOverseas ? '' : 'none';
     if (domesticBtn) domesticBtn.classList.toggle('active', !isOverseas);
     if (overseasBtn) overseasBtn.classList.toggle('active', isOverseas);
+
+    // 해외 모드 진입 시 자동완성용 심볼 리스트를 지연 로드한다.
+    if (isOverseas) _ensureOverseasStocksLoaded();
 
     // 모드 전환 시 결과/차트 영역 초기화 (국내↔해외 잔여 UI 방지)
     // 차트 카드를 먼저 대피시킨 뒤 결과를 비운다.
@@ -207,6 +235,28 @@ StockAutocomplete({
     onConfirm: function() { searchStock(); }
 });
 
+/* ── 해외 심볼 자동완성 (심볼 prefix + 영문명 매칭, 선택 시 거래소 자동설정) ── */
+function _initOverseasAutocomplete() {
+    StockAutocomplete({
+        inputId: 'overseas-stock-symbol',
+        listId: 'overseas-autocomplete-list',
+        valueKey: 's',
+        readyEvent: 'all-overseas-stocks-ready',
+        getInitial: function () { return window.ALL_OVERSEAS_STOCKS || null; },
+        searchImpl: _overseasStockSearch,
+        formatItem: function (s) { return s.s + ' — ' + s.n + ' (' + s.e + ')'; },
+        onSelect: function (symbol, name, item) {
+            const input = document.getElementById('overseas-stock-symbol');
+            if (input) input.value = symbol;
+            const sel = document.getElementById('overseas-stock-exchange');
+            if (sel && item && item.e) sel.value = item.e;
+            searchOverseasStock();
+        },
+        onConfirm: function () { searchOverseasStock(); }
+    });
+}
+_initOverseasAutocomplete();
+
 /* ── Pjax 재방문 시 자동완성 재초기화 ── */
 document.addEventListener('pjax:ready', (e) => {
     if (e.detail?.path !== '/stock') return;
@@ -220,6 +270,7 @@ document.addEventListener('pjax:ready', (e) => {
         },
         onConfirm: function() { searchStock(); }
     });
+    _initOverseasAutocomplete();
 
         const urlParams = new URLSearchParams(window.location.search);
         const code = urlParams.get('code');

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -25,15 +25,16 @@
                 <button class="btn" onclick="searchStock()">조회</button>
                 <ul id="stock-autocomplete-list" class="autocomplete-list"></ul>
             </div>
-            <div id="overseas-stock-row" class="form-row" style="display:none;">
-                <label>심볼</label>
-                <input type="text" id="overseas-stock-symbol" placeholder="예: AAPL" maxlength="12" autocomplete="off">
+            <div id="overseas-stock-row" class="form-row" style="display:none; position: relative;">
+                <label>심볼/종목명</label>
+                <input type="text" id="overseas-stock-symbol" placeholder="예: AAPL / Apple" maxlength="40" autocomplete="off">
                 <select id="overseas-stock-exchange">
                     <option value="NASD">NASDAQ</option>
                     <option value="NYSE">NYSE</option>
                     <option value="AMEX">AMEX</option>
                 </select>
                 <button class="btn" onclick="searchOverseasStock()">조회</button>
+                <ul id="overseas-autocomplete-list" class="autocomplete-list"></ul>
             </div>
         </div>
         <div id="stock-result"></div>
@@ -69,8 +70,8 @@
             .catch(function() { ALL_STOCKS = []; });
     }
 </script>
-<script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/stock.js?v=12"></script>
+<script src="/static/js/autocomplete.js?v=2"></script>
+<script src="/static/js/stock.js?v=13"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -16,6 +16,7 @@ from repositories.virtual_trade_repository import VirtualTradeRepository
 from repositories.backtest_journal_repository import BacktestJournalRepository
 from services.virtual_trade_service import VirtualTradeService
 from repositories.stock_code_repository import StockCodeRepository
+from repositories.overseas_stock_code_repository import OverseasStockCodeRepository
 from repositories.rs_rating_repository import RSRatingRepository
 from repositories.favorite_repository import FavoriteRepository
 from services.favorite_service import FavoriteService
@@ -114,6 +115,13 @@ class WebAppContext:
         self.virtual_trade_service = VirtualTradeService(repository=self.virtual_repo, market_clock=self.market_clock)
         self.virtual_trade_service.backfill_snapshots()  # 과거 CSV 기반 스냅샷 역산
         self.stock_code_repository = StockCodeRepository(logger=self.logger)
+        # 해외 심볼 자동완성용 리포지토리. 첫 실행 시 FDR 다운로드가 실패해도
+        # 웹 시작을 막지 않도록 방어적으로 생성한다(실패 시 None → 목록 API는 빈 결과).
+        try:
+            self.overseas_stock_code_repository = OverseasStockCodeRepository(logger=self.logger)
+        except Exception as e:
+            self.logger.warning(f"해외 종목코드 리포지토리 초기화 실패(자동완성 비활성): {e}")
+            self.overseas_stock_code_repository = None
         self.favorite_repo = FavoriteRepository()
         self.favorite_service = FavoriteService(
             repository=self.favorite_repo,


### PR DESCRIPTION
## 요약
`/stock` 화면의 해외 종목 조회에 국내 종목 조회와 동일한 자동완성 기능을 추가합니다. 기존에는 해외 심볼 데이터 소스가 프로젝트에 전혀 없어, 국내 자동완성 흐름(`StockCodeRepository` → `/api/stocks/list` → localStorage → autocomplete 모듈)을 해외용으로 미러링했습니다.

## 결정 사항 (사용자 확인)
- **데이터 소스**: FinanceDataReader 전체 상장목록(NASDAQ/NYSE/AMEX, ~7천 심볼)
- **거래소 자동설정**: 자동완성에서 심볼 선택 시 거래소 드롭다운 자동 변경

## 변경 내용
- **`services/overseas_stock_sync_service.py`** (신규): FDR 3개 거래소 상장목록을 `심볼/종목명/거래소`로 통합해 SQLite DB로 저장 (국내와 동일한 7일 캐시 메타데이터 패턴)
- **`repositories/overseas_stock_code_repository.py`** (신규): 심볼 prefix(대소문자 무시)·영문명 부분일치 검색, 최소 DB fallback
- **`GET /api/overseas/stocks/list`**: 자동완성용 전 심볼 반환. `WebAppContext`에 리포지토리 배선(첫 실행 FDR 다운로드 실패 시 `None`→빈 목록으로 fail-safe, 웹 시작 비차단)
- **`autocomplete.js` 일반화**: `valueKey`/`searchImpl`/`formatItem`/`onSelect(value, name, item)` 옵션 추가. 기본값으로 기존 국내 동작 그대로 보존
- **`stock.html`/`stock.js`**: 해외 입력행에 자동완성 드롭다운 추가, 심볼 리스트는 해외 모드 진입 시 지연 로드(국내 전용 방문자에게 ~7천 심볼 다운로드 부담 회피). 선택 시 심볼·거래소 자동 채움 후 조회

## 테스트
- jsdom 회귀 하네스 추가(`run_autocomplete_dom_tests.mjs`): 국내 자동완성 회귀 보호 + 해외 심볼/영문명 매칭·거래소 자동설정 행위 검증 (6/6)
- 기존 `run_stock_dom_tests.mjs` 스텁 보강(`_overseasStockSearch`, `fetch`) — 4/4 유지
- **unit 6026 passed / integration 243 passed**

## 참고
- FDR 컬럼 실측 확정: `Symbol`, `Name` (+`거래소`는 직접 부여)

🤖 Generated with [Claude Code](https://claude.com/claude-code)