### PR TITLE
feat(overseas): Phase 5 reconcile 서비스 + kill-switch 게이트

### DIFF
--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -34,6 +34,7 @@ class OverseasOrderExecutionService:
         live_enabled: bool = False,
         default_exchange: OverseasExchange = OverseasExchange.NASD,
         journal=None,
+        kill_switch=None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
@@ -41,6 +42,8 @@ class OverseasOrderExecutionService:
         self._live_enabled = bool(live_enabled)
         self._default_exchange = default_exchange
         self._journal = journal
+        # live 실주문 직전 차단 게이트(check_orders_allowed). paper 모드는 실주문이 없어 미적용.
+        self._kill_switch = kill_switch
         self._logger = logger or logging.getLogger(__name__)
 
     async def place_entry(
@@ -103,12 +106,31 @@ class OverseasOrderExecutionService:
         if not self._live_enabled:
             resp = self._would_be_response(symbol, ex, side, int(qty), limit_str, exit_reason)
         else:
+            blocked = await self._kill_switch_block(symbol, side)
+            if blocked is not None:
+                return blocked
             resp = await self._broker.place_overseas_limit_order(
                 symbol=symbol, exchange=ex, side=side, qty=int(qty), limit_price=limit_str,
             )
 
         self._record_journal(symbol, ex, side, int(qty), limit_str, signal, exit_reason, resp)
         return resp
+
+    async def _kill_switch_block(self, symbol: str, side: str) -> Optional[ResCommonResponse]:
+        """live 실주문 직전 kill-switch 차단 확인. 차단이면 응답 반환, 통과면 None."""
+        if self._kill_switch is None:
+            return None
+        allowed, reason = await self._kill_switch.check_orders_allowed()
+        if allowed:
+            return None
+        self._logger.warning({
+            "event": "overseas_order_kill_switch_blocked", "code": symbol,
+            "side": side, "reason": reason,
+        })
+        return ResCommonResponse(
+            rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value,
+            msg1=f"Kill Switch 활성 — {reason or ''}", data=None,
+        )
 
     def _would_be_response(
         self, symbol: str, ex: OverseasExchange, side: str, qty: int,

--- a/services/overseas_reconcile_service.py
+++ b/services/overseas_reconcile_service.py
@@ -1,0 +1,137 @@
+# services/overseas_reconcile_service.py
+"""해외 포지션 reconcile 서비스 (Phase 5).
+
+로컬 기대 포지션(paper/canary 추적)과 브로커 해외 잔고(`get_overseas_balance`)를
+비교해 drift(missing/extra/qty_mismatch)를 감지한다. **순수 비교 — 주문 경로 없음.**
+
+국내 `FillReconciliationService`(OrderStateMachine 결합, 주문 FSM 보정)와 달리, 해외는
+FSM/포지션 스토어가 아직 없고 live 가 잠겨 있으므로 자기완결적 drift 리포트만 산출한다.
+실 캐너리 가동(live_enabled) 단계에서 로컬 추적과 조인해 사용한다.
+
+브로커 잔고 응답은 공식 표본이 부족해 표본별 키가 갈리므로 다중 후보 키로 관용
+파싱한다(실 fixture 확보 시 단일화).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.types import ErrorCode
+
+# KIS 해외 잔고(TTTS3012R) output1 보유종목의 심볼/수량 후보 키.
+_SYMBOL_KEYS = ("ovrs_pdno", "pdno", "OVRS_PDNO", "PDNO")
+_QTY_KEYS = ("ovrs_cblc_qty", "cblc_qty", "hldg_qty", "ord_psbl_qty",
+             "OVRS_CBLC_QTY", "CBLC_QTY")
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+class OverseasReconcileService:
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+
+    @staticmethod
+    def parse_broker_positions(balance_response) -> Dict[str, int]:
+        """해외 잔고 응답에서 {심볼(대문자): 보유수량}을 관용 추출한다.
+
+        rt_cd 실패 / data 비정상 / 0·blank 수량은 모두 제외한다.
+        """
+        if balance_response is None:
+            return {}
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return {}
+        data = getattr(balance_response, "data", None)
+        if not isinstance(data, dict):
+            return {}
+        holdings = data.get("output1")
+        if not isinstance(holdings, list):
+            return {}
+
+        positions: Dict[str, int] = {}
+        for row in holdings:
+            if not isinstance(row, dict):
+                continue
+            symbol = ""
+            for k in _SYMBOL_KEYS:
+                if row.get(k):
+                    symbol = str(row.get(k)).strip().upper()
+                    break
+            if not symbol:
+                continue
+            qty = 0
+            for k in _QTY_KEYS:
+                if k in row:
+                    qty = _to_int(row.get(k))
+                    break
+            if qty > 0:
+                positions[symbol] = positions.get(symbol, 0) + qty
+        return positions
+
+    def reconcile(
+        self,
+        local_positions: Dict[str, int],
+        balance_response,
+    ) -> Dict[str, Any]:
+        """로컬 기대 포지션과 브로커 잔고를 비교해 drift 리포트를 반환한다.
+
+        반환: {ok, matched, missing_in_broker, extra_in_broker, qty_mismatch,
+               broker_positions, [error]}
+        잔고 조회 실패 시 ok=False + error="balance_query_failed" — 로컬을 함부로
+        missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+        """
+        local = {str(s).upper(): _to_int(q) for s, q in (local_positions or {}).items()}
+
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            self._logger.warning({
+                "event": "overseas_reconcile_balance_failed",
+                "msg": getattr(balance_response, "msg1", ""),
+            })
+            return {
+                "ok": False,
+                "error": "balance_query_failed",
+                "matched": [],
+                "missing_in_broker": [],
+                "extra_in_broker": [],
+                "qty_mismatch": [],
+                "broker_positions": {},
+            }
+
+        broker = self.parse_broker_positions(balance_response)
+
+        matched: List[str] = []
+        missing: List[Dict[str, Any]] = []
+        extra: List[Dict[str, Any]] = []
+        mismatch: List[Dict[str, Any]] = []
+
+        for symbol, lqty in local.items():
+            bqty = broker.get(symbol, 0)
+            if bqty == 0:
+                missing.append({"symbol": symbol, "local_qty": lqty})
+            elif bqty != lqty:
+                mismatch.append({"symbol": symbol, "local_qty": lqty, "broker_qty": bqty})
+            else:
+                matched.append(symbol)
+
+        for symbol, bqty in broker.items():
+            if symbol not in local:
+                extra.append({"symbol": symbol, "broker_qty": bqty})
+
+        ok = not (missing or extra or mismatch)
+        report = {
+            "ok": ok,
+            "matched": sorted(matched),
+            "missing_in_broker": sorted(missing, key=lambda d: d["symbol"]),
+            "extra_in_broker": sorted(extra, key=lambda d: d["symbol"]),
+            "qty_mismatch": sorted(mismatch, key=lambda d: d["symbol"]),
+            "broker_positions": broker,
+        }
+        if not ok:
+            self._logger.warning({"event": "overseas_reconcile_drift",
+                                  "missing": len(missing), "extra": len(extra),
+                                  "qty_mismatch": len(mismatch)})
+        return report

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -121,6 +121,41 @@ async def test_invalid_price_rejected_before_broker(price):
     broker.place_overseas_limit_order.assert_not_called()
 
 
+# ── kill-switch 게이트 (live 경로) ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_live_blocked_by_kill_switch_does_not_call_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "일일 손실 한도 초과"))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.KILL_SWITCH_BLOCKED.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_allowed_by_kill_switch_calls_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(True, None))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    broker.place_overseas_limit_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_paper_mode_skips_kill_switch_check():
+    """paper(live off)는 실주문이 없으므로 kill-switch 를 호출하지 않는다."""
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "blocked"))
+    svc = OverseasOrderExecutionService(None, live_enabled=False, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    ks.check_orders_allowed.assert_not_called()
+
+
 # ── 일봉 기반 exit 판정 (순수 로직) ───────────────────────────────────────────
 
 def test_decide_daily_exit_stop_when_low_breaks_stop():

--- a/tests/unit_test/services/test_overseas_reconcile_service.py
+++ b/tests/unit_test/services/test_overseas_reconcile_service.py
@@ -1,0 +1,99 @@
+"""해외 포지션 reconcile 서비스 테스트 (Phase 5).
+
+로컬 기대 포지션 vs 브로커 해외 잔고 drift 감지(순수 비교, 주문 경로 없음).
+브로커 잔고 응답은 표본별 키가 갈리므로 다중 후보 키로 관용 파싱한다.
+"""
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_reconcile_service import OverseasReconcileService
+
+
+def _balance(holdings: list[dict]) -> ResCommonResponse:
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+        data={"output1": holdings, "output2": {}},
+    )
+
+
+# ── parse_broker_positions ────────────────────────────────────────────────────
+
+def test_parse_positions_primary_keys():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+        {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"},
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"AAPL": 10, "MSFT": 5}
+
+
+def test_parse_positions_fallback_keys_and_uppercase():
+    resp = _balance([
+        {"pdno": "tsla", "cblc_qty": "3"},   # fallback 키 + 소문자 심볼
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"TSLA": 3}
+
+
+def test_parse_positions_skips_zero_and_blank():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "0"},   # 0 수량 제외
+        {"ovrs_pdno": "", "ovrs_cblc_qty": "5"},        # 빈 심볼 제외
+        {"ovrs_pdno": "NVDA", "ovrs_cblc_qty": "bad"},  # 파싱 불가 → 0 → 제외
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+def test_parse_positions_failed_response_returns_empty():
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None)
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+# ── reconcile ─────────────────────────────────────────────────────────────────
+
+def test_reconcile_all_matched_ok():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is True
+    assert report["matched"] == ["AAPL"]
+    assert report["missing_in_broker"] == []
+    assert report["extra_in_broker"] == []
+    assert report["qty_mismatch"] == []
+
+
+def test_reconcile_missing_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([])  # 브로커에 없음
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["missing_in_broker"] == [{"symbol": "AAPL", "local_qty": 10}]
+
+
+def test_reconcile_extra_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+                     {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["extra_in_broker"] == [{"symbol": "MSFT", "broker_qty": 5}]
+
+
+def test_reconcile_qty_mismatch():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "8"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["qty_mismatch"] == [{"symbol": "AAPL", "local_qty": 10, "broker_qty": 8}]
+
+
+def test_reconcile_failed_balance_is_not_ok():
+    svc = OverseasReconcileService()
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="잔고조회실패", data=None)
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["error"] == "balance_query_failed"
+    # 잔고 조회 실패 시 로컬 포지션을 함부로 missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+    assert report["missing_in_broker"] == []
+
+
+def test_reconcile_empty_both_ok():
+    svc = OverseasReconcileService()
+    report = svc.reconcile({}, _balance([]))
+    assert report["ok"] is True


### PR DESCRIPTION
> **스택 PR** — base는 `claude/overseas-phase4-order-execution`(#566). #566 머지 후 base가 main으로 바뀝니다.

## 배경

해외 Phase 5(안전/canary). live가 잠겨 있고 dry-run 수익성도 미검증이라, **실 canary는 후속**으로 두고 지금 코드-착수 가능한 **게이팅 인프라**(reconcile + 안전 게이트)만 구축.

조사 결과: 읽기 API(`get_overseas_balance`/`ccnl`/`unfilled`)는 존재하나 **해외 reconcile 서비스는 0개**(국내 인프라는 해외 미지원).

## 1. `OverseasReconcileService`

로컬 기대 포지션 vs 브로커 해외 잔고 **drift 감지** (순수 비교, 주문 경로 없음):
- `parse_broker_positions(balance_resp)` — output1 보유종목을 다중 후보 키로 관용 파싱({심볼: 수량})
- `reconcile(local, balance_resp)` → `missing_in_broker` / `extra_in_broker` / `qty_mismatch` / `matched` / `ok`
- 잔고 조회 실패 시 `ok=False` + `error="balance_query_failed"` — 로컬을 함부로 missing으로 단정하지 않음(조회 불가 ≠ 미보유)

국내 `FillReconciliationService`(OrderStateMachine 결합 1000줄)와 달리, 해외는 FSM/포지션 스토어가 없으므로 자기완결적 리포트만 산출(단순함 우선).

## 2. kill-switch 게이트 (실행 서비스 확장)

`OverseasOrderExecutionService`에 live 실주문 직전 차단 게이트:
- `live_enabled=True` + `kill_switch` 주입 시 `check_orders_allowed()` 차단 → `KILL_SWITCH_BLOCKED` 반환, broker 미호출
- paper(live off)는 실주문이 없어 kill-switch 미적용

## 테스트
- 단위 27개(reconcile 10 + 실행 17, kill-switch 3 신규 포함)
- 통합 243개 통과

## 남은 것 (Phase 5 후속)
`live_enabled` 활성화 + 스케줄러/factory 배선, RiskGate(포지션 heat) 배선, 실전 소액 canary USD 확장 — 전부 **dry-run 수익성 검증(라이브 데이터)** 선행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)