### PR TITLE
feat(overseas): VBO dry-run 일봉 same-day exit 동봉 (Phase 4)

### DIFF
--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -112,6 +112,15 @@ class OverseasVBODryRunService:
             return None
         entry = target
         stop = entry * (1 + self._stop_loss_pct / 100.0)
+        # 당일 same-day exit(Phase 2 백테스트 모델과 동일): 당일저 <= 손절가면 손절가,
+        # 아니면 당일 종가(eod) 청산. 주문 경로 없는 would-be 청산 결과만 동봉한다.
+        low = self._f(cur.get("low"))
+        close = self._f(cur.get("close"))
+        if low <= stop:
+            exit_price, exit_reason = stop, "stop"
+        else:
+            exit_price, exit_reason = close, "eod"
+        realized_pct = (exit_price / entry - 1) * 100.0 if entry > 0 else 0.0
         return {
             "code": code,
             "action": "BUY",
@@ -120,6 +129,9 @@ class OverseasVBODryRunService:
             "target": target,
             "stop_price": stop,
             "prev_range": prev_range,
+            "exit_price": exit_price,
+            "exit_reason": exit_reason,
+            "realized_pct": realized_pct,
             "reason": "vbo_daily_breakout",
         }
 

--- a/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
@@ -56,6 +56,34 @@ async def test_scan_emits_buy_on_breakout(svc):
 
 
 @pytest.mark.asyncio
+async def test_scan_emits_same_day_eod_exit(svc):
+    """돌파 후 당일저가 손절가 미터치 → 당일 종가(eod) 청산을 동봉한다(Phase 2 모델 동일)."""
+    # target=105, stop=105*0.97=101.85, 당일저 104 > stop → eod 청산(종가 115)
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["exit_reason"] == "eod"
+    assert signals[0]["exit_price"] == 115.0
+    assert signals[0]["realized_pct"] == pytest.approx((115.0 / 105.0 - 1) * 100)
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_same_day_stop_exit(svc):
+    """돌파 후 당일저가 손절가 터치 → 손절가(stop) 청산을 동봉한다."""
+    # target=105, stop=101.85, 당일저 100 <= stop → stop 청산
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 100, 102)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["exit_reason"] == "stop"
+    assert signals[0]["exit_price"] == pytest.approx(101.85)
+    assert signals[0]["realized_pct"] == pytest.approx(-3.0)
+
+
+@pytest.mark.asyncio
 async def test_scan_no_signal_when_no_breakout(svc):
     bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 104, 100, 103)]
     svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))


### PR DESCRIPTION
## 배경

todo_list.md **해외주식 Phase 4(주문/사이징)** 검토 결과, 3개 하위 항목 중 2개는 이미 완료 상태였다:
- `place_overseas_limit_order`(지정가) 연결 — 브로커 API + `broker_api_wrapper` 존재
- USD position sizing/환율 — `OverseasPositionSizingService`(#558)

남은 유일한 미구현 항목이 **일봉 기반 exit**였다. dry-run은 진입 시 `stop_price`만 기록하고 would-be 청산 결과를 산출하지 않았다.

## 변경

`OverseasVBODryRunService._evaluate`에 Phase 2 백테스트(`overseas_daily_vbo_backtest.py`)와 **동일한 same-day exit 모델**을 추가:
- 당일저 ≤ 손절가 → 손절가(`stop`) 청산
- 아니면 당일 종가(`eod`) 청산
- 신호에 `exit_price` / `exit_reason` / `realized_pct` 동봉 → shadow 저널 persist

**주문 경로 없음** 제약 유지: 순수 계산만, order_execution 의존 없음.

## 테스트 (TDD)

- 신규 단위 테스트 2건: `test_scan_emits_same_day_eod_exit`, `test_scan_emits_same_day_stop_exit`
- 전체 단위 + 통합 **6492 passed** (0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)