### PR TITLE
시총갭 리포트: 모바일 가독성 포맷 + 세션별 on/off 토글

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -150,6 +150,13 @@ notifications:
       STRATEGY: ["warning", "error", "critical"]
       API: ["error", "critical"]
 
+# 시총갭 리포트 발송 세션 on/off (기본 둘 다 on)
+#   kr: 한국장 마감(15:50 KST) 후 발송 — 미국 시총은 전일 종가 기준(프리뷰)
+#   us: 미국장 마감(16:30 ET ≈ 익일 06:30 KST) 후 발송 — 양쪽 시총 최신(확정값)
+# 알림 피로를 줄이려면 한쪽을 false 로 둔다.
+market_cap_gap_report_kr_enabled: true
+market_cap_gap_report_us_enabled: true
+
 # 체결 품질 리포트 경고 기준 (사후 평가용, 자동 비활성화는 기본 OFF)
 execution_quality_report:
   enabled: true

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -417,8 +417,12 @@ class AppConfig(BaseModel):
     paths: Dict[str, str] = Field(default_factory=dict)
 
     # ✅ 필드 추가 (기본값 False 설정)
-    performance_logging: bool = False 
+    performance_logging: bool = False
     performance_threshold: float = 0.1
+
+    # 시총갭 리포트 세션별 on/off (기본 둘 다 on)
+    market_cap_gap_report_kr_enabled: bool = True
+    market_cap_gap_report_us_enabled: bool = True
 
     # Extra fields for anything else in config.yaml
     model_config = {"extra": "allow"}

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -481,76 +481,71 @@ class TelegramReporter:
         uk = abs_won / 100_000_000
         return f"{sign}{uk:,.0f}억"
 
-    @staticmethod
-    def _format_usd_cap(value) -> str:
-        try:
-            usd = int(float(value or 0))
-        except (TypeError, ValueError):
-            return "-"
-        if usd <= 0:
-            return "-"
-        trillion = usd / 1_000_000_000_000
-        if trillion >= 1:
-            return f"${trillion:,.2f}T"
-        billion = usd / 1_000_000_000
-        return f"${billion:,.0f}B"
-
     async def send_market_cap_gap_report(self, report: Dict, report_date: str, trigger_label: str, limit: int = 10):
-        """삼성전자/SK하이닉스와 미국 주요 기업 시총갭 리포트를 전송합니다."""
+        """삼성전자/SK하이닉스 대비 미국 주요 기업 시총갭 리포트를 전송합니다.
+
+        US 종목을 기준으로 묶어, 각 종목 아래 국내 앵커별 배율(굵게)·갭(조)을
+        인라인으로 표시한다 (모바일 텔레그램 가독성을 위한 2줄/종목 카드형).
+        """
         fx = report.get("fx_rate")
         fx_text = f"{float(fx):,.2f}" if fx else "-"
-        title = (
-            f"📊 <b>시총갭 리포트 ({report_date})</b>\n"
-            f"기준: {html.escape(str(trigger_label), quote=False)} | USD/KRW: {fx_text}\n"
-        )
-        await self._send_message(title)
+        lines = [
+            f"📊 <b>시총갭 ({report_date})</b>",
+            f"USD/KRW {fx_text} · {html.escape(str(trigger_label), quote=False)}",
+        ]
 
         korean = report.get("korean") or []
-        us_items = report.get("us") or []
+        if korean:
+            kr_summary = " · ".join(
+                f"{html.escape(str(k.get('name') or k.get('symbol') or ''), quote=False)} "
+                f"{self._format_krw_cap(k.get('market_cap_krw'))}"
+                for k in korean
+            )
+            lines += ["", f"🇰🇷 {kr_summary}"]
+
         comparisons = report.get("comparisons") or []
-
-        summary_lines = ["<b>국내 기준</b>"]
-        for item in korean:
-            name = html.escape(str(item.get("name") or item.get("symbol") or ""), quote=False)
-            symbol = html.escape(str(item.get("symbol") or ""), quote=False)
-            summary_lines.append(
-                f"- {name}({symbol}) {self._format_krw_cap(item.get('market_cap_krw'))}"
-            )
-        summary_lines.append("")
-        summary_lines.append("<b>미국 비교군</b>")
-        for item in us_items[:limit]:
-            name = html.escape(str(item.get("name") or item.get("symbol") or ""), quote=False)
-            symbol = html.escape(str(item.get("symbol") or ""), quote=False)
-            summary_lines.append(
-                f"- {name}({symbol}) {self._format_usd_cap(item.get('market_cap_usd'))} "
-                f"/ {self._format_krw_cap(item.get('market_cap_krw'))}"
-            )
-        await self._send_message("\n".join(summary_lines))
-
         if not comparisons:
-            await self._send_message("시총갭 계산 불가: 환율 또는 시총 데이터 부족")
+            lines += ["", "시총갭 계산 불가: 환율 또는 시총 데이터 부족"]
+            await self._send_message("\n".join(lines))
             return
 
-        grouped = {}
-        for row in comparisons:
-            grouped.setdefault(row.get("korean_symbol"), []).append(row)
+        lines += ["", "🇺🇸 미국 비교군  (배율 · 갭조, ✅=한국우위)"]
 
-        for korean_symbol, rows in grouped.items():
-            if not rows:
-                continue
-            korean_name = html.escape(str(rows[0].get("korean_name") or korean_symbol), quote=False)
-            lines = [f"<b>{korean_name} 대비 갭</b>"]
-            for row in rows[:limit]:
-                us_name = html.escape(str(row.get("us_name") or row.get("us_symbol") or ""), quote=False)
-                us_symbol = html.escape(str(row.get("us_symbol") or ""), quote=False)
-                ratio = row.get("ratio")
+        us_cap = {u.get("symbol"): u.get("market_cap_krw") for u in (report.get("us") or [])}
+        order = [u.get("symbol") for u in (report.get("us") or [])]
+        grouped: Dict = {}
+        for row in comparisons:
+            grouped.setdefault(row.get("us_symbol"), []).append(row)
+        if not order:
+            order = list(grouped.keys())
+
+        medals = {1: "🥇", 2: "🥈", 3: "🥉"}
+        blocks = []
+        ranked = [s for s in order if s in grouped][:limit]
+        for rank, sym in enumerate(ranked, 1):
+            prefix = medals.get(rank, f"{rank}.")
+            symbol_text = html.escape(str(sym or ""), quote=False)
+            block = [f"{prefix} {symbol_text}  {self._format_krw_cap(us_cap.get(sym))}"]
+            for row in grouped[sym]:
+                kr_label = html.escape(str(row.get("korean_name") or row.get("korean_symbol") or ""), quote=False)
                 try:
-                    ratio_text = f"{float(ratio):.2f}x"
+                    ratio_val = float(row.get("ratio"))
+                    ratio_text = f"{ratio_val:.2f}x"
                 except (TypeError, ValueError):
+                    ratio_val = None
                     ratio_text = "-"
-                lines.append(
-                    f"- {us_name}({us_symbol}) "
-                    f"갭:{self._format_krw_cap(row.get('gap_krw'))} "
-                    f"배율:{ratio_text}"
-                )
-            await self._send_message("\n".join(lines))
+                gap_text = self._format_krw_cap(row.get("gap_krw"))
+                flag = " ✅" if (ratio_val is not None and ratio_val < 1) else ""
+                block.append(f"   {kr_label} <b>{ratio_text}</b> ({gap_text}){flag}")
+            blocks.append("\n".join(block))
+
+        # Telegram 4096 byte 제한 대비, 종목 블록 단위로 메시지를 나눠 보낸다.
+        current = "\n".join(lines)
+        for block in blocks:
+            candidate = f"{current}\n\n{block}"
+            if len(candidate.encode("utf-8")) > 4000:
+                await self._send_message(current)
+                current = block
+            else:
+                current = candidate
+        await self._send_message(current)

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -866,35 +866,34 @@ async def test_send_market_cap_gap_report_formats_korean_us_gap(telegram_reporte
             {"symbol": "MU", "name": "Micron", "market_cap_usd": 150_000_000_000, "market_cap_krw": 210_000_000_000_000},
         ],
         "comparisons": [
-            {
-                "korean_symbol": "005930",
-                "korean_name": "삼성전자",
-                "korean_market_cap_krw": 500_000_000_000_000,
-                "us_symbol": "NVDA",
-                "us_name": "NVIDIA",
-                "us_market_cap_krw": 4_200_000_000_000_000,
-                "gap_krw": 3_700_000_000_000_000,
-                "ratio": 8.4,
-            },
-            {
-                "korean_symbol": "000660",
-                "korean_name": "SK하이닉스",
-                "korean_market_cap_krw": 200_000_000_000_000,
-                "us_symbol": "MU",
-                "us_name": "Micron",
-                "us_market_cap_krw": 210_000_000_000_000,
-                "gap_krw": 10_000_000_000_000,
-                "ratio": 1.05,
-            },
+            {"korean_symbol": "005930", "korean_name": "삼성전자", "us_symbol": "NVDA",
+             "us_name": "NVIDIA", "gap_krw": 3_700_000_000_000_000, "ratio": 8.4},
+            {"korean_symbol": "000660", "korean_name": "SK하이닉스", "us_symbol": "NVDA",
+             "us_name": "NVIDIA", "gap_krw": 4_000_000_000_000_000, "ratio": 21.0},
+            {"korean_symbol": "005930", "korean_name": "삼성전자", "us_symbol": "MU",
+             "us_name": "Micron", "gap_krw": -290_000_000_000_000, "ratio": 0.42},
+            {"korean_symbol": "000660", "korean_name": "SK하이닉스", "us_symbol": "MU",
+             "us_name": "Micron", "gap_krw": 10_000_000_000_000, "ratio": 1.05},
         ],
     }
 
     await telegram_reporter.send_market_cap_gap_report(report, "20260625", "한국장 마감")
 
     full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
-    assert "시총갭 리포트" in full
+    # 헤더: 제목 / 환율 / 트리거 라벨
+    assert "시총갭" in full
     assert "한국장 마감" in full
-    assert "삼성전자" in full
-    assert "NVIDIA" in full
+    assert "USD/KRW 1,400" in full
+    # 국내 앵커 요약 (이름 + 조 단위 시총)
+    assert "삼성전자" in full and "SK하이닉스" in full
+    assert "500조" in full and "200조" in full
+    # US 종목 기준 그룹 + 순위(메달/숫자) 헤드라인은 티커 사용
+    assert "🥇 NVDA" in full
+    assert "🥈 MU" in full
+    # 배율은 굵게, 삼성/SK 인라인, 갭은 조 단위 괄호
+    assert "<b>8.40x</b>" in full
+    assert "<b>21.00x</b>" in full
     assert "3,700조" in full
-    assert "8.40x" in full
+    # 배율 < 1 (한국 우위) 행에는 ✅ 표시
+    assert "<b>0.42x</b>" in full
+    assert "✅" in full

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -291,6 +291,32 @@ def test_service_container_creates_universe_and_tasks(patched_service_container_
     assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 2
 
 
+def test_service_container_disables_kr_cap_gap_task_via_config(patched_service_container_deps):
+    """config 플래그로 한국장 시총갭 리포트를 끄면 kr_task 만 None 이 된다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {"market_cap_gap_report_kr_enabled": False}
+    ServiceContainer(ctx).run()
+
+    assert ctx.market_cap_gap_report_kr_task is None
+    assert ctx.market_cap_gap_report_us_task is patched_service_container_deps["MarketCapGapReportTask"].return_value
+    assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 1
+
+
+def test_service_container_disables_us_cap_gap_task_via_config(patched_service_container_deps):
+    """config 플래그로 미국장 시총갭 리포트를 끄면 us_task 만 None 이 된다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {"market_cap_gap_report_us_enabled": False}
+    ServiceContainer(ctx).run()
+
+    assert ctx.market_cap_gap_report_us_task is None
+    assert ctx.market_cap_gap_report_kr_task is patched_service_container_deps["MarketCapGapReportTask"].return_value
+    assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 1
+
+
 def test_service_container_does_not_wire_minervini_circular_pair(patched_service_container_deps):
     """MinerviniStage ↔ MinerviniUpdate 후주입은 WiringPhase 책임 — ServiceContainer 는 인스턴스만 만든다."""
     from view.web.bootstrap.service_container import ServiceContainer

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -289,6 +289,9 @@ class ServiceContainer:
                         broker=ctx.broker,
                         logger=ctx.logger,
                     )
+                    # 한국장/미국장 시총갭 리포트는 config 플래그로 개별 on/off (기본 둘 다 on)
+                    kr_gap_enabled = config_dict.get("market_cap_gap_report_kr_enabled", True)
+                    us_gap_enabled = config_dict.get("market_cap_gap_report_us_enabled", True)
                     ctx.market_cap_gap_report_kr_task = MarketCapGapReportTask(
                         market_cap_gap_service=ctx.market_cap_gap_service,
                         telegram_reporter=getattr(ctx, "telegram_reporter", None),
@@ -297,7 +300,7 @@ class ServiceContainer:
                         market_calendar_service=ctx._mcs,
                         market_clock=ctx.market_clock,
                         logger=ctx.logger,
-                    )
+                    ) if kr_gap_enabled else None
                     ctx.market_cap_gap_report_us_task = MarketCapGapReportTask(
                         market_cap_gap_service=ctx.market_cap_gap_service,
                         telegram_reporter=getattr(ctx, "telegram_reporter", None),
@@ -306,7 +309,7 @@ class ServiceContainer:
                         market_calendar_service=None,
                         market_clock=MarketClock.for_us_equities(logger=ctx.logger),
                         logger=ctx.logger,
-                    )
+                    ) if us_gap_enabled else None
                 else:
                     ctx.market_cap_gap_service = None
                     ctx.market_cap_gap_report_kr_task = None


### PR DESCRIPTION
모바일 텔레그램에서 받아보는 시총갭 리포트의 가독성을 개선하고, 발송 세션을 config로 켜고 끌 수 있게 한다.

## 1. 모바일 가독성 포맷 (`send_market_cap_gap_report`)
기존: 국내 종목 기준 그룹으로 갭/배율을 나열 (풀네임 + USD 표기, 와이드).
변경: **US 종목 기준**으로 묶어, 각 종목 아래 국내 앵커별 **배율(굵게)·갭(조)**을 인라인 2줄 카드로 표시.

```
📊 시총갭 (2026-06-25)
USD/KRW 1,542.50 · 한국장 마감

🇰🇷 삼성전자 2,096조 · SK하이닉스 2,079조

🇺🇸 미국 비교군  (배율 · 갭조, ✅=한국우위)

🥇 NVDA  7,435조
   삼성전자 3.55x (5,339조)
   SK하이닉스 3.58x (5,356조)
🥈 MU  1,824조
   삼성전자 0.87x (-272조) ✅
   SK하이닉스 0.88x (-255조) ✅
```

- 순위 메달(🥇🥈🥉)/숫자, 티커 헤드라인, 조 단위 시총
- 배율 < 1 (한국 우위) 행에 ✅
- USD 표기 제거로 orphan 된 `_format_usd_cap` 삭제
- 4096 byte chunking 유지

## 2. 세션별 발송 on/off 토글
한국장 마감(15:50 KST)·미국장 마감(16:30 ET) 하루 2회 발송을 config로 개별 제어.

- `AppConfig.market_cap_gap_report_kr_enabled` / `_us_enabled` (기본 `True` → 현행 2회 유지)
- `ServiceContainer`: 플래그 `false`면 해당 세션 task를 `None` → `scheduler_bootstrap`의 `_register` no-op 경로로 등록 생략
- `config.yaml.example`에 토글 + 세션별 데이터 신선도(kr=프리뷰/us=확정값) 주석

## 테스트
- `test_telegram_notifier.py`: 새 포맷 단언으로 갱신 (US 그룹·배율 볼드·✅·메달) — 40건 통과
- `test_service_container.py`: 토글 off 시 task None 검증 2건 추가 + 기본 call_count 2 회귀 가드 — 17건 통과
- 단위 2519건 + **통합 245건** 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)