### PR TITLE
Split daily theme leader report into background task

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -15,6 +15,7 @@ after_market_tasks:
     after_market_reconcile: 0       # AfterMarketReconcileTask — 장 마감 직후 주문/브로커 상태 검증
     strategy_log_report: 40         # strategy_log_report — replay audit 이후 리포트 생성
     ranking_refresh: 5          # RankingTask — 장 마감 5분 후
+    daily_theme_leader_report: 15  # ThemeDailyLeaderReportTask — 랭킹 갱신 후 당일 주도 테마 리포트 발송
     daily_price_collector: 10      # DailyPriceCollectorTask — 장 마감 10분 후
     ohlcv_update: 20             # OhlcvUpdateTask — 장 마감 20분 후
     post_market_replay_audit: 30  # PostMarketReplayAuditTask — live 후보군 missed-signal 감사

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -55,7 +55,6 @@ class RankingTask(AfterMarketTask):
         performance_profiler: Optional[PerformanceProfiler] = None,
         notification_service: Optional[NotificationService] = None,
         telegram_reporter: Optional[TelegramReporter] = None,
-        theme_daily_leader_service=None,
         market_calendar_service: Optional[MarketCalendarService] = None,
         worker_pool: Optional[WorkerPool] = None,
     ):
@@ -72,7 +71,6 @@ class RankingTask(AfterMarketTask):
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._notification_service = notification_service
         self._telegram_reporter = telegram_reporter
-        self._theme_daily_leader_service = theme_daily_leader_service
         self._suspend_event: asyncio.Event = asyncio.Event()
         self._suspend_event.set()  # 초기에는 실행 가능 상태
 
@@ -87,6 +85,7 @@ class RankingTask(AfterMarketTask):
         # 프로그램 매매 랭킹 캐시
         self._program_net_buy_cache: List[Dict] = []
         self._program_net_sell_cache: List[Dict] = []
+        self._daily_theme_report_rankings: Dict[str, List[Dict] | str] = {}
         self._investor_ranking_updated_at: Optional[datetime] = None
         self._is_refreshing: bool = False
         self._last_collected_date: Optional[str] = None
@@ -224,6 +223,16 @@ class RankingTask(AfterMarketTask):
     def get_investor_ranking_progress(self) -> Dict:
         """투자자 랭킹 수집 진행률 반환."""
         return self.get_progress()
+
+    def get_daily_theme_report_rankings(self) -> Dict:
+        """당일 주도 테마 리포트용 랭킹 원천 데이터를 반환한다."""
+        result: Dict = {}
+        for key, value in self._daily_theme_report_rankings.items():
+            if isinstance(value, list):
+                result[key] = [dict(item) for item in value]
+            else:
+                result[key] = value
+        return result
 
     def get_basic_ranking_cache(self, category: str) -> Optional[ResCommonResponse]:
         """장마감 후 캐시된 기본 랭킹 반환. 캐시 없으면 None."""
@@ -457,38 +466,31 @@ class RankingTask(AfterMarketTask):
                     NotificationCategory.BACKGROUND, NotificationLevel.INFO, "투자자 랭킹 갱신 완료",
                     f"{len(results)}개 종목 수집, 소요: {elapsed:.1f}초",
                 )
+            rankings_for_report = {
+                'foreign_buy': self._foreign_net_buy_cache,
+                'foreign_sell': self._foreign_net_sell_cache,
+                'inst_buy': self._inst_net_buy_cache,
+                'inst_sell': self._inst_net_sell_cache,
+                'prsn_buy': self._prsn_net_buy_cache,
+                'prsn_sell': self._prsn_net_sell_cache,
+                'program_buy': self._program_net_buy_cache,
+                'program_sell': self._program_net_sell_cache,
+                'trading_value': self._trading_value_cache,
+                'all_stocks': results,
+                'program_all_stocks': program_results
+            }
+            self._daily_theme_report_rankings = {
+                key: [dict(item) for item in value] if isinstance(value, list) else value
+                for key, value in rankings_for_report.items()
+            }
+            self._daily_theme_report_rankings["report_date"] = target_date
             if self._telegram_reporter:
                 self._logger.info("텔레그램 랭킹 리포트 전송 시작")
-                rankings_for_report = {
-                    'foreign_buy': self._foreign_net_buy_cache,
-                    'foreign_sell': self._foreign_net_sell_cache,
-                    'inst_buy': self._inst_net_buy_cache,
-                    'inst_sell': self._inst_net_sell_cache,
-                    'prsn_buy': self._prsn_net_buy_cache,
-                    'prsn_sell': self._prsn_net_sell_cache,
-                    'program_buy': self._program_net_buy_cache,
-                    'program_sell': self._program_net_sell_cache,
-                    'trading_value': self._trading_value_cache,
-                    'all_stocks': results,
-                    'program_all_stocks': program_results
-                }
                 try:
                     await self._telegram_reporter.send_ranking_report(rankings_for_report, report_date=target_date)
                     self._logger.info("텔레그램 랭킹 리포트 전송 완료")
                 except Exception as e:
                     self._logger.error(f"텔레그램 랭킹 리포트 전송 중 오류: {e}", exc_info=True)
-                if self._theme_daily_leader_service:
-                    self._logger.info("텔레그램 테마 리포트 전송 시작")
-                    try:
-                        theme_resp = await self._theme_daily_leader_service.build_daily_theme_report(
-                            rankings_for_report,
-                            report_date=target_date,
-                        )
-                        theme_data = theme_resp.data if theme_resp and theme_resp.rt_cd == ErrorCode.SUCCESS.value else []
-                        await self._telegram_reporter.send_daily_theme_report(theme_data or [], report_date=target_date)
-                        self._logger.info("텔레그램 테마 리포트 전송 완료")
-                    except Exception as e:
-                        self._logger.error(f"텔레그램 테마 리포트 전송 중 오류: {e}", exc_info=True)
         except Exception as e:
             self._logger.error(f"투자자 랭킹 갱신 실패: {e}", exc_info=True)
             if self._notification_service:

--- a/task/background/after_market/theme_daily_leader_report_task.py
+++ b/task/background/after_market/theme_daily_leader_report_task.py
@@ -1,0 +1,118 @@
+"""장 마감 후 당일 주도 테마 리포트를 별도 발송하는 태스크."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from common.types import ErrorCode
+from task.background.after_market.after_market_task_base import AfterMarketTask
+from services.notification_service import NotificationCategory, NotificationLevel, NotificationService
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+    from scheduler.worker.worker_pool import WorkerPool
+
+
+class ThemeDailyLeaderReportTask(AfterMarketTask):
+    """RankingTask가 수집한 당일 랭킹 캐시로 주도 테마 리포트를 생성·전송한다."""
+
+    def __init__(
+        self,
+        ranking_task,
+        theme_daily_leader_service,
+        telegram_reporter=None,
+        notification_service: Optional[NotificationService] = None,
+        mcs: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        logger=None,
+        worker_pool: Optional["WorkerPool"] = None,
+    ) -> None:
+        super().__init__(
+            mcs=mcs,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._ranking_task = ranking_task
+        self._theme_daily_leader_service = theme_daily_leader_service
+        self._telegram_reporter = telegram_reporter
+        self._notification_service = notification_service
+        self._progress = {
+            "running": False,
+            "last_report_date": None,
+            "sent_count": 0,
+            "last_error": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "daily_theme_leader_report"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "ThemeDailyLeaderReportTask"
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        await self._send_report(latest_trading_date)
+
+    async def _send_report(self, report_date: str) -> None:
+        self._progress["running"] = True
+        self._progress["last_error"] = None
+        self._logger.info(f"당일 주도 테마 리포트 생성 시작: {report_date}")
+        try:
+            rankings = self._ranking_task.get_daily_theme_report_rankings()
+            if not rankings or not rankings.get("all_stocks"):
+                self._progress["last_error"] = "ranking_cache_empty"
+                message = "랭킹 캐시가 비어 있어 당일 주도 테마 리포트를 건너뜁니다."
+                self._logger.warning(message)
+                if self._notification_service:
+                    await self._notification_service.emit(
+                        NotificationCategory.BACKGROUND,
+                        NotificationLevel.WARNING,
+                        "당일 주도 테마 리포트 스킵",
+                        f"{report_date}: {message}",
+                    )
+                return
+
+            theme_resp = await self._theme_daily_leader_service.build_daily_theme_report(
+                rankings,
+                report_date=report_date,
+            )
+            if not theme_resp or theme_resp.rt_cd != ErrorCode.SUCCESS.value:
+                msg = getattr(theme_resp, "msg1", "") if theme_resp else "응답 없음"
+                self._progress["last_error"] = f"theme_service_error:{msg}"
+                self._logger.warning(f"당일 주도 테마 리포트 생성 실패: {msg}")
+                return
+
+            theme_data = theme_resp.data or []
+            if self._telegram_reporter:
+                await self._telegram_reporter.send_daily_theme_report(
+                    theme_data,
+                    report_date=report_date,
+                )
+            self._progress["last_report_date"] = report_date
+            self._progress["sent_count"] = len(theme_data)
+            self._logger.info(f"당일 주도 테마 리포트 발송 완료: {len(theme_data)}개 테마")
+        except Exception as e:
+            self._progress["last_error"] = str(e)
+            self._logger.error(f"당일 주도 테마 리포트 발송 실패: {e}", exc_info=True)
+        finally:
+            self._progress["running"] = False
+
+    def get_progress(self) -> dict:
+        return dict(self._progress)
+
+    async def force_run(self) -> None:
+        """skip/delay를 우회하고 즉시 당일 주도 테마 리포트를 생성·발송한다."""
+        target_date: Optional[str] = None
+        if self._mcs:
+            try:
+                target_date = await self._mcs.get_latest_trading_date()
+            except Exception as e:
+                self._logger.warning(f"최근 거래일 조회 실패 — 오늘 날짜로 대체: {e}")
+        if not target_date:
+            target_date = datetime.now().strftime("%Y%m%d")
+        async with self._running_state():
+            await self._send_report(target_date)

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -1308,8 +1308,8 @@ async def test_refresh_investor_ranking_calls_telegram_reporter(bg_service, mock
 
 
 @pytest.mark.asyncio
-async def test_refresh_investor_ranking_sends_daily_theme_report(bg_service, mock_deps):
-    """투자자 랭킹 리포트 데이터로 당일 주도 테마 리포트도 전송한다."""
+async def test_refresh_investor_ranking_caches_daily_theme_report_source(bg_service, mock_deps):
+    """투자자 랭킹 갱신은 테마 리포트 원천 데이터만 캐시하고 직접 전송하지 않는다."""
     broker, mapper, _, _, _, _ = mock_deps
     mock_reporter = AsyncMock()
     theme_service = MagicMock()
@@ -1329,18 +1329,17 @@ async def test_refresh_investor_ranking_sends_daily_theme_report(bg_service, moc
 
     await bg_service.refresh_investor_ranking()
 
-    theme_service.build_daily_theme_report.assert_awaited_once()
-    rankings_arg = theme_service.build_daily_theme_report.call_args.args[0]
-    assert "all_stocks" in rankings_arg
-    mock_reporter.send_daily_theme_report.assert_awaited_once_with(
-        [{"normalized_name": "반도체/소부장", "leaders": []}],
-        report_date="20250101",
-    )
+    theme_service.build_daily_theme_report.assert_not_called()
+    mock_reporter.send_daily_theme_report.assert_not_called()
+    rankings = bg_service.get_daily_theme_report_rankings()
+    assert "all_stocks" in rankings
+    assert rankings["all_stocks"][0]["stck_shrn_iscd"] == "005930"
+    assert rankings["report_date"] == "20250101"
 
 
 @pytest.mark.asyncio
-async def test_refresh_investor_ranking_theme_report_exception_handled(bg_service, mock_deps):
-    """테마 리포트 예외는 랭킹 리포트 전송을 막지 않는다."""
+async def test_refresh_investor_ranking_does_not_call_theme_report_service(bg_service, mock_deps):
+    """테마 리포트는 별도 task 책임이므로 RankingTask에서 호출하지 않는다."""
     broker, mapper, _, logger, _, _ = mock_deps
     mock_reporter = AsyncMock()
     theme_service = MagicMock()
@@ -1354,8 +1353,8 @@ async def test_refresh_investor_ranking_theme_report_exception_handled(bg_servic
     await bg_service.refresh_investor_ranking()
 
     mock_reporter.send_ranking_report.assert_awaited_once()
-    logger.error.assert_called()
-    assert "텔레그램 테마 리포트 전송 중 오류" in str(logger.error.call_args)
+    theme_service.build_daily_theme_report.assert_not_called()
+    logger.error.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/after_market/test_theme_daily_leader_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_theme_daily_leader_report_task.py
@@ -1,0 +1,102 @@
+"""ThemeDailyLeaderReportTask 단위 테스트."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
+
+
+def _make_task(*, ranking_source=None, service_response=None):
+    ranking_task = MagicMock()
+    ranking_task.get_daily_theme_report_rankings.return_value = ranking_source or {
+        "report_date": "20260630",
+        "all_stocks": [{"stck_shrn_iscd": "005930"}],
+    }
+    theme_service = MagicMock()
+    theme_service.build_daily_theme_report = AsyncMock(
+        return_value=service_response or ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="성공",
+            data=[{"normalized_name": "반도체/소부장", "leaders": []}],
+        )
+    )
+    telegram_reporter = AsyncMock()
+    notification_service = AsyncMock()
+    logger = MagicMock()
+    task = ThemeDailyLeaderReportTask(
+        ranking_task=ranking_task,
+        theme_daily_leader_service=theme_service,
+        telegram_reporter=telegram_reporter,
+        notification_service=notification_service,
+        logger=logger,
+    )
+    return SimpleNamespace(
+        task=task,
+        ranking_task=ranking_task,
+        theme_service=theme_service,
+        telegram_reporter=telegram_reporter,
+        notification_service=notification_service,
+        logger=logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_sends_daily_theme_report_from_ranking_cache():
+    deps = _make_task()
+
+    await deps.task.execute({"date": "20260630"})
+
+    deps.theme_service.build_daily_theme_report.assert_awaited_once_with(
+        {
+            "report_date": "20260630",
+            "all_stocks": [{"stck_shrn_iscd": "005930"}],
+        },
+        report_date="20260630",
+    )
+    deps.telegram_reporter.send_daily_theme_report.assert_awaited_once_with(
+        [{"normalized_name": "반도체/소부장", "leaders": []}],
+        report_date="20260630",
+    )
+    progress = deps.task.get_progress()
+    assert progress["running"] is False
+    assert progress["last_report_date"] == "20260630"
+    assert progress["sent_count"] == 1
+    assert progress["last_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_when_ranking_cache_is_empty():
+    deps = _make_task(ranking_source={"report_date": "20260630", "all_stocks": []})
+
+    await deps.task.execute({"date": "20260630"})
+
+    deps.theme_service.build_daily_theme_report.assert_not_called()
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+    deps.notification_service.emit.assert_awaited_once()
+    assert deps.task.get_progress()["last_error"] == "ranking_cache_empty"
+
+
+@pytest.mark.asyncio
+async def test_force_run_uses_latest_trading_date_from_calendar():
+    deps = _make_task()
+    deps.task._mcs = AsyncMock()
+    deps.task._mcs.get_latest_trading_date.return_value = "20260701"
+
+    await deps.task.force_run()
+
+    deps.theme_service.build_daily_theme_report.assert_awaited_once()
+    assert deps.theme_service.build_daily_theme_report.call_args.kwargs["report_date"] == "20260701"
+
+
+def test_task_identity_and_initial_progress():
+    deps = _make_task()
+
+    assert deps.task.task_name == "daily_theme_leader_report"
+    assert deps.task.get_progress() == {
+        "running": False,
+        "last_report_date": None,
+        "sent_count": 0,
+        "last_error": None,
+    }

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -45,6 +45,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "ranking_task", "minervini_update_task", "daily_price_collector_task",
         "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
         "log_cleanup_task", "strategy_log_report_task", "theme_classification_task",
+        "theme_daily_leader_report_task",
         "opening_position_reconcile_task", "after_market_reconcile_task",
         "post_market_replay_audit_task",
         "websocket_watchdog_task", "pre_market_health_check_task",
@@ -92,13 +93,13 @@ def test_all_mode_registers_16_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 18
+    assert bg.register.call_count == 19
 
 
 def test_all_mode_registers_12_tasks_to_time_dispatcher(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
-    assert ctx.time_dispatcher.register_task.call_count == 12
+    assert ctx.time_dispatcher.register_task.call_count == 13
 
 
 # ---------- mode 별 task 등록 ----------
@@ -180,7 +181,7 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
         "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
         "log_cleanup_task", "post_market_replay_audit_task",
         "strategy_log_report_task", "after_market_reconcile_task",
-        "theme_classification_task",
+        "theme_classification_task", "theme_daily_leader_report_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
     }
     assert names == expected
@@ -230,6 +231,6 @@ def test_skips_none_tasks(patched_scheduler_deps):
     _run(ctx)
     # opening_position_reconcile_task 는 TRADING 그룹 + TimeDispatcher 등록 대상이었으므로
     # 둘 다 -1 감소한다.
-    assert ctx.time_dispatcher.register_task.call_count == 11
+    assert ctx.time_dispatcher.register_task.call_count == 12
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 17
+    assert bg.register.call_count == 18

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -28,7 +28,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OrderPolicyService", "DeferredOrderQueue", "OrderExecutionService",
     "OneilUniverseService", "NaverFinanceScraperService",
     "StockClassificationRepository", "ThemeLeaderService", "ThemeDailyLeaderService",
-    "ThemeClassificationCollectorService", "ThemeClassificationTask",
+    "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "MarketCapGapService", "MarketCapGapReportTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
@@ -233,6 +233,7 @@ def test_service_container_web_mode_keeps_realtime_and_skips_trading_batch_tasks
     patched_service_container_deps["DailyPriceCollectorTask"].assert_not_called()
     patched_service_container_deps["OhlcvUpdateTask"].assert_not_called()
     patched_service_container_deps["AfterMarketReconcileTask"].assert_not_called()
+    patched_service_container_deps["ThemeDailyLeaderReportTask"].assert_not_called()
     patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
 
     assert ctx.pre_market_health_check_task is None
@@ -265,6 +266,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     patched_service_container_deps["DailyPriceCollectorTask"].assert_not_called()
     patched_service_container_deps["OhlcvUpdateTask"].assert_not_called()
     patched_service_container_deps["AfterMarketReconcileTask"].assert_not_called()
+    patched_service_container_deps["ThemeDailyLeaderReportTask"].assert_not_called()
     patched_service_container_deps["StrategyLogReportTask"].assert_not_called()
     patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
 
@@ -273,6 +275,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     assert ctx.daily_price_collector_task is None
     assert ctx.ohlcv_update_task is None
     assert ctx.after_market_reconcile_task is None
+    assert ctx.theme_daily_leader_report_task is None
     assert ctx.strategy_log_report_task is None
     assert ctx.post_market_replay_audit_task is None
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
@@ -280,7 +283,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
 
 
 def test_service_container_creates_universe_and_tasks(patched_service_container_deps):
-    """OneilUniverseService, RankingTask, StrategyLogReportTask 가 생성된다."""
+    """OneilUniverseService, RankingTask, ThemeDailyLeaderReportTask, StrategyLogReportTask 가 생성된다."""
     from view.web.bootstrap.service_container import ServiceContainer
 
     ctx = _make_fake_context()
@@ -289,7 +292,13 @@ def test_service_container_creates_universe_and_tasks(patched_service_container_
     assert ctx.oneil_universe_service is patched_service_container_deps["OneilUniverseService"].return_value
     assert ctx.ranking_task is patched_service_container_deps["RankingTask"].return_value
     ranking_kwargs = patched_service_container_deps["RankingTask"].call_args.kwargs
-    assert ranking_kwargs["theme_daily_leader_service"] is ctx.theme_daily_leader_service
+    assert "theme_daily_leader_service" not in ranking_kwargs
+    assert ctx.theme_daily_leader_report_task is patched_service_container_deps[
+        "ThemeDailyLeaderReportTask"
+    ].return_value
+    theme_report_kwargs = patched_service_container_deps["ThemeDailyLeaderReportTask"].call_args.kwargs
+    assert theme_report_kwargs["ranking_task"] is ctx.ranking_task
+    assert theme_report_kwargs["theme_daily_leader_service"] is ctx.theme_daily_leader_service
     assert ctx.strategy_log_report_task is patched_service_container_deps["StrategyLogReportTask"].return_value
     assert ctx.market_cap_gap_service is patched_service_container_deps["MarketCapGapService"].return_value
     assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 2

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -598,6 +598,25 @@ def test_get_background_status_theme_classification_is_after_market(web_client, 
     assert item["schedule_type"] == "after_market"
 
 
+def test_get_background_status_daily_theme_leader_report_is_after_market(web_client, mock_web_ctx):
+    """당일 주도 테마 리포트 태스크는 독립 장마감 배치로 분류된다."""
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": False}
+
+    mock_web_ctx.background_scheduler = MagicMock()
+    mock_web_ctx.background_scheduler.get_all_status.return_value = [
+        {"name": "daily_theme_leader_report", "state": "idle", "priority": 100},
+    ]
+    mock_web_ctx.background_scheduler.get_task.return_value = mock_task
+
+    response = web_client.get("/api/background/status")
+
+    assert response.status_code == 200
+    item = response.json()["data"][0]
+    assert item["name"] == "daily_theme_leader_report"
+    assert item["schedule_type"] == "after_market"
+
+
 def test_get_background_status_pre_market_health_check_schedule_type(web_client, mock_web_ctx):
     """pre_market_health_check는 IDLE이어도 실제 점검 progress를 반환한다."""
     class PreMarketTask:
@@ -780,6 +799,41 @@ async def test_force_ranking_update_running(web_client, mock_web_ctx):
 async def test_force_ranking_update_not_init(web_client, mock_web_ctx):
     mock_web_ctx.ranking_task = None
     response = web_client.post("/api/background/ranking/force-update")
+    assert response.status_code == 503
+
+
+# ── POST /api/background/daily-theme-leader-report/force-update ─────────────
+
+@pytest.mark.asyncio
+async def test_force_daily_theme_leader_report_success(web_client, mock_web_ctx):
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": False}
+    mock_task.force_run = AsyncMock()
+    mock_web_ctx.theme_daily_leader_report_task = mock_task
+
+    response = web_client.post("/api/background/daily-theme-leader-report/force-update")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    await asyncio.sleep(0)
+    mock_task.force_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_force_daily_theme_leader_report_running(web_client, mock_web_ctx):
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": True}
+    mock_web_ctx.theme_daily_leader_report_task = mock_task
+
+    response = web_client.post("/api/background/daily-theme-leader-report/force-update")
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_force_daily_theme_leader_report_not_init(web_client, mock_web_ctx):
+    mock_web_ctx.theme_daily_leader_report_task = None
+    response = web_client.post("/api/background/daily-theme-leader-report/force-update")
     assert response.status_code == 503
 
 

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -124,6 +124,7 @@ class SchedulerBootstrap:
         self._register(ctx.premium_watchlist_generator_task, TaskPriority.LOW)
         self._register(ctx.newhigh_task, TaskPriority.LOW)
         self._register(ctx.theme_classification_task, TaskPriority.LOW)
+        self._register(self._optional_task("theme_daily_leader_report_task"), TaskPriority.LOW)
         self._register(ctx.log_cleanup_task, TaskPriority.MAINTENANCE)
         self._register(ctx.post_market_replay_audit_task, TaskPriority.LOW)
         self._register(ctx.strategy_log_report_task, TaskPriority.LOW)

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -72,6 +72,7 @@ from task.background.after_market.ohlcv_update_task import OhlcvUpdateTask
 from task.background.after_market.premium_watchlist_generator_task import PremiumWatchlistGeneratorTask
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
+from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
 from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
@@ -300,7 +301,6 @@ class ServiceContainer:
                     performance_profiler=ctx.pm,
                     notification_service=ctx.notification_service,
                     telegram_reporter=getattr(ctx, 'telegram_reporter', None),
-                    theme_daily_leader_service=getattr(ctx, "theme_daily_leader_service", None),
                     market_calendar_service=ctx._mcs,
                     market_data_service=ctx.market_data_service,
                     worker_pool=ctx.worker_pool,
@@ -707,6 +707,17 @@ class ServiceContainer:
                         logger=ctx.logger,
                         worker_pool=ctx.worker_pool,
                     )
+                if ctx.theme_daily_leader_service is not None:
+                    ctx.theme_daily_leader_report_task = ThemeDailyLeaderReportTask(
+                        ranking_task=ctx.ranking_task,
+                        theme_daily_leader_service=ctx.theme_daily_leader_service,
+                        telegram_reporter=getattr(ctx, 'telegram_reporter', None),
+                        notification_service=ctx.notification_service,
+                        mcs=ctx._mcs,
+                        market_clock=ctx.market_clock,
+                        logger=ctx.logger,
+                        worker_pool=ctx.worker_pool,
+                    )
                 ctx.strategy_log_report_task = StrategyLogReportTask(
                     report_service=StrategyLogReportService(
                         log_dir=os.path.join(ctx.logger.log_dir, "strategies"),
@@ -764,6 +775,7 @@ class ServiceContainer:
                 ctx.newhigh_task = None
                 ctx.newhigh_service = None
                 ctx.theme_classification_task = None
+                ctx.theme_daily_leader_report_task = None
                 ctx.strategy_log_report_task = None
                 ctx.post_market_replay_audit_task = None
                 ctx.after_market_reconcile_task = None

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -31,6 +31,7 @@ _SCHEDULE_TYPES = {
     "전일기준주도주_생성":  "after_market",
     "newhigh":             "after_market",
     "theme_classification": "after_market",
+    "daily_theme_leader_report": "after_market",
     "market_cap_gap_report_kr": "after_market",
     "market_cap_gap_report_us": "after_market",
     "overseas_vbo_dryrun": "after_market",
@@ -822,6 +823,22 @@ async def force_theme_classification_update():
 
     asyncio.create_task(task.force_run())
     return {"success": True, "message": "테마 분류 강제 수집이 시작되었습니다."}
+
+
+@router.post("/background/daily-theme-leader-report/force-update")
+async def force_daily_theme_leader_report():
+    """skip 조건을 무시하고 당일 주도 테마 리포트를 강제로 생성/전송한다."""
+    ctx = _get_ctx()
+    task = getattr(ctx, "theme_daily_leader_report_task", None)
+    if not task:
+        raise HTTPException(status_code=503, detail="ThemeDailyLeaderReportTask가 초기화되지 않았습니다")
+
+    progress = task.get_progress()
+    if progress.get("running"):
+        raise HTTPException(status_code=409, detail="이미 리포트 생성이 진행 중입니다")
+
+    asyncio.create_task(task.force_run())
+    return {"success": True, "message": "당일 주도 테마 리포트 강제 생성이 시작되었습니다."}
 
 
 @router.post("/background/strategy-log-report/force-update")

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -528,6 +528,7 @@ const FORCE_UPDATE_CONFIG = {
     cache_warmup:         { endpoint: '/api/background/cache-warmup/force-update',     label: '강제 웜업' },
     newhigh:              { endpoint: '/api/background/newhigh/force-update',          label: '강제 수집' },
     theme_classification:  { endpoint: '/api/background/theme-classification/force-update', label: '강제 수집' },
+    daily_theme_leader_report: { endpoint: '/api/background/daily-theme-leader-report/force-update', label: '강제 발송' },
     minervini_update:     { endpoint: '/api/background/minervini/force-update',         label: '강제 수집' },
     strategy_log_report:  { endpoint: '/api/background/strategy-log-report/force-update', label: '강제 발송' },
 };

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -151,6 +151,7 @@ class WebAppContext:
         self.theme_classification_task = None
         self.theme_leader_service = None
         self.theme_daily_leader_service = None
+        self.theme_daily_leader_report_task = None
         self.strategy_log_report_task: StrategyLogReportTask = None
         self.post_market_replay_audit_task: PostMarketReplayAuditTask = None
         self.stock_repository: StockRepository = None


### PR DESCRIPTION
## Summary
- split the daily theme leader report into its own after-market background task
- keep RankingTask responsible for ranking cache collection only
- expose background status/force-send controls for the new task

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v