### PR TITLE
Add strategy risk controls

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -34,6 +34,13 @@ def _chunked(lst, size):
         yield lst[i:i + size]
 
 
+_ETF_NAME_PREFIXES = (
+    "KODEX", "TIGER", "KBSTAR", "ARIRANG", "SOL", "ACE",
+    "HANARO", "KOSEF", "PLUS", "TIMEFOLIO", "WON", "FOCUS",
+    "VITA", "TREX", "MASTER", "WOORI", "KINDEX", "RISE",
+)
+
+
 class OneilUniverseService:
     """오닐 전략 유니버스 관리 서비스.
     
@@ -190,7 +197,11 @@ class OneilUniverseService:
         # 1) Pool A 로드
         if not self._pool_a_loaded:
             raw = self._load_premium_stocks()
-            self._pool_a_items = {item.code: item for item in raw}
+            self._pool_a_items = {
+                item.code: item
+                for item in raw
+                if not self._is_excluded_etf(item.code, item.name, logger=logger)
+            }
             self._pool_a_loaded = True
 
         # 2) 당일 급등주 빌드 (실시간 랭킹)
@@ -259,7 +270,7 @@ class OneilUniverseService:
                 else:
                     code = getattr(stock, "mksc_shrn_iscd", "") or getattr(stock, "stck_shrn_iscd", "")
                     name = getattr(stock, "hts_kor_isnm", "")
-                if code:
+                if code and not self._is_excluded_etf(code, name, logger=logger):
                     candidate_map[code] = name
 
         # 분석 및 필터링
@@ -322,6 +333,9 @@ class OneilUniverseService:
     async def _analyze_premium_candidate(self, code: str, name: str, logger: Optional[logging.Logger] = None) -> Optional[OSBWatchlistItem]:
         """장마감 후 전일 기준 우량주(Pool A) 분석. 
         어제까지의 확정된 일봉 데이터만 사용하므로 별도의 슬라이싱이 필요하지 않습니다."""
+        if self._is_excluded_etf(code, name, logger=logger):
+            return None
+
         ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=260)
         ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
 
@@ -471,6 +485,8 @@ class OneilUniverseService:
         """장중 실시간 급등주(Pool B) 분석.
         어제까지의 캐시된 OHLCV 데이터와 오늘의 실시간 가격을 결합하여 분석합니다.
         """
+        if self._is_excluded_etf(code, name, logger=logger):
+            return None
 
         # 1. 어제 날짜 계산 (전략의 _check_entry 패턴 적용)
         now = self._tm.get_current_kst_time()
@@ -653,7 +669,9 @@ class OneilUniverseService:
         all_stocks = [
             (code, name, market)
             for code, name, market in zip(codes, names, markets)
-            if code and market in ("KOSPI", "KOSDAQ")
+            if code
+            and market in ("KOSPI", "KOSDAQ")
+            and not self._is_excluded_etf(code, name, logger=pool_a_logger)
         ]
 
         total_stocks = len(all_stocks)
@@ -806,6 +824,21 @@ class OneilUniverseService:
         }
 
     # ── 헬퍼 메서드 ───────────────────────────────────────────────
+
+    def _is_excluded_etf(
+        self,
+        code: str,
+        name: str,
+        logger: Optional[logging.Logger] = None,
+    ) -> bool:
+        if not self._cfg.exclude_etf_universe:
+            return False
+        normalized = str(name or "").strip().upper()
+        if not any(normalized.startswith(prefix) for prefix in _ETF_NAME_PREFIXES):
+            return False
+        if logger:
+            logger.debug({"event": "drop", "code": code, "name": name, "reason": "etf_excluded"})
+        return True
 
     def _reset_daily_exclusions(self, today: Optional[str] = None) -> None:
         if not today:

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -501,15 +501,22 @@ class FirstPullbackStrategy(LiveStrategy):
             state.mae_pct = round(pnl, 2)
             state_dirty = True
 
-        # 20MA 동적 계산 (매일 변하는 최신 MA)
-        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=self._cfg.ma_period)
-        ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
-        closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
-
         reason = ""
 
+        # 🚨 하드스탑: 20MA 유예와 무관하게 진입가 대비 손실 한도 도달 시 즉시 청산.
+        if pnl_net <= self._cfg.hard_stop_loss_pct:
+            reason = f"하드스탑(net {pnl_net:.1f}% ≤ {self._cfg.hard_stop_loss_pct:.1f}%)"
+
+        # 20MA 동적 계산 (매일 변하는 최신 MA)
+        if not reason:
+            ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(code, limit=self._cfg.ma_period)
+            ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == "0" else []
+            closes = [r.get("close", 0) for r in ohlcv if r.get("close")]
+        else:
+            closes = []
+
         # 🚨 손절: 20MA -2% 이탈 → 10분 유예 후 확정 (14:50 이후는 즉시) — 가격 기준 trigger, log 는 net 표시
-        if len(closes) >= self._cfg.ma_period:
+        if not reason and len(closes) >= self._cfg.ma_period:
             ma_20d = float(sum(closes[-self._cfg.ma_period:]) / self._cfg.ma_period)
             threshold = ma_20d * (1 + self._cfg.stop_loss_below_ma_pct / 100)
             if current < threshold:
@@ -520,14 +527,14 @@ class FirstPullbackStrategy(LiveStrategy):
                     second=0, microsecond=0,
                 )
                 if now >= eod:
-                    reason = f"손절(20MA {ma_20d:,.0f} 장마감전 이탈, net {pnl_net:.1f}%)"
+                    reason = f"손절(20MA {ma_20d:,.0f}, trigger {threshold:,.0f} 장마감전 이탈, net {pnl_net:.1f}%)"
                 elif not state.ma_break_since_ts:
                     state.ma_break_since_ts = now.strftime("%Y%m%d%H%M%S")
                     state_dirty = True
                 else:
                     break_dt = datetime.strptime(state.ma_break_since_ts, "%Y%m%d%H%M%S").replace(tzinfo=now.tzinfo)
                     if (now - break_dt).total_seconds() / 60 >= self._cfg.ma_break_grace_minutes:
-                        reason = f"손절(20MA {ma_20d:,.0f} {self._cfg.ma_break_grace_minutes}분 이탈유지, net {pnl_net:.1f}%)"
+                        reason = f"손절(20MA {ma_20d:,.0f}, trigger {threshold:,.0f} {self._cfg.ma_break_grace_minutes}분 이탈유지, net {pnl_net:.1f}%)"
             else:
                 if state.ma_break_since_ts:
                     state.ma_break_since_ts = None

--- a/strategies/first_pullback_types.py
+++ b/strategies/first_pullback_types.py
@@ -29,6 +29,7 @@ class FirstPullbackConfig(BaseStrategyConfig):
     reversal_min_relative_pos: float = 0.5         # 캔들 내 현재가 상대위치 최소값 (0.5=중간)
 
     # Phase 4: Exit (기계적 청산)
+    hard_stop_loss_pct: float = -5.0        # 진입가 대비 하드스탑 (net 기준)
     stop_loss_below_ma_pct: float = -2.0    # 20MA -2% 이탈 시 손절
     ma_break_grace_minutes: int = 10        # 20MA 이탈 후 손절 유예 시간 (분)
     ma_break_eod_hour: int = 14             # 장마감 전 즉시손절 기준 시각 (시)

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -52,6 +52,7 @@ class OneilUniverseConfig(BaseStrategyConfig):
 
     # 종목 상태 필터 (주문 정책과 동일 계열의 위험 종목을 유니버스 단계에서 제외)
     security_status_filter_enabled: bool = True
+    exclude_etf_universe: bool = True
     block_managed_issue: bool = True
     block_investment_warning: bool = True
     block_investment_caution: bool = False

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -147,6 +147,22 @@ async def test_analyze_premium_candidate_success(mock_deps):
     assert item.market == "KOSDAQ"
     assert item.rs_return_3m == 10.0
 
+async def test_analyze_premium_candidate_rejects_etf_name_before_api(mock_deps):
+    """Pool A 후보가 ETF/ETN 이름이면 상세 분석 API 호출 전 제외한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+
+    item = await service._analyze_premium_candidate("395160", "KODEX AI반도체TOP2플러스", logger=logger)
+
+    assert item is None
+    sqs.get_recent_daily_ohlcv.assert_not_awaited()
+    assert any(
+        call.args
+        and isinstance(call.args[0], dict)
+        and call.args[0].get("reason") == "etf_excluded"
+        for call in logger.debug.call_args_list
+    )
+
 async def test_analyze_premium_candidate_filter_market_cap(mock_deps):
     """_analyze_premium_candidate: 시가총액 범위(2천억~2조) 벗어날 시 탈락 검증."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
@@ -238,6 +254,36 @@ async def test_get_watchlist_filters_loaded_premium_blocked_security_status(mock
     assert watchlist == {}
     assert service._watchlist == {}
 
+async def test_get_watchlist_filters_loaded_premium_etfs(mock_deps):
+    """저장된 Pool A 파일에 남은 ETF도 워치리스트 빌드 시 제외한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 1, 9, 10, 0)
+    tm.get_market_open_time.return_value = datetime(2025, 1, 1, 9, 0, 0)
+
+    etf_item = OSBWatchlistItem(
+        code="395160", name="KODEX AI반도체TOP2플러스", market="KOSPI",
+        high_20d=1000, ma_20d=900, ma_50d=800, avg_vol_20d=10000,
+        bb_width_min_20d=10, prev_bb_width=11, w52_hgpr=1200,
+        avg_trading_value_5d=20_000_000_000, market_cap=500_000_000_000,
+    )
+    stock_item = OSBWatchlistItem(
+        code="222800", name="심텍", market="KOSDAQ",
+        high_20d=1000, ma_20d=900, ma_50d=800, avg_vol_20d=10000,
+        bb_width_min_20d=10, prev_bb_width=11, w52_hgpr=1200,
+        avg_trading_value_5d=20_000_000_000, market_cap=500_000_000_000,
+    )
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": create_mock_stock_info({})},
+    )
+
+    with patch.object(service, "_load_premium_stocks", return_value=[etf_item, stock_item]), \
+         patch.object(service, "_build_daily_surge_pool", new_callable=AsyncMock, return_value={}):
+        watchlist = await service.get_watchlist(logger=logger)
+
+    assert list(watchlist) == ["222800"]
+    assert list(service._pool_a_items) == ["222800"]
+
 async def test_get_watchlist_retains_subscription_sync_task(mock_deps):
     """get_watchlist: sync_subscriptions fire-and-forget 태스크를 강참조로 보관한다(GC 방지)."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
@@ -292,9 +338,9 @@ async def test_generate_premium_watchlist(mock_deps, tmp_path):
     
     # 1. 전체 종목 리스트 Mock
     mapper.df = pd.DataFrame({
-        "종목코드": ["000001", "000002"],
-        "종목명": ["StockA", "StockB"],
-        "시장구분": ["KOSPI", "KOSDAQ"]
+        "종목코드": ["000001", "000002", "395160"],
+        "종목명": ["StockA", "StockB", "KODEX AI반도체TOP2플러스"],
+        "시장구분": ["KOSPI", "KOSDAQ", "KOSPI"]
     })
     
     # 2. 1차 필터 (시총) Mock
@@ -336,6 +382,7 @@ async def test_generate_premium_watchlist(mock_deps, tmp_path):
             assert isinstance(result['kospi_stocks'], list)
             assert len(result['kospi_stocks']) == 1
             assert result['kospi_stocks'][0]['code'] == "000001"
+            assert "395160" not in [call.args[0] for call in sqs.get_current_price.await_args_list]
 
 async def test_get_watchlist_refresh_logic(mock_deps):
     """get_watchlist: 시간 경과에 따른 갱신 및 캐싱 로직 검증."""
@@ -1587,6 +1634,26 @@ async def test_analyze_surge_candidate_success_with_dict_output(mock_deps):
     assert item.w52_hgpr == 1500
     passed_ohlcv = indicator.calc_bb_widths_sync.call_args[0][0]
     assert passed_ohlcv[-1]["date"] != "20250102"
+
+
+@pytest.mark.asyncio
+async def test_analyze_surge_candidate_rejects_etf_name_before_api(mock_deps):
+    """Pool B 후보가 ETF/ETN 이름이면 OHLCV/현재가 API 호출 전 제외한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+
+    item = await service._analyze_surge_candidate("0167A0", "SOL AI반도체TOP2플러스", logger=logger)
+
+    assert item is None
+    tm.get_current_kst_time.assert_not_called()
+    sqs.get_recent_daily_ohlcv.assert_not_awaited()
+    sqs.get_current_price.assert_not_awaited()
+    assert any(
+        call.args
+        and isinstance(call.args[0], dict)
+        and call.args[0].get("reason") == "etf_excluded"
+        for call in logger.debug.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_first_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_first_pullback_strategy.py
@@ -731,6 +731,35 @@ async def test_scan_cgld_exception_returns_none(fp_scan_setup):
 # ════════════════════════════════════════════════════════════════
 
 @pytest.mark.asyncio
+async def test_exits_hard_stop_before_ma_break_grace(mock_deps):
+    """진입가 기준 하드스탑 도달 시 20MA 유예 없이 즉시 전량 매도."""
+    sqs, universe, tm, logger = mock_deps
+    strategy = FirstPullbackStrategy(sqs, universe, tm, logger=logger)
+    strategy._save_state = MagicMock()
+
+    strategy._position_state["005930"] = FPPositionState(10000, "20250101", 10500, 12000, False)
+
+    # 20MA 기준 손절선은 8,820원이라 현재가 9,400원은 MA 손절 조건이 아니다.
+    ohlcv = _make_ohlcv(20, close=9000)
+    sqs.get_recent_daily_ohlcv.return_value = ResCommonResponse(rt_cd="0", msg1="OK", data=ohlcv)
+    sqs.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data={"output": {"stck_prpr": "9400"}}
+    )
+
+    signals = await strategy.check_exits([
+        {"code": "005930", "buy_price": 10000, "qty": 4, "market": "KOSPI"}
+    ])
+
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert signals[0].qty == 4
+    assert "하드스탑" in signals[0].reason
+    assert "005930" not in strategy._position_state
+    assert strategy._position_state.get("005930") is None
+    assert tm.get_current_kst_time.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_exits_stop_loss_below_ma(mock_deps):
     """손절: 현재가 < 20MA * 0.98 → 잔량 전체 매도."""
     sqs, universe, tm, logger = mock_deps


### PR DESCRIPTION
## Summary
- add a FirstPullback net hard stop before the 20MA grace-period exit path
- include the MA stop trigger price in FirstPullback sell reasons
- exclude ETF/ETN-like names from the O'Neil universe at Pool A generation, saved Pool A load, and Pool B surge candidate collection

## Tests
- `pytest tests/unit_test -v`
- `pytest tests/integration_test -v`