### PR TITLE
Fix RS missing in 52-week new-high Telegram report

### DIFF
--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -309,8 +309,8 @@ class TelegramReporter:
             except (ValueError, TypeError):
                 tv_str = "-"
             
-            # RS (상대강도) - 추후 연동 전까지 기본값 표기
-            rs = s.get("rs", "-")
+            # RS (상대강도) - RS enrichment는 rs_rating 키에만 값을 주입하므로 우선 사용
+            rs = s.get("rs_rating") or s.get("rs") or "-"
 
             try:
                 rate_f = float(s.get("change_rate") or "0")

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -604,6 +604,35 @@ async def test_send_newhigh_report_numeric_formatting_and_exceptions(telegram_re
 
 
 @pytest.mark.asyncio
+async def test_send_newhigh_report_uses_rs_rating_when_rs_placeholder(telegram_reporter):
+    """RS enrichment 후 rs_rating에만 값이 채워지고 rs는 '-' 인 실제 흐름을 검증한다.
+
+    NewHighTask._filter_newhigh가 rs='-'를 선점하고
+    _enrich_and_filter_rs_rating이 rs_rating에만 값을 주입하므로,
+    리포트는 rs_rating을 우선 읽어야 한다.
+    """
+    stocks = [
+        {
+            "code": "000660",
+            "name": "SK하이닉스",
+            "current_price": 2917000,
+            "market_cap": 207895280000000,
+            "trading_value": 18752600000000,
+            "change_rate": 13.06,
+            "rs": "-",
+            "rs_rating": 88,
+        },
+    ]
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+
+    await telegram_reporter.send_newhigh_report(stocks, "2026-06-25")
+
+    full = "".join([c[0][0] for c in telegram_reporter._send_message.call_args_list])
+    assert "RS:88" in full
+    assert "RS:-" not in full
+
+
+@pytest.mark.asyncio
 async def test_send_premium_watchlist_report_basic(telegram_reporter):
     """send_premium_watchlist_report: 정상 데이터 전송 검증"""
     kospi = [


### PR DESCRIPTION
## 문제
52주 신고가 텔레그램 리포트가 항상 `RS:-`로 표기됨 (실로그: 20260625 SK하이닉스·SK 모두 `RS:-`).

## 원인 (키 불일치 + 처리 순서)
1. `NewHighTask._filter_newhigh`가 RS enrichment **이전에** `s["rs"]="-"`를 선점 — 이 시점 스냅샷에는 `rs`/`rs_rating` 키가 없음.
2. `_enrich_and_filter_rs_rating`은 실제 RS 값을 `rs_rating` 키에만 주입하고 `rs`는 갱신하지 않음.
3. `send_newhigh_report` 포매터는 `rs` 키만 읽음 → 항상 `"-"`.

> 웹 응답 경로(`NewHighService._format_item`)는 `rs_rating`을 읽어 정상이므로 **텔레그램 리포트만** 깨져 있었음.

## 수정
`send_newhigh_report`가 `rs_rating`을 우선 읽도록 변경(웹과 동일한 키 우선순위). `rs_rating`이 비면 기존 `rs` 폴백 유지.

```python
rs = s.get("rs_rating") or s.get("rs") or "-"
```

## 테스트 (TDD)
- 추가: `test_send_newhigh_report_uses_rs_rating_when_rs_placeholder` — `rs="-"` + `rs_rating=88` 실제 흐름에서 `RS:88` 출력 검증 (수정 전 실패 확인).
- 단위: `test_telegram_notifier.py` 40 passed, `test_newhigh_service.py`/`test_newhigh_task.py` 73 passed.
- 통합: `tests/integration_test` 245 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)