### PR TITLE
한국장/미국장 장마감 배치 task 동시 스케줄링: TimeDispatcher 시장별 다중화

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -22,3 +22,5 @@ after_market_tasks:
     minervini_update: 21        # MinerviniUpdateTask — 장 마감 21분 후
     전일기준주도주_생성: 50        # PremiumWatchlistGeneratorTask — 장 마감 50분 후
     log_cleanup: 300              # LogCleanupTask — 장 마감 300분(5시간) 후
+    # 미국장 배치(time_dispatcher_us 가 NY 16:00 마감 감지 후 적용) — 16:30 ET 효과 트리거
+    overseas_vbo_dryrun: 30      # OverseasDryRunTask — 미국장 마감 30분 후

--- a/scheduler/background_scheduler.py
+++ b/scheduler/background_scheduler.py
@@ -29,12 +29,17 @@ class BackgroundScheduler:
         performance_profiler: Optional[PerformanceProfiler] = None,
         worker_pool=None,
         time_dispatcher=None,
+        time_dispatchers=None,
     ):
         self._logger = logger or logging.getLogger(__name__)
         self._pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._tasks: Dict[str, SchedulableTask] = {}  # name -> task
         self._worker_pool = worker_pool
-        self._time_dispatcher = time_dispatcher
+        # 시장별 TimeDispatcher 복수 지원: 단수 time_dispatcher 와 복수 time_dispatchers 를
+        # 함께 받아 하나의 리스트로 정규화한다 (KR + US 동시 구동).
+        self._time_dispatchers = list(time_dispatchers or [])
+        if time_dispatcher is not None:
+            self._time_dispatchers.insert(0, time_dispatcher)
         self._infra_tasks: List[asyncio.Task] = []  # WorkerPool/Dispatcher asyncio.Task 목록
         self._start_lock: Optional[asyncio.Lock] = None
         self._shutdown_lock: Optional[asyncio.Lock] = None
@@ -97,10 +102,13 @@ class BackgroundScheduler:
         if self._worker_pool is not None:
             await self._worker_pool.start()
             self._logger.info("[BackgroundScheduler] WorkerPool 시작 완료")
-        if self._time_dispatcher is not None:
-            t = asyncio.create_task(self._time_dispatcher.run(), name="time-dispatcher")
+        for idx, dispatcher in enumerate(self._time_dispatchers):
+            t = asyncio.create_task(dispatcher.run(), name=f"time-dispatcher-{idx}")
             self._infra_tasks.append(t)
-            self._logger.info("[BackgroundScheduler] TimeDispatcher 시작 완료")
+        if self._time_dispatchers:
+            self._logger.info(
+                f"[BackgroundScheduler] TimeDispatcher {len(self._time_dispatchers)}개 시작 완료"
+            )
 
         for name, task in self._tasks.items():
             if task.state == TaskState.SUSPENDED:
@@ -143,8 +151,8 @@ class BackgroundScheduler:
         self._logger.info(f"[BackgroundScheduler] 전체 종료: {len(self._tasks)}개 태스크")
 
         # 1. TimeDispatcher 중지 (새 티켓 발행 차단)
-        if self._time_dispatcher is not None:
-            self._time_dispatcher.stop()
+        for dispatcher in self._time_dispatchers:
+            dispatcher.stop()
         for t in self._infra_tasks:
             if not t.done():
                 t.cancel()

--- a/scheduler/dispatcher/time_dispatcher.py
+++ b/scheduler/dispatcher/time_dispatcher.py
@@ -37,7 +37,7 @@ class TimeDispatcher:
         self,
         broker: MessageBroker,
         market_clock: "MarketClock",
-        mcs: "MarketCalendarService",
+        mcs: Optional["MarketCalendarService"],
         logger: Optional[logging.Logger] = None,
         db_path: Optional[str] = None,
     ) -> None:
@@ -137,7 +137,13 @@ class TimeDispatcher:
         if not self._is_after_market_close():
             return
 
-        latest_trading_date = await self._mcs.get_latest_trading_date()
+        if self._mcs is not None:
+            latest_trading_date = await self._mcs.get_latest_trading_date()
+        else:
+            # 거래 캘린더 미주입(해외장 등): clock 날짜를 거래일 식별자로 사용한다.
+            # 주말 발행 차단은 _is_after_market_close()의 weekday 필터가 담당하며,
+            # 공휴일은 미반영(현행 AfterMarketLoop mcs=None 동작과 동일한 한계).
+            latest_trading_date = self._market_clock.get_current_kst_date_str()
         if not latest_trading_date:
             return
 

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -4,10 +4,13 @@
 OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 after-market 스케줄러에
 얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
 
-트리거는 미국 정규장 마감(America/New_York 16:00) 직후 16:30 ET 로 맞춘다
-(AfterMarketLoop 의 timezone/cron 훅 오버라이드). 한국 거래 캘린더(mcs)는 미국장에
-적용되지 않으므로 미주입(None)하며, cron 의 mon-fri(NY) 필터 + 클럭 날짜로 거래일을
-식별한다. 미국 공휴일에는 직전 완성봉을 재평가할 수 있으나 dry-run 이라 무해하다.
+트리거는 미국장 전용 TimeDispatcher(time_dispatcher_us)가 담당한다 — NY 정규장
+마감(16:00 ET) 감지 후 task delay(30분)만큼 대기해 16:30 ET 효과로 티켓을 발행하면
+WorkerPool 이 execute() 를 호출한다(Ticket-driven, worker_pool 주입). 한국 거래
+캘린더(mcs)는 미국장에 적용되지 않으므로 dispatcher 에 미주입(None)하며, NY 주말
+필터 + 클럭 날짜로 거래일을 식별한다. 미국 공휴일에는 직전 완성봉을 재평가할 수
+있으나 dry-run 이라 무해하다. (_loop_* 프로퍼티는 시스템 상태 화면의 트리거 표기용
+메타데이터로 유지된다.)
 
 **주문 경로 없음** — OverseasVBODryRunService 가 order_execution 의존을 갖지 않아
 실주문이 발생하지 않는다.
@@ -61,7 +64,9 @@ class OverseasDryRunTask(AfterMarketTask):
     def _scheduler_label(self) -> str:
         return "OverseasVBODryRun"
 
-    # ── 미국 정규장 마감(16:00 ET) 직후 16:30 ET 트리거 ──
+    # ── 트리거 표기용 메타데이터 (16:30 ET) ──
+    # Ticket-driven 모드(worker_pool 주입)에서는 스케줄링에 사용되지 않으며,
+    # 시스템 상태 화면(/api/background/status)의 trigger 표기에만 쓰인다.
     @property
     def _loop_timezone(self) -> str:
         return "America/New_York"

--- a/tests/unit_test/scheduler/test_background_scheduler.py
+++ b/tests/unit_test/scheduler/test_background_scheduler.py
@@ -220,6 +220,37 @@ async def test_shutdown_with_worker_pool_and_time_dispatcher():
 
 
 @pytest.mark.asyncio
+async def test_start_and_shutdown_with_multiple_time_dispatchers():
+    """time_dispatchers(복수) 주입 시 각 dispatcher가 run/stop 된다 (KR + US 동시)."""
+    mock_worker_pool = MagicMock()
+    mock_worker_pool.start = AsyncMock()
+    mock_worker_pool.shutdown = AsyncMock()
+
+    td_kr = MagicMock()
+    td_kr.run = AsyncMock(return_value=None)
+    td_kr.stop = MagicMock()
+    td_us = MagicMock()
+    td_us.run = AsyncMock(return_value=None)
+    td_us.stop = MagicMock()
+
+    scheduler = BackgroundScheduler(
+        logger=MagicMock(),
+        worker_pool=mock_worker_pool,
+        time_dispatchers=[td_kr, td_us],
+    )
+    task = _make_mock_task("t1", TaskState.IDLE)
+    scheduler.register(task)
+
+    await scheduler.start_all()
+    assert len(scheduler._infra_tasks) == 2
+
+    await scheduler.shutdown()
+    td_kr.stop.assert_called_once()
+    td_us.stop.assert_called_once()
+    assert scheduler._infra_tasks == []
+
+
+@pytest.mark.asyncio
 async def test_suspend_all_with_worker_pool():
     """suspend_all 시 worker_pool.suspend()도 호출된다."""
     mock_worker_pool = MagicMock()

--- a/tests/unit_test/scheduler/test_time_dispatcher.py
+++ b/tests/unit_test/scheduler/test_time_dispatcher.py
@@ -12,15 +12,17 @@ def db_path(tmp_path):
     return str(tmp_path / "dispatcher_state.db")
 
 
-def _make_clock(*, is_operating: bool, is_after_close: bool, weekday: int = 1):
+def _make_clock(*, is_operating: bool, is_after_close: bool, weekday: int = 1, date_str: str = "20250417"):
     """MarketClock mock 생성.
 
     is_after_close=True  → 장 마감 후 (정상 발행 시간)
     is_after_close=False → 장 전 오전 (발행 차단)
     weekday: 0=월 ~ 4=금, 5=토, 6=일
+    date_str: get_current_kst_date_str() 반환값 (mcs=None fallback 거래일 식별자)
     """
     clock = MagicMock()
     clock.is_market_operating_hours.return_value = is_operating
+    clock.get_current_kst_date_str.return_value = date_str
 
     now_mock = MagicMock(spec=datetime)
     now_mock.weekday.return_value = weekday
@@ -345,6 +347,80 @@ def test_get_status_handles_market_clock_exception(db_path):
             "last_dispatched_date": "20250416",
         }
     ]
+
+
+# ── mcs=None (해외장 등 거래 캘린더 미주입) TC ──────────────────────────────
+
+def _make_dispatcher_no_mcs(
+    is_operating: bool,
+    db_path: str,
+    *,
+    is_after_close: bool = True,
+    weekday: int = 1,
+    date_str: str = "20250417",
+):
+    """mcs=None 인 dispatcher (미국장 등). 거래일 식별자는 clock 날짜로 대체된다."""
+    broker = MessageBroker()
+    market_clock = _make_clock(
+        is_operating=is_operating, is_after_close=is_after_close,
+        weekday=weekday, date_str=date_str,
+    )
+    dispatcher = TimeDispatcher(
+        broker=broker, market_clock=market_clock, mcs=None, db_path=db_path
+    )
+    return dispatcher, broker
+
+
+async def test_no_mcs_publishes_after_close_using_clock_date(db_path):
+    """mcs=None이면 clock 날짜를 거래일 식별자로 사용해 마감 후 발행한다."""
+    dispatcher, broker = _make_dispatcher_no_mcs(
+        is_operating=False, db_path=db_path, date_str="20250417"
+    )
+    dispatcher.register_task("OVERSEAS_DRYRUN", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
+    assert broker.qsize == 1
+    ticket = await broker.consume()
+    broker.task_done()
+    assert ticket.task_name == "OVERSEAS_DRYRUN"
+    assert ticket.payload["date"] == "20250417"
+
+
+async def test_no_mcs_no_ticket_during_market_hours(db_path):
+    """mcs=None이어도 장중에는 발행하지 않는다."""
+    dispatcher, broker = _make_dispatcher_no_mcs(is_operating=True, db_path=db_path)
+    dispatcher.register_task("OVERSEAS_DRYRUN", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    assert broker.empty is True
+
+
+async def test_no_mcs_no_ticket_before_close(db_path):
+    """mcs=None이어도 평일 장 마감 전에는 발행하지 않는다."""
+    dispatcher, broker = _make_dispatcher_no_mcs(
+        is_operating=False, db_path=db_path, is_after_close=False, weekday=1
+    )
+    dispatcher.register_task("OVERSEAS_DRYRUN", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    assert broker.empty is True
+
+
+async def test_no_mcs_no_duplicate_same_date(db_path):
+    """mcs=None이어도 같은 clock 날짜에는 중복 발행하지 않는다."""
+    dispatcher, broker = _make_dispatcher_no_mcs(
+        is_operating=False, db_path=db_path, date_str="20250417"
+    )
+    dispatcher.register_task("OVERSEAS_DRYRUN", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
+    assert broker.qsize == 1
 
 
 async def test_stop_cancels_pending_publish_tasks(db_path):

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -118,12 +118,18 @@ def test_web_only_registers_notification_and_watchdog(patched_scheduler_deps):
 def test_overseas_us_registers_dryrun_task(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.WEB)
     ctx.market_mode = "overseas_us"
+    ctx.time_dispatcher_us = MagicMock()
     task = MagicMock()
     task.task_name = "overseas_vbo_dryrun"
     ctx.overseas_dryrun_task = task
     _run(ctx)
     names = _registered_bg_task_names(patched_scheduler_deps)
     assert "overseas_vbo_dryrun" in names
+    # 미국장 dispatcher 에 priority 와 함께 등록되고 KST dispatcher 에는 등록되지 않는다.
+    us_dispatched = [c.args[0] for c in ctx.time_dispatcher_us.register_task.call_args_list]
+    kst_dispatched = [c.args[0] for c in ctx.time_dispatcher.register_task.call_args_list]
+    assert "overseas_vbo_dryrun" in us_dispatched
+    assert "overseas_vbo_dryrun" not in kst_dispatched
 
 
 def test_domestic_mode_does_not_register_overseas_task(patched_scheduler_deps):
@@ -139,14 +145,18 @@ def test_domestic_active_with_overseas_enabled_registers_dryrun_task(patched_sch
     ctx = _make_fake_context(RuntimeMode.WEB)
     ctx.market_mode = "domestic"
     ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.time_dispatcher_us = MagicMock()
     ctx.overseas_dryrun_task = MagicMock(task_name="overseas_vbo_dryrun")
     _run(ctx)
     names = _registered_bg_task_names(patched_scheduler_deps)
     assert "overseas_vbo_dryrun" in names
+    # 공존 모드에서도 dry-run 은 KST dispatcher 가 아닌 US dispatcher 에만 등록된다.
     dispatched_names = [
         call.args[0] for call in ctx.time_dispatcher.register_task.call_args_list
     ]
     assert "overseas_vbo_dryrun" not in dispatched_names
+    us_dispatched = [c.args[0] for c in ctx.time_dispatcher_us.register_task.call_args_list]
+    assert "overseas_vbo_dryrun" in us_dispatched
 
 
 def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -388,9 +388,18 @@ def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service
     assert task_kwargs["market_calendar_service"] is None
     # 미국 정규장 클럭 주입 (America/New_York)
     assert task_kwargs["market_clock"].timezone_name == "America/New_York"
-    # KST TimeDispatcher/WorkerPool 티켓 경로에 묶이면 미국장 16:30 ET 트리거가 무시된다.
-    assert task_kwargs["worker_pool"] is None
+    # Ticket-driven 전환: 미국장 TimeDispatcher(time_dispatcher_us)가 NY 마감 후
+    # delay 만큼 대기 뒤 티켓을 발행 → WorkerPool 이 execute() 를 호출한다.
+    assert task_kwargs["worker_pool"] is ctx.worker_pool
     assert task_kwargs["notification_service"] is ctx.notification_service
+    # 미국장 전용 TimeDispatcher 가 mcs=None + 미국장 클럭으로 생성된다.
+    assert ctx.time_dispatcher_us is not None
+    td_us_calls = [
+        c for c in patched_service_container_deps["TimeDispatcher"].call_args_list
+        if c.kwargs.get("mcs") is None
+    ]
+    assert len(td_us_calls) == 1
+    assert td_us_calls[0].kwargs["market_clock"].timezone_name == "America/New_York"
 
 
 def test_domestic_active_with_overseas_enabled_builds_dryrun_task(patched_service_container_deps):

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -61,11 +61,16 @@ class SchedulerBootstrap:
 
     def _create_background_scheduler(self) -> None:
         ctx = self._ctx
+        # 시장별 TimeDispatcher(KST + US)를 모두 BackgroundScheduler에 넘겨 동시 구동한다.
+        dispatchers = [
+            d for d in (ctx.time_dispatcher, getattr(ctx, "time_dispatcher_us", None))
+            if d is not None
+        ]
         ctx.background_scheduler = BackgroundScheduler(
             logger=ctx.logger,
             performance_profiler=ctx.pm,
             worker_pool=ctx.worker_pool,
-            time_dispatcher=ctx.time_dispatcher,
+            time_dispatchers=dispatchers,
         )
 
     def _create_foreground_scheduler(self) -> None:
@@ -76,14 +81,20 @@ class SchedulerBootstrap:
             performance_profiler=ctx.pm,
         )
 
-    def _register(self, task, priority: TaskPriority | None = None) -> None:
+    def _register(
+        self, task, priority: TaskPriority | None = None, market: str = "domestic"
+    ) -> None:
         if not task:
             return
         ctx = self._ctx
         if priority is not None:
-            ctx.time_dispatcher.register_task(
-                task.task_name, priority, delay_sec=self._delays.get(task.task_name, 0)
-            )
+            dispatcher = ctx.time_dispatcher
+            if market == "overseas_us":
+                dispatcher = getattr(ctx, "time_dispatcher_us", None)
+            if dispatcher is not None:
+                dispatcher.register_task(
+                    task.task_name, priority, delay_sec=self._delays.get(task.task_name, 0)
+                )
         ctx.background_scheduler.register(task)
 
     def _optional_task(self, attr_name: str):
@@ -120,8 +131,13 @@ class SchedulerBootstrap:
 
     def _register_overseas_tasks(self) -> None:
         # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
-        # 미국장 16:30 ET cron 을 자체 AfterMarketLoop 로 사용하므로 KST TimeDispatcher 에 등록하지 않는다.
-        self._register(self._optional_task("overseas_dryrun_task"))
+        # 미국장 TimeDispatcher(time_dispatcher_us)에 등록 → NY 마감 후 delay 만큼 대기 뒤
+        # 티켓 발행(task_config 의 overseas_vbo_dryrun delay 로 16:30 ET 효과 트리거).
+        self._register(
+            self._optional_task("overseas_dryrun_task"),
+            TaskPriority.LOW,
+            market="overseas_us",
+        )
 
     def _register_websocket_watchdog(self) -> None:
         # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -253,6 +253,18 @@ class ServiceContainer:
                 mcs=ctx._mcs,
                 logger=ctx.logger,
             )
+            # 미국장 배치(해외 dry-run 등)를 위한 별도 TimeDispatcher. KST dispatcher와
+            # 동일한 MessageBroker/WorkerPool 을 공유하며, 미국장 클럭으로 NY 마감을 감지한다.
+            # 거래 캘린더(mcs)는 미주입 → clock 날짜를 거래일 식별자로 사용(주말 필터만 적용).
+            ctx.time_dispatcher_us = None
+            if is_market_enabled(ctx, "overseas_us"):
+                ctx.time_dispatcher_us = TimeDispatcher(
+                    broker=ctx.message_broker,
+                    market_clock=MarketClock.for_us_equities(logger=ctx.logger),
+                    mcs=None,
+                    logger=ctx.logger,
+                    db_path="data/time_dispatcher_state_us.db",
+                )
             ctx.data_quality_service = DataQualityService(
                 config=getattr(ctx.full_config, "data_quality", None) or DataQualityConfig(),
                 market_clock=ctx.market_clock,
@@ -858,5 +870,7 @@ class ServiceContainer:
             market_clock=MarketClock.for_us_equities(logger=ctx.logger),
             logger=ctx.logger,
             notification_service=ctx.notification_service,
-            worker_pool=None,
+            # Ticket-driven: 미국장 TimeDispatcher(time_dispatcher_us)가 NY 마감 후
+            # 티켓을 발행하면 WorkerPool 이 execute() 를 호출한다(자체 AfterMarketLoop 미사용).
+            worker_pool=ctx.worker_pool,
         )


### PR DESCRIPTION
## 배경

장마감 배치 task가 두 메커니즘으로 갈라져 있었다. 국내(KST) 배치는 `TimeDispatcher`(단일) → `MessageBroker` → `WorkerPool` ticket 경로(priority/retry/SQLite dedup/ForegroundScheduler 연동)를 쓰는 반면, 미국 배치(해외 VBO dry-run)는 이를 우회해 자체 `AfterMarketLoop`(APScheduler NY cron)를 띄워 WorkerPool 의 retry/priority/rate-limit 협조를 받지 못하는 2등 시민이었다. 원인은 `TimeDispatcher`가 단일 KST `MarketClock` + 한국 전용 `MarketCalendarService`에 하드와이어된 것.

## 변경

미국 배치 task가 국내와 **동일한 ticket 인프라**(공유 broker/worker_pool)를 통해 자기 시장(NY) 마감 시각에 스케줄되도록 `TimeDispatcher`를 시장별로 다중화했다.

- **TimeDispatcher.mcs 옵셔널화** — `mcs=None`이면 clock 날짜를 거래일 식별자로 사용(NY 주말 필터 적용, 공휴일 미반영 = 기존 AfterMarketLoop `mcs=None`과 동일 한계)
- **BackgroundScheduler** — `time_dispatchers`(복수) 지원으로 KR/US dispatcher 동시 구동. 기존 `time_dispatcher` 단수 인자는 하위호환 유지
- **service_container** — `overseas_us` enabled 시 미국장 클럭 기반 `time_dispatcher_us` 생성(동일 broker/worker_pool 공유, `db_path` 분리). `overseas_dryrun_task`에 `worker_pool` 주입 → ticket-driven 전환
- **scheduler_bootstrap** — `_register(market=...)` 라우팅으로 dry-run을 US dispatcher에 등록
- **task_config** — `overseas_vbo_dryrun` delay 30분(NY 16:00 마감 + 30분 = 16:30 ET 효과 트리거, 기존 cron 타이밍 보존)
- `overseas_dryrun_task._loop_*`는 시스템 상태화면 트리거 표기용 메타데이터로 유지

## 범위 제외 (별도 과제)

- 실시간 라이브 매매 루프(`StrategyScheduler`)의 KR/US 동시 라이브 (대규모, US 주문경로 미구현)
- 미국 거래 공휴일 캘린더
- `market_cap_gap_us` 전환 — `overseas_us` 모드에 묶이지 않아(도메스틱 배치에서도 동작) dispatcher 수명주기 분리가 선행 필요

## 검증

- 단위 6524개 / 통합 245개 전부 통과
- 신규 TDD: `mcs=None` US 마감 발행·장중/주말 미발행·dedup, BackgroundScheduler 복수 dispatcher 수명주기, bootstrap US 라우팅, service_container US dispatcher 생성 + worker_pool 주입

🤖 Generated with [Claude Code](https://claude.com/claude-code)
