### PR TITLE
테마/업종 주도주 랭킹 기능 (Phase A: 네이버 테마)

### DIFF
--- a/repositories/stock_classification_repository.py
+++ b/repositories/stock_classification_repository.py
@@ -1,0 +1,238 @@
+# repositories/stock_classification_repository.py
+"""
+종목 테마/업종 분류를 다중 소스(NAVER/KIWOOM/WICS)로 저장·조회하는 Repository.
+
+- 테이블: stock_classifications (source, category_type, group_name, normalized_name, code, name, collected_at)
+- 테이블: theme_aliases (source, raw_name, normalized_name)
+- `stocks` 처럼 주기적으로 replace 되는 휘발성 DB와 분리하기 위해 전용 DB 파일을 사용한다.
+- 조회는 normalized_name 기준으로 소스를 union 하고, 종목별 출처(provenance)를 보존한다.
+"""
+import os
+import sqlite3
+import asyncio
+import aiosqlite
+import logging
+from typing import Optional, List, Dict, Any
+
+
+class StockClassificationRepository:
+    """종목 분류(테마/업종) 전담 저장소 (SQLite, 다중 소스 union)."""
+
+    def __init__(self, db_path: str = None, logger=None):
+        self._logger = logger or logging.getLogger(__name__)
+        self._db_path = db_path or os.path.join("data", "stock_classifications.db")
+        self._write_lock: Optional[asyncio.Lock] = None
+        self._write_conn: Optional[aiosqlite.Connection] = None
+        self._read_conn: Optional[aiosqlite.Connection] = None
+        self._read_conn_lock: Optional[asyncio.Lock] = None
+
+        os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
+        self._init_db_sync()
+
+    def _init_db_sync(self):
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA synchronous=NORMAL")
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS stock_classifications (
+                        source TEXT NOT NULL,
+                        category_type TEXT NOT NULL,
+                        group_name TEXT NOT NULL,
+                        normalized_name TEXT NOT NULL,
+                        code TEXT NOT NULL,
+                        name TEXT,
+                        collected_at TEXT,
+                        PRIMARY KEY (source, category_type, group_name, code)
+                    )
+                """)
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS theme_aliases (
+                        source TEXT NOT NULL,
+                        raw_name TEXT NOT NULL,
+                        normalized_name TEXT NOT NULL,
+                        PRIMARY KEY (source, raw_name)
+                    )
+                """)
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_classifications_norm "
+                    "ON stock_classifications(category_type, normalized_name)"
+                )
+                conn.commit()
+        except Exception as e:
+            self._logger.error(f"StockClassificationRepository DB 초기화 실패: {e}")
+
+    async def _get_write_conn(self) -> aiosqlite.Connection:
+        if self._write_conn is None:
+            self._write_conn = await aiosqlite.connect(self._db_path)
+            await self._write_conn.execute("PRAGMA journal_mode=WAL")
+            await self._write_conn.execute("PRAGMA synchronous=NORMAL")
+        return self._write_conn
+
+    async def _get_read_conn(self) -> aiosqlite.Connection:
+        if self._read_conn is None:
+            self._read_conn = await aiosqlite.connect(self._db_path)
+            await self._read_conn.execute("PRAGMA journal_mode=WAL")
+        return self._read_conn
+
+    async def _ensure_locks(self):
+        if self._write_lock is None:
+            self._write_lock = asyncio.Lock()
+        if self._read_conn_lock is None:
+            self._read_conn_lock = asyncio.Lock()
+
+    async def upsert_classifications(self, records: List[Dict[str, Any]]) -> int:
+        """배치 upsert.
+
+        records: [{"source", "category_type", "group_name", "normalized_name",
+                   "code", "name", "collected_at"}] 리스트.
+        성공적으로 저장 시도한 레코드 수를 반환.
+        """
+        if not records:
+            return 0
+        await self._ensure_locks()
+        async with self._write_lock:
+            try:
+                conn = await self._get_write_conn()
+                await conn.executemany(
+                    """
+                    INSERT INTO stock_classifications
+                        (source, category_type, group_name, normalized_name, code, name, collected_at)
+                    VALUES
+                        (:source, :category_type, :group_name, :normalized_name, :code, :name, :collected_at)
+                    ON CONFLICT(source, category_type, group_name, code) DO UPDATE SET
+                        normalized_name = excluded.normalized_name,
+                        name            = excluded.name,
+                        collected_at    = excluded.collected_at
+                    """,
+                    records,
+                )
+                await conn.commit()
+                return len(records)
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.upsert_classifications 실패: {e}")
+                return 0
+
+    async def upsert_aliases(self, records: List[Dict[str, str]]) -> int:
+        """theme_aliases 배치 upsert. records: [{"source","raw_name","normalized_name"}]."""
+        if not records:
+            return 0
+        await self._ensure_locks()
+        async with self._write_lock:
+            try:
+                conn = await self._get_write_conn()
+                await conn.executemany(
+                    """
+                    INSERT INTO theme_aliases (source, raw_name, normalized_name)
+                    VALUES (:source, :raw_name, :normalized_name)
+                    ON CONFLICT(source, raw_name) DO UPDATE SET
+                        normalized_name = excluded.normalized_name
+                    """,
+                    records,
+                )
+                await conn.commit()
+                return len(records)
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.upsert_aliases 실패: {e}")
+                return 0
+
+    async def get_alias_map(self, source: str) -> Dict[str, str]:
+        """특정 소스의 {raw_name: normalized_name} 매핑 반환. 없으면 빈 딕셔너리."""
+        await self._ensure_locks()
+        async with self._read_conn_lock:
+            try:
+                conn = await self._get_read_conn()
+                async with conn.execute(
+                    "SELECT raw_name, normalized_name FROM theme_aliases WHERE source = ?",
+                    (source,),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                return {row[0]: row[1] for row in rows}
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.get_alias_map({source}) 실패: {e}")
+                return {}
+
+    async def get_groups(
+        self,
+        category_types: tuple = ("theme",),
+        sources: Optional[tuple] = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        """normalized_name 기준으로 분류 그룹을 union 하여 반환.
+
+        Returns:
+            {
+                normalized_name: {
+                    "sources": ["NAVER", ...],   # 그룹 전체 소스(정렬)
+                    "members": [{"code", "name", "sources": [...]}, ...]
+                }, ...
+            }
+        데이터가 없으면 빈 딕셔너리.
+        """
+        if not category_types:
+            return {}
+        await self._ensure_locks()
+        async with self._read_conn_lock:
+            try:
+                conn = await self._get_read_conn()
+                params: list = list(category_types)
+                cat_ph = ",".join("?" for _ in category_types)
+                sql = (
+                    "SELECT normalized_name, code, name, source "
+                    "FROM stock_classifications "
+                    f"WHERE category_type IN ({cat_ph})"
+                )
+                if sources:
+                    src_ph = ",".join("?" for _ in sources)
+                    sql += f" AND source IN ({src_ph})"
+                    params.extend(sources)
+                async with conn.execute(sql, params) as cursor:
+                    rows = await cursor.fetchall()
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.get_groups 실패: {e}")
+                return {}
+
+        # normalized_name → {code → {name, sources(set)}}, group sources(set)
+        groups: Dict[str, Dict[str, Any]] = {}
+        for normalized_name, code, name, source in rows:
+            g = groups.setdefault(normalized_name, {"_sources": set(), "_members": {}})
+            g["_sources"].add(source)
+            m = g["_members"].setdefault(code, {"code": code, "name": name, "_sources": set()})
+            m["_sources"].add(source)
+            if name and not m["name"]:
+                m["name"] = name
+
+        result: Dict[str, Dict[str, Any]] = {}
+        for normalized_name, g in groups.items():
+            members = [
+                {"code": m["code"], "name": m["name"], "sources": sorted(m["_sources"])}
+                for m in g["_members"].values()
+            ]
+            result[normalized_name] = {
+                "sources": sorted(g["_sources"]),
+                "members": members,
+            }
+        return result
+
+    async def get_latest_collected_at(self) -> Optional[str]:
+        """가장 최근 collected_at 값 반환. 데이터가 없으면 None."""
+        await self._ensure_locks()
+        async with self._read_conn_lock:
+            try:
+                conn = await self._get_read_conn()
+                async with conn.execute(
+                    "SELECT MAX(collected_at) FROM stock_classifications"
+                ) as cursor:
+                    row = await cursor.fetchone()
+                return row[0] if row and row[0] else None
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.get_latest_collected_at 실패: {e}")
+                return None
+
+    async def close(self):
+        """비동기 연결 종료."""
+        if self._write_conn:
+            await self._write_conn.close()
+            self._write_conn = None
+        if self._read_conn:
+            await self._read_conn.close()
+            self._read_conn = None

--- a/services/theme_classification_collector_service.py
+++ b/services/theme_classification_collector_service.py
@@ -1,0 +1,141 @@
+# services/theme_classification_collector_service.py
+"""
+네이버 금융 테마 분류를 스크래핑하여 StockClassificationRepository에 적재하는 서비스.
+
+- 목록: finance.naver.com/sise/sise_group.naver?type=theme  → 테마명 + detail no
+- 상세: finance.naver.com/sise/sise_group_detail.naver?type=theme&no=N → 구성종목(code, name)
+- 개별 실패는 warning 후 skip(부분 성공 허용). 파싱은 정적 메서드로 분리해 테스트 가능.
+- HTML 구조 변경 시 깨질 수 있으므로 graceful degrade(예외 흡수, 0 반환)를 유지한다.
+"""
+import re
+import asyncio
+import logging
+from datetime import datetime
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+import aiohttp
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    from repositories.stock_classification_repository import StockClassificationRepository
+
+_BASE = "https://finance.naver.com"
+_LIST_URL = _BASE + "/sise/sise_group.naver?type=theme"
+_DETAIL_URL = _BASE + "/sise/sise_group_detail.naver?type=theme&no={no}"
+
+_RE_DETAIL_NO = re.compile(r"no=(\d+)")
+_RE_CODE = re.compile(r"code=(\d{6})")
+
+
+class ThemeClassificationCollectorService:
+    """네이버 테마 분류 수집기 (NAVER, category_type=theme)."""
+
+    SOURCE = "NAVER"
+    CATEGORY_TYPE = "theme"
+
+    def __init__(
+        self,
+        classification_repository: "StockClassificationRepository",
+        logger: Optional[logging.Logger] = None,
+        request_delay: float = 0.3,
+    ):
+        self._repo = classification_repository
+        self._logger = logger or logging.getLogger(__name__)
+        self._request_delay = request_delay
+        self._headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            )
+        }
+
+    async def collect_naver_themes(self) -> int:
+        """네이버 테마 전체를 수집·저장하고 저장한 레코드 수를 반환한다."""
+        try:
+            list_html = await self._fetch_html(_LIST_URL)
+            themes = self._parse_theme_list(list_html)
+        except Exception as e:
+            self._logger.warning({"event": "theme_list_fetch_failed", "error": str(e)})
+            return 0
+
+        if not themes:
+            self._logger.warning({"event": "theme_list_empty"})
+            return 0
+
+        alias_map = await self._repo.get_alias_map(self.SOURCE)
+        collected_at = datetime.now().isoformat(timespec="seconds")
+        records: List[dict] = []
+
+        for no, raw_name in themes:
+            try:
+                detail_html = await self._fetch_html(_DETAIL_URL.format(no=no))
+                members = self._parse_theme_members(detail_html)
+            except Exception as e:
+                self._logger.warning({"event": "theme_detail_fetch_failed", "no": no, "error": str(e)})
+                continue
+
+            normalized = alias_map.get(raw_name, raw_name)
+            for code, name in members:
+                records.append({
+                    "source": self.SOURCE,
+                    "category_type": self.CATEGORY_TYPE,
+                    "group_name": raw_name,
+                    "normalized_name": normalized,
+                    "code": code,
+                    "name": name,
+                    "collected_at": collected_at,
+                })
+            if self._request_delay:
+                await asyncio.sleep(self._request_delay)
+
+        if not records:
+            return 0
+        saved = await self._repo.upsert_classifications(records)
+        self._logger.info({"event": "theme_collect_done", "themes": len(themes), "records": saved})
+        return saved
+
+    async def _fetch_html(self, url: str) -> str:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=self._headers, timeout=10) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"HTTP {response.status}")
+                # 네이버 금융은 EUC-KR 인코딩
+                return await response.text(encoding="euc-kr", errors="replace")
+
+    @staticmethod
+    def _parse_theme_list(html: str) -> List[Tuple[str, str]]:
+        """테마 목록 페이지에서 [(no, raw_name)] 추출."""
+        soup = BeautifulSoup(html, "html.parser")
+        out: List[Tuple[str, str]] = []
+        seen = set()
+        for a in soup.select('a[href*="sise_group_detail.naver"]'):
+            href = a.get("href", "")
+            m = _RE_DETAIL_NO.search(href)
+            if not m:
+                continue
+            no = m.group(1)
+            name = a.get_text(strip=True)
+            if not name or no in seen:
+                continue
+            seen.add(no)
+            out.append((no, name))
+        return out
+
+    @staticmethod
+    def _parse_theme_members(html: str) -> List[Tuple[str, str]]:
+        """테마 상세 페이지에서 [(code, name)] 추출."""
+        soup = BeautifulSoup(html, "html.parser")
+        out: List[Tuple[str, str]] = []
+        seen = set()
+        for a in soup.select('a[href*="code="]'):
+            href = a.get("href", "")
+            m = _RE_CODE.search(href)
+            if not m:
+                continue
+            code = m.group(1)
+            name = a.get_text(strip=True)
+            if not name or code in seen:
+                continue
+            seen.add(code)
+            out.append((code, name))
+        return out

--- a/services/theme_leader_service.py
+++ b/services/theme_leader_service.py
@@ -1,0 +1,113 @@
+# services/theme_leader_service.py
+"""
+테마/업종 그룹별 주도주(RS Rating 상위 종목)를 식별하는 서비스.
+
+분류 데이터(StockClassificationRepository)와 이미 계산된 RS Rating(RSRatingRepository)을
+join 하여, 각 그룹 안에서 RS 상위 종목을 주도주로 선정한다. 네트워크 호출 없이
+저장된 데이터만 읽는 온디맨드 조회이며, 수집(스크래핑)은 별도 태스크가 담당한다.
+"""
+import logging
+import statistics
+from typing import Optional, TYPE_CHECKING
+
+from common.types import ResCommonResponse, ErrorCode
+from core.performance_profiler import PerformanceProfiler
+
+if TYPE_CHECKING:
+    from repositories.stock_classification_repository import StockClassificationRepository
+    from repositories.rs_rating_repository import RSRatingRepository
+
+
+class ThemeLeaderService:
+    """그룹(테마/업종) 내 RS 상위 종목을 주도주로 반환하는 서비스."""
+
+    def __init__(
+        self,
+        classification_repository: "StockClassificationRepository",
+        rs_rating_repository: "RSRatingRepository",
+        logger=None,
+        performance_profiler: Optional[PerformanceProfiler] = None,
+    ):
+        self._classification_repo = classification_repository
+        self._rs_repo = rs_rating_repository
+        self._logger = logger or logging.getLogger(__name__)
+        self.pm = performance_profiler or PerformanceProfiler(enabled=False)
+
+    async def get_theme_leaders(
+        self,
+        top_n: int = 5,
+        category_types: tuple = ("theme",),
+    ) -> ResCommonResponse:
+        """그룹별 주도주 목록을 그룹 강도(RS 중앙값) 내림차순으로 반환한다.
+
+        data = [{
+            "normalized_name": str,
+            "sources": [str, ...],
+            "group_rs_median": float,
+            "member_count": int,
+            "leaders": [{"code", "name", "rs_rating", "sources"}, ...]
+        }, ...]
+        """
+        t_start = self.pm.start_timer()
+        try:
+            groups = await self._classification_repo.get_groups(category_types)
+            if not groups:
+                return ResCommonResponse(
+                    rt_cd=ErrorCode.SUCCESS.value,
+                    msg1="테마 데이터가 아직 수집되지 않았습니다.",
+                    data=[],
+                )
+
+            trade_date = await self._rs_repo.get_latest_date()
+            rs_map = await self._rs_repo.get_by_date(trade_date) if trade_date else {}
+            if not rs_map:
+                return ResCommonResponse(
+                    rt_cd=ErrorCode.SUCCESS.value,
+                    msg1="RS Rating 데이터가 아직 없습니다.",
+                    data=[],
+                )
+
+            result = []
+            for normalized_name, group in groups.items():
+                scored = [
+                    (member, rs_map[member["code"]])
+                    for member in group["members"]
+                    if member["code"] in rs_map
+                ]
+                if not scored:
+                    continue
+                scored.sort(key=lambda x: x[1], reverse=True)
+                leaders = [
+                    {
+                        "code": member["code"],
+                        "name": member["name"],
+                        "rs_rating": rs,
+                        "sources": member["sources"],
+                    }
+                    for member, rs in scored[:top_n]
+                ]
+                rs_values = [rs for _, rs in scored]
+                result.append({
+                    "normalized_name": normalized_name,
+                    "sources": group["sources"],
+                    "group_rs_median": float(statistics.median(rs_values)),
+                    "member_count": len(scored),
+                    "leaders": leaders,
+                })
+
+            result.sort(key=lambda g: g["group_rs_median"], reverse=True)
+
+            self.pm.log_timer("ThemeLeaderService.get_theme_leaders", t_start,
+                              extra_info=f"groups={len(result)}")
+            return ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1=f"성공 ({len(result)}개 그룹)",
+                data=result,
+            )
+        except Exception as e:
+            self._logger.exception(f"ThemeLeaderService.get_theme_leaders 오류: {e}")
+            return ResCommonResponse(
+                rt_cd=ErrorCode.UNKNOWN_ERROR.value,
+                msg1=str(e),
+                data=None,
+            )

--- a/task/background/after_market/theme_classification_task.py
+++ b/task/background/after_market/theme_classification_task.py
@@ -1,0 +1,98 @@
+# task/background/after_market/theme_classification_task.py
+"""
+장 마감 후 네이버 테마 분류를 주기적으로 수집하는 백그라운드 태스크.
+
+테마 구성은 천천히 변하므로 기본 7일 간격으로만 수집한다(최근 수집 후 간격 미경과 시 skip).
+수집 자체는 ThemeClassificationCollectorService가 담당하고, 본 태스크는 스케줄링/주기 가드만 맡는다.
+"""
+import logging
+from datetime import datetime
+from typing import Dict, Optional, TYPE_CHECKING
+
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+    from services.theme_classification_collector_service import ThemeClassificationCollectorService
+    from repositories.stock_classification_repository import StockClassificationRepository
+
+
+class ThemeClassificationTask(AfterMarketTask):
+    """장 마감 후 네이버 테마 분류를 주기적으로 수집하는 태스크."""
+
+    def __init__(
+        self,
+        collector_service: "ThemeClassificationCollectorService",
+        classification_repository: "StockClassificationRepository",
+        market_calendar_service: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        logger=None,
+        refresh_interval_days: int = 7,
+        worker_pool=None,
+    ):
+        super().__init__(
+            mcs=market_calendar_service,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._collector = collector_service
+        self._repo = classification_repository
+        self._refresh_interval_days = refresh_interval_days
+        self._progress: Dict = {
+            "running": False,
+            "last_collected_at": None,
+            "record_count": 0,
+            "status": None,
+            "last_error": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "theme_classification"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "ThemeClassificationTask"
+
+    def get_progress(self) -> Dict:
+        return dict(self._progress)
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        if await self._is_fresh():
+            self._logger.info({"event": "theme_collect_skip", "reason": "interval_not_elapsed"})
+            self._progress["status"] = "skipped"
+            return
+        await self._collect()
+
+    async def force_run(self) -> None:
+        """주기 가드를 무시하고 즉시 수집한다."""
+        async with self._running_state():
+            await self._collect()
+
+    async def _collect(self) -> None:
+        self._progress["running"] = True
+        self._progress["last_error"] = None
+        try:
+            count = await self._collector.collect_naver_themes()
+            self._progress["record_count"] = count
+            self._progress["last_collected_at"] = await self._repo.get_latest_collected_at()
+            self._progress["status"] = "done"
+        except Exception as e:
+            self._progress["status"] = "error"
+            self._progress["last_error"] = str(e)
+            self._logger.error({"event": "theme_collect_error", "error": str(e)})
+        finally:
+            self._progress["running"] = False
+
+    async def _is_fresh(self) -> bool:
+        """최근 수집 시각이 refresh_interval_days 이내면 True."""
+        last = await self._repo.get_latest_collected_at()
+        if not last:
+            return False
+        try:
+            last_dt = datetime.fromisoformat(last)
+        except (ValueError, TypeError):
+            return False
+        return (datetime.now() - last_dt).days < self._refresh_interval_days

--- a/tests/unit_test/repositories/test_stock_classification_repository.py
+++ b/tests/unit_test/repositories/test_stock_classification_repository.py
@@ -1,0 +1,109 @@
+"""StockClassificationRepository 단위 테스트.
+
+- normalized_name 기준 union + 종목 출처(provenance) 보존
+- alias 매핑 조회
+- 빈 테이블 graceful (예외 없이 빈 결과)
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from repositories.stock_classification_repository import StockClassificationRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    db_path = str(tmp_path / "stock_classifications.db")
+    return StockClassificationRepository(db_path=db_path, logger=MagicMock())
+
+
+def _rec(source, code, name, group="로봇", normalized="로봇", cat="theme", at="2026-06-21T18:00:00"):
+    return {
+        "source": source, "category_type": cat, "group_name": group,
+        "normalized_name": normalized, "code": code, "name": name, "collected_at": at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_empty_db_graceful(repo):
+    """데이터가 없으면 빈 결과를 반환하고 예외를 던지지 않는다."""
+    assert await repo.get_groups(("theme",)) == {}
+    assert await repo.get_latest_collected_at() is None
+    assert await repo.get_alias_map("NAVER") == {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_groups_single_source(repo):
+    n = await repo.upsert_classifications([
+        _rec("NAVER", "005930", "삼성전자"),
+        _rec("NAVER", "000660", "SK하이닉스"),
+    ])
+    assert n == 2
+
+    groups = await repo.get_groups(("theme",))
+    assert "로봇" in groups
+    assert groups["로봇"]["sources"] == ["NAVER"]
+    codes = {m["code"] for m in groups["로봇"]["members"]}
+    assert codes == {"005930", "000660"}
+
+
+@pytest.mark.asyncio
+async def test_union_across_sources_with_provenance(repo):
+    """두 소스를 normalized_name 으로 OR 병합하고 종목별 출처를 보존한다."""
+    await repo.upsert_classifications([
+        _rec("NAVER", "005930", "삼성전자"),
+        _rec("KIWOOM", "005930", "삼성전자"),   # 양쪽 소스에 등장
+        _rec("KIWOOM", "247540", "에코프로비엠"),  # 키움 전용
+    ])
+
+    groups = await repo.get_groups(("theme",))
+    g = groups["로봇"]
+    assert g["sources"] == ["KIWOOM", "NAVER"]
+
+    by_code = {m["code"]: m for m in g["members"]}
+    assert by_code["005930"]["sources"] == ["KIWOOM", "NAVER"]
+    assert by_code["247540"]["sources"] == ["KIWOOM"]
+
+
+@pytest.mark.asyncio
+async def test_normalized_name_merges_different_raw_names(repo):
+    """raw group_name 이 달라도 normalized_name 이 같으면 하나의 그룹으로 합쳐진다."""
+    await repo.upsert_classifications([
+        _rec("NAVER", "247540", "에코프로비엠", group="2차전지", normalized="2차전지"),
+        _rec("KIWOOM", "086520", "에코프로", group="2차전지 소재", normalized="2차전지"),
+    ])
+    groups = await repo.get_groups(("theme",))
+    assert set(groups.keys()) == {"2차전지"}
+    assert len(groups["2차전지"]["members"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_category_type_filter(repo):
+    await repo.upsert_classifications([
+        _rec("NAVER", "005930", "삼성전자", cat="theme", group="반도체", normalized="반도체"),
+        _rec("WICS", "005930", "삼성전자", cat="industry", group="전기전자", normalized="전기전자"),
+    ])
+    theme_only = await repo.get_groups(("theme",))
+    assert set(theme_only.keys()) == {"반도체"}
+
+    both = await repo.get_groups(("theme", "industry"))
+    assert set(both.keys()) == {"반도체", "전기전자"}
+
+
+@pytest.mark.asyncio
+async def test_alias_map_roundtrip(repo):
+    await repo.upsert_aliases([
+        {"source": "KIWOOM", "raw_name": "2차전지 소재", "normalized_name": "2차전지"},
+    ])
+    amap = await repo.get_alias_map("KIWOOM")
+    assert amap == {"2차전지 소재": "2차전지"}
+    assert await repo.get_alias_map("NAVER") == {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_is_idempotent_on_pk(repo):
+    """같은 (source, category_type, group_name, code) 는 갱신된다."""
+    await repo.upsert_classifications([_rec("NAVER", "005930", "삼성전자", at="2026-06-20T18:00:00")])
+    await repo.upsert_classifications([_rec("NAVER", "005930", "삼성전자", at="2026-06-21T18:00:00")])
+    groups = await repo.get_groups(("theme",))
+    assert len(groups["로봇"]["members"]) == 1
+    assert await repo.get_latest_collected_at() == "2026-06-21T18:00:00"

--- a/tests/unit_test/services/test_theme_classification_collector_service.py
+++ b/tests/unit_test/services/test_theme_classification_collector_service.py
@@ -1,0 +1,107 @@
+"""ThemeClassificationCollectorService 단위 테스트.
+
+- 테마 목록/구성종목 HTML 파싱
+- collect 흐름: alias 적용 + upsert 레코드 형태
+- 상세 페이지 실패 시 해당 테마만 skip(부분 성공)
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.theme_classification_collector_service import ThemeClassificationCollectorService
+
+
+def _list_html(themes):
+    """themes: [(no, name)] → 목록 페이지 HTML."""
+    rows = "".join(
+        f'<td><a href="/sise/sise_group_detail.naver?type=theme&no={no}">{name}</a></td>'
+        for no, name in themes
+    )
+    return f"<table>{rows}</table>"
+
+
+def _detail_html(members):
+    """members: [(code, name)] → 상세 페이지 HTML."""
+    rows = "".join(
+        f'<td class="name"><a href="/item/main.naver?code={code}">{name}</a></td>'
+        for code, name in members
+    )
+    return f"<table class='type_5'>{rows}</table>"
+
+
+@pytest.fixture
+def repo():
+    r = MagicMock()
+    r.get_alias_map = AsyncMock(return_value={})
+    r.upsert_classifications = AsyncMock(side_effect=lambda recs: len(recs))
+    r.get_latest_collected_at = AsyncMock(return_value=None)
+    return r
+
+
+def test_parse_theme_list():
+    html = _list_html([("123", "2차전지"), ("456", "로봇")])
+    out = ThemeClassificationCollectorService._parse_theme_list(html)
+    assert out == [("123", "2차전지"), ("456", "로봇")]
+
+
+def test_parse_theme_list_dedup():
+    html = _list_html([("123", "2차전지"), ("123", "2차전지")])
+    out = ThemeClassificationCollectorService._parse_theme_list(html)
+    assert out == [("123", "2차전지")]
+
+
+def test_parse_theme_members():
+    html = _detail_html([("005930", "삼성전자"), ("000660", "SK하이닉스")])
+    out = ThemeClassificationCollectorService._parse_theme_members(html)
+    assert out == [("005930", "삼성전자"), ("000660", "SK하이닉스")]
+
+
+@pytest.mark.asyncio
+async def test_collect_builds_records_with_alias(repo):
+    repo.get_alias_map = AsyncMock(return_value={"2차전지 소재": "2차전지"})
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+
+    svc._fetch_html = AsyncMock(side_effect=[
+        _list_html([("1", "2차전지 소재")]),
+        _detail_html([("247540", "에코프로비엠")]),
+    ])
+
+    saved = await svc.collect_naver_themes()
+    assert saved == 1
+    recs = repo.upsert_classifications.call_args[0][0]
+    assert recs[0]["source"] == "NAVER"
+    assert recs[0]["category_type"] == "theme"
+    assert recs[0]["group_name"] == "2차전지 소재"
+    assert recs[0]["normalized_name"] == "2차전지"   # alias 적용
+    assert recs[0]["code"] == "247540"
+
+
+@pytest.mark.asyncio
+async def test_collect_skips_failed_detail(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(side_effect=[
+        _list_html([("1", "테마A"), ("2", "테마B")]),
+        RuntimeError("detail A 실패"),                 # 테마A 상세 실패 → skip
+        _detail_html([("000660", "SK하이닉스")]),       # 테마B 성공
+    ])
+    saved = await svc.collect_naver_themes()
+    assert saved == 1
+    recs = repo.upsert_classifications.call_args[0][0]
+    assert [r["code"] for r in recs] == ["000660"]
+    assert recs[0]["group_name"] == "테마B"
+
+
+@pytest.mark.asyncio
+async def test_collect_empty_list_returns_zero(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(return_value="<html>no themes</html>")
+    saved = await svc.collect_naver_themes()
+    assert saved == 0
+    repo.upsert_classifications.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collect_list_fetch_failure_returns_zero(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(side_effect=RuntimeError("목록 실패"))
+    saved = await svc.collect_naver_themes()
+    assert saved == 0

--- a/tests/unit_test/services/test_theme_leader_service.py
+++ b/tests/unit_test/services/test_theme_leader_service.py
@@ -1,0 +1,107 @@
+"""ThemeLeaderService 단위 테스트.
+
+- 그룹 내 RS 내림차순 top_n 선정
+- 그룹 강도 = 멤버 RS 중앙값, 그 기준 그룹 정렬
+- 종목 출처(provenance) 전달
+- 분류/ RS 데이터 미비 시 graceful (data=[])
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from common.types import ErrorCode
+from services.theme_leader_service import ThemeLeaderService
+
+
+def _make_service(groups, latest_date="20260620", rs_map=None):
+    classification_repo = MagicMock()
+    classification_repo.get_groups = AsyncMock(return_value=groups)
+    rs_repo = MagicMock()
+    rs_repo.get_latest_date = AsyncMock(return_value=latest_date)
+    rs_repo.get_by_date = AsyncMock(return_value=rs_map or {})
+    return ThemeLeaderService(
+        classification_repository=classification_repo,
+        rs_rating_repository=rs_repo,
+        logger=MagicMock(),
+    )
+
+
+def _member(code, name, sources=("NAVER",)):
+    return {"code": code, "name": name, "sources": list(sources)}
+
+
+@pytest.mark.asyncio
+async def test_no_classification_data_returns_empty():
+    svc = _make_service(groups={})
+    resp = await svc.get_theme_leaders()
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data == []
+
+
+@pytest.mark.asyncio
+async def test_no_rs_data_returns_empty():
+    svc = _make_service(
+        groups={"로봇": {"sources": ["NAVER"], "members": [_member("005930", "삼성전자")]}},
+        latest_date=None,
+        rs_map={},
+    )
+    resp = await svc.get_theme_leaders()
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data == []
+
+
+@pytest.mark.asyncio
+async def test_leaders_sorted_by_rs_and_topn():
+    groups = {
+        "로봇": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("A", "에이"), _member("B", "비"),
+                _member("C", "씨"), _member("D", "디"),
+            ],
+        }
+    }
+    rs_map = {"A": 50, "B": 99, "C": 70, "D": 10}
+    svc = _make_service(groups=groups, rs_map=rs_map)
+    resp = await svc.get_theme_leaders(top_n=2)
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    leaders = resp.data[0]["leaders"]
+    assert [l["code"] for l in leaders] == ["B", "C"]  # RS 99, 70
+    assert resp.data[0]["member_count"] == 4
+    # 중앙값(10,50,70,99) = (50+70)/2 = 60
+    assert resp.data[0]["group_rs_median"] == 60.0
+
+
+@pytest.mark.asyncio
+async def test_groups_sorted_by_median_strength():
+    groups = {
+        "약한그룹": {"sources": ["NAVER"], "members": [_member("X", "엑스"), _member("Y", "와이")]},
+        "강한그룹": {"sources": ["NAVER"], "members": [_member("P", "피"), _member("Q", "큐")]},
+    }
+    rs_map = {"X": 20, "Y": 30, "P": 80, "Q": 90}
+    svc = _make_service(groups=groups, rs_map=rs_map)
+    resp = await svc.get_theme_leaders()
+    assert [g["normalized_name"] for g in resp.data] == ["강한그룹", "약한그룹"]
+
+
+@pytest.mark.asyncio
+async def test_member_without_rs_is_excluded():
+    groups = {"로봇": {"sources": ["NAVER", "KIWOOM"], "members": [
+        _member("A", "에이", sources=["NAVER", "KIWOOM"]),
+        _member("Z", "지", sources=["KIWOOM"]),  # RS 없음 → 제외
+    ]}}
+    rs_map = {"A": 88}
+    svc = _make_service(groups=groups, rs_map=rs_map)
+    resp = await svc.get_theme_leaders()
+    leaders = resp.data[0]["leaders"]
+    assert [l["code"] for l in leaders] == ["A"]
+    assert leaders[0]["sources"] == ["NAVER", "KIWOOM"]  # provenance 전달
+    assert resp.data[0]["member_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_group_with_no_scored_members_skipped():
+    groups = {"빈그룹": {"sources": ["NAVER"], "members": [_member("NONE", "노알에스")]}}
+    svc = _make_service(groups=groups, rs_map={"OTHER": 50})
+    resp = await svc.get_theme_leaders()
+    assert resp.data == []

--- a/tests/unit_test/task/background/after_market/test_theme_classification_task.py
+++ b/tests/unit_test/task/background/after_market/test_theme_classification_task.py
@@ -1,0 +1,70 @@
+"""ThemeClassificationTask 단위 테스트 (주기 가드 + force_run)."""
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from task.background.after_market.theme_classification_task import ThemeClassificationTask
+
+
+def _make_task(collector, repo, refresh_interval_days=7):
+    return ThemeClassificationTask(
+        collector_service=collector,
+        classification_repository=repo,
+        market_calendar_service=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+        refresh_interval_days=refresh_interval_days,
+    )
+
+
+@pytest.mark.asyncio
+async def test_collects_when_no_prior_data():
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock(return_value=12)
+    repo = MagicMock()
+    repo.get_latest_collected_at = AsyncMock(return_value=None)
+    task = _make_task(collector, repo)
+
+    await task._on_market_closed("20260621")
+    collector.collect_naver_themes.assert_awaited_once()
+    assert task.get_progress()["record_count"] == 12
+
+
+@pytest.mark.asyncio
+async def test_skips_when_recently_collected():
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock()
+    repo = MagicMock()
+    recent = (datetime.now() - timedelta(days=2)).isoformat(timespec="seconds")
+    repo.get_latest_collected_at = AsyncMock(return_value=recent)
+    task = _make_task(collector, repo, refresh_interval_days=7)
+
+    await task._on_market_closed("20260621")
+    collector.collect_naver_themes.assert_not_awaited()
+    assert task.get_progress()["status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_collects_when_interval_elapsed():
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock(return_value=5)
+    repo = MagicMock()
+    stale = (datetime.now() - timedelta(days=10)).isoformat(timespec="seconds")
+    repo.get_latest_collected_at = AsyncMock(return_value=stale)
+    task = _make_task(collector, repo, refresh_interval_days=7)
+
+    await task._on_market_closed("20260621")
+    collector.collect_naver_themes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_run_ignores_guard():
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock(return_value=3)
+    repo = MagicMock()
+    recent = datetime.now().isoformat(timespec="seconds")
+    repo.get_latest_collected_at = AsyncMock(return_value=recent)
+    task = _make_task(collector, repo)
+
+    await task.force_run()
+    collector.collect_naver_themes.assert_awaited_once()

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -27,6 +27,8 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "PositionSizingService", "RiskGateService", "ExecutionFlowService",
     "OrderPolicyService", "DeferredOrderQueue", "OrderExecutionService",
     "OneilUniverseService", "NaverFinanceScraperService",
+    "StockClassificationRepository", "ThemeLeaderService",
+    "ThemeClassificationCollectorService", "ThemeClassificationTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
     "StrategyLogReportService", "NotificationQueueTask",
@@ -98,6 +100,18 @@ def test_service_container_creates_query_and_order_services(patched_service_cont
     assert ctx.stock_query_service is patched_service_container_deps["StockQueryService"].return_value
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
     assert ctx.risk_gate_service is patched_service_container_deps["RiskGateService"].return_value
+
+
+def test_service_container_creates_theme_leader_service(patched_service_container_deps):
+    """ThemeLeaderService 와 분류 저장소가 ctx 에 주입된다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ServiceContainer(ctx).run()
+
+    assert ctx.theme_classification_repository is patched_service_container_deps[
+        "StockClassificationRepository"].return_value
+    assert ctx.theme_leader_service is patched_service_container_deps["ThemeLeaderService"].return_value
 
 
 def test_service_container_passes_order_execution_retry_config(patched_service_container_deps):

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -2,7 +2,49 @@
 랭킹/시가총액 관련 테스트 (ranking.html, marketcap.html).
 """
 import pytest
+from unittest.mock import AsyncMock
 from common.types import ResCommonResponse
+
+
+@pytest.mark.asyncio
+async def test_get_theme_leaders_success(web_client, mock_web_ctx):
+    """GET /api/ranking/theme_leaders 정상 응답 + 기본 category_types=theme."""
+    mock_web_ctx.theme_leader_service = AsyncMock()
+    mock_web_ctx.theme_leader_service.get_theme_leaders.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공",
+        data=[{"normalized_name": "로봇", "sources": ["NAVER"], "group_rs_median": 88.0,
+               "member_count": 3, "leaders": [{"code": "005930", "name": "삼성전자",
+                                               "rs_rating": 99, "sources": ["NAVER"]}]}],
+    )
+    response = web_client.get("/api/ranking/theme_leaders")
+    assert response.status_code == 200
+    assert response.json()["data"][0]["normalized_name"] == "로봇"
+    mock_web_ctx.theme_leader_service.get_theme_leaders.assert_awaited_once_with(
+        category_types=("theme",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_theme_leaders_include_industry(web_client, mock_web_ctx):
+    """include_industry=true 면 category_types 에 industry 가 포함된다."""
+    mock_web_ctx.theme_leader_service = AsyncMock()
+    mock_web_ctx.theme_leader_service.get_theme_leaders.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data=[]
+    )
+    response = web_client.get("/api/ranking/theme_leaders?include_industry=true")
+    assert response.status_code == 200
+    mock_web_ctx.theme_leader_service.get_theme_leaders.assert_awaited_once_with(
+        category_types=("theme", "industry")
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_theme_leaders_service_missing(web_client, mock_web_ctx):
+    """ThemeLeaderService 미설정 시 rt_cd=1 안내."""
+    mock_web_ctx.theme_leader_service = None
+    response = web_client.get("/api/ranking/theme_leaders")
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == "1"
 
 
 @pytest.mark.asyncio

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -22,6 +22,7 @@ from core.account_snapshot import AccountSnapshotCache
 from core.cache.cache_store import CacheStore
 from core.performance_profiler import PerformanceProfiler
 from repositories.rs_rating_repository import RSRatingRepository
+from repositories.stock_classification_repository import StockClassificationRepository
 from repositories.stock_repository import StockRepository
 from repositories.streaming_stock_repo import StreamingStockRepo
 from scheduler.dispatcher.time_dispatcher import TimeDispatcher
@@ -37,6 +38,9 @@ from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
 from services.oneil_universe_service import OneilUniverseService
+from services.theme_classification_collector_service import ThemeClassificationCollectorService
+from services.theme_leader_service import ThemeLeaderService
+from task.background.after_market.theme_classification_task import ThemeClassificationTask
 from services.opening_position_reconcile_service import OpeningPositionReconcileService
 from services.order_execution_service import OrderExecutionService
 from services.order_policy_service import OrderPolicyService
@@ -204,6 +208,19 @@ class ServiceContainer:
             )
         except Exception as e:
             ctx.logger.warning(f"[ServiceBootstrap:RSRating] 초기화 실패: {e}")
+
+        try:
+            ctx.theme_classification_repository = StockClassificationRepository(logger=ctx.logger)
+            ctx.theme_leader_service = ThemeLeaderService(
+                classification_repository=ctx.theme_classification_repository,
+                rs_rating_repository=getattr(ctx, "rs_rating_repository", None),
+                logger=ctx.logger,
+                performance_profiler=ctx.pm,
+            )
+        except Exception as e:
+            ctx.logger.warning(f"[ServiceBootstrap:ThemeLeader] 초기화 실패: {e}")
+            ctx.theme_classification_repository = None
+            ctx.theme_leader_service = None
 
         try:
             ctx.market_data_service = MarketDataService(
@@ -661,6 +678,18 @@ class ServiceContainer:
                     newhigh_task=ctx.newhigh_task,
                     logger=ctx.logger,
                 )
+                if ctx.theme_classification_repository is not None:
+                    ctx.theme_classification_task = ThemeClassificationTask(
+                        collector_service=ThemeClassificationCollectorService(
+                            classification_repository=ctx.theme_classification_repository,
+                            logger=ctx.logger,
+                        ),
+                        classification_repository=ctx.theme_classification_repository,
+                        market_calendar_service=ctx._mcs,
+                        market_clock=ctx.market_clock,
+                        logger=ctx.logger,
+                        worker_pool=ctx.worker_pool,
+                    )
                 ctx.strategy_log_report_task = StrategyLogReportTask(
                     report_service=StrategyLogReportService(
                         log_dir=os.path.join(ctx.logger.log_dir, "strategies"),
@@ -714,6 +743,7 @@ class ServiceContainer:
                 ctx.log_cleanup_task = None
                 ctx.newhigh_task = None
                 ctx.newhigh_service = None
+                ctx.theme_classification_task = None
                 ctx.strategy_log_report_task = None
                 ctx.post_market_replay_audit_task = None
                 ctx.after_market_reconcile_task = None

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -55,6 +55,22 @@ async def get_minervini_stage2():
     return {"rt_cd": resp.rt_cd, "msg1": resp.msg1, "data": resp.data}
 
 
+@router.get("/ranking/theme_leaders")
+async def get_theme_leaders(include_industry: bool = False):
+    """테마(선택적으로 업종 포함) 그룹별 주도주(RS 상위)를 그룹 강도순으로 반환한다.
+
+    각 그룹: { normalized_name, sources, group_rs_median, member_count, leaders[...] }
+    데이터 미수집 시 rt_cd="0", data=[] 로 응답한다(진행률 폴링 없음).
+    """
+    ctx = _get_ctx()
+    svc = getattr(ctx, "theme_leader_service", None)
+    if not svc:
+        return {"rt_cd": "1", "msg1": "ThemeLeaderService 미설정", "data": None}
+    cats = ("theme", "industry") if include_industry else ("theme",)
+    resp = await svc.get_theme_leaders(category_types=cats)
+    return {"rt_cd": resp.rt_cd, "msg1": resp.msg1, "data": resp.data}
+
+
 @router.get("/ranking/{category}")
 async def get_ranking(category: str):
     """랭킹 조회 (rise/fall/volume/trading_value/foreign_buy/foreign_sell/inst_buy/inst_sell/prsn_buy/prsn_sell)."""

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -252,6 +252,83 @@ async function loadInvestorRanking() {
     }
 }
 
+async function loadThemeLeaders() {
+    if (_rankingPollTimer) {
+        clearTimeout(_rankingPollTimer);
+        _rankingPollTimer = null;
+    }
+    if (window.Paginator) window.Paginator.reset('ranking');
+    _rankingCurrentCategory = 'theme_leaders';
+    _rankingDirection = null;
+
+    document.querySelectorAll('.ranking-tab').forEach(b => {
+        b.classList.remove('active');
+        if (b.dataset.cat === 'theme_leaders') b.classList.add('active');
+    });
+    const invRow = document.getElementById('investor-type-row');
+    if (invRow) invRow.style.display = 'none';
+
+    const div = document.getElementById('ranking-result');
+    _showRankingSkeleton();
+
+    try {
+        const res = await fetchWithTimeout('/api/ranking/theme_leaders');
+        const json = await res.json();
+
+        if (json.rt_cd !== "0") {
+            div.innerHTML = `<p class="error">실패: ${json.msg1}</p>`;
+            return;
+        }
+        // 빈 데이터는 진행률 폴링이 아니라 전용 안내로 처리한다.
+        if (!json.data || json.data.length === 0) {
+            div.innerHTML = `<div class="card" style="text-align:center; padding:40px;">
+                <p style="font-size:1.1em;">${json.msg1 || '테마 데이터가 아직 수집되지 않았습니다.'}</p>
+                <p style="color:#888; margin-top:8px;">장 마감 후 테마 분류 수집이 완료되면 표시됩니다.</p>
+            </div>`;
+            return;
+        }
+        renderThemeLeaders(json.data);
+    } catch (e) {
+        if (e.name === 'AbortError') {
+            div.innerHTML = '<p class="error">요청 시간이 초과되었습니다. 다시 시도해주세요.</p>';
+        } else {
+            div.innerHTML = "오류: " + e;
+        }
+    }
+}
+
+function _sourceBadges(sources) {
+    const label = { NAVER: '네이버', KIWOOM: '키움', WICS: 'WICS' };
+    return (sources || []).map(s =>
+        `<span style="display:inline-block; font-size:0.75em; padding:1px 6px; margin-left:4px;
+            border-radius:8px; background:var(--accent-secondary,#3b82f6); color:#fff;">${label[s] || s}</span>`
+    ).join('');
+}
+
+function renderThemeLeaders(groups) {
+    const div = document.getElementById('ranking-result');
+    const cards = groups.map(g => {
+        const rows = g.leaders.map((l, i) => `
+            <tr>
+                <td>${i + 1}</td>
+                <td>${l.name || l.code}</td>
+                <td>${l.rs_rating}</td>
+                <td>${_sourceBadges(l.sources)}</td>
+            </tr>`).join('');
+        return `<div class="card" style="margin-bottom:12px;">
+            <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;">
+                <h3 style="margin:0;">${g.normalized_name}${_sourceBadges(g.sources)}</h3>
+                <span style="color:#888;">RS 중앙값 ${g.group_rs_median} · ${g.member_count}종목</span>
+            </div>
+            <table class="data-table">
+                <thead><tr><th>순위</th><th>종목명</th><th>RS</th><th>출처</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table>
+        </div>`;
+    }).join('');
+    div.innerHTML = cards;
+}
+
 function _formatElapsed(sec) {
     if (sec < 60) return `${sec.toFixed(1)}s`;
     const m = Math.floor(sec / 60);

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -18,6 +18,7 @@
                 <button class="btn ranking-tab" data-cat="trading_value" onclick="loadRanking('trading_value')">거래대금</button>
                 <button class="btn ranking-tab" data-cat="minervini_stage2" onclick="loadRanking('minervini_stage2')">Minervini S2</button>
                 <button class="btn ranking-tab" data-cat="newhigh" onclick="loadRanking('newhigh')">신고가</button>
+                <button class="btn ranking-tab" data-cat="theme_leaders" onclick="loadThemeLeaders()">테마주도</button>
             </div>
             <div class="ranking-investor-group" style="margin-top: 6px;">
                 <div class="form-row" style="margin-bottom: 0;">
@@ -38,7 +39,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=2"></script>
+<script src="/static/js/ranking.js?v=3"></script>
 <script>
     loadRanking('rise');
 </script>

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -147,6 +147,9 @@ class WebAppContext:
         self.cache_warmup_task: CacheWarmupTask = None
         self.log_cleanup_task: LogCleanupTask = None
         self.newhigh_task: NewHighTask = None
+        self.theme_classification_repository = None
+        self.theme_classification_task = None
+        self.theme_leader_service = None
         self.strategy_log_report_task: StrategyLogReportTask = None
         self.post_market_replay_audit_task: PostMarketReplayAuditTask = None
         self.stock_repository: StockRepository = None


### PR DESCRIPTION
## 요약
종목을 테마/업종으로 분류하고 각 그룹 내 **주도주(RS Rating 상위 종목)** 를 웹 랭킹 탭(조회 전용)에 표시하는 기능. 계획상 **Phase A(네이버 테마 MVP)** 구현분.

## 배경
- 기존 코드에 강도 판별 로직(RS Rating)과 분류 추적 프레임은 있으나, **테마/업종 분류 데이터 자체가 없었음**.
- FDR `StockListing('KRX')` 에는 업종 컬럼이 없음(py310 실측) → 분류는 외부 수집으로 확보.
- 다중 소스 union 구조로 설계하되, 이번 PR은 **네이버 테마 단일 소스**로 동작하는 MVP.

## 변경 내용
- **`repositories/stock_classification_repository.py`** (신규): 다중 소스(NAVER/KIWOOM/WICS) 분류를 `normalized_name` 기준 union + 종목 출처(provenance) 보존. 전용 DB `data/stock_classifications.db`. `theme_aliases` 정규화 테이블 포함.
- **`services/theme_classification_collector_service.py`** (신규): 네이버 테마 목록/구성종목 스크래핑(aiohttp+BeautifulSoup). 개별 실패 skip(부분 성공), graceful degrade.
- **`task/background/after_market/theme_classification_task.py`** (신규): 장 마감 후 주간(기본 7일) 수집 스케줄. 주기 가드 + `force_run`.
- **`services/theme_leader_service.py`** (신규): 분류 그룹 × 기존 `rs_ratings` join → 그룹 내 RS 상위를 주도주로 선정, **그룹 강도(RS 중앙값)** 순 정렬. 네트워크 없는 온디맨드 조회.
- **`view/web/routes/ranking.py`**: `GET /api/ranking/theme_leaders?include_industry=` 추가.
- **웹 UI**(`ranking.html`/`ranking.js`): `테마주도` 탭 + 전용 핸들러/렌더러. 빈 데이터는 **진행률 폴링이 아닌 전용 안내**로 처리. 출처 배지 표시.
- **DI 배선**(`service_container.py`/`web_app_initializer.py`) + 회귀 테스트(`test_service_container.py`).

## 설계 메모
- 주도주 = "그룹 내 RS 최상위". 이미 매일 저장되는 `rs_ratings` 를 재사용(재계산 없음).
- 키움/WICS 소스, 업종(industry) 토글은 스키마/엔진이 이미 수용 — 후속 단계로 분리(스크래퍼 취약성·취득 방식 미정).

## 테스트
- 단위: 6378 passed (신규 repo/service/collector/task/route/DI 포함).
- 통합: 243 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)