### PR TITLE
Inverse-ETF regime sleeve strategy (R-2 Phase 1)

### DIFF
--- a/strategies/inverse_etf_regime_strategy.py
+++ b/strategies/inverse_etf_regime_strategy.py
@@ -1,0 +1,369 @@
+# strategies/inverse_etf_regime_strategy.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import asdict
+from datetime import date, timedelta
+from typing import Dict, List, Optional, Tuple
+
+from interfaces.live_strategy import LiveStrategy
+from common.types import TradeSignal
+from services.stock_query_service import StockQueryService
+from services.indicator_service import IndicatorService
+from services.market_regime_service import MarketRegimeService
+from core.market_clock import MarketClock
+from core.logger import get_strategy_logger
+from strategies.inverse_etf_regime_types import (
+    InverseEtfRegimeConfig,
+    InverseEtfPositionState,
+)
+from utils.strategy_state_io import StrategyStateIO
+from utils.transaction_cost_utils import TransactionCostUtils
+from utils.atomic_json import write_json_atomic
+
+_BEAR = "bear"
+
+
+class InverseEtfRegimeStrategy(LiveStrategy):
+    """레짐 게이트 인버스 ETF 슬리브 (R-2 비상관 엣지).
+
+    진입 (scan):
+      - 레짐 게이트: MarketRegimeService 가 regime_market 을 'bear'(hard_decline)로 분류
+      - 추세 확인: 인버스 ETF 현재가 > trend_ma_period MA (당일봉 제외)
+      - 단일 종목·에피소드 1회 (position_state 보유 중이면 미진입)
+
+    청산 (check_exits), 우선순위:
+      1. 레짐 해제: regime_market 이 bear 에서 이탈 → 즉시 청산(헤지 종료)
+      2. 하드 스탑: 진입가 대비 net -5%
+      3. 트레일링 스톱: 보유 중 고점 대비 -8%
+
+    long-only 7전략이 죽는 하락 구간에서만 켜지므로 구조적으로 음의 상관을 갖는다.
+    실행은 일봉 셋업 + REST 가격으로 WS 틱에 비의존(ETF 무틱 블로커 우회).
+    """
+    STATE_FILE = os.path.join("data", "inverse_etf_regime_state.json")
+
+    def __init__(
+        self,
+        stock_query_service: StockQueryService,
+        market_regime_service: MarketRegimeService,
+        indicator_service: IndicatorService,
+        market_clock: MarketClock,
+        config: Optional[InverseEtfRegimeConfig] = None,
+        logger: Optional[logging.Logger] = None,
+        state_file: Optional[str] = None,
+    ):
+        self._sqs = stock_query_service
+        self._regime = market_regime_service
+        self._indicator = indicator_service
+        self._tm = market_clock
+        self._cfg = config or InverseEtfRegimeConfig()
+        if logger:
+            self._logger = logger
+        else:
+            self._logger = get_strategy_logger("InverseEtfRegime", sub_dir="regime")
+
+        self._position_state: Dict[str, InverseEtfPositionState] = {}
+        self._cooldown: Dict[str, str] = {}  # code → unblock_date (YYYYMMDD)
+        if state_file is not None:
+            self.STATE_FILE = str(state_file)
+        self._load_state()
+
+    @property
+    def name(self) -> str:
+        return "인버스ETF레짐"
+
+    @property
+    def strategy_id(self) -> str:
+        return "inverse_etf_regime"
+
+    # ── scan ────────────────────────────────────────────────────────
+
+    async def scan(self) -> List[TradeSignal]:
+        self._logger.info({"event": "scan_started", "strategy_name": self.name})
+        code = self._cfg.inverse_etf_code
+        name = self._cfg.inverse_etf_name
+
+        # 단일 종목·에피소드 1회: 이미 보유 중이면 미진입
+        if code in self._position_state:
+            self._logger.info({"event": "scan_skipped", "reason": "already_holding", "code": code})
+            return []
+
+        today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
+        if today_str < self._cooldown.get(code, ""):
+            self._logger.info({"event": "scan_skipped", "reason": "cooldown", "code": code})
+            return []
+
+        # 1) 레짐 게이트 — bear 가 아니면 미진입 (R-2 디코릴레이션 핵심)
+        regime = await self._regime.classify(self._cfg.regime_market, logger=self._logger)
+        if regime.regime_label != _BEAR:
+            self._logger.info({
+                "event": "entry_rejected", "code": code, "reason": "regime_not_bear",
+                "regime_label": regime.regime_label,
+            })
+            return []
+
+        # 2) 추세 확인 — 인버스 ETF 현재가 > MA (당일 미확정 봉 제외)
+        ma_resp = await self._indicator.get_moving_average(
+            code, period=self._cfg.trend_ma_period, candle_type="D", exclude_today=True
+        )
+        ma = self._latest_ma(ma_resp)
+        if ma is None:
+            self._logger.info({"event": "entry_rejected", "code": code, "reason": "ma_unavailable"})
+            return []
+
+        cp_resp = await self._sqs.get_current_price(code, caller=self.name)
+        current = self._extract_current_price(cp_resp)
+        if current <= 0:
+            self._logger.info({"event": "entry_rejected", "code": code, "reason": "invalid_current_price"})
+            return []
+        if current <= ma:
+            self._logger.info({
+                "event": "entry_rejected", "code": code, "reason": "below_trend_ma",
+                "current": current, "ma": round(ma, 2),
+            })
+            return []
+
+        qty = self._calculate_qty(current)
+        if qty <= 0:
+            self._logger.info({"event": "entry_rejected", "code": code, "reason": "zero_qty"})
+            return []
+
+        # 포지션 등록 (고점 = 진입가)
+        self._position_state[code] = InverseEtfPositionState(
+            entry_price=current,
+            entry_date=today_str,
+            peak_price=current,
+        )
+        self._save_state()
+
+        stop_loss_price = current * (1 + self._cfg.hard_stop_pct / 100)
+        reason_msg = (
+            f"베어 레짐({regime.trend_status}) + 추세확인(현재가 {current} > {self._cfg.trend_ma_period}MA "
+            f"{ma:.0f}) 진입"
+        )
+        self._logger.info({
+            "event": "entry_signal_generated", "code": code, "name": name,
+            "current": current, "qty": qty, "regime": regime.regime_label,
+        })
+        return [TradeSignal(
+            code=code, name=name, action="BUY", price=current, qty=qty,
+            reason=reason_msg, strategy_name=self.name,
+            entry_reason="inverse_etf_bear_regime",
+            invalidation_price=round(stop_loss_price, 2),
+            stop_loss_price=round(stop_loss_price, 2),
+            trailing_rule=f"peak_drawdown_{abs(self._cfg.trailing_stop_pct):.0f}pct",
+            confidence=0.5,
+            required_data=["market_regime", "moving_average", "current_price"],
+        )]
+
+    # ── check_exits ─────────────────────────────────────────────────
+
+    async def check_exits(self, holdings: List[dict]) -> List[TradeSignal]:
+        signals: List[TradeSignal] = []
+        if not holdings:
+            return signals
+
+        # 레짐은 종목 무관·일 1회 분류이므로 한 번만 조회
+        regime = await self._regime.classify(self._cfg.regime_market, logger=self._logger)
+        regime_is_bear = regime.regime_label == _BEAR
+
+        state_dirty = False
+        for hold in holdings:
+            try:
+                result = await self._check_single_exit(hold, regime_is_bear)
+            except Exception as e:  # noqa: BLE001 - 단일 종목 실패가 전체 청산을 막지 않도록
+                self._logger.error(f"check_exits error: {e}")
+                continue
+            if result is None:
+                continue
+            sig, dirty = result
+            if sig is not None:
+                signals.append(sig)
+            if dirty:
+                state_dirty = True
+
+        if state_dirty:
+            self._save_state()
+        return signals
+
+    async def _check_single_exit(
+        self, hold: dict, regime_is_bear: bool
+    ) -> Optional[Tuple[Optional[TradeSignal], bool]]:
+        """단일 보유 종목 청산 조건 검사. (signal, state_dirty) 반환."""
+        code = hold.get("code")
+        if not code:
+            return None
+
+        cp_resp = await self._sqs.get_current_price(code, caller=self.name)
+        current = self._extract_current_price(cp_resp)
+        if current <= 0:
+            return None
+
+        buy_price = int(hold.get("buy_price", 0) or 0)
+        if buy_price <= 0:
+            buy_price = current
+
+        # 고점 갱신 (트레일링 기준). state 가 없으면 매수가/현재가 기준으로 초기화.
+        state = self._position_state.get(code)
+        state_dirty = False
+        if state is None:
+            state = InverseEtfPositionState(
+                entry_price=buy_price,
+                entry_date=hold.get("buy_date", "") or "",
+                peak_price=max(buy_price, current),
+            )
+            self._position_state[code] = state
+            state_dirty = True
+        if current > state.peak_price:
+            state.peak_price = current
+            state_dirty = True
+
+        pnl_pct = TransactionCostUtils.net_return_pct(buy_price, current)
+        peak_drawdown_pct = (current - state.peak_price) / state.peak_price * 100 if state.peak_price else 0.0
+        reason: Optional[str] = None
+        is_stop_loss = False
+
+        # 1) 레짐 해제: bear 이탈 → 헤지 종료
+        if not regime_is_bear:
+            reason = "레짐 해제 청산: 하락추세 종료"
+        # 2) 하드 스탑: 진입가 대비 net 손절
+        elif pnl_pct <= self._cfg.hard_stop_pct:
+            reason = f"하드 스탑 손절: PnL(net) {pnl_pct:.2f}% ≤ {self._cfg.hard_stop_pct}%"
+            is_stop_loss = True
+        # 3) 트레일링 스톱: 고점 대비 하락
+        elif peak_drawdown_pct <= self._cfg.trailing_stop_pct:
+            reason = (
+                f"트레일링 스톱: 고점 {state.peak_price} 대비 {peak_drawdown_pct:.2f}% "
+                f"≤ {self._cfg.trailing_stop_pct}%"
+            )
+
+        if not reason:
+            return (None, state_dirty)
+
+        holding_qty = int(hold.get("qty", 1) or 1)
+        self._logger.info({
+            "event": "exit_signal_generated", "code": code, "name": hold.get("name", code),
+            "reason": reason, "pnl_pct": round(pnl_pct, 2), "pnl_basis": "net",
+        })
+
+        self._position_state.pop(code, None)
+        state_dirty = True
+        if is_stop_loss:
+            unblock = (date.today() + timedelta(days=self._cfg.cooldown_days)).strftime("%Y%m%d")
+            self._cooldown[code] = unblock
+
+        return (
+            TradeSignal(
+                code=code, name=hold.get("name", code), action="SELL",
+                price=current, qty=holding_qty, reason=reason, strategy_name=self.name,
+            ),
+            state_dirty,
+        )
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_current_price(resp) -> int:
+        """get_current_price 응답에서 현재가 정수값을 추출. 실패 시 0."""
+        if not resp or getattr(resp, "rt_cd", "") != "0":
+            return 0
+        data = getattr(resp, "data", None)
+        out = data.get("output") if isinstance(data, dict) else data
+        if not out:
+            return 0
+        try:
+            if isinstance(out, dict):
+                return int(out.get("stck_prpr", 0) or 0)
+            return int(getattr(out, "stck_prpr", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _latest_ma(resp) -> Optional[float]:
+        """get_moving_average 응답에서 최신 MA 값을 추출. 실패 시 None."""
+        if isinstance(resp, Exception):
+            return None
+        if not resp or getattr(resp, "rt_cd", "") != "0" or not getattr(resp, "data", None):
+            return None
+        try:
+            ma = resp.data[-1].get("ma")
+            return float(ma) if ma is not None else None
+        except (TypeError, ValueError, IndexError):
+            return None
+
+    def _calculate_qty(self, price: int) -> int:
+        """Fixed-fractional 사이징(소형 슬롯). use_fixed_qty=True 면 1주."""
+        if price <= 0:
+            return self._cfg.min_qty
+        if self._cfg.use_fixed_qty:
+            return self._cfg.min_qty
+        budget = self._cfg.total_portfolio_krw * (self._cfg.position_size_pct / 100.0)
+        return max(int(budget / price), self._cfg.min_qty)
+
+    # ── state persistence ───────────────────────────────────────────
+
+    def _apply_loaded_state(self, data) -> None:
+        if not isinstance(data, dict):
+            return
+        positions = data.get("positions", {}) or {}
+        cooldown = data.get("cooldown", {}) or {}
+        for k, v in positions.items():
+            self._position_state[k] = InverseEtfPositionState(**v)
+        self._cooldown = dict(cooldown)
+
+    def _load_state(self):
+        """sync entry. 이벤트 루프 안이면 async 태스크로, 밖이면 동기 경로."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            if not os.path.exists(self.STATE_FILE):
+                return
+            try:
+                with open(self.STATE_FILE, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                self._apply_loaded_state(data)
+            except Exception as e:
+                self._logger.error(f"Failed to load state for {self.name}: {e}")
+            return
+        asyncio.create_task(self._load_state_async())
+
+    async def _load_state_async(self):
+        try:
+            data = await StrategyStateIO.load(self.STATE_FILE)
+        except Exception as e:
+            self._logger.error(f"Failed to load state async for {self.name}: {e}")
+            return
+        if data is None:
+            return
+        self._apply_loaded_state(data)
+
+    async def load_state(self):
+        """초기화 직후 scan 전에 호출. _load_state_async() 를 명시적으로 await."""
+        await self._load_state_async()
+
+    def _payload(self) -> dict:
+        return {
+            "positions": {k: asdict(v) for k, v in self._position_state.items()},
+            "cooldown": dict(self._cooldown),
+        }
+
+    def _save_state(self):
+        """sync entry. 이벤트 루프 안이면 schedule_save, 밖이면 동기 atomic write."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                write_json_atomic(self.STATE_FILE, self._payload(), indent=2, ensure_ascii=False)
+            except Exception as e:
+                self._logger.error(f"Failed to save state for {self.name}: {e}")
+            return
+        StrategyStateIO.schedule_save(self.STATE_FILE, self._payload())
+
+    async def _save_state_async(self):
+        try:
+            await StrategyStateIO.save_atomic(self.STATE_FILE, self._payload())
+        except Exception as e:
+            self._logger.error(f"Failed to save state async for {self.name}: {e}")

--- a/strategies/inverse_etf_regime_types.py
+++ b/strategies/inverse_etf_regime_types.py
@@ -1,0 +1,39 @@
+# strategies/inverse_etf_regime_types.py
+from dataclasses import dataclass
+from strategies.base_strategy_config import BaseStrategyConfig
+
+
+@dataclass
+class InverseEtfRegimeConfig(BaseStrategyConfig):
+    """레짐 게이트 인버스 ETF 슬리브 설정 (R-2 비상관 엣지).
+
+    KOSPI가 확인된 하락추세(bear)일 때만 -1x 인버스 ETF를 추세추종 매수해
+    하락장에서 (-)베타 수익을 얻는다. long-only 7전략과 구조적으로 음의 상관.
+    """
+    # 종목 (KODEX 인버스, KOSPI200 일간 -1x). 곱버스(-2x)는 변동성 감쇠로 제외.
+    inverse_etf_code: str = "114800"
+    inverse_etf_name: str = "KODEX 인버스"
+
+    # 레짐 게이트 — 어느 시장의 레짐으로 진입을 통제할지
+    regime_market: str = "KOSPI"
+
+    # 추세 확인 — 인버스 ETF 자체가 일봉 상승추세일 때만 진입(낙하 칼날/휩쏘 방지)
+    trend_ma_period: int = 20
+
+    # 청산
+    hard_stop_pct: float = -5.0       # 진입가 대비 net 손절(%)
+    trailing_stop_pct: float = -8.0   # 고점 대비 트레일링 스톱(%)
+
+    # 자금 관리 (디버시파이어이므로 소형 슬롯)
+    total_portfolio_krw: int = 10_000_000
+    position_size_pct: float = 3.0
+    min_qty: int = 1
+    cooldown_days: int = 2             # 손절 후 재진입 차단 일수
+
+
+@dataclass
+class InverseEtfPositionState:
+    """인버스 ETF 슬리브 포지션 추적 상태."""
+    entry_price: int                   # 진입가
+    entry_date: str                    # 진입일 (YYYYMMDD)
+    peak_price: int                    # 보유 중 기록한 최고가 (트레일링 기준)

--- a/tests/unit_test/strategies/test_inverse_etf_regime_strategy.py
+++ b/tests/unit_test/strategies/test_inverse_etf_regime_strategy.py
@@ -1,0 +1,248 @@
+# tests/unit_test/strategies/test_inverse_etf_regime_strategy.py
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from datetime import datetime
+
+from common.types import ResCommonResponse, TradeSignal
+from strategies.inverse_etf_regime_strategy import InverseEtfRegimeStrategy
+from strategies.inverse_etf_regime_types import (
+    InverseEtfRegimeConfig,
+    InverseEtfPositionState,
+)
+from services.stock_query_service import StockQueryService
+from services.indicator_service import IndicatorService
+from services.market_regime_service import MarketRegimeService, RegimeSnapshot
+from core.market_clock import MarketClock
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────
+
+def _price_resp(current="10000"):
+    return ResCommonResponse(
+        rt_cd="0", msg1="OK",
+        data={"output": {"stck_prpr": current}},
+    )
+
+
+def _ma_resp(value):
+    return ResCommonResponse(
+        rt_cd="0", msg1="OK",
+        data=[{"code": "114800", "date": "20250101", "close": 10000.0, "ma": value}],
+    )
+
+
+def _regime(label):
+    return RegimeSnapshot(
+        market="KOSPI",
+        trend_status="hard_decline" if label == "bear" else "rising",
+        regime_label=label,
+        snapshot_date="20250102",
+        is_rising=(label != "bear"),
+        net_change_pct=-0.5 if label == "bear" else 0.5,
+        max_daily_drop_pct=-0.3 if label == "bear" else 0.0,
+    )
+
+
+# ── 공통 Fixture ──────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_deps():
+    sqs = MagicMock(spec=StockQueryService)
+    regime = MagicMock(spec=MarketRegimeService)
+    indicator = MagicMock(spec=IndicatorService)
+    tm = MagicMock(spec=MarketClock)
+    logger = MagicMock()
+
+    sqs.get_current_price = AsyncMock(spec=StockQueryService.get_current_price)
+    regime.classify = AsyncMock(spec=MarketRegimeService.classify)
+    indicator.get_moving_average = AsyncMock(spec=IndicatorService.get_moving_average)
+
+    return sqs, regime, indicator, tm, logger
+
+
+@pytest.fixture
+def strategy(mock_deps):
+    sqs, regime, indicator, tm, logger = mock_deps
+    strat = InverseEtfRegimeStrategy(sqs, regime, indicator, tm, logger=logger)
+    strat._position_state = {}
+    strat._cooldown = {}
+    strat._save_state = MagicMock()
+    strat._load_state = MagicMock()
+    tm.get_current_kst_time.return_value = datetime(2025, 1, 2, 15, 15, 0)
+    return strat
+
+
+@pytest.fixture
+def bear_setup(strategy, mock_deps):
+    """모든 진입 조건(베어 레짐 + 추세 확인 + 유효 현재가)이 통과하는 셋업."""
+    sqs, regime, indicator, tm, logger = mock_deps
+    regime.classify.return_value = _regime("bear")
+    indicator.get_moving_average.return_value = _ma_resp(9500.0)  # current(10000) > MA
+    sqs.get_current_price.return_value = _price_resp("10000")
+    return strategy, sqs, regime, indicator, tm, logger
+
+
+# ── scan() 진입 테스트 ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_when_bear_and_trend_confirmed(bear_setup):
+    """베어 레짐 + 인버스 ETF 현재가 > MA → BUY 시그널 1건."""
+    strat, _, _, _, _, _ = bear_setup
+    signals = await strat.scan()
+    assert len(signals) == 1
+    sig = signals[0]
+    assert isinstance(sig, TradeSignal)
+    assert sig.action == "BUY"
+    assert sig.code == "114800"
+    assert sig.strategy_name == strat.name
+    assert sig.entry_reason == "inverse_etf_bear_regime"
+
+
+@pytest.mark.asyncio
+async def test_scan_no_signal_when_not_bear(bear_setup):
+    """레짐이 베어가 아니면(상승/횡보) 진입하지 않는다 — R-2 디코릴레이션 핵심."""
+    strat, _, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bull")
+    signals = await strat.scan()
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_no_signal_when_sideways(bear_setup):
+    """횡보장에서도 진입하지 않는다(휩쏘 방지)."""
+    strat, _, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("sideways")
+    signals = await strat.scan()
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_no_signal_when_below_ma(bear_setup):
+    """베어라도 인버스 ETF가 추세 미확인(현재가 <= MA)이면 진입하지 않는다."""
+    strat, sqs, _, indicator, _, _ = bear_setup
+    indicator.get_moving_average.return_value = _ma_resp(10500.0)  # current(10000) < MA
+    signals = await strat.scan()
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_no_signal_when_ma_unavailable(bear_setup):
+    """MA 조회 실패 시 진입하지 않는다(보수)."""
+    strat, _, _, indicator, _, _ = bear_setup
+    indicator.get_moving_average.return_value = ResCommonResponse(rt_cd="1", msg1="err", data=None)
+    signals = await strat.scan()
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_already_holding(bear_setup):
+    """이미 포지션 보유 중이면 중복 진입하지 않는다."""
+    strat, _, _, _, _, _ = bear_setup
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=9000, entry_date="20250101", peak_price=9000)
+    }
+    signals = await strat.scan()
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_buy_signal_has_stop_and_trailing_fields(bear_setup):
+    """BUY 시그널은 손절선·트레일링 규칙 등 P3-4 9필드를 채운다."""
+    strat, _, _, _, _, _ = bear_setup
+    sig = (await strat.scan())[0]
+    assert sig.stop_loss_price is not None
+    assert sig.stop_loss_price < sig.price
+    assert sig.trailing_rule is not None
+    assert sig.required_data
+
+
+# ── check_exits() 청산 테스트 ──────────────────────────────────────
+
+def _hold(code="114800", buy_price=10000, qty=3):
+    return {"code": code, "name": "KODEX 인버스", "buy_price": buy_price, "qty": qty}
+
+
+@pytest.mark.asyncio
+async def test_exit_when_regime_flips_to_bull(bear_setup):
+    """레짐이 베어에서 이탈하면 즉시 청산(헤지 목적 종료)."""
+    strat, sqs, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bull")
+    sqs.get_current_price.return_value = _price_resp("10000")
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=10000, entry_date="20250101", peak_price=10000)
+    }
+    signals = await strat.check_exits([_hold()])
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert "레짐" in signals[0].reason
+
+
+@pytest.mark.asyncio
+async def test_exit_on_hard_stop(bear_setup):
+    """베어 유지 중이라도 진입가 대비 하드 스탑 도달 시 손절."""
+    strat, sqs, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bear")
+    sqs.get_current_price.return_value = _price_resp("9000")  # -10% < -5%
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=10000, entry_date="20250101", peak_price=10000)
+    }
+    signals = await strat.check_exits([_hold(buy_price=10000)])
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert "스탑" in signals[0].reason or "손절" in signals[0].reason
+
+
+@pytest.mark.asyncio
+async def test_exit_on_trailing_stop_from_peak(bear_setup):
+    """고점 대비 트레일링 스톱(-8%) 도달 시 청산."""
+    strat, sqs, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bear")
+    # 고점 12000 기록 후 현재 11000 (고점 대비 -8.3% < -8%)
+    sqs.get_current_price.return_value = _price_resp("11000")
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=10000, entry_date="20250101", peak_price=12000)
+    }
+    signals = await strat.check_exits([_hold(buy_price=10000)])
+    assert len(signals) == 1
+    assert signals[0].action == "SELL"
+    assert "트레일" in signals[0].reason
+
+
+@pytest.mark.asyncio
+async def test_no_exit_when_bear_and_above_stops(bear_setup):
+    """베어 유지 + 스탑/트레일링 미도달이면 보유 지속."""
+    strat, sqs, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bear")
+    sqs.get_current_price.return_value = _price_resp("10500")  # +5%, 고점 갱신
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=10000, entry_date="20250101", peak_price=10500)
+    }
+    signals = await strat.check_exits([_hold(buy_price=10000)])
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_check_exits_updates_peak(bear_setup):
+    """현재가가 기존 고점을 갱신하면 position_state.peak_price 가 올라간다."""
+    strat, sqs, regime, _, _, _ = bear_setup
+    regime.classify.return_value = _regime("bear")
+    sqs.get_current_price.return_value = _price_resp("13000")
+    strat._position_state = {
+        "114800": InverseEtfPositionState(entry_price=10000, entry_date="20250101", peak_price=11000)
+    }
+    await strat.check_exits([_hold(buy_price=10000)])
+    assert strat._position_state["114800"].peak_price == 13000
+
+
+@pytest.mark.asyncio
+async def test_check_exits_empty_holdings(strategy):
+    """보유가 없으면 빈 리스트."""
+    signals = await strategy.check_exits([])
+    assert signals == []
+
+
+# ── 식별자 ────────────────────────────────────────────────────────
+
+def test_strategy_identifiers(strategy):
+    assert strategy.strategy_id == "inverse_etf_regime"
+    assert isinstance(strategy.name, str) and strategy.name


### PR DESCRIPTION
## 배경 (R-2)
활성 7전략 전부 long-only 모멘텀/돌파/눌림목 → 단일 상승/추세 regime 베팅으로 약세·횡보장 동시 손실 위험. 이 PR은 R-2의 "비상관 엣지 1개 도입"을 위한 **인버스 ETF 일봉 슬리브 Phase 1**(전략 클래스 + TDD).

## 컨셉
KOSPI가 확인된 하락추세(`regime_label == bear`)일 때만 -1x 인버스 ETF(KODEX 인버스 114800)를 추세추종 매수 → 7개 long 전략이 죽는 구간에서만 켜지므로 **구조적으로 음의 상관**.

- **진입**(`scan`): 레짐 게이트(bear) + 추세 확인(현재가 > 20MA, 당일봉 제외) + 단일종목 에피소드 1회
- **청산**(`check_exits`): ① 레짐 해제 ② 하드 스탑(net -5%) ③ 트레일링 스톱(고점 대비 -8%)
- **무틱 블로커 우회**: 일봉 셋업 + REST 가격으로 WS 틱 비의존 (ETF 무틱 = P2 2-4 실험 B와 무관)
- **소형 슬롯** 사이징(디버시파이어)

## 변경
- `strategies/inverse_etf_regime_strategy.py` — `InverseEtfRegimeStrategy(LiveStrategy)`
- `strategies/inverse_etf_regime_types.py` — config/position state
- `tests/unit_test/strategies/test_inverse_etf_regime_strategy.py` — 14건

## 테스트
- 신규 단위 14건 통과 (진입 게이트·청산 우선순위·고점 트레일링·식별자)
- 통합 테스트 245건 전부 통과

## 범위 밖 (후속 Phase)
- Phase 2: 다중 하락 사이클 일봉 백테스트(ETF 비용 모델 = 거래세 0)
- Phase 3: strategy_factory 등록 `live_enabled=False` + shadow/paper journal
- Phase 4: profitability gate(regime-scoped min_trades) → canary → live 전환

⚠️ 아직 scheduler/factory에 **미배선** — 실행 경로에 들어가지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)