### PR TITLE
Schedule overseas dry-run by US market close

### DIFF
--- a/scripts/run_overseas_dryrun.py
+++ b/scripts/run_overseas_dryrun.py
@@ -31,26 +31,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from common.overseas_types import OverseasExchange
 
-from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
-from brokers.broker_api_wrapper import BrokerAPIWrapper
-from config.config_loader import load_configs
-from core.cache.cache_store import CacheStore
-from core.market_clock import MarketClock
-from core.performance_profiler import PerformanceProfiler
-from repositories.overseas_stock_code_repository import OverseasStockCodeRepository
-from repositories.stock_code_repository import StockCodeRepository
-from services.event_shadow_journal_service import EventShadowJournalService
-from services.indicator_service import IndicatorService
-from services.market_calendar_service import MarketCalendarService
-from services.market_data_service import MarketDataService
-from services.overseas_candidate_service import OverseasCandidateService
-from services.overseas_position_sizing_service import (
-    OverseasPositionSizingService,
-    extract_fx_krw_per_usd,
-)
-from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
-from services.stock_query_service import StockQueryService
-
 
 def _make_stdout_logger(level: int = logging.INFO) -> logging.Logger:
     logger = logging.getLogger("overseas_dryrun_runner")
@@ -83,6 +63,26 @@ async def build_dryrun_service(
     Returns:
         (OverseasVBODryRunService, EventShadowJournalService, MarketClock(US))
     """
+    from brokers.broker_api_wrapper import BrokerAPIWrapper
+    from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
+    from config.config_loader import load_configs
+    from core.cache.cache_store import CacheStore
+    from core.market_clock import MarketClock
+    from core.performance_profiler import PerformanceProfiler
+    from repositories.overseas_stock_code_repository import OverseasStockCodeRepository
+    from repositories.stock_code_repository import StockCodeRepository
+    from services.event_shadow_journal_service import EventShadowJournalService
+    from services.indicator_service import IndicatorService
+    from services.market_calendar_service import MarketCalendarService
+    from services.market_data_service import MarketDataService
+    from services.overseas_candidate_service import OverseasCandidateService
+    from services.overseas_position_sizing_service import (
+        OverseasPositionSizingService,
+        extract_fx_krw_per_usd,
+    )
+    from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
+    from services.stock_query_service import StockQueryService
+
     config_data = load_configs()
     config_dict = config_data
     if hasattr(config_data, "model_dump"):

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -19,6 +19,7 @@ from typing import Optional, TYPE_CHECKING
 
 from common.overseas_types import OverseasExchange
 from interfaces.schedulable_task import TaskPriority
+from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.after_market_task_base import AfterMarketTask
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ class OverseasDryRunTask(AfterMarketTask):
         market_calendar_service: Optional["MarketCalendarService"] = None,
         market_clock: Optional["MarketClock"] = None,
         logger=None,
+        notification_service=None,
         worker_pool=None,
         exchange: OverseasExchange = OverseasExchange.NASD,
     ) -> None:
@@ -47,6 +49,7 @@ class OverseasDryRunTask(AfterMarketTask):
         )
         self._dryrun_service = dryrun_service
         self._journal = shadow_journal
+        self._notification_service = notification_service
         self._exchange = exchange
         self._last_run_date: Optional[str] = None
 
@@ -91,8 +94,22 @@ class OverseasDryRunTask(AfterMarketTask):
             self._logger.info(
                 {"event": "overseas_dryrun_done", "date": latest_trading_date, "signals": len(signals or [])}
             )
+            if self._notification_service:
+                await self._notification_service.emit(
+                    NotificationCategory.BACKGROUND,
+                    NotificationLevel.INFO,
+                    "해외 VBO dry-run 완료",
+                    f"{latest_trading_date} 기준 {len(signals or [])}개 신호",
+                )
             self._last_run_date = latest_trading_date  # 성공 시에만 dedup 마킹 → 실패 시 재시도
         except Exception as e:
             self._logger.error(
                 {"event": "overseas_dryrun_error", "date": latest_trading_date, "error": str(e)}, exc_info=True
             )
+            if self._notification_service:
+                await self._notification_service.emit(
+                    NotificationCategory.BACKGROUND,
+                    NotificationLevel.ERROR,
+                    "해외 VBO dry-run 실패",
+                    str(e),
+                )

--- a/tests/integration_test/strategies/test_it_api_traditional_volume_breakout_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_traditional_volume_breakout_strategy.py
@@ -22,6 +22,7 @@ async def test_tvb_scan_cache_behavior_reduces_api_calls(deep_paper_ctx, mocker)
     md_service = deep_paper_ctx.stock_query_service.market_data_service
     broker = md_service._broker_api_wrapper
     stock_repo = md_service._stock_repo
+    mocker.patch.object(stock_repo._ohlcv_repo, "get_stock_data", new_callable=AsyncMock, return_value=None)
 
     # 2. Broker API 모킹 (현재가 조회: 가격 돌파와 거래량 돌파 조건을 통과하도록 데이터 세팅)
     mock_get_price = mocker.patch.object(

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -1,11 +1,12 @@
 """해외 VBO dry-run after-market 태스크 테스트 (Phase 3c).
 
-기존 한국장 after-market 스케줄러(KST 트리거)에 등록해 매일 1회 dry-run 신호를
+미국장 after-market 스케줄러(16:30 ET 트리거)에 등록해 매일 1회 dry-run 신호를
 산출·flush 한다. 주문 경로 없음(서비스에 order 의존 부재).
 """
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from interfaces.schedulable_task import TaskPriority
 from common.overseas_types import OverseasExchange
@@ -15,19 +16,21 @@ def _make_task(exchange=OverseasExchange.NASD):
     dryrun = MagicMock()
     dryrun.scan_dry_run = AsyncMock(return_value=[{"code": "AAA", "action": "BUY"}])
     journal = MagicMock()
+    notification_service = AsyncMock()
     task = OverseasDryRunTask(
         dryrun_service=dryrun,
         shadow_journal=journal,
         market_calendar_service=MagicMock(),
         market_clock=MagicMock(),
         logger=MagicMock(),
+        notification_service=notification_service,
         exchange=exchange,
     )
-    return task, dryrun, journal
+    return task, dryrun, journal, notification_service
 
 
 def test_task_metadata():
-    task, _, _ = _make_task()
+    task, _, _, _ = _make_task()
     assert task.task_name == "overseas_vbo_dryrun"
     assert task._scheduler_label == "OverseasVBODryRun"
     assert task.priority == TaskPriority.LOW
@@ -39,7 +42,7 @@ def test_loop_triggers_on_us_market_close():
     KST 15:41 하드코딩이 아니라 America/New_York 16:30 으로 트리거되도록
     AfterMarketLoop 파라미터 훅을 오버라이드한다.
     """
-    task, _, _ = _make_task()
+    task, _, _, _ = _make_task()
     assert task._loop_timezone == "America/New_York"
     assert task._loop_cron_hour == 16
     assert task._loop_cron_minute == 30
@@ -47,7 +50,7 @@ def test_loop_triggers_on_us_market_close():
 
 @pytest.mark.asyncio
 async def test_on_market_closed_runs_scan_and_flushes():
-    task, dryrun, journal = _make_task(OverseasExchange.NASD)
+    task, dryrun, journal, notification_service = _make_task(OverseasExchange.NASD)
 
     await task._on_market_closed("20260615")
 
@@ -55,11 +58,17 @@ async def test_on_market_closed_runs_scan_and_flushes():
     args, kwargs = dryrun.scan_dry_run.await_args
     assert (kwargs.get("exchange") == OverseasExchange.NASD) or (args and args[0] == OverseasExchange.NASD)
     journal.flush_to_file.assert_called_once_with("20260615")
+    notification_service.emit.assert_awaited_once_with(
+        NotificationCategory.BACKGROUND,
+        NotificationLevel.INFO,
+        "해외 VBO dry-run 완료",
+        "20260615 기준 1개 신호",
+    )
 
 
 @pytest.mark.asyncio
 async def test_dedup_same_date_skips_second_run():
-    task, dryrun, journal = _make_task()
+    task, dryrun, journal, _ = _make_task()
 
     await task._on_market_closed("20260615")
     await task._on_market_closed("20260615")
@@ -69,7 +78,7 @@ async def test_dedup_same_date_skips_second_run():
 
 @pytest.mark.asyncio
 async def test_failure_does_not_mark_date_done_allowing_retry():
-    task, dryrun, journal = _make_task()
+    task, dryrun, journal, _ = _make_task()
     dryrun.scan_dry_run = AsyncMock(side_effect=RuntimeError("boom"))
 
     await task._on_market_closed("20260615")  # 예외 삼킴
@@ -80,6 +89,6 @@ async def test_failure_does_not_mark_date_done_allowing_retry():
 
 
 def test_task_has_no_order_dependency():
-    task, _, _ = _make_task()
+    task, _, _, _ = _make_task()
     assert not hasattr(task, "_order_execution_service")
     assert not hasattr(task, "_order_service")

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -143,6 +143,10 @@ def test_domestic_active_with_overseas_enabled_registers_dryrun_task(patched_sch
     _run(ctx)
     names = _registered_bg_task_names(patched_scheduler_deps)
     assert "overseas_vbo_dryrun" in names
+    dispatched_names = [
+        call.args[0] for call in ctx.time_dispatcher.register_task.call_args_list
+    ]
+    assert "overseas_vbo_dryrun" not in dispatched_names
 
 
 def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -364,7 +364,7 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
 
 
 def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):
-    """overseas_us dry-run 태스크는 미국장 클럭으로, 한국 캘린더(mcs) 없이 배선한다."""
+    """overseas_us dry-run 태스크는 미국장 cron으로, 한국 캘린더/티켓 큐 없이 배선한다."""
     from config.config_loader import AppConfig
     from view.web.bootstrap.service_container import ServiceContainer
 
@@ -388,6 +388,9 @@ def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service
     assert task_kwargs["market_calendar_service"] is None
     # 미국 정규장 클럭 주입 (America/New_York)
     assert task_kwargs["market_clock"].timezone_name == "America/New_York"
+    # KST TimeDispatcher/WorkerPool 티켓 경로에 묶이면 미국장 16:30 ET 트리거가 무시된다.
+    assert task_kwargs["worker_pool"] is None
+    assert task_kwargs["notification_service"] is ctx.notification_service
 
 
 def test_domestic_active_with_overseas_enabled_builds_dryrun_task(patched_service_container_deps):

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -385,6 +385,33 @@ def test_get_background_status_returns_task_info(web_client, mock_web_ctx):
     assert item["progress"]["total"] == 500
 
 
+def test_get_background_status_includes_us_cron_trigger(web_client, mock_web_ctx):
+    """미국장 after-market task는 상태 응답에 NY cron 트리거 정보를 노출한다."""
+    mock_task = MagicMock()
+    mock_task._loop_timezone = "America/New_York"
+    mock_task._loop_cron_hour = 16
+    mock_task._loop_cron_minute = 30
+    mock_task.get_progress.return_value = {"running": False, "last_run_date": None}
+
+    mock_web_ctx.background_scheduler = MagicMock()
+    mock_web_ctx.background_scheduler.get_all_status.return_value = [
+        {"name": "overseas_vbo_dryrun", "state": "idle", "priority": 100},
+    ]
+    mock_web_ctx.background_scheduler.get_task.return_value = mock_task
+
+    response = web_client.get("/api/background/status")
+
+    assert response.status_code == 200
+    item = response.json()["data"][0]
+    assert item["name"] == "overseas_vbo_dryrun"
+    assert item["schedule_type"] == "after_market"
+    assert item["trigger"] == {
+        "timezone": "America/New_York",
+        "hour": 16,
+        "minute": 30,
+    }
+
+
 def test_get_background_status_task_not_found_gives_none_progress(web_client, mock_web_ctx):
     """get_task()가 None 반환 시 해당 항목의 progress는 None."""
     mock_web_ctx.background_scheduler = MagicMock()

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -120,7 +120,8 @@ class SchedulerBootstrap:
 
     def _register_overseas_tasks(self) -> None:
         # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
-        self._register(self._optional_task("overseas_dryrun_task"), TaskPriority.LOW)
+        # 미국장 16:30 ET cron 을 자체 AfterMarketLoop 로 사용하므로 KST TimeDispatcher 에 등록하지 않는다.
+        self._register(self._optional_task("overseas_dryrun_task"))
 
     def _register_websocket_watchdog(self) -> None:
         # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -857,5 +857,6 @@ class ServiceContainer:
             market_calendar_service=None,
             market_clock=MarketClock.for_us_equities(logger=ctx.logger),
             logger=ctx.logger,
-            worker_pool=getattr(ctx, "worker_pool", None),
+            notification_service=ctx.notification_service,
+            worker_pool=None,
         )

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -28,6 +28,13 @@ _SCHEDULE_TYPES = {
     "전일기준주도주_생성":  "after_market",
     "newhigh":             "after_market",
     "theme_classification": "after_market",
+    "market_cap_gap_report_kr": "after_market",
+    "market_cap_gap_report_us": "after_market",
+    "overseas_vbo_dryrun": "after_market",
+    "after_market_reconcile": "after_market",
+    "post_market_replay_audit": "after_market",
+    "strategy_log_report": "after_market",
+    "log_cleanup": "after_market",
     "notification_queue_task":  "always_on",
     "program_trading_monitor":  "always_on",
 }
@@ -39,6 +46,24 @@ _SCHEDULE_ORDER = {
     "after_market": 3,
     "unknown": 99,
 }
+
+
+def _task_trigger_info(task) -> dict | None:
+    """APScheduler cron 기반 task의 트리거 정보를 상태 API용으로 정규화한다."""
+    if task is None:
+        return None
+    timezone = getattr(task, "_loop_timezone", None)
+    hour = getattr(task, "_loop_cron_hour", None)
+    minute = getattr(task, "_loop_cron_minute", None)
+    if not isinstance(timezone, str):
+        return None
+    if not isinstance(hour, int) or not isinstance(minute, int):
+        return None
+    return {
+        "timezone": timezone,
+        "hour": hour,
+        "minute": minute,
+    }
 
 
 @router.get("/cache/status")
@@ -448,6 +473,7 @@ async def get_background_status():
             "schedule_type": schedule_type,
             "schedule_order": _SCHEDULE_ORDER.get(schedule_type, 99),
             "delay_sec": delays.get(name, 0),
+            "trigger": _task_trigger_info(task),
             "progress": progress,
         })
 


### PR DESCRIPTION
## Summary
- Register overseas VBO dry-run on its own US after-market loop instead of the KST TimeDispatcher path
- Wire background notifications for overseas dry-run success/failure
- Expose after-market cron trigger metadata in `/api/background/status`
- Keep the overseas dry-run CLI help path lightweight by lazy-loading runtime dependencies

## Tests
- `python -m pytest tests\unit_test -q`
- `python -m pytest tests\integration_test -q`