### PR TITLE
[codex] Fix VBO event shadow price dispatch

### DIFF
--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -64,6 +64,9 @@ class StreamingService:
 
         # Observer 레지스트리: data_type → [handler, ...]
         self._handlers: Dict[str, List[Callable[[dict], None]]] = {}
+        # PriceStreamService.on_price_tick 처럼 running event loop 가 필요한
+        # non-blocking 동기 핸들러는 executor 로 보내지 않고 현재 루프에서 실행한다.
+        self._event_loop_handlers: List[Callable[[dict], None]] = []
 
         if price_stream_service is not None:
             self.set_price_stream_service(price_stream_service)
@@ -94,9 +97,12 @@ class StreamingService:
             handlers = self._handlers.get('realtime_price', [])
             if self._price_stream_service.on_price_tick in handlers:
                 handlers.remove(self._price_stream_service.on_price_tick)
+            if self._price_stream_service.on_price_tick in self._event_loop_handlers:
+                self._event_loop_handlers.remove(self._price_stream_service.on_price_tick)
 
         self._price_stream_service = svc
         self.register_handler('realtime_price', svc.on_price_tick)
+        self._event_loop_handlers.append(svc.on_price_tick)
 
     def set_streaming_stock_repo(self, repo: "StreamingStockRepo") -> None:
         """StreamingStockRepo를 사후 주입한다."""
@@ -288,6 +294,9 @@ class StreamingService:
                             pass
                     task.add_done_callback(_log_done)
                 else:
+                    if handler in self._event_loop_handlers:
+                        handler(inner)
+                        continue
                     # 동기(또는 블로킹) 핸들러는 스레드 풀로 오프로드
                     try:
                         loop = asyncio.get_running_loop()

--- a/tests/unit_test/services/test_streaming_service.py
+++ b/tests/unit_test/services/test_streaming_service.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from services.streaming_service import StreamingService
+from services.price_stream_service import PriceStreamService
 from common.types import ResCommonResponse, ErrorCode
 
 @pytest.fixture
@@ -409,6 +410,30 @@ def test_set_price_stream_service_registers_handler(streaming_service):
     streaming_service.dispatch_realtime_message({'type': 'realtime_price', 'data': inner})
 
     mock_svc.on_price_tick.assert_called_once_with(inner)
+
+
+@pytest.mark.asyncio
+async def test_price_stream_handler_dispatches_event_router_from_streaming_service(
+    streaming_service,
+):
+    """StreamingService 경유 realtime_price도 event router까지 전달되어야 한다."""
+    router = MagicMock()
+    router.on_price_tick = AsyncMock()
+    stock_repo = MagicMock()
+    price_stream = PriceStreamService(stock_repo=stock_repo, event_router=router)
+    streaming_service.set_price_stream_service(price_stream)
+
+    inner = {'유가증권단축종목코드': '005930', '주식현재가': '70000'}
+    streaming_service.dispatch_realtime_message({'type': 'realtime_price', 'data': inner})
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    router.on_price_tick.assert_awaited_once()
+    snap = price_stream.tick_ingest_stats_snapshot(["005930"])
+    assert snap["005930"]["received"] == 1
+    assert snap["005930"]["dispatched"] == 1
 
 
 def test_set_price_stream_service_replaces_previous_handler(streaming_service):


### PR DESCRIPTION
## Summary
- Keep the price stream handler on the active event loop instead of offloading it to the executor.
- Add a regression test that verifies realtime_price dispatch reaches the event router and increments VBO tick ingest stats.

## Root Cause
StreamingService sent synchronous handlers through run_in_executor. PriceStreamService.on_price_tick then ran in a worker thread without a running asyncio loop, so it skipped StrategyEventRouter dispatch. VBO shadow status files were written, but event-driven evaluation was not actually receiving ticks.

## Validation
- python -m pytest tests/unit_test/services/test_streaming_service.py::test_price_stream_handler_dispatches_event_router_from_streaming_service -v
- python -m pytest tests/unit_test/services/test_streaming_service.py tests/unit_test/services/test_price_stream_service_event_router.py tests/unit_test/services/test_price_stream_service_tick_ingest_stats.py tests/unit_test/scheduler/test_event_shadow_pipeline_e2e.py tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py -v
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v