### PR TITLE
S-9: scheduler god class에서 EventShadowManager 분리

### DIFF
--- a/scheduler/event_shadow_manager.py
+++ b/scheduler/event_shadow_manager.py
@@ -1,0 +1,395 @@
+"""P2 2-4 event-driven shadow 구독/저널링 관리자.
+
+StrategyScheduler 에서 분리(S-9)된 god class sub-responsibility. 실 주문은 발생시키지
+않고, event router 구독 + evaluate_single/evaluate_exit_single 결과를 shadow journal 에
+기록하는 역할만 담당한다. 동작은 분리 전과 동일하다.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING
+
+from repositories.streaming_stock_repo import StreamingType
+from services.price_subscription_service import SubscriptionPriority
+
+if TYPE_CHECKING:
+    from scheduler.strategy_scheduler import StrategySchedulerConfig
+
+
+class EventShadowManager:
+    """event_driven_shadow 전략의 entry/exit router 구독과 shadow journal 기록을 담당."""
+
+    def __init__(
+        self,
+        *,
+        event_router=None,
+        logger=None,
+        market_clock=None,
+        price_stream_svc=None,
+        price_sub_svc=None,
+        get_strategy_holdings: Optional[Callable] = None,
+        journal=None,
+    ):
+        self._event_router = event_router
+        self._logger = logger
+        self._tm = market_clock
+        self._price_stream_svc = price_stream_svc
+        self._price_sub_svc = price_sub_svc
+        self._get_strategy_holdings = get_strategy_holdings
+        self._event_shadow_journal = journal
+        # strategy_name → 현재 router 에 구독된 종목 set
+        self._event_shadow_subscriptions: Dict[str, set[str]] = {}
+        # strategy_name → 현재 exit shadow 로 구독된 보유 종목 set (P2 2-4 exit)
+        self._exit_shadow_subscriptions: Dict[str, set[str]] = {}
+
+    async def _refresh_event_shadow_subscriptions(self, cfg: StrategySchedulerConfig) -> None:
+        """P2 2-4: cfg.event_driven_shadow=True 인 전략의 router 구독을 scan 후 갱신.
+
+        - cfg.event_driven_shadow=False / router 미주입 / shadow journal 미주입 시 no-op.
+        - 새 후보 집합 vs 이전 구독 집합을 diff 해 unsubscribe/subscribe.
+        - subscribe evaluator wrapper 는 evaluate_single 결과를 shadow journal 에 기록하고
+          항상 None 을 반환 (실 주문 미발생 보장).
+        """
+        if not cfg.event_driven_shadow:
+            return
+        if self._event_shadow_journal is None:
+            return
+        if self._event_router is None:
+            await self._record_event_shadow_status(
+                strategy_name=getattr(cfg.strategy, "name", ""),
+                event="subscriptions_skipped",
+                details={"reason": "event_router_missing"},
+            )
+            return
+
+        strategy = cfg.strategy
+        name = strategy.name
+        try:
+            new_codes = set(strategy.current_candidate_codes() or [])
+        except Exception as e:
+            self._logger.warning(
+                f"[Scheduler] {name} current_candidate_codes() 호출 오류: {e}"
+            )
+            await self._record_event_shadow_status(
+                strategy_name=name,
+                event="subscriptions_skipped",
+                details={"reason": "candidate_codes_error", "error": str(e)},
+            )
+            return
+
+        old_codes = self._event_shadow_subscriptions.get(name, set())
+        to_remove = old_codes - new_codes
+        to_add = new_codes - old_codes
+
+        for code in to_remove:
+            try:
+                self._event_router.unsubscribe(code, name)
+            except Exception as e:
+                self._logger.warning(
+                    f"[Scheduler] {name} router.unsubscribe({code}) 실패: {e}"
+                )
+
+        if to_add:
+            evaluator = self._build_shadow_evaluator(strategy)
+            for code in to_add:
+                try:
+                    self._event_router.subscribe(
+                        code, strategy_name=name, evaluator=evaluator
+                    )
+                except Exception as e:
+                    self._logger.warning(
+                        f"[Scheduler] {name} router.subscribe({code}) 실패: {e}"
+                    )
+
+        self._event_shadow_subscriptions[name] = new_codes
+        await self._sync_event_shadow_price_subscriptions(name, new_codes)
+        details = {
+            "candidate_count": len(new_codes),
+            "added_count": len(to_add),
+            "removed_count": len(to_remove),
+            "candidate_codes": sorted(new_codes),
+            "added_codes": sorted(to_add),
+            "removed_codes": sorted(to_remove),
+        }
+        tick_ingest = self._tick_ingest_snapshot_for(new_codes)
+        if tick_ingest is not None:
+            details["tick_ingest"] = tick_ingest
+        await self._record_event_shadow_status(
+            strategy_name=name,
+            event="subscriptions_refreshed",
+            details=details,
+        )
+
+    def _tick_ingest_snapshot_for(self, codes: set[str]) -> Optional[dict]:
+        """후보 종목별 tick 처리 카운터 스냅샷 (P2 2-4 shadow no-tick 진단).
+
+        price_stream_service 미주입 또는 스냅샷 메서드 부재 시 None (no-op).
+        """
+        svc = self._price_stream_svc
+        if svc is None:
+            return None
+        snapshot_fn = getattr(svc, "tick_ingest_stats_snapshot", None)
+        if not callable(snapshot_fn):
+            return None
+        try:
+            return snapshot_fn(sorted(codes))
+        except Exception as e:
+            self._logger.warning(f"[Scheduler] tick_ingest 스냅샷 실패: {e}")
+            return None
+
+    async def _sync_event_shadow_price_subscriptions(self, strategy_name: str, codes: set[str],
+                                                      category_key: Optional[str] = None) -> None:
+        if self._price_sub_svc is None:
+            return
+        sync_fn = getattr(self._price_sub_svc, "sync_subscriptions", None)
+        if not callable(sync_fn):
+            return
+        try:
+            result = sync_fn(
+                sorted(codes),
+                (category_key or self._event_shadow_category_key(strategy_name)),
+                SubscriptionPriority.MEDIUM,
+                StreamingType.UNIFIED_PRICE,
+            )
+            if asyncio.iscoroutine(result):
+                await result
+        except TypeError:
+            try:
+                result = sync_fn(
+                    sorted(codes),
+                    (category_key or self._event_shadow_category_key(strategy_name)),
+                    SubscriptionPriority.MEDIUM,
+                )
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                self._logger.warning(
+                    f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
+                )
+        except Exception as e:
+            self._logger.warning(
+                f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
+            )
+
+    @staticmethod
+    def _event_shadow_category_key(strategy_name: str) -> str:
+        return f"event_shadow_{strategy_name}"
+
+    def _build_shadow_evaluator(self, strategy):
+        """evaluate_single → shadow journal 기록 → None 반환을 수행하는 wrapper.
+
+        매번 새 wrapper 를 만드는 게 정상이다 (strategy reference 가 closure 에 포함).
+        """
+        logger = self._logger
+
+        async def _evaluator(code: str, snapshot: dict):
+            try:
+                signal = await strategy.evaluate_single(code, snapshot)
+            except Exception as e:
+                logger.warning(
+                    f"[EventShadow] evaluate_single 예외 strategy={strategy.name} code={code} err={e}"
+                )
+                return None
+            if signal is None:
+                return None
+            try:
+                payload = signal.model_dump() if hasattr(signal, "model_dump") else dict(signal.__dict__)
+            except Exception:
+                payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
+            try:
+                await self._record_event_shadow_signal(
+                    strategy_name=strategy.name,
+                    code=code,
+                    signal=payload,
+                    snapshot=snapshot,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[EventShadow] journal.record 실패 strategy={strategy.name} code={code} err={e}"
+                )
+            return None  # shadow 는 router 결과로 전파되지 않음 (실 주문 차단)
+
+        return _evaluator
+
+    def _event_shadow_date_str(self) -> str:
+        try:
+            now = self._tm.get_current_kst_time()
+            return now.strftime("%Y%m%d")
+        except Exception:
+            return time.strftime("%Y%m%d")
+
+    async def _record_event_shadow_signal(
+        self,
+        *,
+        strategy_name: str,
+        code: str,
+        signal: dict,
+        snapshot: dict,
+        signal_source: Optional[str] = None,
+    ) -> None:
+        journal = self._event_shadow_journal
+        if journal is None:
+            return
+        journal.record(
+            strategy_name=strategy_name,
+            code=code,
+            signal=signal,
+            snapshot=snapshot,
+            signal_source=signal_source,
+        )
+        await self._flush_event_shadow_journal()
+
+    async def _record_event_shadow_status(
+        self,
+        *,
+        strategy_name: str,
+        event: str,
+        details: Optional[dict] = None,
+    ) -> None:
+        journal = self._event_shadow_journal
+        if journal is None:
+            return
+        record_status_fn = getattr(journal, "record_status", None)
+        if not callable(record_status_fn):
+            return
+        record_status_fn(
+            strategy_name=strategy_name,
+            event=event,
+            details=details or {},
+        )
+        await self._flush_event_shadow_journal()
+
+    async def _flush_event_shadow_journal(self) -> None:
+        """journal flush 를 worker thread 로 오프로드 (틱 경로 이벤트 루프 blocking 방지)."""
+        flush_fn = getattr(self._event_shadow_journal, "flush_to_file", None)
+        if callable(flush_fn):
+            await asyncio.to_thread(flush_fn, self._event_shadow_date_str())
+
+    @staticmethod
+    def _exit_shadow_category_key(strategy_name: str) -> str:
+        return f"event_shadow_exit_{strategy_name}"
+
+    @staticmethod
+    def _exit_shadow_subscriber_name(strategy_name: str) -> str:
+        # entry shadow 와 같은 종목을 구독해도 router 키가 겹치지 않도록 접미사를 붙인다.
+        return f"{strategy_name}__exit"
+
+    async def _refresh_exit_shadow_subscriptions(
+        self,
+        cfg: StrategySchedulerConfig,
+        holdings: Optional[List[dict]] = None,
+    ) -> None:
+        """P2 2-4 exit: event_driven_shadow 전략의 보유 종목을 손절 shadow 로 router 구독.
+
+        - flag False / router·journal 미주입 시 no-op.
+        - 보유 종목 set 변화를 diff 해 unsubscribe. evaluator 는 evaluate_exit_single 결과를
+          journal(signal_source="event_shadow_exit")에 기록하고 항상 None 반환(실 주문 미발생).
+        - entry shadow 와 구분되는 subscriber name 을 써서 같은 종목 구독이 겹치지 않게 한다.
+        - entry gate 와 무관하게 매 사이클 호출되어 보유 종목 변화를 반영한다.
+        """
+        if not cfg.event_driven_shadow:
+            return
+        if self._event_router is None or self._event_shadow_journal is None:
+            return
+
+        strategy = cfg.strategy
+        name = strategy.name
+        if holdings is None:
+            try:
+                holdings = self._get_strategy_holdings(cfg) or []
+            except Exception as e:
+                self._logger.warning(f"[Scheduler] {name} exit shadow 보유 조회 오류: {e}")
+                return
+
+        holdings_by_code: Dict[str, dict] = {}
+        for hold in holdings:
+            code = str(hold.get("code", "")).strip()
+            if code:
+                holdings_by_code[code] = hold
+        new_codes = set(holdings_by_code)
+
+        sub_name = self._exit_shadow_subscriber_name(name)
+        old_codes = self._exit_shadow_subscriptions.get(name, set())
+
+        for code in (old_codes - new_codes):
+            try:
+                self._event_router.unsubscribe(code, sub_name)
+            except Exception as e:
+                self._logger.warning(f"[Scheduler] {name} exit shadow unsubscribe({code}) 실패: {e}")
+
+        if new_codes:
+            # router.subscribe 는 (code, sub_name) 중복을 evaluator 교체로 처리하므로,
+            # 보유 정보를 최신으로 유지하도록 매 사이클 새 evaluator 로 재구독한다.
+            evaluator = self._build_exit_shadow_evaluator(strategy, holdings_by_code)
+            for code in new_codes:
+                try:
+                    self._event_router.subscribe(code, strategy_name=sub_name, evaluator=evaluator)
+                except Exception as e:
+                    self._logger.warning(f"[Scheduler] {name} exit shadow subscribe({code}) 실패: {e}")
+
+        self._exit_shadow_subscriptions[name] = new_codes
+        await self._sync_event_shadow_price_subscriptions(
+            name, new_codes, category_key=self._exit_shadow_category_key(name)
+        )
+
+    def _build_exit_shadow_evaluator(self, strategy, holdings_by_code: Dict[str, dict]):
+        """evaluate_exit_single → exit shadow journal 기록 → None 반환 wrapper."""
+        logger = self._logger
+
+        async def _evaluator(code: str, snapshot: dict):
+            holding = holdings_by_code.get(code)
+            if not holding:
+                return None
+            try:
+                signal = await strategy.evaluate_exit_single(code, snapshot, holding)
+            except Exception as e:
+                logger.warning(
+                    f"[EventShadow] evaluate_exit_single 예외 strategy={strategy.name} code={code} err={e}"
+                )
+                return None
+            if signal is None:
+                return None
+            try:
+                payload = signal.model_dump() if hasattr(signal, "model_dump") else dict(signal.__dict__)
+            except Exception:
+                payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
+            try:
+                await self._record_event_shadow_signal(
+                    strategy_name=strategy.name,
+                    code=code,
+                    signal=payload,
+                    snapshot=snapshot,
+                    signal_source="event_shadow_exit",
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[EventShadow] exit journal.record 실패 strategy={strategy.name} code={code} err={e}"
+                )
+            return None  # shadow 는 router 결과로 전파되지 않음 (실 주문 차단)
+
+        return _evaluator
+
+    async def teardown_strategy(self, name: str) -> None:
+        """전략 비활성화 시 entry/exit shadow router 구독을 해제한다 (P2 2-4).
+
+        호출 측(stop_strategy)에서 cfg.event_driven_shadow=True 일 때만 호출한다.
+        가격 구독 카테고리(`_price_sub_svc`) 제거는 해당 서비스를 소유한 호출 측에서 수행한다.
+        """
+        if self._event_router is None:
+            return
+        for code in self._event_shadow_subscriptions.pop(name, set()):
+            try:
+                self._event_router.unsubscribe(code, name)
+            except Exception as e:
+                self._logger.warning(
+                    f"[Scheduler] {name} shadow unsubscribe({code}) 실패: {e}"
+                )
+        exit_sub_name = self._exit_shadow_subscriber_name(name)
+        for code in self._exit_shadow_subscriptions.pop(name, set()):
+            try:
+                self._event_router.unsubscribe(code, exit_sub_name)
+            except Exception as e:
+                self._logger.warning(
+                    f"[Scheduler] {name} exit shadow unsubscribe({code}) 실패: {e}"
+                )

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -40,6 +40,7 @@ from services.kill_switch_service import KillSwitchService
 from core.account_snapshot import AccountSnapshotCache
 from services.position_sizing_service import PositionSizingService
 from utils.strategy_state_io import StrategyStateIO
+from scheduler.event_shadow_manager import EventShadowManager
 
 
 @dataclass
@@ -148,14 +149,18 @@ class StrategyScheduler:
         self._kill_switch = kill_switch_service
         self._account_snapshot_cache = account_snapshot_cache
         self._position_sizer = position_sizing_service
-        self._event_router = event_router
-        self._event_shadow_journal = event_shadow_journal
         self._price_stream_svc = price_stream_service
         self._live_expansion_gate = live_expansion_gate_service
-        # strategy_name → 현재 router 에 구독된 종목 set
-        self._event_shadow_subscriptions: Dict[str, set[str]] = {}
-        # strategy_name → 현재 exit shadow 로 구독된 보유 종목 set (P2 2-4 exit)
-        self._exit_shadow_subscriptions: Dict[str, set[str]] = {}
+        # P2 2-4 event-driven shadow 구독/저널링은 EventShadowManager 로 분리(S-9).
+        self._event_shadow_manager = EventShadowManager(
+            event_router=event_router,
+            logger=self._logger,
+            market_clock=market_clock,
+            price_stream_svc=price_stream_service,
+            price_sub_svc=price_subscription_service,
+            get_strategy_holdings=self._get_strategy_holdings,
+            journal=event_shadow_journal,
+        )
 
         self._strategies: List[StrategySchedulerConfig] = []
         self._running = False
@@ -496,7 +501,7 @@ class StrategyScheduler:
         post_exit_holdings = holdings if not sells_dispatched else None
 
         # P2 2-4 exit: 보유 종목 손절 shadow 구독 갱신 (entry gate 와 무관하게 매 사이클 실행).
-        await self._refresh_exit_shadow_subscriptions(cfg, holdings=post_exit_holdings)
+        await self._event_shadow_manager._refresh_exit_shadow_subscriptions(cfg, holdings=post_exit_holdings)
 
         # 2) 새 매수 스캔
         # Profitability gate 는 BUY 주문 직전에만 적용한다. scan/event-shadow 는
@@ -585,7 +590,7 @@ class StrategyScheduler:
         })
 
         # P2 2-4: event-driven shadow 구독 갱신 (scan 직후 후보군 변화 반영)
-        await self._refresh_event_shadow_subscriptions(cfg)
+        await self._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
         # 이미 보유 중인 종목은 추가 매수(불타기) 방지
         if cfg.allow_pyramiding:
@@ -1199,333 +1204,6 @@ class StrategyScheduler:
                 )
             return
 
-    async def _refresh_event_shadow_subscriptions(self, cfg: StrategySchedulerConfig) -> None:
-        """P2 2-4: cfg.event_driven_shadow=True 인 전략의 router 구독을 scan 후 갱신.
-
-        - cfg.event_driven_shadow=False / router 미주입 / shadow journal 미주입 시 no-op.
-        - 새 후보 집합 vs 이전 구독 집합을 diff 해 unsubscribe/subscribe.
-        - subscribe evaluator wrapper 는 evaluate_single 결과를 shadow journal 에 기록하고
-          항상 None 을 반환 (실 주문 미발생 보장).
-        """
-        if not cfg.event_driven_shadow:
-            return
-        if self._event_shadow_journal is None:
-            return
-        if self._event_router is None:
-            await self._record_event_shadow_status(
-                strategy_name=getattr(cfg.strategy, "name", ""),
-                event="subscriptions_skipped",
-                details={"reason": "event_router_missing"},
-            )
-            return
-
-        strategy = cfg.strategy
-        name = strategy.name
-        try:
-            new_codes = set(strategy.current_candidate_codes() or [])
-        except Exception as e:
-            self._logger.warning(
-                f"[Scheduler] {name} current_candidate_codes() 호출 오류: {e}"
-            )
-            await self._record_event_shadow_status(
-                strategy_name=name,
-                event="subscriptions_skipped",
-                details={"reason": "candidate_codes_error", "error": str(e)},
-            )
-            return
-
-        old_codes = self._event_shadow_subscriptions.get(name, set())
-        to_remove = old_codes - new_codes
-        to_add = new_codes - old_codes
-
-        for code in to_remove:
-            try:
-                self._event_router.unsubscribe(code, name)
-            except Exception as e:
-                self._logger.warning(
-                    f"[Scheduler] {name} router.unsubscribe({code}) 실패: {e}"
-                )
-
-        if to_add:
-            evaluator = self._build_shadow_evaluator(strategy)
-            for code in to_add:
-                try:
-                    self._event_router.subscribe(
-                        code, strategy_name=name, evaluator=evaluator
-                    )
-                except Exception as e:
-                    self._logger.warning(
-                        f"[Scheduler] {name} router.subscribe({code}) 실패: {e}"
-                    )
-
-        self._event_shadow_subscriptions[name] = new_codes
-        await self._sync_event_shadow_price_subscriptions(name, new_codes)
-        details = {
-            "candidate_count": len(new_codes),
-            "added_count": len(to_add),
-            "removed_count": len(to_remove),
-            "candidate_codes": sorted(new_codes),
-            "added_codes": sorted(to_add),
-            "removed_codes": sorted(to_remove),
-        }
-        tick_ingest = self._tick_ingest_snapshot_for(new_codes)
-        if tick_ingest is not None:
-            details["tick_ingest"] = tick_ingest
-        await self._record_event_shadow_status(
-            strategy_name=name,
-            event="subscriptions_refreshed",
-            details=details,
-        )
-
-    def _tick_ingest_snapshot_for(self, codes: set[str]) -> Optional[dict]:
-        """후보 종목별 tick 처리 카운터 스냅샷 (P2 2-4 shadow no-tick 진단).
-
-        price_stream_service 미주입 또는 스냅샷 메서드 부재 시 None (no-op).
-        """
-        svc = self._price_stream_svc
-        if svc is None:
-            return None
-        snapshot_fn = getattr(svc, "tick_ingest_stats_snapshot", None)
-        if not callable(snapshot_fn):
-            return None
-        try:
-            return snapshot_fn(sorted(codes))
-        except Exception as e:
-            self._logger.warning(f"[Scheduler] tick_ingest 스냅샷 실패: {e}")
-            return None
-
-    async def _sync_event_shadow_price_subscriptions(self, strategy_name: str, codes: set[str],
-                                                      category_key: Optional[str] = None) -> None:
-        if self._price_sub_svc is None:
-            return
-        sync_fn = getattr(self._price_sub_svc, "sync_subscriptions", None)
-        if not callable(sync_fn):
-            return
-        try:
-            result = sync_fn(
-                sorted(codes),
-                (category_key or self._event_shadow_category_key(strategy_name)),
-                SubscriptionPriority.MEDIUM,
-                StreamingType.UNIFIED_PRICE,
-            )
-            if asyncio.iscoroutine(result):
-                await result
-        except TypeError:
-            try:
-                result = sync_fn(
-                    sorted(codes),
-                    (category_key or self._event_shadow_category_key(strategy_name)),
-                    SubscriptionPriority.MEDIUM,
-                )
-                if asyncio.iscoroutine(result):
-                    await result
-            except Exception as e:
-                self._logger.warning(
-                    f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
-                )
-        except Exception as e:
-            self._logger.warning(
-                f"[Scheduler] {strategy_name} event shadow 가격 구독 갱신 실패: {e}"
-            )
-
-    @staticmethod
-    def _event_shadow_category_key(strategy_name: str) -> str:
-        return f"event_shadow_{strategy_name}"
-
-    def _build_shadow_evaluator(self, strategy):
-        """evaluate_single → shadow journal 기록 → None 반환을 수행하는 wrapper.
-
-        매번 새 wrapper 를 만드는 게 정상이다 (strategy reference 가 closure 에 포함).
-        """
-        logger = self._logger
-
-        async def _evaluator(code: str, snapshot: dict):
-            try:
-                signal = await strategy.evaluate_single(code, snapshot)
-            except Exception as e:
-                logger.warning(
-                    f"[EventShadow] evaluate_single 예외 strategy={strategy.name} code={code} err={e}"
-                )
-                return None
-            if signal is None:
-                return None
-            try:
-                payload = signal.model_dump() if hasattr(signal, "model_dump") else dict(signal.__dict__)
-            except Exception:
-                payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
-            try:
-                await self._record_event_shadow_signal(
-                    strategy_name=strategy.name,
-                    code=code,
-                    signal=payload,
-                    snapshot=snapshot,
-                )
-            except Exception as e:
-                logger.warning(
-                    f"[EventShadow] journal.record 실패 strategy={strategy.name} code={code} err={e}"
-                )
-            return None  # shadow 는 router 결과로 전파되지 않음 (실 주문 차단)
-
-        return _evaluator
-
-    def _event_shadow_date_str(self) -> str:
-        try:
-            now = self._tm.get_current_kst_time()
-            return now.strftime("%Y%m%d")
-        except Exception:
-            return time.strftime("%Y%m%d")
-
-    async def _record_event_shadow_signal(
-        self,
-        *,
-        strategy_name: str,
-        code: str,
-        signal: dict,
-        snapshot: dict,
-        signal_source: Optional[str] = None,
-    ) -> None:
-        journal = self._event_shadow_journal
-        if journal is None:
-            return
-        journal.record(
-            strategy_name=strategy_name,
-            code=code,
-            signal=signal,
-            snapshot=snapshot,
-            signal_source=signal_source,
-        )
-        await self._flush_event_shadow_journal()
-
-    async def _record_event_shadow_status(
-        self,
-        *,
-        strategy_name: str,
-        event: str,
-        details: Optional[dict] = None,
-    ) -> None:
-        journal = self._event_shadow_journal
-        if journal is None:
-            return
-        record_status_fn = getattr(journal, "record_status", None)
-        if not callable(record_status_fn):
-            return
-        record_status_fn(
-            strategy_name=strategy_name,
-            event=event,
-            details=details or {},
-        )
-        await self._flush_event_shadow_journal()
-
-    async def _flush_event_shadow_journal(self) -> None:
-        """journal flush 를 worker thread 로 오프로드 (틱 경로 이벤트 루프 blocking 방지)."""
-        flush_fn = getattr(self._event_shadow_journal, "flush_to_file", None)
-        if callable(flush_fn):
-            await asyncio.to_thread(flush_fn, self._event_shadow_date_str())
-
-    @staticmethod
-    def _exit_shadow_category_key(strategy_name: str) -> str:
-        return f"event_shadow_exit_{strategy_name}"
-
-    @staticmethod
-    def _exit_shadow_subscriber_name(strategy_name: str) -> str:
-        # entry shadow 와 같은 종목을 구독해도 router 키가 겹치지 않도록 접미사를 붙인다.
-        return f"{strategy_name}__exit"
-
-    async def _refresh_exit_shadow_subscriptions(
-        self,
-        cfg: StrategySchedulerConfig,
-        holdings: Optional[List[dict]] = None,
-    ) -> None:
-        """P2 2-4 exit: event_driven_shadow 전략의 보유 종목을 손절 shadow 로 router 구독.
-
-        - flag False / router·journal 미주입 시 no-op.
-        - 보유 종목 set 변화를 diff 해 unsubscribe. evaluator 는 evaluate_exit_single 결과를
-          journal(signal_source="event_shadow_exit")에 기록하고 항상 None 반환(실 주문 미발생).
-        - entry shadow 와 구분되는 subscriber name 을 써서 같은 종목 구독이 겹치지 않게 한다.
-        - entry gate 와 무관하게 매 사이클 호출되어 보유 종목 변화를 반영한다.
-        """
-        if not cfg.event_driven_shadow:
-            return
-        if self._event_router is None or self._event_shadow_journal is None:
-            return
-
-        strategy = cfg.strategy
-        name = strategy.name
-        if holdings is None:
-            try:
-                holdings = self._get_strategy_holdings(cfg) or []
-            except Exception as e:
-                self._logger.warning(f"[Scheduler] {name} exit shadow 보유 조회 오류: {e}")
-                return
-
-        holdings_by_code: Dict[str, dict] = {}
-        for hold in holdings:
-            code = str(hold.get("code", "")).strip()
-            if code:
-                holdings_by_code[code] = hold
-        new_codes = set(holdings_by_code)
-
-        sub_name = self._exit_shadow_subscriber_name(name)
-        old_codes = self._exit_shadow_subscriptions.get(name, set())
-
-        for code in (old_codes - new_codes):
-            try:
-                self._event_router.unsubscribe(code, sub_name)
-            except Exception as e:
-                self._logger.warning(f"[Scheduler] {name} exit shadow unsubscribe({code}) 실패: {e}")
-
-        if new_codes:
-            # router.subscribe 는 (code, sub_name) 중복을 evaluator 교체로 처리하므로,
-            # 보유 정보를 최신으로 유지하도록 매 사이클 새 evaluator 로 재구독한다.
-            evaluator = self._build_exit_shadow_evaluator(strategy, holdings_by_code)
-            for code in new_codes:
-                try:
-                    self._event_router.subscribe(code, strategy_name=sub_name, evaluator=evaluator)
-                except Exception as e:
-                    self._logger.warning(f"[Scheduler] {name} exit shadow subscribe({code}) 실패: {e}")
-
-        self._exit_shadow_subscriptions[name] = new_codes
-        await self._sync_event_shadow_price_subscriptions(
-            name, new_codes, category_key=self._exit_shadow_category_key(name)
-        )
-
-    def _build_exit_shadow_evaluator(self, strategy, holdings_by_code: Dict[str, dict]):
-        """evaluate_exit_single → exit shadow journal 기록 → None 반환 wrapper."""
-        logger = self._logger
-
-        async def _evaluator(code: str, snapshot: dict):
-            holding = holdings_by_code.get(code)
-            if not holding:
-                return None
-            try:
-                signal = await strategy.evaluate_exit_single(code, snapshot, holding)
-            except Exception as e:
-                logger.warning(
-                    f"[EventShadow] evaluate_exit_single 예외 strategy={strategy.name} code={code} err={e}"
-                )
-                return None
-            if signal is None:
-                return None
-            try:
-                payload = signal.model_dump() if hasattr(signal, "model_dump") else dict(signal.__dict__)
-            except Exception:
-                payload = {"action": getattr(signal, "action", ""), "code": getattr(signal, "code", code)}
-            try:
-                await self._record_event_shadow_signal(
-                    strategy_name=strategy.name,
-                    code=code,
-                    signal=payload,
-                    snapshot=snapshot,
-                    signal_source="event_shadow_exit",
-                )
-            except Exception as e:
-                logger.warning(
-                    f"[EventShadow] exit journal.record 실패 strategy={strategy.name} code={code} err={e}"
-                )
-            return None  # shadow 는 router 결과로 전파되지 않음 (실 주문 차단)
-
-        return _evaluator
-
     async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig):
         """전략 중지 시 보유 종목 강제 청산 (force_exit_on_close=True)."""
         name = cfg.strategy.name
@@ -1866,31 +1544,17 @@ class StrategyScheduler:
                 cfg.enabled = False
                 self._logger.info(f"[Scheduler] 전략 비활성화: {name}")
 
-                if cfg.event_driven_shadow and self._event_router is not None:
-                    for code in self._event_shadow_subscriptions.pop(name, set()):
-                        try:
-                            self._event_router.unsubscribe(code, name)
-                        except Exception as e:
-                            self._logger.warning(
-                                f"[Scheduler] {name} shadow unsubscribe({code}) 실패: {e}"
-                            )
-                    exit_sub_name = self._exit_shadow_subscriber_name(name)
-                    for code in self._exit_shadow_subscriptions.pop(name, set()):
-                        try:
-                            self._event_router.unsubscribe(code, exit_sub_name)
-                        except Exception as e:
-                            self._logger.warning(
-                                f"[Scheduler] {name} exit shadow unsubscribe({code}) 실패: {e}"
-                            )
+                if cfg.event_driven_shadow:
+                    await self._event_shadow_manager.teardown_strategy(name)
 
                 if self._price_sub_svc:
                     await self._price_sub_svc.remove_category(f"scheduler_{name}")
                     if cfg.event_driven_shadow:
                         await self._price_sub_svc.remove_category(
-                            self._event_shadow_category_key(name)
+                            self._event_shadow_manager._event_shadow_category_key(name)
                         )
                         await self._price_sub_svc.remove_category(
-                            self._exit_shadow_category_key(name)
+                            self._event_shadow_manager._exit_shadow_category_key(name)
                         )
 
                 return True

--- a/tests/unit_test/scheduler/test_event_shadow_pipeline_e2e.py
+++ b/tests/unit_test/scheduler/test_event_shadow_pipeline_e2e.py
@@ -112,14 +112,14 @@ async def test_live_tick_flows_to_entry_shadow_jsonl(tmp_path):
     scheduler = _make_scheduler(clock, event_router=None, event_shadow_journal=journal)
     # 실제 router/price_stream 으로 교체 (scheduler 는 evaluator 빌드/기록 경로용).
     router, price_stream = _build_pipeline(clock, journal)
-    scheduler._event_router = router
+    scheduler._event_shadow_manager._event_router = router
 
     # Open 74,000 + Range 2,000 × K 0.5 = Target 75,000.
     vbo = _make_vbo(clock, candidates=["005930"], ranges={"005930": 2000.0})
     cfg = StrategySchedulerConfig(strategy=vbo, event_driven_shadow=True)
 
     # scan 직후 배선과 동일: 후보를 router 에 구독 + (price_sub None 이라) 가격 sync no-op.
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     assert "래리윌리엄스VBO" in router.subscribers_for("005930")
 
     # 실제 KIS realtime_price 필드 모양의 돌파 틱 (현재가 == Target).
@@ -160,11 +160,11 @@ async def test_below_target_tick_writes_no_entry_record(tmp_path):
     journal = EventShadowJournalService(log_root=tmp_path)
     scheduler = _make_scheduler(clock, event_router=None, event_shadow_journal=journal)
     router, price_stream = _build_pipeline(clock, journal)
-    scheduler._event_router = router
+    scheduler._event_shadow_manager._event_router = router
 
     vbo = _make_vbo(clock, candidates=["005930"], ranges={"005930": 2000.0})
     cfg = StrategySchedulerConfig(strategy=vbo, event_driven_shadow=True)
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     price_stream.on_price_tick({
         "유가증권단축종목코드": "005930",
@@ -188,7 +188,7 @@ async def test_live_tick_flows_to_exit_shadow_jsonl(tmp_path):
     journal = EventShadowJournalService(log_root=tmp_path)
     scheduler = _make_scheduler(clock, event_router=None, event_shadow_journal=journal)
     router, price_stream = _build_pipeline(clock, journal)
-    scheduler._event_router = router
+    scheduler._event_shadow_manager._event_router = router
 
     vbo = _make_vbo(clock, candidates=[], ranges={})
     holdings_by_code = {
@@ -196,7 +196,7 @@ async def test_live_tick_flows_to_exit_shadow_jsonl(tmp_path):
     }
     # exit evaluator 는 holdings 를 closure 로 받는다(= _refresh_exit_shadow_subscriptions
     # 가 vts 조회 후 빌드하는 것과 동일 형태). vts mock 부담을 피해 직접 빌드/구독한다.
-    evaluator = scheduler._build_exit_shadow_evaluator(vbo, holdings_by_code)
+    evaluator = scheduler._event_shadow_manager._build_exit_shadow_evaluator(vbo, holdings_by_code)
     router.subscribe("005930", strategy_name="래리윌리엄스VBO__exit", evaluator=evaluator)
 
     # 80,000 매수 대비 75,000 → net 손절(-3%)보다 큰 손실 → SELL.

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -626,7 +626,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         scheduler.register(config)
 
         with patch.object(
-            scheduler, "_refresh_event_shadow_subscriptions", new_callable=AsyncMock
+            scheduler._event_shadow_manager, "_refresh_event_shadow_subscriptions", new_callable=AsyncMock
         ) as refresh_shadow:
             await scheduler._run_strategy(config)
 
@@ -840,10 +840,10 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
     def _make_shadow_scheduler(self):
         """event_router + event_shadow_journal 주입된 scheduler (price_sub_svc 없음 → sync no-op)."""
         scheduler, vm, oes, tm, mcs = self._make_scheduler(dry_run=True)
-        scheduler._event_router = MagicMock()
-        scheduler._event_router.subscribe = MagicMock()
-        scheduler._event_router.unsubscribe = MagicMock()
-        scheduler._event_shadow_journal = MagicMock()
+        scheduler._event_shadow_manager._event_router = MagicMock()
+        scheduler._event_shadow_manager._event_router.subscribe = MagicMock()
+        scheduler._event_shadow_manager._event_router.unsubscribe = MagicMock()
+        scheduler._event_shadow_manager._event_shadow_journal = MagicMock()
         return scheduler, vm
 
     async def test_refresh_exit_shadow_subscribes_held_codes_with_exit_subscriber_name(self):
@@ -854,11 +854,11 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         ]
         cfg = StrategySchedulerConfig(strategy=MockStrategy(name="VBO"), event_driven_shadow=True)
 
-        await scheduler._refresh_exit_shadow_subscriptions(cfg)
+        await scheduler._event_shadow_manager._refresh_exit_shadow_subscriptions(cfg)
 
-        scheduler._event_router.subscribe.assert_called_once()
-        _, kwargs = scheduler._event_router.subscribe.call_args
-        self.assertEqual(scheduler._event_router.subscribe.call_args.args[0], "005930")
+        scheduler._event_shadow_manager._event_router.subscribe.assert_called_once()
+        _, kwargs = scheduler._event_shadow_manager._event_router.subscribe.call_args
+        self.assertEqual(scheduler._event_shadow_manager._event_router.subscribe.call_args.args[0], "005930")
         self.assertTrue(kwargs["strategy_name"].endswith("__exit"))
         self.assertTrue(callable(kwargs["evaluator"]))
 
@@ -868,9 +868,9 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         vm.get_holds_by_strategy.return_value = [{"code": "005930", "buy_price": 70000, "qty": 1}]
         cfg = StrategySchedulerConfig(strategy=MockStrategy(name="VBO"), event_driven_shadow=False)
 
-        await scheduler._refresh_exit_shadow_subscriptions(cfg)
+        await scheduler._event_shadow_manager._refresh_exit_shadow_subscriptions(cfg)
 
-        scheduler._event_router.subscribe.assert_not_called()
+        scheduler._event_shadow_manager._event_router.subscribe.assert_not_called()
 
     async def test_refresh_exit_shadow_unsubscribes_sold_codes(self):
         """이전 사이클 보유 종목이 청산되면 다음 refresh 에서 unsubscribe 한다."""
@@ -878,14 +878,14 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         cfg = StrategySchedulerConfig(strategy=MockStrategy(name="VBO"), event_driven_shadow=True)
 
         vm.get_holds_by_strategy.return_value = [{"code": "005930", "buy_price": 70000, "qty": 1}]
-        await scheduler._refresh_exit_shadow_subscriptions(cfg)
+        await scheduler._event_shadow_manager._refresh_exit_shadow_subscriptions(cfg)
 
         vm.get_holds_by_strategy.return_value = []
-        await scheduler._refresh_exit_shadow_subscriptions(cfg)
+        await scheduler._event_shadow_manager._refresh_exit_shadow_subscriptions(cfg)
 
-        scheduler._event_router.unsubscribe.assert_called_once()
-        self.assertEqual(scheduler._event_router.unsubscribe.call_args.args[0], "005930")
-        self.assertTrue(scheduler._event_router.unsubscribe.call_args.args[1].endswith("__exit"))
+        scheduler._event_shadow_manager._event_router.unsubscribe.assert_called_once()
+        self.assertEqual(scheduler._event_shadow_manager._event_router.unsubscribe.call_args.args[0], "005930")
+        self.assertTrue(scheduler._event_shadow_manager._event_router.unsubscribe.call_args.args[1].endswith("__exit"))
 
     async def test_exit_shadow_evaluator_records_signal_source_exit_and_returns_none(self):
         """exit shadow evaluator: evaluate_exit_single → journal(signal_source=event_shadow_exit) → None."""
@@ -897,12 +897,12 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         strategy.evaluate_exit_single = AsyncMock(return_value=sell)
         holdings_by_code = {"005930": {"code": "005930", "buy_price": 70000, "qty": 1}}
 
-        evaluator = scheduler._build_exit_shadow_evaluator(strategy, holdings_by_code)
+        evaluator = scheduler._event_shadow_manager._build_exit_shadow_evaluator(strategy, holdings_by_code)
         result = await evaluator("005930", {"price": "67800"})
 
         self.assertIsNone(result)  # 실 주문 미발생
-        scheduler._event_shadow_journal.record.assert_called_once()
-        _, rkwargs = scheduler._event_shadow_journal.record.call_args
+        scheduler._event_shadow_manager._event_shadow_journal.record.assert_called_once()
+        _, rkwargs = scheduler._event_shadow_manager._event_shadow_journal.record.call_args
         self.assertEqual(rkwargs["signal_source"], "event_shadow_exit")
         self.assertEqual(rkwargs["code"], "005930")
         self.assertEqual(rkwargs["strategy_name"], "VBO")
@@ -914,11 +914,11 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         strategy.name = "VBO"
         strategy.evaluate_exit_single = AsyncMock(return_value=None)
 
-        evaluator = scheduler._build_exit_shadow_evaluator(strategy, {"005930": {"buy_price": 70000}})
+        evaluator = scheduler._event_shadow_manager._build_exit_shadow_evaluator(strategy, {"005930": {"buy_price": 70000}})
         result = await evaluator("005930", {"price": "70000"})
 
         self.assertIsNone(result)
-        scheduler._event_shadow_journal.record.assert_not_called()
+        scheduler._event_shadow_manager._event_shadow_journal.record.assert_not_called()
 
     async def test_run_strategy_scans_and_logs_rejections_when_position_full_option_enabled(self):
         """옵션이 켜져 있으면 max_positions 도달 후에도 스캔하고 매수 신호를 reject 로그로 남긴다."""

--- a/tests/unit_test/scheduler/test_strategy_scheduler_audit_fixes.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_audit_fixes.py
@@ -303,13 +303,13 @@ async def test_stop_strategy_unsubscribes_event_shadow_router():
     strategy = MockStrategy(name=name)
     cfg = StrategySchedulerConfig(strategy=strategy, event_driven_shadow=True)
     scheduler.register(cfg)
-    scheduler._event_shadow_subscriptions[name] = {"000001"}
-    scheduler._exit_shadow_subscriptions[name] = {"000002"}
+    scheduler._event_shadow_manager._event_shadow_subscriptions[name] = {"000001"}
+    scheduler._event_shadow_manager._exit_shadow_subscriptions[name] = {"000002"}
 
     result = await scheduler.stop_strategy(name)
 
     assert result is True
     router.unsubscribe.assert_any_call("000001", name)
     router.unsubscribe.assert_any_call("000002", f"{name}__exit")
-    assert name not in scheduler._event_shadow_subscriptions
-    assert name not in scheduler._exit_shadow_subscriptions
+    assert name not in scheduler._event_shadow_manager._event_shadow_subscriptions
+    assert name not in scheduler._event_shadow_manager._exit_shadow_subscriptions

--- a/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_event_shadow.py
@@ -62,7 +62,7 @@ async def test_refresh_subscriptions_adds_codes_from_candidate_set():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     assert router.subscribe.call_count == 2
     subscribed_codes = sorted(call.args[0] for call in router.subscribe.call_args_list)
@@ -80,12 +80,12 @@ async def test_refresh_subscriptions_diffs_against_previous_set():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=MagicMock())
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     router.subscribe.reset_mock()
 
     # 다음 scan: 005930 빠지고 035720 추가
     cfg.strategy.current_candidate_codes.return_value = ["000660", "035720"]
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     router.unsubscribe.assert_called_once_with("005930", "VBO")
     router.subscribe.assert_called_once()
@@ -98,7 +98,7 @@ async def test_refresh_subscriptions_noop_when_flag_off():
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=MagicMock())
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=False, codes=["005930"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     router.subscribe.assert_not_called()
     router.unsubscribe.assert_not_called()
@@ -111,7 +111,7 @@ async def test_refresh_subscriptions_noop_when_router_missing():
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     # router 없이도 예외 없이 종료해야 한다
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_refresh_subscriptions_syncs_price_subscription_category():
     )
 
     cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     price_sub.sync_subscriptions.assert_awaited_once_with(
         ["000660", "005930"],
@@ -146,7 +146,7 @@ async def test_refresh_subscriptions_writes_status_record_to_daily_jsonl(tmp_pat
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
 
     cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     path = tmp_path / "event_shadow" / "20260520.jsonl"
     assert path.exists()
@@ -179,7 +179,7 @@ async def test_refresh_subscriptions_attaches_tick_ingest_stats(tmp_path):
     )
 
     cfg = _make_strategy_cfg("래리윌리엄스VBO", event_driven_shadow=True, codes=["005930", "000660"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     price_stream.tick_ingest_stats_snapshot.assert_called_once_with(["000660", "005930"])
     path = tmp_path / "event_shadow" / "20260520.jsonl"
@@ -202,7 +202,7 @@ async def test_refresh_subscriptions_omits_tick_ingest_when_no_price_stream(tmp_
     scheduler = _make_scheduler(event_router=router, event_shadow_journal=journal)
 
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
 
     path = tmp_path / "event_shadow" / "20260520.jsonl"
     records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
@@ -224,7 +224,7 @@ async def test_shadow_evaluator_records_signal_and_returns_none():
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
 
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     journal.record.reset_mock()
     journal.flush_to_file.reset_mock()
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
@@ -258,7 +258,7 @@ async def test_shadow_record_flush_offloaded_to_thread():
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
 
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
 
     with patch("asyncio.to_thread", new_callable=AsyncMock) as to_thread:
@@ -278,7 +278,7 @@ async def test_shadow_evaluator_does_not_record_when_no_signal():
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=None)
 
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     journal.record.reset_mock()
     journal.flush_to_file.reset_mock()
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
@@ -304,7 +304,7 @@ async def test_shadow_evaluator_persists_signal_to_event_shadow_jsonl(tmp_path):
     cfg = _make_strategy_cfg("VBO", event_driven_shadow=True, codes=["005930"])
     cfg.strategy.evaluate_single = AsyncMock(return_value=sig)
 
-    await scheduler._refresh_event_shadow_subscriptions(cfg)
+    await scheduler._event_shadow_manager._refresh_event_shadow_subscriptions(cfg)
     evaluator = router.subscribe.call_args.kwargs["evaluator"]
     await evaluator("005930", {"price": "75000", "open": 74000.0})
 
@@ -327,7 +327,7 @@ async def test_exit_shadow_evaluator_flushes_record_to_daily_jsonl():
     strategy.name = "VBO"
     strategy.evaluate_exit_single = AsyncMock(return_value=sell)
 
-    evaluator = scheduler._build_exit_shadow_evaluator(
+    evaluator = scheduler._event_shadow_manager._build_exit_shadow_evaluator(
         strategy,
         {"005930": {"code": "005930", "buy_price": 71000, "qty": 1}},
     )

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-06-25 (완료·해소 항목 정리, 남은 실행 항목 중심으로 슬림화)
+최종 업데이트: 2026-06-28 (S-9 god class 분리 착수 반영)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -136,7 +136,7 @@
 
 ### 보류 — 정책 합의 후 재승격
 
-- [ ] **S-9 god class 분리** (EventShadowManager 등, scheduler shadow 블록 ≈330줄) — 테스트 ~26곳이 내부 표면 직접 잠금 + shadow 코드 거취가 **2-4 PR-3 판정**에 달림. parity 판정 후 재평가(Go=분리 선행 / No-Go=shadow 삭제로 종결).
+- [x] **S-9 god class 분리** — `EventShadowManager`(`scheduler/event_shadow_manager.py`)로 shadow 블록 ~327줄 추출 완료(2026-06-28). scheduler 2432→2097줄. entry/exit 구독·evaluator·journal record/flush·teardown 이동, 테스트 ~44곳 receiver를 `_event_shadow_manager`로 갱신(동작 불변, unit 6505 + integration 245 green). 분리로 2-4 PR-3 No-Go(삭제) 시에도 단일 파일 제거로 종결 가능.
 - [ ] **3-4 active strategy lifecycle 7단계 분해**(`get_watchlist`/`filter_candidates`/`evaluate_entries_bounded`/`evaluate_exits_bounded`/`emit_metrics`) — 현재 `scan`/`check_exits`에 묻혀 있어 대형 리팩토링. checklist 테스트는 적용 완료. 공통 흐름이 더 쌓이면 재승격.
 - [ ] 기타: tiered force-exit window / RiskGate 실패 주문 cap 정책 / 전략별 min trading value·market cap 하한 / 매도 RiskGate 우회·KillSwitch auto-trigger / volatility hard gate / 성과 저하 자동 해제·수량 축소 / WebSocket health probe 자동화 / 레거시 전략 백테스트 통합 여부.
 


### PR DESCRIPTION
## 요약
P2 2-4 event-driven shadow 구독/저널링 로직(~327줄)을 `StrategyScheduler`에서 `scheduler/event_shadow_manager.py`의 **`EventShadowManager`**로 추출(Extract Class). 동작 불변 순수 리팩토링.

## 변경
- **신규** `scheduler/event_shadow_manager.py`: entry/exit router 구독 갱신, evaluator wrapper, shadow journal record/flush, 카테고리 키 헬퍼, tick-ingest 스냅샷, `teardown_strategy` 이동.
- `StrategyScheduler`는 `_event_shadow_manager` 생성 후 위임. 공유 협력자(`market_clock`, `price_subscription_service`, `_get_strategy_holdings` 콜백)는 주입하고, shadow 전용 상태(`event_router`, journal, entry/exit 구독 set)는 manager가 소유.
- `stop_strategy`의 `remove_category` 호출 순서는 그대로 유지(router unsubscribe → `scheduler_{name}` → `event_shadow_{name}` → `event_shadow_exit_{name}`).
- 테스트 ~44곳 receiver를 `scheduler._event_shadow_manager`로 갱신(기존 테스트가 내부 표면을 직접 잠그고 있어 receiver만 이동).
- `strategy_scheduler.py` 2432 → 2097줄(−335).

## 검증
- 스케줄러/shadow 4개 테스트: **207 passed** (리팩토링 전후 동일).
- 전체 단위 **6505 passed**, 통합 **245 passed**.

## 비고
- `EventShadowManager`로 단일 모듈에 격리되어, todo 2-4 PR-3 판정이 **No-Go(shadow 삭제)** 로 나도 파일 1개 제거로 종결 가능.
- 현재 브랜치의 무관한 'shutdown button' 기능과 분리하기 위해 `main`에서 새로 분기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)