### PR TITLE
브로커 호출 체인 계층별 성능 계측 (S2 캐시/S3 재시도큐/S4 HTTP)

### DIFF
--- a/brokers/korea_investment/korea_invest_api_base.py
+++ b/brokers/korea_investment/korea_invest_api_base.py
@@ -17,6 +17,7 @@ import ssl
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv  # TokenProvider를 import
 from brokers.korea_investment.korea_invest_token_provider import TokenRateLimitError
 from common.types import ErrorCode, ResCommonResponse
+from core.performance_profiler import layer_profiler
 from typing import Union, Optional
 from brokers.korea_investment.korea_invest_header_provider import build_header_provider_from_env, \
     KoreaInvestHeaderProvider
@@ -51,8 +52,10 @@ class KoreaInvestApiBase:
                  async_client: Optional[httpx.AsyncClient] = None,
                  header_provider: Optional[KoreaInvestHeaderProvider] = None,
                  url_provider: Optional[KoreaInvestUrlProvider] = None,
-                 trid_provider: Optional[KoreaInvestTrIdProvider] = None):
+                 trid_provider: Optional[KoreaInvestTrIdProvider] = None,
+                 performance_profiler=None):
         self._logger = logger if logger else logging.getLogger(__name__)
+        self._pm = layer_profiler(performance_profiler)
         self.market_clock = market_clock
         self._env = env
         self._base_url = None
@@ -80,6 +83,26 @@ class KoreaInvestApiBase:
         return self._url_provider.url(key_or_path)
 
     async def call_api(self,
+                       method,
+                       key_or_path,
+                       params=None,
+                       data=None,
+                       expect_standard_schema: bool = True,
+                       retry_count=10,
+                       delay=1):
+        # [S4 계층 타이머] HTTP 계층 총 소요 = 네트워크 RTT + 응답파싱 + 토큰갱신/재시도(백오프 대기 포함).
+        # threshold 미만은 미기록(핫패스 보호). EGW00133 토큰 대기가 여기 잡힌다.
+        _t_perf = self._pm.start_timer()
+        try:
+            return await self._call_api_impl(
+                method, key_or_path, params=params, data=data,
+                expect_standard_schema=expect_standard_schema,
+                retry_count=retry_count, delay=delay,
+            )
+        finally:
+            self._pm.log_timer(f"KISApiBase.call_api({method} {key_or_path})", _t_perf)
+
+    async def _call_api_impl(self,
                        method,
                        key_or_path,
                        params=None,

--- a/core/cache/cache_wrapper.py
+++ b/core/cache/cache_wrapper.py
@@ -5,6 +5,7 @@ from typing import TypeVar, Callable, Optional, Any
 from common.types import ResCommonResponse, ErrorCode
 from core.cache.cache_store import CacheStore
 from core.cache.cache_config import load_cache_config
+from core.performance_profiler import layer_profiler
 from datetime import datetime
 from collections import OrderedDict
 
@@ -20,10 +21,12 @@ class ClientWithCache:
             mode_fn: Callable[[], str],
             cache_store: Optional[CacheStore] = None,
             config: Optional[dict] = None,
-            market_calendar_service: Optional[Any] = None  # [추가] MarketCalendarService 주입
+            market_calendar_service: Optional[Any] = None,  # [추가] MarketCalendarService 주입
+            performance_profiler=None
     ):
         self._client = client
         self._logger = logger
+        self._pm = layer_profiler(performance_profiler)
         self._market_clock = market_clock
         self._mcs = market_calendar_service  # [추가]
         self._mode_fn = mode_fn  # 동적으로 모드 가져오기
@@ -66,7 +69,7 @@ class ClientWithCache:
             parts = [p for p in [mode, func_name, arg_str, kwarg_str] if p]
             return "_".join(parts)
 
-        async def wrapped(*args, **kwargs):
+        async def _wrapped_impl(*args, **kwargs):
             # _skip_cache 플래그가 있으면 캐시를 완전히 우회 (무한 재귀 방지용)
             skip_cache = kwargs.pop("_skip_cache", False)
             if skip_cache:
@@ -198,6 +201,15 @@ class ClientWithCache:
 
             return result
 
+        async def wrapped(*args, **kwargs):
+            # [S2 계층 타이머] 캐시 계층 총 소요(캐시 로직 + 하위 호출).
+            # HIT은 짧고, MISS는 하위(S3 재시도큐/S4 HTTP)를 포함 → 계층 분해 비교용.
+            _t_perf = self._pm.start_timer()
+            try:
+                return await _wrapped_impl(*args, **kwargs)
+            finally:
+                self._pm.log_timer(f"Cache.{name}", _t_perf)
+
         return wrapped
 
     def __dir__(self):
@@ -232,7 +244,8 @@ def cache_wrap_client(
         mode_getter: Callable[[], str],
         config: Optional[dict] = None,
         cache_store: Optional[CacheStore] = None,
-        market_calendar_service: Optional[Any] = None
+        market_calendar_service: Optional[Any] = None,
+        performance_profiler=None
 ) -> T:
     return ClientWithCache(
         client=api_client,
@@ -241,5 +254,6 @@ def cache_wrap_client(
         mode_fn=mode_getter,
         cache_store=cache_store,
         config=config,
-        market_calendar_service=market_calendar_service
+        market_calendar_service=market_calendar_service,
+        performance_profiler=performance_profiler
     )

--- a/core/performance_profiler.py
+++ b/core/performance_profiler.py
@@ -22,9 +22,22 @@ class PerformanceProfiler:
     PROFILE_OUTPUT_DIR = "logs/profile"
 
     def __init__(self, logger: Optional[logging.Logger] = None, enabled: bool = False, threshold: float = 0.0):
-        self.logger = logger if logger else get_performance_logger()
+        # 로거는 지연 해석(lazy): 생성만으로 get_performance_logger() 의 부수효과
+        # (파일 핸들러/리스너 전역 등록)를 일으키지 않도록 첫 기록 시점까지 미룬다.
+        # 계층 진단용 프로파일러가 다수 생성돼도 전역 로거 상태를 오염시키지 않는다.
+        self._logger = logger
         self.enabled = enabled
         self.threshold = threshold
+
+    @property
+    def logger(self):
+        if self._logger is None:
+            self._logger = get_performance_logger()
+        return self._logger
+
+    @logger.setter
+    def logger(self, value):
+        self._logger = value
 
     # ── 타이머 (기존) ──
 
@@ -119,3 +132,23 @@ class PerformanceProfiler:
         finally:
             profiler.stop()
             self._save_profile_result(profiler, name, save_html)
+
+
+# ── 레이어 경계 진단용 (S2 캐시 / S3 재시도큐 / S4 HTTP) ──
+# 브로커 호출 체인의 각 계층이 소비하는 시간을 분해하기 위한 threshold-gated 타이머.
+# 기본 ON이지만 threshold(기본 1.0s)로 정상 호출은 기록하지 않아 핫패스 로그 폭주를 막는다.
+# 환경변수로 전체 토글/임계값 조정 가능: KIS_LAYER_TIMING=0 으로 끄기.
+_LAYER_TIMING_ENABLED = os.getenv("KIS_LAYER_TIMING", "1") != "0"
+_LAYER_TIMING_THRESHOLD = float(os.getenv("KIS_LAYER_TIMING_THRESHOLD", "1.0"))
+
+
+def layer_profiler(performance_profiler: Optional["PerformanceProfiler"] = None) -> "PerformanceProfiler":
+    """
+    브로커 호출 체인의 계층 경계(cache/retry-queue/HTTP)에서 쓰는 진단용 프로파일러.
+
+    - performance_profiler가 주입되면 그대로 사용(테스트/중앙 제어 시).
+    - 없으면 enabled=_LAYER_TIMING_ENABLED, threshold=_LAYER_TIMING_THRESHOLD 로 생성.
+    """
+    if performance_profiler is not None:
+        return performance_profiler
+    return PerformanceProfiler(enabled=_LAYER_TIMING_ENABLED, threshold=_LAYER_TIMING_THRESHOLD)

--- a/core/retry_queue/client_with_retry_queue.py
+++ b/core/retry_queue/client_with_retry_queue.py
@@ -2,6 +2,7 @@
 import asyncio
 from core.api_priority import current_priority
 from core.retry_queue.api_request_queue import ApiRequestQueue
+from core.performance_profiler import layer_profiler
 
 
 # 주문(멱등성 우려) 및 WebSocket(상태 기반) 메서드는 큐를 통하지 않고 직접 호출
@@ -251,10 +252,11 @@ class ClientWithRetryQueue:
     - 주문/WebSocket API: retry queue 우회, global budget 만 적용 후 직접 위임
     """
 
-    def __init__(self, client, queue: ApiRequestQueue, budget_limiter=None):
+    def __init__(self, client, queue: ApiRequestQueue, budget_limiter=None, performance_profiler=None):
         self._client = client
         self._queue = queue
         self._budget_limiter = budget_limiter
+        self._pm = layer_profiler(performance_profiler)
         # 캐시된 래퍼 함수 저장: 동적 함수 객체 생성을 방지
         self._method_cache: dict = {}
 
@@ -274,23 +276,33 @@ class ClientWithRetryQueue:
                 return attr
 
             async def budgeted_direct(*args, **kwargs):
-                async with self._budget_limiter.acquire(category, priority=current_priority()):
-                    return await attr(*args, **kwargs)
+                # [S3 계층 타이머] budget 대기 + 직접 호출 총 소요(주문/WS 경로).
+                _t_perf = self._pm.start_timer()
+                try:
+                    async with self._budget_limiter.acquire(category, priority=current_priority()):
+                        return await attr(*args, **kwargs)
+                finally:
+                    self._pm.log_timer(f"RetryQueue.{name}(budget)", _t_perf)
 
             self._method_cache[name] = budgeted_direct
             return budgeted_direct
 
         # 비동기 조회 메서드 → 큐를 통해 실행
         async def queued(*args, **kwargs):
-            future = await self._queue.submit(
-                attr,
-                *args,
-                request_id=name,
-                request_category=_budget_category_for_method(name),
-                budget_limiter=self._budget_limiter,
-                **kwargs,
-            )
-            return await future
+            # [S3 계층 타이머] 큐 대기 + budget throttle + 재시도 + 하위(HTTP) 호출 총 소요.
+            _t_perf = self._pm.start_timer()
+            try:
+                future = await self._queue.submit(
+                    attr,
+                    *args,
+                    request_id=name,
+                    request_category=_budget_category_for_method(name),
+                    budget_limiter=self._budget_limiter,
+                    **kwargs,
+                )
+                return await future
+            finally:
+                self._pm.log_timer(f"RetryQueue.{name}", _t_perf)
 
         # 캐싱 후 반환
         self._method_cache[name] = queued
@@ -306,6 +318,6 @@ def _budget_category_for_method(name: str) -> str:
     return "quotation"
 
 
-def retry_queue_wrap_client(client, queue: ApiRequestQueue, budget_limiter=None) -> ClientWithRetryQueue:
+def retry_queue_wrap_client(client, queue: ApiRequestQueue, budget_limiter=None, performance_profiler=None) -> ClientWithRetryQueue:
     """BrokerAPIWrapper.__init__ 에서 호출하는 팩토리 함수."""
-    return ClientWithRetryQueue(client, queue, budget_limiter=budget_limiter)
+    return ClientWithRetryQueue(client, queue, budget_limiter=budget_limiter, performance_profiler=performance_profiler)

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_api_base.py
@@ -59,6 +59,29 @@ def get_mock_env():
     return mock_env
 
 
+@pytest.mark.asyncio
+async def test_call_api_emits_s4_layer_timer():
+    """[S4] call_api는 HTTP 계층 타이머(KISApiBase.call_api)를 항상 호출한다 (계층 분해 계측)."""
+    mock_pm = MagicMock()
+    api_base = KoreaInvestApiBase(
+        env=get_mock_env(),
+        logger=MagicMock(),
+        market_clock=AsyncMock(),
+        trid_provider=MagicMock(),
+        performance_profiler=mock_pm,
+    )
+    # 실제 네트워크 대신 내부 구현을 모킹 → call_api 래퍼의 타이머 동작만 검증
+    api_base._call_api_impl = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data={"ok": 1}))
+
+    resp = await api_base.call_api("GET", "some/path")
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    mock_pm.start_timer.assert_called_once()
+    mock_pm.log_timer.assert_called_once()
+    assert mock_pm.log_timer.call_args.args[0].startswith("KISApiBase.call_api(")
+
+
 class TestKoreaInvestApiBase(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         """ 각 테스트 실행 전에 필요한 객체들을 초기화합니다. """

--- a/tests/unit_test/core/cache/test_cache_wrapper.py
+++ b/tests/unit_test/core/cache/test_cache_wrapper.py
@@ -29,6 +29,36 @@ class DummyApiClient:
         )
 
 @pytest.mark.asyncio
+async def test_cache_wrapper_emits_s2_layer_timer(cache_store, test_cache_config):
+    """[S2] 캐시 래퍼 호출은 캐시 계층 타이머(Cache.<method>)를 호출한다 (계층 분해 계측)."""
+    logger = MagicMock()
+    market_clock = MagicMock()
+    market_clock.is_market_operating_hours.return_value = False
+    seoul_tz = pytz.timezone("Asia/Seoul")
+    market_clock.market_timezone = seoul_tz
+    now = seoul_tz.localize(datetime.now())
+    market_clock.get_latest_market_close_time.return_value = now - timedelta(minutes=5)
+    market_clock.get_next_market_open_time.return_value = now + timedelta(hours=8)
+    mock_pm = MagicMock()
+
+    wrapped = cache_wrap_client(
+        api_client=DummyApiClient(),
+        logger=logger,
+        market_clock=market_clock,
+        mode_getter=lambda: "TEST",
+        cache_store=cache_store,
+        config=test_cache_config,
+        performance_profiler=mock_pm,
+    )
+
+    result = await wrapped.get_data(1)
+
+    assert result.data.get("key") == "value-1"
+    mock_pm.log_timer.assert_called_once()
+    assert mock_pm.log_timer.call_args.args[0] == "Cache.get_data"
+
+
+@pytest.mark.asyncio
 async def test_cache_wrapper_hit_and_miss(cache_store, test_cache_config):
     logger = MagicMock()
     market_clock = MagicMock()

--- a/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
+++ b/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
@@ -119,6 +119,18 @@ def wrapped(fake_client, queue):
     return ClientWithRetryQueue(fake_client, queue)
 
 
+async def test_queued_call_emits_s3_layer_timer(fake_client, queue):
+    """[S3] 큐를 통하는 조회 호출은 retry-queue 계층 타이머(RetryQueue.<method>)를 호출한다."""
+    mock_pm = MagicMock()
+    wrapped = ClientWithRetryQueue(fake_client, queue, performance_profiler=mock_pm)
+
+    result = await wrapped.get_current_price("005930")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    mock_pm.log_timer.assert_called_once()
+    assert mock_pm.log_timer.call_args.args[0] == "RetryQueue.get_current_price"
+
+
 class TestAsyncMethodThroughQueue:
     async def test_quotation_method_uses_queue(self, wrapped, queue):
         result = await wrapped.get_current_price("005930")


### PR DESCRIPTION
## 배경
현재 `[Performance]` 타이머는 **service/route 경계**에만 있어, `MarketData.get_recent_daily_ohlcv`가 2.8s로 찍혀도 그 시간이 **어느 계층**에서 소비되는지 알 수 없었다(캐시 미스? 큐/budget 대기? 네트워크 RTT?). 브로커 클라이언트는 `cache_wrap → retry_queue_wrap → KoreaInvestApiClient → call_api` 3겹 데코레이터 체인인데 하위 계층은 전부 미계측이었다.

## 변경 — 세 이음매에 계층 타이머 추가
| 계측 | 위치 | 라벨 | 의미 |
|---|---|---|---|
| **S2** | `core/cache/cache_wrapper.py` | `Cache.{method}` | 캐시 계층 총 소요(HIT 짧음 / MISS는 하위 포함) |
| **S3** | `core/retry_queue/client_with_retry_queue.py` | `RetryQueue.{method}` | 큐 대기 + budget throttle + 재시도 + 하위 |
| **S4** | `brokers/korea_investment/korea_invest_api_base.py` | `KISApiBase.call_api(...)` | 네트워크 RTT + 응답파싱 + 토큰갱신/재시도(EGW00133 대기 포함) |

세 라벨의 로그를 비교하면 한 호출의 시간이 어느 계층에서 가는지 **세로 분해**된다.

## 설계
- `core/performance_profiler.py`에 `layer_profiler()` 헬퍼 추가. 주입(`performance_profiler=`) 우선, 없으면 env로 토글되는 기본 인스턴스 생성.
  - `KIS_LAYER_TIMING=0` 으로 전체 OFF, `KIS_LAYER_TIMING_THRESHOLD`(기본 **1.0s**)로 임계값 조정.
- **핫패스 보호**: threshold 미만은 미기록 → 정상(빠른) 호출은 로그 0건, 느린 호출(2s+)만 잡힘. (과거 장마감 100k줄/9분 로그 폭주 같은 재현 방지.)
- **DI 무변경**: BrokerAPIWrapper/composition root 시그니처를 건드리지 않음(각 래퍼가 자체 생성, 테스트는 mock 주입).
- **부수 수정**: `PerformanceProfiler`의 로거를 **지연 해석(lazy)** 으로 변경 — 생성만으로 `get_performance_logger()`의 전역 리스너/파일핸들러 등록 부수효과가 일어나지 않게 함(다수 래퍼 생성 시 전역 로거 상태 오염 제거; 이로 인한 `test_logger` 격리 회귀를 근본 차단).

## 테스트
- 각 계층 TDD 단위 테스트 추가(S2/S3/S4): mock pm 주입 후 해당 계층 라벨로 `log_timer` 호출 검증.
- 전체 단위 **6548 passed**, 통합 **245 passed**, 0 failed.
- lazy 수정 전 재현(래퍼 테스트 → `test_logger` 직렬)에서 2건 실패 → 수정 후 통과 확인.

## 다음 단계(미포함)
이번은 "**어디서** 시간이 가나"(②)를 밝히는 단계. 다음 세션 로그로 지배 계층 확인 후, 그 계층만 상세화(③ RTT 분해/큐깊이 게이지)할 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)