### PR TITLE
Trigger overseas VBO dry-run on US market close

### DIFF
--- a/scheduler/after_market_loop.py
+++ b/scheduler/after_market_loop.py
@@ -55,6 +55,9 @@ class AfterMarketLoop:
         label: str = "AfterMarketLoop",
         delay_sec: int = 0,
         store=None,
+        timezone: str = "Asia/Seoul",
+        cron_hour: int = _CRON_HOUR,
+        cron_minute: int = _CRON_MINUTE,
     ) -> None:
         """
         Args:
@@ -62,6 +65,10 @@ class AfterMarketLoop:
                 제공 시 last_run_date를 SQLite에 영속화하여
                 catch-up 중복 실행을 방지한다.
                 미제공 시 on_market_closed 콜백이 멱등성을 직접 책임진다.
+            timezone: cron 트리거 타임존. 기본 Asia/Seoul(국내 마감).
+                미국장 dry-run 등은 America/New_York 로 주입한다.
+            cron_hour / cron_minute: 트리거 시각. 기본 15:41 KST.
+                해당 타임존 기준 마감 직후 시각으로 주입한다.
         """
         self._mcs = mcs
         self._market_clock = market_clock
@@ -70,9 +77,11 @@ class AfterMarketLoop:
         self._label = label
         self._delay_sec = delay_sec
         self._store = store
+        self._cron_hour = cron_hour
+        self._cron_minute = cron_minute
 
         self._stop_event: asyncio.Event = asyncio.Event()
-        self._scheduler: AsyncIOScheduler = AsyncIOScheduler(timezone="Asia/Seoul")
+        self._scheduler: AsyncIOScheduler = AsyncIOScheduler(timezone=timezone)
 
     # ── 생명주기 ──
 
@@ -87,8 +96,8 @@ class AfterMarketLoop:
             self._run_job,
             "cron",
             day_of_week="mon-fri",
-            hour=_CRON_HOUR,
-            minute=_CRON_MINUTE,
+            hour=self._cron_hour,
+            minute=self._cron_minute,
             misfire_grace_time=_MISFIRE_GRACE_SEC,
             id=f"after_market_{self._label}",
             replace_existing=True,
@@ -117,8 +126,8 @@ class AfterMarketLoop:
             return
 
         now_kst = self._market_clock.get_current_kst_time()
-        past_close = now_kst.hour > _CRON_HOUR or (
-            now_kst.hour == _CRON_HOUR and now_kst.minute >= _CRON_MINUTE
+        past_close = now_kst.hour > self._cron_hour or (
+            now_kst.hour == self._cron_hour and now_kst.minute >= self._cron_minute
         )
         if not past_close:
             return
@@ -145,15 +154,17 @@ class AfterMarketLoop:
 
     async def _run_job(self) -> None:
         """APScheduler 또는 catch-up에 의해 호출되는 실제 작업 실행 메서드."""
+        today_str = (
+            self._market_clock.get_current_kst_date_str() if self._market_clock else None
+        )
+        # mcs(거래 캘린더) 미주입 시 클럭 날짜를 거래일 식별자로 사용한다.
+        # 미국장 dry-run 은 한국 캘린더가 없으므로 cron 의 mon-fri 필터 + 클럭 날짜로 대체.
         latest_trading_date = (
-            await self._mcs.get_latest_trading_date() if self._mcs else None
+            await self._mcs.get_latest_trading_date() if self._mcs else today_str
         )
         if not latest_trading_date:
             return
 
-        today_str = (
-            self._market_clock.get_current_kst_date_str() if self._market_clock else None
-        )
         if today_str and latest_trading_date != today_str:
             self._log.info(
                 f"[{self._label}] 오늘({today_str})은 휴장일 — 콜백 스킵 (latest={latest_trading_date})"
@@ -192,6 +203,9 @@ async def run_after_market_loop(
     on_market_closed: Callable[[str], Awaitable[None]],
     label: str = "AfterMarketLoop",
     delay_sec: int = 0,
+    timezone: str = "Asia/Seoul",
+    cron_hour: int = _CRON_HOUR,
+    cron_minute: int = _CRON_MINUTE,
 ) -> None:
     """하위 호환 래퍼 — 기존 코드는 이 함수를 asyncio.create_task()로 실행한다.
 
@@ -205,6 +219,8 @@ async def run_after_market_loop(
         label: 로그 메시지에 표시할 태스크 이름.
         delay_sec: 장 마감 감지 후 콜백 실행 전까지의 Padding 시간(초).
             여러 태스크의 실행 시점을 분산시킬 때 사용한다.
+        timezone / cron_hour / cron_minute: cron 트리거 타임존·시각.
+            기본 Asia/Seoul 15:41(국내 마감). 미국장 등은 별도 주입.
     """
     loop = AfterMarketLoop(
         mcs=mcs,
@@ -213,6 +229,9 @@ async def run_after_market_loop(
         on_market_closed=on_market_closed,
         label=label,
         delay_sec=delay_sec,
+        timezone=timezone,
+        cron_hour=cron_hour,
+        cron_minute=cron_minute,
     )
     try:
         await loop.start()

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -198,6 +198,25 @@ class FillReconciliationService:
             return None
         return round((sell - buy) / buy * 100, 2)
 
+    @staticmethod
+    def _format_won(value) -> str:
+        try:
+            amount = float(value)
+        except (TypeError, ValueError):
+            return "N/A"
+        if amount <= 0:
+            return "N/A"
+        if amount.is_integer():
+            return f"{int(amount):,}원"
+        return f"{amount:,.2f}원"
+
+    @classmethod
+    def _format_fill_total_won(cls, context: OrderContext, fill_price) -> str:
+        total_amount = context.total_fill_amount
+        if not total_amount and fill_price and context.filled_qty > 0:
+            total_amount = round(float(fill_price) * context.filled_qty)
+        return cls._format_won(total_amount)
+
     async def _emit_terminal_order_notification(
         self,
         context: OrderContext,
@@ -286,10 +305,14 @@ class FillReconciliationService:
                 level = NotificationLevel.ERROR
                 title = f"[{strategy_name}] {stock_name} {side_label} 실패"
                 status_line = f"상태: {context.state.value}"
+            displayed_fill_price = fill_price if context.filled_qty > 0 else None
+            fill_price_text = self._format_won(displayed_fill_price)
+            fill_total_text = self._format_fill_total_won(context, displayed_fill_price)
             message = (
                 f"종목: {stock_name}({context.stock_code})\n"
                 f"주문: {requested_price_text} × {requested_qty}주\n"
-                f"체결: {fill_price or 'N/A'}원 × {context.filled_qty}/{context.qty}주\n"
+                f"평균체결가: {fill_price_text} × {context.filled_qty}/{context.qty}주\n"
+                f"총체결금액: {fill_total_text}\n"
                 f"사유: {reason}\n"
                 f"{status_line}"
             )

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -245,6 +245,22 @@ def _to_float(value: Any) -> Optional[float]:
         return None
 
 
+def _to_int(value: Any, default: int = 0) -> int:
+    numeric = _to_float(value)
+    if numeric is None:
+        return default
+    return int(numeric)
+
+
+def _format_krw(value: Any, *, force_integer: bool = False) -> str:
+    amount = _to_float(value)
+    if amount is None or amount <= 0:
+        return ""
+    if force_integer or amount.is_integer():
+        return f"₩{int(round(amount)):,}"
+    return f"₩{amount:,.2f}"
+
+
 def _first_number(data: dict, *keys: str) -> Optional[float]:
     for key in keys:
         if key in data:
@@ -510,14 +526,15 @@ class StrategyLogReportService:
             if not strategy or not code:
                 continue
 
-            try:
-                price = int(float(trade.get('buy_price') or 0))
-            except (TypeError, ValueError):
-                price = 0
+            price = _to_float(trade.get('buy_price')) or 0.0
+            qty = max(_to_int(trade.get('qty'), default=1), 0)
+            total_amount = round(price * qty) if price > 0 and qty > 0 else 0
 
             result.setdefault(_strategy_report_key(strategy), {})[code] = {
                 'name': str(trade.get('name') or code),
                 'price': price,
+                'qty': qty,
+                'total_amount': total_amount,
                 'reason': str(trade.get('reason') or '체결 원장 기록'),
                 'time': str(trade.get('buy_date', ''))[11:16],
                 'volatility_20d_annualized': _to_float(trade.get('volatility_20d_annualized')),
@@ -530,6 +547,22 @@ class StrategyLogReportService:
         # 원장을 읽을 수 있으면 buy_signal_generated 로그보다 원장을 신뢰한다.
         # 전략 태그가 없는 당일 거래가 있어도 테스트/드라이런 로그를 실매수로 오인하지 않는다.
         return True, result
+
+    @staticmethod
+    def _format_buy_execution_detail(info: Mapping[str, Any]) -> str:
+        avg_price = _format_krw(info.get('price'))
+        if not avg_price:
+            return ""
+
+        qty = _to_int(info.get('qty'), default=0)
+        if qty <= 1:
+            return f" @ {avg_price}"
+
+        total_amount = info.get('total_amount')
+        total_text = _format_krw(total_amount, force_integer=True)
+        if not total_text:
+            return f" — 평균체결가 {avg_price}"
+        return f" — 평균체결가 {avg_price} / 총체결금액 {total_text}"
 
     def _get_enabled_strategy_keys(self) -> Optional[set[str]]:
         if not self._enabled_strategy_provider:
@@ -1751,7 +1784,7 @@ class StrategyLogReportService:
             if summary['bought']:
                 lines.append(f"\n✅ 매수 완료 ({len(summary['bought'])}건)")
                 for code, info in summary['bought'].items():
-                    price_str = f" @ ₩{info['price']:,}" if info['price'] else ""
+                    price_str = self._format_buy_execution_detail(info)
                     time_str = f" ({info['time']})" if info.get('time') else ""
                     confluence = confluence_map.get(code, {})
                     confluence_str = ""

--- a/task/background/after_market/after_market_task_base.py
+++ b/task/background/after_market/after_market_task_base.py
@@ -148,6 +148,20 @@ class AfterMarketTask(SchedulableTask, ABC):
     def _scheduler_label(self) -> str:
         """run_after_market_loop 에 전달할 레이블 (로그 식별자)."""
 
+    # ── 루프 트리거 타임존/시각 (기본 KST 마감, 서브클래스 오버라이드) ──
+    # None 이면 run_after_market_loop 의 기본값(Asia/Seoul 15:41)을 사용한다.
+    @property
+    def _loop_timezone(self) -> Optional[str]:
+        return None
+
+    @property
+    def _loop_cron_hour(self) -> Optional[int]:
+        return None
+
+    @property
+    def _loop_cron_minute(self) -> Optional[int]:
+        return None
+
     async def _after_market_scheduler(self) -> None:
         """장 마감 후 자동으로 작업을 스케줄링하는 루프."""
         # 루프 진입 = 대기 구간 시작 → IDLE
@@ -158,6 +172,14 @@ class AfterMarketTask(SchedulableTask, ABC):
             async with self._running_state():
                 await self._on_market_closed(date)
 
+        loop_kwargs = {}
+        if self._loop_timezone is not None:
+            loop_kwargs["timezone"] = self._loop_timezone
+        if self._loop_cron_hour is not None:
+            loop_kwargs["cron_hour"] = self._loop_cron_hour
+        if self._loop_cron_minute is not None:
+            loop_kwargs["cron_minute"] = self._loop_cron_minute
+
         try:
             await run_after_market_loop(
                 mcs=self._mcs,
@@ -165,6 +187,7 @@ class AfterMarketTask(SchedulableTask, ABC):
                 logger=self._logger,
                 on_market_closed=_on_closed_with_state,
                 label=self._scheduler_label,
+                **loop_kwargs,
             )
         except asyncio.CancelledError:
             # Propagate cancellation so callers can cancel the task normally.

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -1,12 +1,16 @@
 # task/background/after_market/overseas_dryrun_task.py
 """해외 VBO dry-run after-market 태스크 (Phase 3c).
 
-OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 기존 한국장 after-market
-스케줄러(KST 마감 트리거)에 얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
+OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 after-market 스케줄러에
+얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
 
-해외는 분봉/실시간/미국장 EOD 스케줄 인프라가 없으므로 한국장 마감을 일일 트리거로
-재사용한다(타이밍은 KST지만 일봉 기반 dry-run 이라 기능상 충분). **주문 경로 없음** —
-OverseasVBODryRunService 가 order_execution 의존을 갖지 않아 실주문이 발생하지 않는다.
+트리거는 미국 정규장 마감(America/New_York 16:00) 직후 16:30 ET 로 맞춘다
+(AfterMarketLoop 의 timezone/cron 훅 오버라이드). 한국 거래 캘린더(mcs)는 미국장에
+적용되지 않으므로 미주입(None)하며, cron 의 mon-fri(NY) 필터 + 클럭 날짜로 거래일을
+식별한다. 미국 공휴일에는 직전 완성봉을 재평가할 수 있으나 dry-run 이라 무해하다.
+
+**주문 경로 없음** — OverseasVBODryRunService 가 order_execution 의존을 갖지 않아
+실주문이 발생하지 않는다.
 """
 from __future__ import annotations
 
@@ -53,6 +57,19 @@ class OverseasDryRunTask(AfterMarketTask):
     @property
     def _scheduler_label(self) -> str:
         return "OverseasVBODryRun"
+
+    # ── 미국 정규장 마감(16:00 ET) 직후 16:30 ET 트리거 ──
+    @property
+    def _loop_timezone(self) -> str:
+        return "America/New_York"
+
+    @property
+    def _loop_cron_hour(self) -> int:
+        return 16
+
+    @property
+    def _loop_cron_minute(self) -> int:
+        return 30
 
     @property
     def priority(self) -> TaskPriority:

--- a/tests/unit_test/scheduler/test_after_market_loop.py
+++ b/tests/unit_test/scheduler/test_after_market_loop.py
@@ -24,18 +24,32 @@ def _make_loop(
     last_run: str | None = None,
     delay_sec: int = 0,
     with_store: bool = False,
+    with_mcs: bool = True,
+    timezone: str | None = None,
+    cron_hour: int | None = None,
+    cron_minute: int | None = None,
 ) -> AfterMarketLoop:
     tm = MagicMock()
     tm.get_current_kst_time.return_value = MagicMock(hour=hour, minute=minute)
     tm.get_current_kst_date_str.return_value = today
 
-    mcs = MagicMock()
-    mcs.get_latest_trading_date = AsyncMock(return_value=latest_trading_date)
+    mcs = None
+    if with_mcs:
+        mcs = MagicMock()
+        mcs.get_latest_trading_date = AsyncMock(return_value=latest_trading_date)
 
     store = None
     if with_store:
         store = MagicMock()
         store.load_keyed.return_value = last_run
+
+    kwargs = {}
+    if timezone is not None:
+        kwargs["timezone"] = timezone
+    if cron_hour is not None:
+        kwargs["cron_hour"] = cron_hour
+    if cron_minute is not None:
+        kwargs["cron_minute"] = cron_minute
 
     return AfterMarketLoop(
         mcs=mcs,
@@ -45,6 +59,7 @@ def _make_loop(
         label="Test",
         delay_sec=delay_sec,
         store=store,
+        **kwargs,
     )
 
 
@@ -100,9 +115,53 @@ class TestCatchUp:
         assert len(created) == 1
 
 
+# ── timezone / cron 시각 파라미터화 ──
+
+class TestSchedulerTimezoneAndCron:
+
+    def test_default_timezone_is_seoul(self):
+        """기본값은 Asia/Seoul (국내 태스크 무영향)."""
+        loop = _make_loop()
+        assert str(loop._scheduler.timezone) == "Asia/Seoul"
+
+    def test_custom_timezone_applied_to_scheduler(self):
+        """timezone 인자가 APScheduler 에 반영된다 (미국장 등)."""
+        loop = _make_loop(timezone="America/New_York")
+        assert str(loop._scheduler.timezone) == "America/New_York"
+
+    async def test_custom_cron_boundary_triggers_catchup(self):
+        """cron_hour/minute 경계 이후이면 catch-up 을 트리거한다 (16:30 ET 등)."""
+        loop = _make_loop(
+            hour=16, minute=30, cron_hour=16, cron_minute=30,
+            with_store=True, last_run=None,
+        )
+        created = []
+        with patch("asyncio.create_task", side_effect=lambda c: created.append(c)):
+            await loop._catch_up_if_needed()
+        assert len(created) == 1
+
+    async def test_custom_cron_boundary_skips_before(self):
+        """cron 경계 1분 전이면 catch-up 을 트리거하지 않는다."""
+        loop = _make_loop(hour=16, minute=29, cron_hour=16, cron_minute=30)
+        with patch("asyncio.create_task") as mock_create:
+            await loop._catch_up_if_needed()
+            mock_create.assert_not_called()
+
+
 # ── _run_job 실행 로직 ──
 
 class TestRunJob:
+
+    async def test_uses_clock_date_when_no_mcs(self):
+        """mcs 미주입 시 market_clock 의 날짜를 latest_trading_date 로 사용한다.
+
+        미국장 dry-run 은 한국 거래 캘린더(mcs)가 없으므로, 클럭 날짜를
+        거래일 식별자로 사용해 콜백을 호출한다(휴장 가드 vacuous).
+        """
+        loop = _make_loop(with_mcs=False, today="20260622")
+        await loop._run_job()
+        loop._on_market_closed.assert_awaited_once_with("20260622")
+
 
     async def test_calls_callback_with_latest_date(self):
         """_run_job이 콜백을 latest_trading_date와 함께 호출한다."""

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -210,6 +210,55 @@ async def test_apply_execution_report_filled_emits_strategy_final_notification(
 
 
 @pytest.mark.asyncio
+async def test_strategy_final_notification_labels_average_fill_price_and_total_amount(
+    broker, fsm, reporter, fixed_now
+):
+    notification = AsyncMock()
+    svc = _make_service(
+        broker=broker,
+        fsm=fsm,
+        reporter=reporter,
+        fixed_now=fixed_now,
+        notification_service=notification,
+    )
+    ctx = fsm.register(_make_context(
+        order_key="KRX:252990:BUY",
+        stock_code="252990",
+        side=OrderSide.BUY,
+        source="strategy:RSI2눌림목",
+        price=12940,
+        qty=154,
+        strategy_notification={
+            "strategy_name": "RSI2눌림목",
+            "stock_name": "샘씨엔에스",
+            "code": "252990",
+            "action": "BUY",
+            "price": 12940,
+            "qty": 154,
+            "reason": "RSI(2)=6.57 ≤ 10.0, Stage 2, 정상비중 진입",
+        },
+    ))
+    fsm.transition(ctx.order_key, OrderState.SUBMITTED, broker_order_no="B0001")
+
+    await svc.apply_execution_report(OrderExecutionReport(
+        broker_order_no="B0001", stock_code="252990", side=OrderSide.BUY,
+        fill_qty=129, fill_price=12930, cumulative_filled_qty=129, remaining_qty=25,
+    ))
+    await svc.apply_execution_report(OrderExecutionReport(
+        broker_order_no="B0001", stock_code="252990", side=OrderSide.BUY,
+        fill_qty=25, fill_price=12940, cumulative_filled_qty=154, remaining_qty=0,
+    ))
+
+    notification.emit.assert_awaited_once()
+    args, kwargs = notification.emit.await_args
+    message = args[3]
+    assert "평균체결가: 12,931.62원 × 154/154주" in message
+    assert "총체결금액: 1,991,470원" in message
+    assert "체결: 12931.623376623376원" not in message
+    assert kwargs["metadata"]["fill_price"] == pytest.approx(12931.623376623376)
+
+
+@pytest.mark.asyncio
 async def test_apply_execution_report_rejected_emits_failure_notification(
     broker, fsm, reporter, fixed_now
 ):

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -930,6 +930,44 @@ async def test_report_matches_virtual_trade_strategy_alias_to_log_section(log_di
 
 
 @pytest.mark.asyncio
+async def test_report_formats_fractional_average_fill_price_with_total_amount(log_dir):
+    """원장 평균 매입가가 소수이면 평균체결가/총체결금액으로 표시한다."""
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return [
+                {
+                    "strategy": "RSI2눌림목",
+                    "code": "252990",
+                    "name": "샘씨엔에스",
+                    "buy_date": "2026-06-23 15:10:48",
+                    "buy_price": 12931.623376623376,
+                    "qty": 154,
+                    "status": "HOLD",
+                    "reason": "체결 원장 기록",
+                },
+            ]
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+    _write_log(os.path.join(log_dir, "20260623_151000_RSI2Pullback.log.json"), [
+        _make_entry("buy_signal_generated", "252990", "샘씨엔에스", date="2026-06-23", reason="RSI2", price=12940),
+    ])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+    )
+    report = await svc.generate_report("20260623")
+
+    assert "샘씨엔에스(252990): 체결 원장 기록 — 평균체결가 ₩12,931.62 / 총체결금액 ₩1,991,470 (15:10)" in report
+    assert "체결 원장 기록 @ ₩12,931" not in report
+
+
+@pytest.mark.asyncio
 async def test_report_matches_virtual_trade_strategy_id_to_vbo_log_section(log_dir):
     """원장 전략명이 stable id여도 대응하는 VBO 로그 섹션의 매수 완료 detail에 표시한다."""
     class DummyVirtualTradeService:

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -33,6 +33,18 @@ def test_task_metadata():
     assert task.priority == TaskPriority.LOW
 
 
+def test_loop_triggers_on_us_market_close():
+    """after-market 루프를 미국 정규장 마감(16:00 ET) 직후 NY 타임존에 맞춘다.
+
+    KST 15:41 하드코딩이 아니라 America/New_York 16:30 으로 트리거되도록
+    AfterMarketLoop 파라미터 훅을 오버라이드한다.
+    """
+    task, _, _ = _make_task()
+    assert task._loop_timezone == "America/New_York"
+    assert task._loop_cron_hour == 16
+    assert task._loop_cron_minute == 30
+
+
 @pytest.mark.asyncio
 async def test_on_market_closed_runs_scan_and_flushes():
     task, dryrun, journal = _make_task(OverseasExchange.NASD)

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -334,6 +334,33 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
     assert callable(fx_provider)
 
 
+def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):
+    """overseas_us dry-run 태스크는 미국장 클럭으로, 한국 캘린더(mcs) 없이 배선한다."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.market_mode = "overseas_us"
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="overseas_us",
+        overseas_stock={"dryrun_slot_usd": 1000.0},
+    )
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True) as task_cls:
+        ServiceContainer(ctx).run()
+
+    task_kwargs = task_cls.call_args.kwargs
+    # 한국 거래 캘린더는 미국장에 적용되지 않으므로 미주입
+    assert task_kwargs["market_calendar_service"] is None
+    # 미국 정규장 클럭 주입 (America/New_York)
+    assert task_kwargs["market_clock"].timezone_name == "America/New_York"
+
+
 @pytest.mark.asyncio
 async def test_overseas_fx_provider_extracts_rate_from_balance(patched_service_container_deps):
     """배선된 fx_provider 는 broker 잔고 응답에서 USD/KRW 환율을 추출한다(실패 시 None)."""

--- a/todo_list.md
+++ b/todo_list.md
@@ -145,7 +145,7 @@
 - [~] **Phase 4 주문/사이징**: 자동 전략 컴포넌트 완료 — `OverseasOrderExecutionService`(`place_overseas_limit_order` 지정가 연결, `live_enabled=False` 구조적 실주문 잠금 + would-be 레코드), `OverseasPositionSizingService`(고정 USD 슬롯÷지정가 floor + `max_qty`/`available_usd` cap), FX 환율(`extract_fx_krw_per_usd` 잔고 관용 추출 + `_overseas_fx_provider` 배선 → dry-run KRW 환산 노출), 일봉 기반 exit(`decide_daily_exit` stop/eod). 테스트 잠금 완료. 별도 웹 수동 해외 지정가 주문은 존재하며, 실전 모드에서는 `overseas_stock.allow_live_trading=true`와 `REAL` 확인 문자열 없이는 broker 호출 전 차단된다.
   - 남은 것(Phase 5 소관): scheduler/factory가 sizing→order_execution 자동 연결(canary auto-fire) + `live_enabled=True` 전환 — dry-run 검증 + canary 후로 게이팅.
 - [ ] **Phase 5 안전/canary**: `get_overseas_balance`/`ccnl` reconcile(`OverseasReconcileService` scaffolding 존재), risk gate/kill switch/canary USD 확장, 실전 소액 canary, canary auto-fire 배선 + `live_enabled` 전환.
-- [ ] 3d(후속): 미국장 마감(ET) 정밀 트리거가 필요하면 US-aware 스케줄 경로 신설(현재 KST 트리거로 충분 판단).
+- [x] 3d(후속): 미국장 마감(ET) 정밀 트리거. `AfterMarketLoop`에 timezone/cron 파라미터화(기본 KST 유지) + mcs 미주입 시 클럭 날짜 폴백 → `OverseasDryRunTask`를 America/New_York 16:30 트리거로 전환, `service_container`가 `MarketClock.for_us_equities()` + `mcs=None` 배선. (#585)
 
 주요 파일: `brokers/korea_investment/korea_invest_overseas_stock_api.py`, `brokers/broker_api_wrapper.py`, `services/overseas_order_execution_service.py`, `services/overseas_position_sizing_service.py`, `services/overseas_reconcile_service.py`, `services/stock_query_service.py`, `view/web/bootstrap/{service_container,strategy_factory}.py`, `config/tr_ids_config.yaml`
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -20,6 +20,7 @@ from config.config_loader import (
 )
 from core.account_snapshot import AccountSnapshotCache
 from core.cache.cache_store import CacheStore
+from core.market_clock import MarketClock
 from core.performance_profiler import PerformanceProfiler
 from repositories.rs_rating_repository import RSRatingRepository
 from repositories.stock_classification_repository import StockClassificationRepository
@@ -601,11 +602,13 @@ class ServiceContainer:
                         position_sizing_service=overseas_position_sizing_service,
                         fx_provider=_overseas_fx_provider,
                     )
+                    # 미국 정규장 마감(16:00 ET) 직후 트리거. 한국 거래 캘린더(mcs)는
+                    # 미국장에 적용되지 않으므로 미주입(None)하고, 미국장 클럭을 주입한다.
                     ctx.overseas_dryrun_task = OverseasDryRunTask(
                         dryrun_service=ctx.overseas_vbo_dryrun_service,
                         shadow_journal=ctx.event_shadow_journal_service,
-                        market_calendar_service=ctx._mcs,
-                        market_clock=ctx.market_clock,
+                        market_calendar_service=None,
+                        market_clock=MarketClock.for_us_equities(logger=ctx.logger),
                         logger=ctx.logger,
                         worker_pool=getattr(ctx, "worker_pool", None),
                     )


### PR DESCRIPTION
## 배경
해외 VBO dry-run 태스크가 한국장 after-market 스케줄러(하드코딩 15:41 KST)를 재사용해, 미국 일봉 신호가 한국 평일에 ~1일 지연되어 산출되고 주말 갭이 발생했습니다. 미국장 클럭 헬퍼 `MarketClock.for_us_equities()`는 정의·테스트만 있고 실제 파이프라인에 배선되지 않았습니다.

## 변경
- `AfterMarketLoop` / `run_after_market_loop`에 `timezone`·`cron_hour`·`cron_minute` 인자 추가. **기본값 Asia/Seoul 15:41 유지** → 국내 after-market 태스크 전부 무영향.
- 거래 캘린더(`mcs`) 미주입 시 `latest_trading_date`를 `market_clock` 날짜로 폴백.
- `AfterMarketTask`에 오버라이드 훅 `_loop_timezone`/`_loop_cron_hour`/`_loop_cron_minute` 추가 (기본 None → KST).
- `OverseasDryRunTask`를 America/New_York 16:30(미국 정규장 16:00 마감 직후) 트리거로 오버라이드. `service_container`에서 `MarketClock.for_us_equities()` + `mcs=None`로 배선(한국 거래 캘린더는 미국 세션에 부적용).

## 주의 / 알려진 한계
- 여전히 **dry-run 전용 — 주문 경로 없음**. `OverseasVBODryRunService`는 order_execution 의존이 없습니다.
- 현재 운영 config는 `market_mode: "domestic"`이라 이 경로는 `overseas_us` 모드에서만 활성화됩니다.
- 미국 공휴일에는 cron(mon-fri NY)이 직전 완성봉을 재평가할 수 있으나 dry-run이라 무해(US 거래 캘린더 인프라 미도입).

## 테스트
- 신규: 루프 timezone/cron 파라미터화, mcs 미주입 폴백, 태스크 US 트리거 훅, service_container US 클럭 배선.
- 단위 6393 + 통합 243 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)