### PR TITLE
해외 VBO dry-run을 국내 active 런과 공존 등록 (시간대 자동 트리거)

### DIFF
--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -127,11 +127,22 @@ def test_overseas_us_registers_dryrun_task(patched_scheduler_deps):
 
 
 def test_domestic_mode_does_not_register_overseas_task(patched_scheduler_deps):
-    ctx = _make_fake_context(RuntimeMode.WEB)  # market_mode 미설정 → domestic
+    ctx = _make_fake_context(RuntimeMode.WEB)  # market_mode 미설정 → domestic, overseas 미활성
     ctx.overseas_dryrun_task = MagicMock(task_name="overseas_vbo_dryrun")
     _run(ctx)
     names = _registered_bg_task_names(patched_scheduler_deps)
     assert "overseas_vbo_dryrun" not in names
+
+
+def test_domestic_active_with_overseas_enabled_registers_dryrun_task(patched_scheduler_deps):
+    """active=domestic 이라도 enabled_market_modes 에 overseas_us 가 있으면 공존 등록한다."""
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    ctx.market_mode = "domestic"
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_dryrun_task = MagicMock(task_name="overseas_vbo_dryrun")
+    _run(ctx)
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert "overseas_vbo_dryrun" in names
 
 
 def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -390,6 +390,36 @@ def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service
     assert task_kwargs["market_clock"].timezone_name == "America/New_York"
 
 
+def test_domestic_active_with_overseas_enabled_builds_dryrun_task(patched_service_container_deps):
+    """active=domestic 이라도 enabled_market_modes 에 overseas_us 가 있으면 dry-run 태스크를 공존 조립한다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()  # market_mode 미설정 → domestic active (국내 전 서비스 조립)
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True) as task_cls:
+        ServiceContainer(ctx).run()
+
+    # 국내 active 서비스가 살아 있으면서(국내 fail-close 아님) 해외 dry-run 태스크도 조립된다.
+    assert ctx.stock_query_service is patched_service_container_deps["StockQueryService"].return_value
+    assert ctx.overseas_dryrun_task is task_cls.return_value
+
+
+def test_domestic_active_without_overseas_enabled_skips_dryrun_task(patched_service_container_deps):
+    """overseas_us 가 enabled 에 없으면 dry-run 태스크는 조립되지 않는다(None)."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()  # enabled 미설정 → domestic 단독
+    ctx.overseas_stock_code_repository = MagicMock()
+    ServiceContainer(ctx).run()
+
+    assert ctx.overseas_dryrun_task is None
+
+
 @pytest.mark.asyncio
 async def test_overseas_fx_provider_extracts_rate_from_balance(patched_service_container_deps):
     """배선된 fx_provider 는 broker 잔고 응답에서 USD/KRW 환율을 추출한다(실패 시 None)."""

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -17,6 +17,7 @@ from interfaces.schedulable_task import TaskPriority
 from scheduler.background_scheduler import BackgroundScheduler
 from scheduler.foreground_scheduler import ForegroundScheduler
 from view.web.bootstrap.runtime_mode import RuntimeMode
+from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -43,8 +44,10 @@ class SchedulerBootstrap:
                 self._register_trading_tasks()
             if mode & RuntimeMode.BATCH:
                 self._register_batch_tasks()
-            # Phase 3c: overseas_us 모드는 batch 가 꺼져 있으므로 dry-run 태스크를 별도 등록.
-            if getattr(ctx, "market_mode", "domestic") == "overseas_us":
+            # Phase 3c: overseas_us 가 enabled_market_modes 에 포함되면 dry-run 태스크를
+            # 별도 등록한다. active=overseas_us(batch off) 와 active=domestic 공존 양쪽을
+            # 모두 포괄한다. 미국장 마감 cron 으로 자체 트리거되므로 KST 배치와 무관.
+            if is_market_enabled(ctx, "overseas_us"):
                 self._register_overseas_tasks()
             # websocket_watchdog: WEB | TRADING 어느 한쪽이라도 켜져 있으면 한 번만 등록.
             if mode & (RuntimeMode.WEB | RuntimeMode.TRADING):

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -78,6 +78,7 @@ from task.background.intraday.opening_position_reconcile_task import OpeningPosi
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
+from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -604,51 +605,7 @@ class ServiceContainer:
                 else:
                     ctx.notification_queue_task = None
                 # Phase 3c: 해외 VBO dry-run 파이프라인 (주문 경로 없음 — 실주문 불가).
-                # 한국장 마감(KST)을 일일 트리거로 재사용해 일봉 기반 dry-run 신호를 누적한다.
-                ctx.event_shadow_journal_service = EventShadowJournalService(
-                    log_root="logs/strategies", logger=ctx.logger,
-                )
-                ctx.overseas_candidate_service = None
-                ctx.overseas_vbo_dryrun_service = None
-                ctx.overseas_dryrun_task = None
-                if getattr(ctx, "overseas_stock_code_repository", None) is not None:
-                    overseas_stock_cfg = getattr(ctx.full_config, "overseas_stock", None)
-                    overseas_position_sizing_service = OverseasPositionSizingService(
-                        slot_usd=getattr(overseas_stock_cfg, "dryrun_slot_usd", 1000.0),
-                        max_qty=getattr(overseas_stock_cfg, "dryrun_max_qty", None),
-                        logger=ctx.logger,
-                    )
-                    ctx.overseas_candidate_service = OverseasCandidateService(
-                        overseas_stock_code_repository=ctx.overseas_stock_code_repository,
-                        stock_query_service=ctx.stock_query_service,
-                        logger=ctx.logger,
-                    )
-                    async def _overseas_fx_provider():
-                        # KIS 해외 잔고(읽기 전용)에서 USD/KRW 환율 추출. 실패 시 None → KRW 생략.
-                        try:
-                            resp = await ctx.broker.get_overseas_balance()
-                        except Exception:
-                            return None
-                        return extract_fx_krw_per_usd(getattr(resp, "data", None))
-
-                    ctx.overseas_vbo_dryrun_service = OverseasVBODryRunService(
-                        candidate_service=ctx.overseas_candidate_service,
-                        stock_query_service=ctx.stock_query_service,
-                        shadow_journal=ctx.event_shadow_journal_service,
-                        logger=ctx.logger,
-                        position_sizing_service=overseas_position_sizing_service,
-                        fx_provider=_overseas_fx_provider,
-                    )
-                    # 미국 정규장 마감(16:00 ET) 직후 트리거. 한국 거래 캘린더(mcs)는
-                    # 미국장에 적용되지 않으므로 미주입(None)하고, 미국장 클럭을 주입한다.
-                    ctx.overseas_dryrun_task = OverseasDryRunTask(
-                        dryrun_service=ctx.overseas_vbo_dryrun_service,
-                        shadow_journal=ctx.event_shadow_journal_service,
-                        market_calendar_service=None,
-                        market_clock=MarketClock.for_us_equities(logger=ctx.logger),
-                        logger=ctx.logger,
-                        worker_pool=getattr(ctx, "worker_pool", None),
-                    )
+                self._build_overseas_dryrun_pipeline()
                 return
 
             ctx.oneil_universe_service = OneilUniverseService(
@@ -832,6 +789,73 @@ class ServiceContainer:
                     open_delay_sec=getattr(reconcile_cfg, "open_delay_sec", 60),
                     run_window_min=getattr(reconcile_cfg, "run_window_min", 10),
                 )
+
+            # 해외 VBO dry-run 공존: active=domestic 이라도 enabled_market_modes 에
+            # overseas_us 가 포함되면 국내 active 런과 함께 조립한다. dry-run 태스크는
+            # 미국 정규장 마감(16:30 ET) cron 으로 자체 트리거되므로 한국장 배치와
+            # 타임존이 충돌하지 않는다(주문 경로 없음 — 실주문 불가).
+            if is_market_enabled(ctx, "overseas_us"):
+                self._build_overseas_dryrun_pipeline()
+            else:
+                ctx.overseas_candidate_service = None
+                ctx.overseas_vbo_dryrun_service = None
+                ctx.overseas_dryrun_task = None
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
+
+    def _build_overseas_dryrun_pipeline(self) -> None:
+        """해외 VBO dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
+
+        overseas_us active 분기와 국내 active 공존 경로가 공유한다.
+        `overseas_stock_code_repository` 가 없으면 no-op. shadow 저널은 realtime 경로에서
+        만든 인스턴스를 재사용하고, 없으면(overseas active 등) 새로 만든다.
+        """
+        ctx = self._ctx
+        ctx.overseas_candidate_service = None
+        ctx.overseas_vbo_dryrun_service = None
+        ctx.overseas_dryrun_task = None
+        if getattr(ctx, "overseas_stock_code_repository", None) is None:
+            return
+        if getattr(ctx, "event_shadow_journal_service", None) is None:
+            ctx.event_shadow_journal_service = EventShadowJournalService(
+                log_root="logs/strategies", logger=ctx.logger,
+            )
+        overseas_stock_cfg = getattr(ctx.full_config, "overseas_stock", None)
+        overseas_position_sizing_service = OverseasPositionSizingService(
+            slot_usd=getattr(overseas_stock_cfg, "dryrun_slot_usd", 1000.0),
+            max_qty=getattr(overseas_stock_cfg, "dryrun_max_qty", None),
+            logger=ctx.logger,
+        )
+        ctx.overseas_candidate_service = OverseasCandidateService(
+            overseas_stock_code_repository=ctx.overseas_stock_code_repository,
+            stock_query_service=ctx.stock_query_service,
+            logger=ctx.logger,
+        )
+
+        async def _overseas_fx_provider():
+            # KIS 해외 잔고(읽기 전용)에서 USD/KRW 환율 추출. 실패 시 None → KRW 생략.
+            try:
+                resp = await ctx.broker.get_overseas_balance()
+            except Exception:
+                return None
+            return extract_fx_krw_per_usd(getattr(resp, "data", None))
+
+        ctx.overseas_vbo_dryrun_service = OverseasVBODryRunService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+            position_sizing_service=overseas_position_sizing_service,
+            fx_provider=_overseas_fx_provider,
+        )
+        # 미국 정규장 마감(16:00 ET) 직후 트리거. 한국 거래 캘린더(mcs)는
+        # 미국장에 적용되지 않으므로 미주입(None)하고, 미국장 클럭을 주입한다.
+        ctx.overseas_dryrun_task = OverseasDryRunTask(
+            dryrun_service=ctx.overseas_vbo_dryrun_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            market_calendar_service=None,
+            market_clock=MarketClock.for_us_equities(logger=ctx.logger),
+            logger=ctx.logger,
+            worker_pool=getattr(ctx, "worker_pool", None),
+        )


### PR DESCRIPTION
## 배경
"해외시장 전략을 시간대별로 자동으로 넘어가게 할 수 있을까?"에 대한 답.

기존에는 해외 VBO dry-run이 **active `market_mode == "overseas_us"`일 때만** 조립·등록되었고, active를 해외로 바꾸면 국내 전략/배치가 fail-close되어 한 프로세스에서 시간대별로 둘 다 돌릴 수 없었다.

## 변경
active 모드를 전환하지 않고, `enabled_market_modes`에 `overseas_us`가 포함되면(현재 config 기본값 `["domestic", "overseas_us"]`) 국내 active 런과 **공존**하도록 한다. dry-run 태스크는 이미 자체 타임존 cron(America/New_York 16:30)을 갖고 있어, 국내 배치는 KST에, 해외 dry-run은 미국장 마감에 **자동으로** 트리거된다.

- `service_container`: 해외 dry-run 조립을 `_build_overseas_dryrun_pipeline()`로 추출 → overseas_us active 분기 + domestic 공존 경로 양쪽에서 호출. shadow 저널은 realtime 경로 인스턴스를 재사용.
- `scheduler_bootstrap`: 등록 게이트를 `active == "overseas_us"` → `is_market_enabled(ctx, "overseas_us")`로 변경.

## 안전
- 주문 경로 없음 — `live_enabled` 잠금 + dry-run 서비스가 order_execution 의존을 갖지 않아 **실주문 발생 불가**. 실거래 전환은 별도 Phase 5(canary) 사안.
- 기존 동작 보존: overseas_us 미활성(기본 domestic) 시 dry-run 미조립·미등록.

## 테스트
- 단위: bootstrap 2개 파일 35 passed (신규 3개: domestic+enabled 등록/조립, 미활성 skip 회귀)
- 회귀 가드: `test_web_app_initializer.py` 55 passed
- 통합: `tests/integration_test` 245 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)