### PR TITLE
[codex] improve no-tick diagnostics

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -499,18 +499,8 @@ class StrategyScheduler:
         await self._refresh_exit_shadow_subscriptions(cfg, holdings=post_exit_holdings)
 
         # 2) 새 매수 스캔
-        entry_gate = self._check_live_expansion_gate(name)
-        if not entry_gate.allowed:
-            self._logger.warning({
-                "event": "scheduler_skip",
-                "strategy_name": name,
-                "reason": "profitability_gate_blocked",
-                "gate_reason": entry_gate.reason,
-                "gate_details": entry_gate.details,
-            })
-            self._pm.log_timer(f"{name}.run_strategy", t_run)
-            return
-
+        # Profitability gate 는 BUY 주문 직전에만 적용한다. scan/event-shadow 는
+        # 실전 차단 중에도 계속 돌려야 gate 통과 근거와 parity 데이터를 축적할 수 있다.
         current_holdings = (
             post_exit_holdings if post_exit_holdings is not None
             else self._get_strategy_holdings(cfg)

--- a/scripts/analyze_no_tick_diagnosis.py
+++ b/scripts/analyze_no_tick_diagnosis.py
@@ -4,8 +4,9 @@ P2 2-4 최우선 블로커 진단 도구. 워치독이 `subscribed_no_tick`(=KIS
 확정 후 0틱)으로 표시한 종목을, event_shadow 의 tick-ingest 카운터 스냅샷과
 종목별로 조인해 다음으로 분류한다.
 
-  - a1_kis_no_send     : received==0 → ACK 후 KIS 가 프레임 자체를 보내지 않음
+  - a1_kis_no_send     : received==0 & malformed==0 → ACK 후 KIS 가 프레임 자체를 보내지 않음
                          (todo P2 2-4 "ACK 후 KIS 미전송" 가설 입증)
+  - malformed_payload  : malformed>0 & received==0 → 프레임은 왔지만 필수 필드 누락/파싱 이상
   - a2_quality_reject  : received>0 & dispatched==0 & quality_reject>0
                          → 프레임은 도착하나 DataQuality 게이트에서 전량 탈락
   - a3_inconsistent    : received>0 & dispatched>0 → 틱이 디스패치됐는데도 워치독이
@@ -44,10 +45,11 @@ from typing import Any, Dict, List, Optional
 A1 = "a1_kis_no_send"
 A2 = "a2_quality_reject"
 A3 = "a3_inconsistent"
+MALFORMED = "malformed_payload"
 RECEIVED_NOT_DISPATCHED = "received_not_dispatched"
 UNKNOWN_NO_SNAPSHOT = "unknown_no_snapshot"
 
-_CLASSES = [A1, A2, A3, RECEIVED_NOT_DISPATCHED, UNKNOWN_NO_SNAPSHOT]
+_CLASSES = [A1, MALFORMED, A2, A3, RECEIVED_NOT_DISPATCHED, UNKNOWN_NO_SNAPSHOT]
 
 
 # ── Loaders ──────────────────────────────────────────────────────────────────
@@ -94,7 +96,7 @@ def load_tick_ingest_snapshots(
     """event_shadow jsonl 에서 종목별 최신(누적) tick-ingest 스냅샷을 반환.
 
     카운터는 monotonic 누적이므로 recorded_at 이 가장 늦은 스냅샷이 종일 합계다.
-    반환: {code: {"received":int, "quality_reject":int, "dispatched":int,
+    반환: {code: {"received":int, "quality_reject":int, "dispatched":int, "malformed":int,
                   "recorded_at":float, "strategy":str}}
     """
     shadow_dir = Path(shadow_dir)
@@ -136,6 +138,7 @@ def load_tick_ingest_snapshots(
                         "received": int(counts.get("received", 0)),
                         "quality_reject": int(counts.get("quality_reject", 0)),
                         "dispatched": int(counts.get("dispatched", 0)),
+                        "malformed": int(counts.get("malformed", 0)),
                         "recorded_at": recorded_at,
                         "strategy": strategy,
                     }
@@ -151,7 +154,10 @@ def classify_code(snap: Optional[Dict[str, Any]]) -> str:
     received = snap.get("received", 0)
     dispatched = snap.get("dispatched", 0)
     quality_reject = snap.get("quality_reject", 0)
+    malformed = snap.get("malformed", 0)
     if received == 0:
+        if malformed > 0:
+            return MALFORMED
         return A1
     if dispatched > 0:
         return A3
@@ -193,6 +199,7 @@ def compute_no_tick_report(
             entry["received"] = snap["received"]
             entry["quality_reject"] = snap["quality_reject"]
             entry["dispatched"] = snap["dispatched"]
+            entry["malformed"] = snap.get("malformed", 0)
         per_code.append(entry)
 
     total = len(no_tick_codes)
@@ -219,6 +226,7 @@ def compute_no_tick_report(
 
 _CLASS_DESC = {
     A1: "ACK 후 KIS 프레임 미전송 (received==0)",
+    MALFORMED: "필수 필드 누락/파싱 이상 (malformed>0)",
     A2: "DataQuality 게이트 전량 탈락 (received>0, dispatched==0)",
     A3: "디스패치됐는데 no-tick 표시 (측정/타이밍 갭, 무틱 아님)",
     RECEIVED_NOT_DISPATCHED: "프레임 진입했으나 reject/dispatch 아님",
@@ -244,12 +252,13 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
     lines.append("")
     lines.append("## 종목별 상세")
     lines.append("")
-    lines.append("| 종목 | 분류 | received | quality_reject | dispatched | no_tick 로그수 |")
-    lines.append("|------|------|----------|----------------|------------|----------------|")
+    lines.append("| 종목 | 분류 | received | malformed | quality_reject | dispatched | no_tick 로그수 |")
+    lines.append("|------|------|----------|-----------|----------------|------------|----------------|")
     for e in report["per_code"]:
         lines.append(
             f"| {e['code']} | {e['classification']} | "
-            f"{e.get('received', '-')} | {e.get('quality_reject', '-')} | "
+            f"{e.get('received', '-')} | {e.get('malformed', '-')} | "
+            f"{e.get('quality_reject', '-')} | "
             f"{e.get('dispatched', '-')} | {e['subscribed_no_tick_log_count']} |"
         )
     lines.append("")

--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -1,0 +1,194 @@
+# services/overseas_order_execution_service.py
+"""해외 VBO 게이팅 주문 실행 서비스 (Phase 4).
+
+sized 신호(수량 산출 완료) → 지정가 매수/매도 주문 경로. 사이징은
+`OverseasPositionSizingService` 가 별도로 담당하며, 본 서비스는 이미 산출된 qty 를
+받아 주문만 낸다(단일 책임).
+
+**핵심 안전 계약 — 구조적 실주문 잠금:**
+`live_enabled=False`(기본)에서는 broker 주문 메서드를 **절대 호출하지 않고** would-be
+주문 레코드만 반환한다(`signal_source="overseas_paper"`). `live_enabled=True` 일 때만
+실호출한다. 해외 주문 TR 은 실전(모의 없음)만 존재하므로, dry-run 검증 + Phase 5
+canary/kill-switch/reconcile 가 이 플래그를 켜는 유일한 주체다.
+
+스케줄러/factory 배선(자동 발사)은 Phase 5 소관 — 본 서비스는 테스트된 게이팅
+컴포넌트로만 제공된다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from common.overseas_types import OverseasExchange, OverseasOrderReport
+from common.types import ErrorCode, ResCommonResponse
+
+
+class OverseasOrderExecutionService:
+    SIGNAL_SOURCE_LIVE = "overseas_live"
+    SIGNAL_SOURCE_PAPER = "overseas_paper"
+
+    def __init__(
+        self,
+        broker,
+        *,
+        live_enabled: bool = False,
+        default_exchange: OverseasExchange = OverseasExchange.NASD,
+        journal=None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
+        self._broker = broker
+        self._live_enabled = bool(live_enabled)
+        self._default_exchange = default_exchange
+        self._journal = journal
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def place_entry(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        exchange: Optional[OverseasExchange] = None,
+        signal: Optional[Dict[str, Any]] = None,
+    ) -> ResCommonResponse:
+        """지정가 매수 주문(게이팅). live_enabled=False 면 would-be 만 반환."""
+        return await self._place(
+            code=code, qty=qty, limit_price=limit_price, side="buy",
+            exchange=exchange, signal=signal, exit_reason=None,
+        )
+
+    async def place_exit(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        reason: str = "",
+        exchange: Optional[OverseasExchange] = None,
+        signal: Optional[Dict[str, Any]] = None,
+    ) -> ResCommonResponse:
+        """지정가 매도(청산) 주문(게이팅). live_enabled=False 면 would-be 만 반환."""
+        return await self._place(
+            code=code, qty=qty, limit_price=limit_price, side="sell",
+            exchange=exchange, signal=signal, exit_reason=reason,
+        )
+
+    async def _place(
+        self,
+        *,
+        code: str,
+        qty: int,
+        limit_price: float,
+        side: str,
+        exchange: Optional[OverseasExchange],
+        signal: Optional[Dict[str, Any]],
+        exit_reason: Optional[str],
+    ) -> ResCommonResponse:
+        symbol = str(code).upper()
+        ex = exchange or self._default_exchange
+        # 어떤 모드에서도 잘못된 입력은 broker 도달 전 차단.
+        if int(qty) <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="주문수량은 0보다 커야 합니다.", data=None,
+            )
+        if self._to_float(limit_price) <= 0:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="지정가는 0보다 커야 합니다(해외는 지정가만 지원).", data=None,
+            )
+        limit_str = self._price_str(limit_price)
+
+        if not self._live_enabled:
+            resp = self._would_be_response(symbol, ex, side, int(qty), limit_str, exit_reason)
+        else:
+            resp = await self._broker.place_overseas_limit_order(
+                symbol=symbol, exchange=ex, side=side, qty=int(qty), limit_price=limit_str,
+            )
+
+        self._record_journal(symbol, ex, side, int(qty), limit_str, signal, exit_reason, resp)
+        return resp
+
+    def _would_be_response(
+        self, symbol: str, ex: OverseasExchange, side: str, qty: int,
+        limit_str: str, exit_reason: Optional[str],
+    ) -> ResCommonResponse:
+        raw: Dict[str, Any] = {"would_be": True, "signal_source": self.SIGNAL_SOURCE_PAPER}
+        if exit_reason:
+            raw["exit_reason"] = exit_reason
+        report = OverseasOrderReport(
+            symbol=symbol, exchange=ex, side=side, qty=qty,
+            limit_price=limit_str, broker_order_no="", raw=raw,
+        )
+        self._logger.info({
+            "event": "overseas_order_would_be", "code": symbol, "side": side,
+            "qty": qty, "limit_price": limit_str, "exchange": ex.value,
+        })
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="would-be (live_enabled=False)", data=report,
+        )
+
+    def _record_journal(
+        self, symbol: str, ex: OverseasExchange, side: str, qty: int,
+        limit_str: str, signal: Optional[Dict[str, Any]], exit_reason: Optional[str],
+        resp: ResCommonResponse,
+    ) -> None:
+        if self._journal is None:
+            return
+        source = self.SIGNAL_SOURCE_LIVE if self._live_enabled else self.SIGNAL_SOURCE_PAPER
+        order = {
+            "code": symbol, "side": side, "qty": qty, "limit_price": limit_str,
+            "rt_cd": getattr(resp, "rt_cd", None),
+        }
+        if exit_reason:
+            order["exit_reason"] = exit_reason
+        if signal:
+            order["signal"] = signal
+        try:
+            self._journal.record(
+                strategy_name="LarryWilliamsVBO_overseas",
+                code=symbol,
+                signal=order,
+                snapshot={"exchange": ex.value},
+                signal_source=source,
+            )
+        except Exception as e:  # 저널 실패가 주문 결과를 가리지 않도록 흡수
+            self._logger.warning({"event": "overseas_order_journal_error", "error": str(e)})
+
+    @staticmethod
+    def decide_daily_exit(
+        *,
+        entry_price: float,
+        stop_price: float,
+        daily_bar: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """보유 포지션을 일봉 한 개에 대해 청산 판정(순수 로직).
+
+        dry-run / 백테스트 모델과 동일: 당일저 <= 손절가면 손절가 청산("stop"),
+        아니면 종가 청산("eod"). 유효 종가/저가가 없으면 None(판정 보류).
+        반환: {"exit_price": float, "exit_reason": "stop"|"eod"} | None
+        """
+        low = OverseasOrderExecutionService._to_float(daily_bar.get("low"))
+        close = OverseasOrderExecutionService._to_float(daily_bar.get("close"))
+        if close <= 0:
+            return None
+        stop = OverseasOrderExecutionService._to_float(stop_price)
+        if low > 0 and stop > 0 and low <= stop:
+            return {"exit_price": stop, "exit_reason": "stop"}
+        return {"exit_price": close, "exit_reason": "eod"}
+
+    @staticmethod
+    def _to_float(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def _price_str(x) -> str:
+        # 정수 가격은 정수 문자열, 그 외는 원본 float 문자열(불필요한 .0 회피).
+        f = OverseasOrderExecutionService._to_float(x)
+        if f == int(f):
+            return str(int(f)) if not isinstance(x, float) else str(f)
+        return str(f)

--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -34,6 +34,7 @@ class OverseasOrderExecutionService:
         live_enabled: bool = False,
         default_exchange: OverseasExchange = OverseasExchange.NASD,
         journal=None,
+        kill_switch=None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
@@ -41,6 +42,8 @@ class OverseasOrderExecutionService:
         self._live_enabled = bool(live_enabled)
         self._default_exchange = default_exchange
         self._journal = journal
+        # live 실주문 직전 차단 게이트(check_orders_allowed). paper 모드는 실주문이 없어 미적용.
+        self._kill_switch = kill_switch
         self._logger = logger or logging.getLogger(__name__)
 
     async def place_entry(
@@ -103,12 +106,31 @@ class OverseasOrderExecutionService:
         if not self._live_enabled:
             resp = self._would_be_response(symbol, ex, side, int(qty), limit_str, exit_reason)
         else:
+            blocked = await self._kill_switch_block(symbol, side)
+            if blocked is not None:
+                return blocked
             resp = await self._broker.place_overseas_limit_order(
                 symbol=symbol, exchange=ex, side=side, qty=int(qty), limit_price=limit_str,
             )
 
         self._record_journal(symbol, ex, side, int(qty), limit_str, signal, exit_reason, resp)
         return resp
+
+    async def _kill_switch_block(self, symbol: str, side: str) -> Optional[ResCommonResponse]:
+        """live 실주문 직전 kill-switch 차단 확인. 차단이면 응답 반환, 통과면 None."""
+        if self._kill_switch is None:
+            return None
+        allowed, reason = await self._kill_switch.check_orders_allowed()
+        if allowed:
+            return None
+        self._logger.warning({
+            "event": "overseas_order_kill_switch_blocked", "code": symbol,
+            "side": side, "reason": reason,
+        })
+        return ResCommonResponse(
+            rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value,
+            msg1=f"Kill Switch 활성 — {reason or ''}", data=None,
+        )
 
     def _would_be_response(
         self, symbol: str, ex: OverseasExchange, side: str, qty: int,

--- a/services/overseas_reconcile_service.py
+++ b/services/overseas_reconcile_service.py
@@ -1,0 +1,137 @@
+# services/overseas_reconcile_service.py
+"""해외 포지션 reconcile 서비스 (Phase 5).
+
+로컬 기대 포지션(paper/canary 추적)과 브로커 해외 잔고(`get_overseas_balance`)를
+비교해 drift(missing/extra/qty_mismatch)를 감지한다. **순수 비교 — 주문 경로 없음.**
+
+국내 `FillReconciliationService`(OrderStateMachine 결합, 주문 FSM 보정)와 달리, 해외는
+FSM/포지션 스토어가 아직 없고 live 가 잠겨 있으므로 자기완결적 drift 리포트만 산출한다.
+실 캐너리 가동(live_enabled) 단계에서 로컬 추적과 조인해 사용한다.
+
+브로커 잔고 응답은 공식 표본이 부족해 표본별 키가 갈리므로 다중 후보 키로 관용
+파싱한다(실 fixture 확보 시 단일화).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.types import ErrorCode
+
+# KIS 해외 잔고(TTTS3012R) output1 보유종목의 심볼/수량 후보 키.
+_SYMBOL_KEYS = ("ovrs_pdno", "pdno", "OVRS_PDNO", "PDNO")
+_QTY_KEYS = ("ovrs_cblc_qty", "cblc_qty", "hldg_qty", "ord_psbl_qty",
+             "OVRS_CBLC_QTY", "CBLC_QTY")
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+class OverseasReconcileService:
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+
+    @staticmethod
+    def parse_broker_positions(balance_response) -> Dict[str, int]:
+        """해외 잔고 응답에서 {심볼(대문자): 보유수량}을 관용 추출한다.
+
+        rt_cd 실패 / data 비정상 / 0·blank 수량은 모두 제외한다.
+        """
+        if balance_response is None:
+            return {}
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return {}
+        data = getattr(balance_response, "data", None)
+        if not isinstance(data, dict):
+            return {}
+        holdings = data.get("output1")
+        if not isinstance(holdings, list):
+            return {}
+
+        positions: Dict[str, int] = {}
+        for row in holdings:
+            if not isinstance(row, dict):
+                continue
+            symbol = ""
+            for k in _SYMBOL_KEYS:
+                if row.get(k):
+                    symbol = str(row.get(k)).strip().upper()
+                    break
+            if not symbol:
+                continue
+            qty = 0
+            for k in _QTY_KEYS:
+                if k in row:
+                    qty = _to_int(row.get(k))
+                    break
+            if qty > 0:
+                positions[symbol] = positions.get(symbol, 0) + qty
+        return positions
+
+    def reconcile(
+        self,
+        local_positions: Dict[str, int],
+        balance_response,
+    ) -> Dict[str, Any]:
+        """로컬 기대 포지션과 브로커 잔고를 비교해 drift 리포트를 반환한다.
+
+        반환: {ok, matched, missing_in_broker, extra_in_broker, qty_mismatch,
+               broker_positions, [error]}
+        잔고 조회 실패 시 ok=False + error="balance_query_failed" — 로컬을 함부로
+        missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+        """
+        local = {str(s).upper(): _to_int(q) for s, q in (local_positions or {}).items()}
+
+        if getattr(balance_response, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            self._logger.warning({
+                "event": "overseas_reconcile_balance_failed",
+                "msg": getattr(balance_response, "msg1", ""),
+            })
+            return {
+                "ok": False,
+                "error": "balance_query_failed",
+                "matched": [],
+                "missing_in_broker": [],
+                "extra_in_broker": [],
+                "qty_mismatch": [],
+                "broker_positions": {},
+            }
+
+        broker = self.parse_broker_positions(balance_response)
+
+        matched: List[str] = []
+        missing: List[Dict[str, Any]] = []
+        extra: List[Dict[str, Any]] = []
+        mismatch: List[Dict[str, Any]] = []
+
+        for symbol, lqty in local.items():
+            bqty = broker.get(symbol, 0)
+            if bqty == 0:
+                missing.append({"symbol": symbol, "local_qty": lqty})
+            elif bqty != lqty:
+                mismatch.append({"symbol": symbol, "local_qty": lqty, "broker_qty": bqty})
+            else:
+                matched.append(symbol)
+
+        for symbol, bqty in broker.items():
+            if symbol not in local:
+                extra.append({"symbol": symbol, "broker_qty": bqty})
+
+        ok = not (missing or extra or mismatch)
+        report = {
+            "ok": ok,
+            "matched": sorted(matched),
+            "missing_in_broker": sorted(missing, key=lambda d: d["symbol"]),
+            "extra_in_broker": sorted(extra, key=lambda d: d["symbol"]),
+            "qty_mismatch": sorted(mismatch, key=lambda d: d["symbol"]),
+            "broker_positions": broker,
+        }
+        if not ok:
+            self._logger.warning({"event": "overseas_reconcile_drift",
+                                  "missing": len(missing), "extra": len(extra),
+                                  "qty_mismatch": len(mismatch)})
+        return report

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -52,6 +52,7 @@ class PriceStreamService:
         self._tick_ingest_received: Dict[str, int] = {}
         self._tick_ingest_quality_reject: Dict[str, int] = {}
         self._tick_ingest_dispatched: Dict[str, int] = {}
+        self._tick_ingest_malformed: Dict[str, int] = {}
 
     def set_event_router(self, event_router) -> None:
         """Late injection 용. WebAppContext 조립 순서 문제로 생성자에 주입 못한 경우 사용."""
@@ -61,6 +62,7 @@ class PriceStreamService:
         """종목별 누적 tick 처리 카운터 스냅샷 (P2 2-4 shadow no-tick 진단).
 
         - received: 유효 payload 로 on_price_tick 에 진입한 frame 수
+        - malformed: 필수 필드(종목코드/현재가) 누락으로 버린 frame 수
         - quality_reject: DataQuality 게이트에서 탈락한 frame 수
         - dispatched: event_router 로 전달된 frame 수
         codes 가 주어지면 해당 종목만(미수신은 0으로) 반환한다.
@@ -70,6 +72,7 @@ class PriceStreamService:
                 set(self._tick_ingest_received)
                 | set(self._tick_ingest_quality_reject)
                 | set(self._tick_ingest_dispatched)
+                | set(self._tick_ingest_malformed)
             )
         else:
             keys = set(codes)
@@ -78,6 +81,7 @@ class PriceStreamService:
                 "received": self._tick_ingest_received.get(c, 0),
                 "quality_reject": self._tick_ingest_quality_reject.get(c, 0),
                 "dispatched": self._tick_ingest_dispatched.get(c, 0),
+                "malformed": self._tick_ingest_malformed.get(c, 0),
             }
             for c in sorted(keys)
         }
@@ -93,6 +97,8 @@ class PriceStreamService:
         current_price = realtime_data.get('주식현재가')
 
         if not stock_code or not current_price:
+            key = str(stock_code).strip() if stock_code else "__unknown__"
+            self._tick_ingest_malformed[key] = self._tick_ingest_malformed.get(key, 0) + 1
             return
 
         self._tick_ingest_received[stock_code] = self._tick_ingest_received.get(stock_code, 0) + 1

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -387,8 +387,19 @@ class WebSocketWatchdogTask(SchedulableTask):
             await asyncio.sleep(self.SUBSCRIBE_DELAY_SEC)
 
             success = await self._streaming_service.subscribe_unified_price(code)
-            if success and self._streaming_logger:
+            ack_confirmed = True
+            if success:
+                wait_ack = getattr(self._streaming_service, "wait_unified_price_ack", None)
+                if callable(wait_ack):
+                    ack_confirmed = bool(await wait_ack(code))
+            if success and ack_confirmed and self._streaming_logger:
                 self._streaming_logger.log_price_subscribe(code, reason="subscribed_no_tick_refresh")
+            elif self._streaming_logger:
+                reason = "ACK 미확정" if success else "구독 요청 실패"
+                self._streaming_logger.log_subscribe_failure(
+                    code,
+                    f"subscribed_no_tick_refresh {reason}",
+                )
 
             self._last_subscribed_no_tick_refresh_ts[code] = time.time()
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -553,8 +553,8 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         # max_positions 도달 → log_buy 호출 안됨
         vm.log_buy_async.assert_not_called()
 
-    async def test_run_strategy_allows_exits_but_skips_scan_when_live_gate_blocks_entries(self):
-        """실전 확대 gate 차단은 기존 포지션 청산을 유지하고 신규 scan만 막는다."""
+    async def test_run_strategy_scans_and_refreshes_shadow_when_live_gate_blocks_entries(self):
+        """실전 확대 gate 차단은 실주문만 막고 scan/shadow 관측 수집은 계속한다."""
         gate = MagicMock()
         gate.check_strategy.return_value = SimpleNamespace(
             allowed=False,
@@ -582,15 +582,20 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             exit_signals=[sell_signal],
         )
         strategy.scan = AsyncMock(return_value=strategy._scan_signals)
+        strategy.current_candidate_codes = MagicMock(return_value=["000660"])
         config = StrategySchedulerConfig(strategy=strategy, max_positions=3)
         scheduler.register(config)
 
-        with patch.object(scheduler, "_execute_signal", new_callable=AsyncMock) as mock_execute:
+        with patch.object(
+            scheduler, "_refresh_event_shadow_subscriptions", new_callable=AsyncMock
+        ) as refresh_shadow:
             await scheduler._run_strategy(config)
 
-        mock_execute.assert_awaited_once_with(sell_signal)
-        strategy.scan.assert_not_awaited()
-        scheduler._logger.warning.assert_called()
+        strategy.scan.assert_awaited_once()
+        refresh_shadow.assert_awaited_once_with(config)
+        scheduler._oes.handle_place_sell_order.assert_awaited_once()
+        scheduler._oes.handle_place_buy_order.assert_not_called()
+        self.assertIn("profitability_gate_blocked", scheduler._signal_history[-1].reason)
 
     async def test_execute_buy_signal_blocks_order_when_live_gate_blocks_entries(self):
         """방어선: scan 밖에서 들어온 BUY도 실전 확대 gate 미통과면 주문하지 않는다."""

--- a/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
@@ -171,8 +171,8 @@ async def test_refresh_subscriptions_attaches_tick_ingest_stats(tmp_path):
     journal = EventShadowJournalService(log_root=tmp_path)
     price_stream = MagicMock()
     price_stream.tick_ingest_stats_snapshot.return_value = {
-        "000660": {"received": 0, "quality_reject": 0, "dispatched": 0},
-        "005930": {"received": 12, "quality_reject": 12, "dispatched": 0},
+        "000660": {"received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 0},
+        "005930": {"received": 12, "quality_reject": 12, "dispatched": 0, "malformed": 0},
     }
     scheduler = _make_scheduler(
         event_router=router, event_shadow_journal=journal, price_stream_service=price_stream
@@ -185,7 +185,9 @@ async def test_refresh_subscriptions_attaches_tick_ingest_stats(tmp_path):
     path = tmp_path / "event_shadow" / "20260520.jsonl"
     records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
     tick_ingest = records[-1]["details"]["tick_ingest"]
-    assert tick_ingest["000660"] == {"received": 0, "quality_reject": 0, "dispatched": 0}
+    assert tick_ingest["000660"] == {
+        "received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 0,
+    }
     assert tick_ingest["005930"]["received"] == 12
     assert tick_ingest["005930"]["quality_reject"] == 12
 

--- a/tests/unit_test/scripts/test_analyze_no_tick_diagnosis.py
+++ b/tests/unit_test/scripts/test_analyze_no_tick_diagnosis.py
@@ -14,6 +14,7 @@ from scripts.analyze_no_tick_diagnosis import (
     A1,
     A2,
     A3,
+    MALFORMED,
     RECEIVED_NOT_DISPATCHED,
     UNKNOWN_NO_SNAPSHOT,
     classify_code,
@@ -59,6 +60,12 @@ def _shadow_status(recorded_at: float, tick_ingest: dict,
 
 def test_classify_a1_received_zero():
     assert classify_code({"received": 0, "quality_reject": 0, "dispatched": 0}) == A1
+
+
+def test_classify_malformed_payload():
+    assert classify_code(
+        {"received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 3}
+    ) == MALFORMED
 
 
 def test_classify_a2_quality_reject_all():

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -121,6 +121,41 @@ async def test_invalid_price_rejected_before_broker(price):
     broker.place_overseas_limit_order.assert_not_called()
 
 
+# ── kill-switch 게이트 (live 경로) ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_live_blocked_by_kill_switch_does_not_call_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "일일 손실 한도 초과"))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.KILL_SWITCH_BLOCKED.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_allowed_by_kill_switch_calls_broker():
+    broker = _broker()
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(True, None))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    broker.place_overseas_limit_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_paper_mode_skips_kill_switch_check():
+    """paper(live off)는 실주문이 없으므로 kill-switch 를 호출하지 않는다."""
+    ks = MagicMock()
+    ks.check_orders_allowed = AsyncMock(return_value=(False, "blocked"))
+    svc = OverseasOrderExecutionService(None, live_enabled=False, kill_switch=ks)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    ks.check_orders_allowed.assert_not_called()
+
+
 # ── 일봉 기반 exit 판정 (순수 로직) ───────────────────────────────────────────
 
 def test_decide_daily_exit_stop_when_low_breaks_stop():

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -1,0 +1,159 @@
+"""해외 VBO 게이팅 주문 실행 서비스 테스트 (Phase 4).
+
+핵심 안전 계약: `live_enabled=False`(기본)에서는 broker 주문 메서드가 **절대 호출되지
+않는다**(구조적 실주문 잠금). live_enabled=True 일 때만 실호출. dry-run 검증 + Phase 5
+canary/kill-switch 가 이 플래그를 켜는 유일한 주체다.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange, OverseasOrderReport
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_order_execution_service import OverseasOrderExecutionService
+
+
+def _broker(order_resp=None):
+    broker = MagicMock()
+    report = OverseasOrderReport(
+        symbol="AAPL", exchange=OverseasExchange.NASD, side="buy",
+        qty=6, limit_price="150.0", broker_order_no="0001234",
+    )
+    broker.place_overseas_limit_order = AsyncMock(
+        return_value=order_resp or ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=report
+        )
+    )
+    return broker
+
+
+# ── live_enabled=False: 구조적 실주문 잠금 ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_entry_default_does_not_call_broker():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=False)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    broker.place_overseas_limit_order.assert_not_called()
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    report = resp.data
+    assert report.side == "buy"
+    assert report.qty == 6
+    assert report.broker_order_no == ""  # would-be — 브로커 주문번호 없음
+    assert report.raw.get("would_be") is True
+    assert report.raw.get("signal_source") == OverseasOrderExecutionService.SIGNAL_SOURCE_PAPER
+
+
+@pytest.mark.asyncio
+async def test_exit_default_does_not_call_broker():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=False)
+    resp = await svc.place_exit(code="AAPL", qty=6, limit_price=148.0, reason="stop")
+    broker.place_overseas_limit_order.assert_not_called()
+    assert resp.data.side == "sell"
+    assert resp.data.raw.get("exit_reason") == "stop"
+
+
+@pytest.mark.asyncio
+async def test_paper_mode_works_without_broker():
+    """live_enabled=False 면 broker=None 이어도 would-be 주문이 가능해야 한다."""
+    svc = OverseasOrderExecutionService(None, live_enabled=False)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data.qty == 6
+
+
+# ── live_enabled=True: 실호출 ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_entry_live_calls_broker_with_buy_side():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True,
+                                        default_exchange=OverseasExchange.NASD)
+    resp = await svc.place_entry(code="aapl", qty=6, limit_price=150.0)
+    broker.place_overseas_limit_order.assert_awaited_once()
+    kwargs = broker.place_overseas_limit_order.await_args.kwargs
+    assert kwargs["side"] == "buy"
+    assert kwargs["symbol"] == "AAPL"  # 대문자 정규화
+    assert kwargs["qty"] == 6
+    assert kwargs["limit_price"] == "150.0"
+    assert kwargs["exchange"] == OverseasExchange.NASD
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data.broker_order_no == "0001234"
+
+
+@pytest.mark.asyncio
+async def test_exit_live_calls_broker_with_sell_side():
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    await svc.place_exit(code="AAPL", qty=6, limit_price=148.0, reason="eod")
+    kwargs = broker.place_overseas_limit_order.await_args.kwargs
+    assert kwargs["side"] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_live_propagates_broker_failure():
+    broker = _broker(ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="rejected", data=None))
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+
+
+# ── 검증: 어떤 모드에서도 잘못된 입력은 broker 도달 전 차단 ────────────────────
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("qty", [0, -1])
+async def test_invalid_qty_rejected_before_broker(qty):
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=qty, limit_price=150.0)
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("price", [0, -5.0])
+async def test_invalid_price_rejected_before_broker(price):
+    broker = _broker()
+    svc = OverseasOrderExecutionService(broker, live_enabled=True)
+    resp = await svc.place_entry(code="AAPL", qty=6, limit_price=price)
+    assert resp.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.place_overseas_limit_order.assert_not_called()
+
+
+# ── 일봉 기반 exit 판정 (순수 로직) ───────────────────────────────────────────
+
+def test_decide_daily_exit_stop_when_low_breaks_stop():
+    out = OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0,
+        daily_bar={"low": 96.0, "close": 99.0},
+    )
+    assert out == {"exit_price": 97.0, "exit_reason": "stop"}
+
+
+def test_decide_daily_exit_eod_when_stop_not_hit():
+    out = OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0,
+        daily_bar={"low": 98.0, "close": 101.0},
+    )
+    assert out == {"exit_price": 101.0, "exit_reason": "eod"}
+
+
+def test_decide_daily_exit_none_on_invalid_bar():
+    assert OverseasOrderExecutionService.decide_daily_exit(
+        entry_price=100.0, stop_price=97.0, daily_bar={}
+    ) is None
+
+
+# ── 저널 연동 (선택) ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_journal_records_order_when_provided():
+    journal = MagicMock()
+    svc = OverseasOrderExecutionService(None, live_enabled=False, journal=journal)
+    await svc.place_entry(code="AAPL", qty=6, limit_price=150.0,
+                          signal={"reason": "vbo_daily_breakout"})
+    journal.record.assert_called_once()
+    kwargs = journal.record.call_args.kwargs
+    assert kwargs["code"] == "AAPL"
+    assert kwargs["signal_source"] == OverseasOrderExecutionService.SIGNAL_SOURCE_PAPER

--- a/tests/unit_test/services/test_overseas_reconcile_service.py
+++ b/tests/unit_test/services/test_overseas_reconcile_service.py
@@ -1,0 +1,99 @@
+"""해외 포지션 reconcile 서비스 테스트 (Phase 5).
+
+로컬 기대 포지션 vs 브로커 해외 잔고 drift 감지(순수 비교, 주문 경로 없음).
+브로커 잔고 응답은 표본별 키가 갈리므로 다중 후보 키로 관용 파싱한다.
+"""
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_reconcile_service import OverseasReconcileService
+
+
+def _balance(holdings: list[dict]) -> ResCommonResponse:
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+        data={"output1": holdings, "output2": {}},
+    )
+
+
+# ── parse_broker_positions ────────────────────────────────────────────────────
+
+def test_parse_positions_primary_keys():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+        {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"},
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"AAPL": 10, "MSFT": 5}
+
+
+def test_parse_positions_fallback_keys_and_uppercase():
+    resp = _balance([
+        {"pdno": "tsla", "cblc_qty": "3"},   # fallback 키 + 소문자 심볼
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {"TSLA": 3}
+
+
+def test_parse_positions_skips_zero_and_blank():
+    resp = _balance([
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "0"},   # 0 수량 제외
+        {"ovrs_pdno": "", "ovrs_cblc_qty": "5"},        # 빈 심볼 제외
+        {"ovrs_pdno": "NVDA", "ovrs_cblc_qty": "bad"},  # 파싱 불가 → 0 → 제외
+    ])
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+def test_parse_positions_failed_response_returns_empty():
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None)
+    assert OverseasReconcileService.parse_broker_positions(resp) == {}
+
+
+# ── reconcile ─────────────────────────────────────────────────────────────────
+
+def test_reconcile_all_matched_ok():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is True
+    assert report["matched"] == ["AAPL"]
+    assert report["missing_in_broker"] == []
+    assert report["extra_in_broker"] == []
+    assert report["qty_mismatch"] == []
+
+
+def test_reconcile_missing_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([])  # 브로커에 없음
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["missing_in_broker"] == [{"symbol": "AAPL", "local_qty": 10}]
+
+
+def test_reconcile_extra_in_broker():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "10"},
+                     {"ovrs_pdno": "MSFT", "ovrs_cblc_qty": "5"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["extra_in_broker"] == [{"symbol": "MSFT", "broker_qty": 5}]
+
+
+def test_reconcile_qty_mismatch():
+    svc = OverseasReconcileService()
+    resp = _balance([{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "8"}])
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["qty_mismatch"] == [{"symbol": "AAPL", "local_qty": 10, "broker_qty": 8}]
+
+
+def test_reconcile_failed_balance_is_not_ok():
+    svc = OverseasReconcileService()
+    resp = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="잔고조회실패", data=None)
+    report = svc.reconcile({"AAPL": 10}, resp)
+    assert report["ok"] is False
+    assert report["error"] == "balance_query_failed"
+    # 잔고 조회 실패 시 로컬 포지션을 함부로 missing 으로 단정하지 않는다(조회 불가 ≠ 미보유).
+    assert report["missing_in_broker"] == []
+
+
+def test_reconcile_empty_both_ok():
+    svc = OverseasReconcileService()
+    report = svc.reconcile({}, _balance([]))
+    assert report["ok"] is True

--- a/tests/unit_test/services/test_price_stream_service_tick_ingest_stats.py
+++ b/tests/unit_test/services/test_price_stream_service_tick_ingest_stats.py
@@ -90,13 +90,15 @@ def test_no_router_no_dispatch_but_received(stock_repo, logger):
     assert snap["005930"]["quality_reject"] == 0
 
 
-def test_missing_payload_not_counted(stock_repo, logger):
+def test_missing_payload_counted_as_malformed(stock_repo, logger):
     svc = PriceStreamService(stock_repo=stock_repo, logger=logger)
 
     svc.on_price_tick({"주식현재가": "75000"})  # 코드 누락
     svc.on_price_tick({"유가증권단축종목코드": "005930"})  # 현재가 누락
 
-    assert svc.tick_ingest_stats_snapshot() == {}
+    snap = svc.tick_ingest_stats_snapshot(["005930", "__unknown__"])
+    assert snap["005930"] == {"received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 1}
+    assert snap["__unknown__"] == {"received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 1}
 
 
 def test_snapshot_zero_fills_requested_unseen_codes(stock_repo, logger):
@@ -107,4 +109,4 @@ def test_snapshot_zero_fills_requested_unseen_codes(stock_repo, logger):
     snap = svc.tick_ingest_stats_snapshot(["005930", "403870"])
     assert snap["005930"]["received"] == 1
     # 구독은 됐으나 tick 미수신인 종목 → 0으로 표면화 (a1 진단)
-    assert snap["403870"] == {"received": 0, "quality_reject": 0, "dispatched": 0}
+    assert snap["403870"] == {"received": 0, "quality_reject": 0, "dispatched": 0, "malformed": 0}

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -441,6 +441,7 @@ async def test_streaming_watchdog_refreshes_subscribed_no_tick_codes(watchdog_ta
     svc._price_stream_service.get_subscription_age.return_value = 190.0
     svc._price_stream_service.get_last_tick_ts.return_value = 0.0
     svc._streaming_service.broker.is_websocket_receive_alive.return_value = True
+    svc._streaming_service.wait_unified_price_ack = AsyncMock(return_value=True)
     svc.force_reconnect = AsyncMock()
 
     with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", side_effect=make_sleep_side_effect(2)):
@@ -452,6 +453,7 @@ async def test_streaming_watchdog_refreshes_subscribed_no_tick_codes(watchdog_ta
     svc._streaming_logger.log_missing_reason.assert_called_with("005930", "subscribed_no_tick")
     svc._streaming_service.unsubscribe_unified_price.assert_awaited_once_with("005930")
     svc._streaming_service.subscribe_unified_price.assert_awaited_once_with("005930")
+    svc._streaming_service.wait_unified_price_ack.assert_awaited_once_with("005930")
     svc.force_reconnect.assert_not_called()
 
 


### PR DESCRIPTION
## What changed
- Keep strategy scans and event-shadow refreshes running while the live profitability gate blocks BUY entries.
- Track malformed WebSocket price payloads separately from valid tick frames.
- Include malformed payloads in the no-tick diagnosis script/report so `received=0` no longer always means KIS sent no frames.
- Require ACK confirmation when the watchdog refreshes subscribed no-tick price streams.

## Why
The no-tick investigation needs cleaner evidence. A BUY gate should not stop shadow/parity data collection, malformed frames should not be classified as KIS no-send, and refresh success logs should mean the subscription was actually ACK-confirmed.

## Validation
- `pytest tests/unit_test -v` — 6292 passed
- `pytest tests/integration_test -v` — 243 passed