### PR TITLE
Surface profitability gate per-strategy status in daily report (P1 1-6)

### DIFF
--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -25,6 +25,10 @@ from services.strategy_performance_degradation_service import (
     analyze_strategy_performance_degradation,
     compute_strategy_window_metrics,
 )
+from services.strategy_profitability_gate_service import (
+    StrategyProfitabilityGateConfig,
+    evaluate_strategy_profitability_gate,
+)
 
 
 def _esc(value: Any) -> str:
@@ -40,6 +44,36 @@ _REGIME_BUCKET_LABELS = {
     "BEAR": "하락",
     "TRADING_VALUE_SURGE": "거래대금급증",
 }
+
+
+# P1 1-6: profitability gate 결과(status/blocking_reasons)를 일일 리포트 한글로 노출.
+_PROFITABILITY_GATE_STATUS_LABELS = {
+    "pass": "통과",
+    "fail": "차단",
+    "insufficient_sample": "표본 부족",
+}
+
+_PROFITABILITY_GATE_REASON_LABELS = {
+    "insufficient_trades": "거래 수 부족",
+    "profit_factor_below": "수익팩터 미달",
+    "payoff_ratio_below": "손익비 미달",
+    "win_rate_below": "승률 미달",
+    "avg_net_return_below": "평균 순수익률 미달",
+    "total_net_pnl_not_positive": "순손익 음수",
+    "mdd_pct_above": "MDD 초과",
+    "monte_carlo_ruin_probability_above": "몬테카를로 파산확률 초과",
+    "monte_carlo_worst_mdd_pct_above": "몬테카를로 최악 MDD 초과",
+    "monte_carlo_unavailable": "몬테카를로 미산출",
+    "regime_balance_incomplete": "레짐 균형 미충족",
+    "parameter_stability_unavailable": "파라미터 안정성 미산출",
+    "multiple_testing_bias_warning": "다중검정 편향 경고",
+}
+
+
+def _profitability_gate_reason_label(reason: Any) -> str:
+    """blocking_reason 코드를 한글 라벨로 변환한다. 동적 사유(regime_*_negative_pnl 등)는
+    매핑이 없으면 원본 코드를 그대로 노출한다."""
+    return _PROFITABILITY_GATE_REASON_LABELS.get(str(reason), str(reason))
 
 
 def _numeric_values(values: List[Any]) -> List[float]:
@@ -405,6 +439,7 @@ class StrategyLogReportService:
         backtest_journal_provider: Optional[Callable[[str], List[dict]]] = None,
         enabled_strategy_provider: Optional[Callable[[], Optional[List[str]]]] = None,
         strategy_degradation_config: Optional[Any] = None,
+        profitability_gate_config: Optional[Any] = None,
     ):
         self._log_dir = log_dir
         self._stock_code_repo = stock_code_repo
@@ -413,6 +448,7 @@ class StrategyLogReportService:
         self._backtest_journal_provider = backtest_journal_provider
         self._enabled_strategy_provider = enabled_strategy_provider
         self._strategy_degradation_config = strategy_degradation_config
+        self._profitability_gate_config = profitability_gate_config
         self._last_execution_quality_candidates: List[dict] = []
         self._last_strategy_degradation_candidates: List[dict] = []
 
@@ -900,6 +936,63 @@ class StrategyLogReportService:
         rest_count = len(candidates) - 5
         if rest_count > 0:
             lines.append(f"  …외 {rest_count}개 전략")
+        return "\n".join(lines)
+
+    def _profitability_gate_cfg(self) -> StrategyProfitabilityGateConfig:
+        cfg = self._profitability_gate_config
+        if isinstance(cfg, StrategyProfitabilityGateConfig):
+            return cfg
+        values = {}
+        if cfg is not None:
+            for field in StrategyProfitabilityGateConfig.__dataclass_fields__:
+                if hasattr(cfg, field):
+                    values[field] = getattr(cfg, field)
+        return StrategyProfitabilityGateConfig(**values)
+
+    def _build_profitability_gate_section(self, target_date: str) -> Optional[str]:
+        """라이브 표준 journal 에 profitability gate 를 돌려 전략별 통과/차단 근거를
+        일일 리포트에 노출한다 (P1 1-6). 운영자가 "이 전략이 실전 확대 기준을
+        통과하는가 / 어떤 사유로 막히는가"를 일일 리포트에서 확인하기 위함이다."""
+        if not self._virtual_trade_service:
+            return None
+        try:
+            live_records = self._virtual_trade_service.get_standard_journal_records() or []
+        except Exception:
+            return None
+        if not live_records:
+            return None
+
+        cfg = self._profitability_gate_cfg()
+        try:
+            result = evaluate_strategy_profitability_gate(live_records, cfg)
+        except Exception:
+            return None
+        strategies = result.get("strategies") or {}
+        if not strategies:
+            return None
+
+        lines = ["<b>💹 전략별 수익성 게이트</b>"]
+        for name in sorted(strategies):
+            decision = strategies[name] or {}
+            metrics = decision.get("metrics") or {}
+            status = str(decision.get("status") or "")
+            status_label = _esc(_PROFITABILITY_GATE_STATUS_LABELS.get(status, status))
+            strategy = _esc(_strategy_display_label(name))
+            pf = metrics.get("profit_factor")
+            payoff = metrics.get("payoff_ratio")
+            pf_text = f"{float(pf):.2f}" if pf is not None else "—"
+            payoff_text = f"{float(payoff):.2f}" if payoff is not None else "—"
+            lines.append(
+                f"• {strategy}: {status_label} — "
+                f"거래 {int(metrics.get('trade_count') or 0)}/{int(cfg.min_trades)}, "
+                f"승률 {float(metrics.get('win_rate') or 0) * 100:.1f}%, "
+                f"PF {pf_text}, payoff {payoff_text}, "
+                f"순손익 {int(round(float(metrics.get('total_net_pnl') or 0))):,}원"
+            )
+            reasons = decision.get("blocking_reasons") or []
+            if reasons:
+                reason_text = ", ".join(_profitability_gate_reason_label(r) for r in reasons)
+                lines.append(f"  - 차단 사유: {_esc(reason_text)}")
         return "\n".join(lines)
 
     def _build_multiple_testing_section(self, target_date: str) -> Optional[str]:
@@ -1861,6 +1954,7 @@ class StrategyLogReportService:
         execution_quality_section = self._build_execution_quality_section(execution_quality_records)
         divergence_section = self._build_backtest_live_divergence_section(target_date)
         degradation_section = self._build_strategy_degradation_section(target_date)
+        profitability_gate_section = self._build_profitability_gate_section(target_date)
         volatility_section = self._build_volatility_section(strategy_summaries)
         signal_metadata_section = self._build_signal_metadata_section(strategy_summaries)
         multiple_testing_section = self._build_multiple_testing_section(target_date)
@@ -1877,6 +1971,7 @@ class StrategyLogReportService:
                     portfolio_summary,
                     divergence_section,
                     degradation_section,
+                    profitability_gate_section,
                     execution_quality_section,
                     volatility_section,
                     signal_metadata_section,
@@ -1903,6 +1998,8 @@ class StrategyLogReportService:
             body += f"\n\n{divergence_section}"
         if degradation_section:
             body += f"\n\n{degradation_section}"
+        if profitability_gate_section:
+            body += f"\n\n{profitability_gate_section}"
         if execution_quality_section:
             body += f"\n\n{execution_quality_section}"
         if volatility_section:

--- a/tests/unit_test/services/test_strategy_log_report_profitability_gate.py
+++ b/tests/unit_test/services/test_strategy_log_report_profitability_gate.py
@@ -1,0 +1,91 @@
+# tests/unit_test/services/test_strategy_log_report_profitability_gate.py
+"""HTML 일일 리포트의 전략별 수익성 게이트 섹션 검증 (P1 1-6).
+
+라이브 표준 journal 에 evaluate_strategy_profitability_gate 를 돌려
+전략별 통과/차단 상태와 차단 사유를 리포트에 노출하는지 확인한다.
+파이프라인 보강 전에는 이 섹션이 존재하지 않아 통과 근거를 운영자가
+일일 리포트에서 볼 수 없었다.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from services.strategy_log_report_service import StrategyLogReportService
+from services.strategy_profitability_gate_service import StrategyProfitabilityGateConfig
+
+
+def _sold(strategy: str, net_return: float, net_pnl: float, date: str = "2026-04-18") -> dict:
+    return {
+        "strategy": strategy,
+        "status": "SOLD",
+        "net_return": net_return,
+        "net_pnl": net_pnl,
+        "sell_date": date,
+    }
+
+
+def test_section_reports_pass_status_for_profitable_strategy():
+    vts = MagicMock()
+    vts.get_standard_journal_records.return_value = [
+        _sold("S1", 3.0, 300.0),
+        _sold("S1", 4.0, 400.0),
+        _sold("S1", 5.0, 500.0),
+    ]
+    svc = StrategyLogReportService(
+        log_dir=".",
+        virtual_trade_service=vts,
+        profitability_gate_config=StrategyProfitabilityGateConfig(min_trades=2),
+    )
+
+    section = svc._build_profitability_gate_section("20260418")
+
+    assert section is not None
+    assert "수익성 게이트" in section
+    assert "S1" in section
+    assert "통과" in section
+    # min_trades 진척 표기 (거래 3/2)
+    assert "거래 3/2" in section
+
+
+def test_section_flags_insufficient_sample_with_default_min_trades():
+    vts = MagicMock()
+    vts.get_standard_journal_records.return_value = [_sold("S1", 1.0, 100.0)]
+    # config 미주입 → 기본 min_trades=30
+    svc = StrategyLogReportService(log_dir=".", virtual_trade_service=vts)
+
+    section = svc._build_profitability_gate_section("20260418")
+
+    assert section is not None
+    assert "표본 부족" in section
+    assert "거래 1/30" in section
+
+
+def test_section_renders_blocking_reason_in_korean():
+    vts = MagicMock()
+    vts.get_standard_journal_records.return_value = [
+        _sold("S1", -2.0, -200.0),
+        _sold("S1", -3.0, -300.0),
+    ]
+    svc = StrategyLogReportService(
+        log_dir=".",
+        virtual_trade_service=vts,
+        profitability_gate_config=StrategyProfitabilityGateConfig(min_trades=2),
+    )
+
+    section = svc._build_profitability_gate_section("20260418")
+
+    assert section is not None
+    assert "차단" in section
+    assert "순손익 음수" in section
+
+
+def test_section_none_without_service():
+    svc = StrategyLogReportService(log_dir=".")
+    assert svc._build_profitability_gate_section("20260418") is None
+
+
+def test_section_none_on_empty_journal():
+    vts = MagicMock()
+    vts.get_standard_journal_records.return_value = []
+    svc = StrategyLogReportService(log_dir=".", virtual_trade_service=vts)
+    assert svc._build_profitability_gate_section("20260418") is None

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-06-24 (Phase 4 상태·no-tick 착수 순서 정리)
+최종 업데이트: 2026-06-24 (no-tick 블로커를 외부 액션으로 재분류·코드 진행 가능 항목 명시)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR로 추적하고 본 문서에서 제거한다.
 
@@ -12,9 +12,13 @@
 - 주문/브로커/스케줄러 변경은 테스트 hang 가이드와 paper/real 분기 검증을 함께 적용한다.
 - `VolumeBreakoutStrategy`, `VolumeBreakoutLiveStrategy`, `TraditionalVolumeBreakoutStrategy`, `GapUpPullbackStrategy`, `ProgramBuyFollowStrategy`, `MomentumStrategy`는 비활성/레거시이므로 신규 연결·개선 우선순위에서 제외한다.
 
+## 현재 코드 진행 가능 항목
+
+> **순수 코드로 지금 착수 가능한 신규 P0~P2 구현은 없다** — P0 0-1·P1 1-5/1-7·P2 2-2/2-4 잔여는 외부 데이터 확보·KIS 운영 액션에 의존(아래 각 항목 참조). 단 **P1 1-6(paper/소액 canary journal 축적)은 무틱 블로커와 독립적으로 라이브 런타임에서 시간 축적만 하면 진행 가능**하다(코드 확인: gate journal은 `virtual_trade_service.get_standard_journal_records` ← polling scan + REST 가격 경로로 채워짐, 틱 비의존. 무틱에 막히는 건 1-6의 "shadow" 하위 요소뿐이며 이는 2-4 parity와 동일 의존). 그 밖에 코드 착수가 가능한 것은 ① 신규 비상관 엣지(R-2) 정책 결정 후 구현, ② 키움 테마 REST(T-1), ③ 보류 항목 재승격(S-9·lifecycle 분해 등)이며 모두 정책 합의가 선행 조건이다.
+
 ## 남은 실행 영역 요약 (우선순위 순)
 
-- **[최우선·블로커] P2 2-4 WS price 피드 무틱 ≈55%**: 구독 종목 절반 이상이 종일 no-tick → VBO shadow parity 수집 불가 + 라이브 실시간 데이터 품질 문제. 2026-06-19 로그 진단 결과 `a1_kis_no_send` 우세(ACK 후 KIS 프레임 미전송)로 확인. 2026-06-22 운영 실험 A~D 라이브 실행으로 원인을 **종목/상품군/계정 단위 KIS측 미전송**으로 좁힘(subscribe/ack/quality_reject 전부 0, received 5 vs no_tick 18). 후속은 코드 선제 수정이 아니라 KIS 에스컬레이션/운영 우회책(무틱 종목 격리) 판단.
+- **[최우선·블로커 / 외부 액션] P2 2-4 WS price 피드 무틱 ≈55%**: 구독 종목 절반 이상이 종일 no-tick → VBO shadow parity 수집 불가 + 라이브 실시간 데이터 품질 문제. **이 레포에서 코드로 할 수 있는 작업은 종결**(무틱 종목 격리 구현 완료) — 남은 것은 KIS 에스컬레이션/운영 우회책뿐이며 코드 액션 없음. 2026-06-19 로그 진단 결과 `a1_kis_no_send` 우세(ACK 후 KIS 프레임 미전송)로 확인. 2026-06-22 운영 실험 A~D 라이브 실행으로 원인을 **종목/상품군/계정 단위 KIS측 미전송**으로 좁힘(subscribe/ack/quality_reject 전부 0, received 5 vs no_tick 18).
 - **P1 1-6** 실전 journal/shadow/paper/canary 성과 데이터로 profitability gate 실제 통과 근거 확보 — "돈을 버는가"의 핵심, 라이브 데이터 축적 의존.
 - **P1 1-7** formal 과최적화 방어(DSR + PBO CSCV + purge embargo) 완료. PBO/adjusted-Sharpe hard gate 옵션과 real-mode overlay는 구현됨. 남은 것은 DSR hard 기준 포함 최종 운영 정책 결정(canary 데이터 후).
 - **P0 0-1** 실전 submit/signing notice raw fixture 확보 후 mapper 회귀 보강(외부 데이터 의존).
@@ -54,6 +58,7 @@
 ### 1-6. 실전 수익성 데이터 확보와 profitability gate 운영
 
 - [ ] shadow / paper / 소액 canary journal을 표준 포맷으로 누적하고, 전략별 profitability gate 통과 근거를 리포트한다. (라이브 데이터 축적 의존 — "돈을 버는가"의 실증 단계)
+  - **무틱 블로커와의 관계**: paper/canary journal은 polling scan → REST 가격 → `log_buy/log_sell` → `virtual_trade_service.get_standard_journal_records`(=gate 입력) 경로로 채워지며 WS 틱에 비의존이므로 **2-4 무틱 블로커와 독립적으로 축적 가능**(라이브 런타임 시간만 필요). 무틱에 막히는 건 본 항목의 "shadow" 하위 요소(=event_shadow parity, 2-4와 동일 의존)뿐이다.
   - 최소 유지 기준: 실전 override `min_trades=100`, `profit_factor>=1.3`, `payoff_ratio>=1.2`, `win_rate>=40%`, `max_drawdown<=12%`, regime별 최소 거래 30. parameter stability·Monte Carlo·regime balance·multiple testing 보정을 운영 편의로 낮추지 않는다.
   - 완료(기반): fail-close 잠금(provider/journal 부재 시 real BUY 차단, paper bypass), gate 배선 lock 테스트, 전략 신호 9필드(`entry_reason`/`invalidation_price`/`stop_loss_price`/`target_price`/`trailing_rule`/`expected_holding_period_days`/`confidence`/`required_data`/`config_hash`) journal persist + surfacing.
 
@@ -146,7 +151,6 @@
 - 완료: **Phase 4 주문/사이징** 자동 전략 컴포넌트 — `OverseasOrderExecutionService`(`place_overseas_limit_order` 지정가 연결, `live_enabled=False` 구조적 실주문 잠금 + would-be 레코드), `OverseasPositionSizingService`(고정 USD 슬롯÷지정가 floor + `max_qty`/`available_usd` cap), FX 환율(`extract_fx_krw_per_usd` 잔고 관용 추출 + `_overseas_fx_provider` 배선 → dry-run KRW 환산 노출), 일봉 기반 exit(`decide_daily_exit` stop/eod). 테스트 잠금 완료. 별도 웹 수동 해외 지정가 주문은 존재하며, 실전 모드에서는 `overseas_stock.allow_live_trading=true`와 `REAL` 확인 문자열 없이는 broker 호출 전 차단된다.
   - 남은 것(Phase 5 소관): scheduler/factory가 sizing→order_execution 자동 연결(canary auto-fire) + `live_enabled=True` 전환 — dry-run 검증 + canary 후로 게이팅.
 - [ ] **Phase 5 안전/canary**: `get_overseas_balance`/`ccnl` reconcile(`OverseasReconcileService` scaffolding 존재), risk gate/kill switch/canary USD 확장, 실전 소액 canary, canary auto-fire 배선 + `live_enabled` 전환.
-- [x] 3d(후속): 미국장 마감(ET) 정밀 트리거. `AfterMarketLoop`에 timezone/cron 파라미터화(기본 KST 유지) + mcs 미주입 시 클럭 날짜 폴백 → `OverseasDryRunTask`를 America/New_York 16:30 트리거로 전환, `service_container`가 `MarketClock.for_us_equities()` + `mcs=None` 배선. (#585)
 
 주요 파일: `brokers/korea_investment/korea_invest_overseas_stock_api.py`, `brokers/broker_api_wrapper.py`, `services/overseas_order_execution_service.py`, `services/overseas_position_sizing_service.py`, `services/overseas_reconcile_service.py`, `services/stock_query_service.py`, `view/web/bootstrap/{service_container,strategy_factory}.py`, `config/tr_ids_config.yaml`
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -703,6 +703,9 @@ class ServiceContainer:
                         strategy_degradation_config=getattr(
                             ctx.full_config, "strategy_performance_degradation", None
                         ),
+                        profitability_gate_config=getattr(
+                            ctx.full_config, "strategy_profitability_gate", None
+                        ),
                         enabled_strategy_provider=ctx._get_enabled_strategy_names_for_report,
                     ),
                     notification_service=ctx.notification_service,


### PR DESCRIPTION
## 무엇을

전략 수익성 게이트(`evaluate_strategy_profitability_gate`)는 지금까지 스케줄러에서 **실 BUY 차단** 용도로만 소비되었고, 전략별 통과/차단 근거는 일일 리포트에 노출되지 않았다. 운영자는 라이브 누적 journal 기준으로 "이 전략이 실전 확대 기준을 통과하는가 / 어떤 사유로 막히는가"를 볼 방법이 없었다 (유일한 노출 = 실 BUY 차단 순간의 스케줄러 로그 한 줄).

이 PR은 `StrategyLogReportService`에 **`_build_profitability_gate_section`**을 추가해 라이브 표준 journal에 gate를 돌려 전략별 status·거래수 진척(`거래 N/min_trades`)·핵심 지표(승률/PF/payoff/순손익)·**한글 차단 사유**를 일일 리포트에 노출한다.

## 왜 (P1 1-6 검증 결과)

파이프라인 검증 결과:
- **축적→gate 계약 정상**: `get_standard_journal_records → normalize_virtual_trade`가 비용 반영 `net_pnl`/`net_return`을 산출하고, gate가 읽는 필드를 모두 내보냄(조용히 0이 되는 경로 없음).
- gate 입력 journal은 **polling scan + REST 가격** 경로로 채워져 WS 틱 비의존 → **2-4 무틱 블로커와 독립적으로 축적·평가 가능**.
- **유일한 공백 = 리포트 노출**: degradation/correlation/multiple-testing 등 섹션은 있으나 profitability gate 섹션만 부재. 본 PR이 이를 보강.

## 변경

- `services/strategy_log_report_service.py`: gate import, 한글 status/reason 라벨, `profitability_gate_config` 생성자 파라미터 + `_profitability_gate_cfg()` 헬퍼, `_build_profitability_gate_section`, `generate_report` 두 분기 배선.
- `view/web/bootstrap/service_container.py`: `full_config.strategy_profitability_gate`를 리포트 서비스에 주입.
- `todo_list.md`: 무틱 블로커를 외부 KIS-에스컬레이션 액션으로 재분류, 1-6 누적이 무틱과 독립임을 명시.

## 테스트

- 신규 `tests/unit_test/services/test_strategy_log_report_profitability_gate.py` 5건: 통과/표본부족/한글 차단사유/서비스 미주입 None/빈 journal None.
- 기존 report 관련 단위 91건 회귀 없음.
- 통합 테스트 243건 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)