### PR TITLE
차트 Stage 밴드 및 장마감 시총갭 리포트

### DIFF
--- a/services/market_cap_gap_service.py
+++ b/services/market_cap_gap_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import sqlite3
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Iterable, Optional, Protocol
 
 import httpx
 
 from common.types import ErrorCode
+
+_DEFAULT_KOREAN_PROVIDER = object()
 
 
 @dataclass(frozen=True)
@@ -25,6 +31,105 @@ class UsMarketCapProvider(Protocol):
         ...
 
 
+class KoreanMarketCapProvider(Protocol):
+    async def fetch_market_caps(self, codes: Iterable[str], report_date: str) -> dict[str, int]:
+        ...
+
+
+class PykrxKoreanMarketCapProvider:
+    """pykrx 기반 국내 시총 fallback provider.
+
+    KIS 모의투자 환경에서는 일부 시총 API가 "없는 서비스 코드"로 실패할 수 있어
+    장마감 리포트 전용 fallback으로 사용한다.
+    """
+
+    def __init__(self, logger=None, lookback_days: int = 7, db_path: str | Path = "data/stocks.db"):
+        self._logger = logger or logging.getLogger(__name__)
+        self._lookback_days = lookback_days
+        self._db_path = Path(db_path)
+
+    async def fetch_market_caps(self, codes: Iterable[str], report_date: str) -> dict[str, int]:
+        wanted = [str(code).zfill(6) for code in codes]
+        if not wanted:
+            return {}
+        return await asyncio.to_thread(self._fetch_sync, wanted, report_date)
+
+    def _fetch_sync(self, codes: list[str], report_date: str) -> dict[str, int]:
+        found = self._fetch_local_db(codes, report_date)
+        if len(found) == len(codes):
+            return found
+
+        try:
+            from pykrx import stock
+        except Exception as exc:
+            self._logger.warning(f"pykrx 국내 시총 fallback import 실패: {exc}")
+            return found
+
+        try:
+            base_date = datetime.strptime(str(report_date), "%Y%m%d")
+        except ValueError:
+            base_date = datetime.now()
+
+        missing_codes = [code for code in codes if code not in found]
+        for offset in range(max(self._lookback_days, 0) + 1):
+            date = (base_date - timedelta(days=offset)).strftime("%Y%m%d")
+            try:
+                df = stock.get_market_cap_by_ticker(date, market="ALL")
+            except Exception as exc:
+                self._logger.warning(f"pykrx 국내 시총 조회 실패: {date} {exc}")
+                continue
+            if df is None or getattr(df, "empty", True):
+                continue
+
+            for code in missing_codes:
+                if code in found or code not in df.index:
+                    continue
+                try:
+                    value = int(df.loc[code].get("시가총액") or 0)
+                except (TypeError, ValueError, AttributeError):
+                    continue
+                if value > 0:
+                    found[code] = value
+            if len(found) == len(codes):
+                break
+        return found
+
+    def _fetch_local_db(self, codes: list[str], report_date: str) -> dict[str, int]:
+        if not self._db_path.exists():
+            return {}
+        placeholders = ",".join("?" for _ in codes)
+        query = f"""
+            SELECT code, market_cap, trade_date
+            FROM daily_prices
+            WHERE code IN ({placeholders})
+              AND trade_date <= ?
+              AND market_cap IS NOT NULL
+              AND market_cap > 0
+            ORDER BY trade_date DESC
+        """
+        found: dict[str, int] = {}
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                rows = conn.execute(query, [*codes, str(report_date)]).fetchall()
+        except Exception as exc:
+            self._logger.warning(f"로컬 국내 시총 fallback 조회 실패: {exc}")
+            return found
+
+        for code, raw_cap, _trade_date in rows:
+            if code in found:
+                continue
+            try:
+                cap = int(raw_cap or 0)
+            except (TypeError, ValueError):
+                continue
+            if cap <= 0:
+                continue
+            if cap < 1_000_000_000:
+                cap *= 100_000_000
+            found[str(code).zfill(6)] = cap
+        return found
+
+
 class YahooUsMarketCapProvider:
     """Yahoo quote endpoint 기반 미국주식 시총 provider.
 
@@ -32,6 +137,9 @@ class YahooUsMarketCapProvider:
     """
 
     _QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+    _COOKIE_URL = "https://fc.yahoo.com"
+    _CRUMB_URL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+    _CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
 
     def __init__(self, logger=None, timeout_sec: float = 10.0):
         self._logger = logger or logging.getLogger(__name__)
@@ -44,12 +152,51 @@ class YahooUsMarketCapProvider:
             "region": "US",
         }
         headers = {"User-Agent": "Mozilla/5.0"}
-        async with httpx.AsyncClient(timeout=self._timeout_sec, headers=headers) as client:
+        async with httpx.AsyncClient(timeout=self._timeout_sec, headers=headers, follow_redirects=True) as client:
             response = await client.get(self._QUOTE_URL, params=params)
+            if response.status_code in (401, 403):
+                crumb = await self._fetch_crumb(client)
+                if crumb:
+                    params = dict(params)
+                    params["crumb"] = crumb
+                    response = await client.get(self._QUOTE_URL, params=params)
             response.raise_for_status()
             payload = response.json()
         result = payload.get("quoteResponse", {}).get("result", [])
         return result if isinstance(result, list) else []
+
+    async def _fetch_crumb(self, client: httpx.AsyncClient) -> Optional[str]:
+        try:
+            await client.get(self._COOKIE_URL)
+            response = await client.get(self._CRUMB_URL)
+        except Exception as exc:
+            self._logger.warning(f"Yahoo crumb 조회 실패: {exc}")
+            return None
+        if response.status_code != 200:
+            return None
+        crumb = response.text.strip()
+        return crumb or None
+
+    async def _fetch_chart_price(self, symbol: str) -> Optional[float]:
+        headers = {"User-Agent": "Mozilla/5.0"}
+        url = self._CHART_URL.format(symbol=str(symbol).upper())
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_sec, headers=headers, follow_redirects=True) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as exc:
+            self._logger.warning(f"Yahoo chart 가격 조회 실패: {symbol} {exc}")
+            return None
+        results = payload.get("chart", {}).get("result", [])
+        if not results:
+            return None
+        meta = results[0].get("meta") or {}
+        try:
+            value = float(meta.get("regularMarketPrice") or meta.get("previousClose") or 0)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
 
     async def fetch_quotes(self, symbols: Iterable[str]) -> list[MarketCapQuote]:
         quotes: list[MarketCapQuote] = []
@@ -84,7 +231,7 @@ class YahooUsMarketCapProvider:
             rows = await self._fetch_raw(["KRW=X"])
         except Exception as exc:
             self._logger.error(f"USD/KRW 환율 조회 실패: {exc}", exc_info=True)
-            return None
+            return await self._fetch_chart_price("KRW=X")
         for row in rows:
             if not isinstance(row, dict):
                 continue
@@ -94,7 +241,7 @@ class YahooUsMarketCapProvider:
                 continue
             if value > 0:
                 return value
-        return None
+        return await self._fetch_chart_price("KRW=X")
 
 
 class StaticUsMarketCapProvider:
@@ -134,32 +281,43 @@ class MarketCapGapService:
         self,
         broker,
         us_provider: Optional[UsMarketCapProvider] = None,
+        korean_provider=_DEFAULT_KOREAN_PROVIDER,
         korean_targets: Iterable[tuple[str, str]] = DEFAULT_KOREAN_TARGETS,
         us_targets: Iterable[str] = DEFAULT_US_TARGETS,
         logger=None,
     ):
         self._broker = broker
         self._us_provider = us_provider or YahooUsMarketCapProvider(logger=logger)
+        self._korean_provider = (
+            PykrxKoreanMarketCapProvider(logger=logger)
+            if korean_provider is _DEFAULT_KOREAN_PROVIDER
+            else korean_provider
+        )
         self._korean_targets = tuple(korean_targets)
         self._us_targets = tuple(str(symbol).upper() for symbol in us_targets)
         self._logger = logger or logging.getLogger(__name__)
 
-    async def _fetch_korean_caps(self) -> list[dict]:
+    async def _fetch_korean_caps(self, report_date: str) -> list[dict]:
         items: list[dict] = []
+        missing: list[tuple[str, str]] = []
         for code, name in self._korean_targets:
             try:
                 resp = await self._broker.get_market_cap(code)
             except Exception as exc:
                 self._logger.warning(f"국내 시총 조회 실패: {code} {exc}")
+                missing.append((code, name))
                 continue
             if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
                 self._logger.warning(f"국내 시총 응답 실패: {code} {getattr(resp, 'msg1', '')}")
+                missing.append((code, name))
                 continue
             try:
                 market_cap = int(getattr(resp, "data", 0) or 0)
             except (TypeError, ValueError):
+                missing.append((code, name))
                 continue
             if market_cap <= 0:
+                missing.append((code, name))
                 continue
             items.append({
                 "symbol": code,
@@ -167,6 +325,21 @@ class MarketCapGapService:
                 "currency": "KRW",
                 "market_cap_krw": market_cap,
             })
+        if missing and self._korean_provider:
+            fallback_caps = await self._korean_provider.fetch_market_caps(
+                [code for code, _ in missing],
+                report_date,
+            )
+            for code, name in missing:
+                market_cap = int(fallback_caps.get(code) or 0)
+                if market_cap <= 0:
+                    continue
+                items.append({
+                    "symbol": code,
+                    "name": name,
+                    "currency": "KRW",
+                    "market_cap_krw": market_cap,
+                })
         return items
 
     async def _fetch_us_caps(self, fx_rate: Optional[float]) -> list[dict]:
@@ -213,7 +386,7 @@ class MarketCapGapService:
 
     async def build_report(self, report_date: str, trigger: str) -> dict:
         fx_rate = await self._us_provider.fetch_usdkrw()
-        korean = await self._fetch_korean_caps()
+        korean = await self._fetch_korean_caps(report_date)
         us = await self._fetch_us_caps(fx_rate)
         return {
             "report_date": report_date,

--- a/services/market_cap_gap_service.py
+++ b/services/market_cap_gap_service.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional, Protocol
+
+import httpx
+
+from common.types import ErrorCode
+
+
+@dataclass(frozen=True)
+class MarketCapQuote:
+    symbol: str
+    name: str
+    currency: str
+    market_cap: int
+
+
+class UsMarketCapProvider(Protocol):
+    async def fetch_quotes(self, symbols: Iterable[str]) -> list[MarketCapQuote]:
+        ...
+
+    async def fetch_usdkrw(self) -> Optional[float]:
+        ...
+
+
+class YahooUsMarketCapProvider:
+    """Yahoo quote endpoint 기반 미국주식 시총 provider.
+
+    공식 보장 API는 아니므로 서비스 테스트에서는 provider를 주입해 네트워크를 격리한다.
+    """
+
+    _QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+
+    def __init__(self, logger=None, timeout_sec: float = 10.0):
+        self._logger = logger or logging.getLogger(__name__)
+        self._timeout_sec = timeout_sec
+
+    async def _fetch_raw(self, symbols: Iterable[str]) -> list[dict]:
+        params = {
+            "symbols": ",".join(str(symbol).upper() for symbol in symbols),
+            "lang": "en-US",
+            "region": "US",
+        }
+        headers = {"User-Agent": "Mozilla/5.0"}
+        async with httpx.AsyncClient(timeout=self._timeout_sec, headers=headers) as client:
+            response = await client.get(self._QUOTE_URL, params=params)
+            response.raise_for_status()
+            payload = response.json()
+        result = payload.get("quoteResponse", {}).get("result", [])
+        return result if isinstance(result, list) else []
+
+    async def fetch_quotes(self, symbols: Iterable[str]) -> list[MarketCapQuote]:
+        quotes: list[MarketCapQuote] = []
+        try:
+            rows = await self._fetch_raw(symbols)
+        except Exception as exc:
+            self._logger.error(f"미국 시총 조회 실패: {exc}", exc_info=True)
+            return quotes
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                symbol = str(row.get("symbol") or "").upper()
+                market_cap = int(row.get("marketCap") or 0)
+            except (TypeError, ValueError):
+                continue
+            if not symbol or market_cap <= 0:
+                continue
+            quotes.append(
+                MarketCapQuote(
+                    symbol=symbol,
+                    name=str(row.get("shortName") or row.get("longName") or symbol),
+                    currency=str(row.get("currency") or "USD"),
+                    market_cap=market_cap,
+                )
+            )
+        return quotes
+
+    async def fetch_usdkrw(self) -> Optional[float]:
+        try:
+            rows = await self._fetch_raw(["KRW=X"])
+        except Exception as exc:
+            self._logger.error(f"USD/KRW 환율 조회 실패: {exc}", exc_info=True)
+            return None
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                value = float(row.get("regularMarketPrice") or row.get("bid") or 0)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                return value
+        return None
+
+
+class StaticUsMarketCapProvider:
+    """테스트용 정적 provider."""
+
+    def __init__(self, quotes: list[MarketCapQuote], usdkrw: Optional[float]):
+        self._quotes = quotes
+        self._usdkrw = usdkrw
+
+    async def fetch_quotes(self, symbols: Iterable[str]) -> list[MarketCapQuote]:
+        wanted = {str(symbol).upper() for symbol in symbols}
+        return [quote for quote in self._quotes if quote.symbol.upper() in wanted]
+
+    async def fetch_usdkrw(self) -> Optional[float]:
+        return self._usdkrw
+
+
+class MarketCapGapService:
+    DEFAULT_KOREAN_TARGETS = (
+        ("005930", "삼성전자"),
+        ("000660", "SK하이닉스"),
+    )
+    DEFAULT_US_TARGETS = (
+        "NVDA",
+        "AAPL",
+        "MSFT",
+        "GOOGL",
+        "AMZN",
+        "META",
+        "AVGO",
+        "TSLA",
+        "MU",
+        "SNDK",
+    )
+
+    def __init__(
+        self,
+        broker,
+        us_provider: Optional[UsMarketCapProvider] = None,
+        korean_targets: Iterable[tuple[str, str]] = DEFAULT_KOREAN_TARGETS,
+        us_targets: Iterable[str] = DEFAULT_US_TARGETS,
+        logger=None,
+    ):
+        self._broker = broker
+        self._us_provider = us_provider or YahooUsMarketCapProvider(logger=logger)
+        self._korean_targets = tuple(korean_targets)
+        self._us_targets = tuple(str(symbol).upper() for symbol in us_targets)
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def _fetch_korean_caps(self) -> list[dict]:
+        items: list[dict] = []
+        for code, name in self._korean_targets:
+            try:
+                resp = await self._broker.get_market_cap(code)
+            except Exception as exc:
+                self._logger.warning(f"국내 시총 조회 실패: {code} {exc}")
+                continue
+            if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+                self._logger.warning(f"국내 시총 응답 실패: {code} {getattr(resp, 'msg1', '')}")
+                continue
+            try:
+                market_cap = int(getattr(resp, "data", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if market_cap <= 0:
+                continue
+            items.append({
+                "symbol": code,
+                "name": name,
+                "currency": "KRW",
+                "market_cap_krw": market_cap,
+            })
+        return items
+
+    async def _fetch_us_caps(self, fx_rate: Optional[float]) -> list[dict]:
+        quotes = await self._us_provider.fetch_quotes(self._us_targets)
+        items: list[dict] = []
+        for quote in quotes:
+            if quote.market_cap <= 0:
+                continue
+            market_cap_krw = int(quote.market_cap * fx_rate) if fx_rate else None
+            items.append({
+                "symbol": quote.symbol.upper(),
+                "name": quote.name,
+                "currency": quote.currency,
+                "market_cap_usd": quote.market_cap,
+                "market_cap_krw": market_cap_krw,
+            })
+        items.sort(key=lambda item: item.get("market_cap_krw") or item.get("market_cap_usd") or 0, reverse=True)
+        return items
+
+    @staticmethod
+    def _build_comparisons(korean: list[dict], us: list[dict]) -> list[dict]:
+        comparisons: list[dict] = []
+        for kr in korean:
+            kr_cap = int(kr["market_cap_krw"])
+            if kr_cap <= 0:
+                continue
+            for us_item in us:
+                us_cap = us_item.get("market_cap_krw")
+                if not us_cap:
+                    continue
+                gap = int(us_cap) - kr_cap
+                comparisons.append({
+                    "korean_symbol": kr["symbol"],
+                    "korean_name": kr["name"],
+                    "korean_market_cap_krw": kr_cap,
+                    "us_symbol": us_item["symbol"],
+                    "us_name": us_item["name"],
+                    "us_market_cap_krw": int(us_cap),
+                    "gap_krw": gap,
+                    "ratio": round(int(us_cap) / kr_cap, 2),
+                })
+        comparisons.sort(key=lambda item: (item["korean_symbol"], -item["us_market_cap_krw"]))
+        return comparisons
+
+    async def build_report(self, report_date: str, trigger: str) -> dict:
+        fx_rate = await self._us_provider.fetch_usdkrw()
+        korean = await self._fetch_korean_caps()
+        us = await self._fetch_us_caps(fx_rate)
+        return {
+            "report_date": report_date,
+            "trigger": trigger,
+            "fx_rate": fx_rate,
+            "korean": korean,
+            "us": us,
+            "comparisons": self._build_comparisons(korean, us) if fx_rate else [],
+        }

--- a/services/minervini_stage_service.py
+++ b/services/minervini_stage_service.py
@@ -230,23 +230,50 @@ class MinerviniStageService:
         low_window = lows[-252:] if len(lows) >= 252 else lows
         w52_low = min(low_window) if low_window else min(closes)
 
-        # ── Stage 4 (최우선 필터) ──────────────────────────────────────────
-        if price < ma200:
-            reason = f"가격이 MA200 아래 (가격={price:.2f} < MA200={ma200:.2f})"
-            return (self.STAGE_4_DECLINING, reason) if return_reason else self.STAGE_4_DECLINING
-        if ma200_slope <= 0:
-            reason = f"MA200 기울기 비양수 (기울기={ma200_slope:.6f})"
-            return (self.STAGE_4_DECLINING, reason) if return_reason else self.STAGE_4_DECLINING
-
-        # ── Stage 2 (트렌드 템플릿 8조건) ────────────────────────────────
         # 조건 8: RS Rating — 데이터 없으면(0) skip하고 경고 로그
         if rs_rating == 0:
             self._logger.debug(
                 f"[MinerviniStage] RS Rating 데이터 부족 — RS 조건 skip (stage 판정 계속)"
             )
-            rs_ok = True
-        else:
-            rs_ok = rs_rating >= 70
+
+        is_high_vol = self._is_high_volatility(closes)
+        return self._classify_from_metrics(
+            price, ma50, ma150, ma200, ma200_slope,
+            w52_high, w52_low, is_high_vol, rs_rating, return_reason,
+        )
+
+    def _classify_from_metrics(
+        self,
+        price: float,
+        ma50: float,
+        ma150: float,
+        ma200: float,
+        ma200_slope: float,
+        w52_high: float,
+        w52_low: float,
+        is_high_vol: bool,
+        rs_rating: int,
+        return_reason: bool = False,
+    ) -> tuple[int, str] | int:
+        """사전 계산된 지표로 Stage를 판정한다 (classify_stage/series 공용 결정 로직).
+
+        단일/일자별 경로 모두 동일한 트렌드 템플릿 임계값을 쓰도록 결정부를
+        한 곳에 모은 헬퍼. 지표 산출 방식만 호출자가 다르게(스칼라 vs 벡터) 구현한다.
+        """
+        # 일자별 시리즈는 return_reason=False로 수백 회 호출되므로
+        # reason f-string은 조건식 안에서만(필요 시) 생성한다.
+        # ── Stage 4 (최우선 필터) ──────────────────────────────────────────
+        if price < ma200:
+            if not return_reason:
+                return self.STAGE_4_DECLINING
+            return self.STAGE_4_DECLINING, f"가격이 MA200 아래 (가격={price:.2f} < MA200={ma200:.2f})"
+        if ma200_slope <= 0:
+            if not return_reason:
+                return self.STAGE_4_DECLINING
+            return self.STAGE_4_DECLINING, f"MA200 기울기 비양수 (기울기={ma200_slope:.6f})"
+
+        # ── Stage 2 (트렌드 템플릿 8조건) ────────────────────────────────
+        rs_ok = True if rs_rating == 0 else rs_rating >= 70
 
         is_stage2 = (
             ma200_slope > 0              # ①  MA200 우상향
@@ -258,20 +285,84 @@ class MinerviniStageService:
             and rs_ok                    # ⑧  RS Rating >= 70
         )
         if is_stage2:
-            reason = (
+            if not return_reason:
+                return self.STAGE_2_ADVANCING
+            return self.STAGE_2_ADVANCING, (
                 f"트렌드 템플릿 충족: ma200_slope={ma200_slope:.6f}, ma50={ma50:.2f}, "
                 f"ma150={ma150:.2f}, ma200={ma200:.2f}, 가격={price:.2f}, RS={rs_rating}"
             )
-            return (self.STAGE_2_ADVANCING, reason) if return_reason else self.STAGE_2_ADVANCING
 
         # ── Stage 3 (고점/배분) ───────────────────────────────────────────
-        if price < ma50 and self._is_high_volatility(closes):
-            reason = f"MA50 아래이면서 고변동성 (가격={price:.2f} < MA50={ma50:.2f})"
-            return (self.STAGE_3_TOPPING, reason) if return_reason else self.STAGE_3_TOPPING
+        if price < ma50 and is_high_vol:
+            if not return_reason:
+                return self.STAGE_3_TOPPING
+            return self.STAGE_3_TOPPING, f"MA50 아래이면서 고변동성 (가격={price:.2f} < MA50={ma50:.2f})"
 
         # ── Stage 1 (무관심/횡보) ─────────────────────────────────────────
-        reason = "기본: 무관심/횡보"
-        return (self.STAGE_1_NEGLECT, reason) if return_reason else self.STAGE_1_NEGLECT
+        return (self.STAGE_1_NEGLECT, "기본: 무관심/횡보") if return_reason else self.STAGE_1_NEGLECT
+
+    def classify_stage_series(
+        self,
+        closes: List[float],
+        lows: List[float],
+        rs_rating: int = 0,
+    ) -> List[int]:
+        """일자별 Stage를 계산한다 (차트 일자별 표기용).
+
+        각 인덱스 i에 대해 그 시점까지의 윈도우(closes[:i+1], lows[:i+1])로
+        classify_stage를 호출해 해당 날짜의 Stage를 산출한다. 200일 룩백이
+        확보되지 않는 앞 구간은 STAGE_UNKNOWN(0)으로 채운다.
+
+        Args:
+            closes:    종가 리스트 (오래된 순).
+            lows:      장중 저가 리스트 (오래된 순). closes와 길이 동일 가정.
+            rs_rating: RS Rating. 과거 일자별 값은 없으므로 보통 0(조건 skip).
+
+        Returns:
+            closes와 동일 길이의 Stage 리스트 (각 원소 0~4).
+        """
+        import pandas as pd
+
+        n = len(closes)
+        stages = [self.STAGE_UNKNOWN] * n
+        if n < 200:
+            return stages
+
+        c = pd.Series(closes, dtype=float)
+        l = pd.Series(lows, dtype=float)
+
+        # 롤링 지표를 1회 벡터화 계산 (classify_stage가 매 시점 재계산하던 부분).
+        ma50 = c.rolling(50).mean().to_numpy()
+        ma150 = c.rolling(150).mean().to_numpy()
+        ma200_s = c.rolling(200).mean()
+        ma200 = ma200_s.to_numpy()
+        # 52주 고가(종가)/저가(장중 저가): 데이터가 252일 미만이면 보유분 전체 기준.
+        w52_high = c.rolling(252, min_periods=1).max().to_numpy()
+        w52_low = l.rolling(252, min_periods=1).min().to_numpy()
+        # 고변동성(ATR-proxy): 최근 20일 |Δ| 평균 / 최근 20일 평균가 > 임계값.
+        chg_mean = c.diff().abs().rolling(20).mean().to_numpy()
+        px_mean20 = c.rolling(20).mean().to_numpy()
+
+        lookback = self._slope_lookback
+        for i in range(199, n):
+            # MA200 기울기: MA200 시리즈의 최근 lookback개 점에 선형회귀.
+            # _ma_series와 동일하게 사용 가능한 점 수가 부족하면 그만큼만 사용.
+            # polyfit 대신 등간격 x 폐형식(최소제곱 기울기)으로 루프 비용 절감.
+            points = min(lookback, i - 198)
+            slope = self._slope_evenly_spaced(ma200[i - points + 1 : i + 1])
+
+            avg_px = px_mean20[i]
+            is_high_vol = bool(
+                i >= 20
+                and avg_px
+                and (chg_mean[i] / (avg_px or 1.0)) > self._vol_threshold
+            )
+
+            stages[i] = self._classify_from_metrics(
+                closes[i], ma50[i], ma150[i], ma200[i], slope,
+                w52_high[i], w52_low[i], is_high_vol, rs_rating,
+            )
+        return stages
 
     # ── 내부 헬퍼 ──────────────────────────────────────────────────────────
 
@@ -291,6 +382,23 @@ class MinerviniStageService:
             mean(closes[i - window + 1: i + 1])
             for i in range(n - points, n)
         ]
+
+    @staticmethod
+    def _slope_evenly_spaced(y: np.ndarray) -> float:
+        """등간격 x(0,1,2,…)에 대한 최소제곱 기울기를 폐형식으로 산출.
+
+        polyfit(deg=1) 기울기와 수학적으로 동일하나 객체 생성/일반화 비용이
+        없어 일자별 시리즈 루프에서 훨씬 빠르다. 점이 2개 미만이면 0.0.
+        """
+        k = y.shape[0]
+        if k < 2:
+            return 0.0
+        x = np.arange(k, dtype=float)
+        xm = (k - 1) / 2.0
+        denom = float(((x - xm) ** 2).sum())
+        if denom == 0.0:
+            return 0.0
+        return float(((x - xm) * (y - y.mean())).sum() / denom)
 
     def _calculate_slope(self, values: List[float]) -> float:
         """numpy 선형회귀로 기울기 산출.

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -32,6 +32,7 @@ class StockQueryService:
         self.logger = logger
         self.market_clock = market_clock
         self.indicator_service = indicator_service
+        self.minervini_stage_service = None  # 후주입 (순환 의존 해소: ServiceContainer)
         self.ranking_task = ranking_task
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._notification_service = notification_service
@@ -60,6 +61,10 @@ class StockQueryService:
         self._multi_price_prefetch_cooldown_sec = 300.0
         self._multi_price_prefetch_consecutive_failures = 0
         self._multi_price_prefetch_disabled_until = 0.0
+
+    def set_minervini_stage_service(self, minervini_stage_service) -> None:
+        """MinerviniStageService 후주입 — 차트 일자별 Stage 표기용 (ServiceContainer 호출)."""
+        self.minervini_stage_service = minervini_stage_service
 
     def _count_price_lookup(self, key: str, enabled: bool = True) -> None:
         """운영 현재가 조회 통계를 선택적으로 증가시킨다."""
@@ -1190,6 +1195,33 @@ class StockQueryService:
                 indicators_data = {"ma5": [], "ma10": [], "ma20": [], "ma60": [], "ma120": [], "bb": [], "rs": []}
             else:
                 indicators_data = indicators_resp.data
+
+            # 3. 일자별 Minervini Stage (차트 배경 밴드용) — 서비스가 주입된 경우에만.
+            #    프론트는 minervini_stage[i]를 ohlcv[i]에 정렬하므로 1:1 인덱스를
+            #    유지해야 한다 → 행 제거/재정렬 없이 ohlcv_data 순서 그대로 추출하고,
+            #    비정상(0 이하) 종가는 직전 유효가로 보정해 MA 왜곡만 방지한다.
+            #    과거 일자별 RS Rating은 없으므로 rs_rating=0(⑧조건 skip)으로 계산한다.
+            if self.minervini_stage_service is not None and len(ohlcv_data) >= 200:
+                try:
+                    closes, lows, prev = [], [], 0.0
+                    for r in ohlcv_data:
+                        try:
+                            c = float(r.get("close") or r.get("stck_clpr") or 0)
+                            lo = float(r.get("low") or r.get("stck_lwpr") or c)
+                        except (TypeError, ValueError):
+                            c, lo = 0.0, 0.0
+                        if c <= 0:
+                            c = prev
+                        if lo <= 0:
+                            lo = c
+                        prev = c
+                        closes.append(c)
+                        lows.append(lo)
+                    indicators_data["minervini_stage"] = (
+                        self.minervini_stage_service.classify_stage_series(closes, lows, 0)
+                    )
+                except Exception as e:
+                    self.logger.warning(f"{stock_code} Minervini Stage 시리즈 계산 실패: {e}")
 
             result = {
                 "ohlcv": ohlcv_data,

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -464,3 +464,93 @@ class TelegramReporter:
 
         if current:
             await self._send_message(current)
+
+    @staticmethod
+    def _format_krw_cap(value) -> str:
+        try:
+            won = int(float(value or 0))
+        except (TypeError, ValueError):
+            return "-"
+        if won == 0:
+            return "-"
+        sign = "-" if won < 0 else ""
+        abs_won = abs(won)
+        jo = abs_won / 1_000_000_000_000
+        if jo >= 1:
+            return f"{sign}{jo:,.0f}조"
+        uk = abs_won / 100_000_000
+        return f"{sign}{uk:,.0f}억"
+
+    @staticmethod
+    def _format_usd_cap(value) -> str:
+        try:
+            usd = int(float(value or 0))
+        except (TypeError, ValueError):
+            return "-"
+        if usd <= 0:
+            return "-"
+        trillion = usd / 1_000_000_000_000
+        if trillion >= 1:
+            return f"${trillion:,.2f}T"
+        billion = usd / 1_000_000_000
+        return f"${billion:,.0f}B"
+
+    async def send_market_cap_gap_report(self, report: Dict, report_date: str, trigger_label: str, limit: int = 10):
+        """삼성전자/SK하이닉스와 미국 주요 기업 시총갭 리포트를 전송합니다."""
+        fx = report.get("fx_rate")
+        fx_text = f"{float(fx):,.2f}" if fx else "-"
+        title = (
+            f"📊 <b>시총갭 리포트 ({report_date})</b>\n"
+            f"기준: {html.escape(str(trigger_label), quote=False)} | USD/KRW: {fx_text}\n"
+        )
+        await self._send_message(title)
+
+        korean = report.get("korean") or []
+        us_items = report.get("us") or []
+        comparisons = report.get("comparisons") or []
+
+        summary_lines = ["<b>국내 기준</b>"]
+        for item in korean:
+            name = html.escape(str(item.get("name") or item.get("symbol") or ""), quote=False)
+            symbol = html.escape(str(item.get("symbol") or ""), quote=False)
+            summary_lines.append(
+                f"- {name}({symbol}) {self._format_krw_cap(item.get('market_cap_krw'))}"
+            )
+        summary_lines.append("")
+        summary_lines.append("<b>미국 비교군</b>")
+        for item in us_items[:limit]:
+            name = html.escape(str(item.get("name") or item.get("symbol") or ""), quote=False)
+            symbol = html.escape(str(item.get("symbol") or ""), quote=False)
+            summary_lines.append(
+                f"- {name}({symbol}) {self._format_usd_cap(item.get('market_cap_usd'))} "
+                f"/ {self._format_krw_cap(item.get('market_cap_krw'))}"
+            )
+        await self._send_message("\n".join(summary_lines))
+
+        if not comparisons:
+            await self._send_message("시총갭 계산 불가: 환율 또는 시총 데이터 부족")
+            return
+
+        grouped = {}
+        for row in comparisons:
+            grouped.setdefault(row.get("korean_symbol"), []).append(row)
+
+        for korean_symbol, rows in grouped.items():
+            if not rows:
+                continue
+            korean_name = html.escape(str(rows[0].get("korean_name") or korean_symbol), quote=False)
+            lines = [f"<b>{korean_name} 대비 갭</b>"]
+            for row in rows[:limit]:
+                us_name = html.escape(str(row.get("us_name") or row.get("us_symbol") or ""), quote=False)
+                us_symbol = html.escape(str(row.get("us_symbol") or ""), quote=False)
+                ratio = row.get("ratio")
+                try:
+                    ratio_text = f"{float(ratio):.2f}x"
+                except (TypeError, ValueError):
+                    ratio_text = "-"
+                lines.append(
+                    f"- {us_name}({us_symbol}) "
+                    f"갭:{self._format_krw_cap(row.get('gap_krw'))} "
+                    f"배율:{ratio_text}"
+                )
+            await self._send_message("\n".join(lines))

--- a/task/background/after_market/market_cap_gap_report_task.py
+++ b/task/background/after_market/market_cap_gap_report_task.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from interfaces.schedulable_task import TaskPriority
+from services.notification_service import NotificationCategory, NotificationLevel
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+
+class MarketCapGapReportTask(AfterMarketTask):
+    """삼성전자/SK하이닉스와 미국 주요 기업 시총갭을 장마감 후 전송한다."""
+
+    _SESSION_LABELS = {
+        "kr_close": "한국장 마감",
+        "us_close": "미국장 마감",
+    }
+
+    def __init__(
+        self,
+        market_cap_gap_service,
+        telegram_reporter=None,
+        notification_service=None,
+        session: str = "kr_close",
+        market_calendar_service=None,
+        market_clock=None,
+        logger=None,
+    ):
+        if session not in self._SESSION_LABELS:
+            raise ValueError("session은 kr_close 또는 us_close 이어야 합니다.")
+        super().__init__(
+            mcs=market_calendar_service,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=None,
+        )
+        self._service = market_cap_gap_service
+        self._telegram_reporter = telegram_reporter
+        self._notification_service = notification_service
+        self._session = session
+        self._last_reported_date: Optional[str] = None
+        self._progress = {
+            "running": False,
+            "last_reported_date": None,
+            "last_result": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        suffix = "kr" if self._session == "kr_close" else "us"
+        return f"market_cap_gap_report_{suffix}"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return f"MarketCapGapReport:{self._session}"
+
+    @property
+    def _loop_timezone(self) -> str:
+        return "America/New_York" if self._session == "us_close" else "Asia/Seoul"
+
+    @property
+    def _loop_cron_hour(self) -> int:
+        return 16 if self._session == "us_close" else 15
+
+    @property
+    def _loop_cron_minute(self) -> int:
+        return 30 if self._session == "us_close" else 50
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def get_progress(self) -> dict:
+        return dict(self._progress)
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        if self._last_reported_date == latest_trading_date:
+            self._logger.info(f"{self.task_name}: {latest_trading_date} 이미 전송 완료 — 스킵")
+            return
+
+        self._progress["running"] = True
+        try:
+            report = await self._service.build_report(
+                report_date=latest_trading_date,
+                trigger=self._session,
+            )
+            if self._telegram_reporter is not None:
+                await self._telegram_reporter.send_market_cap_gap_report(
+                    report,
+                    latest_trading_date,
+                    self._SESSION_LABELS[self._session],
+                )
+            self._last_reported_date = latest_trading_date
+            self._progress["last_reported_date"] = latest_trading_date
+            self._progress["last_result"] = {
+                "korean": len(report.get("korean") or []),
+                "us": len(report.get("us") or []),
+                "comparisons": len(report.get("comparisons") or []),
+            }
+            if self._notification_service:
+                await self._notification_service.emit(
+                    NotificationCategory.BACKGROUND,
+                    NotificationLevel.INFO,
+                    "시총갭 리포트 전송 완료",
+                    f"{self._SESSION_LABELS[self._session]} 기준 {latest_trading_date}",
+                )
+        except Exception as exc:
+            self._logger.error(f"시총갭 리포트 전송 실패: {exc}", exc_info=True)
+            if self._notification_service:
+                await self._notification_service.emit(
+                    NotificationCategory.BACKGROUND,
+                    NotificationLevel.ERROR,
+                    "시총갭 리포트 전송 실패",
+                    str(exc),
+                )
+        finally:
+            self._progress["running"] = False

--- a/tests/frontend/package.json
+++ b/tests/frontend/package.json
@@ -5,7 +5,7 @@
   "description": "jsdom regression harness for /stock screen JS (domestic regression guard for overseas features)",
   "type": "module",
   "scripts": {
-    "test": "node run_stock_dom_tests.mjs && node run_overseas_dom_tests.mjs && node run_autocomplete_dom_tests.mjs"
+    "test": "node run_stock_dom_tests.mjs && node run_overseas_dom_tests.mjs && node run_autocomplete_dom_tests.mjs && node run_candle_chart_dom_tests.mjs"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/tests/frontend/run_candle_chart_dom_tests.mjs
+++ b/tests/frontend/run_candle_chart_dom_tests.mjs
@@ -1,0 +1,151 @@
+/*
+ * jsdom 기반 candle_chart.js 회귀 테스트 (Minervini Stage 배경 밴드).
+ *
+ * 목적: 차트 일자별 Stage 배경 밴드 기능을 "문자열 존재"가 아니라 실제 렌더 경로
+ * (loadAndRenderStockChart → renderStockChart)로 검증한다. Chart.js 는 jsdom 에
+ * 없으므로 생성자를 스텁해 config 를 캡처하고, 캡처한 stageBandPlugin 의
+ * beforeDatasetsDraw 를 가짜 chart 로 호출해 fillRect 행위를 확인한다.
+ *
+ * 실행: node run_candle_chart_dom_tests.mjs  (exit 0 = 전부 통과)
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+const CANDLE_JS = resolve(import.meta.dirname, "../../view/web/static/js/candle_chart.js");
+
+// 길이 n 의 OHLCV + 지표(루프가 접근하는 배열) 생성. minervini_stage 는 옵션.
+function makeChartJson(n, { withStage = true } = {}) {
+  const ohlcv = [];
+  for (let i = 0; i < n; i++) {
+    const close = 5000 + i * 30;
+    ohlcv.push({ date: `2023${String(i).padStart(4, "0")}`, open: close, high: close * 1.01, low: close * 0.95, close, volume: 1000 + i });
+  }
+  const nulls = () => new Array(n).fill(null);
+  const indicators = { ma5: nulls(), ma10: nulls(), ma20: nulls(), ma60: nulls(), ma120: nulls(), bb: nulls() };
+  if (withStage) {
+    // 앞 199 미계산(0) + 이후 상승 구간을 Stage 2 로, 마지막 10개를 Stage 4 로.
+    const stage = new Array(n).fill(0);
+    for (let i = 199; i < n; i++) stage[i] = 2;
+    for (let i = n - 10; i < n; i++) stage[i] = 4;
+    indicators.minervini_stage = stage;
+  }
+  return { rt_cd: "0", data: { ohlcv, indicators } };
+}
+
+function makeWindow() {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><html><body>
+      <div class="card" id="stock-chart-card" style="display:none;">
+        <div id="chart-controls-area"></div>
+        <canvas id="stockChart"></canvas>
+      </div>
+    </body></html>`,
+    { url: "http://localhost/stock", runScripts: "dangerously" }
+  );
+  const { window } = dom;
+
+  // 캡처용 + 스텁
+  window.__lastChartConfig = null;
+  window.performance = window.performance || { now: () => 0 };
+  window.HTMLCanvasElement.prototype.getContext = function () { return {}; };
+  class FakeChart {
+    constructor(ctx, config) {
+      window.__lastChartConfig = config;
+      this.data = config.data;
+      this.config = config;
+    }
+    destroy() {}
+    update() {}
+    getDatasetMeta() { return { data: [] }; }
+  }
+  FakeChart.defaults = { plugins: { legend: { labels: { generateLabels: () => [] } } } };
+  window.Chart = FakeChart;
+  window.EventSource = class { constructor() {} close() {} };
+
+  const script = window.document.createElement("script");
+  script.textContent = readFileSync(CANDLE_JS, "utf8");
+  window.document.body.appendChild(script);
+  return window;
+}
+
+// stageBandPlugin 호출용 가짜 chart (fillRect/fillText 기록).
+function makeFakeChart(len) {
+  const calls = { fillRect: [], fillStyles: [] };
+  const ctx = {
+    save() {}, restore() {},
+    set fillStyle(v) { calls.fillStyles.push(v); }, get fillStyle() { return ""; },
+    fillRect(...a) { calls.fillRect.push(a); },
+    fillText() {}, set font(_) {}, set textAlign(_) {},
+  };
+  const scale = (lo, hi) => ({ top: 0, bottom: 300, left: 0, right: 600, getPixelForValue: (v) => (v / Math.max(1, len - 1)) * 600 });
+  return {
+    calls,
+    chart: {
+      ctx,
+      chartArea: { left: 0, right: 600, top: 0, bottom: 400 },
+      scales: { x: scale(), y: scale() },
+    },
+  };
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("renderStockChart 가 stageBandPlugin 을 캔들보다 먼저 그리도록 등록한다", async () => {
+  const window = makeWindow();
+  window.fetch = async () => ({ json: async () => makeChartJson(260) });
+
+  await window.loadAndRenderStockChart("005930");
+
+  const cfg = window.__lastChartConfig;
+  assert(cfg, "Chart 가 생성되지 않음");
+  const ids = cfg.plugins.map((p) => p.id);
+  assert(ids.includes("minerviniStageBand"), "stageBandPlugin 미등록");
+  // 캔들 데이터셋보다 먼저 그려져야 배경이 됨 (plugins 배열 선두 + beforeDatasetsDraw)
+  const plugin = cfg.plugins.find((p) => p.id === "minerviniStageBand");
+  assert(typeof plugin.beforeDatasetsDraw === "function", "beforeDatasetsDraw 훅 없음");
+});
+
+test("stageBandPlugin 이 Stage 구간별 배경 사각형을 그린다", async () => {
+  const window = makeWindow();
+  window.fetch = async () => ({ json: async () => makeChartJson(260) });
+  await window.loadAndRenderStockChart("005930");
+
+  const plugin = window.__lastChartConfig.plugins.find((p) => p.id === "minerviniStageBand");
+  // 3M 슬라이스(66봉)에는 Stage2 와 마지막 Stage4 구간이 포함됨 → 최소 2개 밴드.
+  const fake = makeFakeChart(66);
+  plugin.beforeDatasetsDraw(fake.chart);
+
+  assert(fake.calls.fillRect.length >= 2, `밴드 사각형이 그려지지 않음 (fillRect=${fake.calls.fillRect.length})`);
+  const greenish = fake.calls.fillStyles.some((s) => typeof s === "string" && s.includes("0, 200, 80"));
+  const reddish = fake.calls.fillStyles.some((s) => typeof s === "string" && s.includes("255, 60, 60"));
+  assert(greenish, "Stage2(초록) 밴드 색상 누락");
+  assert(reddish, "Stage4(빨강) 밴드 색상 누락");
+});
+
+test("minervini_stage 가 없으면 밴드를 그리지 않는다 (no-op, 회귀 안전)", async () => {
+  const window = makeWindow();
+  window.fetch = async () => ({ json: async () => makeChartJson(260, { withStage: false }) });
+  await window.loadAndRenderStockChart("005930");
+
+  const plugin = window.__lastChartConfig.plugins.find((p) => p.id === "minerviniStageBand");
+  const fake = makeFakeChart(66);
+  plugin.beforeDatasetsDraw(fake.chart);
+
+  assert(fake.calls.fillRect.length === 0, "stage 데이터 없는데 밴드가 그려짐");
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/frontend/run_poll_abort_dom_tests.mjs
+++ b/tests/frontend/run_poll_abort_dom_tests.mjs
@@ -1,0 +1,99 @@
+/*
+ * Polling fetch AbortError 회귀 테스트.
+ *
+ * 실행: node run_poll_abort_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+const COMMON_JS = resolve(import.meta.dirname, "../../view/web/static/js/common.js");
+const SYSTEM_JS = resolve(import.meta.dirname, "../../view/web/static/js/system.js");
+
+function makeAbortError() {
+  try {
+    return new DOMException("signal is aborted without reason", "AbortError");
+  } catch (_) {
+    const err = new Error("signal is aborted without reason");
+    err.name = "AbortError";
+    return err;
+  }
+}
+
+function makeWindow(pathname = "/") {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <span id="status-time"></span>
+    <span id="status-market"></span>
+    <span id="status-env"></span>
+    <div id="background-tasks-body"></div>
+    <div id="operations-summary"></div>
+    <div id="sub-table-body"></div>
+    <input id="input-max-order-amount">
+    <input id="input-max-position-pct">
+  </body></html>`, {
+    url: `http://localhost${pathname}`,
+    runScripts: "outside-only",
+  });
+
+  const { window } = dom;
+  window.Paginator = null;
+  window.alert = () => {};
+  window.confirm = () => true;
+  window.prompt = () => "REAL";
+  return window;
+}
+
+async function withConsoleErrorSpy(window, fn) {
+  const calls = [];
+  const original = window.console.error;
+  window.console.error = (...args) => calls.push(args);
+  try {
+    await fn();
+  } finally {
+    window.console.error = original;
+  }
+  return calls;
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("common updateStatus ignores fetch AbortError", async () => {
+  const window = makeWindow("/");
+  window.fetch = async () => { throw makeAbortError(); };
+  window.eval(readFileSync(COMMON_JS, "utf8"));
+
+  const errors = await withConsoleErrorSpy(window, () => window.updateStatus());
+
+  assert(errors.length === 0, "AbortError should not be logged by updateStatus");
+});
+
+test("system polling updates ignore fetch AbortError", async () => {
+  const window = makeWindow("/system");
+  window.fetch = async () => { throw makeAbortError(); };
+  window.eval(readFileSync(COMMON_JS, "utf8"));
+  window.eval(readFileSync(SYSTEM_JS, "utf8"));
+
+  const errors = await withConsoleErrorSpy(window, async () => {
+    await window.updateCacheStatus();
+    await window.updateBackgroundStatus();
+    await window.updateOperationsStatus();
+    await window.updateSubscriptionStatus();
+  });
+
+  assert(errors.length === 0, "AbortError should not be logged by system polling updates");
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/frontend/run_poll_abort_dom_tests.mjs
+++ b/tests/frontend/run_poll_abort_dom_tests.mjs
@@ -9,6 +9,7 @@ import { JSDOM } from "jsdom";
 
 const COMMON_JS = resolve(import.meta.dirname, "../../view/web/static/js/common.js");
 const SYSTEM_JS = resolve(import.meta.dirname, "../../view/web/static/js/system.js");
+const KILL_SWITCH_JS = resolve(import.meta.dirname, "../../view/web/static/js/kill_switch.js");
 
 function makeAbortError() {
   try {
@@ -28,6 +29,7 @@ function makeWindow(pathname = "/") {
     <div id="background-tasks-body"></div>
     <div id="operations-summary"></div>
     <div id="sub-table-body"></div>
+    <button id="ks-badge"><span id="ks-badge-text"></span></button>
     <input id="input-max-order-amount">
     <input id="input-max-position-pct">
   </body></html>`, {
@@ -69,6 +71,29 @@ test("common updateStatus ignores fetch AbortError", async () => {
   assert(errors.length === 0, "AbortError should not be logged by updateStatus");
 });
 
+test("header polling fetches do not force abort signals", async () => {
+  const window = makeWindow("/");
+  const calls = [];
+  window.fetch = async (url, options = {}) => {
+    calls.push({ url, hasSignal: !!options.signal });
+    return {
+      ok: true,
+      json: async () => url.includes("kill-switch")
+        ? { is_tripped: false }
+        : { current_time: "09:00:00", market_open: true, env_type: "모의투자", is_paper_trading: true },
+    };
+  };
+  window.eval(readFileSync(COMMON_JS, "utf8"));
+  window.eval(readFileSync(KILL_SWITCH_JS, "utf8"));
+
+  await window.updateStatus();
+  await window.loadKillSwitchStatus();
+
+  assert(calls.some(call => call.url === "/api/status"), "status polling should fetch");
+  assert(calls.some(call => call.url === "/api/kill-switch/status"), "kill switch polling should fetch");
+  assert(calls.every(call => call.hasSignal === false), "header polling should not pass AbortController signals");
+});
+
 test("system polling updates ignore fetch AbortError", async () => {
   const window = makeWindow("/system");
   window.fetch = async () => { throw makeAbortError(); };
@@ -83,6 +108,28 @@ test("system polling updates ignore fetch AbortError", async () => {
   });
 
   assert(errors.length === 0, "AbortError should not be logged by system polling updates");
+});
+
+test("system polling fetches do not force abort signals", async () => {
+  const window = makeWindow("/system");
+  const calls = [];
+  window.fetch = async (url, options = {}) => {
+    calls.push({ url, hasSignal: !!options.signal });
+    return {
+      ok: true,
+      json: async () => ({ success: true, data: [] }),
+    };
+  };
+  window.eval(readFileSync(COMMON_JS, "utf8"));
+  window.eval(readFileSync(SYSTEM_JS, "utf8"));
+
+  await window.updateCacheStatus();
+  await window.updateBackgroundStatus();
+  await window.updateOperationsStatus();
+  await window.updateSubscriptionStatus();
+
+  assert(calls.length >= 4, "system polling should fetch status endpoints");
+  assert(calls.every(call => call.hasSignal === false), "system polling should not pass AbortController signals");
 });
 
 let failed = 0;

--- a/tests/unit_test/services/test_market_cap_gap_service.py
+++ b/tests/unit_test/services/test_market_cap_gap_service.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+import sqlite3
 
 import pytest
 
@@ -7,7 +8,9 @@ from common.types import ErrorCode, ResCommonResponse
 from services.market_cap_gap_service import (
     MarketCapGapService,
     MarketCapQuote,
+    PykrxKoreanMarketCapProvider,
     StaticUsMarketCapProvider,
+    YahooUsMarketCapProvider,
 )
 
 
@@ -29,7 +32,7 @@ async def test_build_report_compares_korean_caps_to_us_caps_in_krw():
         ],
         usdkrw=1400.0,
     )
-    service = MarketCapGapService(broker=broker, us_provider=provider)
+    service = MarketCapGapService(broker=broker, us_provider=provider, korean_provider=None)
 
     report = await service.build_report(report_date="20260625", trigger="kr_close")
 
@@ -61,7 +64,7 @@ async def test_build_report_skips_failed_or_empty_quotes():
         ],
         usdkrw=1400.0,
     )
-    service = MarketCapGapService(broker=broker, us_provider=provider)
+    service = MarketCapGapService(broker=broker, us_provider=provider, korean_provider=None)
 
     report = await service.build_report(report_date="20260625", trigger="us_close")
 
@@ -85,3 +88,124 @@ async def test_build_report_returns_no_comparisons_when_fx_missing():
     assert report["fx_rate"] is None
     assert report["us"][0]["market_cap_krw"] is None
     assert report["comparisons"] == []
+
+
+@pytest.mark.asyncio
+async def test_build_report_uses_korean_fallback_when_broker_market_cap_unavailable():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="paper unsupported", data=None),
+        ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="paper unsupported", data=None),
+    ])
+    korean_provider = SimpleNamespace()
+    korean_provider.fetch_market_caps = AsyncMock(return_value={
+        "005930": 480_000_000_000_000,
+        "000660": 250_000_000_000_000,
+    })
+    provider = StaticUsMarketCapProvider(
+        quotes=[MarketCapQuote(symbol="NVDA", name="NVIDIA", currency="USD", market_cap=3_000_000_000_000)],
+        usdkrw=1400.0,
+    )
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=provider,
+        korean_provider=korean_provider,
+    )
+
+    report = await service.build_report(report_date="20260625", trigger="kr_close")
+
+    korean_provider.fetch_market_caps.assert_awaited_once_with(["005930", "000660"], "20260625")
+    assert [item["symbol"] for item in report["korean"]] == ["005930", "000660"]
+    assert report["korean"][0]["market_cap_krw"] == 480_000_000_000_000
+    assert len(report["comparisons"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_yahoo_provider_retries_quote_with_crumb_after_unauthorized(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, status_code, payload=None, text=""):
+            self.status_code = status_code
+            self._payload = payload or {}
+            self.text = text
+            self.request = None
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise RuntimeError(f"status={self.status_code}")
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            calls.append((url, dict(params or {})))
+            if "v7/finance/quote" in url and not (params or {}).get("crumb"):
+                return FakeResponse(401)
+            if "fc.yahoo.com" in url:
+                return FakeResponse(404)
+            if "getcrumb" in url:
+                return FakeResponse(200, text="crumb-token")
+            if "v7/finance/quote" in url:
+                return FakeResponse(200, payload={
+                    "quoteResponse": {
+                        "result": [{
+                            "symbol": "NVDA",
+                            "shortName": "NVIDIA",
+                            "currency": "USD",
+                            "marketCap": 3_000_000_000_000,
+                        }]
+                    }
+                })
+            return FakeResponse(500)
+
+    monkeypatch.setattr("services.market_cap_gap_service.httpx.AsyncClient", FakeClient)
+    provider = YahooUsMarketCapProvider()
+
+    quotes = await provider.fetch_quotes(["NVDA"])
+
+    assert [quote.symbol for quote in quotes] == ["NVDA"]
+    quote_calls = [call for call in calls if "v7/finance/quote" in call[0]]
+    assert quote_calls[0][1].get("crumb") is None
+    assert quote_calls[1][1]["crumb"] == "crumb-token"
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_reads_local_daily_prices_in_ukwon(tmp_path):
+    db_path = tmp_path / "stocks.db"
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "CREATE TABLE daily_prices (code TEXT, trade_date TEXT, market_cap INTEGER)"
+    )
+    con.execute(
+        "INSERT INTO daily_prices VALUES (?, ?, ?)",
+        ("005930", "20260624", 20_000_000),
+    )
+    con.execute(
+        "INSERT INTO daily_prices VALUES (?, ?, ?)",
+        ("005930", "20260625", 21_000_000),
+    )
+    con.execute(
+        "INSERT INTO daily_prices VALUES (?, ?, ?)",
+        ("000660", "20260625", 15_000_000),
+    )
+    con.commit()
+    con.close()
+    provider = PykrxKoreanMarketCapProvider(db_path=db_path)
+
+    caps = await provider.fetch_market_caps(["005930", "000660"], "20260625")
+
+    assert caps == {
+        "005930": 21_000_000 * 100_000_000,
+        "000660": 15_000_000 * 100_000_000,
+    }

--- a/tests/unit_test/services/test_market_cap_gap_service.py
+++ b/tests/unit_test/services/test_market_cap_gap_service.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from services.market_cap_gap_service import (
+    MarketCapGapService,
+    MarketCapQuote,
+    StaticUsMarketCapProvider,
+)
+
+
+def _domestic_response(value: int):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=value)
+
+
+@pytest.mark.asyncio
+async def test_build_report_compares_korean_caps_to_us_caps_in_krw():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        _domestic_response(500_000_000_000_000),
+        _domestic_response(200_000_000_000_000),
+    ])
+    provider = StaticUsMarketCapProvider(
+        quotes=[
+            MarketCapQuote(symbol="NVDA", name="NVIDIA", currency="USD", market_cap=3_000_000_000_000),
+            MarketCapQuote(symbol="MU", name="Micron", currency="USD", market_cap=150_000_000_000),
+        ],
+        usdkrw=1400.0,
+    )
+    service = MarketCapGapService(broker=broker, us_provider=provider)
+
+    report = await service.build_report(report_date="20260625", trigger="kr_close")
+
+    assert report["report_date"] == "20260625"
+    assert report["trigger"] == "kr_close"
+    assert report["fx_rate"] == 1400.0
+    assert [item["symbol"] for item in report["korean"]] == ["005930", "000660"]
+    assert [item["symbol"] for item in report["us"]] == ["NVDA", "MU"]
+
+    samsung_nvda = next(
+        item for item in report["comparisons"]
+        if item["korean_symbol"] == "005930" and item["us_symbol"] == "NVDA"
+    )
+    assert samsung_nvda["gap_krw"] == 3_700_000_000_000_000
+    assert samsung_nvda["ratio"] == 8.4
+
+
+@pytest.mark.asyncio
+async def test_build_report_skips_failed_or_empty_quotes():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        _domestic_response(500_000_000_000_000),
+        ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None),
+    ])
+    provider = StaticUsMarketCapProvider(
+        quotes=[
+            MarketCapQuote(symbol="NVDA", name="NVIDIA", currency="USD", market_cap=0),
+            MarketCapQuote(symbol="MU", name="Micron", currency="USD", market_cap=150_000_000_000),
+        ],
+        usdkrw=1400.0,
+    )
+    service = MarketCapGapService(broker=broker, us_provider=provider)
+
+    report = await service.build_report(report_date="20260625", trigger="us_close")
+
+    assert [item["symbol"] for item in report["korean"]] == ["005930"]
+    assert [item["symbol"] for item in report["us"]] == ["MU"]
+    assert len(report["comparisons"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_report_returns_no_comparisons_when_fx_missing():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(return_value=_domestic_response(500_000_000_000_000))
+    provider = StaticUsMarketCapProvider(
+        quotes=[MarketCapQuote(symbol="NVDA", name="NVIDIA", currency="USD", market_cap=3_000_000_000_000)],
+        usdkrw=None,
+    )
+    service = MarketCapGapService(broker=broker, us_provider=provider)
+
+    report = await service.build_report(report_date="20260625", trigger="kr_close")
+
+    assert report["fx_rate"] is None
+    assert report["us"][0]["market_cap_krw"] is None
+    assert report["comparisons"] == []

--- a/tests/unit_test/services/test_minervini_stage_service.py
+++ b/tests/unit_test/services/test_minervini_stage_service.py
@@ -104,6 +104,65 @@ class TestClassifyStage:
         assert result != MinerviniStageService.STAGE_4_DECLINING
 
 
+class TestClassifyStageSeries:
+
+    def test_length_matches_input(self):
+        svc = _make_svc()
+        closes = _trending_closes(5000, 15000, 260)
+        lows = [c * 0.95 for c in closes]
+        series = svc.classify_stage_series(closes, lows, rs_rating=80)
+        assert len(series) == len(closes)
+
+    def test_first_199_are_unknown(self):
+        # 200일 미만 룩백 구간은 계산 불가 → STAGE_UNKNOWN.
+        svc = _make_svc()
+        closes = _trending_closes(5000, 15000, 260)
+        lows = [c * 0.95 for c in closes]
+        series = svc.classify_stage_series(closes, lows, rs_rating=80)
+        assert all(s == MinerviniStageService.STAGE_UNKNOWN for s in series[:199])
+        assert series[199] != MinerviniStageService.STAGE_UNKNOWN
+
+    def test_uptrend_last_point_is_stage2(self):
+        svc = _make_svc()
+        closes = _trending_closes(5000, 15000, 260)
+        lows = [c * 0.95 for c in closes]
+        series = svc.classify_stage_series(closes, lows, rs_rating=80)
+        assert series[-1] == MinerviniStageService.STAGE_2_ADVANCING
+
+    def test_short_input_all_unknown(self):
+        svc = _make_svc()
+        closes = _flat_closes(10000, 120)
+        series = svc.classify_stage_series(closes, closes)
+        assert series == [MinerviniStageService.STAGE_UNKNOWN] * 120
+
+    def test_matches_naive_per_slice_classification(self):
+        # 벡터화 시리즈는 매 시점 classify_stage(슬라이스) 호출과 동일해야 한다.
+        import random
+        rng = random.Random(42)
+        price = 8000.0
+        closes, lows = [], []
+        for _ in range(320):
+            price *= 1 + rng.uniform(-0.03, 0.035)
+            closes.append(price)
+            lows.append(price * (1 - rng.uniform(0.0, 0.04)))
+        svc = _make_svc()
+        fast = svc.classify_stage_series(closes, lows, rs_rating=0)
+        naive = [
+            (svc.classify_stage(closes[: i + 1], lows[: i + 1], 0) if i >= 199
+             else MinerviniStageService.STAGE_UNKNOWN)
+            for i in range(len(closes))
+        ]
+        assert fast == naive
+
+    def test_entries_are_plain_ints(self):
+        # return_reason=False 경로 → 튜플이 아닌 int 만 담겨야 한다.
+        svc = _make_svc()
+        closes = _trending_closes(5000, 15000, 210)
+        lows = [c * 0.95 for c in closes]
+        series = svc.classify_stage_series(closes, lows, rs_rating=80)
+        assert all(isinstance(s, int) for s in series)
+
+
 class TestCheckVcpPattern:
 
     def test_contracting_weekly_ranges_returns_true(self):

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -1520,6 +1520,51 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
         self.mock_market_data_service.get_ohlcv.assert_awaited_once_with("005930", period="D", caller="unknown")
         self.mock_indicator_service.get_chart_indicators.assert_awaited_once_with("005930", ohlcv_data)
 
+    async def test_get_ohlcv_with_indicators_includes_minervini_stage(self):
+        """minervini_stage_service 주입 시 일자별 Stage 배열이 ohlcv와 1:1 정렬되어 포함된다."""
+        from services.minervini_stage_service import MinerviniStageService
+
+        n = 260
+        ohlcv_data = [
+            {"date": f"2023{i:04d}", "close": 5000 + i * 30, "low": (5000 + i * 30) * 0.95}
+            for i in range(n)
+        ]
+        self.mock_market_data_service.get_ohlcv.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=ohlcv_data
+        )
+        self.mock_indicator_service.get_chart_indicators.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="성공", data={"ma5": []}
+        )
+        self.stockQueryService.set_minervini_stage_service(
+            MinerviniStageService(stock_query_service=AsyncMock())
+        )
+
+        result = await self.stockQueryService.get_ohlcv_with_indicators("005930", "D")
+
+        stages = result.data["indicators"]["minervini_stage"]
+        self.assertEqual(len(stages), n)  # ohlcv와 동일 길이 (인덱스 정렬)
+        self.assertTrue(all(s == 0 for s in stages[:199]))  # 룩백 부족 구간
+        self.assertEqual(stages[-1], MinerviniStageService.STAGE_2_ADVANCING)
+
+    async def test_get_ohlcv_with_indicators_skips_stage_when_too_few_rows(self):
+        """200봉 미만이면 Stage 시리즈를 계산/포함하지 않는다."""
+        from services.minervini_stage_service import MinerviniStageService
+
+        ohlcv_data = [{"date": f"2023{i:04d}", "close": 100 + i} for i in range(50)]
+        self.mock_market_data_service.get_ohlcv.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=ohlcv_data
+        )
+        self.mock_indicator_service.get_chart_indicators.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value, msg1="성공", data={"ma5": []}
+        )
+        self.stockQueryService.set_minervini_stage_service(
+            MinerviniStageService(stock_query_service=AsyncMock())
+        )
+
+        result = await self.stockQueryService.get_ohlcv_with_indicators("005930", "D")
+
+        self.assertNotIn("minervini_stage", result.data["indicators"])
+
     async def test_get_ohlcv_with_indicators_none_response(self):
         """get_ohlcv_with_indicators: 응답이 None일 때 (Line 602-604 coverage)"""
         self.mock_market_data_service.get_ohlcv.return_value = None

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -819,3 +819,53 @@ async def test_send_minervini_report_empty_and_normal(telegram_reporter):
     assert "삼성전자" in full_message
     assert "SK하이닉스" in full_message
     assert "테스트 사유" in full_message
+
+
+@pytest.mark.asyncio
+async def test_send_market_cap_gap_report_formats_korean_us_gap(telegram_reporter):
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+    report = {
+        "report_date": "20260625",
+        "trigger": "kr_close",
+        "fx_rate": 1400.0,
+        "korean": [
+            {"symbol": "005930", "name": "삼성전자", "market_cap_krw": 500_000_000_000_000},
+            {"symbol": "000660", "name": "SK하이닉스", "market_cap_krw": 200_000_000_000_000},
+        ],
+        "us": [
+            {"symbol": "NVDA", "name": "NVIDIA", "market_cap_usd": 3_000_000_000_000, "market_cap_krw": 4_200_000_000_000_000},
+            {"symbol": "MU", "name": "Micron", "market_cap_usd": 150_000_000_000, "market_cap_krw": 210_000_000_000_000},
+        ],
+        "comparisons": [
+            {
+                "korean_symbol": "005930",
+                "korean_name": "삼성전자",
+                "korean_market_cap_krw": 500_000_000_000_000,
+                "us_symbol": "NVDA",
+                "us_name": "NVIDIA",
+                "us_market_cap_krw": 4_200_000_000_000_000,
+                "gap_krw": 3_700_000_000_000_000,
+                "ratio": 8.4,
+            },
+            {
+                "korean_symbol": "000660",
+                "korean_name": "SK하이닉스",
+                "korean_market_cap_krw": 200_000_000_000_000,
+                "us_symbol": "MU",
+                "us_name": "Micron",
+                "us_market_cap_krw": 210_000_000_000_000,
+                "gap_krw": 10_000_000_000_000,
+                "ratio": 1.05,
+            },
+        ],
+    }
+
+    await telegram_reporter.send_market_cap_gap_report(report, "20260625", "한국장 마감")
+
+    full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
+    assert "시총갭 리포트" in full
+    assert "한국장 마감" in full
+    assert "삼성전자" in full
+    assert "NVIDIA" in full
+    assert "3,700조" in full
+    assert "8.40x" in full

--- a/tests/unit_test/task/background/after_market/test_market_cap_gap_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_market_cap_gap_report_task.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from interfaces.schedulable_task import TaskState
+from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
+
+
+@pytest.fixture
+def service():
+    svc = MagicMock()
+    svc.build_report = AsyncMock(return_value={
+        "report_date": "20260625",
+        "trigger": "kr_close",
+        "fx_rate": 1400.0,
+        "korean": [],
+        "us": [],
+        "comparisons": [],
+    })
+    return svc
+
+
+@pytest.fixture
+def reporter():
+    rep = MagicMock()
+    rep.send_market_cap_gap_report = AsyncMock()
+    return rep
+
+
+@pytest.mark.asyncio
+async def test_on_market_closed_sends_report_once_per_date(service, reporter):
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="kr_close",
+        logger=MagicMock(),
+    )
+
+    await task._on_market_closed("20260625")
+    await task._on_market_closed("20260625")
+
+    service.build_report.assert_awaited_once_with(report_date="20260625", trigger="kr_close")
+    reporter.send_market_cap_gap_report.assert_awaited_once()
+    assert task.get_progress()["last_reported_date"] == "20260625"
+
+
+@pytest.mark.asyncio
+async def test_failed_report_does_not_mark_date(service, reporter):
+    service.build_report.side_effect = RuntimeError("boom")
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="us_close",
+        logger=MagicMock(),
+    )
+
+    await task._on_market_closed("20260625")
+
+    assert task.get_progress()["last_reported_date"] is None
+    reporter.send_market_cap_gap_report.assert_not_called()
+
+
+def test_us_close_task_uses_new_york_close_trigger(service, reporter):
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="us_close",
+        logger=MagicMock(),
+    )
+
+    assert task.task_name == "market_cap_gap_report_us"
+    assert task._loop_timezone == "America/New_York"
+    assert task._loop_cron_hour == 16
+    assert task._loop_cron_minute == 30
+    assert task.state == TaskState.IDLE
+
+
+def test_kr_close_task_uses_korean_close_trigger(service, reporter):
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="kr_close",
+        logger=MagicMock(),
+    )
+
+    assert task.task_name == "market_cap_gap_report_kr"
+    assert task._loop_timezone == "Asia/Seoul"
+    assert task._loop_cron_hour == 15
+    assert task._loop_cron_minute == 50

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -49,6 +49,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "post_market_replay_audit_task",
         "websocket_watchdog_task", "pre_market_health_check_task",
         "cache_warmup_task", "notification_queue_task",
+        "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
     ]:
         task = MagicMock()
         task.task_name = name
@@ -91,7 +92,7 @@ def test_all_mode_registers_16_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 16
+    assert bg.register.call_count == 18
 
 
 def test_all_mode_registers_12_tasks_to_time_dispatcher(patched_scheduler_deps):
@@ -155,6 +156,7 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
         "log_cleanup_task", "post_market_replay_audit_task",
         "strategy_log_report_task", "after_market_reconcile_task",
         "theme_classification_task",
+        "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
     }
     assert names == expected
     assert "websocket_watchdog_task" not in names
@@ -205,4 +207,4 @@ def test_skips_none_tasks(patched_scheduler_deps):
     # 둘 다 -1 감소한다.
     assert ctx.time_dispatcher.register_task.call_count == 11
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 15
+    assert bg.register.call_count == 17

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -29,6 +29,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OneilUniverseService", "NaverFinanceScraperService",
     "StockClassificationRepository", "ThemeLeaderService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask",
+    "MarketCapGapService", "MarketCapGapReportTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
     "StrategyLogReportService", "NotificationQueueTask",
@@ -286,6 +287,8 @@ def test_service_container_creates_universe_and_tasks(patched_service_container_
     assert ctx.oneil_universe_service is patched_service_container_deps["OneilUniverseService"].return_value
     assert ctx.ranking_task is patched_service_container_deps["RankingTask"].return_value
     assert ctx.strategy_log_report_task is patched_service_container_deps["StrategyLogReportTask"].return_value
+    assert ctx.market_cap_gap_service is patched_service_container_deps["MarketCapGapService"].return_value
+    assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 2
 
 
 def test_service_container_does_not_wire_minervini_circular_pair(patched_service_container_deps):

--- a/tests/unit_test/view/web/templates/test_templates.py
+++ b/tests/unit_test/view/web/templates/test_templates.py
@@ -36,3 +36,33 @@ def test_template_local_static_references_exist(template_path):
     for ref in refs:
         static_path = STATIC_ROOT / ref.removeprefix("/static/")
         assert static_path.is_file(), f"{template_path} references missing static asset: {ref}"
+
+
+@pytest.mark.parametrize("template_path", TEMPLATES, ids=lambda p: p.name)
+def test_common_js_loads_before_page_static_scripts(template_path):
+    """페이지별 JS가 common.js 전역 헬퍼(showLoading 등)를 사용할 수 있어야 한다."""
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_ROOT)))
+    html = env.get_template(template_path.name).render(active_page="")
+
+    refs = [
+        urlsplit(match.group(1)).path
+        for match in LOCAL_STATIC_SRC_RE.finditer(html)
+        if urlsplit(match.group(1)).path.startswith("/static/js/")
+    ]
+    page_refs = [
+        ref for ref in refs
+        if ref not in {
+            "/static/js/common.js",
+            "/static/js/notifications.js",
+            "/static/js/kill_switch.js",
+            "/static/js/pagination.js",
+        }
+    ]
+    if not page_refs:
+        return
+
+    common_idx = html.find("/static/js/common.js")
+    assert common_idx != -1, f"{template_path} rendered page scripts without common.js"
+
+    for ref in page_refs:
+        assert common_idx < html.find(ref), f"{template_path} loads {ref} before common.js"

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -83,6 +83,9 @@ class SchedulerBootstrap:
             )
         ctx.background_scheduler.register(task)
 
+    def _optional_task(self, attr_name: str):
+        return getattr(self._ctx, "__dict__", {}).get(attr_name)
+
     def _register_web_tasks(self) -> None:
         ctx = self._ctx
         # NotificationQueueTask 는 TimeDispatcher 등록 대상이 아님 (always-on)
@@ -97,6 +100,10 @@ class SchedulerBootstrap:
     def _register_batch_tasks(self) -> None:
         ctx = self._ctx
         self._register(ctx.ranking_task, TaskPriority.LOW)
+        # 자체 AfterMarketLoop 사용: 한국장/미국장 각각의 cron timezone이 필요해
+        # KST TimeDispatcher에는 등록하지 않는다.
+        self._register(self._optional_task("market_cap_gap_report_kr_task"))
+        self._register(self._optional_task("market_cap_gap_report_us_task"))
         self._register(ctx.minervini_update_task, TaskPriority.LOW)
         self._register(ctx.daily_price_collector_task, TaskPriority.LOW)
         self._register(ctx.ohlcv_update_task, TaskPriority.LOW)
@@ -110,7 +117,7 @@ class SchedulerBootstrap:
 
     def _register_overseas_tasks(self) -> None:
         # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
-        self._register(getattr(self._ctx, "overseas_dryrun_task", None), TaskPriority.LOW)
+        self._register(self._optional_task("overseas_dryrun_task"), TaskPriority.LOW)
 
     def _register_websocket_watchdog(self) -> None:
         # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -35,6 +35,7 @@ from services.execution_flow_service import ExecutionFlowService
 from services.indicator_service import IndicatorService
 from services.deferred_order_queue import DeferredOrderQueue
 from services.market_data_service import MarketDataService
+from services.market_cap_gap_service import MarketCapGapService
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
@@ -63,6 +64,7 @@ from task.background.after_market.after_market_reconcile_task import AfterMarket
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
 from task.background.after_market.daily_price_collector_task import DailyPriceCollectorTask
 from task.background.after_market.log_cleanup_task import LogCleanupTask
+from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
 from task.background.after_market.minervini_update_task import MinerviniUpdateTask
 from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.ohlcv_update_task import OhlcvUpdateTask
@@ -265,6 +267,9 @@ class ServiceContainer:
         try:
             if is_overseas_us:
                 ctx.ranking_task = None
+                ctx.market_cap_gap_service = None
+                ctx.market_cap_gap_report_kr_task = None
+                ctx.market_cap_gap_report_us_task = None
             else:
                 ctx.ranking_task = RankingTask(
                     broker_api_wrapper=ctx.broker,
@@ -279,6 +284,33 @@ class ServiceContainer:
                     market_data_service=ctx.market_data_service,
                     worker_pool=ctx.worker_pool,
                 )
+                if needs_batch:
+                    ctx.market_cap_gap_service = MarketCapGapService(
+                        broker=ctx.broker,
+                        logger=ctx.logger,
+                    )
+                    ctx.market_cap_gap_report_kr_task = MarketCapGapReportTask(
+                        market_cap_gap_service=ctx.market_cap_gap_service,
+                        telegram_reporter=getattr(ctx, "telegram_reporter", None),
+                        notification_service=ctx.notification_service,
+                        session="kr_close",
+                        market_calendar_service=ctx._mcs,
+                        market_clock=ctx.market_clock,
+                        logger=ctx.logger,
+                    )
+                    ctx.market_cap_gap_report_us_task = MarketCapGapReportTask(
+                        market_cap_gap_service=ctx.market_cap_gap_service,
+                        telegram_reporter=getattr(ctx, "telegram_reporter", None),
+                        notification_service=ctx.notification_service,
+                        session="us_close",
+                        market_calendar_service=None,
+                        market_clock=MarketClock.for_us_equities(logger=ctx.logger),
+                        logger=ctx.logger,
+                    )
+                else:
+                    ctx.market_cap_gap_service = None
+                    ctx.market_cap_gap_report_kr_task = None
+                    ctx.market_cap_gap_report_us_task = None
             ctx.stock_query_service = StockQueryService(
                 market_data_service=ctx.market_data_service, logger=ctx.logger, market_clock=ctx.market_clock,
                 indicator_service=ctx.indicator_service,

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -303,6 +303,8 @@ class ServiceContainer:
                     stock_repository=ctx.stock_repository,
                     logger=ctx.logger,
                 )
+                # 차트 일자별 Stage 표기를 위해 StockQueryService에 후주입.
+                ctx.stock_query_service.set_minervini_stage_service(ctx.minervini_stage_service)
             # NOTE: favorite_service.minervini_stage_service wiring is performed by WiringPhase.
         except Exception as e:
             ctx.logger.warning(f"[ServiceBootstrap:MinerviniStage] 초기화 실패: {e}")

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -292,6 +292,9 @@ function renderStockChart(period) {
     const ma60 = new Array(len), ma120 = new Array(len), ma150 = new Array(len), ma200 = new Array(len);
     const bbUpper = new Array(len), bbMiddle = new Array(len), bbLower = new Array(len);
     const volMa5 = new Array(len), volMa20 = new Array(len), volMa60 = new Array(len);
+    // 일자별 Minervini Stage (백엔드 제공 시에만). ohlcv와 1:1 정렬되어 rawIdx로 접근.
+    const hasStage = Array.isArray(g_chartIndicators.minervini_stage);
+    const stages = hasStage ? new Array(len) : null;
 
     const currentPrice = slicedRaw[len - 1].close;
     let highestPrice = -Infinity, lowestPrice = Infinity;
@@ -328,6 +331,7 @@ function renderStockChart(period) {
         if (ind.vol_ma5  && ind.vol_ma5[rawIdx])  volMa5[i]  = { x: i, y: ind.vol_ma5[rawIdx].ma };
         if (ind.vol_ma20 && ind.vol_ma20[rawIdx]) volMa20[i] = { x: i, y: ind.vol_ma20[rawIdx].ma };
         if (ind.vol_ma60 && ind.vol_ma60[rawIdx]) volMa60[i] = { x: i, y: ind.vol_ma60[rawIdx].ma };
+        if (hasStage) stages[i] = ind.minervini_stage[rawIdx];
     }
 
     const highPct = ((highestPrice - currentPrice) / currentPrice * 100).toFixed(1);
@@ -372,6 +376,62 @@ function renderStockChart(period) {
         }
     };
 
+    // [추가] Minervini Stage 배경 컬러 밴드 플러그인 (캔들 뒤에 그림)
+    // Stage 2(상승)=초록, 3(고점)=노랑, 4(하락)=빨강, 1(무관심)=회색, 0(미계산)=없음.
+    const STAGE_BANDS = {
+        1: { color: 'rgba(150, 150, 150, 0.10)', label: 'S1 무관심' },
+        2: { color: 'rgba(0, 200, 80, 0.12)',    label: 'S2 상승' },
+        3: { color: 'rgba(255, 200, 0, 0.14)',   label: 'S3 고점' },
+        4: { color: 'rgba(255, 60, 60, 0.12)',   label: 'S4 하락' },
+    };
+    const stageBandPlugin = {
+        id: 'minerviniStageBand',
+        beforeDatasetsDraw(chart) {
+            if (!stages) return;
+            const { ctx: c, chartArea, scales: { x, y } } = chart;
+            if (!x || !y) return;
+            const top = y.top, height = y.bottom - y.top;
+            const step = len > 1
+                ? Math.abs(x.getPixelForValue(1) - x.getPixelForValue(0))
+                : (chartArea.right - chartArea.left);
+            const clampL = (v) => Math.max(chartArea.left, v);
+            const clampR = (v) => Math.min(chartArea.right, v);
+
+            c.save();
+            // 동일 Stage 연속 구간을 한 사각형으로 묶어 그린다.
+            let runStart = 0;
+            for (let i = 1; i <= len; i++) {
+                if (i < len && stages[i] === stages[runStart]) continue;
+                const st = stages[runStart];
+                const band = STAGE_BANDS[st];
+                if (band) {
+                    const left = clampL(x.getPixelForValue(runStart) - step / 2);
+                    const right = clampR(x.getPixelForValue(i - 1) + step / 2);
+                    c.fillStyle = band.color;
+                    c.fillRect(left, top, right - left, height);
+                }
+                runStart = i;
+            }
+
+            // 우상단 범례 (현재 차트에 존재하는 Stage만)
+            const present = [...new Set(stages.filter((s) => STAGE_BANDS[s]))].sort();
+            if (present.length) {
+                c.font = 'bold 10px sans-serif';
+                c.textAlign = 'left';
+                let ly = top + 8;
+                for (const st of present) {
+                    const band = STAGE_BANDS[st];
+                    c.fillStyle = band.color.replace(/[\d.]+\)$/, '0.9)');
+                    c.fillRect(chartArea.left + 6, ly, 10, 10);
+                    c.fillStyle = '#888';
+                    c.fillText(band.label, chartArea.left + 20, ly + 9);
+                    ly += 14;
+                }
+            }
+            c.restore();
+        }
+    };
+
     // [추가] 차트 구분선 플러그인 (주가/거래량 사이)
     const splitLinePlugin = {
         id: 'splitLine',
@@ -400,7 +460,7 @@ function renderStockChart(period) {
     const tChartStart = performance.now();
     stockChartInstance = new Chart(ctx, {
         type: 'candlestick',
-        plugins: [highLowPlugin, splitLinePlugin],
+        plugins: [stageBandPlugin, highLowPlugin, splitLinePlugin],
         data: {
             labels: labels, // X축 라벨 (날짜)
             datasets: [

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -264,10 +264,8 @@ async function updateStatus() {
     if (window.__pjaxNavigating) return;
     if (_statusInFlight) return;
     _statusInFlight = true;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 4000);
     try {
-        const res = await fetch('/api/status', { signal: controller.signal });
+        const res = await fetch('/api/status');
         const data = await res.json();
 
         document.getElementById('status-time').innerText = data.current_time || '--:--:--';
@@ -304,7 +302,6 @@ async function updateStatus() {
         if (isAbortError(e)) return;
         console.error("Status update failed:", e);
     } finally {
-        clearTimeout(timer);
         _statusInFlight = false;
     }
 }

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -73,13 +73,17 @@ function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
         .finally(() => clearTimeout(timer));
 }
 
+function isAbortError(error) {
+    return error && error.name === 'AbortError';
+}
+
 async function withLoading(btn, targetEl, message, asyncFn) {
     if (btn) btn.disabled = true;
     showLoading(targetEl, message);
     try {
         await asyncFn();
     } catch (e) {
-        if (e.name === 'AbortError') {
+        if (isAbortError(e)) {
             if (targetEl) targetEl.innerHTML = '<p class="error">요청 시간이 초과되었습니다. 다시 시도해주세요.</p>';
         } else {
             if (targetEl) targetEl.innerHTML = `<p class="error">오류: ${escapeHtml(String(e.message || e))}</p>`;
@@ -297,6 +301,7 @@ async function updateStatus() {
         }
 
     } catch (e) {
+        if (isAbortError(e)) return;
         console.error("Status update failed:", e);
     } finally {
         clearTimeout(timer);

--- a/view/web/static/js/kill_switch.js
+++ b/view/web/static/js/kill_switch.js
@@ -14,16 +14,13 @@ async function loadKillSwitchStatus() {
     if (window.__pjaxNavigating) return;
     if (_ksStatusInFlight) return;
     _ksStatusInFlight = true;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 4000);
     try {
-        const res = await fetch('/api/kill-switch/status', { signal: controller.signal });
+        const res = await fetch('/api/kill-switch/status');
         if (!res.ok) return;
         _ksStatus = await res.json();
         _updateBadge(_ksStatus);
     } catch (_) { /* silent */ }
     finally {
-        clearTimeout(timer);
         _ksStatusInFlight = false;
     }
 }

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -15,13 +15,7 @@ function _isSystemPageActive() {
 }
 
 async function _fetchWithTimeout(url, options = {}, timeoutMs = SYSTEM_POLL_TIMEOUT_MS) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-        return await fetch(url, { ...options, signal: controller.signal });
-    } finally {
-        clearTimeout(timer);
-    }
+    return await fetch(url, options);
 }
 
 function _isPollAbortError(error) {

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -24,6 +24,11 @@ async function _fetchWithTimeout(url, options = {}, timeoutMs = SYSTEM_POLL_TIME
     }
 }
 
+function _isPollAbortError(error) {
+    if (typeof isAbortError === 'function') return isAbortError(error);
+    return error && error.name === 'AbortError';
+}
+
 function _clearSystemTimer(name) {
     const timer = _systemPollTimers[name];
     if (timer) clearTimeout(timer);
@@ -233,6 +238,7 @@ async function updateCacheStatus() {
         if (_cacheExpanded.price)  renderPriceCacheDetails(stats.price_cache || {});
         if (_cacheExpanded.ohlcv)  renderOhlcvCacheDetails(stats.ohlcv_cache || {});
     } catch (error) {
+        if (_isPollAbortError(error)) return;
         console.error('캐시 상태를 가져오는 중 오류 발생:', error);
     } finally {
         _cacheStatusInFlight = false;
@@ -626,6 +632,7 @@ async function updateBackgroundStatus() {
             `;
         }).join('');
     } catch (e) {
+        if (_isPollAbortError(e)) return;
         console.error('백그라운드 태스크 상태 조회 오류:', e);
     } finally {
         _backgroundStatusInFlight = false;
@@ -691,6 +698,7 @@ async function updateOperationsStatus() {
             plMeasuredTotal > 0 ? renderOpsMetric('Snap 우회', `Fresh ${plForceFresh} / 상세 ${plFullOutput} / 연결 ${plStreamUnavailable}`) : '',
         ].join('');
     } catch (e) {
+        if (_isPollAbortError(e)) return;
         console.error('운영 요약 조회 오류:', e);
     } finally {
         _operationsStatusInFlight = false;
@@ -786,6 +794,7 @@ async function updateSubscriptionStatus() {
 
         renderSubTable();
     } catch (e) {
+        if (_isPollAbortError(e)) return;
         console.error('구독 현황 조회 오류:', e);
     } finally {
         _subscriptionStatusInFlight = false;

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -146,9 +146,9 @@
 </div>
 
 <!-- 공통 스크립트 -->
-<script src="/static/js/common.js?v=6"></script>
+<script src="/static/js/common.js?v=7"></script>
 <script src="/static/js/notifications.js?v=1"></script>
-<script src="/static/js/kill_switch.js?v=3"></script>
+<script src="/static/js/kill_switch.js?v=4"></script>
 <script src="/static/js/pagination.js?v=1"></script>
 
 <!-- ── 서버 요청 진단 패널 (hang 디버깅용) ─────────────────────────────

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -48,6 +48,7 @@
     {% block head_scripts %}
     <!-- 차트 라이브러리는 필요한 페이지에서만 로드 -->
     {% endblock %}
+    <script src="/static/js/common.js?v=8"></script>
 </head>
 <body>
 
@@ -146,7 +147,6 @@
 </div>
 
 <!-- 공통 스크립트 -->
-<script src="/static/js/common.js?v=7"></script>
 <script src="/static/js/notifications.js?v=1"></script>
 <script src="/static/js/kill_switch.js?v=4"></script>
 <script src="/static/js/pagination.js?v=1"></script>

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -146,7 +146,7 @@
 </div>
 
 <!-- 공통 스크립트 -->
-<script src="/static/js/common.js?v=5"></script>
+<script src="/static/js/common.js?v=6"></script>
 <script src="/static/js/notifications.js?v=1"></script>
 <script src="/static/js/kill_switch.js?v=3"></script>
 <script src="/static/js/pagination.js?v=1"></script>

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -156,5 +156,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=20"></script>
+<script src="/static/js/system.js?v=21"></script>
 {% endblock %}

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -156,5 +156,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=19"></script>
+<script src="/static/js/system.js?v=20"></script>
 {% endblock %}


### PR DESCRIPTION
## 요약
- 주식 차트(`/stock`)에 일자별 Minervini Stage(1~4) 배경 밴드를 표시한다.
- 한국장/미국장 마감 시 삼성전자·SK하이닉스와 미국 주요 기업(NVDA, AAPL, MSFT, GOOGL, AMZN, META, AVGO, TSLA, MU, SNDK)의 시총갭 리포트를 전송한다.
- Yahoo/KIS 데이터 실패 시 시총갭 리포트가 빈 메시지로 나가는 문제를 보완했다.

## 변경 내용
- `MinerviniStageService.classify_stage_series()`로 일자별 Stage를 계산하고 차트 페이로드에 `indicators.minervini_stage`를 추가.
- `candle_chart.js`의 `stageBandPlugin`으로 캔들 뒤 Stage별 배경 밴드와 범례 표시.
- `MarketCapGapService`와 `MarketCapGapReportTask`를 추가해 한국장 마감/미국장 마감 알림 태스크 등록.
- Yahoo quote endpoint가 `401/403`을 반환하면 cookie/crumb 획득 후 재시도하고, USD/KRW는 chart endpoint fallback 사용.
- KIS 모의투자에서 국내 시총 API가 실패하면 `data/stocks.db.daily_prices` 최신 스냅샷을 fallback으로 사용하고, 필요 시 pykrx fallback 시도.

## 운영 확인
- 서비스 재시작 후 `/api/background/status` 기준 `market_cap_gap_report_kr.last_result = { korean: 2, us: 10, comparisons: 20 }` 확인.
- 빈 리포트 원인: Yahoo quote 401 + KIS paper `get_market_cap` 미지원이 동시에 발생.

## 테스트
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v` 통과
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v` 통과 (`245 passed`)

## 알려진 한계
- 과거 일자별 RS Rating 데이터가 없어 과거 구간 Minervini Stage 2가 다소 후하게 잡힐 수 있다.
- 시총갭 리포트의 Yahoo 기반 시총은 비공식 endpoint라 cookie/crumb 정책 변경 시 추가 보완이 필요할 수 있다.