### PR TITLE
[codex] Add overseas VBO dry-run position sizing

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -42,6 +42,9 @@ overseas_stock:
   manual_order_only: true
   # 실전 해외 주문은 기본 차단. 운영 검증 후 별도 승인으로만 true 전환.
   allow_live_trading: false
+  # 해외 VBO dry-run would-be 수량 계산용 고정 USD 슬롯. 실주문 경로 없음.
+  dryrun_slot_usd: 1000.0
+  dryrun_max_qty:
 
 # 선택
 htsid: ""

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -363,6 +363,8 @@ class OverseasStockConfig(BaseModel):
     currency: Literal["USD"] = "USD"
     manual_order_only: bool = True
     allow_live_trading: bool = False
+    dryrun_slot_usd: float = Field(1000.0, gt=0)
+    dryrun_max_qty: Optional[int] = Field(default=None, gt=0)
 
     model_config = {"extra": "allow"}
 

--- a/services/overseas_position_sizing_service.py
+++ b/services/overseas_position_sizing_service.py
@@ -1,0 +1,126 @@
+# services/overseas_position_sizing_service.py
+"""해외 VBO canary 포지션 사이징 (Phase 4 — 고정 USD 슬롯).
+
+**실주문 fire 경로 없음(순수 계산).** dry-run 검증 전 실주문 배선 금지 제약에 따라
+본 서비스는 broker/order_execution 의존을 갖지 않으며 수량 산출만 한다.
+
+사이징 모델: 고정 USD 캐너리 슬롯 ÷ 지정가(USD) = 수량(floor).
+환율(USD/KRW)은 KRW 환산 노출 리포팅용 부가값이며 사이징 자체엔 불필요하다
+(USD 슬롯을 USD 가격으로 나누므로). FX 는 KIS 잔고 응답에서 추출한다.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Optional
+
+# KIS 해외 잔고/현재잔고 응답의 환율 후보 필드.
+# 공식 표본이 부족해 표본별로 키가 갈리므로 다중 후보 탐색 — 실 fixture 확보 시 단일화.
+_FX_RATE_KEYS = ("frst_bltn_exrt", "bass_exrt", "ovrs_excg_exrt", "exrt")
+
+
+def _to_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def extract_fx_krw_per_usd(balance_data: Any) -> Optional[float]:
+    """KIS 잔고 응답(raw dict)에서 USD/KRW 환율을 관용적으로 추출한다.
+
+    output1(보유종목 list)·output2(요약 dict 또는 list)를 후보 키로 탐색해
+    첫 양수 환율을 반환한다. 없거나 비양수면 None(→ KRW 환산 생략).
+    """
+    if not isinstance(balance_data, dict):
+        return None
+    sections: list[dict] = []
+    for key in ("output1", "output2"):
+        sec = balance_data.get(key)
+        if isinstance(sec, list):
+            sections.extend(s for s in sec if isinstance(s, dict))
+        elif isinstance(sec, dict):
+            sections.append(sec)
+    for sec in sections:
+        for fx_key in _FX_RATE_KEYS:
+            if fx_key in sec:
+                rate = _to_float(sec.get(fx_key))
+                if rate > 0:
+                    return rate
+    return None
+
+
+class OverseasPositionSizingService:
+    """고정 USD 슬롯 기반 해외 캐너리 사이징 (실주문 경로 없음)."""
+
+    def __init__(
+        self,
+        *,
+        slot_usd: float,
+        max_qty: Optional[int] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        if slot_usd <= 0:
+            raise ValueError("slot_usd must be positive")
+        if max_qty is not None and max_qty <= 0:
+            raise ValueError("max_qty must be positive when provided")
+        self._slot_usd = float(slot_usd)
+        self._max_qty = max_qty
+        self._logger = logger or logging.getLogger(__name__)
+
+    def size(
+        self,
+        *,
+        limit_price_usd: float,
+        available_usd: Optional[float] = None,
+        fx_krw_per_usd: Optional[float] = None,
+    ) -> dict:
+        """지정가(USD)에 대해 고정 슬롯 기준 매수 수량을 산출한다.
+
+        반환: {qty, limit_price_usd, notional_usd, slot_usd,
+               fx_krw_per_usd, krw_exposure, reason}
+        """
+        price = _to_float(limit_price_usd)
+        if price <= 0:
+            return self._result(0, 0.0, fx_krw_per_usd, "invalid_price")
+
+        qty = math.floor(self._slot_usd / price)
+        if qty < 1:
+            return self._result(0, price, fx_krw_per_usd, "slot_too_small")
+
+        reason = "slot"
+        if self._max_qty is not None and qty > self._max_qty:
+            qty = self._max_qty
+            reason = "capped_by_max_qty"
+
+        if available_usd is not None:
+            affordable = math.floor(_to_float(available_usd) / price)
+            if affordable < qty:
+                qty = max(affordable, 0)
+                reason = "capped_by_available_usd"
+            if qty < 1:
+                return self._result(0, price, fx_krw_per_usd, "insufficient_usd")
+
+        return self._result(qty, price, fx_krw_per_usd, reason)
+
+    def _result(
+        self,
+        qty: int,
+        price: float,
+        fx: Optional[float],
+        reason: str,
+    ) -> dict:
+        notional_usd = round(qty * price, 4)
+        fx_valid = fx if (fx and fx > 0) else None
+        krw_exposure = (
+            round(notional_usd * fx_valid, 2) if (fx_valid and qty > 0) else None
+        )
+        return {
+            "qty": qty,
+            "limit_price_usd": price,
+            "notional_usd": notional_usd,
+            "slot_usd": self._slot_usd,
+            "fx_krw_per_usd": fx_valid,
+            "krw_exposure": krw_exposure,
+            "reason": reason,
+        }

--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -32,6 +32,7 @@ class OverseasVBODryRunService:
         k_value: float = 0.5,
         stop_loss_pct: float = -3.0,
         exchange: OverseasExchange = OverseasExchange.NASD,
+        position_sizing_service=None,
     ):
         self._candidate_service = candidate_service
         self._sqs = stock_query_service
@@ -40,6 +41,8 @@ class OverseasVBODryRunService:
         self._k = k_value
         self._stop_loss_pct = stop_loss_pct
         self._default_exchange = exchange
+        # 고정 USD 슬롯 사이징(순수 계산, 주문 경로 없음). 미주입 시 qty 미산출.
+        self._sizing_service = position_sizing_service
 
     async def scan_dry_run(
         self,
@@ -71,6 +74,10 @@ class OverseasVBODryRunService:
             sig = self._evaluate(code, resp.data)
             if not sig:
                 continue
+            if self._sizing_service is not None:
+                sizing = self._sizing_service.size(limit_price_usd=sig["entry_price"])
+                sig["qty"] = sizing.get("qty")
+                sig["notional_usd"] = sizing.get("notional_usd")
             signals.append(sig)
             if record and self._journal is not None:
                 self._journal.record(

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -139,6 +139,8 @@ def test_app_config_defaults_to_paper_trading_when_omitted():
     assert config.overseas_stock.currency == "USD"
     assert config.overseas_stock.manual_order_only is True
     assert config.overseas_stock.allow_live_trading is False
+    assert config.overseas_stock.dryrun_slot_usd == 1000.0
+    assert config.overseas_stock.dryrun_max_qty is None
 
 
 def test_app_config_accepts_overseas_us_market_mode():
@@ -159,6 +161,20 @@ def test_app_config_accepts_overseas_us_market_mode():
     assert config.overseas_stock.enabled_exchanges == ["NASD", "NYSE"]
     assert config.overseas_stock.default_exchange == "NYSE"
     assert config.overseas_stock.allow_live_trading is True
+    assert config.overseas_stock.dryrun_slot_usd == 1000.0
+
+
+def test_app_config_accepts_overseas_dryrun_sizing_values():
+    config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        overseas_stock={
+            "dryrun_slot_usd": 500.0,
+            "dryrun_max_qty": 3,
+        },
+    )
+
+    assert config.overseas_stock.dryrun_slot_usd == 500.0
+    assert config.overseas_stock.dryrun_max_qty == 3
 
 
 def test_app_config_rejects_invalid_market_mode():

--- a/tests/unit_test/services/test_overseas_position_sizing_service.py
+++ b/tests/unit_test/services/test_overseas_position_sizing_service.py
@@ -1,0 +1,96 @@
+"""해외 캐너리 포지션 사이징 테스트 (Phase 4 — 고정 USD 슬롯).
+
+실주문 경로 없음(순수 계산). 고정 USD 슬롯 ÷ 지정가 = 수량(floor).
+환율은 KRW 환산 노출용 부가값이며 KIS 잔고 응답에서 관용 추출한다.
+"""
+import pytest
+
+from services.overseas_position_sizing_service import (
+    OverseasPositionSizingService,
+    extract_fx_krw_per_usd,
+)
+
+
+def _svc(slot_usd=1000.0, max_qty=None):
+    return OverseasPositionSizingService(slot_usd=slot_usd, max_qty=max_qty)
+
+
+def test_qty_is_floor_of_slot_over_price():
+    res = _svc(slot_usd=1000.0).size(limit_price_usd=150.0)
+    assert res["qty"] == 6  # 1000/150 = 6.66 → 6
+    assert res["notional_usd"] == pytest.approx(900.0)
+    assert res["reason"] == "slot"
+
+
+def test_invalid_price_returns_zero_qty():
+    res = _svc().size(limit_price_usd=0.0)
+    assert res["qty"] == 0
+    assert res["reason"] == "invalid_price"
+
+
+def test_slot_too_small_returns_zero_qty():
+    res = _svc(slot_usd=100.0).size(limit_price_usd=150.0)
+    assert res["qty"] == 0
+    assert res["reason"] == "slot_too_small"
+
+
+def test_available_usd_caps_qty():
+    res = _svc(slot_usd=1000.0).size(limit_price_usd=150.0, available_usd=500.0)
+    assert res["qty"] == 3  # 500/150 = 3.33 → 3 < 6
+    assert res["reason"] == "capped_by_available_usd"
+
+
+def test_insufficient_usd_returns_zero_qty():
+    res = _svc(slot_usd=1000.0).size(limit_price_usd=150.0, available_usd=100.0)
+    assert res["qty"] == 0
+    assert res["reason"] == "insufficient_usd"
+
+
+def test_max_qty_caps_qty():
+    res = _svc(slot_usd=1000.0, max_qty=5).size(limit_price_usd=10.0)
+    assert res["qty"] == 5  # 1000/10 = 100 → capped 5
+    assert res["reason"] == "capped_by_max_qty"
+
+
+def test_fx_yields_krw_exposure():
+    res = _svc(slot_usd=1000.0).size(limit_price_usd=150.0, fx_krw_per_usd=1350.0)
+    assert res["fx_krw_per_usd"] == 1350.0
+    assert res["krw_exposure"] == pytest.approx(900.0 * 1350.0)
+
+
+def test_no_fx_leaves_krw_exposure_none():
+    res = _svc(slot_usd=1000.0).size(limit_price_usd=150.0)
+    assert res["krw_exposure"] is None
+    assert res["fx_krw_per_usd"] is None
+
+
+def test_init_rejects_nonpositive_slot():
+    with pytest.raises(ValueError):
+        OverseasPositionSizingService(slot_usd=0.0)
+    with pytest.raises(ValueError):
+        OverseasPositionSizingService(slot_usd=1000.0, max_qty=0)
+
+
+# --- extract_fx_krw_per_usd ---
+
+def test_extract_fx_from_output2_dict():
+    data = {"output2": {"frst_bltn_exrt": "1342.50"}}
+    assert extract_fx_krw_per_usd(data) == pytest.approx(1342.50)
+
+
+def test_extract_fx_from_output1_row():
+    data = {"output1": [{"pdno": "AAPL", "bass_exrt": "1310.00"}]}
+    assert extract_fx_krw_per_usd(data) == pytest.approx(1310.00)
+
+
+def test_extract_fx_missing_returns_none():
+    assert extract_fx_krw_per_usd({"output2": {"tot_evlu_amt": "1000"}}) is None
+
+
+def test_extract_fx_nonpositive_returns_none():
+    assert extract_fx_krw_per_usd({"output2": {"frst_bltn_exrt": "0"}}) is None
+
+
+def test_extract_fx_non_dict_returns_none():
+    assert extract_fx_krw_per_usd(None) is None
+    assert extract_fx_krw_per_usd([1, 2, 3]) is None

--- a/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
@@ -107,3 +107,47 @@ async def test_scan_has_no_order_path(svc):
     """서비스는 order_execution 의존을 갖지 않는다(실주문 불가 보장)."""
     assert not hasattr(svc.service, "_order_execution_service")
     assert not hasattr(svc.service, "_order_service")
+
+
+@pytest.mark.asyncio
+async def test_scan_omits_qty_when_no_sizing(svc):
+    """사이징 서비스 미주입 시 신호에 qty 를 넣지 않는다(하위 호환)."""
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert "qty" not in signals[0]
+
+
+@pytest.mark.asyncio
+async def test_scan_includes_qty_when_sizing_injected():
+    """사이징 서비스 주입 시 would-be qty/notional 을 신호에 동봉한다(주문 경로 없음)."""
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 9, "notional_usd": 945.0, "reason": "slot"})
+
+    service = OverseasVBODryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing,
+    )
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 9
+    assert signals[0]["notional_usd"] == 945.0
+    # entry_price(=target 105) 로 사이징 호출
+    _, kwargs = sizing.size.call_args
+    assert kwargs["limit_price_usd"] == 105.0
+    # 사이징 주입돼도 order_execution 의존은 없다
+    assert not hasattr(service, "_order_execution_service")

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -285,3 +285,33 @@ def test_service_container_does_not_wire_minervini_circular_pair(patched_service
     update_instance = patched_service_container_deps["MinerviniUpdateTask"].return_value
     assert ctx.minervini_stage_service is stage_instance
     assert ctx.minervini_update_task is update_instance
+
+
+def test_service_container_wires_overseas_dryrun_position_sizing(patched_service_container_deps):
+    """overseas_us 모드의 VBO dry-run 에 고정 USD 슬롯 사이징을 주입한다."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.market_mode = "overseas_us"
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="overseas_us",
+        overseas_stock={"dryrun_slot_usd": 750.0, "dryrun_max_qty": 4},
+    )
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True) as sizing_cls, \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True) as candidate_cls, \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True) as dryrun_cls, \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True):
+        ServiceContainer(ctx).run()
+
+    sizing_cls.assert_called_once_with(
+        slot_usd=750.0,
+        max_qty=4,
+        logger=ctx.logger,
+    )
+    dryrun_kwargs = dryrun_cls.call_args.kwargs
+    assert dryrun_kwargs["candidate_service"] is candidate_cls.return_value
+    assert dryrun_kwargs["position_sizing_service"] is sizing_cls.return_value

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -50,6 +50,7 @@ from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
 from services.event_shadow_journal_service import EventShadowJournalService
 from services.overseas_candidate_service import OverseasCandidateService
+from services.overseas_position_sizing_service import OverseasPositionSizingService
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.post_market_replay_audit_service import PostMarketReplayAuditService
 from services.strategy_log_report_service import StrategyLogReportService
@@ -556,6 +557,12 @@ class ServiceContainer:
                 ctx.overseas_vbo_dryrun_service = None
                 ctx.overseas_dryrun_task = None
                 if getattr(ctx, "overseas_stock_code_repository", None) is not None:
+                    overseas_stock_cfg = getattr(ctx.full_config, "overseas_stock", None)
+                    overseas_position_sizing_service = OverseasPositionSizingService(
+                        slot_usd=getattr(overseas_stock_cfg, "dryrun_slot_usd", 1000.0),
+                        max_qty=getattr(overseas_stock_cfg, "dryrun_max_qty", None),
+                        logger=ctx.logger,
+                    )
                     ctx.overseas_candidate_service = OverseasCandidateService(
                         overseas_stock_code_repository=ctx.overseas_stock_code_repository,
                         stock_query_service=ctx.stock_query_service,
@@ -566,6 +573,7 @@ class ServiceContainer:
                         stock_query_service=ctx.stock_query_service,
                         shadow_journal=ctx.event_shadow_journal_service,
                         logger=ctx.logger,
+                        position_sizing_service=overseas_position_sizing_service,
                     )
                     ctx.overseas_dryrun_task = OverseasDryRunTask(
                         dryrun_service=ctx.overseas_vbo_dryrun_service,


### PR DESCRIPTION
## Summary
- Add a pure-calculation overseas VBO dry-run position sizing service for fixed USD canary slots.
- Include optional dry-run sizing config under `overseas_stock` and wire it into the overseas US ServiceContainer path.
- Attach would-be `qty` and `notional_usd` to overseas VBO dry-run signals only when sizing is injected, preserving the no-order-path invariant.

## Validation
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_test -v`