### PR TITLE
feat(stock-sync): ETF 종목명 매핑 DB 포함 + 리스팅 로더 분리

### DIFF
--- a/services/stock_sync_service.py
+++ b/services/stock_sync_service.py
@@ -56,27 +56,14 @@ def save_stock_code_list_fdr(force_update=False):
 
     try:
         print("🔄 FinanceDataReader를 통해 KRX 종목 목록을 다운로드합니다...")
-        # 전체 종목 리스트 가져오기
-        df_all = fdr.StockListing('KRX')
-
-        # 1. 필요한 컬럼만 추출 및 이름 변경 (pykrx 형식에 맞춤)
-        # FinanceDataReader: Code -> 종목코드, Name -> 종목명
-        # MarketId를 통해 시장구분 생성
-        df_all = df_all[['Code', 'Name', 'MarketId']].copy()
-        
-        # MarketId를 KOSPI/KOSDAQ으로 변환 (KONEX 포함 여부는 선택)
-        market_map = {
-            'STK': 'KOSPI',
-            'KSQ': 'KOSDAQ',
-            'KNX': 'KONEX'
-        }
-        df_all['시장구분'] = df_all['MarketId'].map(market_map)
-        
-        # 컬럼명 최종 변경
-        df = df_all.rename(columns={'Code': '종목코드', 'Name': '종목명'})
-        
-        # 필요한 시장만 필터링 (KONEX를 제외하려면 아래 주석 해제)
-        df = df[df['시장구분'].isin(['KOSPI', 'KOSDAQ'])]
+        stock_df = _load_krx_stock_listing()
+        etf_df = _load_etf_listing()
+        df = pd.concat([stock_df, etf_df], ignore_index=True)
+        df = df.dropna(subset=["종목코드", "종목명"])
+        df["종목코드"] = df["종목코드"].astype(str).str.strip()
+        df["종목명"] = df["종목명"].astype(str).str.strip()
+        df = df[(df["종목코드"] != "") & (df["종목명"] != "")]
+        df = df.drop_duplicates(subset=["종목코드"], keep="first")
 
         # --- 이후 DB 저장 로직은 기존과 동일 ---
         os.makedirs(DATA_DIR, exist_ok=True)
@@ -97,6 +84,46 @@ def save_stock_code_list_fdr(force_update=False):
     except Exception as e:
         print(f"❌ 데이터 업데이트 실패: {e}")
         raise
+
+
+def _load_krx_stock_listing() -> pd.DataFrame:
+    # 전체 종목 리스트 가져오기
+    df_all = fdr.StockListing('KRX')
+
+    # 1. 필요한 컬럼만 추출 및 이름 변경 (pykrx 형식에 맞춤)
+    # FinanceDataReader: Code -> 종목코드, Name -> 종목명
+    # MarketId를 통해 시장구분 생성
+    df_all = df_all[['Code', 'Name', 'MarketId']].copy()
+
+    # MarketId를 KOSPI/KOSDAQ으로 변환 (KONEX 포함 여부는 선택)
+    market_map = {
+        'STK': 'KOSPI',
+        'KSQ': 'KOSDAQ',
+        'KNX': 'KONEX'
+    }
+    df_all['시장구분'] = df_all['MarketId'].map(market_map)
+
+    # 컬럼명 최종 변경
+    df = df_all.rename(columns={'Code': '종목코드', 'Name': '종목명'})
+
+    # 필요한 시장만 필터링 (KONEX를 제외하려면 아래 주석 해제)
+    return df[df['시장구분'].isin(['KOSPI', 'KOSDAQ'])][['종목코드', '종목명', '시장구분']]
+
+
+def _load_etf_listing() -> pd.DataFrame:
+    try:
+        df_all = fdr.StockListing('ETF/KR')
+    except Exception as e:
+        print(f"⚠️ ETF 목록 다운로드 실패. ETF 종목명 매핑은 건너뜁니다: {e}")
+        return pd.DataFrame(columns=['종목코드', '종목명', '시장구분'])
+
+    if df_all.empty or not {'Symbol', 'Name'}.issubset(df_all.columns):
+        return pd.DataFrame(columns=['종목코드', '종목명', '시장구분'])
+
+    df = df_all[['Symbol', 'Name']].copy()
+    df = df.rename(columns={'Symbol': '종목코드', 'Name': '종목명'})
+    df['시장구분'] = 'ETF'
+    return df[['종목코드', '종목명', '시장구분']]
 
 def load_stock_code_list():
     conn = sqlite3.connect(DB_FILE_PATH)

--- a/tests/unit_test/services/test_stock_sync_service.py
+++ b/tests/unit_test/services/test_stock_sync_service.py
@@ -35,11 +35,14 @@ def setup_and_teardown(tmp_path, mocker):
 @patch("FinanceDataReader.StockListing")
 def test_force_update_saves_files(mock_fdr_listing):
     """force_update=True로 save_stock_code_list를 호출하면 DB와 메타데이터가 저장됩니다."""
-    mock_fdr_listing.return_value = pd.DataFrame({
-        'Code': ['005930', '123456'],
-        'Name': ['삼성전자', '코스닥종목'],
-        'MarketId': ['STK', 'KSQ']
-    })
+    mock_fdr_listing.side_effect = [
+        pd.DataFrame({
+            'Code': ['005930', '123456'],
+            'Name': ['삼성전자', '코스닥종목'],
+            'MarketId': ['STK', 'KSQ']
+        }),
+        pd.DataFrame(),
+    ]
 
     stock_sync_service.save_stock_code_list(force_update=True)
 
@@ -56,12 +59,43 @@ def test_force_update_saves_files(mock_fdr_listing):
 
 
 @patch("FinanceDataReader.StockListing")
+def test_force_update_includes_etf_codes(mock_fdr_listing):
+    """ETF/KR 목록도 종목명 매핑 DB에 함께 저장합니다."""
+    mock_fdr_listing.side_effect = [
+        pd.DataFrame({
+            'Code': ['005930'],
+            'Name': ['삼성전자'],
+            'MarketId': ['STK'],
+        }),
+        pd.DataFrame({
+            'Symbol': ['069500', '0162Z0'],
+            'Name': ['KODEX 200', 'RISE 삼성전자SK하이닉스채권혼합50'],
+        }),
+    ]
+
+    stock_sync_service.save_stock_code_list(force_update=True)
+
+    conn = sqlite3.connect(stock_sync_service.DB_FILE_PATH)
+    df = pd.read_sql("SELECT * FROM stocks", conn, dtype={"종목코드": str})
+    conn.close()
+
+    names = dict(zip(df["종목코드"], df["종목명"]))
+    markets = dict(zip(df["종목코드"], df["시장구분"]))
+    assert names["069500"] == "KODEX 200"
+    assert names["0162Z0"] == "RISE 삼성전자SK하이닉스채권혼합50"
+    assert markets["069500"] == "ETF"
+
+
+@patch("FinanceDataReader.StockListing")
 def test_metadata_blocks_update_within_7_days(mock_fdr_listing, capfd):
-    mock_fdr_listing.return_value = pd.DataFrame({
-        'Code': ['005930'],
-        'Name': ['삼성전자'],
-        'MarketId': ['STK']
-    })
+    mock_fdr_listing.side_effect = [
+        pd.DataFrame({
+            'Code': ['005930'],
+            'Name': ['삼성전자'],
+            'MarketId': ['STK']
+        }),
+        pd.DataFrame(),
+    ]
     # 강제로 한 번 저장
     stock_sync_service.save_stock_code_list(force_update=True)
 


### PR DESCRIPTION
## 배경
종목코드→종목명 매핑 DB가 KRX 주식 목록만 담아 ETF 종목명이 매핑되지 않던 문제. ETF/KR 목록을 함께 적재한다.

## 변경
- `save_stock_code_list_fdr`: KRX 주식/ETF 로딩을 `_load_krx_stock_listing`/`_load_etf_listing`로 분리 후 `concat`. 종목코드/종목명 strip·공백 제거·중복코드 제거(주식 우선) 정리 추가.
- `_load_etf_listing`: `fdr.StockListing('ETF/KR')` Symbol/Name → 종목코드/종목명, 시장구분 `ETF`. 다운로드 실패·스키마 불일치 시 빈 DF로 graceful skip(주식 매핑은 유지).
- 테스트: ETF 코드 매핑 저장 검증 TC 추가(`test_force_update_includes_etf_codes`), 기존 TC를 stock+ETF 2회 호출 `side_effect`로 갱신.

## 테스트
- `tests/unit_test/services/test_stock_sync_service.py`: **7 passed**.
- 전체 unit/integration 스위트: 실행 중(결과 후속 보고).

🤖 Generated with [Claude Code](https://claude.com/claude-code)