### PR TITLE
[codex] Use unified realtime price for CLI streams

### DIFF
--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -807,7 +807,7 @@ class OrderExecutionService:
 
         # 웹소켓 연결 및 구독 요청
         if await self.broker_api_wrapper.connect_websocket(on_message_callback=realtime_data_display_callback):
-            await self.broker_api_wrapper.subscribe_realtime_price(stock_code)
+            await self.broker_api_wrapper.subscribe_unified_price(stock_code)
             await self.broker_api_wrapper.subscribe_realtime_quote(stock_code)
 
             try:
@@ -816,7 +816,7 @@ class OrderExecutionService:
             except KeyboardInterrupt:
                 self.logger.info("실시간 구독 중단 (KeyboardInterrupt).")
             finally:
-                await self.broker_api_wrapper.unsubscribe_realtime_price(stock_code)
+                await self.broker_api_wrapper.unsubscribe_unified_price(stock_code)
                 await self.broker_api_wrapper.unsubscribe_realtime_quote(stock_code)
                 await self.broker_api_wrapper.disconnect_websocket()
                 self.logger.info(f"실시간 주식 스트림 종료: 종목={stock_code}")

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -28,6 +28,7 @@ class ProgramTradingStreamService:
     FLUSH_BATCH_SIZE = 100
     HOURLY_TICK_ALERT_INTERVAL_SEC = 60 * 60
     REGULAR_SESSION_CLOSE_TIME = "15:30"
+    CLOSING_AUCTION_START_TIME = "15:20"
 
     def __init__(self, logger=None):
         self.logger = logger if logger else logging.getLogger(__name__)
@@ -546,15 +547,21 @@ class ProgramTradingStreamService:
             if item["ok"]:
                 lines.append(f"{html.escape(label)}: OK ({saved}/{expected})")
             else:
-                sample = ", ".join(item["missing_minutes"][:10])
-                extra = "" if item["missing_minute_count"] <= 10 else f" 외 {item['missing_minute_count'] - 10}분"
+                display_missing_minutes = [
+                    minute for minute in item["missing_minutes"]
+                    if minute < self.CLOSING_AUCTION_START_TIME
+                ]
+                sample = ", ".join(display_missing_minutes[:10])
+                extra = "" if len(display_missing_minutes) <= 10 else f" 외 {len(display_missing_minutes) - 10}분"
                 unsaved = item.get("unsaved_received_minute_count", 0)
                 no_tick = item.get("no_tick_minute_count", item["missing_minute_count"])
-                lines.append(
+                line = (
                     f"{html.escape(label)}: 누락 {item['missing_minute_count']}분 "
-                    f"(DB 미저장 {unsaved}분, 수신없음 {no_tick}분, 저장 {saved}/{expected}) "
-                    f"예: {html.escape(sample)}{extra}"
+                    f"(DB 미저장 {unsaved}분, 수신없음 {no_tick}분, 저장 {saved}/{expected})"
                 )
+                if sample:
+                    line += f" 예: {html.escape(sample)}{extra}"
+                lines.append(line)
         return "\n".join(lines)
 
     def get_background_task_status(self) -> dict:

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -234,7 +234,7 @@ class StreamingService:
             await self.connect_websocket()
             for code in stock_codes:
                 if "price" in fields:
-                    await self.subscribe_realtime_price(code)
+                    await self.subscribe_unified_price(code)
                 if "quote" in fields:
                     await self.broker.subscribe_realtime_quote(code)
 
@@ -247,7 +247,7 @@ class StreamingService:
         finally:
             for code in stock_codes:
                 if "price" in fields:
-                    await self.unsubscribe_realtime_price(code)
+                    await self.unsubscribe_unified_price(code)
                 if "quote" in fields:
                     await self.broker.unsubscribe_realtime_quote(code)
             await self.disconnect_websocket()

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -383,9 +383,9 @@ async def test_overseas_mode_blocks_strategy_buy_before_broker_call(
 async def test_handle_realtime_price_quote_stream_success(handler, mock_broker_api_wrapper, mock_logger, mock_market_calendar_service):
     """실시간 스트림이 성공적으로 연결, 구독, 종료되는지 테스트합니다."""
     mock_broker_api_wrapper.connect_websocket.return_value = True
-    mock_broker_api_wrapper.subscribe_realtime_price.return_value = True
+    mock_broker_api_wrapper.subscribe_unified_price.return_value = True
     mock_broker_api_wrapper.subscribe_realtime_quote.return_value = True
-    mock_broker_api_wrapper.unsubscribe_realtime_price.return_value = True # This was missing in the original mock setup
+    mock_broker_api_wrapper.unsubscribe_unified_price.return_value = True
     mock_broker_api_wrapper.unsubscribe_realtime_quote.return_value = True
     mock_broker_api_wrapper.disconnect_websocket.return_value = True
 
@@ -397,9 +397,11 @@ async def test_handle_realtime_price_quote_stream_success(handler, mock_broker_a
         mock_broker_api_wrapper.connect_websocket.assert_awaited_once_with(
             on_message_callback=ANY
         )
-        mock_broker_api_wrapper.subscribe_realtime_price.assert_awaited_once_with("005930")
+        mock_broker_api_wrapper.subscribe_unified_price.assert_awaited_once_with("005930")
+        mock_broker_api_wrapper.subscribe_realtime_price.assert_not_awaited()
         mock_broker_api_wrapper.subscribe_realtime_quote.assert_awaited_once_with("005930")
-        mock_broker_api_wrapper.unsubscribe_realtime_price.assert_awaited_once_with("005930")
+        mock_broker_api_wrapper.unsubscribe_unified_price.assert_awaited_once_with("005930")
+        mock_broker_api_wrapper.unsubscribe_realtime_price.assert_not_awaited()
         mock_broker_api_wrapper.unsubscribe_realtime_quote.assert_awaited_once_with("005930")
         mock_broker_api_wrapper.disconnect_websocket.assert_awaited_once()
         mock_logger.info.assert_any_call(f"실시간 주식 스트림 종료: 종목=005930")
@@ -415,15 +417,16 @@ async def test_handle_realtime_price_quote_stream_connection_failure(handler, mo
         on_message_callback=ANY
     )
     mock_broker_api_wrapper.subscribe_realtime_price.assert_not_awaited()
+    mock_broker_api_wrapper.subscribe_unified_price.assert_not_awaited()
     mock_logger.error.assert_called_once_with("실시간 웹소켓 연결 실패.")
 
 @pytest.mark.asyncio
 async def test_handle_realtime_price_quote_stream_keyboard_interrupt(handler, mock_broker_api_wrapper, mock_logger, mock_market_calendar_service):
     """스트림 수신 중 KeyboardInterrupt 발생 시 정상적으로 종료되는지 테스트합니다."""
     mock_broker_api_wrapper.connect_websocket.return_value = True
-    mock_broker_api_wrapper.subscribe_realtime_price.return_value = True
+    mock_broker_api_wrapper.subscribe_unified_price.return_value = True
     mock_broker_api_wrapper.subscribe_realtime_quote.return_value = True
-    mock_broker_api_wrapper.unsubscribe_realtime_price.return_value = True
+    mock_broker_api_wrapper.unsubscribe_unified_price.return_value = True
     mock_broker_api_wrapper.unsubscribe_realtime_quote.return_value = True
     mock_broker_api_wrapper.disconnect_websocket.return_value = True
 
@@ -436,7 +439,8 @@ async def test_handle_realtime_price_quote_stream_keyboard_interrupt(handler, mo
             call("실시간 구독 중단 (KeyboardInterrupt)."),
             call(f"실시간 주식 스트림 종료: 종목=005930")
         ])
-        mock_broker_api_wrapper.unsubscribe_realtime_price.assert_awaited_once()
+        mock_broker_api_wrapper.unsubscribe_unified_price.assert_awaited_once_with("005930")
+        mock_broker_api_wrapper.unsubscribe_realtime_price.assert_not_awaited()
         mock_broker_api_wrapper.disconnect_websocket.assert_awaited_once()
 
 @pytest.mark.asyncio # This test is directly related to the market open check.
@@ -457,9 +461,9 @@ async def test_realtime_data_display_callback_logic(handler, mock_broker_api_wra
     realtime_data_display_callback 함수의 내부 로직을 다양한 데이터 타입으로 검증합니다.
     """
     mock_broker_api_wrapper.connect_websocket.return_value = True
-    mock_broker_api_wrapper.subscribe_realtime_price.return_value = True
+    mock_broker_api_wrapper.subscribe_unified_price.return_value = True
     mock_broker_api_wrapper.subscribe_realtime_quote.return_value = True
-    mock_broker_api_wrapper.unsubscribe_realtime_price.return_value = True
+    mock_broker_api_wrapper.unsubscribe_unified_price.return_value = True
     mock_broker_api_wrapper.unsubscribe_realtime_quote.return_value = True
     mock_broker_api_wrapper.disconnect_websocket.return_value = True
 

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -712,6 +712,34 @@ def test_format_db_persistence_report_explains_no_tick_cause(manager):
     assert "수신없음 1분" in message
 
 
+def test_format_db_persistence_report_hides_call_auction_missing_examples(manager):
+    """15:20 이후 동시호가 누락 시간은 예시 목록에 표시하지 않는다."""
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.return_value = "제주반도체"
+    manager.wire_alert_dependencies(stock_code_repository=mock_stock_repo)
+
+    message = manager._format_db_persistence_report({
+        "date": "20260618",
+        "window": {"start": "2026-06-18 09:00:00", "end": "2026-06-18 15:30:00"},
+        "expected_minute_count": 391,
+        "codes": {
+            "080220": {
+                "ok": False,
+                "saved_minute_count": 385,
+                "missing_minute_count": 6,
+                "missing_minutes": ["09:00", "15:21", "15:22", "15:24", "15:25", "15:27"],
+                "unsaved_received_minute_count": 0,
+                "no_tick_minute_count": 6,
+            }
+        },
+    })
+
+    assert "제주반도체: 누락 6분" in message
+    assert "예: 09:00" in message
+    assert "15:21" not in message
+    assert "15:27" not in message
+
+
 def test_get_background_task_status_reports_internal_loops(manager):
     """서비스 내부 루프 상태를 system.py에서 읽을 수 있는 형태로 반환한다."""
     manager._flush_task = MagicMock()

--- a/tests/unit_test/services/test_streaming_service.py
+++ b/tests/unit_test/services/test_streaming_service.py
@@ -225,7 +225,7 @@ async def test_handle_program_trading_stream_exception(streaming_service, mock_b
 
 @pytest.mark.asyncio
 async def test_handle_realtime_stream(streaming_service, mock_broker, mock_market_clock):
-    """고수준 스트림 핸들러: 실시간 스트림 다중 종목/필드 구독 및 해지 처리"""
+    """고수준 스트림 핸들러: price 필드는 KRX+NXT 통합 체결가로 구독/해지한다."""
     # duration=0 을 넘겨서 while 루프를 한 번도 돌지 않도록 빠르게 통과
     await streaming_service.handle_realtime_stream(
         stock_codes=["005930", "000660"],
@@ -234,17 +234,19 @@ async def test_handle_realtime_stream(streaming_service, mock_broker, mock_marke
     )
 
     mock_broker.connect_websocket.assert_awaited_once()
-    assert mock_broker.subscribe_realtime_price.await_count == 2
+    mock_broker.subscribe_realtime_price.assert_not_awaited()
+    assert mock_broker.subscribe_unified_price.await_count == 2
     assert mock_broker.subscribe_realtime_quote.await_count == 2
 
-    assert mock_broker.unsubscribe_realtime_price.await_count == 2
+    mock_broker.unsubscribe_realtime_price.assert_not_awaited()
+    assert mock_broker.unsubscribe_unified_price.await_count == 2
     assert mock_broker.unsubscribe_realtime_quote.await_count == 2
     mock_broker.disconnect_websocket.assert_awaited_once()
 
 @pytest.mark.asyncio
 async def test_handle_realtime_stream_exception(streaming_service, mock_broker):
     """실시간 스트림 핸들러 수행 중 오류 발생 시 정상적인 리소스 정리(finally) 테스트"""
-    mock_broker.subscribe_realtime_price.side_effect = Exception("Test Error")
+    mock_broker.subscribe_unified_price.side_effect = Exception("Test Error")
 
     await streaming_service.handle_realtime_stream(
         stock_codes=["005930"],
@@ -253,7 +255,8 @@ async def test_handle_realtime_stream_exception(streaming_service, mock_broker):
     )
 
     streaming_service.logger.exception.assert_called_once()
-    mock_broker.unsubscribe_realtime_price.assert_awaited_once_with("005930")
+    mock_broker.unsubscribe_unified_price.assert_awaited_once_with("005930")
+    mock_broker.unsubscribe_realtime_price.assert_not_awaited()
     mock_broker.disconnect_websocket.assert_awaited_once()
 
 @pytest.mark.asyncio
@@ -266,8 +269,10 @@ async def test_handle_realtime_stream_only_quote(streaming_service, mock_broker)
     )
 
     mock_broker.subscribe_realtime_price.assert_not_awaited()
+    mock_broker.subscribe_unified_price.assert_not_awaited()
     mock_broker.subscribe_realtime_quote.assert_awaited_once_with("005930")
     mock_broker.unsubscribe_realtime_price.assert_not_awaited()
+    mock_broker.unsubscribe_unified_price.assert_not_awaited()
     mock_broker.unsubscribe_realtime_quote.assert_awaited_once_with("005930")
 
 # ── Observer 패턴 테스트 ──────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary

- Route CLI/manual price stream subscriptions through `subscribe_unified_price()` so price ticks use the KRX+NXT unified realtime TR.
- Keep quote subscriptions unchanged.
- Update unit tests to lock the unified price subscription behavior and cleanup path.

## Why

The web/strategy price subscription path already uses the unified realtime price stream, but CLI/manual realtime streams still subscribed to the legacy realtime price TR. That meant NXT-inclusive realtime ticks were not used on those manual stream paths.

## Validation

- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`
