### PR TITLE
[codex] Fix fill and program trading reports

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -495,14 +495,53 @@ class KoreaInvestWebSocketAPI:
         parsed["CNTG_YN"] = parsed.get("체결여부", "")
         parsed["ACPT_YN"] = parsed.get("접수여부", "")
         parsed["RFUS_YN"] = parsed.get("거부여부", "")
+        def _field(index: int) -> str:
+            return values[index] if index < len(values) else ""
+
+        parsed.update({
+            "CUST_ID": _field(0),
+            "ACNT_NO": _field(1),
+            "ODER_NO": _field(2),
+            "ORGN_ODER_NO": _field(3),
+            "SELN_BYOV_CLS": _field(4),
+            "STCK_SHRN_ISCD": _field(8),
+            "STCK_CNTG_HOUR": _field(11),
+            "RFUS_YN": _field(12),
+            "CNTG_YN": _field(13),
+            "ACPT_YN": _field(14),
+        })
+        if is_fill_notice:
+            parsed["CNTG_QTY"] = _field(9)
+            parsed["CNTG_UNPR"] = _field(10)
+            parsed["ODER_QTY"] = _field(16)
+            parsed["ORD_UNPR"] = _field(25)
+        else:
+            parsed["ODER_QTY"] = _field(9)
+            parsed["ORD_UNPR"] = _field(10)
+            parsed["CNTG_QTY"] = ""
+            parsed["CNTG_UNPR"] = _field(25)
+
         if len(values) < len(keys):
             parsed["parse_warning"] = "short_payload"
             parsed["field_count"] = len(values)
             parsed["raw"] = data_str
-            self._logger.warning(
-                f"체결통보 payload가 공식 필드 수보다 짧습니다: TR_ID={tr_id}, "
-                f"field_count={len(values)}, expected={len(keys)}"
-            )
+            required_indices = (2, 4, 8, 11, 12, 13, 14)
+            required_indices += (9, 10) if is_fill_notice else (9,)
+            missing_required = [
+                index for index in required_indices
+                if index >= len(values) or values[index] in (None, "")
+            ]
+            if missing_required:
+                parsed["missing_required_indices"] = missing_required
+                self._logger.warning(
+                    f"체결통보 payload가 공식 필드 수보다 짧고 필수 필드가 비었습니다: TR_ID={tr_id}, "
+                    f"field_count={len(values)}, expected={len(keys)}, missing={missing_required}"
+                )
+            else:
+                self._logger.debug(
+                    f"체결통보 payload optional fields omitted: TR_ID={tr_id}, "
+                    f"field_count={len(values)}, expected={len(keys)}"
+                )
         if parsed["RFUS_YN"].upper() == "Y":
             parsed["통보유형"] = "거부"
         elif parsed["CNTG_YN"] == "2":

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -1058,7 +1058,7 @@ class StrategyScheduler:
                    f"주문: {log_price:,}원 × {signal.qty}주\n"
                    f"사유: {signal.reason}")
             if api_success and not self._dry_run:
-                msg = f"{msg}\n상태: 주문 접수(API 성공, 체결은 별도 확인 필요)"
+                msg = f"{msg}\n상태: 주문 접수(API 성공, 체결 미확정 - 체결통보/조회로 별도 확인)"
             if not api_success:
                 title = f"[{signal.strategy_name}] {signal.name} {action_kr} 실패"
                 if order_error_msg:

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -199,11 +199,11 @@ class FillReconciliationService:
 
         strategy_name, is_strategy_source = self._strategy_name_from_source(context.source)
         record_qty = context.filled_qty
-        record_price = report.fill_price or context.price
-        if self._kill_switch and report.fill_price and context.price > 0:
+        record_price = context.average_fill_price or report.fill_price or context.price
+        if self._kill_switch and record_price and context.price > 0:
             await self._kill_switch.record_fill_event(
                 context.price,
-                report.fill_price,
+                record_price,
                 context.stock_code,
                 record_qty,
                 side=context.side.value,

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -517,7 +517,7 @@ class OrderExecutionService:
                     ))
                 if self._notification_service:
                     await self._notification_service.emit(NotificationCategory.API, NotificationLevel.INFO, "매수 주문 접수",
-                                        f"{stock_code} {qty}주 @ {price}원 - 체결은 별도 확인 필요",
+                                        f"{stock_code} {qty}주 @ {price}원 주문 접수 - 체결 미확정, 체결통보/조회로 별도 확인",
                                         metadata={"code": stock_code, "qty": qty, "price": price, "trace_id": current_trace})
             else:
                 rt_cd = buy_order_result.rt_cd if buy_order_result else 'None'
@@ -580,7 +580,7 @@ class OrderExecutionService:
                     ))
                 if self._notification_service:
                     await self._notification_service.emit(NotificationCategory.API, NotificationLevel.INFO, "매도 주문 접수",
-                                        f"{stock_code} {qty}주 @ {price}원 - 체결은 별도 확인 필요",
+                                        f"{stock_code} {qty}주 @ {price}원 주문 접수 - 체결 미확정, 체결통보/조회로 별도 확인",
                                         metadata={"code": stock_code, "qty": qty, "price": price, "trace_id": current_trace})
             else:
                 rt_cd = sell_order_result.rt_cd if sell_order_result else 'None'

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -27,6 +27,7 @@ class ProgramTradingStreamService:
     FLUSH_INTERVAL_SEC = 1.0
     FLUSH_BATCH_SIZE = 100
     HOURLY_TICK_ALERT_INTERVAL_SEC = 60 * 60
+    REGULAR_SESSION_CLOSE_TIME = "15:30"
 
     def __init__(self, logger=None):
         self.logger = logger if logger else logging.getLogger(__name__)
@@ -435,6 +436,9 @@ class ProgramTradingStreamService:
 
         open_time = getattr(self._market_clock, "market_open_time_str", "09:00")
         close_time = getattr(self._market_clock, "market_close_time_str", "15:40")
+        regular_close_time = self.REGULAR_SESSION_CLOSE_TIME
+        if close_time > regular_close_time:
+            close_time = regular_close_time
         open_hour, open_minute = map(int, open_time.split(":"))
         close_hour, close_minute = map(int, close_time.split(":"))
         start_dt = datetime(day.year, day.month, day.day, open_hour, open_minute)
@@ -479,7 +483,7 @@ class ProgramTradingStreamService:
         records = self._repo.get_history_records_for_persistence_by_code(
             codes,
             start_dt.timestamp(),
-            end_dt.timestamp(),
+            (end_dt + timedelta(seconds=59)).timestamp(),
         )
         expected_set = set(expected_minutes)
 
@@ -532,7 +536,7 @@ class ProgramTradingStreamService:
             f"<b>프로그램매매 DB 저장 점검 ({html.escape(str(status.get('date', '')))}일)</b>",
             f"구간: {html.escape(status['window']['start'])} ~ {html.escape(status['window']['end'])}",
             f"기대 분봉: {status['expected_minute_count']}분",
-            "기준: 체결시간 기준, 수신 분봉 대비 DB 저장 여부",
+            "기준: 체결시간 기준, 정규장 프로그램매매 수신 분봉 대비 DB 저장 여부",
             "",
         ]
         for code, item in status["codes"].items():

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -584,6 +584,7 @@ async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
     with patch("view.web.bootstrap.config_bootstrap.load_configs", return_value=mock_config), \
          patch("view.web.web_app_initializer.VirtualTradeRepository") as MockVTM, \
          patch("view.web.web_app_initializer.StockCodeRepository"), \
+         patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
          patch("brokers.broker_api_wrapper.StockCodeRepository"), \
          patch("view.web.bootstrap.config_bootstrap.MarketCalendarService") as Mockmcs:
 

--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -547,6 +547,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())
@@ -605,6 +606,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())
@@ -636,6 +638,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())
@@ -667,6 +670,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())
@@ -707,6 +711,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())
@@ -745,6 +750,7 @@ class TestWebAppContextInitialization:
         with patch("config.config_loader.load_configs", return_value=mock_config), \
              patch("view.web.web_app_initializer.VirtualTradeRepository"), \
              patch("brokers.broker_api_wrapper.StockCodeRepository"), \
+             patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
             ctx = WebAppContext(SimpleContext())

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -904,6 +904,12 @@ def test_parse_signing_notice_fill_data(websocket_api_instance):
     assert parsed["체결단가"] == "70000"
     assert parsed["통보유형"] == "체결"
     assert parsed["tr_id"] == "H0STCNI0"
+    assert parsed["ODER_NO"] == "A0001"
+    assert parsed["STCK_SHRN_ISCD"] == "005930"
+    assert parsed["SELN_BYOV_CLS"] == "02"
+    assert parsed["CNTG_QTY"] == "4"
+    assert parsed["CNTG_UNPR"] == "70000"
+    assert parsed["STCK_CNTG_HOUR"] == "101500"
 
 
 def test_parse_signing_notice_acceptance_data(websocket_api_instance):
@@ -920,7 +926,34 @@ def test_parse_signing_notice_acceptance_data(websocket_api_instance):
     assert parsed["주문수량"] == "10"
     assert parsed["체결여부"] == "1"
     assert parsed["CNTG_YN"] == "1"
+    assert parsed["ODER_NO"] == "A0001"
+    assert parsed["ODER_QTY"] == "10"
+    assert parsed["ORD_UNPR"] == "70000"
     assert parsed["통보유형"] == "접수"
+
+
+def test_parse_signing_notice_short_fill_payload_with_required_fields_is_not_warning(websocket_api_instance):
+    api = websocket_api_instance
+    values = [
+        "test-htsid", "12345678", "A0001", "", "02", "00", "00", "00",
+        "005930", "5", "5660", "151046", "N", "2", "Y", "001",
+        "353", "계좌명", "0", "KRX", "Y", "", ""
+    ]
+
+    parsed = KoreaInvestWebSocketAPI._parse_signing_notice(api, "^".join(values), "H0STCNI9")
+
+    assert parsed["parse_warning"] == "short_payload"
+    assert parsed["field_count"] == 23
+    assert parsed["ODER_NO"] == "A0001"
+    assert parsed["STCK_SHRN_ISCD"] == "005930"
+    assert parsed["SELN_BYOV_CLS"] == "02"
+    assert parsed["CNTG_QTY"] == "5"
+    assert parsed["CNTG_UNPR"] == "5660"
+    assert parsed["ODER_QTY"] == "353"
+    assert parsed["STCK_CNTG_HOUR"] == "151046"
+    assert parsed["통보유형"] == "체결"
+    api._logger.warning.assert_not_called()
+    api._logger.debug.assert_called_once()
 
 
 def test_parse_signing_notice_short_payload_is_observable(websocket_api_instance):

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -2890,7 +2890,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args[0], NotificationCategory.STRATEGY)
         self.assertEqual(args[1], NotificationLevel.CRITICAL)
         self.assertTrue("주문 접수" in args[2])
-        self.assertTrue("체결은 별도 확인 필요" in args[3])
+        self.assertTrue("체결 미확정" in args[3])
 
     async def test_execute_sell_signal_notification_includes_estimated_return_rate(self):
         """실전 매도 알림은 체결 확정 전에도 보유 매수가 기준 수익률을 포함한다."""

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -520,6 +520,26 @@ async def test_persist_records_buy_via_virtual_trade(broker, fsm, reporter, fixe
 # ── resolve_submitted_order + mark_* ─────────────────────────────────────
 
 @pytest.mark.asyncio
+async def test_persist_records_average_fill_price_when_available(broker, fsm, reporter, fixed_now):
+    vts = AsyncMock()
+    svc = _make_service(broker=broker, fsm=fsm, reporter=reporter, fixed_now=fixed_now, virtual_trade_service=vts)
+    ctx = fsm.register(_make_context(source="strategy:momentum"))
+    fsm.transition(ctx.order_key, OrderState.SUBMITTED)
+    filled = fsm.transition(
+        ctx.order_key,
+        OrderState.FILLED,
+        filled_qty=10,
+        average_fill_price=70525.5,
+    )
+
+    report = OrderExecutionReport(broker_order_no="X", stock_code="005930", side=OrderSide.BUY, fill_price=70600)
+    await svc._persist_virtual_trade_for_terminal_report(filled, report)
+
+    args = vts.log_buy_async.await_args.args
+    assert args[2] == 70525.5
+
+
+@pytest.mark.asyncio
 async def test_resolve_submitted_transitions_to_filled(broker, fsm, reporter, fixed_now):
     svc = _make_service(broker=broker, fsm=fsm, reporter=reporter, fixed_now=fixed_now)
     fsm.register(_make_context())

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -260,7 +260,7 @@ async def test_handle_sell_stock_place_order_delegation_failure(handler, mock_br
     assert "005930" in logged_msg
 
 @pytest.mark.asyncio
-async def test_handle_place_buy_order_success(handler, mock_broker_api_wrapper, mock_logger):
+async def test_handle_place_buy_order_success(handler, mock_broker_api_wrapper, mock_logger, mock_notification_service):
     """handle_place_buy_order 매수 주문 실행 성공 테스트."""
     mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
         rt_cd="0",
@@ -273,6 +273,9 @@ async def test_handle_place_buy_order_success(handler, mock_broker_api_wrapper, 
         "005930", 70000, 10, is_buy=True, exchange=Exchange.KRX
     )
     mock_logger.info.assert_called()
+    emit_args = mock_notification_service.emit.await_args.args
+    assert emit_args[2] == "매수 주문 접수"
+    assert "체결 미확정" in emit_args[3]
     assert result.rt_cd == "0"
     assert result.msg1 == "주문 성공"
 
@@ -291,7 +294,7 @@ async def test_handle_place_buy_order_trading_service_failure(handler, mock_brok
     assert result.msg1 == "잔고 부족"
 
 @pytest.mark.asyncio
-async def test_handle_place_sell_order_success(handler, mock_broker_api_wrapper, mock_logger):
+async def test_handle_place_sell_order_success(handler, mock_broker_api_wrapper, mock_logger, mock_notification_service):
     """handle_place_sell_order 매도 주문 실행 성공 테스트."""
     mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
         rt_cd="0",
@@ -304,6 +307,9 @@ async def test_handle_place_sell_order_success(handler, mock_broker_api_wrapper,
         "005930", 60000, 5, is_buy=False, exchange=Exchange.KRX
     )
     mock_logger.info.assert_called()
+    emit_args = mock_notification_service.emit.await_args.args
+    assert emit_args[2] == "매도 주문 접수"
+    assert "체결 미확정" in emit_args[3]
     assert result.rt_cd == "0"
     assert result.msg1 == "매도 성공"
 
@@ -1322,7 +1328,7 @@ async def test_partial_fill_then_cancel_persists_confirmed_partial_qty(mock_brok
 
     assert canceled.state == OrderState.CANCELED
     assert canceled.virtual_recorded_qty == 4
-    virtual_trade_service.log_buy_async.assert_awaited_once_with("수동매매", "005930", 70200, 4, volatility_20d_annualized=None)
+    virtual_trade_service.log_buy_async.assert_awaited_once_with("수동매매", "005930", 70100.0, 4, volatility_20d_annualized=None)
 
 
 def _seed_order_context(

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -630,6 +630,27 @@ def test_build_db_minute_persistence_status_splits_unsaved_and_no_tick_minutes(m
     assert item["no_tick_minutes"] == ["09:02"]
 
 
+def test_build_db_minute_persistence_status_caps_to_regular_session_and_includes_close_minute(manager):
+    clock = MarketClock(market_open_time="15:29", market_close_time="15:40")
+    manager.wire_alert_dependencies(market_clock=clock)
+
+    day = clock.market_timezone.localize(datetime(2026, 6, 15, 15, 30, 26))
+    with manager._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO pt_history (code, trade_time, created_at) VALUES (?, ?, ?)",
+            ("005930", "153026", day.timestamp()),
+        )
+
+    status = manager.build_db_minute_persistence_status(["005930"], "20260615")
+    item = status["codes"]["005930"]
+
+    assert status["window"]["end"] == "2026-06-15 15:30:00"
+    assert status["expected_minute_count"] == 2
+    assert item["saved_minute_count"] == 1
+    assert item["missing_minutes"] == ["15:29"]
+    assert "15:31" not in item["missing_minutes"]
+
+
 @pytest.mark.asyncio
 async def test_send_db_persistence_report_sends_summary(manager):
     """장마감 DB 저장 점검 결과를 텔레그램으로 전송한다."""

--- a/tests/unit_test/services/test_program_trading_stream_service_branches.py
+++ b/tests/unit_test/services/test_program_trading_stream_service_branches.py
@@ -188,7 +188,7 @@ def test_build_trading_window_defaults_to_today_for_short_date(svc):
     start_dt, end_dt, minutes, tz = svc._build_trading_window("abc")
     assert tz is None
     assert minutes[0] == "09:00"
-    assert minutes[-1] == "15:40"
+    assert minutes[-1] == "15:30"
 
 
 def test_minute_from_trade_time_invalid(svc):
@@ -241,6 +241,8 @@ async def test_hourly_tick_alert_loop_swallows_generic_error(svc):
 
 @pytest.mark.asyncio
 async def test_after_market_db_check_loop_reports_once_per_date(svc):
+    import scheduler.after_market_loop
+
     svc._market_calendar_service = MagicMock()
     svc._market_clock = MagicMock()
     svc.send_db_persistence_report = AsyncMock(return_value=True)

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -968,6 +968,65 @@ async def test_report_matches_virtual_trade_strategy_id_to_vbo_log_section(log_d
 
 
 @pytest.mark.asyncio
+async def test_report_includes_strategy_regime_decomposition_section(log_dir):
+    """일일 리포트 본문에 전략별 regime 분해 섹션을 포함한다."""
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return []
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+        def get_standard_journal_records(self):
+            return [
+                {
+                    "strategy": "S1",
+                    "code": "000001",
+                    "status": "SOLD",
+                    "signal_time": "2026-04-15 10:00:00",
+                    "net_pnl": 100.0,
+                    "net_return": 2.0,
+                    "market_regime": {
+                        "kospi": "bull",
+                        "kosdaq": "bull",
+                        "stock_market": "KOSPI",
+                    },
+                },
+                {
+                    "strategy": "S2",
+                    "code": "000002",
+                    "status": "SOLD",
+                    "signal_time": "2026-04-16 10:00:00",
+                    "net_pnl": 120.0,
+                    "net_return": 1.5,
+                    "market_regime": {
+                        "kospi": "bull",
+                        "kosdaq": "bull",
+                        "stock_market": "KOSPI",
+                    },
+                },
+            ]
+
+    scan_entry = _make_entry("scan_with_watchlist", "", "", date="2026-04-18")
+    scan_entry["data"]["count"] = 2
+    _write_log(os.path.join(log_dir, "20260418_093000_FirstPullback.log.json"), [scan_entry])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+    )
+    report = await svc.generate_report("20260418")
+
+    assert "전략별 시장국면(regime) 분해" in report
+    assert "집중도: 2/2" in report
+    assert "S1" in report
+    assert "S2" in report
+
+
+@pytest.mark.asyncio
 async def test_report_filters_disabled_strategy_sections_and_execution_quality(log_dir):
     """스케줄러에서 제외된 전략은 실행 섹션과 체결 품질 요약에서 제외한다."""
     scan_entry = _make_entry("scan_with_watchlist", "", "", reason="")

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -22,6 +22,7 @@ def mock_deps():
         ("vtm", patch("view.web.web_app_initializer.VirtualTradeRepository", autospec=True)),
         ("backtest_journal_repo", patch("view.web.web_app_initializer.BacktestJournalRepository", autospec=True)),
         ("scm", patch("view.web.web_app_initializer.StockCodeRepository", autospec=True)),
+        ("oscm", patch("view.web.web_app_initializer.OverseasStockCodeRepository", autospec=True)),
         ("sched", patch("view.web.bootstrap.strategy_factory.StrategyScheduler", autospec=True)),
         ("rdm", patch("view.web.web_app_initializer.ProgramTradingStreamService", autospec=True)),
         ("ind", patch("view.web.bootstrap.service_container.IndicatorService", autospec=True)),

--- a/tests/unit_test/view/web/test_web_app_program_trading.py
+++ b/tests/unit_test/view/web/test_web_app_program_trading.py
@@ -13,6 +13,7 @@ def mock_ctx():
     with patch('view.web.web_app_initializer.ProgramTradingStreamService') as MockRDM, \
          patch('view.web.web_app_initializer.StockRepository'), \
          patch('view.web.web_app_initializer.StockCodeRepository'), \
+         patch('view.web.web_app_initializer.OverseasStockCodeRepository'), \
          patch('view.web.web_app_initializer.VirtualTradeService'), \
          patch('view.web.web_app_initializer.Logger'):
         ctx = WebAppContext(app_context)

--- a/todo_list.md
+++ b/todo_list.md
@@ -24,7 +24,7 @@
 - P3 3-4: active strategy lifecycle contract 최소 공통 단계 강제 여부 재설계(현재 보류).
 - Pool B 튜닝: 후보 부족 재발 시 거래대금/정배열 조건 완화 검토.
 - 완료 기준의 전략 성과 `[~]`: `MomentumStrategy` 등 비활성 백테스트 경로의 표준 journal 통합 여부 결정.
-- 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. 자금 확대 전 R-1~R-3 우선 해소 권장. (R-5 거래세율은 검토 결과 0.20% 정확 → 해소, 변경 없음. 하단 "시스템 트레이더 관점 리뷰" 섹션)
+- 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. R-2/R-3/R-4/R-5는 핵심 코드·리포트 대응 완료, R-1 PIT 배선과 실전 성과 데이터 축적은 계속 진행. (하단 "시스템 트레이더 관점 리뷰" 섹션)
 - StrategyScheduler 코드 리뷰(S-1~S-10, 2026-06-12): `stop()` 강제청산 데드 패스, 매도 병렬 에러 처리 비대칭, 이력 트림 vs 복구 충돌 등 버그 + 수명/구조 개선. S-1/S-2/S-4~S-8 수정 완료, S-3/S-10은 의도된 설계 확인 후 주석 명시로 종결. S-9는 부분 진행(prune 통합/trace_id 영속화/import 정리) — getter 부수효과는 의도된 계약으로 판명되어 철회, god class 분리는 P2 2-4 parity 판정 후 재평가로 보류. (하단 "StrategyScheduler 코드 리뷰" 섹션)
 - 해외주식 Mode 후속 제외: 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 현재 착수 범위가 아니다.
 
@@ -507,10 +507,11 @@
 - 증거: 활성 등록 7개 전략(`first_pullback`/`high_tight_flag`/`larry_williams_channel_breakout`/`larry_williams_vbo`/`oneil_pocket_pivot`/`oneil_squeeze_breakout`/`rsi2_pullback`)이 **전부 long-only 모멘텀/돌파/눌림목 계열**(RSI2 mean-reversion도 long). 숏·헤지·마켓뉴트럴·비상관 자산 없음.
 - 왜 위험한가: 사실상 **단일 "상승/추세 regime 베팅"**이다. 강세장에서 동시 수익, 약세·횡보장에서 **동시 손실**. 전략 수가 분산처럼 보이지만 실제 포트폴리오 상관이 높아 drawdown이 합산된다. multiple testing(1-7)으로 과최적화는 방어해도 regime 집중 자체는 별개 리스크.
 - [x] 전략 간 실현수익률 상관행렬을 journal로 산출해 리포트(1-7 DSR 섹션 옆)에 노출하고, 고상관 클러스터를 명시한다. (2026-06-09) 계산은 기존 `services/strategy_correlation_service.py::compute_strategy_correlation_summary`(이미 gate에서 사용 중)가 있어 재구축 없이 **리포트 노출만** 추가. `StrategyLogReportService._build_strategy_correlation_section`이 live journal 일별 net_return으로 최고 상관쌍 + 고상관(≥0.8) 클러스터 + 경고를 노출. active/inactive 양쪽 배선. **부수 수정**: DSR `multiple_testing_section`이 active(정상) 리포트 경로 body append에서 누락돼 inactive 경로에만 나오던 #505 버그를 함께 바로잡음. 테스트: `test_strategy_log_report_correlation.py` 4종. 단위 5810 / 통합 240 passed.
-- [~] regime별(상승/하락/횡보) 전략군 성과를 분해해 "전 전략이 같은 regime에서만 작동"하는지 정량 확인한다. (`market_regime_service` 활용)
+- [x] regime별(상승/하락/횡보) 전략군 성과를 분해해 "전 전략이 같은 regime에서만 작동"하는지 정량 확인한다. (`market_regime_service` 활용)
   - 적용 완료(journal-time 캡처, 2026-06-09): 사용자 결정에 따라 매수 시점 `market_regime`({kospi,kosdaq,stock_market})을 journal에 persist. 조사 결과 계산(`regime_performance_service.compute_performance_by_regime`)과 전략별 웹 엔드포인트(`GET /strategies/performance-by-regime?strategy=`)는 **이미 존재**했으나 trade에 `market_regime`을 채우는 곳이 없어 dark 상태였다. (1) `VirtualTradeRepository`에 `market_regime` JSON 컬럼+migration+log_buy 파라미터+읽기 dict 역직렬화(1-6 `required_data` 패턴), (2) `StrategyScheduler._market_regime_log_kwargs`가 scan-warm된 cached snapshot+`is_kosdaq`로 dict 구성→매수 log에 stamp, (3) `OneilUniverseService.market_regime_service` property로 공유 instance를 scheduler에 주입(`strategy_factory`). 이제 기존 엔드포인트가 populated 버킷을 받는다. 테스트: repo 6종 + scheduler 5종. 단위 5821 / 통합 240 passed.
   - 특성(prospective): journal-time 캡처라 **배선 후 매수분부터** regime이 채워진다. 과거 trade 소급 분류는 별도(retroactive) 작업.
   - 적용 완료(일일 리포트 regime 분해 섹션, 2026-06-11): 웹 엔드포인트로만 노출되던 per-strategy regime 성과를 일일 HTML 리포트에 노출. 순수 함수 `regime_performance_service.compute_strategy_regime_decomposition`(기존 `compute_performance_by_regime`를 전략별로 묶어 dominant primary 버킷 + regime 집중도 산출, SURGE overlay 는 by_bucket 노출하되 primary total/dominant 미합산) + `StrategyLogReportService._build_regime_decomposition_section`. live journal(`get_standard_journal_records`)로 전략별 주력 국면·버킷별 승률/평균순익 + "N/M 전략이 같은 국면에 몰림" 집중도(≥70%면 ⚠️ 단일 regime 집중)를 노출. regime 채워진 SOLD 전략 <2개면 생략. active/inactive 양쪽 배선(상관/DSR/오버나이트 섹션과 동일 패턴). 테스트: `test_regime_performance_service.py` 5종(분해/집중도/HOLD·regime 누락 제외/SURGE 미합산) + `test_strategy_log_report_regime.py` 4종. 단위 5873 / 통합 240 passed.
+  - 회귀 보강(2026-06-15): `generate_report()` 본문에 regime 분해 섹션이 실제 포함되는지 `test_report_includes_strategy_regime_decomposition_section`로 고정.
 - [ ] 자금 확대 전 비상관 엣지(역추세/숏 가능 시점/저변동 등) 1개 이상 도입 여부를 정책 결정한다.
 - 관련: `services/market_regime_service.py`, `services/strategy_log_report_service.py`, P1 1-1 상관 follow-up과 통합
 
@@ -656,7 +657,6 @@
    - VBO 실 적용 + OSB shadow 진입은 PR-2.5 결과가 양호할 때만 진행한다.
 
 3. **코드·리포트로 바로 진행 가능**
-   - regime별(상승/하락/횡보) 전략군 성과 분해 리포트 구현/검증 (R-2; `market_regime_service` 활용)
    - formal PBO(CSCV) / walk-forward / purged validation / ablation 자동 리포트 범위를 정하고, 작은 단위부터 구현한다 (P1 1-7)
    - 수익률 모멘트 metric 추가 여부를 DSR/PBO 리포트와 함께 결정한다 (P1 1-7)
 

--- a/view/web/static/js/order.js
+++ b/view/web/static/js/order.js
@@ -92,7 +92,7 @@ async function placeOrder(side) {
         const json = await res.json();
 
         if (json.rt_cd === "0") {
-            resDiv.innerHTML = `<p class="success">주문 접수! 체결은 별도 확인 필요 (주문번호: ${json.data.ord_no})</p>`;
+            resDiv.innerHTML = `<p class="success">주문 접수! 체결 미확정 - 체결통보/조회로 별도 확인 (주문번호: ${json.data.ord_no})</p>`;
             if (typeof invalidateVirtualChartCache === 'function') invalidateVirtualChartCache();
         } else {
             resDiv.innerHTML = `<p class="error">주문 실패: ${json.msg1}</p>`;


### PR DESCRIPTION
## Summary
- record virtual trades and fill-quality hooks with average fill price when available
- clarify order accepted notifications as execution unconfirmed until signing notice or query confirmation
- normalize short KIS signing notice payload aliases and reduce false warnings when required fields are present
- cap program trading DB minute persistence checks to the regular session through 15:30 while still including the full 15:30 minute

## Validation
- python -m pytest -o addopts= tests/unit_test/scheduler/test_strategy_scheduler.py::TestStrategyScheduler::test_execute_signal_notification_success tests/unit_test/services/test_fill_reconciliation_service.py tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py tests/unit_test/services/test_order_execution_service.py -q
- python -m pytest -o addopts= tests/unit_test/services/test_program_trading_stream_service.py tests/unit_test/services/test_program_trading_stream_service_branches.py -q
- verified 20260615 program trading DB status: 000660 and 005930 saved 391/391; 080220 saved 386/391 with only 15:21, 15:22, 15:24, 15:25, 15:27 missing