### PR TITLE
해외주식 미국 주문 정규장(모의) 전환 + 미체결 취소(API+UI)

### DIFF
--- a/common/overseas_types.py
+++ b/common/overseas_types.py
@@ -42,6 +42,18 @@ class OverseasOrderRequest(BaseModel):
         return self.model_dump()
 
 
+class OverseasCancelRequest(BaseModel):
+    symbol: str
+    exchange: OverseasExchange
+    original_order_no: str
+    qty: int
+    currency: Literal["USD"] = "USD"
+    real_order_confirmation: str | None = None
+
+    def to_dict(self):
+        return self.model_dump()
+
+
 class OverseasOrderReport(BaseModel):
     symbol: str
     exchange: OverseasExchange

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -45,9 +45,12 @@ tr_ids:
     inquire_ccnl_paper: VTTS3035R # 해외주식 주문체결내역 (모의)
     inquire_nccs_real: TTTS3018R # 해외주식 미체결내역 (실전)
     inquire_nccs_paper: VTTS3018R # 해외주식 미체결내역 (모의)
-    order_buy_real: TTTS6036U # 해외주식 미국주간 지정가 매수
-    order_sell_real: TTTS6037U # 해외주식 미국주간 지정가 매도
-    order_rvsecncl_real: TTTS6038U # 해외주식 미국주간 정정취소
+    order_buy_real: TTTT1002U # 해외주식 미국 정규장 지정가 매수 (실전)
+    order_buy_paper: VTTT1002U # 해외주식 미국 정규장 지정가 매수 (모의)
+    order_sell_real: TTTT1006U # 해외주식 미국 정규장 지정가 매도 (실전)
+    order_sell_paper: VTTT1006U # 해외주식 미국 정규장 지정가 매도 (모의)
+    order_rvsecncl_real: TTTT1004U # 해외주식 미국 정규장 정정취소 (실전)
+    order_rvsecncl_paper: VTTT1004U # 해외주식 미국 정규장 정정취소 (모의)
   # --- 웹소켓 TR ID 추가 ---
   websocket:
     approval_key: 실시간-000 # 웹소켓 접속키 발급 TR ID (문서에 명시된 값)

--- a/tests/frontend/run_overseas_dom_tests.mjs
+++ b/tests/frontend/run_overseas_dom_tests.mjs
@@ -23,6 +23,12 @@ const SCAFFOLD = `
 <div id="overseas-quote-result"></div>
 <div id="overseas-chart-result"></div>
 <div id="overseas-balance-result"></div>
+<input id="overseas-order-symbol" type="text">
+<select id="overseas-order-exchange"><option value="NASD">NASDAQ</option></select>
+<input id="overseas-order-qty" type="number">
+<input id="overseas-order-price" type="number">
+<div id="overseas-order-result"></div>
+<div id="overseas-orders-result"></div>
 `;
 
 function makeWindow() {
@@ -98,6 +104,80 @@ test("loadOverseasChart 가 이미 배열인 data 도 처리한다(하위호환)
   const html = window.document.getElementById("overseas-chart-result").innerHTML;
   assert(html.includes("20260103"), "배열 형태 data 미처리");
   assert(html.includes("$195.00"), "배열 형태 종가 미표시");
+});
+
+test("loadOverseasOrders 가 미체결 주문을 행으로 렌더하고 취소 버튼을 단다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (url.includes("/api/overseas/orders")) {
+      return { ok: true, json: async () => ({
+        rt_cd: "0",
+        // KIS 미체결(inquire_ccnl, ccld_nccs_dvsn=02) 원본: data.output 배열
+        data: { output: [
+          { odno: "39870", pdno: "AAPL", prdt_name: "애플", sll_buy_dvsn_cd_name: "매수",
+            ft_ord_qty: "1", nccs_qty: "1", ft_ord_unpr3: "197.00000000", ovrs_excg_cd: "NASD" },
+        ] },
+      }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+
+  await window.loadOverseasOrders();
+
+  const html = window.document.getElementById("overseas-orders-result").innerHTML;
+  assert(html.includes("39870"), "회귀: 주문번호 미표시");
+  assert(html.includes("AAPL"), "회귀: 심볼 미표시");
+  assert(html.includes("$197.00"), "회귀: 지정가(ft_ord_unpr3) 매핑 실패");
+  assert(/취소/.test(html), "회귀: 취소 버튼 미표시");
+  assert(html.includes("cancelOverseasOrder"), "회귀: 취소 버튼에 핸들러 미연결");
+  assert(!html.includes("미체결 없음"), "회귀: 데이터 있는데 빈 표시");
+});
+
+test("cancelOverseasOrder 가 취소 API에 올바른 body로 POST하고 목록을 갱신한다", async () => {
+  const window = makeWindow();
+  window.confirm = () => true;
+  let postBody = null;
+  let ordersReloaded = 0;
+  window.fetchWithTimeout = async (url, opts) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (url.includes("/api/overseas/order/cancel")) {
+      postBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => ({ rt_cd: "0", data: {} }) };
+    }
+    if (url.includes("/api/overseas/orders")) {
+      ordersReloaded += 1;
+      return { ok: true, json: async () => ({ rt_cd: "0", data: { output: [] } }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+
+  await window.cancelOverseasOrder("39870", "AAPL", "NASD", 1);
+
+  assert(postBody, "회귀: 취소 API가 호출되지 않음");
+  assert(postBody.original_order_no === "39870", "회귀: 주문번호 전달 오류");
+  assert(postBody.symbol === "AAPL", "회귀: 심볼 전달 오류");
+  assert(postBody.exchange === "NASD", "회귀: 거래소 전달 오류");
+  assert(postBody.qty === 1, "회귀: 수량 전달 오류");
+  assert(ordersReloaded >= 1, "회귀: 취소 후 미체결 목록 갱신 안 함");
+});
+
+test("cancelOverseasOrder 가 paper 모드에서 confirm 취소 시 API를 호출하지 않는다", async () => {
+  const window = makeWindow();
+  window.confirm = () => false;
+  let called = false;
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/overseas/order/cancel")) called = true;
+    return { ok: true, json: async () => ({ rt_cd: "0", data: {} }) };
+  };
+
+  await window.cancelOverseasOrder("39870", "AAPL", "NASD", 1);
+
+  assert(!called, "회귀: confirm 거부에도 취소 API가 호출됨");
 });
 
 let failed = 0;

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_overseas_stock_api.py
@@ -47,9 +47,12 @@ def overseas_api(overseas_env):
             "inquire_ccnl_paper": "VTTS3035R",
             "inquire_nccs_real": "TTTS3018R",
             "inquire_nccs_paper": "VTTS3018R",
-            "order_buy_real": "TTTS6036U",
-            "order_sell_real": "TTTS6037U",
-            "order_rvsecncl_real": "TTTS6038U",
+            "order_buy_real": "TTTT1002U",
+            "order_buy_paper": "VTTT1002U",
+            "order_sell_real": "TTTT1006U",
+            "order_sell_paper": "VTTT1006U",
+            "order_rvsecncl_real": "TTTT1004U",
+            "order_rvsecncl_paper": "VTTT1004U",
         }
     }
     api = KoreaInvestOverseasStockApi(
@@ -141,7 +144,7 @@ async def test_place_overseas_limit_order_uses_overseas_body_and_hashkey(oversea
     }
     assert overseas_api.call_api.await_args.args[1] == EndpointKey.OVERSEAS_STOCK_ORDER
     assert overseas_api.call_api.await_args.kwargs["data"] == body
-    assert overseas_api._headers.build()["tr_id"] == "TTTS6036U"
+    assert overseas_api._headers.build()["tr_id"] == "VTTT1002U"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_trid_provider.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_trid_provider.py
@@ -158,3 +158,27 @@ def test_overseas_stock_convenience_methods_respect_paper_and_real(mock_env, moc
     assert provider.overseas_stock_order(is_buy=True) == "TR_OVRS_BUY_REAL"
     assert provider.overseas_stock_order(is_buy=False) == "TR_OVRS_SELL_REAL"
     assert provider.overseas_stock_order_rvsecncl() == "TR_OVRS_CANCEL_REAL"
+
+
+def test_overseas_us_order_tr_ids_use_regular_session_with_mock(mock_env):
+    """실제 config: 미국 해외주식 주문 TR은 정규장(TTTT...)이며 모의(VTTT...) 쌍이 존재해야 한다.
+
+    주간거래(TTTS603x)는 KIS 모의투자를 지원하지 않아 모의 주문 검증이 불가능하므로,
+    모의 검증이 가능한 정규장(/uapi/overseas-stock/v1/trading/order) TR로 통일한다.
+    값 출처: KIS open-trading-api 공식 예제 (order.py / order_rvsecncl.py).
+    """
+    from config.config_loader import load_config, TR_IDS_CONFIG_PATH
+
+    tr_ids = load_config(TR_IDS_CONFIG_PATH)["tr_ids"]
+    provider = KoreaInvestTrIdProvider(mock_env, tr_ids)
+
+    # 모의투자 (mock_env.is_paper_trading=True)
+    assert provider.overseas_stock_order(is_buy=True) == "VTTT1002U"
+    assert provider.overseas_stock_order(is_buy=False) == "VTTT1006U"
+    assert provider.overseas_stock_order_rvsecncl() == "VTTT1004U"
+
+    # 실전투자
+    mock_env.is_paper_trading = False
+    assert provider.overseas_stock_order(is_buy=True) == "TTTT1002U"
+    assert provider.overseas_stock_order(is_buy=False) == "TTTT1006U"
+    assert provider.overseas_stock_order_rvsecncl() == "TTTT1004U"

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -289,6 +289,73 @@ async def test_place_overseas_real_order_requires_confirmation_when_live_allowed
 
 
 @pytest.mark.asyncio
+async def test_cancel_overseas_order_calls_broker(web_client, mock_web_ctx):
+    """POST /api/overseas/order/cancel는 미체결 주문 취소를 브로커에 위임한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.broker.cancel_overseas_order.return_value = ResCommonResponse(
+        rt_cd="0", msg1="취소 완료", data={"odno": "39870"}
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "original_order_no": "0000039870",
+        "qty": 1,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order/cancel", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == "0"
+    mock_web_ctx.broker.cancel_overseas_order.assert_awaited_once_with(
+        symbol="AAPL",
+        exchange=OverseasExchange.NASD,
+        original_order_no="0000039870",
+        qty=1,
+        limit_price="0",
+        rvse_cncl_dvsn_cd="02",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_overseas_order_requires_overseas_mode(web_client, mock_web_ctx):
+    """overseas_us가 enabled되지 않은 run에서는 해외 주문 취소가 닫혀 있어야 한다."""
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "original_order_no": "0000039870",
+        "qty": 1,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order/cancel", json=payload)
+
+    assert response.status_code == 400
+    mock_web_ctx.broker.cancel_overseas_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancel_overseas_real_order_requires_allow_live_trading(web_client, mock_web_ctx):
+    """실전 해외주문 취소도 allow_live_trading=False이면 정책 차단 응답을 반환한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.env.is_paper_trading = False
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "original_order_no": "0000039870",
+        "qty": 1,
+        "currency": "USD",
+        "real_order_confirmation": "REAL",
+    }
+    response = web_client.post("/api/overseas/order/cancel", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert response.json()["data"]["rule"] == "overseas_live_trading_disabled"
+    mock_web_ctx.broker.cancel_overseas_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_overseas_orders_requires_overseas_mode(web_client, mock_web_ctx):
     """overseas_us가 enabled되지 않은 run에서는 해외 주문 조회가 닫혀 있다."""
     response = web_client.get("/api/overseas/orders")

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -3,7 +3,7 @@
 """
 from fastapi import APIRouter, HTTPException
 from fastapi import Query
-from common.overseas_types import OverseasOrderRequest
+from common.overseas_types import OverseasOrderRequest, OverseasCancelRequest
 from common.types import ErrorCode, ResCommonResponse
 from view.web.api_common import _get_ctx, _serialize_response, OrderRequest
 from view.web.market_mode_utils import is_market_enabled
@@ -80,6 +80,40 @@ async def place_overseas_order(req: OverseasOrderRequest):
         side=req.side,
         qty=req.qty,
         limit_price=req.limit_price,
+    )
+    return _serialize_response(resp)
+
+
+@router.post("/overseas/order/cancel")
+async def cancel_overseas_order(req: OverseasCancelRequest):
+    """해외주식 미체결 주문 취소. v1은 미국 3시장 + USD만 지원한다."""
+    ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(status_code=400, detail="해외주식 주문 취소는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
+
+    cfg = getattr(getattr(ctx, "full_config", None), "overseas_stock", None)
+    enabled_exchanges = set(getattr(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
+    if req.exchange.value not in enabled_exchanges:
+        raise HTTPException(status_code=400, detail="활성화되지 않은 해외 거래소입니다.")
+    if _is_real_trading_mode(ctx):
+        if not bool(getattr(cfg, "allow_live_trading", False)):
+            return _serialize_response(
+                ResCommonResponse(
+                    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+                    msg1="실전 해외주식 주문 취소는 overseas_stock.allow_live_trading=true 설정 전까지 차단됩니다.",
+                    data={"rule": "overseas_live_trading_disabled"},
+                )
+            )
+        if req.real_order_confirmation != "REAL":
+            raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
+
+    resp = await ctx.broker.cancel_overseas_order(
+        symbol=req.symbol,
+        exchange=req.exchange,
+        original_order_no=req.original_order_no,
+        qty=req.qty,
+        limit_price="0",
+        rvse_cncl_dvsn_cd="02",
     )
     return _serialize_response(resp)
 

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -247,6 +247,109 @@ async function placeOverseasOrder(side) {
     }
 }
 
+async function loadOverseasOrders() {
+    const exchange = _overseasExchangeValue('overseas-order-exchange');
+    const resultDiv = document.getElementById('overseas-orders-result');
+    showLoading(resultDiv, '미체결 조회 중...');
+
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout(`/api/overseas/orders?exchange=${exchange}&ccld_nccs_dvsn=02`, {}, 12000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            resultDiv.innerHTML = `<p class="error">미체결 조회 실패: ${json.msg1 || res.status}</p>`;
+            return;
+        }
+        const data = json.data || {};
+        const rows = Array.isArray(data.output) ? data.output : (Array.isArray(data) ? data : []);
+        const body = rows.map((row) => {
+            const odno = String(row.odno || row.ODNO || '');
+            const sym = String(row.pdno || row.ovrs_pdno || row.symbol || '');
+            const exc = row.ovrs_excg_cd || exchange;
+            const nccs = Number(String(row.nccs_qty ?? row.ft_ord_qty ?? row.qty ?? '0').replace(/,/g, '')) || 0;
+            return `
+            <tr>
+                <td>${odno || '-'}</td>
+                <td>${sym || '-'}</td>
+                <td>${row.sll_buy_dvsn_cd_name || '-'}</td>
+                <td>${_formatNumber(row.ft_ord_qty || row.qty)}</td>
+                <td>${_formatNumber(nccs)}</td>
+                <td>${_formatUsd(row.ft_ord_unpr3 || row.price)}</td>
+                <td><button class="btn btn-sell" onclick="cancelOverseasOrder('${odno}','${sym}','${exc}',${nccs})">취소</button></td>
+            </tr>
+        `;
+        }).join('');
+        resultDiv.innerHTML = `
+            <div class="card">
+                <h3>미체결 주문 <span style="color:#aaa;font-size:0.85rem;">${exchange} USD</span></h3>
+                <table>
+                    <thead><tr><th>주문번호</th><th>심볼</th><th>구분</th><th>수량</th><th>미체결</th><th>지정가</th><th></th></tr></thead>
+                    <tbody>${body || '<tr><td colspan="7">미체결 없음</td></tr>'}</tbody>
+                </table>
+            </div>
+        `;
+    } catch (e) {
+        resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
+    }
+}
+
+async function cancelOverseasOrder(orderNo, symbol, exchange, qty) {
+    if (!orderNo) {
+        alert('주문번호가 없습니다.');
+        return;
+    }
+    const resultDiv = document.getElementById('overseas-orders-result');
+
+    let realOrderConfirmation = null;
+    if (_overseasIsRealMode()) {
+        const step1 = confirm(
+            `[실전투자] 해외 주문 취소\n\n` +
+            `심볼: ${symbol}\n거래소: ${exchange}\n주문번호: ${orderNo}\n수량: ${qty}\n\n` +
+            `계속하시겠습니까?`
+        );
+        if (!step1) return;
+        realOrderConfirmation = prompt('최종 확인을 위해 "REAL"을 입력하세요:');
+        if (realOrderConfirmation !== 'REAL') {
+            alert('확인 문자열이 일치하지 않아 취소 요청이 중단되었습니다.');
+            return;
+        }
+    } else if (!confirm(`해외 주문 취소\n심볼: ${symbol}\n주문번호: ${orderNo}\n수량: ${qty}`)) {
+        return;
+    }
+
+    try {
+        const enabled = await _ensureOverseasEnabled();
+        if (!enabled) {
+            if (resultDiv) resultDiv.innerHTML = '<p class="error">overseas_us가 enabled되어 있지 않습니다.</p>';
+            return;
+        }
+        const res = await fetchWithTimeout('/api/overseas/order/cancel', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                symbol,
+                exchange,
+                original_order_no: orderNo,
+                qty,
+                currency: 'USD',
+                real_order_confirmation: realOrderConfirmation
+            })
+        }, 15000);
+        const json = await res.json();
+        if (!res.ok || json.rt_cd !== '0') {
+            alert(`취소 실패: ${json.msg1 || res.status}`);
+            return;
+        }
+        await loadOverseasOrders();
+    } catch (e) {
+        alert(`통신 오류: ${e.message || e}`);
+    }
+}
+
 function initOverseasPage() {
     _refreshOverseasRealBanner();
     if (!window.__overseasRealBannerTimer) {

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -60,9 +60,18 @@
     </div>
 
     <div id="overseas-order-result"></div>
+
+    <div class="card">
+        <h2>미체결 주문</h2>
+        <div class="form-row">
+            <button class="btn" onclick="loadOverseasOrders()">미체결 조회</button>
+        </div>
+    </div>
+
+    <div id="overseas-orders-result"></div>
 </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/overseas.js?v=2"></script>
+<script src="/static/js/overseas.js?v=3"></script>
 {% endblock %}


### PR DESCRIPTION
## 배경
해외주식 주문 TR이 **미국 주간거래(daytime, TTTS603x)** 값으로 설정돼 있었다. KIS 모의투자는 주간거래를 지원하지 않아(`daytime_order`에 `env_dv`/모의 분기 자체가 없음), 실제 주문 경로를 **모의로 한 번도 검증할 수 없는** 상태였다. 또한 주문 URL은 정규장(`/uapi/overseas-stock/v1/trading/order`)인데 TR만 주간거래라 endpoint–TR 불일치이기도 했다.

## 변경

### 1. 주문 TR을 정규장(모의 지원)으로 통일
| 구분 | 실전 | 모의 |
|---|---|---|
| 매수 | `TTTT1002U` | `VTTT1002U` |
| 매도 | `TTTT1006U` | `VTTT1006U` |
| 정정취소 | `TTTT1004U` | `VTTT1004U` |
- URL은 이미 정규장이라 `kis_config.yaml` 변경 없음. provider는 paper 키 자동 사용 로직이 이미 있어 코드 변경 불필요.
- 값 출처: [KIS open-trading-api 공식 예제](https://github.com/koreainvestment/open-trading-api) `order.py` / `order_rvsecncl.py`.

### 2. 미체결 주문 취소 — API + UI
- `POST /api/overseas/order/cancel` (+ `OverseasCancelRequest`) 추가. 브로커 `cancel_overseas_order`는 이미 배선돼 웹 노출만 없던 상태였다.
- 해외 페이지([overseas.html](view/web/templates/overseas.html))에 **미체결 목록 + 행별 취소 버튼** 추가([overseas.js](view/web/static/js/overseas.js) `loadOverseasOrders`/`cancelOverseasOrder`). 해외는 국내와 별도 단일 페이지이며 그동안 주문은 되나 조회·취소 수단이 없었다.
- paper 통과, 실전은 place와 동일하게 `allow_live_trading` + "REAL" 확인 게이트.

## 테스트 (TDD)
- 실제 `tr_ids_config.yaml` 로드 → 정규장 TR 검증 회귀 테스트.
- 취소 라우트 단위 3건(위임/모드게이트/실전차단).
- jsdom 회귀 3건(목록 렌더/취소 POST body·목록 갱신/confirm 거부) — `tests/frontend/run_overseas_dom_tests.mjs`.
- overseas_stock_api 픽스처·단언 정규장/모의 값 갱신.
- **단위 6528 + 통합 245 전체 통과.**

## KIS 모의환경 E2E 검증 ✅
실제 모의 계좌 왕복:
- 매수(`VTTT1002U`): `rt_cd=0`, ODNO 발급 (AAPL 1주 @ $197, 미체결)
- 미체결 조회(`VTTS3035R`): 주문 노출
- 취소(`VTTT1004U`): `rt_cd=0`, "모의투자 취소주문이 완료 되었습니다", 미체결 재조회 `output: []`

## 참고
- KIS 모의(VTTT)는 **지정가(`ORD_DVSN=00`)만** 지원 (VBO 지정가 진입과 호환).
- 주간거래(한국 낮 운영)는 live 단계에서 필요 시 별도 `/daytime-order`로 재도입 가능.
- `overseas_stock.allow_live_trading=false` 게이트 유지.
- `todo_list.md`의 "해외 주문 TR은 실전만, 모의 없음" 메모는 사실이 바뀌었으므로 갱신 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)