### PR TITLE
당일 주도 테마: 수급(flow_ratio) 정렬 반영 + 단일 출처 배지 제거

### DIFF
--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -128,6 +128,7 @@ class ThemeDailyLeaderService:
                 key=lambda item: (
                     item["leader_avg_change_rate"],
                     item["advancing_ratio"],
+                    item["flow_ratio"],
                     item["trading_value_sum_won"],
                 ),
                 reverse=True,

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -113,6 +113,40 @@ async def test_builds_theme_report_from_ranking_data():
 
 
 @pytest.mark.asyncio
+async def test_flow_ratio_breaks_tie_between_equal_price_themes():
+    """등락률·상승비율·거래대금이 같으면 수급(flow_ratio)이 높은 테마가 상위로 온다."""
+    groups = {
+        # 삽입 순서상 약수급이 먼저 — 수급 타이브레이크가 없으면 이 순서가 유지된다.
+        "약수급": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "A"), _member("B", "B"), _member("C", "C")],
+        },
+        "강수급": {
+            "sources": ["NAVER"],
+            "members": [_member("D", "D"), _member("E", "E"), _member("F", "F")],
+        },
+    }
+    svc, _ = _service(groups)
+    rankings = {
+        "all_stocks": [
+            # 두 테마 모두 전 종목 +10.0%, 거래대금 1000억 동일 → 가격 지표는 완전 동률
+            _stock("A", "A", 10.0, 100_000_000_000),
+            _stock("B", "B", 10.0, 100_000_000_000),
+            _stock("C", "C", 10.0, 100_000_000_000),
+            _stock("D", "D", 10.0, 100_000_000_000, foreign=5_000),
+            _stock("E", "E", 10.0, 100_000_000_000, foreign=5_000),
+            _stock("F", "F", 10.0, 100_000_000_000, foreign=5_000),
+        ],
+    }
+
+    resp = await svc.build_daily_theme_report(rankings, "20260630")
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [item["normalized_name"] for item in resp.data] == ["강수급", "약수급"]
+    assert resp.data[0]["flow_ratio"] > resp.data[1]["flow_ratio"]
+
+
+@pytest.mark.asyncio
 async def test_skips_theme_with_less_than_min_members():
     svc, _ = _service({
         "개별주": {

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -297,14 +297,6 @@ async function loadThemeLeaders() {
     }
 }
 
-function _sourceBadges(sources) {
-    const label = { NAVER: '네이버', KIWOOM: '키움', WICS: 'WICS' };
-    return (sources || []).map(s =>
-        `<span style="display:inline-block; font-size:0.75em; padding:1px 6px; margin-left:4px;
-            border-radius:8px; background:var(--accent-secondary,#3b82f6); color:#fff;">${label[s] || s}</span>`
-    ).join('');
-}
-
 function renderThemeLeaders(groups) {
     const div = document.getElementById('ranking-result');
     const cards = groups.map(g => {
@@ -313,15 +305,14 @@ function renderThemeLeaders(groups) {
                 <td>${i + 1}</td>
                 <td>${l.name || l.code}</td>
                 <td>${l.rs_rating}</td>
-                <td>${_sourceBadges(l.sources)}</td>
             </tr>`).join('');
         return `<div class="card" style="margin-bottom:12px;">
             <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;">
-                <h3 style="margin:0;">${g.normalized_name}${_sourceBadges(g.sources)}</h3>
+                <h3 style="margin:0;">${g.normalized_name}</h3>
                 <span style="color:#888;">RS 중앙값 ${g.group_rs_median} · ${g.member_count}종목</span>
             </div>
             <table class="data-table">
-                <thead><tr><th>순위</th><th>종목명</th><th>RS</th><th>출처</th></tr></thead>
+                <thead><tr><th>순위</th><th>종목명</th><th>RS</th></tr></thead>
                 <tbody>${rows}</tbody>
             </table>
         </div>`;


### PR DESCRIPTION
## 배경
`주도 테마 관련 기능 검토` 세션 중 발견한 두 가지를 반영한다.

## 변경
### 1. 당일 주도 테마 정렬에 수급 반영 (`ThemeDailyLeaderService`)
- 기존 정렬: `리더 평균 등락률 → 상승비율 → 거래대금` (순수 가격 지표만)
- 외국인/기관/프로그램 순매수 비중(`flow_ratio`)을 **이미 계산·텔레그램 표시**하면서 정렬엔 쓰지 않고 있었음.
- 등락률·상승비율이 동률일 때 `flow_ratio`를 거래대금보다 우선하는 타이브레이크로 추가 → 수급이 들어온 테마가 상위로.
- 안전한 방식(A안): 기존 1·2순위 키는 그대로 두어 순위 급변 없음.

### 2. 테마 주도주 UI 출처 배지 제거 (`ranking.js`)
- 분류 소스가 **네이버 단일**이라 출처 배지/컬럼이 무의미 → 제거.
- orphan이 된 `_sourceBadges()` 함수 삭제. API payload의 `sources` 필드는 향후 소스 추가 대비해 유지.

## 검증
- TDD: 등락률·상승비율·거래대금 동률 + 수급만 다른 두 테마의 정렬 순서 검증 테스트 추가 (수정 전 실패 → 후 통과).
- 단위 `test_theme_daily_leader_service.py` 4개 통과, 리포트 태스크 테스트 통과.
- 통합 테스트 245개 전부 통과.

## 참고 (별도, 미포함)
- `theme_aliases.yaml`이 비어 있어 테마명 정규화 미작동. 네이버 테마명 표준화(taxonomy 큐레이션, todo T-0) 선행 필요 — 데이터 작업이라 이 PR에는 미포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)