### PR TITLE
[codex] Report return rate in sell fill alerts

### DIFF
--- a/common/types.py
+++ b/common/types.py
@@ -131,6 +131,16 @@ class OrderContext(BaseModel):
     slippage_pct: Optional[float] = None
     first_fill_latency_sec: Optional[float] = None
     volatility_20d_annualized: Optional[float] = None  # 매수 신호 생성 시점 변동성 (리포트 집계용)
+    config_hash: Optional[str] = None
+    invalidation_price: Optional[float] = None
+    stop_loss_price: Optional[float] = None
+    target_price: Optional[float] = None
+    entry_reason: Optional[str] = None
+    trailing_rule: Optional[str] = None
+    expected_holding_period_days: Optional[int] = None
+    confidence: Optional[float] = None
+    required_data: Optional[list[str]] = None
+    market_regime: Optional[Dict[str, Any]] = None
     strategy_notification: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -746,14 +746,14 @@ class StrategyScheduler:
             "trace_id": tid,
         })
 
-    def _estimate_return_rate_from_hold(self, strategy_name: str, code: str, sell_price: int) -> Optional[float]:
-        if not self._virtual_trade_service or sell_price <= 0:
+    def _find_buy_price_from_hold(self, strategy_name: str, code: str) -> Optional[float]:
+        if not self._virtual_trade_service:
             return None
         try:
             holds = self._virtual_trade_service.get_holds_by_strategy(strategy_name) or []
         except Exception as exc:
             self._logger.warning(
-                f"[Scheduler] 수익률 추정 실패: strategy={strategy_name} code={code} error={exc}"
+                f"[Scheduler] 보유 매수가 조회 실패: strategy={strategy_name} code={code} error={exc}"
             )
             return None
 
@@ -766,9 +766,20 @@ class StrategyScheduler:
                 return None
             if buy_price <= 0:
                 return None
-            return round((sell_price - buy_price) / buy_price * 100, 2)
+            return buy_price
 
         return None
+
+    def _estimate_return_rate_from_hold(self, strategy_name: str, code: str, sell_price: int) -> Optional[float]:
+        if sell_price <= 0:
+            return None
+        buy_price = self._find_buy_price_from_hold(strategy_name, code)
+        if buy_price is None:
+            return None
+        try:
+            return round((sell_price - buy_price) / buy_price * 100, 2)
+        except (TypeError, ValueError, ZeroDivisionError):
+            return None
 
     def _should_emit_strategy_signal_notification(
         self,
@@ -831,6 +842,7 @@ class StrategyScheduler:
         order_error_msg = ""
         order_deferred = False
         resp = None
+        estimated_return_rate = None
 
         if self._dry_run:
             if signal.action == "BUY":
@@ -947,12 +959,18 @@ class StrategyScheduler:
                         signal.price = adjusted_sell_price
                         log_price = adjusted_sell_price
                     self._log_signal_to_order_latency(signal, tid)
+                    sell_strategy_notification = self._strategy_notification_payload(signal, log_price)
+                    buy_price = self._find_buy_price_from_hold(signal.strategy_name, signal.code)
+                    if buy_price is not None and log_price > 0:
+                        estimated_return_rate = round((log_price - buy_price) / buy_price * 100, 2)
+                        sell_strategy_notification["buy_price"] = buy_price
+                        sell_strategy_notification["return_rate"] = estimated_return_rate
                     sell_order_kwargs = {
                         "exchange": signal_exchange,
                         "source": self._source_for_signal(signal),
                         "finalize_immediately": False,
                         "trace_id": tid,
-                        "strategy_notification": self._strategy_notification_payload(signal, log_price),
+                        "strategy_notification": sell_strategy_notification,
                     }
                     sell_order_kwargs.update(self._signal_price_policy_kwargs(signal))
                     resp = await self._oes.handle_place_sell_order(
@@ -1017,9 +1035,11 @@ class StrategyScheduler:
                     break
 
         if signal.action == "SELL" and return_rate is None and api_success:
-            return_rate = self._estimate_return_rate_from_hold(
-                signal.strategy_name, signal.code, log_price
-            )
+            return_rate = estimated_return_rate
+            if return_rate is None:
+                return_rate = self._estimate_return_rate_from_hold(
+                    signal.strategy_name, signal.code, log_price
+                )
 
         # 시그널 이력 기록 (메모리 + CSV 영속화)
         now = self._tm.get_current_kst_time()

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -943,10 +943,12 @@ class StrategyScheduler:
                             "source": f"strategy:{signal.strategy_name}",
                             "finalize_immediately": False,
                             "trace_id": tid,
-                            "volatility_20d_annualized": signal.volatility_20d_annualized,
                             "strategy_notification": self._strategy_notification_payload(signal, log_price),
                         }
-                        buy_order_kwargs.update(self._signal_price_policy_kwargs(signal))
+                        buy_order_kwargs.update(self._virtual_trade_log_kwargs(signal))
+                        buy_order_kwargs.update(self._market_regime_log_kwargs(
+                            self._market_regime_service, self.stock_code_repository, signal.code
+                        ))
                         resp = await self._oes.handle_place_buy_order(
                             signal.code,
                             signal.price,

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -187,6 +187,17 @@ class FillReconciliationService:
     def _side_label(side: OrderSide) -> str:
         return "매수" if side == OrderSide.BUY else "매도"
 
+    @staticmethod
+    def _calculate_return_rate(buy_price, sell_price) -> Optional[float]:
+        try:
+            buy = float(buy_price)
+            sell = float(sell_price)
+        except (TypeError, ValueError):
+            return None
+        if buy <= 0:
+            return None
+        return round((sell - buy) / buy * 100, 2)
+
     async def _emit_terminal_order_notification(
         self,
         context: OrderContext,
@@ -256,6 +267,13 @@ class FillReconciliationService:
             requested_price = strategy_notification.get("price") or context.price
             requested_qty = strategy_notification.get("qty") or context.qty
             reason = strategy_notification.get("reason") or ""
+            if context.side == OrderSide.SELL:
+                actual_return_rate = self._calculate_return_rate(
+                    strategy_notification.get("buy_price"),
+                    fill_price,
+                )
+                if actual_return_rate is not None:
+                    strategy_notification["return_rate"] = actual_return_rate
             try:
                 requested_price_text = f"{int(requested_price):,}원"
             except (TypeError, ValueError):

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -338,9 +338,27 @@ class FillReconciliationService:
         sell_result = None
         try:
             if context.side == OrderSide.BUY:
+                buy_log_kwargs = {
+                    "volatility_20d_annualized": context.volatility_20d_annualized,
+                }
+                for key in (
+                    "config_hash",
+                    "invalidation_price",
+                    "stop_loss_price",
+                    "target_price",
+                    "entry_reason",
+                    "trailing_rule",
+                    "expected_holding_period_days",
+                    "confidence",
+                    "required_data",
+                    "market_regime",
+                ):
+                    value = getattr(context, key, None)
+                    if value is not None:
+                        buy_log_kwargs[key] = value
                 await self._virtual_trade_service.log_buy_async(
                     strategy_name, context.stock_code, record_price, record_qty,
-                    volatility_20d_annualized=context.volatility_20d_annualized,
+                    **buy_log_kwargs,
                 )
             elif is_strategy_source:
                 sell_result = await self._virtual_trade_service.log_sell_by_strategy_async_with_result(

--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -470,8 +470,16 @@ class OrderExecutionService:
         trace_id: Optional[str] = None,
         intent_id: Optional[str] = None,
         volatility_20d_annualized: Optional[float] = None,
+        config_hash: Optional[str] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        target_price: Optional[float] = None,
+        entry_reason: Optional[str] = None,
+        trailing_rule: Optional[str] = None,
+        expected_holding_period_days: Optional[int] = None,
+        confidence: Optional[float] = None,
+        required_data: Optional[list] = None,
+        market_regime: Optional[dict] = None,
         strategy_notification: Optional[dict] = None,
     ):
         """주식 매수 주문 요청 및 결과 출력."""
@@ -506,8 +514,16 @@ class OrderExecutionService:
                 trace_id=current_trace,
                 intent_id=intent_id,
                 volatility_20d_annualized=volatility_20d_annualized,
+                config_hash=config_hash,
                 invalidation_price=invalidation_price,
                 stop_loss_price=stop_loss_price,
+                target_price=target_price,
+                entry_reason=entry_reason,
+                trailing_rule=trailing_rule,
+                expected_holding_period_days=expected_holding_period_days,
+                confidence=confidence,
+                required_data=required_data,
+                market_regime=market_regime,
                 strategy_notification=strategy_notification,
             )
             if buy_order_result and buy_order_result.rt_cd == ErrorCode.SUCCESS.value:

--- a/services/order_submission_coordinator.py
+++ b/services/order_submission_coordinator.py
@@ -123,8 +123,17 @@ class OrderSubmissionCoordinator:
         side: OrderSide,
         source: str,
         existing,
+        volatility_20d_annualized: Optional[float] = None,
+        config_hash: Optional[str] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        target_price: Optional[float] = None,
+        entry_reason: Optional[str] = None,
+        trailing_rule: Optional[str] = None,
+        expected_holding_period_days: Optional[int] = None,
+        confidence: Optional[float] = None,
+        required_data: Optional[list] = None,
+        market_regime: Optional[dict] = None,
     ) -> Optional[ResCommonResponse]:
         """진행 중 주문이 있을 때 신규 주문을 deferred queue 에 enqueue.
 
@@ -142,8 +151,17 @@ class OrderSubmissionCoordinator:
                 side=side,
                 source=source,
                 finalize_immediately=False,
+                volatility_20d_annualized=volatility_20d_annualized,
+                config_hash=config_hash,
                 invalidation_price=invalidation_price,
                 stop_loss_price=stop_loss_price,
+                target_price=target_price,
+                entry_reason=entry_reason,
+                trailing_rule=trailing_rule,
+                expected_holding_period_days=expected_holding_period_days,
+                confidence=confidence,
+                required_data=required_data,
+                market_regime=market_regime,
             )
 
         result = await self._deferred_queue.enqueue(
@@ -177,8 +195,16 @@ class OrderSubmissionCoordinator:
         trace_id: Optional[str] = None,
         intent_id: Optional[str] = None,
         volatility_20d_annualized: Optional[float] = None,
+        config_hash: Optional[str] = None,
         invalidation_price: Optional[float] = None,
         stop_loss_price: Optional[float] = None,
+        target_price: Optional[float] = None,
+        entry_reason: Optional[str] = None,
+        trailing_rule: Optional[str] = None,
+        expected_holding_period_days: Optional[int] = None,
+        confidence: Optional[float] = None,
+        required_data: Optional[list] = None,
+        market_regime: Optional[dict] = None,
         strategy_notification: Optional[dict] = None,
     ) -> ResCommonResponse:
         order_key = self._fsm.make_order_key(stock_code, side, exchange)
@@ -227,8 +253,17 @@ class OrderSubmissionCoordinator:
                             side=side,
                             source=source,
                             existing=existing,
+                            volatility_20d_annualized=volatility_20d_annualized,
+                            config_hash=config_hash,
                             invalidation_price=invalidation_price,
                             stop_loss_price=stop_loss_price,
+                            target_price=target_price,
+                            entry_reason=entry_reason,
+                            trailing_rule=trailing_rule,
+                            expected_holding_period_days=expected_holding_period_days,
+                            confidence=confidence,
+                            required_data=required_data,
+                            market_regime=market_regime,
                         )
                         if deferred_resp is not None:
                             return deferred_resp
@@ -318,6 +353,16 @@ class OrderSubmissionCoordinator:
                 order_type=self._exec_quality_reporter.resolve_order_type(price, policy_decision),
                 spread_pct=self._exec_quality_reporter.resolve_spread_pct(policy_decision),
                 volatility_20d_annualized=volatility_20d_annualized,
+                config_hash=config_hash,
+                invalidation_price=invalidation_price,
+                stop_loss_price=stop_loss_price,
+                target_price=target_price,
+                entry_reason=entry_reason,
+                trailing_rule=trailing_rule,
+                expected_holding_period_days=expected_holding_period_days,
+                confidence=confidence,
+                required_data=required_data,
+                market_regime=market_regime,
                 strategy_notification=dict(strategy_notification or {}),
             )
             self._fsm.register(context)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -2921,6 +2921,9 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         vm.log_sell_by_strategy_async.assert_not_awaited()
         mock_notifier.emit.assert_not_awaited()
+        payload = oes.handle_place_sell_order.call_args.kwargs["strategy_notification"]
+        self.assertEqual(payload["buy_price"], 10000.0)
+        self.assertEqual(payload["return_rate"], 10.0)
         self.assertEqual(scheduler._signal_history[-1].return_rate, 10.0)
 
     async def test_execute_signal_notification_failure(self):

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -461,6 +461,40 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kwargs["invalidation_price"], 68_000)
         self.assertEqual(kwargs["stop_loss_price"], 66_000)
 
+    async def test_execute_buy_signal_passes_signal_metadata_to_order_execution(self):
+        """실전 주문 경로도 journal 재현용 signal metadata 를 주문 컨텍스트로 전달한다."""
+        scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
+        signal = TradeSignal(
+            code="005930",
+            name="삼성전자",
+            action="BUY",
+            price=70_000,
+            qty=1,
+            reason="테스트",
+            strategy_name="테스트전략",
+            config_hash="abc123def456",
+            invalidation_price=68_000,
+            stop_loss_price=66_000,
+            target_price=78_000,
+            entry_reason="pocket_pivot_breakout",
+            trailing_rule="ma20_after_profit",
+            expected_holding_period_days=20,
+            confidence=0.75,
+            required_data=["daily_ohlcv", "execution_strength"],
+        )
+
+        await scheduler._execute_signal(signal)
+
+        oes.handle_place_buy_order.assert_awaited_once()
+        kwargs = oes.handle_place_buy_order.await_args.kwargs
+        self.assertEqual(kwargs["config_hash"], "abc123def456")
+        self.assertEqual(kwargs["target_price"], 78_000)
+        self.assertEqual(kwargs["entry_reason"], "pocket_pivot_breakout")
+        self.assertEqual(kwargs["trailing_rule"], "ma20_after_profit")
+        self.assertEqual(kwargs["expected_holding_period_days"], 20)
+        self.assertEqual(kwargs["confidence"], 0.75)
+        self.assertEqual(kwargs["required_data"], ["daily_ohlcv", "execution_strength"])
+
     async def test_execute_buy_signal_dry_run(self):
         """dry_run 모드에서 BUY 시그널 실행: CSV만 기록, API 미호출."""
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=True)

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -655,6 +655,49 @@ async def test_persist_records_buy_via_virtual_trade(broker, fsm, reporter, fixe
     assert result.virtual_recorded_qty == 10
 
 
+@pytest.mark.asyncio
+async def test_persist_records_buy_signal_metadata_via_virtual_trade(broker, fsm, reporter, fixed_now):
+    vts = AsyncMock()
+    svc = _make_service(broker=broker, fsm=fsm, reporter=reporter, fixed_now=fixed_now, virtual_trade_service=vts)
+    ctx = fsm.register(_make_context(
+        source="strategy:momentum",
+        volatility_20d_annualized=0.42,
+        config_hash="abc123def456",
+        invalidation_price=68000,
+        stop_loss_price=66000,
+        target_price=78000,
+        entry_reason="pocket_pivot_breakout",
+        trailing_rule="ma20_after_profit",
+        expected_holding_period_days=20,
+        confidence=0.75,
+        required_data=["daily_ohlcv", "execution_strength"],
+        market_regime={"kospi": "bull", "kosdaq": "sideways", "stock_market": "KOSPI"},
+    ))
+    fsm.transition(ctx.order_key, OrderState.SUBMITTED)
+    filled = fsm.transition(ctx.order_key, OrderState.FILLED, filled_qty=10)
+
+    report = OrderExecutionReport(broker_order_no="X", stock_code="005930", side=OrderSide.BUY, fill_price=70500)
+    await svc._persist_virtual_trade_for_terminal_report(filled, report)
+
+    vts.log_buy_async.assert_awaited_once_with(
+        "momentum",
+        "005930",
+        70500,
+        10,
+        volatility_20d_annualized=0.42,
+        config_hash="abc123def456",
+        invalidation_price=68000,
+        stop_loss_price=66000,
+        target_price=78000,
+        entry_reason="pocket_pivot_breakout",
+        trailing_rule="ma20_after_profit",
+        expected_holding_period_days=20,
+        confidence=0.75,
+        required_data=["daily_ohlcv", "execution_strength"],
+        market_regime={"kospi": "bull", "kosdaq": "sideways", "stock_market": "KOSPI"},
+    )
+
+
 # ── resolve_submitted_order + mark_* ─────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -185,6 +185,7 @@ async def test_apply_execution_report_filled_emits_strategy_final_notification(
             "action": "SELL",
             "price": 179400,
             "qty": 10,
+            "buy_price": 170000,
             "reason": "칼손절",
         },
     ))
@@ -204,6 +205,7 @@ async def test_apply_execution_report_filled_emits_strategy_final_notification(
     assert "체결 완료" in args[3]
     assert "칼손절" in args[3]
     assert kwargs["metadata"]["strategy_name"] == "LarryWilliamsCB"
+    assert kwargs["metadata"]["return_rate"] == pytest.approx(5.47)
     assert kwargs["metadata"]["state"] == OrderState.FILLED.value
 
 

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -1168,6 +1168,73 @@ async def test_execution_confirmed_buy_persists_virtual_trade(mock_broker_api_wr
 
 
 @pytest.mark.asyncio
+async def test_execution_confirmed_buy_persists_signal_metadata(mock_broker_api_wrapper, mock_logger, mock_market_clock, mock_market_calendar_service):
+    virtual_trade_service = AsyncMock()
+    handler = OrderExecutionService(
+        broker_api_wrapper=mock_broker_api_wrapper,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_calendar_service=mock_market_calendar_service,
+        virtual_trade_service=virtual_trade_service,
+    )
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="주문 성공",
+        data={"ordno": "A0001"},
+    )
+    await handler.handle_place_buy_order(
+        "005930",
+        70000,
+        10,
+        source="strategy:모멘텀",
+        finalize_immediately=False,
+        volatility_20d_annualized=0.42,
+        config_hash="abc123def456",
+        invalidation_price=68000,
+        stop_loss_price=66000,
+        target_price=78000,
+        entry_reason="pocket_pivot_breakout",
+        trailing_rule="ma20_after_profit",
+        expected_holding_period_days=20,
+        confidence=0.75,
+        required_data=["daily_ohlcv", "execution_strength"],
+        market_regime={"kospi": "bull", "kosdaq": "sideways", "stock_market": "KOSPI"},
+    )
+
+    filled = await handler.handle_signing_notice({
+        "ODER_NO": "A0001",
+        "STCK_SHRN_ISCD": "005930",
+        "SELN_BYOV_CLS": "02",
+        "CNTG_QTY": "10",
+        "CNTG_UNPR": "70100",
+        "STCK_CNTG_HOUR": "101500",
+        "RFUS_YN": "N",
+        "CNTG_YN": "2",
+        "ACPT_YN": "Y",
+        "ODER_QTY": "10",
+    }, tr_id="H0STCNI0")
+
+    assert filled.state == OrderState.FILLED
+    virtual_trade_service.log_buy_async.assert_awaited_once_with(
+        "모멘텀",
+        "005930",
+        70100,
+        10,
+        volatility_20d_annualized=0.42,
+        config_hash="abc123def456",
+        invalidation_price=68000,
+        stop_loss_price=66000,
+        target_price=78000,
+        entry_reason="pocket_pivot_breakout",
+        trailing_rule="ma20_after_profit",
+        expected_holding_period_days=20,
+        confidence=0.75,
+        required_data=["daily_ohlcv", "execution_strength"],
+        market_regime={"kospi": "bull", "kosdaq": "sideways", "stock_market": "KOSPI"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_reconcile_source_does_not_persist_virtual_trade(mock_broker_api_wrapper, mock_logger, mock_market_clock, mock_market_calendar_service):
     virtual_trade_service = AsyncMock()
     handler = OrderExecutionService(


### PR DESCRIPTION
﻿## What changed
- Carry strategy sell `buy_price` and estimated `return_rate` into the order `strategy_notification` payload.
- Recalculate sell fill alert `return_rate` from the actual fill price when `buy_price` is available.
- Add unit coverage for scheduler payload propagation and filled strategy notification metadata.

## Why
Sell fill Telegram alerts were missing return-rate metadata, so the existing Telegram formatter could not add the profit/loss line to strategy sell completion reports.

## Validation
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`
