### PR TITLE
feat(overseas): Phase 4 게이팅 주문 실행 서비스

### DIFF
--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -1,0 +1,194 @@
+# services/overseas_order_execution_service.py
+"""해외 VBO 게이팅 주문 실행 서비스 (Phase 4).
+
+sized 신호(수량 산출 완료) → 지정가 매수/매도 주문 경로. 사이징은
+`OverseasPositionSizingService` 가 별도로 담당하며, 본 서비스는 이미 산출된 qty 를
+받아 주문만 낸다(단일 책임).
+
+**핵심 안전 계약 — 구조적 실주문 잠금:**
+`live_enabled=False`(기본)에서는 broker 주문 메서드를 **절대 호출하지 않고** would-be
+주문 레코드만 반환한다(`signal_source="overseas_paper"`). `live_enabled=True` 일 때만
+실호출한다. 해외 주문 TR 은 실전(모의 없음)만 존재하므로, dry-run 검증 + Phase 5
+canary/kill-switch/reconcile 가 이 플래그를 켜는 유일한 주체다.
+
+스케줄러/factory 배선(자동 발사)은 Phase 5 소관 — 본 서비스는 테스트된 게이팅
+컴포넌트로만 제공된다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from common.overseas_types import OverseasExchange, OverseasOrderReport
+from common.types import ErrorCode, ResCommonResponse
+
+
+class OverseasOrderExecutionService:
+    SIGNAL_SOURCE_LIVE = "overseas_live"
+    SIGNAL_SOURCE_PAPER = "overseas_paper"
+
+    def __init__(
+        self,
+        broker,
+        *,
+        live_enabled: bool = False,
+        default_exchange: OverseasExchange = OverseasExchange.NASD,
+        journal=None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
+        self._broker = broker
+        self._live_enabled = bool(live_enabled)
+        self._default_exchange = default_exchange
+        self._journal = journal
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def place_entry(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        exchange: Optional[OverseasExchange] = None,
+        signal: Optional[Dict[str, Any]] = None,
+    ) -> ResCommonResponse:
+        """지정가 매수 주문(게이팅). live_enabled=False 면 would-be 만 반환."""
+        return await self._place(
+            code=code, qty=qty, limit_price=limit_price, side="buy",
+            exchange=exchange, signal=signal, exit_reason=None,
+        )
+
+    async def place_exit(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        reason: str = "",
+        exchange: Optional[OverseasExchange] = None,
+        signal: Optional[Dict[str, Any]] = None,
+    ) -> ResCommonResponse:
+        """지정가 매도(청산) 주문(게이팅). live_enabled=False 면 would-be 만 반환."""
+        return await self._place(
+            code=code, qty=qty, limit_price=limit_price, side="sell",
+            exchange=exchange, signal=signal, exit_reason=reason,
+        )
+
+    async def _place(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        side: str,
+        exchange: Optional[OverseasExchange],
+        signal: Optional[Dict[str, Any]],
+        exit_reason: Optional[str],
+    ) -> ResCommonResponse:
+        symbol = str(code).upper()
+        ex = exchange or self._default_exchange
+        # 어떤 모드에서도 잘못된 입력은 broker 도달 전 차단.
+        if int(qty) <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="주문수량은 0보다 커야 합니다.", data=None,
+            )
+        if self._to_float(limit_price) <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="지정가는 0보다 커야 합니다(해외는 지정가만 지원).", data=None,
+            )
+        limit_str = self._price_str(limit_price)
+
+        if not self._live_enabled:
+            resp = self._would_be_response(symbol, ex, side, int(qty), limit_str, exit_reason)
+        else:
+            resp = await self._broker.place_overseas_limit_order(
+                symbol=symbol, exchange=ex, side=side, qty=int(qty), limit_price=limit_str,
+            )
+
+        self._record_journal(symbol, ex, side, int(qty), limit_str, signal, exit_reason, resp)
+        return resp
+
+    def _would_be_response(
+        self, symbol: str, ex: OverseasExchange, side: str, qty: int,
+        limit_str: str, exit_reason: Optional[str],
+    ) -> ResCommonResponse:
+        raw: Dict[str, Any] = {"would_be": True, "signal_source": self.SIGNAL_SOURCE_PAPER}
+        if exit_reason:
+            raw["exit_reason"] = exit_reason
+        report = OverseasOrderReport(
+            symbol=symbol, exchange=ex, side=side, qty=qty,
+            limit_price=limit_str, broker_order_no="", raw=raw,
+        )
+        self._logger.info({
+            "event": "overseas_order_would_be", "code": symbol, "side": side,
+            "qty": qty, "limit_price": limit_str, "exchange": ex.value,
+        })
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="would-be (live_enabled=False)", data=report,
+        )
+
+    def _record_journal(
+        self, symbol: str, ex: OverseasExchange, side: str, qty: int,
+        limit_str: str, signal: Optional[Dict[str, Any]], exit_reason: Optional[str],
+        resp: ResCommonResponse,
+    ) -> None:
+        if self._journal is None:
+            return
+        source = self.SIGNAL_SOURCE_LIVE if self._live_enabled else self.SIGNAL_SOURCE_PAPER
+        order = {
+            "code": symbol, "side": side, "qty": qty, "limit_price": limit_str,
+            "rt_cd": getattr(resp, "rt_cd", None),
+        }
+        if exit_reason:
+            order["exit_reason"] = exit_reason
+        if signal:
+            order["signal"] = signal
+        try:
+            self._journal.record(
+                strategy_name="LarryWilliamsVBO_overseas",
+                code=symbol,
+                signal=order,
+                snapshot={"exchange": ex.value},
+                signal_source=source,
+            )
+        except Exception as e:  # 저널 실패가 주문 결과를 가리지 않도록 흡수
+            self._logger.warning({"event": "overseas_order_journal_error", "error": str(e)})
+
+    @staticmethod
+    def decide_daily_exit(
+        *,
+        entry_price: float,
+        stop_price: float,
+        daily_bar: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """보유 포지션을 일봉 한 개에 대해 청산 판정(순수 로직).
+
+        dry-run / 백테스트 모델과 동일: 당일저 <= 손절가면 손절가 청산("stop"),
+        아니면 종가 청산("eod"). 유효 종가/저가가 없으면 None(판정 보류).
+        반환: {"exit_price": float, "exit_reason": "stop"|"eod"} | None
+        """
+        low = OverseasOrderExecutionService._to_float(daily_bar.get("low"))
+        close = OverseasOrderExecutionService._to_float(daily_bar.get("close"))
+        if close <= 0:
+            return None
+        stop = OverseasOrderExecutionService._to_float(stop_price)
+        if low > 0 and stop > 0 and low <= stop:
+            return {"exit_price": stop, "exit_reason": "stop"}
+        return {"exit_price": close, "exit_reason": "eod"}
+
+    @staticmethod
+    def _to_float(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def _price_str(x) -> str:
+        # 정수 가격은 정수 문자열, 그 외는 원본 float 문자열(불필요한 .0 회피).
+        f = OverseasOrderExecutionService._to_float(x)
+        if f == int(f):
+            return str(int(f)) if not isinstance(x, float) else str(f)
+        return str(f)

--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -34,6 +34,7 @@ class OverseasOrderExecutionService:
         live_enabled: bool = False,
         default_exchange: OverseasExchange = OverseasExchange.NASD,
         journal=None,
+        kill_switch=None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
@@ -41,6 +42,8 @@ class OverseasOrderExecutionService:
         self._live_enabled = bool(live_enabled)
         self._default_exchange = default_exchange
         self._journal = journal
+        # live 실주문 직전 차단 게이트(check_orders_allowed). paper 모드는 실주문이 없어 미적용.
+        self._kill_switch = kill_switch
         self._logger = logger or logging.getLogger(__name__)
 
     async def place_entry(
@@ -103,12 +106,31 @@ class OverseasOrderExecutionService:
         if not self._live_enabled:
             resp = self._would_be_response(symbol, ex, side, int(qty), limit_str, exit_reason)
         else:
+            blocked = await self._kill_switch_block(symbol, side)
+            if blocked is not None:
+                return blocked
             resp = await self._broker.place_overseas_limit_order(
                 symbol=symbol, exchange=ex, side=side, qty=int(qty), limit_price=limit_str,
             )
 
         self._record_journal(symbol, ex, side, int(qty), limit_str, signal, exit_reason, resp)
         return resp
+
+    async def _kill_switch_block(self, symbol: str, side: str) -> Optional[ResCommonResponse]:
+        """live 실주문 직전 kill-switch 차단 확인. 차단이면 응답 반환, 통과면 None."""
+        if self._kill_switch is None:
+            return None
+        allowed, reason = await self._kill_switch.check_orders_allowed()
+        if allowed:
+            return None
+        self._logger.warning({
+            "event": "overseas_order_kill_switch_blocked", "code": symbol,
+            "side": side, "reason": reason,
+        })
+        return ResCommonResponse(
+            rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value,
+            msg1=f"Kill Switch 활성 — {reason or ''}", data=None,
+        )
 
     def _would_be_response(
         self, symbol: str, ex: OverseasExchange, side: str, qty: int,

--- a/services/overseas_reconcile_service.py
+++ b/services/overseas_reconcile_service.py
@@ -1,0 +1,137 @@
+# services/overseas_reconcile_service.py
+"""해외 포지션 reconcile 서비스 (Phase 5).
+
+로컬 기대 포지션(paper/canary 추적)과 브로커 해외 잔고(`get_overseas_balance`)를
+비교해 drift(missing/extra/qty_mismatch)를 감지한다. **순수 비교 — 주문 경로 없음.**
+
+국내 `FillReconciliationService`(OrderStateMachine 결합, 주문 FSM 보정)와 달리, 해외는
+FSM/포지션 스토어가 아직 없고 live 가 잠겨 있으므로 자기완결적 drift 리포트만 산출한다.
+실 캐너리 가동(live_enabled) 단계에서 로컬 추적과 조인해 사용한다.
+
+브로커 잔고 응답은 공식 표본이 부족해 표본별 키가 갈리므로 다중 후보 키로 관용
+파싱한다(실 fixture 확보 시 단일화).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.types import ErrorCode
+
+# KIS 해외 잔고(TTTS3012R) output1 보유종목의 심볼/수량 후보 키.
+_SYMBOL_KEYS = ("ovrs_pdno", "pdno", "OVRS_PDNO", "PDNO")
+_QTY_KEYS = ("ovrs_cblc_qty", "cblc_qty", "hldg_qty", "ord_psbl_qty",
+             "OVRS_CBLC_QTY", "CBLC_QTY")
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+class OverseasReconcileService:
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+
+    @staticmethod
+    def parse_broker_positions(balance_response) -> Dict[str, int]:
+        """해외 잔고 응답에서 {심볼(대문자): 보유수량}을 관용 추출한다.
+
+        rt_cd 실패 / data 비정상 / 0·blank 수량은 모두 제외한다.
+        """
+        if balance_response is None:
+            return {}
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return {}
+        data = getattr(balance_response, "data", None)
+        if not isinstance(data, dict):
+            return {}
+        holdings = data.get("output1")
+        if not isinstance(holdings, list):
+            return {}
+
+        positions: Dict[str, int] = {}
+        for row in holdings:
+            if not isinstance(row, dict):
+                continue
+            symbol = ""
+            for k in _SYMBOL_KEYS:
+                if row.get(k):
+                    symbol = str(row.get(k)).strip().upper()
+                    break
+            if not symbol:
+                continue
+            qty = 0
+            for k in _QTY_KEYS:
+                if k in row:
+                    qty = _to_int(row.get(k))
+                    break
+            if qty > 0:
+                positions[symbol] = positions.get(symbol, 0) + qty
+        return positions
+
+    def reconcile(
+        self,
+        local_positions: Dict[str, int],
+        balance_response,
+    ) -> Dict[str, Any]:
+        """로컬 기대 포지션과 브로커 잔고를 비교해 drift 리포트를 반환한다.
+
+        반환: {ok, matched, missing_in_broker, extra_in_broker, qty_mismatch,
+               broker_positions, [error]}
+        잔고 조회 실패 시 ok=False + error="balance_query_failed" — 로컬을 함부로
+        missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+        """
+        local = {str(s).upper(): _to_int(q) for s, q in (local_positions or {}).items()}
+
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            self._logger.warning({
+                "event": "overseas_reconcile_balance_failed",
+                "msg": getattr(balance_response, "msg1", ""),
+            })
+            return {
+                "ok": False,
+                "error": "balance_query_failed",
+                "matched": [],
+                "missing_in_broker": [],
+                "extra_in_broker": [],
+                "qty_mismatch": [],
+                "broker_positions": {},
+            }
+
+        broker = self.parse_broker_positions(balance_response)
+
+        matched: List[str] = []
+        missing: List[Dict[str, Any]] = []
+        extra: List[Dict[str, Any]] = []
+        mismatch: List[Dict[str, Any]] = []
+
+        for symbol, lqty in local.items():
+            bqty = broker.get(symbol, 0)
+            if bqty == 0:
+                missing.append({"symbol": symbol, "local_qty": lqty})
+            elif bqty != lqty:
+                mismatch.append({"symbol": symbol, "local_qty": lqty, "broker_qty": bqty})
+            else:
+                matched.append(symbol)
+
+        for symbol, bqty in broker.items():
+            if symbol not in local:
+                extra.append({"symbol": symbol, "broker_qty": bqty})
+
+        ok = not (missing or extra or mismatch)
+        report = {
+            "ok": ok,
+            "matched": sorted(matched),
+            "missing_in_broker": sorted(missing, key=lambda d: d["symbol"]),
+            "extra_in_broker": sorted(extra, key=lambda d: d["symbol"]),
+            "qty_mismatch": sorted(mismatch, key=lambda d: d["symbol"]),
+            "broker_positions": broker,
+        }
+        if not ok:
+            self._logger.warning({"event": "overseas_reconcile_drift",
+                                  "missing": len(missing), "extra": len(extra),
+                                  "qty_mismatch": len(mismatch)})
+        return report

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -121,6 +121,41 @@ async def test_invalid_price_rejected_before_broker(price):
     broker.place_overseas_limit_order.assert_not_called()
 
 
+# ── kill-switch 게이트 (live 경로) ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_live_blocked_by_kill_switch_does_not_call_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "일일 손실 한도 초과"))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.KILL_SWITCH_BLOCKED.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_allowed_by_kill_switch_calls_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(True, None))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    broker.place_overseas_limit_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_paper_mode_skips_kill_switch_check():
+    """paper(live off)는 실주문이 없으므로 kill-switch 를 호출하지 않는다."""
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "blocked"))
+    svc = OverseasOrderExecutionService(None, live_enabled=False, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    ks.check_orders_allowed.assert_not_called()
+
+
 # ── 일봉 기반 exit 판정 (순수 로직) ───────────────────────────────────────────
 
 def test_decide_daily_exit_stop_when_low_breaks_stop():

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -1,0 +1,159 @@
+"""해외 VBO 게이팅 주문 실행 서비스 테스트 (Phase 4).
+
+핵심 안전 계약: `live_enabled=False`(기본)에서는 broker 주문 메서드가 **절대 호출되지
+않는다**(구조적 실주문 잠금). live_enabled=True 일 때만 실호출. dry-run 검증 + Phase 5
+canary/kill-switch 가 이 플래그를 켜는 유일한 주체다.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange, OverseasOrderReport
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_order_execution_service import OverseasOrderExecutionService
+
+
+def _broker(order_resp=None):
+    broker = MagicMock()
+    report = OverseasOrderReport(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="buy",
+        qty=6, limit_price="150.0", broker_order_no="0001234",
+    )
+    broker.place_overseas_limit_order = AsyncMock(
+        return_value=order_resp or ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=report
+        )
+    )
+    return broker
+
+
+# ── live_enabled=False: 구조적 실주문 잠금 ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_entry_default_does_not_call_broker():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=False)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    broker.place_overseas_limit_order.assert_not_called()
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    report = resp.data
+    assert report.side == "buy"
+    assert report.qty == 6
+    assert report.broker_order_no == ""  # would-be — 브로커 주문번호 없음
+    assert report.raw.get("would_be") is True
+    assert report.raw.get("signal_source") == OverseasOrderExecutionService.SIGNAL_SOURCE_PAPER
+
+
+@pytest.mark.asyncio
+async def test_exit_default_does_not_call_broker():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=False)
+    resp = await svc.place_exit(code="AAPL", qty=6, limit_price=148.0, reason="stop")
+    broker.place_overseas_limit_order.assert_not_called()
+    assert resp.data.side == "sell"
+    assert resp.data.raw.get("exit_reason") == "stop"
+
+
+@pytest.mark.asyncio
+async def test_paper_mode_works_without_broker():
+    """live_enabled=False 면 broker=None 이어도 would-be 주문이 가능해야 한다."""
+    svc = OverseasOrderExecutionService(None, live_enabled=False)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data.qty == 6
+
+
+# ── live_enabled=True: 실호출 ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_entry_live_calls_broker_with_buy_side():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True,
+                                        default_exchange=OverseasExchange.NASD)
+    resp = await svc.place_entry(code="aapl", qty=6, limit_price=150.0)
+    broker.place_overseas_limit_order.assert_awaited_once()
+    kwargs = broker.place_overseas_limit_order.await_args.kwargs
+    assert kwargs["side"] == "buy"
+    assert kwargs["symbol"] == "AAPL"  # 대문자 정규화
+    assert kwargs["qty"] == 6
+    assert kwargs["limit_price"] == "150.0"
+    assert kwargs["exchange"] == OverseasExchange.NASD
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data.broker_order_no == "0001234"
+
+
+@pytest.mark.asyncio
+async def test_exit_live_calls_broker_with_sell_side():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    await svc.place_exit(code="AAPL", qty=6, limit_price=148.0, reason="eod")
+    kwargs = broker.place_overseas_limit_order.await_args.kwargs
+    assert kwargs["side"] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_live_propagates_broker_failure():
+    broker = _broker(ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="rejected", data=None))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+
+
+# ── 검증: 어떤 모드에서도 잘못된 입력은 broker 도달 전 차단 ────────────────────
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("qty", [0, -1])
+async def test_invalid_qty_rejected_before_broker(qty):
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=qty, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("price", [0, -5.0])
+async def test_invalid_price_rejected_before_broker(price):
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=price)
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+# ── 일봉 기반 exit 판정 (순수 로직) ───────────────────────────────────────────
+
+def test_decide_daily_exit_stop_when_low_breaks_stop():
+    out = OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0,
+        daily_bar={"low": 96.0, "close": 99.0},
+    )
+    assert out == {"exit_price": 97.0, "exit_reason": "stop"}
+
+
+def test_decide_daily_exit_eod_when_stop_not_hit():
+    out = OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0,
+        daily_bar={"low": 98.0, "close": 101.0},
+    )
+    assert out == {"exit_price": 101.0, "exit_reason": "eod"}
+
+
+def test_decide_daily_exit_none_on_invalid_bar():
+    assert OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0, daily_bar={}
+    ) is None
+
+
+# ── 저널 연동 (선택) ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_journal_records_order_when_provided():
+    journal = MagicMock()
+    svc = OverseasOrderExecutionService(None, live_enabled=False, journal=journal)
+    await svc.place_entry(code="AAPL", qty=6, limit_price=150.0,
+                          signal={"reason": "vbo_daily_breakout"})
+    journal.record.assert_called_once()
+    kwargs = journal.record.call_args.kwargs
+    assert kwargs["code"] == "AAPL"
+    assert kwargs["signal_source"] == OverseasOrderExecutionService.SIGNAL_SOURCE_PAPER

--- a/tests/unit_test/services/test_overseas_reconcile_service.py
+++ b/tests/unit_test/services/test_overseas_reconcile_service.py
@@ -1,0 +1,99 @@
+"""해외 포지션 reconcile 서비스 테스트 (Phase 5).
+
+로컬 기대 포지션 vs 브로커 해외 잔고 drift 감지(순수 비교, 주문 경로 없음).
+브로커 잔고 응답은 표본별 키가 갈리므로 다중 후보 키로 관용 파싱한다.
+"""
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_reconcile_service import OverseasReconcileService
+
+
+def _balance(holdings: list[dict]) -> ResCommonResponse:
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+        data={"output1": holdings, "output2": {}},
+    )
+
+
+# ── parse_broker_positions ────────────────────────────────────────────────────
+
+def test_parse_positions_primary_keys():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+        {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"},
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"AAPL": 10, "MSFT": 5}
+
+
+def test_parse_positions_fallback_keys_and_uppercase():
+    resp = _balance([
+        {"pdno": "tsla", "cblc_qty": "3"},   # fallback 키 + 소문자 심볼
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"TSLA": 3}
+
+
+def test_parse_positions_skips_zero_and_blank():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "0"},   # 0 수량 제외
+        {"ovrs_pdno": "", "ovrs_cblc_qty": "5"},        # 빈 심볼 제외
+        {"ovrs_pdno": "NVDA", "ovrs_cblc_qty": "bad"},  # 파싱 불가 → 0 → 제외
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+def test_parse_positions_failed_response_returns_empty():
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None)
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+# ── reconcile ─────────────────────────────────────────────────────────────────
+
+def test_reconcile_all_matched_ok():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is True
+    assert report["matched"] == ["AAPL"]
+    assert report["missing_in_broker"] == []
+    assert report["extra_in_broker"] == []
+    assert report["qty_mismatch"] == []
+
+
+def test_reconcile_missing_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([])  # 브로커에 없음
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["missing_in_broker"] == [{"symbol": "AAPL", "local_qty": 10}]
+
+
+def test_reconcile_extra_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+                     {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["extra_in_broker"] == [{"symbol": "MSFT", "broker_qty": 5}]
+
+
+def test_reconcile_qty_mismatch():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "8"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["qty_mismatch"] == [{"symbol": "AAPL", "local_qty": 10, "broker_qty": 8}]
+
+
+def test_reconcile_failed_balance_is_not_ok():
+    svc = OverseasReconcileService()
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="잔고조회실패", data=None)
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["error"] == "balance_query_failed"
+    # 잔고 조회 실패 시 로컬 포지션을 함부로 missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+    assert report["missing_in_broker"] == []
+
+
+def test_reconcile_empty_both_ok():
+    svc = OverseasReconcileService()
+    report = svc.reconcile({}, _balance([]))
+    assert report["ok"] is True


### PR DESCRIPTION
## 배경

해외주식 Phase 4(주문/사이징). 조사 결과 **사이징·환율은 이미 완료**(`OverseasPositionSizingService`, `extract_fx_krw_per_usd`)였고, `place_overseas_limit_order`/`cancel_overseas_order`도 API·wrapper에 존재. 남은 진짜 갭은 **"주문 연결" + "일봉 기반 exit"** 둘뿐이었다.

제약: **"dry-run 검증 전 실주문 배선 금지"** (해외 주문 TR은 실전만, 모의 없음). dry-run 수익성은 아직 미검증 → 지금 실주문이 발사될 수 있는 경로는 금지.

## 설계 — 게이팅된 실행 서비스

`OverseasOrderExecutionService` 신규. 핵심 안전장치 `live_enabled: bool = False`(기본 off):

| 모드 | 동작 |
|------|------|
| `live_enabled=False` (기본) | broker 주문 메서드 **절대 미호출**, would-be 레코드만 반환(`signal_source=overseas_paper`). `broker=None`이어도 동작 |
| `live_enabled=True` | `place_overseas_limit_order` 실호출(buy/sell side 분기) |

이 플래그를 켜는 유일한 주체 = dry-run 검증 + **Phase 5**(canary/kill-switch/reconcile). 스케줄러/factory **자동 발사 배선은 본 PR에 없음**(Phase 5 소관) — 테스트된 게이팅 컴포넌트까지만.

### 메서드
- `place_entry(...)` / `place_exit(...)` — 게이팅된 지정가 매수/매도
- `decide_daily_exit(entry_price, stop_price, daily_bar)` — 순수 일봉 청산 판정(stop/eod), 기존 dry-run/백테스트 모델과 동일
- 잘못된 입력(qty<=0, price<=0)은 **어떤 모드에서도 broker 도달 전 차단**
- 선택적 저널 연동(paper canary journal)

## 테스트
- 단위 14개: live-off 미호출(broker=None 포함)/live-on 실호출 side 분기/입력 검증/exit 판정/저널
- 통합 243개 통과

## 남은 것 (Phase 5)
`get_overseas_balance`/`ccnl` reconcile, risk gate/kill-switch, canary USD 확장, `live_enabled` 활성화 + 스케줄러 배선, 실전 소액 canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)