### PR TITLE
테스트 세션의 프로덕션 성능로그 오염 근본 수정

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,35 @@
+import os
+import shutil
+import tempfile
+
 import pytest
+
+# [로그 격리] "performance"/"strategy.*" 등 core/logger.py 로거는 프로세스 전역
+# 싱글톤(logging.getLogger)이며, 핸들러가 한 번 붙으면 이후 호출은 그대로 재사용한다
+# (get_performance_logger 등의 `if logger.handlers: return logger` 캐시).
+# 테스트별 INVESTMENT_LOG_DIR monkeypatch(아래 isolate_live_strategy_files, 함수 스코프)는
+# "그 싱글톤이 최초로 핸들러를 붙이는 시점"에만 유효한데, pytest-xdist 워커는 같은 프로세스에서
+# 수백 개 테스트를 순차 실행하므로 그 최초 시점이 우연히 실제 프로젝트 logs/ 로 잡히면
+# 워커 수명 내내 실제 logs/performance/ 등에 테스트 데이터가 섞여 들어간다.
+# → 세션(워커 프로세스) 시작 시점(pytest_configure, 어떤 테스트 모듈 임포트보다도 먼저 실행)에
+#   INVESTMENT_LOG_DIR을 세션 전용 임시 디렉터리로 선고정해 이 최초 바인딩 자체를 실제
+#   프로젝트 경로에서 원천 차단한다.
+_SESSION_LOG_DIR: str | None = None
+
+
+def pytest_configure(config):
+    global _SESSION_LOG_DIR
+    _SESSION_LOG_DIR = tempfile.mkdtemp(prefix="investment_test_logs_")
+    os.environ["INVESTMENT_LOG_DIR"] = _SESSION_LOG_DIR
+    # 브로커 계층 진단 타이머(S2/S3/S4, RQBudget/RQRetryDelay)는 실운영 진단용이라
+    # 테스트에서는 기본 비활성화. 타이머 동작 자체를 검증하는 테스트는 이미
+    # performance_profiler=mock_pm 을 직접 주입해 이 env 설정과 무관하게 동작한다.
+    os.environ.setdefault("KIS_LAYER_TIMING", "0")
+
+
+def pytest_unconfigure(config):
+    if _SESSION_LOG_DIR and os.path.isdir(_SESSION_LOG_DIR):
+        shutil.rmtree(_SESSION_LOG_DIR, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_test/test_log_isolation.py
+++ b/tests/unit_test/test_log_isolation.py
@@ -1,0 +1,27 @@
+"""테스트 세션이 실제 프로젝트 logs/ 를 오염시키지 않는지 검증.
+
+pytest-xdist 워커는 같은 프로세스에서 다수 테스트를 순차 실행하며, core/logger.py의
+"performance" 등 로거는 프로세스 전역 싱글톤이라 최초 핸들러 부착 시점의 log_dir이
+워커 수명 내내 고정된다. tests/conftest.py::pytest_configure 가 그 최초 바인딩을
+세션 전용 임시 디렉터리로 선점해야 한다.
+"""
+import os
+
+
+def test_investment_log_dir_isolated_from_project_logs():
+    log_dir = os.environ.get("INVESTMENT_LOG_DIR")
+    assert log_dir, "pytest_configure가 INVESTMENT_LOG_DIR을 세션 시작 시 설정해야 한다"
+
+    project_logs_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "logs")
+    )
+    resolved = os.path.abspath(log_dir)
+    assert resolved != project_logs_dir
+    assert not resolved.startswith(project_logs_dir + os.sep), (
+        f"INVESTMENT_LOG_DIR({resolved})가 실제 프로젝트 logs/ 아래를 가리키면 안 된다"
+    )
+
+
+def test_layer_timing_disabled_by_default_in_tests():
+    """S2/S3/S4·RQBudget/RQRetryDelay 진단 타이머는 테스트에서 기본 비활성화되어야 한다."""
+    assert os.environ.get("KIS_LAYER_TIMING") == "0"


### PR DESCRIPTION
## 배경
07-02 성능로그 검토 중 09:40에 `RQRetryDelay.get_overseas_dailyprice` 172건이 몰려 있어 "해외 일봉 API 56% 실패"로 오판할 뻔했다. 원인을 추적하니 직전 09:30에 `mock.py:1188`/"의도적 타임아웃"(pytest 픽스처 문구) 3,550줄이 동시에 찍혀 있었다 — **통합테스트 실행이 실제 프로덕션 `logs/performance/`·`logs/common/`에 실로그를 남긴 것**이었다. 해당 창을 제외하고 재집계하니 그 엔드포인트는 오늘 실거래 호출이 0건.

## 근본 원인
- `core/logger.py`의 `get_performance_logger()`(strategy/streaming/cache 로거도 동일 패턴)는 `logging.getLogger()` **프로세스 전역 싱글톤**이며, `if logger.handlers: return logger`로 **최초 핸들러만 유지**한다.
- `tests/conftest.py`의 기존 `INVESTMENT_LOG_DIR` monkeypatch는 **함수 스코프** — "그 싱글톤이 최초로 핸들러를 붙이는 시점"에만 유효하다.
- `pytest-xdist` 워커는 같은 프로세스에서 수백 개 테스트를 순차 실행한다. 그 최초 시점이 우연히 실제 프로젝트 `logs/` 로 잡히면, **워커 수명 내내** 실제 로그 파일에 테스트 데이터가 섞인다.
- PR #609/#613에서 추가한 `KIS_LAYER_TIMING` 기본 ON 진단 타이머가 `deep_paper_ctx`(실제 broker/재시도큐/budget-limiter 체인을 통째로 빌드하는 통합테스트 fixture)에서 발화하며 이 기존 문제를 실증했다.

## 수정
`tests/conftest.py`에 `pytest_configure`/`pytest_unconfigure` 훅 추가:
- **세션(워커 프로세스) 시작 시점**에 `INVESTMENT_LOG_DIR`을 임시 디렉터리로 선점 — 어떤 테스트 모듈 임포트보다 먼저 실행되어 최초 바인딩 자체를 실제 프로젝트 경로에서 원천 차단.
- `KIS_LAYER_TIMING` 기본값을 테스트 중 `"0"`으로 설정 — 진단 타이머는 실운영 전용이라 테스트에는 불필요. 타이머 동작 자체를 검증하는 기존 테스트들은 이미 `performance_profiler=mock_pm`을 직접 주입해 이 값과 무관하게 동작(영향 없음).

`core/logger.py`(프로덕션 코드)는 건드리지 않음 — 순수 테스트 설정 변경.

## 검증
- **재현 검증**: 오염을 유발했던 실제 조건(`test_it_strategy_scan.py`, 실제 broker 체인)을 재실행해 `logs/performance/` 파일 수·최신 파일이 수정 전/후 완전히 불변함을 확인(수정 전엔 이 조건에서 실제로 오염 발생 확인됨).
- 회귀 테스트 2개 추가: `INVESTMENT_LOG_DIR`이 실제 프로젝트 `logs/` 밖을 가리키는지, `KIS_LAYER_TIMING` 기본 OFF인지.
- 단위 **6563 passed**, 통합 **245 passed**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)