### PR TITLE
feat(overseas): dry-run FX/KRW 노출 + 멀티데이 회고 재구성 (Phase 5 선행)

### DIFF
--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -83,6 +83,7 @@ def load_dryrun_records(
                     "exchange": snapshot.get("exchange") or "",
                     "trade_date": str(signal.get("date") or stem),
                     "entry_price": _to_float(signal.get("entry_price")),
+                    "stop_price": _to_float(signal.get("stop_price")),
                     "exit_price": _to_float(signal.get("exit_price")),
                     "exit_reason": signal.get("exit_reason") or "",
                     "realized_pct": realized,
@@ -160,6 +161,185 @@ def compute_dryrun_report(records: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def _f0(value: Any) -> float:
+    """float 변환 실패 시 0.0(봉 OHLC 파싱용)."""
+    try:
+        return float(value if value is not None else 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def reconstruct_multiday_exit(
+    entry_price: float,
+    stop_price: float,
+    bars: List[Dict[str, Any]],
+    *,
+    trailing_stop_pct: Optional[float],
+    time_stop_days: Optional[int],
+    round_trip_cost_pct: float = 0.0,
+) -> Optional[Dict[str, Any]]:
+    """확정 진입(entry_price/stop_price)에 멀티데이 청산 규칙을 회고 적용한다.
+
+    `bars`는 진입일(포함) 이후 일봉 오름차순. 규칙은 `MultiDayDailyBreakoutBacktest`와
+    동일하다: (1) hard stop — 저가 ≤ stop, gap-through 시 시가 체결(보수적),
+    (2) trailing — 고점×(1−trail/100) 하향 이탈(이익 구간), (3) time — 보유일수 ≥
+    time_stop_days 종가 청산, (4) terminal — 미청산 시 마지막 봉 종가.
+
+    same-day 청산만 담던 dry-run 신호를 "만약 멀티세션 보유했다면"으로 회고 재구성해
+    same-day 모델이 과소/과대 평가하는 정도(GAP)를 측정하기 위함이다. 데이터 끝까지의
+    재구성이므로 미래 봉이 필요 — 신호 시점엔 알 수 없는 회고값임에 유의.
+    """
+    rows = [b for b in (bars or []) if isinstance(b, dict)]
+    if entry_price <= 0 or not rows:
+        return None
+
+    peak = entry_price
+    exit_price: Optional[float] = None
+    exit_reason: Optional[str] = None
+    exit_idx = len(rows) - 1
+    for j, bar in enumerate(rows):
+        o = _f0(bar.get("open"))
+        h = _f0(bar.get("high"))
+        low = _f0(bar.get("low"))
+        c = _f0(bar.get("close"))
+
+        if stop_price > 0 and low <= stop_price:
+            exit_price = o if (0 < o < stop_price) else stop_price
+            exit_reason, exit_idx = "stop", j
+            break
+
+        if h > peak:
+            peak = h
+        if trailing_stop_pct:
+            trail = peak * (1 - float(trailing_stop_pct) / 100.0)
+            if trail > stop_price and low <= trail:
+                exit_price = o if (0 < o < trail) else trail
+                exit_reason, exit_idx = "trailing", j
+                break
+
+        if time_stop_days and j >= int(time_stop_days):
+            exit_price, exit_reason, exit_idx = c, "time", j
+            break
+
+    if exit_price is None:
+        exit_price = _f0(rows[-1].get("close"))
+        exit_reason, exit_idx = "terminal", len(rows) - 1
+
+    gross = (exit_price / entry_price - 1) * 100.0
+    return {
+        "exit_price": exit_price,
+        "exit_reason": exit_reason,
+        "holding_days": exit_idx,  # 진입일=0
+        "gross_return_pct": gross,
+        "net_return_pct": gross - float(round_trip_cost_pct),
+    }
+
+
+def load_ohlcv_dir(ohlcv_dir: Path | str) -> Dict[str, List[Dict[str, Any]]]:
+    """`<ohlcv_dir>/<CODE>.jsonl`(한 줄=일봉 dict)을 종목코드→오름차순 봉 list 로 로드."""
+    ohlcv_dir = Path(ohlcv_dir)
+    if not ohlcv_dir.exists():
+        return {}
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    for path in sorted(ohlcv_dir.glob("*.jsonl")):
+        code = path.stem
+        bars: List[Dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    bar = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(bar, dict):
+                    bars.append(bar)
+        bars.sort(key=lambda b: str(b.get("date") or ""))
+        out[code] = bars
+    return out
+
+
+def compute_multiday_report(
+    records: List[Dict[str, Any]],
+    ohlcv_by_code: Dict[str, List[Dict[str, Any]]],
+    *,
+    trailing_stop_pct: Optional[float],
+    time_stop_days: Optional[int],
+    cost_pct: float,
+) -> Dict[str, Any]:
+    """누적 dry-run 신호 + per-code OHLCV 로 멀티세션 보유 성과를 회고 재구성한다.
+
+    각 신호의 진입일(`trade_date`) 이후 봉으로 청산을 시뮬해 same-day 모델 대비
+    GAP(멀티데이 평균 gross − same-day 평균 realized)을 집계한다. OHLCV 가 없는
+    신호는 unmatched 로 분리한다.
+    """
+    nets: List[float] = []
+    grosses: List[float] = []
+    holding_days: List[int] = []
+    same_day_matched: List[float] = []
+    by_exit_reason: Dict[str, int] = {}
+    unmatched = 0
+
+    for r in records:
+        entry = r.get("entry_price")
+        stop = r.get("stop_price")
+        code = r.get("code") or ""
+        trade_date = str(r.get("trade_date") or "")
+        all_bars = ohlcv_by_code.get(code)
+        if entry is None or stop is None or not all_bars:
+            unmatched += 1
+            continue
+        future = [b for b in all_bars if str(b.get("date") or "") >= trade_date]
+        result = reconstruct_multiday_exit(
+            float(entry), float(stop), future,
+            trailing_stop_pct=trailing_stop_pct,
+            time_stop_days=time_stop_days,
+            round_trip_cost_pct=cost_pct,
+        )
+        if result is None:
+            unmatched += 1
+            continue
+        nets.append(result["net_return_pct"])
+        grosses.append(result["gross_return_pct"])
+        holding_days.append(result["holding_days"])
+        reason = result["exit_reason"] or "unknown"
+        by_exit_reason[reason] = by_exit_reason.get(reason, 0) + 1
+        sd = r.get("realized_pct")
+        if sd is not None:
+            same_day_matched.append(float(sd))
+
+    nstats = _stats(nets)
+    gstats = _stats(grosses)
+    same_day_avg = (sum(same_day_matched) / len(same_day_matched)) if same_day_matched else None
+    multiday_avg = gstats["avg"]
+    gap = (multiday_avg - same_day_avg) if (multiday_avg is not None and same_day_avg is not None) else None
+    wins = sum(1 for x in nets if x > 0)
+    losses = sum(1 for x in nets if x < 0)
+
+    return {
+        "reconstructed_count": len(nets),
+        "unmatched_count": unmatched,
+        "wins": wins,
+        "losses": losses,
+        "win_rate": (wins / len(nets)) if nets else None,
+        "avg_holding_days": (sum(holding_days) / len(holding_days)) if holding_days else None,
+        "net_return_pct": nstats,
+        "gross_return_pct": gstats,
+        "by_exit_reason": by_exit_reason,
+        "same_day_vs_multiday": {
+            "same_day_avg_realized_pct": same_day_avg,
+            "multiday_avg_gross_pct": multiday_avg,
+            "gap_pct": gap,
+        },
+        "params": {
+            "trailing_stop_pct": trailing_stop_pct,
+            "time_stop_days": time_stop_days,
+            "round_trip_cost_pct": cost_pct,
+        },
+    }
+
+
 def format_markdown_report(report: Dict[str, Any]) -> str:
     cfg = report.get("config", {})
     t = report["totals"]
@@ -226,6 +406,27 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
     lines.append(f"- avg_krw_exposure: {_fmt(sz.get('avg_krw_exposure'))}")
     lines.append("")
 
+    md = report.get("multiday")
+    if md:
+        g = md.get("same_day_vs_multiday", {})
+        ng = md.get("net_return_pct", {})
+        lines.append("## 멀티데이 회고 재구성 (would-be 멀티세션 보유)")
+        lines.append("")
+        lines.append(f"- reconstructed_count: {md.get('reconstructed_count', 0)}")
+        lines.append(f"- unmatched_count: {md.get('unmatched_count', 0)}")
+        lines.append(f"- win_rate: {_fmt(md.get('win_rate'))}")
+        lines.append(f"- avg_holding_days: {_fmt(md.get('avg_holding_days'))}")
+        lines.append(f"- avg_net_return_pct: {_fmt(ng.get('avg'), '%')}")
+        lines.append(f"- same_day_avg_realized_pct: {_fmt(g.get('same_day_avg_realized_pct'), '%')}")
+        lines.append(f"- multiday_avg_gross_pct: {_fmt(g.get('multiday_avg_gross_pct'), '%')}")
+        lines.append(f"- **gap_pct (multiday − same_day): {_fmt(g.get('gap_pct'), '%')}**")
+        lines.append("")
+        lines.append("| exit_reason | count |")
+        lines.append("| --- | ---: |")
+        for reason, cnt in sorted(md.get("by_exit_reason", {}).items()):
+            lines.append(f"| {reason} | {cnt} |")
+        lines.append("")
+
     return "\n".join(lines)
 
 
@@ -237,6 +438,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--date-from", required=True, help="YYYYMMDD")
     parser.add_argument("--date-to", required=True, help="YYYYMMDD")
     parser.add_argument("--signal-source", default=_SIGNAL_SOURCE)
+    parser.add_argument("--ohlcv-dir", default=None,
+                        help="멀티데이 회고 재구성용 per-code 일봉 디렉토리(<CODE>.jsonl). 지정 시 multiday 섹션 추가.")
+    parser.add_argument("--trailing-stop-pct", type=float, default=8.0,
+                        help="멀티데이 trailing stop %% (회고 가정값)")
+    parser.add_argument("--time-stop-days", type=int, default=20,
+                        help="멀티데이 time stop 보유일수(회고 가정값)")
+    parser.add_argument("--cost-pct", type=float, default=0.2,
+                        help="멀티데이 왕복 비용 %% (net 산출)")
     parser.add_argument("--output-json", default=None)
     parser.add_argument("--output-markdown", default=None)
     return parser
@@ -258,6 +467,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         "signal_source": args.signal_source,
         "shadow_dir": str(args.shadow_dir),
     }
+
+    if args.ohlcv_dir:
+        ohlcv_by_code = load_ohlcv_dir(args.ohlcv_dir)
+        report["multiday"] = compute_multiday_report(
+            records, ohlcv_by_code,
+            trailing_stop_pct=args.trailing_stop_pct,
+            time_stop_days=args.time_stop_days,
+            cost_pct=args.cost_pct,
+        )
+        report["config"]["ohlcv_dir"] = str(args.ohlcv_dir)
 
     if args.output_json:
         out_json = Path(args.output_json)

--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -88,6 +88,7 @@ def load_dryrun_records(
                     "realized_pct": realized,
                     "qty": signal.get("qty"),
                     "notional_usd": _to_float(signal.get("notional_usd")),
+                    "krw_exposure": _to_float(signal.get("krw_exposure")),
                 })
     return out
 
@@ -130,10 +131,14 @@ def compute_dryrun_report(records: List[Dict[str, Any]]) -> Dict[str, Any]:
         d_b["sum_realized_pct"] += r["realized_pct"]
 
     notionals = [r["notional_usd"] for r in records if r.get("notional_usd") is not None]
+    krw_exposures = [r["krw_exposure"] for r in records if r.get("krw_exposure") is not None]
     sizing = {
         "sized_count": len(notionals),
         "total_notional_usd": round(sum(notionals), 4) if notionals else 0.0,
         "avg_notional_usd": round(sum(notionals) / len(notionals), 4) if notionals else None,
+        "fx_sized_count": len(krw_exposures),
+        "total_krw_exposure": round(sum(krw_exposures), 2) if krw_exposures else 0.0,
+        "avg_krw_exposure": round(sum(krw_exposures) / len(krw_exposures), 2) if krw_exposures else None,
     }
 
     return {
@@ -216,6 +221,9 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
     lines.append(f"- sized_count: {sz.get('sized_count', 0)}")
     lines.append(f"- total_notional_usd: {_fmt(sz.get('total_notional_usd'))}")
     lines.append(f"- avg_notional_usd: {_fmt(sz.get('avg_notional_usd'))}")
+    lines.append(f"- fx_sized_count: {sz.get('fx_sized_count', 0)}")
+    lines.append(f"- total_krw_exposure: {_fmt(sz.get('total_krw_exposure'))}")
+    lines.append(f"- avg_krw_exposure: {_fmt(sz.get('avg_krw_exposure'))}")
     lines.append("")
 
     return "\n".join(lines)

--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -33,6 +33,7 @@ class OverseasVBODryRunService:
         stop_loss_pct: float = -3.0,
         exchange: OverseasExchange = OverseasExchange.NASD,
         position_sizing_service=None,
+        fx_provider=None,
     ):
         self._candidate_service = candidate_service
         self._sqs = stock_query_service
@@ -43,6 +44,9 @@ class OverseasVBODryRunService:
         self._default_exchange = exchange
         # 고정 USD 슬롯 사이징(순수 계산, 주문 경로 없음). 미주입 시 qty 미산출.
         self._sizing_service = position_sizing_service
+        # USD/KRW 환율 조회용 async callable(`() -> Optional[float]`). 사이징이 있을 때만
+        # scan당 1회 호출해 KRW 환산 노출을 동봉한다. 미주입/실패/비양수 시 KRW 생략.
+        self._fx_provider = fx_provider
 
     async def scan_dry_run(
         self,
@@ -58,6 +62,7 @@ class OverseasVBODryRunService:
             ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
         )
 
+        fx_rate = await self._resolve_fx_rate()
         signals: List[Dict[str, Any]] = []
         for cand in candidates or []:
             code = cand.get("code")
@@ -75,9 +80,15 @@ class OverseasVBODryRunService:
             if not sig:
                 continue
             if self._sizing_service is not None:
-                sizing = self._sizing_service.size(limit_price_usd=sig["entry_price"])
+                sizing = self._sizing_service.size(
+                    limit_price_usd=sig["entry_price"], fx_krw_per_usd=fx_rate
+                )
                 sig["qty"] = sizing.get("qty")
                 sig["notional_usd"] = sizing.get("notional_usd")
+                if sizing.get("fx_krw_per_usd") is not None:
+                    sig["fx_krw_per_usd"] = sizing.get("fx_krw_per_usd")
+                if sizing.get("krw_exposure") is not None:
+                    sig["krw_exposure"] = sizing.get("krw_exposure")
             signals.append(sig)
             if record and self._journal is not None:
                 self._journal.record(
@@ -90,6 +101,25 @@ class OverseasVBODryRunService:
         self._logger.info({"event": "overseas_dryrun_scan", "exchange": ex.value,
                            "candidates": len(candidates or []), "signals": len(signals)})
         return signals
+
+    async def _resolve_fx_rate(self) -> Optional[float]:
+        """scan당 1회 USD/KRW 환율을 조회한다(사이징·provider 모두 있을 때만).
+
+        provider 예외·None·비양수는 모두 None으로 흡수해 KRW 환산을 생략한다
+        (dry-run 수집 중단/실주문 없음). FX는 부가 리포팅값이므로 실패해도 신호는 산출된다.
+        """
+        if self._sizing_service is None or self._fx_provider is None:
+            return None
+        try:
+            rate = await self._fx_provider()
+        except Exception as e:
+            self._logger.warning({"event": "overseas_dryrun_fx_error", "error": str(e)})
+            return None
+        try:
+            rate = float(rate) if rate is not None else None
+        except (TypeError, ValueError):
+            return None
+        return rate if (rate is not None and rate > 0) else None
 
     def _evaluate(self, code: str, rows: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """최근 일봉(오름차순)에서 VBO 일봉 진입 규칙으로 BUY 신호 판정.

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -12,10 +12,17 @@ import pytest
 
 from scripts.analyze_overseas_dryrun import (
     compute_dryrun_report,
+    compute_multiday_report,
     format_markdown_report,
     load_dryrun_records,
+    load_ohlcv_dir,
     main,
+    reconstruct_multiday_exit,
 )
+
+
+def _bar(d, o, h, l, c):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c}
 
 
 def _write_jsonl(shadow_dir: Path, yyyymmdd: str, lines: list[dict]) -> Path:
@@ -179,6 +186,147 @@ def test_format_markdown_smoke():
     md = format_markdown_report(report)
     assert "Overseas VBO Dry-run" in md
     assert "win_rate" in md
+
+
+# ── multiday 회고 재구성 ─────────────────────────────────────────────────────
+
+def test_reconstruct_stop_on_later_day():
+    # entry 100, stop 97. day0 미터치, day1 저가 96 <= 97 → stop 청산(시가 미갭 → stop가)
+    bars = [_bar("20260601", 100, 102, 98, 101), _bar("20260602", 100, 101, 96, 99)]
+    r = reconstruct_multiday_exit(100.0, 97.0, bars, trailing_stop_pct=None, time_stop_days=None)
+    assert r["exit_reason"] == "stop"
+    assert r["exit_price"] == pytest.approx(97.0)
+    assert r["holding_days"] == 1
+    assert r["gross_return_pct"] == pytest.approx(-3.0)
+
+
+def test_reconstruct_gap_through_stop_at_open():
+    # day1 시가 95 < stop 97 로 갭다운 → 시가 체결(보수적)
+    bars = [_bar("20260601", 100, 102, 98, 101), _bar("20260602", 95, 96, 94, 95)]
+    r = reconstruct_multiday_exit(100.0, 97.0, bars, trailing_stop_pct=None, time_stop_days=None)
+    assert r["exit_reason"] == "stop"
+    assert r["exit_price"] == pytest.approx(95.0)
+    assert r["gross_return_pct"] == pytest.approx(-5.0)
+
+
+def test_reconstruct_trailing_exit():
+    # entry 100, stop 95, trailing 10%. day0 고가 120 → peak 120, trail 108.
+    # day1 저가 107 <= 108, 시가 119 > trail → trail 체결 108
+    bars = [_bar("20260601", 100, 120, 118, 119), _bar("20260602", 119, 119, 107, 108)]
+    r = reconstruct_multiday_exit(100.0, 95.0, bars, trailing_stop_pct=10.0, time_stop_days=None)
+    assert r["exit_reason"] == "trailing"
+    assert r["exit_price"] == pytest.approx(108.0)
+    assert r["holding_days"] == 1
+    assert r["gross_return_pct"] == pytest.approx(8.0)
+
+
+def test_reconstruct_time_stop():
+    # time_stop_days=2 → j>=2 인 day2 종가 청산(stop/trailing 미터치)
+    bars = [_bar("20260601", 100, 101, 99, 100), _bar("20260602", 100, 102, 99, 101),
+            _bar("20260603", 101, 103, 100, 102)]
+    r = reconstruct_multiday_exit(100.0, 95.0, bars, trailing_stop_pct=None, time_stop_days=2)
+    assert r["exit_reason"] == "time"
+    assert r["exit_price"] == pytest.approx(102.0)
+    assert r["holding_days"] == 2
+
+
+def test_reconstruct_terminal_when_no_trigger():
+    # 어떤 청산도 트리거되지 않으면 마지막 봉 종가 강제청산(terminal)
+    bars = [_bar("20260601", 100, 101, 99, 100), _bar("20260602", 100, 103, 99, 102)]
+    r = reconstruct_multiday_exit(100.0, 95.0, bars, trailing_stop_pct=None, time_stop_days=None)
+    assert r["exit_reason"] == "terminal"
+    assert r["exit_price"] == pytest.approx(102.0)
+    assert r["holding_days"] == 1
+
+
+def test_reconstruct_applies_round_trip_cost():
+    bars = [_bar("20260601", 100, 103, 99, 102)]
+    r = reconstruct_multiday_exit(100.0, 95.0, bars, trailing_stop_pct=None,
+                                  time_stop_days=None, round_trip_cost_pct=0.2)
+    assert r["gross_return_pct"] == pytest.approx(2.0)
+    assert r["net_return_pct"] == pytest.approx(1.8)
+
+
+def test_reconstruct_returns_none_on_no_bars_or_bad_entry():
+    assert reconstruct_multiday_exit(100.0, 95.0, [], trailing_stop_pct=None, time_stop_days=None) is None
+    assert reconstruct_multiday_exit(0.0, 0.0, [_bar("d", 1, 1, 1, 1)],
+                                     trailing_stop_pct=None, time_stop_days=None) is None
+
+
+def test_load_ohlcv_dir_reads_per_code_jsonl(tmp_path):
+    d = tmp_path / "ohlcv"
+    d.mkdir()
+    with (d / "AAA.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_bar("20260602", 1, 2, 1, 2)) + "\n")
+        f.write(json.dumps(_bar("20260601", 1, 2, 1, 2)) + "\n")
+    by_code = load_ohlcv_dir(d)
+    assert "AAA" in by_code
+    # 날짜 오름차순 정렬
+    assert [b["date"] for b in by_code["AAA"]] == ["20260601", "20260602"]
+
+
+def test_load_ohlcv_dir_missing_returns_empty(tmp_path):
+    assert load_ohlcv_dir(tmp_path / "nope") == {}
+
+
+def test_compute_multiday_report_aggregates_and_gap():
+    records = [
+        {"code": "AAA", "exchange": "NASD", "trade_date": "20260601",
+         "entry_price": 100.0, "stop_price": 95.0, "realized_pct": 2.0, "exit_reason": "eod"},
+    ]
+    # day0(진입일) 종가 102 → same-day +2. 이후 day1 고가 110 보유 시 종가 108 → +8
+    ohlcv = {"AAA": [_bar("20260601", 100, 103, 99, 102), _bar("20260602", 102, 110, 101, 108)]}
+    report = compute_multiday_report(
+        records, ohlcv, trailing_stop_pct=None, time_stop_days=None, cost_pct=0.0,
+    )
+    assert report["reconstructed_count"] == 1
+    assert report["unmatched_count"] == 0
+    # terminal 보유 → +8
+    assert report["gross_return_pct"]["avg"] == pytest.approx(8.0)
+    gap = report["same_day_vs_multiday"]
+    assert gap["same_day_avg_realized_pct"] == pytest.approx(2.0)
+    assert gap["multiday_avg_gross_pct"] == pytest.approx(8.0)
+    assert gap["gap_pct"] == pytest.approx(6.0)
+
+
+def test_compute_multiday_report_counts_unmatched():
+    records = [
+        {"code": "AAA", "exchange": "NASD", "trade_date": "20260601",
+         "entry_price": 100.0, "stop_price": 95.0, "realized_pct": 2.0, "exit_reason": "eod"},
+        {"code": "ZZZ", "exchange": "NASD", "trade_date": "20260601",
+         "entry_price": 100.0, "stop_price": 95.0, "realized_pct": 1.0, "exit_reason": "eod"},
+    ]
+    ohlcv = {"AAA": [_bar("20260601", 100, 103, 99, 102)]}  # ZZZ 없음
+    report = compute_multiday_report(
+        records, ohlcv, trailing_stop_pct=None, time_stop_days=None, cost_pct=0.0,
+    )
+    assert report["reconstructed_count"] == 1
+    assert report["unmatched_count"] == 1
+
+
+def test_main_writes_multiday_section_with_ohlcv_dir(tmp_path):
+    shadow = tmp_path / "event_shadow"
+    _write_jsonl(shadow, "20260601", [
+        _rec(code="AAA", exchange="NASD", date="20260601", realized_pct=2.0, exit_reason="eod"),
+    ])
+    ohlcv = tmp_path / "ohlcv"
+    ohlcv.mkdir()
+    with (ohlcv / "AAA.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_bar("20260601", 100, 103, 99, 102)) + "\n")
+        f.write(json.dumps(_bar("20260602", 102, 110, 101, 108)) + "\n")
+    out_json = tmp_path / "reports" / "overseas.json"
+
+    rc = main([
+        "--shadow-dir", str(shadow),
+        "--date-from", "20260601", "--date-to", "20260601",
+        "--ohlcv-dir", str(ohlcv),
+        "--output-json", str(out_json),
+    ])
+
+    assert rc == 0
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert "multiday" in report
+    assert report["multiday"]["reconstructed_count"] == 1
 
 
 def test_main_writes_json(tmp_path):

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -142,6 +142,27 @@ def test_compute_sizing_aggregates_only_when_present():
     assert sz["total_notional_usd"] == pytest.approx(945.0)
 
 
+def test_compute_krw_exposure_aggregates_only_when_present():
+    records = [
+        {"code": "AAA", "exchange": "NASD", "trade_date": "20260601",
+         "realized_pct": 5.0, "exit_reason": "eod", "qty": 9, "notional_usd": 945.0,
+         "krw_exposure": 1_275_750.0},
+        {"code": "BBB", "exchange": "NASD", "trade_date": "20260601",
+         "realized_pct": 2.0, "exit_reason": "eod", "qty": 4, "notional_usd": 400.0,
+         "krw_exposure": 540_000.0},
+        {"code": "CCC", "exchange": "NYSE", "trade_date": "20260602",
+         "realized_pct": 1.0, "exit_reason": "eod", "qty": None, "notional_usd": None,
+         "krw_exposure": None},
+    ]
+
+    report = compute_dryrun_report(records)
+
+    sz = report["sizing"]
+    assert sz["fx_sized_count"] == 2
+    assert sz["total_krw_exposure"] == pytest.approx(1_815_750.0)
+    assert sz["avg_krw_exposure"] == pytest.approx(907_875.0)
+
+
 def test_compute_empty_records():
     report = compute_dryrun_report([])
     assert report["totals"]["signals"] == 0

--- a/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
+from services.overseas_position_sizing_service import OverseasPositionSizingService
 from common.types import ErrorCode, ResCommonResponse
 from common.overseas_types import OverseasExchange
 
@@ -179,3 +180,101 @@ async def test_scan_includes_qty_when_sizing_injected():
     assert kwargs["limit_price_usd"] == 105.0
     # 사이징 주입돼도 order_execution 의존은 없다
     assert not hasattr(service, "_order_execution_service")
+
+
+def _sizing_svc(slot_usd=1000.0):
+    return OverseasPositionSizingService(slot_usd=slot_usd)
+
+
+def _breakout_service(*, fx_provider=None, sizing=None):
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+    return OverseasVBODryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing if sizing is not None else _sizing_svc(),
+        fx_provider=fx_provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_passes_fx_to_sizing_and_records_krw_exposure():
+    """fx_provider 주입 시 scan당 FX를 조회해 사이징에 전달하고 krw_exposure 를 동봉한다."""
+    fx_provider = AsyncMock(return_value=1350.0)
+    service = _breakout_service(fx_provider=fx_provider)
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    # entry=105 → qty=floor(1000/105)=9, notional=945, krw=945*1350
+    assert signals[0]["qty"] == 9
+    assert signals[0]["fx_krw_per_usd"] == 1350.0
+    assert signals[0]["krw_exposure"] == pytest.approx(945.0 * 1350.0)
+
+
+@pytest.mark.asyncio
+async def test_scan_omits_krw_when_fx_provider_returns_none():
+    """fx_provider 가 None 반환 시 KRW 환산을 생략한다(qty 는 유지, 하위 호환)."""
+    service = _breakout_service(fx_provider=AsyncMock(return_value=None))
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 9
+    assert "krw_exposure" not in signals[0]
+    assert "fx_krw_per_usd" not in signals[0]
+
+
+@pytest.mark.asyncio
+async def test_scan_tolerates_fx_provider_error():
+    """fx_provider 예외는 삼키고 KRW 없이 신호를 산출한다(실주문/수집 중단 없음)."""
+    service = _breakout_service(fx_provider=AsyncMock(side_effect=RuntimeError("boom")))
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 9
+    assert "krw_exposure" not in signals[0]
+
+
+@pytest.mark.asyncio
+async def test_scan_fetches_fx_once_per_scan():
+    """후보가 여러 개여도 FX 조회는 scan당 1회만 수행한다."""
+    fx_provider = AsyncMock(return_value=1350.0)
+    service = _breakout_service(fx_provider=fx_provider)
+    service._candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "avg_trading_value": 1.0},
+        {"code": "BBB", "avg_trading_value": 1.0},
+    ])
+
+    await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    fx_provider.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_fx_when_no_sizing_service():
+    """사이징 미주입 시 fx_provider 를 호출하지 않는다(KRW 산출 불가)."""
+    fx_provider = AsyncMock(return_value=1350.0)
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "avg_trading_value": 1.0},
+    ])
+    sqs = MagicMock()
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+    service = OverseasVBODryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        fx_provider=fx_provider,
+    )
+
+    await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    fx_provider.assert_not_awaited()

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -9,7 +9,7 @@
 """
 import contextlib
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -315,3 +315,38 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
     dryrun_kwargs = dryrun_cls.call_args.kwargs
     assert dryrun_kwargs["candidate_service"] is candidate_cls.return_value
     assert dryrun_kwargs["position_sizing_service"] is sizing_cls.return_value
+    # FX provider 배선: KIS 해외 잔고에서 USD/KRW 환율 추출(읽기 전용, 실주문 없음)
+    fx_provider = dryrun_kwargs["fx_provider"]
+    assert callable(fx_provider)
+
+
+@pytest.mark.asyncio
+async def test_overseas_fx_provider_extracts_rate_from_balance(patched_service_container_deps):
+    """배선된 fx_provider 는 broker 잔고 응답에서 USD/KRW 환율을 추출한다(실패 시 None)."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.market_mode = "overseas_us"
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="overseas_us",
+        overseas_stock={"dryrun_slot_usd": 750.0},
+    )
+    ctx.overseas_stock_code_repository = MagicMock()
+    ctx.broker.get_overseas_balance = AsyncMock(
+        return_value=SimpleNamespace(data={"output2": {"frst_bltn_exrt": "1357.5"}})
+    )
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True) as dryrun_cls, \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True):
+        ServiceContainer(ctx).run()
+
+    fx_provider = dryrun_cls.call_args.kwargs["fx_provider"]
+    assert await fx_provider() == 1357.5
+
+    # 잔고 조회 실패 시 None → KRW 환산 생략
+    ctx.broker.get_overseas_balance = AsyncMock(side_effect=RuntimeError("boom"))
+    assert await fx_provider() is None

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -50,7 +50,7 @@ from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
 from services.event_shadow_journal_service import EventShadowJournalService
 from services.overseas_candidate_service import OverseasCandidateService
-from services.overseas_position_sizing_service import OverseasPositionSizingService
+from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.post_market_replay_audit_service import PostMarketReplayAuditService
 from services.strategy_log_report_service import StrategyLogReportService
@@ -568,12 +568,21 @@ class ServiceContainer:
                         stock_query_service=ctx.stock_query_service,
                         logger=ctx.logger,
                     )
+                    async def _overseas_fx_provider():
+                        # KIS 해외 잔고(읽기 전용)에서 USD/KRW 환율 추출. 실패 시 None → KRW 생략.
+                        try:
+                            resp = await ctx.broker.get_overseas_balance()
+                        except Exception:
+                            return None
+                        return extract_fx_krw_per_usd(getattr(resp, "data", None))
+
                     ctx.overseas_vbo_dryrun_service = OverseasVBODryRunService(
                         candidate_service=ctx.overseas_candidate_service,
                         stock_query_service=ctx.stock_query_service,
                         shadow_journal=ctx.event_shadow_journal_service,
                         logger=ctx.logger,
                         position_sizing_service=overseas_position_sizing_service,
+                        fx_provider=_overseas_fx_provider,
                     )
                     ctx.overseas_dryrun_task = OverseasDryRunTask(
                         dryrun_service=ctx.overseas_vbo_dryrun_service,


### PR DESCRIPTION
해외 VBO dry-run shadow의 성과 충실도를 높이는 두 가지 코드-전용 보강. **주문 경로 무추가**(실주문 불가 제약 유지), 외부 데이터/정책 게이트 비의존.

## 1. dry-run FX/환율 반영 — would-be KRW 노출
사이징이 순수 USD만 산출해 shadow 저널이 KRW 자본 제약을 반영 못하던 갭. `OverseasPositionSizingService`는 이미 `fx_krw_per_usd`/`krw_exposure`를 지원했으나 dry-run 서비스가 FX를 전달하지 않았다.
- `OverseasVBODryRunService`: 선택적 `fx_provider`(async) 주입 → scan당 1회 환율 조회 → `size(fx_krw_per_usd=...)` → `fx_krw_per_usd`/`krw_exposure` 동봉. 미주입·예외·비양수 시 KRW 생략(하위 호환).
- `service_container`: `ctx.broker.get_overseas_balance`(읽기 전용) + `extract_fx_krw_per_usd` 클로저 배선.
- `analyze_overseas_dryrun`: `total_krw_exposure`/`avg_krw_exposure` 집계.

## 2. 분석기 멀티데이 회고 재구성 + same-day GAP
same-day 청산만 담던 신호를 "만약 멀티세션 보유했다면"으로 회고 재구성해, same-day 모델의 과소/과대 평가 정도(GAP)를 측정.
- `reconstruct_multiday_exit`: 확정 진입(entry/stop)에 `MultiDayDailyBreakoutBacktest`와 동일 청산 규칙(hard stop gap-through·trailing·time·terminal) 회고 적용. **미래 봉 의존 회고값**(신호 시점 미지)임을 명시.
- `load_ohlcv_dir`: per-code `<CODE>.jsonl` 일봉 로드.
- `compute_multiday_report`: reconstructed/unmatched 분리 + `same_day_vs_multiday.gap_pct` 집계.
- CLI `--ohlcv-dir`/`--trailing-stop-pct`/`--time-stop-days`/`--cost-pct` + JSON·markdown multiday 섹션. ohlcv-dir 미지정 시 동작 불변.

## 테스트 (TDD)
- 서비스 5 TC(FX 전달·KRW 동봉·None/예외 생략·scan당 1회·미사이징 미조회), 컨테이너 2 TC(배선·잔고 추출/실패).
- 분석기 multiday 13 TC(stop/gap-through/trailing/time/terminal/cost/none, ohlcv 로드, 집계·GAP·unmatched, main 통합) + KRW 집계 1 TC.
- 전체: **unit 6276 passed, integration 243 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)