### PR TITLE
P0: 장 마감 강제 청산 단계화 (tiered force-exit)

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -94,7 +94,10 @@ class StrategyScheduler:
 
     LOOP_INTERVAL_SEC = 1           # 메인 루프 깨어나는 주기
     MARKET_CLOSED_SLEEP_SEC = 60    # 장 외 시간 sleep
-    FORCE_EXIT_MINUTES_BEFORE = 30  # 장 마감 N분 전 강제 청산
+    FORCE_EXIT_MINUTES_BEFORE = 30  # 장 마감 N분 전 강제 청산 (= 첫 tier 진입 시점)
+    # tiered force-exit: (마감 N분 전, 누적 청산 비율). 마지막 tier 는 반드시 1.0(전량) 으로
+    # 마감 전 flat 보장. 1주 포지션은 중간 tier 에서 floor 라운딩으로 0주 → 최종 tier 에서 전량.
+    FORCE_EXIT_TIERS = [(30, 0.5), (15, 1.0)]
     # 15:40 설정 기준 15:20(KRX 종가 동시호가 시작) 이후 전략 주문 중단.
     # 의도: 동시호가 구간은 연속체결이 없어 현재가 기반 전략 판단이 무의미하다.
     # check_exits 도 함께 중단된다 — 당일청산 전략은 FORCE_EXIT(마감 30분 전)가
@@ -169,7 +172,7 @@ class StrategyScheduler:
         self._last_run: Dict[str, datetime] = {}
         self._last_execution_time: Optional[datetime] = None  # 전략 간 실행 쿨다운용
         self._last_order_poll_time: Optional[datetime] = None
-        self._force_exit_done: set = set()  # 당일 강제 청산 완료된 전략
+        self._force_exit_progress: Dict[str, float] = {}  # 전략명 → 당일 누적 강제청산 비율(0~1)
         self._force_exit_done_date: Optional[str] = None
         self._order_cutoff_logged = False  # 컷오프 스킵 로그 1회화 (매초 반복 방지)
         self._reconciled_dates: set = set()  # 원장 대사 완료된 날짜 (YYYY-MM-DD)
@@ -295,10 +298,12 @@ class StrategyScheduler:
                     last = self._last_run.get(name)
                     elapsed = (now - last).total_seconds() if last else float('inf')
 
-                    # 강제 청산: 마감 N분 전이면 즉시 실행 (1회만) — kill switch와 무관하게 허용
-                    force_exit = (cfg.force_exit_on_close
-                                  and in_force_exit_window
-                                  and name not in self._force_exit_done)
+                    # 강제 청산: 마감 전 단계별(tier) 청산 — kill switch와 무관하게 허용
+                    force_exit_tier = (
+                        self._pending_force_exit_tier(name, minutes_to_close)
+                        if cfg.force_exit_on_close else None
+                    )
+                    force_exit = force_exit_tier is not None
 
                     # 정규 실행: force_exit_on_close 전략은 마감 전 구간에서 새 매수 금지
                     # kill switch 활성 시 신규 전략 실행 차단
@@ -312,13 +317,14 @@ class StrategyScheduler:
                         overdue = elapsed - (cfg.interval_minutes * 60) if last else float('inf')
                         if force_exit:
                             overdue = float('inf') # 강제 청산은 최우선순위
-                        evaluations.append((overdue, cfg, force_exit))
+                        evaluations.append((overdue, cfg, force_exit_tier))
 
                 # 2. 가장 오래 지연된(overdue가 큰) 전략부터 내림차순 정렬
                 evaluations.sort(key=lambda x: x[0], reverse=True)
 
-                for overdue, cfg, force_exit in evaluations:
+                for overdue, cfg, force_exit_tier in evaluations:
                     name = cfg.strategy.name
+                    force_exit = force_exit_tier is not None
 
                     # 전략 간 API 자원 충돌 방지 (강제 청산은 쿨다운 무시)
                     if not force_exit and self._last_execution_time:
@@ -327,12 +333,18 @@ class StrategyScheduler:
                             continue
 
                     self._last_run[name] = now
+                    sell_fraction = 1.0
                     if force_exit:
-                        self._force_exit_done.add(name)
-                        self._logger.info(f"[Scheduler] {name}: 장 마감 {minutes_to_close:.1f}분 전 — 강제 청산 실행")
-                    
+                        target_cum, sell_fraction = force_exit_tier
+                        self._force_exit_progress[name] = target_cum
+                        self._logger.info(
+                            f"[Scheduler] {name}: 장 마감 {minutes_to_close:.1f}분 전 — "
+                            f"강제 청산 tier 실행 (누적 {target_cum:.0%}, 이번 매도 비율 {sell_fraction:.0%})"
+                        )
+
                     try:
-                        await self._run_strategy(cfg, force_exit_only=force_exit)
+                        await self._run_strategy(cfg, force_exit_only=force_exit,
+                                                 force_exit_fraction=sell_fraction)
                     except Exception as e:
                         self._logger.error(f"[Scheduler] {name} 실행 오류: {e}", exc_info=True)
                     finally:
@@ -357,7 +369,7 @@ class StrategyScheduler:
         today = now.strftime("%Y-%m-%d")
         if self._force_exit_done_date == today:
             return
-        self._force_exit_done.clear()
+        self._force_exit_progress.clear()
         self._force_exit_done_date = today
         self._order_cutoff_logged = False
         # 날짜 키를 포함하는 set 의 과거 항목 purge (장기 구동 시 무한 증가 방지)
@@ -448,14 +460,38 @@ class StrategyScheduler:
 
         return False
 
-    async def _run_strategy(self, cfg: StrategySchedulerConfig, force_exit_only: bool = False):
+    def _pending_force_exit_tier(self, name: str, minutes_to_close: float):
+        """현재 마감 잔여시간 기준 발화할 force-exit tier 반환.
+
+        반환: (target_cumulative_fraction, sell_fraction_of_current_holdings) 또는 None.
+        - 이미 누적 1.0(전량) 청산 완료면 None.
+        - 발화 가능한 tier 중 가장 큰 누적 목표 선택(놓친 tier 자동 catch-up).
+        - sell_fraction 은 현재 보유 대비 비율 (target-progress)/(1-progress), 최종 tier 는 1.0.
+        """
+        progress = self._force_exit_progress.get(name, 0.0)
+        if progress >= 1.0 - 1e-9:
+            return None
+        target = None
+        for minutes_before, cumulative in self.FORCE_EXIT_TIERS:
+            if minutes_to_close <= minutes_before and cumulative > progress + 1e-9:
+                target = cumulative if target is None else max(target, cumulative)
+        if target is None:
+            return None
+        if target >= 1.0 - 1e-9:
+            sell_fraction = 1.0
+        else:
+            sell_fraction = (target - progress) / (1.0 - progress)
+        return target, sell_fraction
+
+    async def _run_strategy(self, cfg: StrategySchedulerConfig, force_exit_only: bool = False,
+                            force_exit_fraction: float = 1.0):
         name = cfg.strategy.name
         t_run = self._pm.start_timer()
         self._logger.info(f"[Scheduler] {name} 실행 시작 (force_exit_only={force_exit_only})")
 
-        # 강제 청산 모드: 전략의 check_exits 로직 무시, 보유 종목 전량 시장가 매도
+        # 강제 청산 모드: 전략의 check_exits 로직 무시, 보유 종목(비율) 시장가 매도
         if force_exit_only:
-            await self._force_liquidate_strategy(cfg)
+            await self._force_liquidate_strategy(cfg, sell_fraction=force_exit_fraction)
             self._pm.log_timer(f"{name}.run_strategy(force_exit)", t_run)
             return
 
@@ -1204,8 +1240,12 @@ class StrategyScheduler:
                 )
             return
 
-    async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig):
-        """전략 중지 시 보유 종목 강제 청산 (force_exit_on_close=True)."""
+    async def _force_liquidate_strategy(self, cfg: StrategySchedulerConfig, sell_fraction: float = 1.0):
+        """전략 중지/마감 강제 청산 (force_exit_on_close=True).
+
+        sell_fraction<1.0 이면 보유별 floor(qty*fraction) 만 매도(tiered force-exit 중간 단계).
+        sell_fraction>=1.0(기본) 이면 보유 전량 매도.
+        """
         name = cfg.strategy.name
         holdings = await self._get_force_liquidation_holdings(cfg)
         if not holdings:
@@ -1223,6 +1263,13 @@ class StrategyScheduler:
             holding_qty = int(hold.get("qty") or 0)
             if holding_qty <= 0:
                 holding_qty = cfg.order_qty
+
+            if sell_fraction >= 1.0:
+                sell_qty = holding_qty
+            else:
+                sell_qty = int(holding_qty * sell_fraction)
+            if sell_qty <= 0:
+                continue
 
             # 최우선매수호가(bidp1) 조회 → 지정가 청산, 실패 시 시장가 fallback
             sell_price = 0
@@ -1243,7 +1290,7 @@ class StrategyScheduler:
                 name=stock_name,
                 action="SELL",
                 price=sell_price,
-                qty=holding_qty,
+                qty=sell_qty,
                 reason=reason,
             )
             await self._execute_signal(signal)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1131,8 +1131,8 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         with patch.object(scheduler, '_force_liquidate_strategy', new_callable=AsyncMock) as mock_liq:
             await scheduler._run_strategy(config, force_exit_only=True)
 
-            # _force_liquidate_strategy가 호출되어야 함
-            mock_liq.assert_awaited_once_with(config)
+            # _force_liquidate_strategy가 호출되어야 함 (기본 force_exit_fraction=1.0 → 전량)
+            mock_liq.assert_awaited_once_with(config, sell_fraction=1.0)
 
     async def test_run_strategy_force_exit_sells_all_holdings(self):
         """force_exit_only=True 시 check_exits와 무관하게 보유 종목 전량이 시장가 매도되는지 테스트.
@@ -1738,10 +1738,10 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
                     pass
 
             # 전략 A는 강제 청산 모드(True)로 실행되어야 함
-            mock_run.assert_any_call(config_a, force_exit_only=True)
+            mock_run.assert_any_call(config_a, force_exit_only=True, force_exit_fraction=0.5)
 
             # 전략 B는 일반 모드(False)로 실행되어야 함 (쿨다운 이후 두 번째 루프에서 실행)
-            mock_run.assert_any_call(config_b, force_exit_only=False)
+            mock_run.assert_any_call(config_b, force_exit_only=False, force_exit_fraction=1.0)
 
     async def test_loop_skips_strategy_after_order_cutoff(self):
         """주문 컷오프 이후에는 일반 실행과 강제청산 모두 시그널을 만들지 않는다."""
@@ -1863,6 +1863,97 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         # 에러 로그가 호출되었는지 확인
         scheduler._logger.error.assert_called()
     
+    def test_pending_force_exit_tier_progression(self):
+        """tiered force-exit: 마감 잔여시간/진행률에 따른 tier 선택과 catch-up 동작."""
+        scheduler, _, _, _, _ = self._make_scheduler()
+        scheduler._force_exit_progress = {}
+
+        # 윈도우 밖(T-40): 발화 tier 없음
+        assert scheduler._pending_force_exit_tier("S", 40) is None
+
+        # T-25: 1단계(30분,0.5)만 발화 → 현재 보유의 50% 매도
+        assert scheduler._pending_force_exit_tier("S", 25) == (0.5, 0.5)
+
+        # 진행률 0.5 기록 후 T-25 재호출: 동일 tier 재발화 안 함
+        scheduler._force_exit_progress["S"] = 0.5
+        assert scheduler._pending_force_exit_tier("S", 25) is None
+
+        # T-10: 2단계(15분,1.0) 발화 → 잔여 전량(fraction=1.0)
+        target, fraction = scheduler._pending_force_exit_tier("S", 10)
+        assert target == 1.0 and abs(fraction - 1.0) < 1e-9
+
+        # 진행률 1.0(전량 완료) 후: 더 이상 발화 없음
+        scheduler._force_exit_progress["S"] = 1.0
+        assert scheduler._pending_force_exit_tier("S", 10) is None
+
+        # 1단계를 놓치고 T-10에 처음 진입: 곧장 누적 1.0 전량으로 catch-up
+        assert scheduler._pending_force_exit_tier("LATE", 10) == (1.0, 1.0)
+
+    async def test_force_liquidate_partial_fraction_sells_floor(self):
+        """sell_fraction<1.0 시 floor(qty*fraction) 수량만 매도한다."""
+        scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
+        scheduler._sqs.get_current_price = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {"stck_prpr": "60000"}}
+            )
+        )
+        config = StrategySchedulerConfig(
+            strategy=MockStrategy(name="T"), force_exit_on_close=True, order_qty=10
+        )
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "name": "S", "buy_price": 50000, "qty": 10}
+        ]
+
+        await scheduler._force_liquidate_strategy(config, sell_fraction=0.5)
+
+        oes.handle_place_sell_order.assert_called_once_with(
+            "005930", 0, 5, exchange=Exchange.KRX,
+            source="strategy_force_exit:T", finalize_immediately=False,
+            trace_id=ANY, strategy_notification=ANY,
+        )
+
+    async def test_force_liquidate_full_fraction_sells_all(self):
+        """sell_fraction>=1.0(기본) 시 보유 전량 매도(기존 동작 유지)."""
+        scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
+        scheduler._sqs.get_current_price = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {"stck_prpr": "60000"}}
+            )
+        )
+        config = StrategySchedulerConfig(
+            strategy=MockStrategy(name="T"), force_exit_on_close=True, order_qty=10
+        )
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "name": "S", "buy_price": 50000, "qty": 10}
+        ]
+
+        await scheduler._force_liquidate_strategy(config, sell_fraction=1.0)
+
+        oes.handle_place_sell_order.assert_called_once_with(
+            "005930", 0, 10, exchange=Exchange.KRX,
+            source="strategy_force_exit:T", finalize_immediately=False,
+            trace_id=ANY, strategy_notification=ANY,
+        )
+
+    async def test_force_liquidate_one_share_intermediate_tier_no_order(self):
+        """1주 포지션 + 중간 tier(0.5): floor(0.5)=0 → 매도 주문 미발생(전량은 최종 tier에서)."""
+        scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
+        scheduler._sqs.get_current_price = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {"stck_prpr": "60000"}}
+            )
+        )
+        config = StrategySchedulerConfig(
+            strategy=MockStrategy(name="T"), force_exit_on_close=True, order_qty=1
+        )
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "005930", "name": "S", "buy_price": 50000, "qty": 1}
+        ]
+
+        await scheduler._force_liquidate_strategy(config, sell_fraction=0.5)
+
+        oes.handle_place_sell_order.assert_not_called()
+
     async def test_force_liquidate_strategy_execution(self):
         """강제 청산 실행 시: 현재가 조회 후 시장가 매도 주문 및 로깅 확인."""
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
@@ -3064,7 +3155,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         config = StrategySchedulerConfig(strategy=strategy, force_exit_on_close=True, enabled=True)
         scheduler.register(config)
         
-        scheduler._force_exit_done = set() 
+        scheduler._force_exit_progress = {} 
         scheduler._running = True
         
         with patch.object(scheduler, '_run_strategy', side_effect=Exception("Liquidate Error")) as mock_run:
@@ -3422,7 +3513,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
     async def test_loop_continues_after_market_closed_wait_returns(self):
         scheduler, _, _, _, mcs = self._make_scheduler()
         scheduler._running = True
-        scheduler._force_exit_done = set()
+        scheduler._force_exit_progress = {}
         mcs.is_market_open_now.return_value = False
         mcs.wait_until_next_open = AsyncMock(
             side_effect=[None, asyncio.CancelledError()]

--- a/tests/unit_test/scheduler/test_strategy_scheduler_audit_fixes.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_audit_fixes.py
@@ -267,13 +267,13 @@ def test_date_rollover_purges_stale_date_keys():
     scheduler._strategy_failure_alert_keys = {old_key, today_key}
     scheduler._reconciled_dates = {"2026-06-11", "2026-06-12"}
     scheduler._force_exit_done_date = "2026-06-11"
-    scheduler._force_exit_done = {"전략"}
+    scheduler._force_exit_progress = {"전략": 1.0}
 
     scheduler._sync_force_exit_done_date(datetime(2026, 6, 12, 9, 0, 0))
 
     assert scheduler._strategy_failure_alert_keys == {today_key}
     assert scheduler._reconciled_dates == {"2026-06-12"}
-    assert scheduler._force_exit_done == set()
+    assert scheduler._force_exit_progress == {}
 
 
 # ── S-9. 시그널 이력 복원 시 trace_id 유지 (S-5 잔여) ──

--- a/tests/unit_test/scheduler/test_strategy_scheduler_time_window.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_time_window.py
@@ -159,5 +159,5 @@ class TestTimeWindowGate(unittest.IsolatedAsyncioTestCase):
             force_exit_on_close=True,
         )
         await scheduler._run_strategy(cfg, force_exit_only=True)
-        scheduler._force_liquidate_strategy.assert_awaited_once_with(cfg)
+        scheduler._force_liquidate_strategy.assert_awaited_once_with(cfg, sell_fraction=1.0)
         strategy._scan_mock.assert_not_called()  # force_exit 경로는 어차피 scan 안 함

--- a/todo_list.md
+++ b/todo_list.md
@@ -138,7 +138,8 @@
 
 - [x] **S-9 god class 분리** — `EventShadowManager`(`scheduler/event_shadow_manager.py`)로 shadow 블록 ~327줄 추출 완료(2026-06-28). scheduler 2432→2097줄. entry/exit 구독·evaluator·journal record/flush·teardown 이동, 테스트 ~44곳 receiver를 `_event_shadow_manager`로 갱신(동작 불변, unit 6505 + integration 245 green). 분리로 2-4 PR-3 No-Go(삭제) 시에도 단일 파일 제거로 종결 가능.
 - [ ] **3-4 active strategy lifecycle 7단계 분해**(`get_watchlist`/`filter_candidates`/`evaluate_entries_bounded`/`evaluate_exits_bounded`/`emit_metrics`) — 현재 `scan`/`check_exits`에 묻혀 있어 대형 리팩토링. checklist 테스트는 적용 완료. 공통 흐름이 더 쌓이면 재승격.
-- [ ] 기타: tiered force-exit window / RiskGate 실패 주문 cap 정책 / 전략별 min trading value·market cap 하한 / 매도 RiskGate 우회·KillSwitch auto-trigger / volatility hard gate / 성과 저하 자동 해제·수량 축소 / WebSocket health probe 자동화 / 레거시 전략 백테스트 통합 여부.
+- [x] **tiered force-exit window** — 단일 T-30 전량 청산을 단계화(2026-06-28). 기본 `FORCE_EXIT_TIERS=[(30,0.5),(15,1.0)]`(마지막 tier 1.0 = 마감 전 flat 보장 유지), `_force_exit_done` set→`_force_exit_progress` dict, `_pending_force_exit_tier`(놓친 tier catch-up), `_force_liquidate_strategy(sell_fraction)` floor 라운딩(초과 매도 없음). 1주 포지션은 중간 tier 0주→최종 tier 전량. unit 6509 + integration 245 green.
+- [ ] 기타: RiskGate 실패 주문 cap 정책 / 전략별 min trading value·market cap 하한 / 매도 RiskGate 우회·KillSwitch auto-trigger / volatility hard gate / 성과 저하 자동 해제·수량 축소 / WebSocket health probe 자동화 / 레거시 전략 백테스트 통합 여부. (※ KillSwitch auto-trigger·WS health probe·daily cap 등 상당수는 이미 구현됨 — 잔여는 정책/임계 결정 동반.)
 
 주요 파일: `interfaces/live_strategy.py`, `tests/unit_test/strategies/test_live_strategy_lifecycle_contract.py`
 


### PR DESCRIPTION
## 요약
장 마감 강제 청산을 **단일 T-30 전량 → 단계별(tier) 청산**으로 변경. 마감 직전 일괄 덤핑의 시장충격을 완화하되, **마지막 tier(1.0)에서 잔여 전량 청산 → 마감 전 flat 보장은 유지**.

## 동작
- 기본 `FORCE_EXIT_TIERS = [(30, 0.5), (15, 1.0)]` — T-30에 50%, T-15에 잔여 전량.
- 상태: `_force_exit_done`(set) → `_force_exit_progress`(dict, 전략→당일 누적 청산비율).
- `_pending_force_exit_tier(name, minutes_to_close)` — 잔여시간/진행률 기준 발화 tier 선택. 놓친 tier는 자동 catch-up(늦게 진입 시 곧장 누적 1.0).
- `_force_liquidate_strategy(cfg, sell_fraction)` — 보유별 `floor(qty*fraction)` 매도. **floor 라운딩이라 초과 매도 없음**, 최종 tier(1.0)는 전량.

## 안전
- 안전 불변식 유지: 마지막 tier 1.0 → 마감 전 전량 청산 보장.
- `stop_strategy`/직접 청산 경로는 기본 `sell_fraction=1.0`(전량) → 기존 동작 불변.
- **1주 포지션 한계**: 중간 tier에서 `floor(0.5)=0`주 → 최종 tier에서 전량. 티어링은 다주 포지션에서만 실효(안전엔 영향 없음).

## 검증
- 신규 단위 테스트 4건: tier 진행/catch-up, 부분(floor) 청산, 전량 청산, 1주 중간 tier 무주문.
- 기존 force-exit 테스트 호출 인자 갱신(`force_exit_fraction`/`sell_fraction`).
- 스케줄러 **371 passed**, 전체 unit **6509**, integration **245** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)