### PR TITLE
retry-queue S3 내부 분해 계측 (budget throttle / 재시도 백오프)

### DIFF
--- a/core/retry_queue/api_request_queue.py
+++ b/core/retry_queue/api_request_queue.py
@@ -5,6 +5,7 @@ import random
 from typing import Callable, Coroutine, Any
 
 from core.retry_queue.retry_classifier import classify, RequestOutcome
+from core.performance_profiler import layer_profiler
 
 
 @dataclasses.dataclass
@@ -34,10 +35,12 @@ class ApiRequestQueue:
     BASE_DELAY  = 1.0   # 초 (지수 백오프: BASE_DELAY * 2^(attempt-1))
     MAX_DELAY   = 30.0  # 최대 지연
 
-    def __init__(self, logger, budget_limiter=None, default_request_category: str = "quotation"):
+    def __init__(self, logger, budget_limiter=None, default_request_category: str = "quotation",
+                 performance_profiler=None):
         self._logger = logger
         self._budget_limiter = budget_limiter
         self._default_request_category = default_request_category
+        self._pm = layer_profiler(performance_profiler)
         self._done_q: asyncio.Queue[tuple[QueuedRequest, Any]] = asyncio.Queue()
         self._fail_q: asyncio.Queue[tuple[QueuedRequest, Any]] = asyncio.Queue()
         self._pending_tasks: set[asyncio.Task] = set()
@@ -99,7 +102,11 @@ class ApiRequestQueue:
             if limiter is None:
                 result = await req.fn(*req.args, **req.kwargs)
             else:
+                # [S3 분해] budget acquire 대기 = global/category rate slot + semaphore 대기.
+                # 타이머 시작 후 컨텍스트 진입 직후 기록 → __aenter__(throttle) 소요만 잡힌다.
+                _t_bud = self._pm.start_timer()
                 async with limiter.acquire(req.request_category):
+                    self._pm.log_timer(f"RQBudget.{req.request_category}", _t_bud)
                     result = await req.fn(*req.args, **req.kwargs)
         except Exception as e:
             self._logger.warning(
@@ -142,7 +149,10 @@ class ApiRequestQueue:
             await self._fail_q.put((req, result))
 
     async def _delay_and_execute(self, req: QueuedRequest, delay: float):
+        # [S3 분해] 재시도 백오프 대기(지수, 1~30s). throttle 대기와 구분.
+        _t_retry = self._pm.start_timer()
         await asyncio.sleep(delay)
+        self._pm.log_timer(f"RQRetryDelay.{req.request_id}", _t_retry)
         await self._execute(req)
 
     def _resolve(self, req: QueuedRequest, result: Any):

--- a/tests/unit_test/core/retry_queue/test_api_request_queue.py
+++ b/tests/unit_test/core/retry_queue/test_api_request_queue.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, AsyncMock
 
 from common.types import ResCommonResponse, ErrorCode
-from core.retry_queue.api_request_queue import ApiRequestQueue
+from core.retry_queue.api_request_queue import ApiRequestQueue, QueuedRequest
 
 
 def success_resp() -> ResCommonResponse:
@@ -31,6 +31,37 @@ def logger():
 @pytest.fixture
 def queue(logger):
     return ApiRequestQueue(logger=logger)
+
+
+class FakeBudgetLimiter:
+    @asynccontextmanager
+    async def acquire(self, category, **kwargs):
+        yield
+
+
+async def test_execute_emits_budget_wait_timer(logger):
+    """[S3분해] budget 경유 실행 시 RQBudget.{category} 타이머를 기록한다."""
+    mock_pm = MagicMock()
+    queue = ApiRequestQueue(logger=logger, budget_limiter=FakeBudgetLimiter(),
+                            performance_profiler=mock_pm)
+    fn = AsyncMock(return_value=success_resp())
+    future = await queue.submit(fn, "005930", request_id="ohlcv",
+                                request_category="quotation_ohlcv")
+    await future
+    names = [c.args[0] for c in mock_pm.log_timer.call_args_list]
+    assert "RQBudget.quotation_ohlcv" in names
+
+
+async def test_delay_and_execute_emits_retry_delay_timer(logger):
+    """[S3분해] 재시도 백오프 대기 시 RQRetryDelay.{id} 타이머를 기록한다."""
+    mock_pm = MagicMock()
+    queue = ApiRequestQueue(logger=logger, performance_profiler=mock_pm)
+    fut = asyncio.get_event_loop().create_future()
+    req = QueuedRequest(fn=AsyncMock(return_value=success_resp()), args=(), kwargs={},
+                        future=fut, request_id="get_price")
+    await queue._delay_and_execute(req, 0.0)
+    names = [c.args[0] for c in mock_pm.log_timer.call_args_list]
+    assert "RQRetryDelay.get_price" in names
 
 
 class TestSubmitSuccess:


### PR DESCRIPTION
## 배경 (#609 후속)
#609로 브로커 3계층 타이머(S2/S3/S4)를 넣고 **2026-07-01 실세션 로그**를 분해한 결과, 지연의 진원지가 **S3 재시도큐 계층**으로 확정됨:
- S4(HTTP) mean 1.18s / **p95 1.27s** (빠르고 일관), sum 876s
- S3(재시도큐) p95 4.35s / max 21.7s / **sum 8,638s (≈S4의 10배)**
- 큐 대기(S3−S4): **get_overseas_dailyprice ≈4.8s (p95 18.4s)**, inquire_daily_itemchartprice ~1.4s
- 반면 get_current_price·get_account_balance는 큐대기≈0 (네트워크/KIS 바운드)

→ "MarketData 2.8s ≈ 네트워크" 가설 반증. 진범은 우리쪽 큐/budget throttle.

## 변경 — S3를 내부 성분으로 분해
`ApiRequestQueue.submit()`이 **즉시 task를 spawn**(직렬 admission 큐 없음)하므로, S3−S4 gap은 **budget throttle** 아니면 **재시도 백오프** 둘 중 하나. 이를 직접 계측:

| 타이머 | 위치 | 측정 |
|---|---|---|
| `RQBudget.{category}` | `_execute` acquire 진입 | ApiBudgetLimiter global/category rate slot + semaphore 대기 = 순수 throttle |
| `RQRetryDelay.{request_id}` | `_delay_and_execute` | 지수 백오프 재시도 대기(1~30s) |

기존 S4(실행)와 합쳐 **S3 = throttle + 실행 + 재시도** 로 완전 분해.

## 설계
- `ApiRequestQueue`에 `performance_profiler=` 주입(기본 `layer_profiler()`, `KIS_LAYER_TIMING`/threshold 1.0s 게이팅). DI 무변경.
- throttle이 1s+ 걸린 콜만 `RQBudget` 기록 → 다음 세션 로그에서 해외 일봉 4.8s가 throttle인지 재시도인지 즉시 판별.

## 테스트
- TDD: `RQBudget.{category}` / `RQRetryDelay.{id}` 방출 검증 2개 추가.
- 단위 **6559 passed**, 통합 **245 passed**, 0 failed.

## 다음
다음 실세션 로그로 `RQBudget` vs `RQRetryDelay`를 보면 해외 일봉 병목이 budget 카테고리 saturation인지 재시도 폭주인지 확정 → 그에 맞춰 budget 한도/카테고리 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)