### PR TITLE
시스템 페이지에 웹 서버 프로세스 종료 버튼 추가

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -299,6 +299,37 @@ def test_get_data_quality_history_missing_service(web_client, mock_web_ctx):
     assert response.json() == {"success": True, "data": []}
 
 
+# ── POST /api/system/shutdown ───────────────────────────────────────────────
+
+
+def test_shutdown_server_schedules_termination(web_client, mock_web_ctx, monkeypatch):
+    """종료 엔드포인트는 200으로 응답하고 프로세스 종료를 예약한다(실제 종료는 훅으로 분리)."""
+    from view.web.routes import system
+
+    called = {}
+    monkeypatch.setattr(system, "_schedule_shutdown", lambda *a, **k: called.setdefault("hit", True))
+
+    response = web_client.post("/api/system/shutdown")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert called.get("hit") is True
+
+
+def test_terminate_process_falls_back_to_os_exit(monkeypatch):
+    """os.kill 이 실패하면 os._exit 로 강제 종료한다(테스트에서는 호출만 검증)."""
+    from view.web.routes import system
+
+    monkeypatch.setattr(system.os, "kill", MagicMock(side_effect=OSError("no signal")))
+    exit_called = {}
+    monkeypatch.setattr(system.os, "_exit", lambda code: exit_called.setdefault("code", code))
+
+    system._terminate_process()
+
+    assert exit_called.get("code") == 0
+
+
 # ── GET /api/background/status ──────────────────────────────────────────────
 
 

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -2,6 +2,9 @@
 시스템 상태 및 캐시 모니터링 API 엔드포인트.
 """
 import asyncio
+import os
+import signal
+import threading
 import time
 from fastapi import APIRouter, HTTPException, Query
 from repositories.streaming_stock_repo import StreamingType
@@ -374,6 +377,38 @@ def get_data_quality_history(
         except Exception:
             pass
     return {"success": True, "data": []}
+
+
+# ── 서버 프로세스 종료 (UI 종료 버튼) ────────────────────────────────────
+
+_SHUTDOWN_DELAY_SEC = 0.5
+
+
+def _terminate_process() -> None:
+    """현재 웹 서버 프로세스를 종료한다.
+
+    uvicorn 메인 스레드의 시그널 핸들러를 깨워 종료를 유도한다. Windows 는 os.kill 이
+    SIGINT 를 지원하지 않으므로 SIGTERM 으로 대체하고, 둘 다 실패하면 os._exit 로 강제 종료한다.
+    """
+    sig = signal.SIGTERM if os.name == "nt" else signal.SIGINT
+    try:
+        os.kill(os.getpid(), sig)
+    except (ValueError, OSError, AttributeError):
+        os._exit(0)
+
+
+def _schedule_shutdown(delay_sec: float = _SHUTDOWN_DELAY_SEC) -> None:
+    """HTTP 응답이 먼저 전송되도록 약간의 지연 후 프로세스를 종료하도록 예약한다."""
+    timer = threading.Timer(delay_sec, _terminate_process)
+    timer.daemon = True
+    timer.start()
+
+
+@router.post("/system/shutdown")
+async def shutdown_server():
+    """웹 서버 프로세스를 종료한다. 종료 후에는 터미널에서 다시 실행해야 한다."""
+    _schedule_shutdown()
+    return {"success": True, "message": "서버를 종료합니다. 잠시 후 연결이 끊어집니다."}
 
 
 # 1. 동기(def) 함수를 비동기(async def) 함수로 변경하여 이벤트 루프 데드락 방지

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -858,4 +858,27 @@ async function savePositionSizingLimits() {
     }
 }
 
+// ── 서버 프로세스 종료 ───────────────────────────────────────
+async function shutdownServer(btn) {
+    if (!confirm('웹 서버 프로세스를 종료합니다.\n종료 후에는 터미널에서 다시 실행해야 합니다.\n\n계속하시겠습니까?')) return;
+    const msgEl = document.getElementById('shutdown-msg');
+    if (btn) btn.disabled = true;
+    if (msgEl) { msgEl.textContent = '종료 요청 중...'; msgEl.style.color = 'var(--text-secondary, #888)'; }
+    try {
+        const res = await fetch('/api/system/shutdown', { method: 'POST' });
+        const data = await res.json().catch(() => ({}));
+        if (res.ok && data.success) {
+            if (msgEl) { msgEl.textContent = '서버를 종료합니다. 잠시 후 연결이 끊어집니다.'; msgEl.style.color = 'var(--danger-color, #f44336)'; }
+            if (typeof showToast === 'function') showToast('서버 종료 요청을 전송했습니다.', 'success');
+        } else {
+            if (btn) btn.disabled = false;
+            if (msgEl) { msgEl.textContent = '종료 실패: ' + (data.detail || JSON.stringify(data)); msgEl.style.color = 'var(--danger-color, #f44336)'; }
+        }
+    } catch (e) {
+        // 서버가 즉시 종료되면 fetch 가 네트워크 에러로 끝날 수 있다 — 정상 종료로 간주.
+        if (msgEl) { msgEl.textContent = '서버 연결이 종료되었습니다.'; msgEl.style.color = 'var(--danger-color, #f44336)'; }
+        if (typeof showToast === 'function') showToast('서버가 종료되었습니다.', 'success');
+    }
+}
+
 document.addEventListener('DOMContentLoaded', startSystemPolling);

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -151,10 +151,23 @@
             </div>
             <div id="position-sizing-msg" style="margin-top: 10px; font-size: 0.9rem;"></div>
         </div>
+
+        <!-- 서버 제어 -->
+        <div class="card" style="padding: 20px 12px;">
+            <h3 style="margin-top: 0; margin-bottom: 12px;">🖥️ 서버 제어</h3>
+            <p style="font-size: 0.9rem; color: var(--text-secondary, #888); margin: 0 0 12px;">
+                웹 서버 프로세스를 종료합니다. 종료 후에는 터미널에서 <code>python main.py --web</code> 으로 다시 실행해야 합니다.
+            </p>
+            <button id="btn-shutdown-server" class="btn" onclick="shutdownServer(this)"
+                    style="background: var(--danger-color, #f44336); color: #fff; height: 36px;">
+                프로세스 종료
+            </button>
+            <span id="shutdown-msg" style="margin-left: 12px; font-size: 0.9rem;"></span>
+        </div>
     </div>
 </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=21"></script>
+<script src="/static/js/system.js?v=22"></script>
 {% endblock %}


### PR DESCRIPTION
## 요약
`/system` 페이지에서 클릭 한 번으로 웹 서버 프로세스를 종료할 수 있는 버튼을 추가했다. (그동안 터미널/작업관리자에서 수동으로 프로세스를 죽이던 작업을 UI로 대체)

## 변경
- **백엔드** `POST /api/system/shutdown`
  - 응답을 먼저 전송한 뒤 `_schedule_shutdown()`(`threading.Timer` 0.5s)으로 종료 예약
  - 실제 종료 로직은 `_terminate_process()`로 분리 → 단위 테스트에서 monkeypatch 가능(테스트 러너를 죽이지 않음)
  - 종료 시그널: POSIX `SIGINT` / Windows `SIGTERM`, 실패 시 `os._exit(0)` 폴백
- **프론트** `system.html`: "🖥️ 서버 제어" 카드 + confirm 동반 `프로세스 종료` 버튼
- **프론트** `system.js`: `shutdownServer()` — confirm → POST → toast/메시지. 서버가 즉시 종료돼 fetch가 네트워크 에러로 끝나는 경우도 정상 종료로 처리
- `system.js` 캐시 버전 v=21 → v=22

## 안전장치
- 클릭 시 confirm 대화상자
- 오클릭 방지를 위해 페이지 최하단 카드에 배치

## 테스트
- 단위(신규 2): 종료 예약 검증 + `os.kill` 실패 시 `os._exit` 폴백 검증
- `test_web_routes_system.py` + `test_web_pages.py`: 83 passed
- 정적 자산 참조 통합 테스트 통과 (v=22 반영)
- 전체 통합 테스트: 245 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)