### PR TITLE
Wire inverse-ETF regime sleeve into factory (R-2 Phase 3)

### DIFF
--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -659,7 +659,7 @@ class TestWebAppContextInitialization:
     async def test_initialize_scheduler_registers_strategies(self, mock_config, test_logger):
         """
         initialize_scheduler 호출 시 스케줄러가 생성되고
-        7개 전략이 등록되는지 검증.
+        8개 전략이 등록되는지 검증.
         """
         from view.web.web_app_initializer import WebAppContext
         from scheduler.strategy_scheduler import StrategyScheduler
@@ -691,11 +691,11 @@ class TestWebAppContextInitialization:
             assert ctx.scheduler is not None
             assert isinstance(ctx.scheduler, StrategyScheduler)
 
-            # 등록된 전략 개수 검증 (7개: OneilSqueezeBreakout, OneilPocketPivot, HighTightFlag, FirstPullback,
-            # LarryWilliamsVBO, RSI2Pullback, LarryWilliamsCB)
+            # 등록된 전략 개수 검증 (8개: OneilSqueezeBreakout, OneilPocketPivot, HighTightFlag, FirstPullback,
+            # LarryWilliamsVBO, RSI2Pullback, LarryWilliamsCB, InverseEtfRegime)
             # VolumeBreakoutLive / ProgramBuyFollow / TraditionalVolumeBreakout 은 스케줄러 등록에서 제거됨
             registered = ctx.scheduler.get_status()
-            assert len(registered["strategies"]) == 7
+            assert len(registered["strategies"]) == 8
 
     @pytest.mark.asyncio
     async def test_initialize_then_switch_environment(self, mock_config, test_logger):

--- a/tests/unit_test/strategies/test_live_strategy_lifecycle_contract.py
+++ b/tests/unit_test/strategies/test_live_strategy_lifecycle_contract.py
@@ -1,7 +1,8 @@
 """활성 라이브 전략의 lifecycle contract checklist 테스트 (P3 3-4 ①).
 
-`LiveStrategy` 인터페이스 + 활성 전략 7개가 공유해야 할 최소 lifecycle hook 의
-존재/타입을 고정한다. 신규 전략 추가 시 contract 누락을 자동 탐지하기 위한 안전망.
+`LiveStrategy` 인터페이스 + 등록 전략(활성 7 + 인버스 ETF 슬리브 shadow/paper)이
+공유해야 할 최소 lifecycle hook 의 존재/타입을 고정한다. 신규 전략 추가 시 contract
+누락을 자동 탐지하기 위한 안전망.
 
 검증 항목:
   - 식별자 3종 (`name`/`strategy_id`/`display_name`) 이 non-empty str.
@@ -22,6 +23,7 @@ import pytest
 from interfaces.live_strategy import LiveStrategy
 from strategies.first_pullback_strategy import FirstPullbackStrategy
 from strategies.high_tight_flag_strategy import HighTightFlagStrategy
+from strategies.inverse_etf_regime_strategy import InverseEtfRegimeStrategy
 from strategies.larry_williams_channel_breakout_strategy import (
     LarryWilliamsChannelBreakoutStrategy,
 )
@@ -78,6 +80,16 @@ def _factory_vbo() -> LiveStrategy:
     )
 
 
+def _factory_inverse() -> LiveStrategy:
+    return InverseEtfRegimeStrategy(
+        stock_query_service=MagicMock(),
+        market_regime_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
 ACTIVE_STRATEGY_FACTORIES: list[tuple[str, Callable[[], LiveStrategy]]] = [
     ("oneil_pocket_pivot", _factory_pp),
     ("high_tight_flag", _factory_htf),
@@ -86,6 +98,7 @@ ACTIVE_STRATEGY_FACTORIES: list[tuple[str, Callable[[], LiveStrategy]]] = [
     ("rsi2_pullback", _factory_rsi2),
     ("larry_williams_channel_breakout", _factory_cb),
     ("larry_williams_vbo", _factory_vbo),
+    ("inverse_etf_regime", _factory_inverse),
 ]
 
 

--- a/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
+++ b/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
@@ -20,6 +20,7 @@ STRATEGY_CLASS_NAMES = [
     "LarryWilliamsVBOStrategy",
     "RSI2PullbackStrategy",
     "LarryWilliamsChannelBreakoutStrategy",
+    "InverseEtfRegimeStrategy",
 ]
 
 
@@ -89,13 +90,31 @@ def test_strategy_factory_wires_live_expansion_gate_with_journal_provider(patche
     assert gate._enabled is True
 
 
-def test_strategy_factory_registers_seven_strategies(patched_factory_deps):
+def test_strategy_factory_registers_eight_strategies(patched_factory_deps):
     from view.web.bootstrap.strategy_factory import StrategyFactory
 
     ctx = _make_fake_context()
     StrategyFactory(ctx).build()
 
-    assert ctx.scheduler.register.call_count == 7
+    assert ctx.scheduler.register.call_count == 8
+
+
+def test_strategy_factory_registers_inverse_etf_sleeve_disabled(patched_factory_deps):
+    """R-2 인버스 ETF 슬리브는 등록되되 수동 활성화 대기(enabled=False)이며
+    단일 종목(max_positions=1)·오버나잇 허용(force_exit_on_close=False)으로 배선된다."""
+    from view.web.bootstrap.strategy_factory import StrategyFactory
+
+    ctx = _make_fake_context()
+    StrategyFactory(ctx).build()
+
+    inverse_strategy = patched_factory_deps["InverseEtfRegimeStrategy"].return_value
+    registered_configs = [call.args[0] for call in ctx.scheduler.register.call_args_list]
+    cfg = next(c for c in registered_configs if c.strategy is inverse_strategy)
+
+    assert cfg.enabled is False
+    assert cfg.max_positions == 1
+    assert cfg.force_exit_on_close is False
+    assert cfg.allow_pyramiding is False
 
 
 def test_strategy_factory_enables_vbo_event_shadow_without_live_trading(patched_factory_deps):
@@ -185,5 +204,5 @@ def test_strategy_factory_builds_when_trading_enabled_via_combination(patched_fa
     StrategyFactory(ctx).build()
 
     assert ctx.scheduler is patched_factory_deps["StrategyScheduler"].return_value
-    assert ctx.scheduler.register.call_count == 7
+    assert ctx.scheduler.register.call_count == 8
     patched_factory_deps["StrategySchedulerTaskAdapter"].assert_called_once()

--- a/todo_list.md
+++ b/todo_list.md
@@ -20,7 +20,6 @@
 
 - **코드 착수 가능 (정책 합의 선행)**
   - **P1 1-6 paper/소액 canary journal 축적** — 무틱 블로커와 독립. journal은 `virtual_trade_service.get_standard_journal_records` ← polling scan + REST 가격 경로로 채워져 틱 비의존. 라이브 런타임 시간만 필요(무틱에 막히는 건 "shadow" 하위 요소뿐, 2-4 parity와 동일 의존).
-  - **R-2 비상관 엣지 도입** — 정책 결정 후 구현.
   - **S-9 god class 분리 / 3-4 lifecycle 분해** — 보류 해제(정책 합의 시).
 - **외부 액션 대기 (블로커)**: P2 2-4(KIS 에스컬레이션), P0 0-1(fixture), P1 1-5(microstructure 캡처), P2 2-2(KIS 유량 한도 재확인), P1 1-7(canary 후 정책), 해외 Phase 5(canary 게이팅).
 - **종결**: T-1 키움 테마 REST — **드롭**. 네이버 테마(`ThemeClassificationCollectorService`) 자동 수집으로 분류 데이터 충분, 키움 추가 소스 불필요. (멀티소스 병합 인프라는 `StockClassificationRepository`에 잔존하나 신규 소스 연결 계획 없음.)
@@ -122,12 +121,14 @@
 - [ ] 거래대금 기준 50억 → 30억 추가 완화 검토.
 - [ ] 정배열 조건을 Pool B 전용 `current > ma_20d` 중심으로 완화 검토.
 
-### R-2. 전략 상관 / 단일 regime 집중 [부분 해소]
+### R-2. 전략 상관 / 단일 regime 집중 [엣지 도입 — Phase 1~3 완료, Phase 4 데이터 대기]
 
 - 활성 7전략 전부 long-only 모멘텀/돌파/눌림목 → 단일 "상승/추세 regime 베팅". 상관행렬·regime 분해는 일일 리포트에 노출 완료.
-- [ ] 자금 확대 전 비상관 엣지(역추세/숏/저변동 등) 1개 이상 도입 여부 정책 결정.
+- 비상관 엣지 = **인버스 ETF 레짐 슬리브**(KOSPI bear에서만 -1x 인버스 ETF 추세추종 매수, long-only와 음의 상관). 직접 숏(공매도)은 개인 비현실적이라 제외.
+  - 완료: Phase 1 전략(#594) · Phase 2 다중 베어 사이클 백테스트(#595, 실데이터 46거래 복리 +20% MDD −11.8%) · Phase 3 factory 배선 `enabled=False`(#596, shadow/paper 관찰). 일봉+REST라 ETF 무틱(2-4) 무관.
+- [ ] **Phase 4 (베어 paper 데이터 + 정책 후 구현)**: profitability gate는 전역 단일 config(per-strategy override 없음)라 인버스 슬리브가 표준 gate와 3중 충돌(① win_rate 0.35/0.40 vs 실측 34.8% ② min_trades 30/100 vs regime-conditional ③ regime-balance vs BEAR 단일). **방향 A 확정**: 추세추종 디코릴레이터엔 win_rate가 잘못된 기준 → gate에 per-strategy override 추가 + 인버스 전용 프로파일(win_rate 완화/제거, payoff·profit_factor·양(+)PnL 유지, min_trades 완화+≥2 독립 베어 에피소드, regime-balance 면제). 임계값 보정할 paper 베어 데이터가 없어 **다음 베어장 paper 축적 후 구현**(선구현 금지). 이후 canary → `enabled=True` 전환.
 
-주요 파일: `services/market_regime_service.py`, `services/strategy_log_report_service.py`
+주요 파일: `strategies/inverse_etf_regime_strategy.py`, `strategies/inverse_etf_regime_backtest.py`, `services/strategy_profitability_gate_service.py`, `services/market_regime_service.py`, `view/web/bootstrap/strategy_factory.py`
 
 ### R-6. 비용 모델 — capacity/시장충격 [관찰]
 
@@ -148,8 +149,8 @@
 1. **운영 관찰·블로커 (최우선, 코드 아님)**
    - WebSocket 무틱 ≈55% — **KIS 에스컬레이션**(ETF/우선주 WS 지원 확인 + 무틱 보통주 계정 단위 문의). 해소 전까지 shadow 수집 불가. (P2 2-4)
    - profitability gate 우회 없이 shadow/paper/canary journal로 전략별 실전 근거 축적 (P1 1-6, 라이브 축적)
-2. **코드 착수 가능 (정책 합의 선행)**
-   - 비상관 엣지 도입 여부 정책 결정 후 구현 (R-2)
+2. **데이터 + 정책 대기**
+   - R-2 인버스 ETF 슬리브 Phase 4(추세추종 게이트 프로파일) — 다음 베어장 paper 데이터 축적 후 구현
 3. **외부 운영·데이터 확보 후**
    - KIS REST/WebSocket 유량 한도 재확인 (P2 2-2) · 실전 submit/signing fixture (P0 0-1) · 장중 microstructure 캡처 (P1 1-5)
 4. **정책 결정 후**

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -11,6 +11,7 @@ from core.logger import get_strategy_logger
 from scheduler.strategy_scheduler import StrategyScheduler, StrategySchedulerConfig
 from strategies.first_pullback_strategy import FirstPullbackStrategy
 from strategies.high_tight_flag_strategy import HighTightFlagStrategy
+from strategies.inverse_etf_regime_strategy import InverseEtfRegimeStrategy
 from strategies.larry_williams_channel_breakout_strategy import LarryWilliamsChannelBreakoutStrategy
 from strategies.larry_williams_vbo_strategy import LarryWilliamsVBOStrategy
 from strategies.oneil_pocket_pivot_strategy import OneilPocketPivotStrategy
@@ -200,6 +201,27 @@ class StrategyFactory:
             enabled=False,              # 수동 활성화 대기
             force_exit_on_close=False,  # 스윙 포지션 — 오버나잇 허용
             allow_pyramiding=False,     # 1종목 1포지션 invariant
+            scan_when_position_full=True,
+        ))
+
+        # 인버스 ETF 레짐 슬리브 등록 (R-2 비상관 엣지) — shadow/paper 관찰용, 수동 활성화 대기.
+        # KOSPI 하락추세(bear)에서만 -1x 인버스 ETF를 추세추종 매수해 long-only 7전략과
+        # 음의 상관을 노린다. 일봉+REST 경로라 WS 틱(ETF 무틱)에 비의존.
+        inverse_etf_strategy = InverseEtfRegimeStrategy(
+            stock_query_service=ctx.stock_query_service,
+            market_regime_service=getattr(ctx.oneil_universe_service, "market_regime_service", None),
+            indicator_service=ctx.indicator_service,
+            market_clock=ctx.market_clock,
+            logger=get_strategy_logger('InverseEtfRegime'),
+        )
+        ctx.scheduler.register(StrategySchedulerConfig(
+            strategy=inverse_etf_strategy,
+            interval_minutes=5,
+            max_positions=1,            # 단일 종목 슬리브
+            order_qty=1,
+            enabled=False,              # 수동 활성화 대기 (shadow/paper 관찰)
+            force_exit_on_close=False,  # 멀티데이 베어 헤지 — 오버나잇 허용
+            allow_pyramiding=False,     # 1포지션 invariant
             scan_when_position_full=True,
         ))
 


### PR DESCRIPTION
## 배경
[R-2 Phase 1 (#594)](../pull/594) 전략 + [Phase 2 (#595)](../pull/595) 백테스트에 이어, 인버스 ETF 레짐 슬리브를 StrategyFactory에 배선하는 **Phase 3**.

이 코드베이스에서 "live_enabled=False"는 `enabled=False`(수동 활성화 대기)로 표현되며, 기존 7전략 모두 동일 상태. shadow/paper journal은 paper 모드 활성 시 scan/check_exits → `log_buy`/`log_sell` → `get_standard_journal_records`(gate 입력) 경로로 채워지고, real BUY는 `StrategyLiveExpansionGateService` fail-close가 차단.

## 변경
- `view/web/bootstrap/strategy_factory.py` — `InverseEtfRegimeStrategy`를 8번째 전략으로 등록
  - `enabled=False`(수동 활성화 대기), `max_positions=1`(단일 종목), `force_exit_on_close=False`(멀티데이 베어 헤지 오버나잇), `allow_pyramiding=False`
  - `market_regime_service`는 `oneil_universe_service`에서 재사용, `indicator_service`는 ctx에서 주입
- `tests/.../test_strategy_factory.py` — 등록 개수 7→8 + 인버스 슬리브 `enabled=False`/단일종목 회귀 잠금
- `tests/.../test_live_strategy_lifecycle_contract.py` — lifecycle 안전망에 `inverse_etf_regime` 추가
- `tests/integration_test/test_it_web_api_paper.py` — 등록 개수 7→8

## 안전
- `current_candidate_codes()` 미오버라이드(기본 `[]`) → ETF WS 구독 발생 안 함(P2 2-4 무틱과 무관)
- `enabled=False` → 자동 scan/주문 경로에 진입하지 않음. 실거래는 Phase 4 게이팅 후.

## 테스트
- 단위 6495건 + 통합 245건 전부 통과

## 범위 밖 (Phase 4)
- profitability gate **regime-scoped min_trades** 정책 결정(표본 부족 대응)
- canary → `enabled=True`/live 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)