### PR TITLE
feat(overseas): Phase 3 — US market clock + VBO dry-run pipeline + scheduler wiring

### DIFF
--- a/core/market_clock.py
+++ b/core/market_clock.py
@@ -32,6 +32,15 @@ class MarketClock:
             self.timezone_name = "Asia/Seoul"
             self.market_timezone = pytz.timezone(self.timezone_name)
 
+    @classmethod
+    def for_us_equities(cls, logger=None) -> "MarketClock":
+        """미국 정규장(America/New_York 09:30~16:00) 구성 MarketClock.
+
+        EST/EDT 서머타임 전환은 pytz 의 America/New_York 가 자동 처리한다.
+        """
+        return cls(market_open_time="09:30", market_close_time="16:00",
+                   timezone="America/New_York", logger=logger)
+
     def get_current_kst_time(self):
         """현재 한국 시간(KST)을 timezone-aware datetime 객체로 반환합니다."""
         return datetime.now(self.market_timezone)

--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -1,0 +1,124 @@
+# services/overseas_vbo_dryrun_service.py
+"""해외 VBO dry-run 신호 서비스 (Phase 3).
+
+후보(OverseasCandidateService) → 일봉(StockQueryService, Phase 1-1 어댑터)
+ → VBO 일봉 진입 규칙(Phase 2) → shadow 저널 기록.
+
+**주문 경로 없음.** order_execution 의존을 갖지 않으며, "만약 진입했다면" 신호만
+shadow 저널에 남긴다. 해외 주문은 실전 TR(모의 없음)만 존재하므로, 라이브 검증
+전 단계에서 실주문이 절대 발생하지 않도록 구조적으로 차단한다.
+
+라이브 VBO(분봉/웹소켓 의존)는 해외에서 재생 불가하므로, 본 서비스는 EOD 성격의
+일봉 기반 dry-run 신호만 산출한다. 실제 스케줄러/factory 등록은 별도 단계.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+class OverseasVBODryRunService:
+    STRATEGY_NAME = "LarryWilliamsVBO_overseas"
+    SIGNAL_SOURCE = "overseas_dryrun"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        shadow_journal=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        k_value: float = 0.5,
+        stop_loss_pct: float = -3.0,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+    ):
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._journal = shadow_journal
+        self._logger = logger if logger else logging.getLogger(__name__)
+        self._k = k_value
+        self._stop_loss_pct = stop_loss_pct
+        self._default_exchange = exchange
+
+    async def scan_dry_run(
+        self,
+        exchange: Optional[OverseasExchange] = None,
+        *,
+        top_n: Optional[int] = None,
+        min_avg_trading_value: Optional[float] = None,
+        record: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """후보를 평가해 BUY would-be 신호를 반환하고(선택) shadow 저널에 기록한다."""
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(
+            ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
+        )
+
+        signals: List[Dict[str, Any]] = []
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            try:
+                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=3, exchange=ex)
+            except Exception as e:
+                self._logger.warning({"event": "overseas_dryrun_ohlcv_error", "code": code, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+
+            sig = self._evaluate(code, resp.data)
+            if not sig:
+                continue
+            signals.append(sig)
+            if record and self._journal is not None:
+                self._journal.record(
+                    strategy_name=self.STRATEGY_NAME,
+                    code=code,
+                    signal=sig,
+                    snapshot={"exchange": ex.value, "avg_trading_value": cand.get("avg_trading_value")},
+                    signal_source=self.SIGNAL_SOURCE,
+                )
+        self._logger.info({"event": "overseas_dryrun_scan", "exchange": ex.value,
+                           "candidates": len(candidates or []), "signals": len(signals)})
+        return signals
+
+    def _evaluate(self, code: str, rows: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """최근 일봉(오름차순)에서 VBO 일봉 진입 규칙으로 BUY 신호 판정.
+
+        rows[-2]=전일, rows[-1]=당일(가장 최근 완성봉).
+        target = 당일시가 + K×전일Range, 당일고 >= target → BUY.
+        """
+        if not rows or len(rows) < 2:
+            return None
+        prev, cur = rows[-2], rows[-1]
+        prev_range = self._f(prev.get("high")) - self._f(prev.get("low"))
+        if prev_range <= 0:
+            return None
+        open_ = self._f(cur.get("open"))
+        high = self._f(cur.get("high"))
+        if open_ <= 0:
+            return None
+        target = open_ + self._k * prev_range
+        if high < target:
+            return None
+        entry = target
+        stop = entry * (1 + self._stop_loss_pct / 100.0)
+        return {
+            "code": code,
+            "action": "BUY",
+            "date": cur.get("date"),
+            "entry_price": entry,
+            "target": target,
+            "stop_price": stop,
+            "prev_range": prev_range,
+            "reason": "vbo_daily_breakout",
+        }
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -1,0 +1,81 @@
+# task/background/after_market/overseas_dryrun_task.py
+"""해외 VBO dry-run after-market 태스크 (Phase 3c).
+
+OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 기존 한국장 after-market
+스케줄러(KST 마감 트리거)에 얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
+
+해외는 분봉/실시간/미국장 EOD 스케줄 인프라가 없으므로 한국장 마감을 일일 트리거로
+재사용한다(타이밍은 KST지만 일봉 기반 dry-run 이라 기능상 충분). **주문 경로 없음** —
+OverseasVBODryRunService 가 order_execution 의존을 갖지 않아 실주문이 발생하지 않는다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional, TYPE_CHECKING
+
+from common.overseas_types import OverseasExchange
+from interfaces.schedulable_task import TaskPriority
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+
+
+class OverseasDryRunTask(AfterMarketTask):
+    """해외 VBO dry-run 신호를 장 마감 후 1회 산출·기록하는 태스크."""
+
+    def __init__(
+        self,
+        dryrun_service,
+        shadow_journal=None,
+        market_calendar_service: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        logger=None,
+        worker_pool=None,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+    ) -> None:
+        super().__init__(
+            mcs=market_calendar_service,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._dryrun_service = dryrun_service
+        self._journal = shadow_journal
+        self._exchange = exchange
+        self._last_run_date: Optional[str] = None
+
+    @property
+    def task_name(self) -> str:
+        return "overseas_vbo_dryrun"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "OverseasVBODryRun"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def get_progress(self) -> dict:
+        return {"last_run_date": self._last_run_date}
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        if self._last_run_date == latest_trading_date:
+            self._logger.info(
+                {"event": "overseas_dryrun_skip", "date": latest_trading_date, "reason": "already_run"}
+            )
+            return
+        try:
+            signals = await self._dryrun_service.scan_dry_run(self._exchange)
+            if self._journal is not None:
+                self._journal.flush_to_file(latest_trading_date)
+            self._logger.info(
+                {"event": "overseas_dryrun_done", "date": latest_trading_date, "signals": len(signals or [])}
+            )
+            self._last_run_date = latest_trading_date  # 성공 시에만 dedup 마킹 → 실패 시 재시도
+        except Exception as e:
+            self._logger.error(
+                {"event": "overseas_dryrun_error", "date": latest_trading_date, "error": str(e)}, exc_info=True
+            )

--- a/tests/unit_test/core/test_market_clock_us.py
+++ b/tests/unit_test/core/test_market_clock_us.py
@@ -1,0 +1,32 @@
+"""미국장 MarketClock 팩토리 테스트 (Phase 3).
+
+MarketClock 은 이미 timezone/open/close 파라미터화돼 있으므로, 미국 정규장
+(America/New_York 09:30~16:00, DST는 pytz 자동) 구성 팩토리만 추가한다.
+"""
+from datetime import datetime
+from core.market_clock import MarketClock
+
+
+def test_for_us_equities_uses_new_york_session():
+    clk = MarketClock.for_us_equities()
+    assert clk.timezone_name == "America/New_York"
+    assert clk.market_open_time_str == "09:30"
+    assert clk.market_close_time_str == "16:00"
+
+
+def test_for_us_equities_current_time_is_tz_aware_new_york():
+    clk = MarketClock.for_us_equities()
+    now = clk.get_current_kst_time()  # 이름은 KST지만 클럭 tz 기준
+    assert now.tzinfo is not None
+    assert "New_York" in str(now.tzinfo)
+
+
+def test_for_us_equities_operating_hours_at_known_instants():
+    clk = MarketClock.for_us_equities()
+    tz = clk.market_timezone
+    # 정규장 중 (10:00 ET, 평일)
+    open_dt = tz.localize(datetime(2026, 6, 15, 10, 0))
+    # 장 마감 후 (17:00 ET)
+    closed_dt = tz.localize(datetime(2026, 6, 15, 17, 0))
+    assert clk.is_market_operating_hours(open_dt) is True
+    assert clk.is_market_operating_hours(closed_dt) is False

--- a/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
@@ -1,0 +1,109 @@
+"""해외 VBO dry-run 신호 서비스 테스트 (Phase 3).
+
+후보(Phase 1-3) → 일봉(Phase 1-1 어댑터) → VBO 일봉 진입 규칙(Phase 2) → shadow 저널.
+**주문 경로 없음**: order_execution 미주입, 저널 기록만. 해외 주문은 실전 TR만
+존재하므로 dry-run 단계에서 실주문이 절대 발생하지 않음을 보장한다.
+"""
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
+from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ohlcv(bars):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+
+
+@pytest.fixture
+def svc():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    journal = MagicMock()
+
+    service = OverseasVBODryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=journal,
+        logger=MagicMock(),
+        k_value=0.5,
+        stop_loss_pct=-3.0,
+    )
+    return SimpleNamespace(service=service, candidate_service=candidate_service, sqs=sqs, journal=journal)
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_on_breakout(svc):
+    # prev range 10 → target = 100+5 = 105, 당일고 120 >= 105 → BUY
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert len(signals) == 1
+    assert signals[0]["code"] == "AAA"
+    assert signals[0]["action"] == "BUY"
+    assert signals[0]["target"] == 105.0
+
+
+@pytest.mark.asyncio
+async def test_scan_no_signal_when_no_breakout(svc):
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 104, 100, 103)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+    svc.journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_records_to_shadow_journal_with_dryrun_source(svc):
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    svc.journal.record.assert_called_once()
+    _, kwargs = svc.journal.record.call_args
+    assert kwargs["signal_source"] == "overseas_dryrun"
+    assert kwargs["code"] == "AAA"
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_insufficient_bars(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv([_bar("20260512", 100, 120, 104, 115)]))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_passes_overseas_exchange_downstream(svc):
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NYSE)
+
+    # 후보 조회와 일봉 조회 모두 해외 거래소 인자로 위임
+    _, cand_kwargs = svc.candidate_service.get_candidates.call_args
+    assert cand_kwargs.get("exchange") == OverseasExchange.NYSE or svc.candidate_service.get_candidates.call_args[0][0] == OverseasExchange.NYSE
+    _, ohlcv_kwargs = svc.sqs.get_recent_daily_ohlcv.await_args
+    assert ohlcv_kwargs.get("exchange") == OverseasExchange.NYSE
+
+
+@pytest.mark.asyncio
+async def test_scan_has_no_order_path(svc):
+    """서비스는 order_execution 의존을 갖지 않는다(실주문 불가 보장)."""
+    assert not hasattr(svc.service, "_order_execution_service")
+    assert not hasattr(svc.service, "_order_service")

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -1,0 +1,73 @@
+"""해외 VBO dry-run after-market 태스크 테스트 (Phase 3c).
+
+기존 한국장 after-market 스케줄러(KST 트리거)에 등록해 매일 1회 dry-run 신호를
+산출·flush 한다. 주문 경로 없음(서비스에 order 의존 부재).
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
+from interfaces.schedulable_task import TaskPriority
+from common.overseas_types import OverseasExchange
+
+
+def _make_task(exchange=OverseasExchange.NASD):
+    dryrun = MagicMock()
+    dryrun.scan_dry_run = AsyncMock(return_value=[{"code": "AAA", "action": "BUY"}])
+    journal = MagicMock()
+    task = OverseasDryRunTask(
+        dryrun_service=dryrun,
+        shadow_journal=journal,
+        market_calendar_service=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+        exchange=exchange,
+    )
+    return task, dryrun, journal
+
+
+def test_task_metadata():
+    task, _, _ = _make_task()
+    assert task.task_name == "overseas_vbo_dryrun"
+    assert task._scheduler_label == "OverseasVBODryRun"
+    assert task.priority == TaskPriority.LOW
+
+
+@pytest.mark.asyncio
+async def test_on_market_closed_runs_scan_and_flushes():
+    task, dryrun, journal = _make_task(OverseasExchange.NASD)
+
+    await task._on_market_closed("20260615")
+
+    dryrun.scan_dry_run.assert_awaited_once()
+    args, kwargs = dryrun.scan_dry_run.await_args
+    assert (kwargs.get("exchange") == OverseasExchange.NASD) or (args and args[0] == OverseasExchange.NASD)
+    journal.flush_to_file.assert_called_once_with("20260615")
+
+
+@pytest.mark.asyncio
+async def test_dedup_same_date_skips_second_run():
+    task, dryrun, journal = _make_task()
+
+    await task._on_market_closed("20260615")
+    await task._on_market_closed("20260615")
+
+    assert dryrun.scan_dry_run.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_does_not_mark_date_done_allowing_retry():
+    task, dryrun, journal = _make_task()
+    dryrun.scan_dry_run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await task._on_market_closed("20260615")  # 예외 삼킴
+    dryrun.scan_dry_run = AsyncMock(return_value=[])
+    await task._on_market_closed("20260615")  # 재시도 → 실행됨
+
+    assert dryrun.scan_dry_run.await_count == 1  # 두번째 mock 기준 1회
+
+
+def test_task_has_no_order_dependency():
+    task, _, _ = _make_task()
+    assert not hasattr(task, "_order_execution_service")
+    assert not hasattr(task, "_order_service")

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -114,6 +114,25 @@ def test_web_only_registers_notification_and_watchdog(patched_scheduler_deps):
     assert names == {"notification_queue_task", "websocket_watchdog_task"}
 
 
+def test_overseas_us_registers_dryrun_task(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    ctx.market_mode = "overseas_us"
+    task = MagicMock()
+    task.task_name = "overseas_vbo_dryrun"
+    ctx.overseas_dryrun_task = task
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert "overseas_vbo_dryrun" in names
+
+
+def test_domestic_mode_does_not_register_overseas_task(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.WEB)  # market_mode 미설정 → domestic
+    ctx.overseas_dryrun_task = MagicMock(task_name="overseas_vbo_dryrun")
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert "overseas_vbo_dryrun" not in names
+
+
 def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.TRADING)
     _run(ctx)

--- a/todo_list.md
+++ b/todo_list.md
@@ -523,7 +523,10 @@ VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_curren
   - [x] 1-2. `get_current_price`/`get_price_summary` 해외 분기 + `OverseasPriceSummary` → 공통 스키마 매핑(`get_current_price`→`stck_prpr`/`price`/`output.stck_prpr`/`acml_vol`, `get_price_summary`→`current`/`change_rate`/`volume`). 국내 캐시/스냅샷 경로 우회. 해외 현재가 API는 OHLC 미제공이라 요약은 best-effort.
   - [x] 1-3. 후보 심볼 소스 — `OverseasCandidateService`(신규): `OverseasStockCodeRepository`(전 심볼) + 일봉 거래대금 필터(close×volume 평균)로 watchlist 산출. 거래소 필터/min 거래대금/top_n/실패 제외/명시 symbols override. 일봉은 Phase 1-1 어댑터 경유(exchange 위임). 배선(VBO 주입)은 Phase 3.
 - [x] **Phase 2 해외 일봉 백테스트** — `OverseasDailyVBOBacktest`(신규): 고전적 Larry Williams 일봉 근사(target=당일시가+K×전일Range, 고≥target 진입, 저≤손절가 손절 / else 종가 청산). 해외 일봉은 Phase 1-1 어댑터(`get_ohlcv_range` exchange 위임) 경유. trades/요약(win_rate/avg/total net) + 비용(round_trip_cost_pct) 반영. ⚠️ VBO는 본래 장중 전략이라 일봉 근사임(분봉/실시간 부재). 실주문 전 신호 유효성 게이트.
-- [ ] **Phase 3 배선 + dry-run** — `strategy_factory`/`service_container` overseas_us 분기 완화(VBO 1종 등록), EOD 스케줄, `market_clock` 미국장 시간대(서머타임) 확장, dry-run shadow 저널(실주문 X).
+- [~] **Phase 3 배선 + dry-run** — 안전 우선으로 **주문 경로 없는 dry-run 파이프라인**부터 구현.
+  - [x] 3a. `MarketClock.for_us_equities()` — America/New_York 09:30~16:00(DST pytz 자동) 팩토리.
+  - [x] 3b. `OverseasVBODryRunService`(신규): 후보(1-3)→일봉(1-1)→VBO 일봉 진입규칙(2)→shadow 저널(`signal_source="overseas_dryrun"`). order_execution 미주입으로 실주문 구조적 차단. 라이브 VBO는 분봉/웹소켓 부재로 해외 재생 불가 → EOD 일봉 dry-run만.
+  - [ ] 3c. `strategy_factory`/`service_container` overseas_us 실제 등록 + EOD 스케줄 — 부팅/스케줄러 경로 변경이라 격리 리뷰 필요(별도 PR). dry-run 서비스를 after-market 태스크로 배선.
 - [ ] **Phase 4 주문/사이징** — `place_overseas_limit_order`(지정가) 연결, USD position sizing/환율, 일봉 기반 exit.
 - [ ] **Phase 5 안전/canary** — `get_overseas_balance`/`ccnl` reconcile, risk gate/kill switch/canary USD 확장, 실전 소액 canary.
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -526,7 +526,8 @@ VBO 결합 지점(3개): `get_recent_daily_ohlcv(code, limit=21/2)`, `get_curren
 - [~] **Phase 3 배선 + dry-run** — 안전 우선으로 **주문 경로 없는 dry-run 파이프라인**부터 구현.
   - [x] 3a. `MarketClock.for_us_equities()` — America/New_York 09:30~16:00(DST pytz 자동) 팩토리.
   - [x] 3b. `OverseasVBODryRunService`(신규): 후보(1-3)→일봉(1-1)→VBO 일봉 진입규칙(2)→shadow 저널(`signal_source="overseas_dryrun"`). order_execution 미주입으로 실주문 구조적 차단. 라이브 VBO는 분봉/웹소켓 부재로 해외 재생 불가 → EOD 일봉 dry-run만.
-  - [ ] 3c. `strategy_factory`/`service_container` overseas_us 실제 등록 + EOD 스케줄 — 부팅/스케줄러 경로 변경이라 격리 리뷰 필요(별도 PR). dry-run 서비스를 after-market 태스크로 배선.
+  - [x] 3c. dry-run 배선 — `OverseasDryRunTask`(AfterMarketTask)로 service_container overseas_us 분기에서 구성(event_shadow_journal + candidate + dryrun service + task), scheduler_bootstrap `_register_overseas_tasks`로 등록. **사용자 결정(2026-06-16)**: 기존 한국장 after-market 스케줄러 재사용(KST 트리거) — 미국장 EOD 스케줄 인프라가 없어 한국장 마감을 일일 트리거로 재사용(일봉 기반이라 기능상 충분). 주문 경로 없음(실주문 불가). market_mode!=overseas_us 면 미등록(국내 회귀 0).
+  - [ ] 3d(후속): 미국장 마감(ET) 기준 정밀 트리거가 필요하면 US-aware 스케줄 경로 신설 검토(현재는 KST 트리거로 충분 판단).
 - [ ] **Phase 4 주문/사이징** — `place_overseas_limit_order`(지정가) 연결, USD position sizing/환율, 일봉 기반 exit.
 - [ ] **Phase 5 안전/canary** — `get_overseas_balance`/`ccnl` reconcile, risk gate/kill switch/canary USD 확장, 실전 소액 canary.
 

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -43,6 +43,9 @@ class SchedulerBootstrap:
                 self._register_trading_tasks()
             if mode & RuntimeMode.BATCH:
                 self._register_batch_tasks()
+            # Phase 3c: overseas_us 모드는 batch 가 꺼져 있으므로 dry-run 태스크를 별도 등록.
+            if getattr(ctx, "market_mode", "domestic") == "overseas_us":
+                self._register_overseas_tasks()
             # websocket_watchdog: WEB | TRADING 어느 한쪽이라도 켜져 있으면 한 번만 등록.
             if mode & (RuntimeMode.WEB | RuntimeMode.TRADING):
                 self._register_websocket_watchdog()
@@ -103,6 +106,10 @@ class SchedulerBootstrap:
         self._register(ctx.post_market_replay_audit_task, TaskPriority.LOW)
         self._register(ctx.strategy_log_report_task, TaskPriority.LOW)
         self._register(ctx.after_market_reconcile_task, TaskPriority.LOW)
+
+    def _register_overseas_tasks(self) -> None:
+        # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
+        self._register(getattr(self._ctx, "overseas_dryrun_task", None), TaskPriority.LOW)
 
     def _register_websocket_watchdog(self) -> None:
         # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -49,6 +49,8 @@ from services.stock_query_service import StockQueryService
 from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
 from services.event_shadow_journal_service import EventShadowJournalService
+from services.overseas_candidate_service import OverseasCandidateService
+from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.post_market_replay_audit_service import PostMarketReplayAuditService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
@@ -62,6 +64,7 @@ from task.background.after_market.premium_watchlist_generator_task import Premiu
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
+from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
@@ -544,6 +547,34 @@ class ServiceContainer:
                     )
                 else:
                     ctx.notification_queue_task = None
+                # Phase 3c: 해외 VBO dry-run 파이프라인 (주문 경로 없음 — 실주문 불가).
+                # 한국장 마감(KST)을 일일 트리거로 재사용해 일봉 기반 dry-run 신호를 누적한다.
+                ctx.event_shadow_journal_service = EventShadowJournalService(
+                    log_root="logs/strategies", logger=ctx.logger,
+                )
+                ctx.overseas_candidate_service = None
+                ctx.overseas_vbo_dryrun_service = None
+                ctx.overseas_dryrun_task = None
+                if getattr(ctx, "overseas_stock_code_repository", None) is not None:
+                    ctx.overseas_candidate_service = OverseasCandidateService(
+                        overseas_stock_code_repository=ctx.overseas_stock_code_repository,
+                        stock_query_service=ctx.stock_query_service,
+                        logger=ctx.logger,
+                    )
+                    ctx.overseas_vbo_dryrun_service = OverseasVBODryRunService(
+                        candidate_service=ctx.overseas_candidate_service,
+                        stock_query_service=ctx.stock_query_service,
+                        shadow_journal=ctx.event_shadow_journal_service,
+                        logger=ctx.logger,
+                    )
+                    ctx.overseas_dryrun_task = OverseasDryRunTask(
+                        dryrun_service=ctx.overseas_vbo_dryrun_service,
+                        shadow_journal=ctx.event_shadow_journal_service,
+                        market_calendar_service=ctx._mcs,
+                        market_clock=ctx.market_clock,
+                        logger=ctx.logger,
+                        worker_pool=getattr(ctx, "worker_pool", None),
+                    )
                 return
 
             ctx.oneil_universe_service = OneilUniverseService(

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -166,6 +166,10 @@ class WebAppContext:
         # P2 2-4: event-driven shadow 인프라 (default: 비활성, event_driven_shadow=False)
         self.strategy_event_router = None
         self.event_shadow_journal_service = None
+        # Phase 3c: 해외 VBO dry-run 파이프라인 (overseas_us 모드에서만 구성)
+        self.overseas_candidate_service = None
+        self.overseas_vbo_dryrun_service = None
+        self.overseas_dryrun_task = None
         self._last_missing_reason_log_ts: dict[tuple[str, str], float] = {}
         self._last_rest_price_refresh_ts: dict[str, float] = {}
         self._pending_rest_price_refresh_tasks: dict[str, asyncio.Task] = {}


### PR DESCRIPTION
## 배경
해외주식 VBO 적용 로드맵 **Phase 3 (배선 + dry-run)** 전체. (Phase 1 데이터 어댑터 + Phase 2 백테스트는 #549 머지 완료.)

**안전 원칙**: 해외 주문은 실전 TR만 존재(모의 주문 TR 없음)하므로, 라이브 검증 전 단계는 **주문 경로가 전혀 없는 dry-run** 으로 제한. dry-run 서비스/태스크 모두 order_execution 의존을 갖지 않음(테스트로 잠금).

## Phase 3a — 미국장 MarketClock
- `MarketClock.for_us_equities()`: America/New_York 09:30~16:00 (EST/EDT 서머타임 pytz 자동). 기존 동작 불변.

## Phase 3b — 해외 VBO dry-run 신호 서비스
- `OverseasVBODryRunService`: 후보(1-3)→일봉(1-1 어댑터)→VBO 일봉 진입규칙(2)→shadow 저널(`signal_source="overseas_dryrun"`). **order_execution 의존 없음** → 실주문 구조적 차단.

## Phase 3c — 스케줄러 배선 (사용자 결정: 기존 한국장 스케줄러 재사용, KST 트리거)
- `OverseasDryRunTask(AfterMarketTask)`: `_on_market_closed`에서 `scan_dry_run` + shadow 저널 flush, 거래일 dedup, 실패 시 재시도. 주문 의존 없음.
- `service_container` overseas_us 분기: event_shadow_journal + candidate + dryrun service + task 구성
- `scheduler_bootstrap._register_overseas_tasks`: `market_mode==overseas_us` 일 때만 등록 → **국내 회귀 0** (ALL/WEB/TRADING/BATCH 등록 수 불변, 테스트로 잠금)
- `web_app_initializer`: ctx 필드 기본값(None)
- 미국장 EOD 스케줄 인프라가 없어 한국장 마감(KST)을 일일 트리거로 재사용 — 일봉 기반 dry-run 이라 기능상 충분 (정밀 ET 트리거는 후속 3d 검토)

## 테스트 (TDD)
- 신규: `test_market_clock_us.py`(3) + `test_overseas_vbo_dryrun_service.py`(6) + `test_overseas_dryrun_task.py`(5) + scheduler_bootstrap overseas 등록 2종
- ✅ 단위 6179 passed / 통합 243 passed (통합이 overseas boot 경로 포함)

## 다음 단계
**Phase 4 주문/사이징** — `place_overseas_limit_order`(실전 지정가) 연결, USD position sizing/환율, 일봉 기반 exit. (실주문 진입 — 별도 신중 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)