### PR TITLE
[codex] Prioritize strategy exit checks

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -313,21 +313,30 @@ class StrategyScheduler:
                                   and _ks_allowed)
 
                     if should_run or force_exit:
+                        has_holdings = False
+                        if not force_exit:
+                            try:
+                                has_holdings = bool(self._get_strategy_holdings(cfg))
+                            except Exception as e:
+                                self._logger.warning(
+                                    f"[Scheduler] {name} 보유 종목 우선순위 확인 실패: {e}",
+                                    exc_info=True,
+                                )
                         # 지연 시간(초) 계산 - 처음 실행 시(last가 None) 무한대로 처리
                         overdue = elapsed - (cfg.interval_minutes * 60) if last else float('inf')
                         if force_exit:
                             overdue = float('inf') # 강제 청산은 최우선순위
-                        evaluations.append((overdue, cfg, force_exit_tier))
+                        evaluations.append((force_exit, has_holdings, overdue, cfg, force_exit_tier))
 
-                # 2. 가장 오래 지연된(overdue가 큰) 전략부터 내림차순 정렬
-                evaluations.sort(key=lambda x: x[0], reverse=True)
+                # 2. 청산 필요 가능성이 있는 보유 전략을 신규 진입 스캔보다 우선 실행한다.
+                #    이후에는 가장 오래 지연된(overdue가 큰) 전략부터 처리한다.
+                evaluations.sort(key=lambda x: (x[0], x[1], x[2]), reverse=True)
 
-                for overdue, cfg, force_exit_tier in evaluations:
+                for force_exit, has_holdings, overdue, cfg, force_exit_tier in evaluations:
                     name = cfg.strategy.name
-                    force_exit = force_exit_tier is not None
 
                     # 전략 간 API 자원 충돌 방지 (강제 청산은 쿨다운 무시)
-                    if not force_exit and self._last_execution_time:
+                    if not force_exit and not has_holdings and self._last_execution_time:
                         since_last_exec = (now - self._last_execution_time).total_seconds()
                         if since_last_exec < self.STAGGER_INTERVAL_SEC:
                             continue

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -3256,6 +3256,57 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
         mock_run.assert_not_awaited()
 
+    async def test_loop_prioritizes_holding_strategy_on_intraday_start(self):
+        from datetime import datetime
+
+        scheduler, vm, _, tm, mcs = self._make_scheduler()
+        now_dt = datetime(2026, 4, 24, 10, 0, 0)
+        tm.get_current_kst_time.return_value = now_dt
+        tm.get_market_close_time.return_value = datetime(2026, 4, 24, 15, 30, 0)
+        mcs.is_market_open_now.return_value = True
+
+        first = MockStrategy(name="NoPosition")
+        second = MockStrategy(name="HasPosition")
+        scheduler.register(StrategySchedulerConfig(strategy=first, interval_minutes=0))
+        scheduler.register(StrategySchedulerConfig(strategy=second, interval_minutes=0))
+        vm.get_holds_by_strategy.side_effect = lambda strategy_name: (
+            [{"code": "067310", "name": "하나마이크론", "buy_price": 51800, "qty": 38, "status": "HOLD"}]
+            if strategy_name == "HasPosition" else []
+        )
+        scheduler._running = True
+
+        with patch.object(scheduler, "_run_reconciliation", new_callable=AsyncMock), \
+             patch.object(scheduler, "_run_strategy", new_callable=AsyncMock) as mock_run, \
+             patch("asyncio.sleep", side_effect=asyncio.CancelledError):
+            await scheduler._loop()
+
+        mock_run.assert_awaited_once()
+        self.assertEqual(mock_run.await_args.args[0].strategy.name, "HasPosition")
+
+    async def test_loop_runs_holding_strategy_inside_stagger_window_for_exit_check(self):
+        from datetime import datetime
+
+        scheduler, vm, _, tm, mcs = self._make_scheduler()
+        now_dt = datetime(2026, 4, 24, 10, 0, 0)
+        tm.get_current_kst_time.return_value = now_dt
+        tm.get_market_close_time.return_value = datetime(2026, 4, 24, 15, 30, 0)
+        mcs.is_market_open_now.return_value = True
+
+        strategy = MockStrategy(name="HasPosition")
+        scheduler.register(StrategySchedulerConfig(strategy=strategy, interval_minutes=0))
+        vm.get_holds_by_strategy.return_value = [
+            {"code": "067310", "name": "하나마이크론", "buy_price": 51800, "qty": 38, "status": "HOLD"}
+        ]
+        scheduler._last_execution_time = now_dt
+        scheduler._running = True
+
+        with patch.object(scheduler, "_run_reconciliation", new_callable=AsyncMock), \
+             patch.object(scheduler, "_run_strategy", new_callable=AsyncMock) as mock_run, \
+             patch("asyncio.sleep", side_effect=asyncio.CancelledError):
+            await scheduler._loop()
+
+        mock_run.assert_awaited_once()
+
     async def test_force_liquidate_uses_best_bid_when_orderbook_available(self):
         scheduler, vm, oes, _, _ = self._make_scheduler(dry_run=False)
         oes.broker_api_wrapper.get_asking_price = AsyncMock(


### PR DESCRIPTION
﻿## What changed
- Prioritize due strategies that currently hold positions before entry-only scans.
- Allow holding strategies to run their exit check even when the normal 60-second strategy stagger window is active.
- Added scheduler regression tests for intraday startup ordering and stagger bypass for exit checks.

## Why
When the app restarted intraday, every restored strategy had no `last_run`, so all strategies were immediately due. The scheduler preserved registration order for that tie and then applied the 60-second stagger. A strategy with an open position could therefore wait behind entry-scan strategies before `check_exits` ran.

## Impact
Exit checks for held positions now run promptly after an intraday restore or while another strategy recently ran. Entry scans still respect the stagger when there is no open position.

## Validation
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`
