### PR TITLE
[codex] Notify strategy orders after fills

### DIFF
--- a/common/types.py
+++ b/common/types.py
@@ -131,6 +131,7 @@ class OrderContext(BaseModel):
     slippage_pct: Optional[float] = None
     first_fill_latency_sec: Optional[float] = None
     volatility_20d_annualized: Optional[float] = None  # 매수 신호 생성 시점 변동성 (리포트 집계용)
+    strategy_notification: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def sync_remaining_qty(self) -> "OrderContext":

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -932,6 +932,7 @@ class StrategyScheduler:
                             "finalize_immediately": False,
                             "trace_id": tid,
                             "volatility_20d_annualized": signal.volatility_20d_annualized,
+                            "strategy_notification": self._strategy_notification_payload(signal, log_price),
                         }
                         buy_order_kwargs.update(self._signal_price_policy_kwargs(signal))
                         resp = await self._oes.handle_place_buy_order(
@@ -951,6 +952,7 @@ class StrategyScheduler:
                         "source": self._source_for_signal(signal),
                         "finalize_immediately": False,
                         "trace_id": tid,
+                        "strategy_notification": self._strategy_notification_payload(signal, log_price),
                     }
                     sell_order_kwargs.update(self._signal_price_policy_kwargs(signal))
                     resp = await self._oes.handle_place_sell_order(
@@ -1036,7 +1038,7 @@ class StrategyScheduler:
         )
         await self._record_signal(record)
 
-        if self._notification_service and not order_deferred:
+        if self._notification_service and not order_deferred and (self._dry_run or not api_success):
             action_kr = "매수" if signal.action == "BUY" else "매도"
             # 성공에 CRITICAL 사용은 의도된 것: Telegram route_levels.STRATEGY 가
             # warning/error/critical 만 통과시키므로 INFO 로 낮추면 실주문 접수
@@ -1071,6 +1073,18 @@ class StrategyScheduler:
                     "return_rate": return_rate,
                     "trace_id": tid,
                 })
+
+    @staticmethod
+    def _strategy_notification_payload(signal: TradeSignal, log_price: int) -> dict:
+        return {
+            "strategy_name": signal.strategy_name,
+            "stock_name": signal.name,
+            "code": signal.code,
+            "action": signal.action,
+            "price": log_price,
+            "qty": signal.qty,
+            "reason": signal.reason,
+        }
 
     @staticmethod
     def _virtual_trade_log_kwargs(signal: TradeSignal) -> dict:

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -220,6 +220,7 @@ class FillReconciliationService:
             "source": context.source,
             "trace_id": context.trace_id or "",
         }
+        strategy_notification = dict(context.strategy_notification or {})
 
         if context.state == OrderState.FILLED:
             level = NotificationLevel.INFO
@@ -249,9 +250,38 @@ class FillReconciliationService:
         else:
             return
 
+        if strategy_notification:
+            strategy_name = strategy_notification.get("strategy_name") or self._strategy_name_from_source(context.source)[0]
+            stock_name = strategy_notification.get("stock_name") or context.stock_code
+            requested_price = strategy_notification.get("price") or context.price
+            requested_qty = strategy_notification.get("qty") or context.qty
+            reason = strategy_notification.get("reason") or ""
+            try:
+                requested_price_text = f"{int(requested_price):,}원"
+            except (TypeError, ValueError):
+                requested_price_text = "N/A"
+            if context.state == OrderState.FILLED:
+                level = NotificationLevel.CRITICAL
+                title = f"[{strategy_name}] {stock_name} {side_label} 체결 완료"
+                status_line = f"상태: 체결 완료({context.filled_qty}/{context.qty}주)"
+            else:
+                level = NotificationLevel.ERROR
+                title = f"[{strategy_name}] {stock_name} {side_label} 실패"
+                status_line = f"상태: {context.state.value}"
+            message = (
+                f"종목: {stock_name}({context.stock_code})\n"
+                f"주문: {requested_price_text} × {requested_qty}주\n"
+                f"체결: {fill_price or 'N/A'}원 × {context.filled_qty}/{context.qty}주\n"
+                f"사유: {reason}\n"
+                f"{status_line}"
+            )
+            if context.state != OrderState.FILLED and metadata.get("reason"):
+                message = f"{message}\n실패: {metadata['reason']}"
+            metadata.update(strategy_notification)
+
         try:
             await self._notification_service.emit(
-                NotificationCategory.TRADE,
+                NotificationCategory.STRATEGY if strategy_notification else NotificationCategory.TRADE,
                 level,
                 title,
                 message,

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -472,6 +472,7 @@ class OrderExecutionService:
         volatility_20d_annualized: Optional[float] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        strategy_notification: Optional[dict] = None,
     ):
         """주식 매수 주문 요청 및 결과 출력."""
         current_trace = trace_id or get_trace_id() or new_trace_id("MANUAL")
@@ -507,6 +508,7 @@ class OrderExecutionService:
                 volatility_20d_annualized=volatility_20d_annualized,
                 invalidation_price=invalidation_price,
                 stop_loss_price=stop_loss_price,
+                strategy_notification=strategy_notification,
             )
             if buy_order_result and buy_order_result.rt_cd == ErrorCode.SUCCESS.value:
                 self.logger.info(
@@ -546,6 +548,7 @@ class OrderExecutionService:
         intent_id: Optional[str] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        strategy_notification: Optional[dict] = None,
     ):
         """주식 매도 주문 요청 및 결과 출력."""
         current_trace = trace_id or get_trace_id() or new_trace_id("MANUAL")
@@ -570,6 +573,7 @@ class OrderExecutionService:
                 intent_id=intent_id,
                 invalidation_price=invalidation_price,
                 stop_loss_price=stop_loss_price,
+                strategy_notification=strategy_notification,
             )
             if sell_order_result and sell_order_result.rt_cd == ErrorCode.SUCCESS.value:
                 self.logger.info(

--- a/services/order_submission_coordinator.py
+++ b/services/order_submission_coordinator.py
@@ -179,6 +179,7 @@ class OrderSubmissionCoordinator:
         volatility_20d_annualized: Optional[float] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        strategy_notification: Optional[dict] = None,
     ) -> ResCommonResponse:
         order_key = self._fsm.make_order_key(stock_code, side, exchange)
         action_kr = "매수" if side == OrderSide.BUY else "매도"
@@ -317,6 +318,7 @@ class OrderSubmissionCoordinator:
                 order_type=self._exec_quality_reporter.resolve_order_type(price, policy_decision),
                 spread_pct=self._exec_quality_reporter.resolve_spread_pct(policy_decision),
                 volatility_20d_annualized=volatility_20d_annualized,
+                strategy_notification=dict(strategy_notification or {}),
             )
             self._fsm.register(context)
             self._fsm.register_intent(resolved_intent_id, order_key)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -527,7 +527,12 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             finalize_immediately=False,
             trace_id=ANY,
             volatility_20d_annualized=None,
+            strategy_notification=ANY,
         )
+        payload = oes.handle_place_buy_order.call_args.kwargs["strategy_notification"]
+        self.assertEqual(payload["strategy_name"], "테스트전략")
+        self.assertEqual(payload["stock_name"], "삼성전자")
+        self.assertEqual(payload["reason"], "테스트")
 
     async def test_run_strategy_scan_respects_max_positions(self):
         """max_positions에 도달하면 스캔을 스킵하는지 테스트."""
@@ -1854,6 +1859,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy_force_exit:TestStrategy",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
         # 3. live 모드 가상매매 기록은 체결 확인 이후 OrderExecutionService가 처리
         vm.log_sell_by_strategy_async.assert_not_awaited()
@@ -1889,6 +1895,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy_force_exit:TestStrategy",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
         vm.log_sell_by_strategy_async.assert_not_awaited()
 
@@ -2015,6 +2022,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy:TestStrat",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
         vm.log_sell_by_strategy_async.assert_not_awaited()
 
@@ -2102,6 +2110,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy:TestStrat",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
 
         vm.log_sell_by_strategy_async.assert_not_awaited()
@@ -2536,6 +2545,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy_force_exit:S",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
 
     async def test_force_liquidate_uses_broker_holding_for_successful_buy_missing_journal(self):
@@ -2587,6 +2597,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             source="strategy_force_exit:래리윌리엄스VBO",
             finalize_immediately=False,
             trace_id=ANY,
+            strategy_notification=ANY,
         )
 
     async def test_force_liquidate_skips_signal_history_recovery_when_buy_order_active(self):
@@ -2882,7 +2893,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         scheduler._logger.warning.assert_called()
 
     async def test_execute_signal_notification_success(self):
-        """_execute_signal() API 주문 성공 시 알림 전송 테스트."""
+        """실주문 성공 직후에는 체결 미확정 전략 알림을 보내지 않는다."""
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
         mock_notifier = AsyncMock()
         scheduler._notification_service = mock_notifier
@@ -2890,12 +2901,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         signal = TradeSignal(code="005930", name="삼성전자", action="BUY", price=70000, qty=1, reason="Test", strategy_name="S1")
         await scheduler._execute_signal(signal)
         
-        mock_notifier.emit.assert_awaited_once()
-        args, kwargs = mock_notifier.emit.call_args
-        self.assertEqual(args[0], NotificationCategory.STRATEGY)
-        self.assertEqual(args[1], NotificationLevel.CRITICAL)
-        self.assertTrue("주문 접수" in args[2])
-        self.assertTrue("체결 미확정" in args[3])
+        mock_notifier.emit.assert_not_awaited()
 
     async def test_execute_sell_signal_notification_includes_estimated_return_rate(self):
         """실전 매도 알림은 체결 확정 전에도 보유 매수가 기준 수익률을 포함한다."""
@@ -2914,10 +2920,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         await scheduler._execute_signal(signal)
 
         vm.log_sell_by_strategy_async.assert_not_awaited()
-        mock_notifier.emit.assert_awaited_once()
-        args, kwargs = mock_notifier.emit.call_args
-        self.assertEqual(args[0], NotificationCategory.STRATEGY)
-        self.assertEqual(kwargs["metadata"]["return_rate"], 10.0)
+        mock_notifier.emit.assert_not_awaited()
         self.assertEqual(scheduler._signal_history[-1].return_rate, 10.0)
 
     async def test_execute_signal_notification_failure(self):
@@ -2972,6 +2975,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             finalize_immediately=False,
             trace_id=ANY,
             volatility_20d_annualized=None,
+            strategy_notification=ANY,
         )
 
     async def test_restore_state_with_price_subscription(self):

--- a/tests/unit_test/scheduler/test_strategy_scheduler_sizing.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_sizing.py
@@ -144,7 +144,7 @@ async def test_buy_with_sizer_zero_qty_emits_failure_notification():
 
 @pytest.mark.asyncio
 async def test_buy_with_sizer_adjusted_qty_recorded_and_notified():
-    """sizer가 수량을 줄이면 기록과 알림에도 실제 주문 수량을 사용한다."""
+    """sizer가 수량을 줄이면 기록과 최종 알림 payload에도 실제 주문 수량을 사용한다."""
     sizer = AsyncMock()
     sizer.adjust_buy_qty.return_value = (3, "risk_limited")
 
@@ -156,9 +156,8 @@ async def test_buy_with_sizer_adjusted_qty_recorded_and_notified():
     await scheduler._execute_signal(signal)
 
     assert scheduler._signal_history[0].qty == 3
-    args, kwargs = notifier.emit.call_args
-    assert "3주" in args[3]
-    assert kwargs["metadata"]["qty"] == 3
+    notifier.emit.assert_not_awaited()
+    assert oes.handle_place_buy_order.call_args.kwargs["strategy_notification"]["qty"] == 3
 
 
 # ── dry_run=True 이면 sizer 호출 안 함 ────────────────────────────────

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -163,6 +163,51 @@ async def test_apply_execution_report_filled_emits_completion_notification(
 
 
 @pytest.mark.asyncio
+async def test_apply_execution_report_filled_emits_strategy_final_notification(
+    broker, fsm, reporter, fixed_now
+):
+    notification = AsyncMock()
+    svc = _make_service(
+        broker=broker,
+        fsm=fsm,
+        reporter=reporter,
+        fixed_now=fixed_now,
+        notification_service=notification,
+    )
+    ctx = fsm.register(_make_context(
+        order_key="KRX:005930:SELL",
+        side=OrderSide.SELL,
+        source="strategy:LarryWilliamsCB",
+        strategy_notification={
+            "strategy_name": "LarryWilliamsCB",
+            "stock_name": "롯데쇼핑",
+            "code": "005930",
+            "action": "SELL",
+            "price": 179400,
+            "qty": 10,
+            "reason": "칼손절",
+        },
+    ))
+    fsm.transition(ctx.order_key, OrderState.SUBMITTED, broker_order_no="B0001")
+
+    report = OrderExecutionReport(
+        broker_order_no="B0001", stock_code="005930", side=OrderSide.SELL,
+        fill_qty=10, fill_price=179300, cumulative_filled_qty=10, remaining_qty=0,
+    )
+    await svc.apply_execution_report(report)
+
+    notification.emit.assert_awaited_once()
+    args, kwargs = notification.emit.await_args
+    assert args[0] == NotificationCategory.STRATEGY
+    assert args[1] == NotificationLevel.CRITICAL
+    assert args[2] == "[LarryWilliamsCB] 롯데쇼핑 매도 체결 완료"
+    assert "체결 완료" in args[3]
+    assert "칼손절" in args[3]
+    assert kwargs["metadata"]["strategy_name"] == "LarryWilliamsCB"
+    assert kwargs["metadata"]["state"] == OrderState.FILLED.value
+
+
+@pytest.mark.asyncio
 async def test_apply_execution_report_rejected_emits_failure_notification(
     broker, fsm, reporter, fixed_now
 ):


### PR DESCRIPTION
﻿## What changed

- Preserve strategy signal details on the order FSM context so fill reconciliation can use them later.
- Suppress live strategy success notifications at API submit time, avoiding the previous "API success, fill unconfirmed" alert.
- Emit the strategy notification only when fill reconciliation reaches a terminal state from websocket/polling results.

## Why

The previous alert reported only API order acceptance. For live strategy orders, users need the confirmed outcome from signing notices or broker polling instead.

## Validation

- `python -m pytest tests\unit_test -q`
- `python -m pytest tests\integration_test -q`
