### PR TITLE
feat(overseas): Phase 1 data adapter + Phase 2 daily VBO backtest

### DIFF
--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -95,6 +95,8 @@ class MarketDataService:
 
     async def get_price_summary(self, stock_code, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
         """주어진 종목코드에 대해 시가/현재가/등락률(%) 요약 정보를 반환합니다 (KoreaInvestApiQuotations 위임)."""
+        if _is_overseas_exchange(exchange):
+            return await self._get_overseas_price_summary(stock_code, exchange)
         self._logger.info(f"MarketDataService - {stock_code} 종목 요약 정보 조회 요청")
         return await self._broker_api_wrapper.get_price_summary(stock_code, exchange=exchange)
 
@@ -104,6 +106,8 @@ class MarketDataService:
         return await self._broker_api_wrapper.get_stock_info_by_code(stock_code, exchange=exchange)
 
     async def get_current_price(self, stock_code, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
+        if _is_overseas_exchange(exchange):
+            return await self._get_overseas_current_price(stock_code, exchange)
         if not force_fresh:
             # 1. StockRepository 단기 캐시 확인 (웹소켓 틱 갱신 또는 최근 API 조회 결과)
             if self._stock_repo:
@@ -616,6 +620,41 @@ class MarketDataService:
             
         self.pm.log_timer(f"MarketData.get_recent_daily_ohlcv({code})", t_start)
         return all_rows
+
+    # ── 해외주식 현재가 어댑터 (Phase 1-2) ────────────────────────────────────
+    @staticmethod
+    def _overseas_summary_values(summary) -> tuple:
+        """OverseasPriceSummary(또는 dict)에서 (price, volume, change_rate) 추출."""
+        def _g(attr):
+            return summary.get(attr) if isinstance(summary, dict) else getattr(summary, attr, None)
+        price = float(_g("price") or 0)
+        volume = int(_g("volume") or 0)
+        change_rate = float(_g("change_rate") or 0)
+        return price, volume, change_rate
+
+    async def _get_overseas_current_price(self, symbol: str, exchange) -> ResCommonResponse:
+        """해외 현재가를 get_overseas_price 로 조회해 국내 스키마(stck_prpr 등)로 매핑한다.
+
+        국내 StockRepository 캐시/DB 스냅샷 경로는 타지 않는다(해외 미지원).
+        전략 호환을 위해 output 중첩 + 평면 키를 모두 채운다.
+        """
+        resp = await self._broker_api_wrapper.get_overseas_price(symbol, exchange=exchange)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp
+        price, volume, change_rate = self._overseas_summary_values(resp.data)
+        output = {"stck_prpr": price, "price": price, "acml_vol": volume, "prdy_ctrt": change_rate}
+        data = {"output": output, "stck_prpr": price, "price": price, "acml_vol": volume, "prdy_ctrt": change_rate}
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK(해외)", data=data)
+
+    async def _get_overseas_price_summary(self, symbol: str, exchange) -> ResCommonResponse:
+        """해외 현재가 요약(current/change_rate/volume) 매핑. 해외 현재가 API는 OHLC 미제공."""
+        resp = await self._broker_api_wrapper.get_overseas_price(symbol, exchange=exchange)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp
+        price, volume, change_rate = self._overseas_summary_values(resp.data)
+        data = {"symbol": str(symbol).upper(), "current": price, "price": price,
+                "change_rate": change_rate, "prdy_ctrt": change_rate, "volume": volume}
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK(해외)", data=data)
 
     # ── 해외주식 일봉 어댑터 (Phase 1-1) ──────────────────────────────────────
     async def _get_overseas_ohlcv_range(self, symbol: str, period: str, start_date: Optional[str],

--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -14,6 +14,7 @@ from common.types import (
     ResTopMarketCapApiItem, ResBasicStockInfo, ResFluctuation, ResDailyChartApiItem, Exchange,
     ResStockFullInfoApiOutput
 )
+from common.overseas_types import OverseasExchange
 from core.cache.cache_store import CacheStore
 from core.performance_profiler import PerformanceProfiler
 from common.date_utils import previous_trading_day_str
@@ -21,6 +22,14 @@ from services.market_calendar_service import MarketCalendarService
 
 if TYPE_CHECKING:
     from repositories.stock_repository import StockRepository
+
+
+def _is_overseas_exchange(exchange) -> bool:
+    """exchange 인자가 해외 거래소(NASD/NYSE/AMEX)를 가리키는지 판정한다."""
+    if isinstance(exchange, OverseasExchange):
+        return True
+    val = getattr(exchange, "value", exchange)
+    return str(val).upper() in {"NASD", "NYSE", "AMEX"}
 
 class MarketDataService:
     """
@@ -371,15 +380,16 @@ class MarketDataService:
             except Exception: return None
         rows = []
         for it in items or []:
-            date = _get(it, "stck_bsop_date") or _get(it, "date")
+            # 국내 키(stck_*) / 표준 키(open..) / 해외 키(xymd,clos,tvol) 모두 수용
+            date = _get(it, "stck_bsop_date") or _get(it, "date") or _get(it, "xymd")
             if not date: continue
             rows.append({
                 "date": date,
                 "open": _to_float(_get(it, "stck_oprc") or _get(it, "open")),
                 "high": _to_float(_get(it, "stck_hgpr") or _get(it, "high")),
                 "low": _to_float(_get(it, "stck_lwpr") or _get(it, "low")),
-                "close": _to_float(_get(it, "stck_clpr") or _get(it, "close")),
-                "volume": _to_int(_get(it, "acml_vol") or _get(it, "volume")),
+                "close": _to_float(_get(it, "stck_clpr") or _get(it, "close") or _get(it, "clos")),
+                "volume": _to_int(_get(it, "acml_vol") or _get(it, "volume") or _get(it, "tvol")),
             })
         rows.sort(key=lambda r: r["date"])
         return rows
@@ -532,6 +542,8 @@ class MarketDataService:
         """
         시작일~종료일 범위형 차트 API 호출 (일/분 공통).
         """
+        if _is_overseas_exchange(exchange):
+            return await self._get_overseas_ohlcv_range(stock_code, period, start_date, end_date, exchange)
         ed = end_date or self._market_clock.get_current_kst_time()
         sd = start_date or (datetime.strptime(ed, "%Y%m%d") - timedelta(days=240)).strftime("%Y%m%d")
         raw = await self._broker_api_wrapper.inquire_daily_itemchartprice(stock_code, start_date=sd, end_date=ed, fid_period_div_code=period.upper(), exchange=exchange)
@@ -549,6 +561,9 @@ class MarketDataService:
         있으면 API를 호출하지 않고 DB에서 바로 반환한다. ohlcv_update_task가 장 마감 후
         전 종목을 갱신하므로 장중에는 API 호출 없이 DB 조회만으로 충분하다.
         """
+        if _is_overseas_exchange(exchange):
+            return await self._get_overseas_recent_daily_ohlcv(code, limit, end_date, exchange)
+
         t_start = self.pm.start_timer()
         current_ed_dt = datetime.strptime(end_date, "%Y%m%d") if end_date else self._market_clock.get_current_kst_time()
 
@@ -601,6 +616,38 @@ class MarketDataService:
             
         self.pm.log_timer(f"MarketData.get_recent_daily_ohlcv({code})", t_start)
         return all_rows
+
+    # ── 해외주식 일봉 어댑터 (Phase 1-1) ──────────────────────────────────────
+    async def _get_overseas_ohlcv_range(self, symbol: str, period: str, start_date: Optional[str],
+                                        end_date: Optional[str], exchange) -> ResCommonResponse:
+        """해외 일봉을 get_overseas_dailyprice 로 조회해 표준 OHLCV 스키마로 정규화한다.
+
+        KIS HHDFS76240000 응답은 full json 의 output2 배열에 일봉 행을 담는다.
+        국내 StockRepository 캐시/today 병합 경로는 타지 않는다.
+        """
+        ed = end_date or self._market_clock.to_yyyymmdd(self._market_clock.get_current_kst_time())
+        raw = await self._broker_api_wrapper.get_overseas_dailyprice(
+            symbol, exchange=exchange, start_date=start_date or "", end_date=ed, period=(period or "D").upper(),
+        )
+        if not raw or raw.rt_cd != ErrorCode.SUCCESS.value:
+            return raw
+        payload = raw.data
+        if isinstance(payload, dict):
+            items = payload.get("output2") or payload.get("output1") or payload.get("output") or []
+        elif isinstance(payload, list):
+            items = payload
+        else:
+            items = []
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=self._normalize_ohlcv_rows(items))
+
+    async def _get_overseas_recent_daily_ohlcv(self, symbol: str, limit: int,
+                                               end_date: Optional[str], exchange) -> List[Dict[str, Any]]:
+        """해외 최근 limit개 일봉을 반환(오름차순). 실패 시 빈 리스트."""
+        resp = await self._get_overseas_ohlcv_range(symbol, "D", None, end_date, exchange)
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return []
+        rows = resp.data or []
+        return rows[-limit:] if limit and len(rows) > limit else rows
 
     async def get_intraday_minutes_today(self, *, stock_code: str, input_hour_1: str) -> ResCommonResponse:
         """

--- a/services/overseas_candidate_service.py
+++ b/services/overseas_candidate_service.py
@@ -1,0 +1,128 @@
+# services/overseas_candidate_service.py
+"""해외 후보 심볼 소스 (Phase 1-3).
+
+국내 랭킹 API(get_top_trading_value_stocks 등)는 해외에 없으므로,
+OverseasStockCodeRepository(전 심볼) + 일봉 거래대금 필터로 watchlist 를 산출한다.
+일봉은 StockQueryService.get_recent_daily_ohlcv(exchange=해외) — Phase 1-1 어댑터 경유.
+
+배선(VBO 주입)은 Phase 3. 본 서비스는 후보 리스트 산출만 담당한다.
+"""
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+class OverseasCandidateService:
+    def __init__(
+        self,
+        overseas_stock_code_repository,
+        stock_query_service,
+        logger: Optional[logging.Logger] = None,
+        *,
+        lookback_days: int = 5,
+        min_avg_trading_value: float = 10_000_000.0,
+        top_n: int = 50,
+        max_universe: int = 300,
+        concurrency: int = 10,
+    ):
+        self._repo = overseas_stock_code_repository
+        self._sqs = stock_query_service
+        self._logger = logger if logger else logging.getLogger(__name__)
+        self._lookback_days = lookback_days
+        self._min_avg_trading_value = min_avg_trading_value
+        self._top_n = top_n
+        self._max_universe = max_universe
+        self._concurrency = concurrency
+
+    async def get_candidates(
+        self,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        *,
+        symbols: Optional[List[str]] = None,
+        min_avg_trading_value: Optional[float] = None,
+        top_n: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """거래대금 필터를 통과한 해외 후보를 내림차순으로 반환한다.
+
+        반환: [{"code","name","exchange","avg_trading_value"}], avg_trading_value 내림차순.
+        """
+        min_tv = self._min_avg_trading_value if min_avg_trading_value is None else min_avg_trading_value
+        cap = self._top_n if top_n is None else top_n
+
+        meta = self._resolve_universe(exchange, symbols)
+        if not meta:
+            return []
+
+        sem = asyncio.Semaphore(self._concurrency)
+
+        async def _score(entry: Dict[str, str]) -> Optional[Dict[str, Any]]:
+            async with sem:
+                avg_tv = await self._avg_trading_value(entry["code"], exchange)
+            if avg_tv is None or avg_tv < min_tv:
+                return None
+            return {
+                "code": entry["code"],
+                "name": entry.get("name", entry["code"]),
+                "exchange": exchange.value,
+                "avg_trading_value": avg_tv,
+            }
+
+        scored = await asyncio.gather(*[_score(e) for e in meta], return_exceptions=True)
+
+        candidates: List[Dict[str, Any]] = []
+        for r in scored:
+            if isinstance(r, Exception):
+                self._logger.warning({"event": "overseas_candidate_error", "error": str(r)})
+                continue
+            if r:
+                candidates.append(r)
+
+        candidates.sort(key=lambda c: c["avg_trading_value"], reverse=True)
+        return candidates[:cap] if cap else candidates
+
+    def _resolve_universe(
+        self, exchange: OverseasExchange, symbols: Optional[List[str]]
+    ) -> List[Dict[str, str]]:
+        """평가 대상 (code,name) 메타 리스트를 결정한다."""
+        if symbols:
+            return [{"code": str(s).upper(), "name": str(s).upper()} for s in symbols]
+
+        try:
+            all_symbols = self._repo.all_symbols() or []
+        except Exception as e:
+            self._logger.warning({"event": "overseas_universe_load_failed", "error": str(e)})
+            return []
+
+        ex = exchange.value.upper()
+        result: List[Dict[str, str]] = []
+        for item in all_symbols:
+            if str(item.get("e", "")).upper() != ex:
+                continue
+            result.append({"code": str(item.get("s", "")).upper(), "name": item.get("n", "")})
+            if len(result) >= self._max_universe:
+                break
+        return result
+
+    async def _avg_trading_value(self, symbol: str, exchange: OverseasExchange) -> Optional[float]:
+        """최근 lookback_days 일봉의 평균 거래대금(close*volume)을 USD로 반환. 실패 시 None."""
+        try:
+            resp = await self._sqs.get_recent_daily_ohlcv(
+                symbol, limit=self._lookback_days, exchange=exchange
+            )
+        except Exception as e:
+            self._logger.warning({"event": "overseas_candidate_ohlcv_error", "code": symbol, "error": str(e)})
+            return None
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+            return None
+        values = []
+        for row in resp.data:
+            close = float(row.get("close") or 0)
+            volume = float(row.get("volume") or 0)
+            if close > 0 and volume > 0:
+                values.append(close * volume)
+        if not values:
+            return None
+        return sum(values) / len(values)

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1203,13 +1203,14 @@ class StockQueryService:
             self.logger.error(f"{stock_code} OHLCV+지표 통합 조회 중 오류: {e}", exc_info=True)
             return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1=str(e), data=None)
 
-    async def get_recent_daily_ohlcv(self, stock_code: str, limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE, end_date: Optional[str] = None) -> ResCommonResponse:
+    async def get_recent_daily_ohlcv(self, stock_code: str, limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE, end_date: Optional[str] = None, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
         """
         타겟 종목의 최근 일봉을 limit개 반환.
         TradingService.get_recent_daily_ohlcv를 래핑하여 ResCommonResponse 형태로 통일.
+        exchange 가 해외(NASD/NYSE/AMEX)면 해외 일봉 API로 위임된다.
         """
         try:
-            rows = await self.market_data_service.get_recent_daily_ohlcv(stock_code, limit=limit, end_date=end_date)
+            rows = await self.market_data_service.get_recent_daily_ohlcv(stock_code, limit=limit, end_date=end_date, exchange=exchange)
             if not rows:
                 return ResCommonResponse(rt_cd=ErrorCode.EMPTY_VALUES.value, msg1="데이터 없음", data=[])
             return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공", data=rows)

--- a/strategies/overseas_daily_vbo_backtest.py
+++ b/strategies/overseas_daily_vbo_backtest.py
@@ -1,0 +1,127 @@
+# strategies/overseas_daily_vbo_backtest.py
+"""해외 일봉 VBO 백테스트 (Phase 2).
+
+해외는 분봉/실시간 데이터가 없으므로 라이브 VBO를 그대로 재생할 수 없다.
+대신 고전적 Larry Williams 변동성 돌파(일봉 근사)로 신호 유효성을 검증한다:
+
+  prev_range = 전일고 - 전일저
+  target     = 당일시가 + K × prev_range
+  진입        : 당일고 >= target → target 에 매수
+  청산        : 당일저 <= 손절가(진입가×(1+stop_loss_pct/100)) → 손절가 청산
+                아니면 종가 청산 (당일 청산, 오버나잇 없음)
+
+실주문/배선(Phase 3/4) 전 "해외에서 의미있는 진입/청산 신호를 내는가"를 확인하는
+게이트용 경량 도구. 라이브 무거운 BacktestPeriodRunner 와는 별개(장중 microstructure 미사용).
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+class OverseasDailyVBOBacktest:
+    def __init__(
+        self,
+        k_value: float = 0.5,
+        stop_loss_pct: float = -3.0,
+        round_trip_cost_pct: float = 0.2,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self._k = k_value
+        self._stop_loss_pct = stop_loss_pct
+        self._cost_pct = round_trip_cost_pct
+        self._logger = logger if logger else logging.getLogger(__name__)
+
+    def run_symbol(self, bars: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """단일 종목 일봉(오름차순)에 일봉 VBO 근사를 적용해 거래/요약 반환."""
+        trades: List[Dict[str, Any]] = []
+        rows = [b for b in (bars or []) if isinstance(b, dict)]
+
+        for i in range(1, len(rows)):
+            prev, cur = rows[i - 1], rows[i]
+            prev_range = self._f(prev.get("high")) - self._f(prev.get("low"))
+            if prev_range <= 0:
+                continue
+            open_ = self._f(cur.get("open"))
+            high = self._f(cur.get("high"))
+            low = self._f(cur.get("low"))
+            close = self._f(cur.get("close"))
+            if open_ <= 0:
+                continue
+
+            target = open_ + self._k * prev_range
+            if high < target:
+                continue  # 돌파 미발생 → 진입 없음
+
+            entry_price = target
+            stop_price = entry_price * (1 + self._stop_loss_pct / 100.0)
+            if low <= stop_price:
+                exit_price, exit_reason = stop_price, "stop"
+            else:
+                exit_price, exit_reason = close, "eod"
+
+            gross = (exit_price / entry_price - 1) * 100
+            net = gross - self._cost_pct
+            trades.append({
+                "date": cur.get("date"),
+                "entry_price": entry_price,
+                "exit_price": exit_price,
+                "exit_reason": exit_reason,
+                "gross_return_pct": gross,
+                "net_return_pct": net,
+            })
+
+        return {"trades": trades, "summary": self._summarize(trades)}
+
+    async def run_backtest(
+        self,
+        stock_query_service,
+        symbols: List[str],
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> Dict[str, Any]:
+        """심볼별 해외 일봉을 조회(Phase 1-1 어댑터)해 백테스트하고 집계한다."""
+        per_symbol: Dict[str, Any] = {}
+        all_trades: List[Dict[str, Any]] = []
+
+        for symbol in symbols:
+            try:
+                resp = await stock_query_service.get_ohlcv_range(
+                    symbol, "D", start_date, end_date, exchange=exchange
+                )
+            except Exception as e:
+                self._logger.warning({"event": "overseas_backtest_fetch_error", "code": symbol, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+            result = self.run_symbol(resp.data)
+            per_symbol[symbol] = result
+            for t in result["trades"]:
+                all_trades.append({**t, "symbol": symbol})
+
+        return {"per_symbol": per_symbol, "trades": all_trades, "summary": self._summarize(all_trades)}
+
+    def _summarize(self, trades: List[Dict[str, Any]]) -> Dict[str, Any]:
+        n = len(trades)
+        if n == 0:
+            return {"total_trades": 0, "wins": 0, "win_rate": 0.0,
+                    "avg_net_return_pct": 0.0, "total_net_return_pct": 0.0}
+        nets = [t["net_return_pct"] for t in trades]
+        wins = sum(1 for x in nets if x > 0)
+        return {
+            "total_trades": n,
+            "wins": wins,
+            "win_rate": wins / n,
+            "avg_net_return_pct": sum(nets) / n,
+            "total_net_return_pct": sum(nets),
+        }
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/tests/unit_test/services/test_market_data_service_overseas.py
+++ b/tests/unit_test/services/test_market_data_service_overseas.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from services.market_data_service import MarketDataService
 from common.types import ErrorCode, ResCommonResponse
-from common.overseas_types import OverseasExchange
+from common.overseas_types import OverseasExchange, OverseasPriceSummary
 
 
 @pytest.fixture
@@ -20,6 +20,9 @@ def mds():
     broker = MagicMock()
     broker.inquire_daily_itemchartprice = AsyncMock()
     broker.get_overseas_dailyprice = AsyncMock()
+    broker.get_overseas_price = AsyncMock()
+    broker.get_current_price = AsyncMock()
+    broker.get_price_summary = AsyncMock()
 
     tm = MagicMock()
     tm.get_current_kst_time.return_value = datetime(2026, 5, 13, 10, 0, 0)
@@ -108,6 +111,66 @@ async def test_get_ohlcv_range_overseas_normalizes_output2(mds):
     assert resp.rt_cd == ErrorCode.SUCCESS.value
     assert [r["date"] for r in resp.data] == ["20260511", "20260512", "20260513"]
     mds.broker.inquire_daily_itemchartprice.assert_not_called()
+
+
+def _price_resp(price=150.5, vol=1000, chg=1.2):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data=OverseasPriceSummary(
+            symbol="AAPL", exchange=OverseasExchange.NASD,
+            price=price, change_rate=chg, volume=vol,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_overseas_routes_and_maps(mds):
+    mds.broker.get_overseas_price.return_value = _price_resp()
+
+    resp = await mds.service.get_current_price("AAPL", exchange=OverseasExchange.NASD)
+
+    # 국내 현재가 경로/캐시는 타지 않는다
+    mds.broker.get_current_price.assert_not_called()
+    mds.broker.get_overseas_price.assert_awaited_once()
+    # 전략이 읽는 키(stck_prpr / price / output.stck_prpr) 모두 매핑
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data["stck_prpr"] == 150.5
+    assert resp.data["price"] == 150.5
+    assert resp.data["acml_vol"] == 1000
+    assert resp.data["output"]["stck_prpr"] == 150.5
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_overseas_accepts_string_exchange(mds):
+    mds.broker.get_overseas_price.return_value = _price_resp(price=42.0)
+
+    resp = await mds.service.get_current_price("MSFT", exchange="NYSE")
+
+    mds.broker.get_overseas_price.assert_awaited_once()
+    assert resp.data["output"]["stck_prpr"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_overseas_failure_propagates(mds):
+    fail = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None)
+    mds.broker.get_overseas_price.return_value = fail
+
+    resp = await mds.service.get_current_price("AAPL", exchange=OverseasExchange.AMEX)
+
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.asyncio
+async def test_get_price_summary_overseas_maps_current(mds):
+    mds.broker.get_overseas_price.return_value = _price_resp(price=200.0, vol=500, chg=-0.8)
+
+    resp = await mds.service.get_price_summary("AAPL", exchange=OverseasExchange.NASD)
+
+    mds.broker.get_price_summary.assert_not_called()
+    assert resp.data["current"] == 200.0
+    assert resp.data["change_rate"] == -0.8
+    assert resp.data["volume"] == 500
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_market_data_service_overseas.py
+++ b/tests/unit_test/services/test_market_data_service_overseas.py
@@ -1,0 +1,123 @@
+"""해외주식 일봉 어댑터 라우팅/정규화 테스트 (Phase 1-1).
+
+기존 전략(LarryWilliamsVBO 등)이 호출하는 get_recent_daily_ohlcv / get_ohlcv_range 가
+overseas exchange 인자를 받으면 get_overseas_dailyprice 로 위임하고
+국내와 동일한 {date,open,high,low,close,volume} 스키마로 정규화하는지 고정한다.
+국내 경로(KRX 기본값)는 건드리지 않는다(별도 파일로 격리).
+"""
+import pytest
+from types import SimpleNamespace
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from services.market_data_service import MarketDataService
+from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange
+
+
+@pytest.fixture
+def mds():
+    broker = MagicMock()
+    broker.inquire_daily_itemchartprice = AsyncMock()
+    broker.get_overseas_dailyprice = AsyncMock()
+
+    tm = MagicMock()
+    tm.get_current_kst_time.return_value = datetime(2026, 5, 13, 10, 0, 0)
+    tm.to_yyyymmdd.side_effect = lambda d: d.strftime("%Y%m%d") if isinstance(d, datetime) else str(d)
+
+    stock_repo = MagicMock()
+    stock_repo.get_stock_data = AsyncMock(return_value=None)
+    stock_repo.upsert_ohlcv = AsyncMock()
+
+    service = MarketDataService(
+        broker_api_wrapper=broker,
+        env=MagicMock(),
+        market_clock=tm,
+        logger=MagicMock(),
+        stock_repository=stock_repo,
+    )
+    return SimpleNamespace(service=service, broker=broker, stock_repo=stock_repo)
+
+
+def _overseas_resp(rows):
+    """KIS HHDFS76240000 응답 형태: full json 의 output2 배열에 일봉 행."""
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data={"output1": {}, "output2": rows})
+
+
+_BARS = [
+    {"xymd": "20260512", "open": "100", "high": "110", "low": "95", "clos": "105", "tvol": "1000"},
+    {"xymd": "20260513", "open": "105", "high": "120", "low": "104", "clos": "118", "tvol": "2000"},
+    {"xymd": "20260511", "open": "98", "high": "101", "low": "96", "clos": "99", "tvol": "500"},
+]
+
+
+@pytest.mark.asyncio
+async def test_get_recent_daily_ohlcv_overseas_routes_and_normalizes(mds):
+    mds.broker.get_overseas_dailyprice.return_value = _overseas_resp(_BARS)
+
+    rows = await mds.service.get_recent_daily_ohlcv("AAPL", limit=3, exchange=OverseasExchange.NASD)
+
+    # 국내 경로는 절대 타지 않는다
+    mds.broker.inquire_daily_itemchartprice.assert_not_called()
+    mds.broker.get_overseas_dailyprice.assert_awaited_once()
+    # 날짜 오름차순 정규화 + 표준 스키마
+    assert [r["date"] for r in rows] == ["20260511", "20260512", "20260513"]
+    assert rows[1] == {"date": "20260512", "open": 100.0, "high": 110.0, "low": 95.0, "close": 105.0, "volume": 1000}
+
+
+@pytest.mark.asyncio
+async def test_get_recent_daily_ohlcv_overseas_slices_to_limit(mds):
+    mds.broker.get_overseas_dailyprice.return_value = _overseas_resp(_BARS)
+
+    rows = await mds.service.get_recent_daily_ohlcv("AAPL", limit=2, exchange=OverseasExchange.NASD)
+
+    assert len(rows) == 2
+    # 가장 최근 2개 (오름차순 정렬 후 뒤에서 2개)
+    assert [r["date"] for r in rows] == ["20260512", "20260513"]
+
+
+@pytest.mark.asyncio
+async def test_get_recent_daily_ohlcv_overseas_accepts_string_exchange(mds):
+    mds.broker.get_overseas_dailyprice.return_value = _overseas_resp(_BARS)
+
+    rows = await mds.service.get_recent_daily_ohlcv("AAPL", limit=3, exchange="NASD")
+
+    mds.broker.get_overseas_dailyprice.assert_awaited_once()
+    assert len(rows) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_recent_daily_ohlcv_overseas_empty_returns_empty(mds):
+    mds.broker.get_overseas_dailyprice.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None
+    )
+
+    rows = await mds.service.get_recent_daily_ohlcv("AAPL", limit=3, exchange=OverseasExchange.NYSE)
+
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_range_overseas_normalizes_output2(mds):
+    mds.broker.get_overseas_dailyprice.return_value = _overseas_resp(_BARS)
+
+    resp = await mds.service.get_ohlcv_range(
+        "AAPL", "D", "20260501", "20260513", exchange=OverseasExchange.AMEX
+    )
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [r["date"] for r in resp.data] == ["20260511", "20260512", "20260513"]
+    mds.broker.inquire_daily_itemchartprice.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normalize_handles_both_domestic_and_overseas_keys(mds):
+    domestic = [{"stck_bsop_date": "20260101", "stck_oprc": "10", "stck_hgpr": "12",
+                 "stck_lwpr": "9", "stck_clpr": "11", "acml_vol": "300"}]
+    overseas = [{"xymd": "20260102", "open": "10", "high": "12", "low": "9", "clos": "11", "tvol": "300"}]
+
+    d_rows = mds.service._normalize_ohlcv_rows(domestic)
+    o_rows = mds.service._normalize_ohlcv_rows(overseas)
+
+    assert d_rows[0] == {"date": "20260101", "open": 10.0, "high": 12.0, "low": 9.0, "close": 11.0, "volume": 300}
+    assert o_rows[0] == {"date": "20260102", "open": 10.0, "high": 12.0, "low": 9.0, "close": 11.0, "volume": 300}

--- a/tests/unit_test/services/test_overseas_candidate_service.py
+++ b/tests/unit_test/services/test_overseas_candidate_service.py
@@ -1,0 +1,111 @@
+"""해외 후보 심볼 소스 테스트 (Phase 1-3).
+
+OverseasStockCodeRepository(전 심볼) + 일봉 거래대금 필터로 watchlist 를 산출한다.
+거래대금 하위 종목 제거 + 내림차순 정렬 + top_n 컷을 고정한다.
+배선(VBO 주입)은 Phase 3 — 여기서는 독립 서비스만 검증.
+"""
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from services.overseas_candidate_service import OverseasCandidateService
+from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange
+
+
+def _bars(close, volume, days=5):
+    return [
+        {"date": f"2026051{i}", "open": close, "high": close, "low": close,
+         "close": close, "volume": volume}
+        for i in range(1, days + 1)
+    ]
+
+
+@pytest.fixture
+def svc():
+    repo = MagicMock()
+    # symbol -> (close, volume) → 일평균 거래대금 = close*volume
+    repo.all_symbols.return_value = [
+        {"s": "AAA", "n": "Aaa Inc", "e": "NASD"},   # 100 * 100000 = 10,000,000
+        {"s": "BBB", "n": "Bbb Inc", "e": "NASD"},   # 50  * 1000   = 50,000   (하위)
+        {"s": "CCC", "n": "Ccc Inc", "e": "NASD"},   # 200 * 500000 = 100,000,000 (최상위)
+        {"s": "ZZZ", "n": "Zzz Inc", "e": "NYSE"},   # 다른 거래소 → 기본 제외
+    ]
+
+    tv = {
+        "AAA": (100.0, 100000),
+        "BBB": (50.0, 1000),
+        "CCC": (200.0, 500000),
+        "ZZZ": (300.0, 999999),
+    }
+
+    sqs = MagicMock()
+
+    async def _ohlcv(symbol, limit=5, end_date=None, exchange=None):
+        close, vol = tv[symbol]
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_bars(close, vol))
+
+    sqs.get_recent_daily_ohlcv = AsyncMock(side_effect=_ohlcv)
+
+    service = OverseasCandidateService(
+        overseas_stock_code_repository=repo,
+        stock_query_service=sqs,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(service=service, repo=repo, sqs=sqs)
+
+
+@pytest.mark.asyncio
+async def test_filters_low_trading_value_and_sorts_desc(svc):
+    result = await svc.service.get_candidates(
+        exchange=OverseasExchange.NASD, min_avg_trading_value=1_000_000.0,
+    )
+
+    codes = [c["code"] for c in result]
+    # BBB(5만) 제거, NYSE ZZZ 제외 → CCC(1억) > AAA(1천만) 내림차순
+    assert codes == ["CCC", "AAA"]
+    assert result[0]["avg_trading_value"] == 100_000_000.0
+    assert result[0]["exchange"] == "NASD"
+    assert result[0]["name"] == "Ccc Inc"
+
+
+@pytest.mark.asyncio
+async def test_top_n_caps_result(svc):
+    result = await svc.service.get_candidates(
+        exchange=OverseasExchange.NASD, min_avg_trading_value=0.0, top_n=1,
+    )
+    assert [c["code"] for c in result] == ["CCC"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_symbols_override_repo(svc):
+    result = await svc.service.get_candidates(
+        exchange=OverseasExchange.NASD, symbols=["AAA"], min_avg_trading_value=0.0,
+    )
+    assert [c["code"] for c in result] == ["AAA"]
+    svc.repo.all_symbols.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ohlcv_failure_excludes_symbol(svc):
+    async def _ohlcv(symbol, limit=5, end_date=None, exchange=None):
+        if symbol == "CCC":
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=[])
+        close, vol = {"AAA": (100.0, 100000), "BBB": (50.0, 1000)}[symbol]
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_bars(close, vol))
+
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(side_effect=_ohlcv)
+
+    result = await svc.service.get_candidates(
+        exchange=OverseasExchange.NASD, min_avg_trading_value=1_000_000.0,
+    )
+    # CCC 실패 → 제외, AAA만 통과
+    assert [c["code"] for c in result] == ["AAA"]
+
+
+@pytest.mark.asyncio
+async def test_passes_overseas_exchange_to_ohlcv(svc):
+    await svc.service.get_candidates(exchange=OverseasExchange.NASD, symbols=["AAA"], min_avg_trading_value=0.0)
+    # 일봉 조회가 해외 거래소 인자로 위임되는지 (Phase 1-1 어댑터 경유)
+    _, kwargs = svc.sqs.get_recent_daily_ohlcv.await_args
+    assert kwargs.get("exchange") == OverseasExchange.NASD

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -1587,7 +1587,8 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         result = await self.stockQueryService.get_recent_daily_ohlcv("005930", limit=10)
 
         # Assert
-        self.mock_market_data_service.get_recent_daily_ohlcv.assert_awaited_once_with("005930", limit=10, end_date=None)
+        from common.types import Exchange
+        self.mock_market_data_service.get_recent_daily_ohlcv.assert_awaited_once_with("005930", limit=10, end_date=None, exchange=Exchange.KRX)
         self.assertEqual(result.rt_cd, ErrorCode.SUCCESS.value)
         self.assertEqual(result.data, rows)
 

--- a/tests/unit_test/strategies/test_overseas_daily_vbo_backtest.py
+++ b/tests/unit_test/strategies/test_overseas_daily_vbo_backtest.py
@@ -1,0 +1,108 @@
+"""해외 일봉 VBO 백테스트 테스트 (Phase 2).
+
+VBO는 본래 장중 전략이나, 해외는 분봉/실시간이 없으므로 고전적 Larry Williams
+일봉 근사로 검증한다:
+  target = 당일시가 + K×전일Range(전일고-전일저)
+  당일고 >= target → target 진입 → (저 <= 손절가) 손절 / else 종가 청산
+배선/실주문 전 "해외에서 의미있는 신호를 내는가"를 확인하는 게이트.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from strategies.overseas_daily_vbo_backtest import OverseasDailyVBOBacktest
+from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+# 전일 range=10 (100~110)
+_PREV = _bar("20260511", 100, 110, 100, 105)
+
+
+def test_entry_when_high_breaks_target_exits_at_close():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    # target = 100 + 0.5*10 = 105, high 120>=105 진입, 저 104 > 손절(101.85) → 종가 115 청산
+    bars = [_PREV, _bar("20260512", 100, 120, 104, 115)]
+
+    res = bt.run_symbol(bars)
+
+    assert res["summary"]["total_trades"] == 1
+    t = res["trades"][0]
+    assert t["entry_price"] == 105.0
+    assert t["exit_price"] == 115.0
+    assert t["exit_reason"] == "eod"
+    assert round(t["net_return_pct"], 3) == round((115 / 105 - 1) * 100, 3)
+
+
+def test_no_entry_when_high_below_target():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    bars = [_PREV, _bar("20260512", 100, 104, 100, 103)]  # high 104 < target 105
+
+    res = bt.run_symbol(bars)
+
+    assert res["summary"]["total_trades"] == 0
+    assert res["trades"] == []
+
+
+def test_stop_loss_exit():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    # target=105 진입, 저 100 <= 손절가 101.85 → 손절 청산 -3%
+    bars = [_PREV, _bar("20260512", 100, 120, 100, 110)]
+
+    res = bt.run_symbol(bars)
+
+    t = res["trades"][0]
+    assert t["exit_reason"] == "stop"
+    assert round(t["net_return_pct"], 4) == -3.0
+
+
+def test_round_trip_cost_reduces_net_return():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.5)
+    bars = [_PREV, _bar("20260512", 100, 120, 104, 115)]
+
+    res = bt.run_symbol(bars)
+    t = res["trades"][0]
+    gross = (115 / 105 - 1) * 100
+    assert round(t["gross_return_pct"], 3) == round(gross, 3)
+    assert round(t["net_return_pct"], 3) == round(gross - 0.5, 3)
+
+
+def test_summary_aggregates_win_rate_and_avg():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    bars = [
+        _bar("20260511", 100, 110, 100, 105),  # prev(range10) for 0512
+        _bar("20260512", 100, 120, 104, 115),  # win: target105, eod 115
+        _bar("20260513", 100, 101, 100, 100),  # no entry (prev range16 → target108 > high101)
+        _bar("20260514", 100, 120, 95, 110),   # stop: prev range1 → target100.5, 저95<=97.485
+    ]
+
+    res = bt.run_symbol(bars)
+    s = res["summary"]
+    assert s["total_trades"] == 2
+    assert s["wins"] == 1
+    assert s["win_rate"] == 0.5
+    assert res["trades"][1]["exit_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_run_backtest_fetches_via_overseas_adapter_and_aggregates():
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    sqs = MagicMock()
+    bars = [_PREV, _bar("20260512", 100, 120, 104, 115)]
+    sqs.get_ohlcv_range = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+    )
+
+    res = await bt.run_backtest(
+        sqs, symbols=["AAPL"], exchange=OverseasExchange.NASD,
+        start_date="20260501", end_date="20260512",
+    )
+
+    # 일봉 조회가 해외 거래소 인자로 위임되는지
+    _, kwargs = sqs.get_ohlcv_range.await_args
+    assert kwargs.get("exchange") == OverseasExchange.NASD
+    assert res["summary"]["total_trades"] == 1
+    assert res["per_symbol"]["AAPL"]["summary"]["total_trades"] == 1

--- a/todo_list.md
+++ b/todo_list.md
@@ -521,7 +521,7 @@ VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_curren
 - [ ] **Phase 1 데이터 어댑터 (시작점)**
   - [x] 1-1. `get_recent_daily_ohlcv`/`get_ohlcv_range` exchange 분기 → 해외면 `get_overseas_dailyprice` 위임 + 필드 정규화(date/open/high/low/close/volume, `output2` 파싱, 국내와 동일 키). `_normalize_ohlcv_rows`에 해외 키(xymd/clos/tvol) 추가(도메스틱 무영향), DB-first/today 병합 우회. (PR #549)
   - [x] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마 매핑(`get_current_price`→`stck_prpr`/`price`/`output.stck_prpr`/`acml_vol`, `get_price_summary`→`current`/`change_rate`/`volume`). 국내 캐시/스냅샷 경로 우회. 해외 현재가 API는 OHLC 미제공이라 요약은 best-effort.
-  - [ ] 1-3. 후보 심볼 소스 — `OverseasStockCodeRepository`(전체 심볼 DB) + 일봉 거래대금 필터로 watchlist 산출. 검증: 거래대금 하위 제거 리스트 반환.
+  - [x] 1-3. 후보 심볼 소스 — `OverseasCandidateService`(신규): `OverseasStockCodeRepository`(전 심볼) + 일봉 거래대금 필터(close×volume 평균)로 watchlist 산출. 거래소 필터/min 거래대금/top_n/실패 제외/명시 symbols override. 일봉은 Phase 1-1 어댑터 경유(exchange 위임). 배선(VBO 주입)은 Phase 3.
 - [ ] **Phase 2 해외 일봉 백테스트** — `get_overseas_dailyprice` 과거 데이터로 VBO 진입/청산 재현. (실주문 전 필수 게이트)
 - [ ] **Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대(서머타임) 확장, dry-run shadow 저널(실주문 X).
 - [ ] **Phase 4 주문/사이징** — `place_overseas_limit_order`(지정가) 연결, USD position sizing/환율, 일봉 기반 exit.

--- a/todo_list.md
+++ b/todo_list.md
@@ -519,8 +519,8 @@ VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_curren
 제약: **해외 주문 TR은 실전(TTTS6036U 등)만 존재, 모의 주문 TR 없음** → 백테스트/dry-run 검증 전 실주문 배선 금지.
 
 - [ ] **Phase 1 데이터 어댑터 (시작점)**
-  - [ ] 1-1. `get_recent_daily_ohlcv`/`get_ohlcv`/`get_ohlcv_range` exchange 분기 → 해외면 `get_overseas_dailyprice` 위임 + 필드 정규화(date/open/high/low/close/volume, 과거→미래 정렬, 국내와 동일 키). 검증: 해외 mock 응답이 국내와 동일 스키마로 반환되는 단위 테스트.
-  - [ ] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마(`stck_prpr` 등) 매핑. 검증: 해외 심볼 호출 시 매핑 고정.
+  - [x] 1-1. `get_recent_daily_ohlcv`/`get_ohlcv_range` exchange 분기 → 해외면 `get_overseas_dailyprice` 위임 + 필드 정규화(date/open/high/low/close/volume, `output2` 파싱, 국내와 동일 키). `_normalize_ohlcv_rows`에 해외 키(xymd/clos/tvol) 추가(도메스틱 무영향), DB-first/today 병합 우회. (PR #549)
+  - [x] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마 매핑(`get_current_price`→`stck_prpr`/`price`/`output.stck_prpr`/`acml_vol`, `get_price_summary`→`current`/`change_rate`/`volume`). 국내 캐시/스냅샷 경로 우회. 해외 현재가 API는 OHLC 미제공이라 요약은 best-effort.
   - [ ] 1-3. 후보 심볼 소스 — `OverseasStockCodeRepository`(전체 심볼 DB) + 일봉 거래대금 필터로 watchlist 산출. 검증: 거래대금 하위 제거 리스트 반환.
 - [ ] **Phase 2 해외 일봉 백테스트** — `get_overseas_dailyprice` 과거 데이터로 VBO 진입/청산 재현. (실주문 전 필수 게이트)
 - [ ] **Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대(서머타임) 확장, dry-run shadow 저널(실주문 X).

--- a/todo_list.md
+++ b/todo_list.md
@@ -27,6 +27,7 @@
 - 시스템 트레이더 관점 리뷰(R-1~R-6, 2026-06-08): 생존편향·전략 상관/regime 집중·총위험 미집계·갭 체결 등 백테스트 신뢰도/실전 리스크 신규 발견. R-2/R-3/R-4/R-5는 핵심 코드·리포트 대응 완료, R-1 PIT 배선과 실전 성과 데이터 축적은 계속 진행. (하단 "시스템 트레이더 관점 리뷰" 섹션)
 - StrategyScheduler 코드 리뷰(S-1~S-10, 2026-06-12): `stop()` 강제청산 데드 패스, 매도 병렬 에러 처리 비대칭, 이력 트림 vs 복구 충돌 등 버그 + 수명/구조 개선. S-1/S-2/S-4~S-8 수정 완료, S-3/S-10은 의도된 설계 확인 후 주석 명시로 종결. S-9는 부분 진행(prune 통합/trace_id 영속화/import 정리) — getter 부수효과는 의도된 계약으로 판명되어 철회, god class 분리는 P2 2-4 parity 판정 후 재평가로 보류. (하단 "StrategyScheduler 코드 리뷰" 섹션)
 - 해외주식 Mode 후속 제외: 자동전략 해외 지원, 해외 WebSocket, 통합 해외 reconciliation은 현재 착수 범위가 아니다.
+- 해외주식 전략 적용 검토(2026-06-15): 일봉 셋업형 전략은 PoC 적용 가능(해외 일봉 API 존재), 장중/실시간 전략은 분봉·랭킹·웹소켓 부재로 불가. 어댑터(broker_wrapper exchange 분기)·해외 유니버스 선행 필요. (하단 "해외주식 전략 적용 검토" 섹션)
 
 ---
 
@@ -465,6 +466,79 @@
 - `scheduler/strategy_scheduler.py`
 - `tests/unit_test/core/test_scan_rejection_counter.py`
 - `tests/unit_test/scheduler/test_strategy_scheduler_scan_metrics.py`
+
+---
+
+## 해외주식 전략 적용 검토 (2026-06-15 추가, 코드 기반)
+
+기존 매매 전략을 해외주식(US)에 적용 가능한지 코드 조사. 결론: **일봉 셋업형 전략은 PoC 적용 가능, 장중/실시간 전략은 현재 인프라로 불가.** 적용하려면 어댑터 + 해외 유니버스 선행 작업 필요.
+
+현재 해외 인프라(이미 존재):
+
+- `brokers/korea_investment/korea_invest_overseas_stock_api.py`: `get_overseas_price`(현재가, HHDFS00000300), `get_overseas_dailyprice`(일/주/월봉, HHDFS76240000), `get_overseas_balance`, `inquire_overseas_ccnl`/`inquire_overseas_unfilled`, `place_overseas_limit_order`(지정가만)/`cancel_overseas_order`.
+- `common/overseas_types.py`: `OverseasExchange`(NASD/NYSE/AMEX), `OverseasPriceSummary`, `OverseasOrderRequest/Report`.
+- `market_mode="overseas_us"` 배선(`view/web/bootstrap/service_container.py`, `view/web/market_mode_utils.py`, 웹 라우트).
+- **현재 설계상 해외는 수동매매 전용**: `view/web/bootstrap/strategy_factory.py`가 `overseas_us` 모드에서 자동전략을 의도적으로 비활성화("해외주식 v1은 자동전략을 비활성화합니다").
+
+데이터/요구사항 격차:
+
+| 전략 요구 | 국내 | 해외 |
+| --- | --- | --- |
+| 현재가 | O | O (`get_overseas_price`) |
+| 일봉 OHLCV | O | O (`get_overseas_dailyprice` D/W/M) |
+| 분봉(intraday) | O | X (TR 없음) |
+| 랭킹 유니버스(거래량/등락률/시총) | O | X (없음) |
+| 실시간 웹소켓 스트림 | O | X (`PriceStreamService` 해외 미지원) |
+| 주문 | 시장가/지정가 | 지정가만 |
+| 응답 스키마 | `stck_prpr`(ResStockFullInfo) | `OverseasPriceSummary`(다른 필드) |
+| broker_wrapper 라우팅 | `exchange=KRX` 경로 | `get_price_summary`/`get_current_price` 해외 미라우팅 |
+
+구조적 차단 요소 3가지:
+
+1. **유니버스 부재** — 모든 전략은 후보 종목을 ranking/universe 서비스(`OneilUniverseService`, `vbo_volatility_universe_service` 등)에서 받는다. 해외용 유니버스 소스(랭킹·유동성) 없음 → 정적 리스트 공급 필요.
+2. **데이터 어댑터 부재** — 전략 코드가 `broker.get_price_summary(code)`/`get_current_price(code)`(KRX 경로, `stck_prpr` 스키마)를 직접 호출. 해외는 별도 API 클래스 + 다른 스키마라, 전략 무수정 적용하려면 `broker_api_wrapper`에서 exchange 분기 라우팅 + 스키마 정규화 필요.
+3. **분봉·웹소켓 부재** — 3분 스캐닝/실시간 유동성 필터(`strategy_executor._lookup_liquidity`) 동작 불가.
+
+적용 가능성 분류:
+
+- **장중·실시간 전략(Momentum, VBO live, 3분 오닐 Squeeze/PocketPivot/HTF)**: 분봉·랭킹·웹소켓 모두 부재로 **현재 불가**. KIS 해외 분봉/실시간 TR 추가 구현 전까지 보류.
+- **일봉 셋업 전략(Oneil 오버나잇, Larry Williams 채널/VBO, RSI2)**: 로직이 일봉 OHLCV만 요구하고 해외 일봉 API가 이미 있어 **PoC 적용 가능성 높음**.
+
+권장 단계(착수 시):
+
+- [ ] 일봉 기반 전략 1종(예: Larry Williams VBO) 해외 PoC — 해외 유니버스를 정적 CSV(S&P500/나스닥100 등)로 공급 → `get_overseas_dailyprice`로 EOD(장마감 후) 셋업 평가 → `place_overseas_limit_order` 진입.
+- [ ] 어댑터 계층 — `broker_api_wrapper`의 `get_current_price`/`get_price_summary`에 exchange 분기 추가, 해외 심볼이면 해외 API로 위임 + `OverseasPriceSummary` → 공통 스키마 매핑. (이게 되면 일봉형 전략 거의 무수정 재사용)
+- [ ] 분봉/랭킹/웹소켓 의존 전략은 해당 해외 TR 구현 이후로 후순위.
+
+### 확정 계획 (2026-06-15): VBO 해외 PoC / 어댑터 통합
+
+사용자 결정 — 첫 대상 전략 = `LarryWilliamsVBOStrategy`(일봉 셋업, universe optional), 접근 = 어댑터 통합(`stock_query_service`/`broker_api_wrapper`에 exchange 분기 추가해 기존 전략 거의 무수정 재사용).
+
+VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_current_price(code)`, `_universe`(optional — 없으면 시장국면 게이트만 skip).
+
+제약: **해외 주문 TR은 실전(TTTS6036U 등)만 존재, 모의 주문 TR 없음** → 백테스트/dry-run 검증 전 실주문 배선 금지.
+
+- [ ] **Phase 1 데이터 어댑터 (시작점)**
+  - [ ] 1-1. `get_recent_daily_ohlcv`/`get_ohlcv`/`get_ohlcv_range` exchange 분기 → 해외면 `get_overseas_dailyprice` 위임 + 필드 정규화(date/open/high/low/close/volume, 과거→미래 정렬, 국내와 동일 키). 검증: 해외 mock 응답이 국내와 동일 스키마로 반환되는 단위 테스트.
+  - [ ] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마(`stck_prpr` 등) 매핑. 검증: 해외 심볼 호출 시 매핑 고정.
+  - [ ] 1-3. 후보 심볼 소스 — `OverseasStockCodeRepository`(전체 심볼 DB) + 일봉 거래대금 필터로 watchlist 산출. 검증: 거래대금 하위 제거 리스트 반환.
+- [ ] **Phase 2 해외 일봉 백테스트** — `get_overseas_dailyprice` 과거 데이터로 VBO 진입/청산 재현. (실주문 전 필수 게이트)
+- [ ] **Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대(서머타임) 확장, dry-run shadow 저널(실주문 X).
+- [ ] **Phase 4 주문/사이징** — `place_overseas_limit_order`(지정가) 연결, USD position sizing/환율, 일봉 기반 exit.
+- [ ] **Phase 5 안전/canary** — `get_overseas_balance`/`ccnl` reconcile, risk gate/kill switch/canary USD 확장, 실전 소액 canary.
+
+주요 파일:
+
+- `brokers/korea_investment/korea_invest_overseas_stock_api.py`
+- `common/overseas_types.py`
+- `brokers/broker_api_wrapper.py`
+- `services/stock_query_service.py`
+- `services/market_data_service.py`
+- `repositories/overseas_stock_code_repository.py`
+- `strategies/larry_williams_vbo_strategy.py`
+- `view/web/bootstrap/strategy_factory.py`
+- `view/web/bootstrap/service_container.py`
+- `config/tr_ids_config.yaml` (overseas_stock 섹션 — 현재 price/dailyprice/order/balance만)
 
 ---
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -522,7 +522,7 @@ VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_curren
   - [x] 1-1. `get_recent_daily_ohlcv`/`get_ohlcv_range` exchange 분기 → 해외면 `get_overseas_dailyprice` 위임 + 필드 정규화(date/open/high/low/close/volume, `output2` 파싱, 국내와 동일 키). `_normalize_ohlcv_rows`에 해외 키(xymd/clos/tvol) 추가(도메스틱 무영향), DB-first/today 병합 우회. (PR #549)
   - [x] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마 매핑(`get_current_price`→`stck_prpr`/`price`/`output.stck_prpr`/`acml_vol`, `get_price_summary`→`current`/`change_rate`/`volume`). 국내 캐시/스냅샷 경로 우회. 해외 현재가 API는 OHLC 미제공이라 요약은 best-effort.
   - [x] 1-3. 후보 심볼 소스 — `OverseasCandidateService`(신규): `OverseasStockCodeRepository`(전 심볼) + 일봉 거래대금 필터(close×volume 평균)로 watchlist 산출. 거래소 필터/min 거래대금/top_n/실패 제외/명시 symbols override. 일봉은 Phase 1-1 어댑터 경유(exchange 위임). 배선(VBO 주입)은 Phase 3.
-- [ ] **Phase 2 해외 일봉 백테스트** — `get_overseas_dailyprice` 과거 데이터로 VBO 진입/청산 재현. (실주문 전 필수 게이트)
+- [x] **Phase 2 해외 일봉 백테스트** — `OverseasDailyVBOBacktest`(신규): 고전적 Larry Williams 일봉 근사(target=당일시가+K×전일Range, 고≥target 진입, 저≤손절가 손절 / else 종가 청산). 해외 일봉은 Phase 1-1 어댑터(`get_ohlcv_range` exchange 위임) 경유. trades/요약(win_rate/avg/total net) + 비용(round_trip_cost_pct) 반영. ⚠️ VBO는 본래 장중 전략이라 일봉 근사임(분봉/실시간 부재). 실주문 전 신호 유효성 게이트.
 - [ ] **Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대(서머타임) 확장, dry-run shadow 저널(실주문 X).
 - [ ] **Phase 4 주문/사이징** — `place_overseas_limit_order`(지정가) 연결, USD position sizing/환율, 일봉 기반 exit.
 - [ ] **Phase 5 안전/canary** — `get_overseas_balance`/`ccnl` reconcile, risk gate/kill switch/canary USD 확장, 실전 소액 canary.


### PR DESCRIPTION
## 배경
기존 매매 전략을 해외주식(US)에 적용하기 위한 검토 결과(→ `todo_list.md` "해외주식 전략 적용 검토" 섹션), 첫 대상 전략 = **LarryWilliamsVBO**, 접근 = **어댑터 통합**으로 확정. 본 PR은 **Phase 1 데이터 어댑터 + Phase 2 일봉 백테스트 게이트**.

핵심 원칙: 해외 경로는 **명시적 overseas exchange 인자**에만 동작. 국내(KRX) 기본 경로는 바이트 단위 불변 — 별도 테스트 파일로 격리.

## Phase 1-1 — 해외 일봉 어댑터
- `MarketDataService._is_overseas_exchange()` (NASD/NYSE/AMEX, enum/문자열)
- `_normalize_ohlcv_rows`에 해외 키(`xymd`/`clos`/`tvol`) 폴백 **추가** — 국내 키와 공존
- `get_ohlcv_range` / `get_recent_daily_ohlcv` 해외 분기 → `get_overseas_dailyprice`(`output2`) 위임 + 표준 `{date,open,high,low,close,volume}` 정규화. 국내 DB-first/today 병합 우회.
- `StockQueryService.get_recent_daily_ohlcv`에 `exchange` 통과

## Phase 1-2 — 해외 현재가 어댑터
- `get_current_price` → `get_overseas_price` 위임, `OverseasPriceSummary` → `stck_prpr`/`price`/`output.stck_prpr`/`acml_vol` 매핑 (전략 리더 호환)
- `get_price_summary` → `current`/`change_rate`/`volume` (해외 현재가 API는 OHLC 미제공)
- 국내 캐시/DB 스냅샷 경로 우회

## Phase 1-3 — 해외 후보 심볼 소스
- 신규 `OverseasCandidateService`: `OverseasStockCodeRepository`(전 심볼) + 일봉 거래대금(close×volume 평균) 필터 → watchlist
- 거래소 필터 / min 거래대금 / top_n / 실패 제외 / 명시 symbols override / bounded concurrency

## Phase 2 — 해외 일봉 VBO 백테스트 (실주문 전 게이트)
- 신규 `OverseasDailyVBOBacktest`: 고전적 Larry Williams 일봉 근사 (`target=당일시가+K×전일Range`, 고≥target 진입, 저≤손절가 손절 / else 종가 청산)
- `run_symbol(bars)` 거래/요약(win_rate/avg/total net) + `round_trip_cost_pct`; `run_backtest(sqs, symbols, exchange, start, end)` 심볼별/전체 집계
- 해외 일봉은 Phase 1-1 어댑터 경유. ⚠️ VBO는 본래 장중 전략이라 일봉 근사임(분봉/실시간 부재)

## 테스트 (TDD)
- 신규: `test_market_data_service_overseas.py`(10) + `test_overseas_candidate_service.py`(5) + `test_overseas_daily_vbo_backtest.py`(6)
- 갱신: SQS 패스스루 어설션 1건
- ✅ 단위 6163 passed / 통합 243 passed

## 다음 단계 (후속 PR)
**Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대, dry-run shadow 저널. → Phase 4 주문/사이징(실전 지정가만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)