### PR TITLE
run_backtest에 슬리피지/스프레드 민감도 인자 노출 (todo 1-8 선행)

### DIFF
--- a/docs/backtest.md
+++ b/docs/backtest.md
@@ -463,6 +463,14 @@ python -m scripts.run_backtest --strategy oneil_pocket_pivot --start-date 202605
 python -m scripts.run_backtest --strategy oneil_pocket_pivot --start-date 20260501 --end-date 20260510 --execution-bar-policy next_bar
 ```
 
+### 슬리피지/스프레드 민감도 (비용 민감도 실행)
+
+`--market-slippage-pct`는 시장가성 주문(MARKET/STOP 손절) 체결에 적용되는 슬리피지 %이고, `--spread-pct`는 bid/ask 부재 시 시장가성 주문에 적용할 스프레드 %(절반이 체결가에 가산)다. **LIMIT 체결에는 둘 다 적용되지 않는다** (지정가는 정의상 지정가 체결). 기본값은 둘 다 0.0이며 run metadata에 기록된다.
+
+```powershell
+python -m scripts.run_backtest --strategy larry_williams_vbo --start-date 20260501 --end-date 20260630 --market-slippage-pct 0.3 --spread-pct 0.1
+```
+
 ### 운영 RiskGate/PositionSizing 설정 적용
 
 ```powershell

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -59,6 +59,20 @@ def _parse_args() -> argparse.Namespace:
         dest="execution_bar_policy",
         help="체결 후보 봉 선택 정책: current_bar=가격에 닿은 첫 분봉, next_bar=가격에 닿은 신호 봉 다음 분봉",
     )
+    parser.add_argument(
+        "--market-slippage-pct",
+        type=float,
+        default=0.0,
+        dest="market_slippage_pct",
+        help="시장가성 주문(MARKET/STOP 손절) 체결 슬리피지 %% (LIMIT 체결엔 미적용, default: 0.0)",
+    )
+    parser.add_argument(
+        "--spread-pct",
+        type=float,
+        default=0.0,
+        dest="spread_pct",
+        help="bid/ask 부재 시 시장가성 주문에 적용할 스프레드 %% — 절반이 체결가에 가산 (default: 0.0)",
+    )
     parser.add_argument("--output", default="console", choices=["console", "json"])
     parser.add_argument("--output-file", default=None, dest="output_file")
     parser.add_argument(
@@ -1405,6 +1419,22 @@ def _format_parameter_stability_row(
     return base + f"  Δtrades={trade_diff:+d} Δnet_pnl={pnl_diff:+,.0f}"
 
 
+def _build_execution_simulator(args: argparse.Namespace):
+    """CLI 슬리피지/스프레드 인자를 체결 정책으로 매핑한 시뮬레이터를 만든다.
+
+    비용 민감도 실행용 (todo 1-8). 두 값 모두 0이면 기본 정책과 동일하다.
+    """
+    from services.backtest_execution_simulator import (
+        BacktestExecutionPolicy,
+        BacktestExecutionSimulator,
+    )
+
+    return BacktestExecutionSimulator(BacktestExecutionPolicy(
+        market_slippage_pct=float(getattr(args, "market_slippage_pct", 0.0) or 0.0),
+        spread_pct=float(getattr(args, "spread_pct", 0.0) or 0.0),
+    ))
+
+
 async def _run(args: argparse.Namespace) -> None:
     from scripts._bootstrap import bootstrap_pp_strategy, make_stdout_logger
     from config.config_loader import load_configs
@@ -1525,6 +1555,8 @@ async def _run(args: argparse.Namespace) -> None:
                 "strategy_key": args.strategy,
                 "backtest_time": args.backtest_time,
                 "execution_bar_policy": args.execution_bar_policy,
+                "market_slippage_pct": args.market_slippage_pct,
+                "spread_pct": args.spread_pct,
                 "use_risk_sizing": args.use_risk_sizing,
                 "output": args.output,
                 "walk_forward": segment is not None,
@@ -1543,6 +1575,7 @@ async def _run(args: argparse.Namespace) -> None:
                 strategy=strategy,
                 bar_provider=bar_provider,
                 ledger=ledger,
+                simulator=_build_execution_simulator(args),
                 backtest_journal_repository=BacktestJournalRepository(),
                 run_id="_".join(run_parts),
                 metadata=metadata,

--- a/tests/unit_test/scripts/test_run_backtest.py
+++ b/tests/unit_test/scripts/test_run_backtest.py
@@ -16,6 +16,7 @@ from scripts.run_backtest import (
     _build_dates,
     _build_risk_sizing_services,
     _build_backtest_strategy,
+    _build_execution_simulator,
     _format_console,
     _format_walk_forward_console,
     _format_walk_forward_json,
@@ -145,6 +146,47 @@ def test_parse_args_accepts_execution_bar_policy(monkeypatch):
     args = _parse_args()
 
     assert args.execution_bar_policy == "next_bar"
+
+
+def test_parse_args_accepts_slippage_and_spread(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_backtest",
+            "--dates",
+            "20260501",
+            "--market-slippage-pct",
+            "0.3",
+            "--spread-pct",
+            "0.1",
+        ],
+    )
+
+    args = _parse_args()
+
+    assert args.market_slippage_pct == 0.3
+    assert args.spread_pct == 0.1
+
+
+def test_parse_args_slippage_and_spread_default_zero(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["run_backtest", "--dates", "20260501"],
+    )
+
+    args = _parse_args()
+
+    assert args.market_slippage_pct == 0.0
+    assert args.spread_pct == 0.0
+
+
+def test_build_execution_simulator_maps_policy_fields():
+    args = SimpleNamespace(market_slippage_pct=0.3, spread_pct=0.1)
+
+    simulator = _build_execution_simulator(args)
+
+    assert simulator.policy.market_slippage_pct == 0.3
+    assert simulator.policy.spread_pct == 0.1
 
 
 def test_parse_args_accepts_backtest_time(monkeypatch):


### PR DESCRIPTION
## 배경 (todo 1-8 — 현행 전략 백테스트 재실행 + 비용 민감도)

`BacktestExecutionPolicy`에 `market_slippage_pct`/`spread_pct` 필드는 있었지만 `run_backtest.py`가 시뮬레이터를 주입하지 않아 **항상 기본 정책(슬리피지 0)으로 실행**됐다. 슬리피지 민감도 표(0/0.1/0.3%) 산출의 선행 조건으로 정책 필드를 CLI에 노출한다.

## 변경 내용

- `--market-slippage-pct` (기본 0.0): 시장가성 주문(MARKET/**STOP 손절**) 체결 슬리피지 %
- `--spread-pct` (기본 0.0): bid/ask 부재 시 시장가성 주문에 적용할 스프레드 % (절반이 체결가에 가산)
- `_build_execution_simulator(args)` 헬퍼 신설 → `make_runner`에 `simulator=` 주입 — `make_runner`를 공유하는 기간/walk-forward/ablation/parameter-stability 경로 전부에 일괄 적용
- run metadata에 두 값 기록 (산출물 재현성)
- `docs/backtest.md`에 사용법 섹션 추가

## 의미론 주의 (민감도 해석 시)

백테스트 매수 주문은 LIMIT, 손절 청산은 STOP으로 모델링된다 (`backtest_period_runner._order_type_for`). 시뮬레이터 의미론상 **LIMIT 체결에는 슬리피지가 적용되지 않으므로**(지정가는 지정가 체결), 이 인자들은 손절 STOP 체결과 시장가성 주문의 비용 민감도를 움직인다. 매수 진입 지연(폴링 랙)의 비용은 별도 레버(`--execution-bar-policy next_bar`)와 조합해 해석해야 한다 — 문서에 명시함.

## 테스트 (TDD)

- 신규 3건: 인자 파싱, 기본값 0, `_build_execution_simulator` 정책 매핑
- **단위 6,566 / 통합 245 전체 통과**

## 후속 (이 PR 머지 후)

todo 1-8 실행 단계: 활성 전략 전체 walk-forward + Monte Carlo 재실행을 슬리피지 0/0.1/0.3% × `current_bar`/`next_bar` 조합으로 돌려 민감도 표 산출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)