### PR TITLE
오닐 유니버스: 주도 테마(leading group) 스코어링 추가

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -66,12 +66,14 @@ class OneilUniverseService:
         minervini_service: Optional["MinerviniStageService"] = None,
         notification_service: Optional[NotificationService] = None,
         market_regime_service: Optional[MarketRegimeService] = None,
+        classification_repository=None,
     ):
         self._sqs = stock_query_service
         self._indicator = indicator_service
         self.stock_code_repository = stock_code_repository
         self._tm = market_clock
         self._scraper = scraper_service
+        self._classification_repo = classification_repository
         self._cfg = config or OneilUniverseConfig()
         self._logger = logger or logging.getLogger(__name__)
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
@@ -790,6 +792,7 @@ class OneilUniverseService:
         self._compute_rs_scores(items, logger=pool_a_logger, rating_map=pool_a_rating_map)
         await self._compute_profit_growth_scores(items, logger=pool_a_logger)
         await self._compute_smart_money_scores(items, logger=pool_a_logger, date=trading_date)
+        await self._compute_theme_scores(items, logger=pool_a_logger)
         self._compute_total_scores(items, logger=pool_a_logger)
         pool_a_logger.info({"event": "scoring_done"})
 
@@ -1203,12 +1206,68 @@ class OneilUniverseService:
 
         logger.debug({"event": "compute_smart_money_scores_finished"})
 
+    def _theme_score_from_count(self, count: int) -> float:
+        """테마 내 선정 종목 수 -> 테마 스코어. 임계 미만은 0, 임계 이상은 선형 가산 후 캡."""
+        if count < self._cfg.theme_min_leaders:
+            return 0.0
+        raw = (count - self._cfg.theme_min_leaders + 1) * self._cfg.theme_score_per_leader
+        return min(raw, self._cfg.theme_score_points)
+
+    async def _compute_theme_scores(self, items: List[OSBWatchlistItem], logger: Optional[logging.Logger] = None):
+        """주도 테마(leading group) 스코어링.
+
+        선정된 종목 집합(items) 내에서, 같은 테마에 몰린 종목이 많을수록 그 테마 소속
+        종목에 가산점을 준다. 카운트 기준 집합이 items 로 고정되므로 total_score 와의
+        순환 참조가 없다. 분류 데이터(StockClassificationRepository)만 읽고 네트워크 호출은 없다.
+        """
+        logger = logger or self._logger
+        if not items:
+            return
+        for item in items:
+            item.theme_score = 0.0
+        if not self._classification_repo:
+            return
+        try:
+            groups = await self._classification_repo.get_groups(("theme",))
+        except Exception as e:
+            logger.warning({"event": "theme_score_repo_error", "error": str(e)})
+            return
+        if not groups:
+            return
+
+        item_codes = {i.code for i in items}
+        theme_leader_count: Dict[str, int] = {}
+        code_to_themes: Dict[str, List[str]] = {}
+        for name, group in groups.items():
+            present = [
+                m.get("code") for m in group.get("members", [])
+                if m.get("code") in item_codes
+            ]
+            theme_leader_count[name] = len(present)
+            for code in present:
+                code_to_themes.setdefault(code, []).append(name)
+
+        scored = 0
+        for item in items:
+            themes = code_to_themes.get(item.code)
+            if not themes:
+                continue
+            best = max(theme_leader_count[t] for t in themes)
+            item.theme_score = self._theme_score_from_count(best)
+            if item.theme_score > 0:
+                scored += 1
+                logger.debug({
+                    "event": "theme_score_assigned", "code": item.code, "name": item.name,
+                    "leader_count": best, "score": item.theme_score,
+                })
+        logger.debug({"event": "compute_theme_scores_finished", "scored_items": scored})
+
     def _compute_total_scores(self, items: List[OSBWatchlistItem], logger: Optional[logging.Logger] = None):
         logger = logger or self._logger
         if not items: return
         logger.debug({"event": "compute_total_scores_started", "item_count": len(items)})
         for item in items:
-            item.total_score = item.rs_score + item.profit_growth_score + item.smart_money_score
+            item.total_score = item.rs_score + item.profit_growth_score + item.smart_money_score + item.theme_score
             # 미너비니 Stage 2 가산점: 트렌드 템플릿 충족 종목 우선
             if item.minervini_stage == 2:
                 item.total_score += 20.0
@@ -1217,6 +1276,7 @@ class OneilUniverseService:
                     "event": "total_score_calculated", "code": item.code, "name": item.name,
                     "rs_score": item.rs_score, "profit_score": item.profit_growth_score,
                     "smart_money_score": item.smart_money_score,
+                    "theme_score": item.theme_score,
                     "minervini_stage": item.minervini_stage,
                     "total_score": item.total_score
                 })

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -792,13 +792,17 @@ class OneilUniverseService:
         self._compute_rs_scores(items, logger=pool_a_logger, rating_map=pool_a_rating_map)
         await self._compute_profit_growth_scores(items, logger=pool_a_logger)
         await self._compute_smart_money_scores(items, logger=pool_a_logger, date=trading_date)
-        await self._compute_theme_scores(items, logger=pool_a_logger)
+        code_to_themes = await self._compute_theme_scores(items, logger=pool_a_logger)
         self._compute_total_scores(items, logger=pool_a_logger)
         pool_a_logger.info({"event": "scoring_done"})
 
         sort_key = lambda x: (x.total_score, self._calc_turnover_ratio(x))
         kospi = sorted([i for i in items if i.market != "KOSDAQ"], key=sort_key, reverse=True)[:self._cfg.premium_stocks_kospi_size]
         kosdaq = sorted([i for i in items if i.market == "KOSDAQ"], key=sort_key, reverse=True)[:self._cfg.premium_stocks_kosdaq_size]
+
+        # 관측: 최종 리스트의 테마 편중(하드 제한 없음). theme_score 편중 risk 모니터링용.
+        theme_distribution = self._summarize_theme_distribution(kospi + kosdaq, code_to_themes)
+        pool_a_logger.info({"event": "theme_distribution", **theme_distribution})
 
         self._save_premium_stocks(kospi, kosdaq, trading_date=trading_date)
         pool_a_logger.info({"event": "save_done", "kospi_count": len(kospi), "kosdaq_count": len(kosdaq)})
@@ -823,7 +827,8 @@ class OneilUniverseService:
             "passed_first": len(passed_first), "first_filter_passed": len(passed_first),
             "second_filter_passed": len(items),
             "market_cap_filter": cap_str,
-            "total_elapsed_seconds": total_elapsed
+            "total_elapsed_seconds": total_elapsed,
+            "theme_distribution": theme_distribution,
         }
 
     # ── 헬퍼 메서드 ───────────────────────────────────────────────
@@ -1213,27 +1218,30 @@ class OneilUniverseService:
         raw = (count - self._cfg.theme_min_leaders + 1) * self._cfg.theme_score_per_leader
         return min(raw, self._cfg.theme_score_points)
 
-    async def _compute_theme_scores(self, items: List[OSBWatchlistItem], logger: Optional[logging.Logger] = None):
+    async def _compute_theme_scores(self, items: List[OSBWatchlistItem], logger: Optional[logging.Logger] = None) -> Dict[str, List[str]]:
         """주도 테마(leading group) 스코어링.
 
         선정된 종목 집합(items) 내에서, 같은 테마에 몰린 종목이 많을수록 그 테마 소속
         종목에 가산점을 준다. 카운트 기준 집합이 items 로 고정되므로 total_score 와의
         순환 참조가 없다. 분류 데이터(StockClassificationRepository)만 읽고 네트워크 호출은 없다.
+
+        Returns:
+            code -> [테마명, ...] 매핑(관측용). repo 미주입/미수집 시 빈 dict.
         """
         logger = logger or self._logger
         if not items:
-            return
+            return {}
         for item in items:
             item.theme_score = 0.0
         if not self._classification_repo:
-            return
+            return {}
         try:
             groups = await self._classification_repo.get_groups(("theme",))
         except Exception as e:
             logger.warning({"event": "theme_score_repo_error", "error": str(e)})
-            return
+            return {}
         if not groups:
-            return
+            return {}
 
         item_codes = {i.code for i in items}
         theme_leader_count: Dict[str, int] = {}
@@ -1261,6 +1269,33 @@ class OneilUniverseService:
                     "leader_count": best, "score": item.theme_score,
                 })
         logger.debug({"event": "compute_theme_scores_finished", "scored_items": scored})
+        return code_to_themes
+
+    @staticmethod
+    def _summarize_theme_distribution(
+        final_items: List[OSBWatchlistItem],
+        code_to_themes: Dict[str, List[str]],
+        top_n: int = 5,
+    ) -> Dict:
+        """최종 저장 리스트의 테마 분포를 관측용으로 요약한다(하드 제한 없음).
+
+        theme_score가 워치리스트를 한 테마로 쏠리게 할 수 있어, 편중 정도를
+        로그/리포트로 노출하기 위한 순수 집계. 선정 로직에는 영향을 주지 않는다.
+        """
+        total = len(final_items)
+        counts: Dict[str, int] = {}
+        for item in final_items:
+            for theme in code_to_themes.get(item.code, []):
+                counts[theme] = counts.get(theme, 0) + 1
+        ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+        top_themes = [{"theme": t, "count": c} for t, c in ranked[:top_n]]
+        max_theme, max_count = ranked[0] if ranked else (None, 0)
+        return {
+            "final_count": total,
+            "max_theme": max_theme,
+            "max_theme_share_pct": round(max_count / total * 100, 1) if total else 0.0,
+            "top_themes": top_themes,
+        }
 
     def _compute_total_scores(self, items: List[OSBWatchlistItem], logger: Optional[logging.Logger] = None):
         logger = logger or self._logger

--- a/strategies/oneil_common_types.py
+++ b/strategies/oneil_common_types.py
@@ -68,6 +68,11 @@ class OneilUniverseConfig(BaseStrategyConfig):
     smart_money_to_tv_pct: float = 10.0           # 또는 누적 거래대금의 10% 이상 매집 시
     smart_money_score_points: float = 15.0        # +15점 부여
 
+    # 주도 테마(leading group) 스코어링 — 동일 테마에 선정 종목이 다수 몰릴수록 가산
+    theme_min_leaders: int = 3                    # 테마당 최소 선정 종목 수(미만은 노이즈, 0점)
+    theme_score_per_leader: float = 3.0           # 임계 이상부터 선정 종목 1개당 가산점
+    theme_score_points: float = 10.0              # 테마 스코어 상한(캡)
+
 @dataclass
 class OneilBreakoutConfig(BaseStrategyConfig):
     """오닐 돌파 매매 전략(Strategy B) 설정."""
@@ -141,6 +146,7 @@ class OSBWatchlistItem:
     rs_rating: int = 0              # 1~99 IBD/오닐 RS Rating (0=미계산)
     profit_growth_score: float = 0.0
     smart_money_score: float = 0.0
+    theme_score: float = 0.0        # 주도 테마(동일 테마 다수 선정) 가산점
     total_score: float = 0.0
 
     # 미너비니 트렌드 템플릿

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1890,6 +1890,82 @@ def test_compute_total_scores_stage2_bonus(mock_deps):
     assert item.total_score == 55.0
 
 
+def _theme_item(code):
+    return OSBWatchlistItem(
+        code=code, name=code, market="KOSPI", high_20d=1, ma_20d=1, ma_50d=1,
+        avg_vol_20d=1, bb_width_min_20d=1, prev_bb_width=1, w52_hgpr=1, avg_trading_value_5d=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compute_theme_scores_leading_group(mock_deps):
+    """동일 테마에 선정 종목이 임계(3) 이상 몰리면 소속 종목에 가산점을 준다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    repo = MagicMock()
+    repo.get_groups = AsyncMock(return_value={
+        # A,B,C 선정 → count 3 (Z는 선정 안됨)
+        "반도체": {"sources": ["NAVER"], "members": [
+            {"code": "A"}, {"code": "B"}, {"code": "C"}, {"code": "Z"}]},
+        # D만 선정 → count 1 < min_leaders
+        "잡테마": {"sources": ["NAVER"], "members": [{"code": "D"}, {"code": "E"}]},
+    })
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger, classification_repository=repo)
+    items = [_theme_item(c) for c in ("A", "B", "C", "D")]
+
+    await service._compute_theme_scores(items, logger=logger)
+
+    by = {i.code: i.theme_score for i in items}
+    # count 3 → (3-3+1)*3 = 3.0
+    assert by["A"] == 3.0 and by["B"] == 3.0 and by["C"] == 3.0
+    assert by["D"] == 0.0  # 테마 내 선정 1개 < 임계
+
+
+@pytest.mark.asyncio
+async def test_compute_theme_scores_cap_and_multi_theme(mock_deps):
+    """점수는 상한(캡=10)에서 멈추고, 다중 테마 소속은 최대 카운트를 쓴다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    repo = MagicMock()
+    repo.get_groups = AsyncMock(return_value={
+        "대형테마": {"members": [{"code": c} for c in ("A", "B", "C", "D", "E", "F", "G")]},  # count 7
+        "소형테마": {"members": [{"code": "A"}, {"code": "B"}, {"code": "C"}]},  # count 3
+    })
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger, classification_repository=repo)
+    items = [_theme_item(c) for c in ("A", "B", "C", "D", "E", "F", "G")]
+
+    await service._compute_theme_scores(items, logger=logger)
+
+    by = {i.code: i.theme_score for i in items}
+    # 대형테마 count 7 → (7-3+1)*3 = 15 → cap 10
+    assert by["G"] == 10.0
+    # A는 대형(7)·소형(3) 둘 다 소속 → max(7) 기준 → cap 10
+    assert by["A"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_compute_theme_scores_no_repo_is_noop(mock_deps):
+    """분류 repo가 없으면 theme_score는 0으로 유지(안전 degrade)."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)  # repo 미주입
+    items = [_theme_item("A"), _theme_item("B")]
+
+    await service._compute_theme_scores(items, logger=logger)
+
+    assert all(i.theme_score == 0.0 for i in items)
+
+
+def test_compute_total_scores_includes_theme_score(mock_deps):
+    """총점에 theme_score가 합산된다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+    item = _theme_item("A")
+    item.rs_score = 10.0
+    item.theme_score = 6.0
+
+    service._compute_total_scores([item], logger=logger)
+
+    assert item.total_score == 16.0
+
+
 def test_save_and_load_premium_stocks_and_meta(mock_deps, tmp_path):
     """저장/로드/메타 조회 및 예외 분기를 검증한다."""
     _, sqs, indicator, mapper, tm, logger = mock_deps

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1966,6 +1966,50 @@ def test_compute_total_scores_includes_theme_score(mock_deps):
     assert item.total_score == 16.0
 
 
+@pytest.mark.asyncio
+async def test_compute_theme_scores_returns_code_to_themes(mock_deps):
+    """_compute_theme_scores는 관측용 종목→테마 매핑을 반환한다."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    repo = MagicMock()
+    repo.get_groups = AsyncMock(return_value={
+        "반도체": {"members": [{"code": "A"}, {"code": "B"}, {"code": "C"}]},
+        "장비": {"members": [{"code": "A"}]},
+    })
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger, classification_repository=repo)
+    items = [_theme_item(c) for c in ("A", "B", "C")]
+
+    c2t = await service._compute_theme_scores(items, logger=logger)
+
+    assert set(c2t["A"]) == {"반도체", "장비"}
+    assert c2t["B"] == ["반도체"]
+
+
+@pytest.mark.asyncio
+async def test_compute_theme_scores_no_repo_returns_empty_map(mock_deps):
+    """repo 미주입 시 빈 매핑을 반환(관측 요약도 자연히 비게 됨)."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+
+    c2t = await service._compute_theme_scores([_theme_item("A")], logger=logger)
+
+    assert c2t == {}
+
+
+def test_summarize_theme_distribution(mock_deps):
+    """최종 리스트의 테마 분포/최대 편중 비율을 관측용으로 요약한다(하드 제한 없음)."""
+    _, sqs, indicator, mapper, tm, logger = mock_deps
+    service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger)
+    final = [_theme_item(c) for c in ("A", "B", "C", "D")]
+    code_to_themes = {"A": ["반도체"], "B": ["반도체"], "C": ["반도체"], "D": ["바이오"]}
+
+    summary = service._summarize_theme_distribution(final, code_to_themes)
+
+    assert summary["final_count"] == 4
+    assert summary["max_theme"] == "반도체"
+    assert summary["max_theme_share_pct"] == 75.0
+    assert {"theme": "반도체", "count": 3} in summary["top_themes"]
+
+
 def test_save_and_load_premium_stocks_and_meta(mock_deps, tmp_path):
     """저장/로드/메타 조회 및 예외 분기를 검증한다."""
     _, sqs, indicator, mapper, tm, logger = mock_deps

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -645,6 +645,7 @@ class ServiceContainer:
                 rs_rating_service=getattr(ctx, "rs_rating_service", None),
                 minervini_service=getattr(ctx, "minervini_stage_service", None),
                 notification_service=getattr(ctx, "notification_service", None),
+                classification_repository=getattr(ctx, "theme_classification_repository", None),
             )
             if needs_batch:
                 ctx.premium_watchlist_generator_task = PremiumWatchlistGeneratorTask(


### PR DESCRIPTION
## 배경
`oneil_universe_service.py` 스코어링 검토 중, 기존 축(RS/실적/수급/미너비니)은 **개별 종목 강도**만 보고 **종목 간 테마 응집**을 반영하지 않는다는 점을 확인. 강한 종목이 한 테마에 다수 선정될수록 그 테마가 주도 테마라는 오닐의 **leading group** 개념을 스코어에 추가한다.

## 동작
장마감 후 전일 기준 우량주(Pool A) 생성 시 2차 필터 통과 종목 집합 내에서:
- 각 테마별 **선정 종목 수**를 카운트
- `theme_min_leaders`(=3) 이상부터 선형 가산 `(count - min + 1) × theme_score_per_leader(3.0)`, 상한 `theme_score_points`(=10)
- 종목이 여러 테마에 속하면 **최대 카운트** 사용
- `total_score = rs + profit + smart_money + theme + (미너비니 보너스)`

## 설계 포인트
- **순환 참조 없음**: 카운트 기준 집합을 theme_score와 무관한 `items`(2차 통과)로 고정.
- **안전 degrade**: 분류 repo 미주입/미수집 시 전 종목 `theme_score=0` → 기존 동작과 동일.
- **범위**: Pool A(장마감 배치)에만 적용. Pool B(장중)는 병목/범위 밖이라 미적용.
- 네트워크 호출 없음 — `StockClassificationRepository` 읽기만.

## Risk 처리
- **테마 편중(#2)**: theme_score가 워치리스트를 한 테마로 쏠리게 할 수 있음. 기능 취지(응집 보상)와 상충하는 하드 캡 대신 **관측만** 적용(사용자 결정). `_summarize_theme_distribution`이 최종 리스트의 테마 분포·`max_theme_share_pct`·상위 테마를 로그(`event: theme_distribution`) + 반환 dict에 노출. 실제 편중 데이터 축적 후 캡 필요성 재판단.
- **alias 공백(#1)**: fail-safe 방향(테마가 쪼개지면 카운트가 작아져 **과소** 부여). 위험이 아닌 품질 상한이며 taxonomy 큐레이션(todo T-0) 데이터 작업. 코드 조치 불필요.

## 검증 (TDD)
- 실패 테스트 선작성 → 구현 후 통과:
  - 임계 이상 몰림 가산 / 임계 미만 0 / 캡·다중테마 max
  - repo 미주입 no-op 및 빈 매핑 반환
  - total_score 합산
  - 편중 관측 요약(분포·최대 편중 비율)
- `test_oneil_universe_service.py` 74개 통과, 관련 유닛(로그/컨테이너/생성태스크) 통과.
- 통합 테스트 245개 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)