### PR TITLE
장마감 후 microstructure 캡처 자동화 태스크 (todo 1-5 상시 가동)

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -157,6 +157,9 @@ notifications:
 market_cap_gap_report_kr_enabled: true
 market_cap_gap_report_us_enabled: true
 
+# 장마감 후 후보/보유 종목 microstructure overlay 캡처 (백테스트 replay 코퍼스 축적, KST 16:05)
+microstructure_capture_enabled: true
+
 # 체결 품질 리포트 경고 기준 (사후 평가용, 자동 비활성화는 기본 OFF)
 execution_quality_report:
   enabled: true

--- a/scripts/capture_backtest_microstructure.py
+++ b/scripts/capture_backtest_microstructure.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import os
 import sys
@@ -84,42 +83,7 @@ def _get_program_provider(stock_query_service: Any) -> Any | None:
 
 
 def _write_output_files(payload: dict[str, Any], output_dir: Path) -> dict[str, Path]:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    trade_date = payload["metadata"]["trade_date"]
-    capture_path = output_dir / f"replay_microstructure_{trade_date}.json"
-    execution_strength_path = output_dir / f"replay_execution_strength_{trade_date}.json"
-    program_trades_path = output_dir / f"replay_program_trades_{trade_date}.json"
-    intraday_path = output_dir / f"replay_intraday_minutes_{trade_date}.json"
-
-    _write_json(capture_path, payload)
-    _write_json(execution_strength_path, payload.get("execution_strength", {}))
-    _write_json(program_trades_path, _flatten_program_trades(payload.get("program_trades", {})))
-    _write_json(intraday_path, payload.get("intraday_minutes", {}))
-
-    return {
-        "capture": capture_path,
-        "execution_strength": execution_strength_path,
-        "program_trades": program_trades_path,
-        "intraday_minutes": intraday_path,
-    }
-
-
-def _flatten_program_trades(program_trades: dict[str, Any]) -> dict[str, int | None]:
-    flattened: dict[str, int | None] = {}
-    for code, row in program_trades.items():
-        flattened[code] = (
-            row.get("program_net_buy_qty")
-            if isinstance(row, dict)
-            else None
-        )
-    return flattened
-
-
-def _write_json(path: Path, payload: Any) -> None:
-    path.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    return BacktestMicrostructureCaptureService.write_overlay_files(payload, output_dir)
 
 
 if __name__ == "__main__":

--- a/services/backtest_microstructure_capture.py
+++ b/services/backtest_microstructure_capture.py
@@ -1,6 +1,7 @@
 """Capture microstructure overlays for historical replay fixtures."""
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -187,6 +188,32 @@ class BacktestMicrostructureCaptureService:
                 result[code] = {"program_net_buy_qty": qty} if qty is not None else None
         return result
 
+    @staticmethod
+    def write_overlay_files(payload: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+        """capture() payload를 replay fixture 규약 파일명 4종으로 저장한다.
+
+        CLI(scripts.capture_backtest_microstructure)와 after-market 태스크가
+        동일한 파일 레이아웃을 쓰도록 단일 소스로 유지한다.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        trade_date = payload["metadata"]["trade_date"]
+        capture_path = output_dir / f"replay_microstructure_{trade_date}.json"
+        execution_strength_path = output_dir / f"replay_execution_strength_{trade_date}.json"
+        program_trades_path = output_dir / f"replay_program_trades_{trade_date}.json"
+        intraday_path = output_dir / f"replay_intraday_minutes_{trade_date}.json"
+
+        _write_json(capture_path, payload)
+        _write_json(execution_strength_path, payload.get("execution_strength", {}))
+        _write_json(program_trades_path, _flatten_program_trades(payload.get("program_trades", {})))
+        _write_json(intraday_path, payload.get("intraday_minutes", {}))
+
+        return {
+            "capture": capture_path,
+            "execution_strength": execution_strength_path,
+            "program_trades": program_trades_path,
+            "intraday_minutes": intraday_path,
+        }
+
 
 def _extract_execution_strength(resp: Any) -> float | None:
     if not _is_success(resp):
@@ -257,4 +284,22 @@ def _to_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _flatten_program_trades(program_trades: dict[str, Any]) -> dict[str, int | None]:
+    flattened: dict[str, int | None] = {}
+    for code, row in program_trades.items():
+        flattened[code] = (
+            row.get("program_net_buy_qty")
+            if isinstance(row, dict)
+            else None
+        )
+    return flattened
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
 

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+
+class MicrostructureCaptureTask(AfterMarketTask):
+    """장마감 후 후보/보유 종목의 microstructure overlay를 캡처해 리플레이 코퍼스를 축적한다.
+
+    todo 1-5: 체결강도·프로그램매매 수급 게이트는 장중 히스토리가 없어 백테스트
+    검증이 불가능하다. 매 거래일 장마감 후 REST 경로로 당일 데이터를 수집해
+    `data/backtest_microstructure/`에 replay fixture 규약 파일로 남긴다.
+    """
+
+    def __init__(
+        self,
+        capture_service,
+        universe_service=None,
+        virtual_trade_service=None,
+        market_calendar_service=None,
+        market_clock=None,
+        scheduler_store=None,
+        output_dir: str | Path = "data/backtest_microstructure",
+        program_db_path: str | Path = "data/program_subscribe/program_trading.db",
+        max_codes: int = 40,
+        logger=None,
+    ):
+        super().__init__(
+            mcs=market_calendar_service,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=None,
+        )
+        self._service = capture_service
+        self._universe_service = universe_service
+        self._virtual_trade_service = virtual_trade_service
+        self._output_dir = Path(output_dir)
+        self._program_db_path = Path(program_db_path)
+        self._max_codes = max_codes
+        # 재시작 시 catch-up 중복 캡처 방지를 위해 "마지막 캡처 날짜"를 영속화한다.
+        self._scheduler_store = scheduler_store
+        self._state_key = "microstructure_capture_last_date"
+        self._last_captured_date: Optional[str] = self._load_last_captured_date()
+        self._progress = {
+            "running": False,
+            "last_captured_date": self._last_captured_date,
+            "last_result": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "microstructure_capture"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "MicrostructureCapture"
+
+    # 시총갭 리포트(15:50)·기본 after-market 루프(15:41)와 클러스터링을 피하고
+    # 당일 프로그램매매 daily REST 데이터가 정리된 뒤 실행한다.
+    @property
+    def _loop_cron_hour(self) -> int:
+        return 16
+
+    @property
+    def _loop_cron_minute(self) -> int:
+        return 5
+
+    def get_progress(self) -> dict:
+        return dict(self._progress)
+
+    def _load_last_captured_date(self) -> Optional[str]:
+        if self._scheduler_store is None:
+            return None
+        try:
+            return self._scheduler_store.load_keyed(self._state_key)
+        except Exception as exc:
+            self._logger.warning(f"{self.task_name}: 마지막 캡처 날짜 로드 실패 — {exc}")
+            return None
+
+    def _save_last_captured_date(self, date_str: str) -> None:
+        if self._scheduler_store is None:
+            return
+        try:
+            self._scheduler_store.save_keyed(self._state_key, date_str)
+        except Exception as exc:
+            self._logger.warning(f"{self.task_name}: 마지막 캡처 날짜 저장 실패 — {exc}")
+
+    async def _resolve_codes(self) -> list[str]:
+        """캡처 대상 종목: 보유 종목 우선 + Pool B 워치리스트, 중복 제거 후 cap."""
+        codes: list[str] = []
+        if self._virtual_trade_service is not None:
+            try:
+                holds = self._virtual_trade_service.get_holds() or []
+                codes.extend(str(h.get("code")) for h in holds if h.get("code"))
+            except Exception as exc:
+                self._logger.warning(f"{self.task_name}: 보유 종목 조회 실패 — {exc}")
+        if self._universe_service is not None:
+            try:
+                watchlist = await self._universe_service.get_watchlist() or {}
+                codes.extend(str(code) for code in watchlist.keys())
+            except Exception as exc:
+                self._logger.warning(f"{self.task_name}: 워치리스트 조회 실패 — {exc}")
+        deduped = list(dict.fromkeys(code for code in codes if code))
+        return deduped[: self._max_codes]
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        if not latest_trading_date:
+            return
+        if self._last_captured_date == latest_trading_date:
+            self._logger.info(
+                f"{self.task_name}: {latest_trading_date} 이미 캡처됨 — skip"
+            )
+            return
+        codes = await self._resolve_codes()
+        if not codes:
+            # 날짜를 저장하지 않아 이후 재실행(예: force) 시 재시도 여지를 남긴다.
+            self._logger.warning(f"{self.task_name}: 캡처 대상 종목 없음 — skip")
+            return
+        program_source = (
+            "program_db" if self._program_db_path.exists() else "daily_rest"
+        )
+        self._progress["running"] = True
+        try:
+            payload = await self._service.capture(
+                codes=codes,
+                date_ymd=latest_trading_date,
+                program_source=program_source,
+            )
+            self._service.write_overlay_files(payload, self._output_dir)
+            self._last_captured_date = latest_trading_date
+            self._save_last_captured_date(latest_trading_date)
+            self._progress["last_captured_date"] = latest_trading_date
+            self._progress["last_result"] = {
+                "codes": len(codes),
+                "program_source": program_source,
+                "row_counts": (payload.get("metadata") or {}).get("row_counts"),
+            }
+            self._logger.info(
+                f"{self.task_name}: {latest_trading_date} 캡처 완료 "
+                f"(codes={len(codes)}, program_source={program_source})"
+            )
+        except Exception as exc:
+            self._logger.error(f"{self.task_name}: 캡처 실패 — {exc}", exc_info=True)
+            self._progress["last_result"] = {"error": str(exc)}
+        finally:
+            self._progress["running"] = False

--- a/tests/unit_test/services/test_backtest_microstructure_capture.py
+++ b/tests/unit_test/services/test_backtest_microstructure_capture.py
@@ -261,3 +261,24 @@ def test_to_float_and_to_int_edge_cases():
     assert _to_int("xyz") is None
     assert _to_int("42") == 42
 
+
+def test_write_overlay_files_creates_four_fixture_files(tmp_path):
+    import json
+
+    payload = {
+        "metadata": {"trade_date": "20260702", "codes": ["000001"]},
+        "intraday_minutes": {"000001": [{"stck_cntg_hour": "090000"}]},
+        "execution_strength": {"000001": 145.5},
+        "program_trades": {"000001": {"program_net_buy_qty": 30000}},
+    }
+
+    paths = BacktestMicrostructureCaptureService.write_overlay_files(payload, tmp_path / "out")
+
+    assert json.loads(paths["capture"].read_text(encoding="utf-8")) == payload
+    assert json.loads(paths["execution_strength"].read_text(encoding="utf-8")) == {"000001": 145.5}
+    assert json.loads(paths["program_trades"].read_text(encoding="utf-8")) == {"000001": 30000}
+    assert json.loads(paths["intraday_minutes"].read_text(encoding="utf-8")) == {
+        "000001": [{"stck_cntg_hour": "090000"}],
+    }
+    assert paths["capture"].name == "replay_microstructure_20260702.json"
+

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -1,0 +1,192 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from task.background.after_market.microstructure_capture_task import MicrostructureCaptureTask
+
+
+def _payload(date="20260702"):
+    return {
+        "metadata": {
+            "trade_date": date,
+            "row_counts": {"intraday_minutes": 3, "execution_strength": 1, "program_trades": 1},
+        },
+        "intraday_minutes": {},
+        "execution_strength": {},
+        "program_trades": {},
+    }
+
+
+@pytest.fixture
+def capture_service():
+    svc = MagicMock()
+    svc.capture = AsyncMock(return_value=_payload())
+    svc.write_overlay_files = MagicMock(return_value={})
+    return svc
+
+
+@pytest.fixture
+def universe_service():
+    svc = MagicMock()
+    svc.get_watchlist = AsyncMock(return_value={"005930": MagicMock(), "000660": MagicMock()})
+    return svc
+
+
+@pytest.fixture
+def virtual_trade_service():
+    svc = MagicMock()
+    svc.get_holds = MagicMock(return_value=[{"code": "035420"}])
+    return svc
+
+
+class _FakeStore:
+    """save_keyed/load_keyed 만 흉내내는 인메모리 스토어 (재시작 영속화 검증용)."""
+
+    def __init__(self):
+        self._data = {}
+
+    def save_keyed(self, key, value):
+        self._data[key] = value
+
+    def load_keyed(self, key):
+        return self._data.get(key)
+
+
+def _make_task(capture_service, tmp_path, **kwargs):
+    defaults = dict(
+        capture_service=capture_service,
+        output_dir=tmp_path / "out",
+        program_db_path=tmp_path / "program_trading.db",
+        logger=MagicMock(),
+    )
+    defaults.update(kwargs)
+    return MicrostructureCaptureTask(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_on_market_closed_captures_once_per_date(capture_service, universe_service, tmp_path):
+    task = _make_task(capture_service, tmp_path, universe_service=universe_service)
+
+    await task._on_market_closed("20260702")
+    await task._on_market_closed("20260702")
+
+    capture_service.capture.assert_awaited_once()
+    capture_service.write_overlay_files.assert_called_once()
+    assert task.get_progress()["last_captured_date"] == "20260702"
+
+
+@pytest.mark.asyncio
+async def test_last_captured_date_persists_across_restart(capture_service, universe_service, tmp_path):
+    store = _FakeStore()
+    task = _make_task(capture_service, tmp_path, universe_service=universe_service, scheduler_store=store)
+    await task._on_market_closed("20260702")
+
+    restarted = _make_task(capture_service, tmp_path, universe_service=universe_service, scheduler_store=store)
+    await restarted._on_market_closed("20260702")
+
+    capture_service.capture.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_codes_union_holdings_first_dedup_and_capped(
+    capture_service, universe_service, virtual_trade_service, tmp_path
+):
+    # 보유 종목이 watchlist 에도 있으면 중복 제거하고 보유 우선 순서를 유지한다.
+    virtual_trade_service.get_holds.return_value = [{"code": "005930"}, {"code": "035420"}]
+
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        virtual_trade_service=virtual_trade_service,
+    )
+    await task._on_market_closed("20260702")
+
+    codes = capture_service.capture.await_args.kwargs["codes"]
+    assert codes == ["005930", "035420", "000660"]
+
+    # max_codes cap 검증
+    capture_service.capture.reset_mock()
+    capped = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        virtual_trade_service=virtual_trade_service,
+        max_codes=1,
+    )
+    await capped._on_market_closed("20260703")
+    assert capture_service.capture.await_args.kwargs["codes"] == ["005930"]
+
+
+@pytest.mark.asyncio
+async def test_program_source_prefers_program_db_when_file_exists(
+    capture_service, universe_service, tmp_path
+):
+    db_path = tmp_path / "program_trading.db"
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+    )
+
+    await task._on_market_closed("20260702")
+    assert capture_service.capture.await_args.kwargs["program_source"] == "daily_rest"
+
+    capture_service.capture.reset_mock()
+    db_path.write_bytes(b"")
+    task2 = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+    )
+    await task2._on_market_closed("20260703")
+    assert capture_service.capture.await_args.kwargs["program_source"] == "program_db"
+
+
+@pytest.mark.asyncio
+async def test_no_codes_skips_capture_and_keeps_date_unmarked(capture_service, tmp_path):
+    empty_universe = MagicMock()
+    empty_universe.get_watchlist = AsyncMock(return_value={})
+    task = _make_task(capture_service, tmp_path, universe_service=empty_universe)
+
+    await task._on_market_closed("20260702")
+    capture_service.capture.assert_not_awaited()
+    assert task.get_progress()["last_captured_date"] is None
+
+    # 이후 후보가 생기면 같은 날짜라도 캡처된다 (날짜 미저장 확인)
+    empty_universe.get_watchlist = AsyncMock(return_value={"005930": MagicMock()})
+    await task._on_market_closed("20260702")
+    capture_service.capture.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_watchlist_error_degrades_to_holdings_only(
+    capture_service, virtual_trade_service, tmp_path
+):
+    broken_universe = MagicMock()
+    broken_universe.get_watchlist = AsyncMock(side_effect=RuntimeError("universe down"))
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=broken_universe,
+        virtual_trade_service=virtual_trade_service,
+    )
+
+    await task._on_market_closed("20260702")
+
+    assert capture_service.capture.await_args.kwargs["codes"] == ["035420"]
+
+
+@pytest.mark.asyncio
+async def test_capture_error_logged_and_date_not_marked(capture_service, universe_service, tmp_path):
+    capture_service.capture = AsyncMock(side_effect=RuntimeError("KIS down"))
+    task = _make_task(capture_service, tmp_path, universe_service=universe_service)
+
+    await task._on_market_closed("20260702")
+
+    assert task.get_progress()["last_captured_date"] is None
+    assert task.get_progress()["last_result"] == {"error": "KIS down"}
+
+
+def test_write_output_dir_passed_through(capture_service, tmp_path):
+    task = _make_task(capture_service, tmp_path)
+    assert task.task_name == "microstructure_capture"
+    assert task.get_progress()["running"] is False

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -51,6 +51,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "websocket_watchdog_task", "pre_market_health_check_task",
         "cache_warmup_task", "notification_queue_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
+        "microstructure_capture_task",
     ]:
         task = MagicMock()
         task.task_name = name
@@ -93,7 +94,7 @@ def test_all_mode_registers_16_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 19
+    assert bg.register.call_count == 20
 
 
 def test_all_mode_registers_12_tasks_to_time_dispatcher(patched_scheduler_deps):
@@ -183,6 +184,7 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
         "strategy_log_report_task", "after_market_reconcile_task",
         "theme_classification_task", "theme_daily_leader_report_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
+        "microstructure_capture_task",
     }
     assert names == expected
     assert "websocket_watchdog_task" not in names
@@ -233,4 +235,4 @@ def test_skips_none_tasks(patched_scheduler_deps):
     # 둘 다 -1 감소한다.
     assert ctx.time_dispatcher.register_task.call_count == 12
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 18
+    assert bg.register.call_count == 19

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -30,6 +30,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "StockClassificationRepository", "ThemeLeaderService", "ThemeDailyLeaderService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "MarketCapGapService", "MarketCapGapReportTask",
+    "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
     "StrategyLogReportService", "NotificationQueueTask",

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -129,6 +129,8 @@ class SchedulerBootstrap:
         self._register(ctx.post_market_replay_audit_task, TaskPriority.LOW)
         self._register(ctx.strategy_log_report_task, TaskPriority.LOW)
         self._register(ctx.after_market_reconcile_task, TaskPriority.LOW)
+        # 자체 AfterMarketLoop 사용 (KST 16:05): market_cap_gap 과 동일 패턴.
+        self._register(self._optional_task("microstructure_capture_task"))
 
     def _register_overseas_tasks(self) -> None:
         # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -31,6 +31,7 @@ from scheduler.strategy_scheduler_store import StrategySchedulerStore
 from scheduler.ticket_queue.dlq_manager import DlqManager
 from scheduler.ticket_queue.message_broker import MessageBroker
 from scheduler.worker.worker_pool import WorkerPool
+from services.backtest_microstructure_capture import BacktestMicrostructureCaptureService
 from services.data_quality_service import DataQualityService
 from services.execution_flow_service import ExecutionFlowService
 from services.indicator_service import IndicatorService
@@ -67,6 +68,7 @@ from task.background.after_market.cache_warmup_task import CacheWarmupTask
 from task.background.after_market.daily_price_collector_task import DailyPriceCollectorTask
 from task.background.after_market.log_cleanup_task import LogCleanupTask
 from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
+from task.background.after_market.microstructure_capture_task import MicrostructureCaptureTask
 from task.background.after_market.minervini_update_task import MinerviniUpdateTask
 from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.ohlcv_update_task import OhlcvUpdateTask
@@ -620,6 +622,7 @@ class ServiceContainer:
                 ctx.post_market_replay_audit_task = None
                 ctx.after_market_reconcile_task = None
                 ctx.opening_position_reconcile_task = None
+                ctx.microstructure_capture_task = None
                 if needs_web:
                     ctx.notification_queue_task = NotificationQueueTask(
                         notification_service=ctx.notification_service,
@@ -776,6 +779,20 @@ class ServiceContainer:
                     logger=ctx.logger,
                     worker_pool=ctx.worker_pool,
                 )
+                # todo 1-5: 장마감 후 후보/보유 종목 microstructure overlay 캡처 (replay 코퍼스 축적)
+                microstructure_enabled = config_dict.get("microstructure_capture_enabled", True)
+                ctx.microstructure_capture_task = MicrostructureCaptureTask(
+                    capture_service=BacktestMicrostructureCaptureService(
+                        stock_query_service=ctx.stock_query_service,
+                        program_provider=ctx.broker,
+                    ),
+                    universe_service=ctx.oneil_universe_service,
+                    virtual_trade_service=ctx.virtual_trade_service,
+                    market_calendar_service=ctx._mcs,
+                    market_clock=ctx.market_clock,
+                    scheduler_store=StrategySchedulerStore(logger=ctx.logger),
+                    logger=ctx.logger,
+                ) if microstructure_enabled else None
             else:
                 ctx.log_cleanup_task = None
                 ctx.newhigh_task = None
@@ -785,6 +802,7 @@ class ServiceContainer:
                 ctx.strategy_log_report_task = None
                 ctx.post_market_replay_audit_task = None
                 ctx.after_market_reconcile_task = None
+                ctx.microstructure_capture_task = None
 
             if needs_web:
                 ctx.notification_queue_task = NotificationQueueTask(


### PR DESCRIPTION
## 배경 (todo 1-5 — 엣지 검증 크리티컬 패스)

VBO/OSB의 수급 게이트(체결강도 ≥120%, 프로그램 순매수 ≥ 거래대금 10%)는 장중 히스토리 데이터가 없어 백테스트 검증이 불가능하다. 캡처 인프라(`scripts.capture_backtest_microstructure` + `BacktestMicrostructureCaptureService`)는 존재하지만 수동 CLI 단발 실행만 가능했고 실제 실행 흔적도 없었다. 매 거래일이 코퍼스 1개이므로, 자동화로 축적을 시작한다.

## 변경 내용

- **`MicrostructureCaptureTask` 신규** (`task/background/after_market/`) — `AfterMarketTask` 상속, `MarketCapGapReportTask` 패턴
  - 자체 after-market 루프 **KST 16:05** (시총갭 15:50·기본 루프 15:41과 클러스터링 회피)
  - 캡처 대상: **보유 종목 우선 + Pool B 워치리스트** 합집합, 중복 제거 후 `max_codes=40` cap
  - `program_source`: `data/program_subscribe/program_trading.db` 존재 시 `program_db`, 없으면 `daily_rest` 폴백
  - `scheduler_store`(`microstructure_capture_last_date`)로 마지막 캡처 날짜 영속화 — 재시작 catch-up 중복 방지
  - 종목 0건·캡처 실패 시 날짜를 저장하지 않아 재시도 여지 유지, 소스별 조회 실패는 부분 소스로 degrade
- **파일 쓰기 단일 소스화**: CLI의 `_write_output_files` 로직을 서비스 `write_overlay_files`(staticmethod)로 이동. CLI는 위임 래퍼로 유지되어 기존 사용법/테스트 그대로 동작. replay fixture 파일명 규약(`replay_*_{date}.json` 4종)이 태스크·CLI 공통으로 보장됨
- **배선**: `service_container.py`(batch 블록, `microstructure_capture_enabled` 플래그 기본 on, 비-batch/해외 모드 None) + `scheduler_bootstrap.py`(`_register_batch_tasks`, market_cap_gap과 동일하게 자체 루프 — KST TimeDispatcher 미등록)
- `config.yaml.example`에 플래그 문서화

## 산출물

`data/backtest_microstructure/`에 거래일별:
`replay_microstructure_YYYYMMDD.json` / `replay_execution_strength_*.json` / `replay_program_trades_*.json` / `replay_intraday_minutes_*.json`
→ `scripts.export_backtest_replay_fixture`로 replay fixture 변환 가능 (todo 1-5 blocked 항목 해제 경로)

## 테스트 (TDD)

- 신규 `test_microstructure_capture_task.py` 8건: 날짜별 1회 캡처, 재시작 영속 dedup, 보유 우선+cap 종목 결정, program_source 분기, 0건 skip, watchlist 장애 degrade, 캡처 실패 시 날짜 미저장
- 서비스 `write_overlay_files` 직접 테스트 추가, 기존 CLI 테스트는 무수정 통과(위임 호환 검증)
- bootstrap 테스트 등록 목록/카운트 갱신
- **단위 6,572 / 통합 245 전체 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)