### PR TITLE
O-1: 규칙 기반 NYSE 캘린더 — 미국 휴장일/조기폐장 반영

### DIFF
--- a/services/us_market_calendar_service.py
+++ b/services/us_market_calendar_service.py
@@ -1,0 +1,143 @@
+"""규칙 기반 NYSE 거래 캘린더 (O-1 — 해외 Phase 5 전제 게이트).
+
+KIS Open API에는 해외 휴장일 조회 TR이 없어(국내 CTCA0903R만 존재) NYSE 공식
+휴장 규칙을 로컬에서 계산한다. AfterMarketLoop / TimeDispatcher가 기대하는
+`get_latest_trading_date()` 인터페이스와 호환되어, 미국장 태스크의 휴장일
+스킵과 (Phase 5) 조기폐장 EOD 청산 시각 판단에 사용한다.
+
+반영 규칙:
+- 전휴장: 신정(일→월 관측, 토는 무관측 — NYSE 규칙), MLK(1월 3째 월),
+  워싱턴 탄생일(2월 3째 월), 성금요일(부활절-2일), 메모리얼(5월 마지막 월),
+  준틴스(6/19, 2022년~), 독립기념일(7/4), 노동절(9월 1째 월),
+  추수감사절(11월 4째 목), 크리스마스(12/25). 고정일 휴장은 토→금/일→월 관측.
+- 조기폐장(13:00 ET): 7/3(월~목요일일 때), 추수감사절 다음날(금), 12/24(월~목요일일 때).
+
+한계: 국장(國葬)·재해 등 임시 특별휴장은 반영하지 않는다.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Dict, Optional, Set
+
+_DATE_FMT = "%Y%m%d"
+
+
+def _easter_sunday(year: int) -> date:
+    """Gregorian computus (Anonymous algorithm)."""
+    a = year % 19
+    b, c = divmod(year, 100)
+    d, e = divmod(b, 4)
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i, k = divmod(c, 4)
+    l = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * l) // 451
+    month = (h + l - 7 * m + 114) // 31
+    day = (h + l - 7 * m + 114) % 31 + 1
+    return date(year, month, day)
+
+
+def _nth_weekday(year: int, month: int, weekday: int, n: int) -> date:
+    """해당 월의 n번째 weekday (월=0)."""
+    first = date(year, month, 1)
+    offset = (weekday - first.weekday()) % 7
+    return first + timedelta(days=offset + 7 * (n - 1))
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> date:
+    """해당 월의 마지막 weekday (월=0)."""
+    next_month = date(year + (month == 12), (month % 12) + 1, 1)
+    d = next_month - timedelta(days=1)
+    return d - timedelta(days=(d.weekday() - weekday) % 7)
+
+
+def _observed(d: date) -> date:
+    """고정일 휴장의 주말 관측 이동: 토→전일(금), 일→익일(월)."""
+    if d.weekday() == 5:
+        return d - timedelta(days=1)
+    if d.weekday() == 6:
+        return d + timedelta(days=1)
+    return d
+
+
+class USMarketCalendarService:
+    """NYSE 휴장일·조기폐장 판단자. `market_clock`은 America/New_York 클럭을 주입한다."""
+
+    def __init__(self, market_clock, logger: Optional[logging.Logger] = None) -> None:
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
+        self._holiday_cache: Dict[int, Set[date]] = {}
+
+    # ── 휴장일 계산 ──
+
+    def _full_holidays(self, year: int) -> Set[date]:
+        cached = self._holiday_cache.get(year)
+        if cached is not None:
+            return cached
+        holidays: Set[date] = set()
+        new_years = date(year, 1, 1)
+        if new_years.weekday() == 6:  # 일 → 월 관측
+            holidays.add(new_years + timedelta(days=1))
+        elif new_years.weekday() < 5:
+            holidays.add(new_years)
+        # 토요일 신정은 전년 12/31로 이동하지 않음 (NYSE 규칙)
+        holidays.add(_nth_weekday(year, 1, 0, 3))    # MLK
+        holidays.add(_nth_weekday(year, 2, 0, 3))    # 워싱턴 탄생일
+        holidays.add(_easter_sunday(year) - timedelta(days=2))  # 성금요일
+        holidays.add(_last_weekday(year, 5, 0))      # 메모리얼
+        if year >= 2022:
+            holidays.add(_observed(date(year, 6, 19)))  # 준틴스
+        holidays.add(_observed(date(year, 7, 4)))    # 독립기념일
+        holidays.add(_nth_weekday(year, 9, 0, 1))    # 노동절
+        holidays.add(_nth_weekday(year, 11, 3, 4))   # 추수감사절
+        holidays.add(_observed(date(year, 12, 25)))  # 크리스마스
+        self._holiday_cache[year] = holidays
+        return holidays
+
+    @staticmethod
+    def _parse(yyyymmdd: str) -> date:
+        return date(int(yyyymmdd[:4]), int(yyyymmdd[4:6]), int(yyyymmdd[6:8]))
+
+    # ── 공개 API ──
+
+    def is_trading_day(self, yyyymmdd: str) -> bool:
+        d = self._parse(yyyymmdd)
+        if d.weekday() >= 5:
+            return False
+        return d not in self._full_holidays(d.year)
+
+    def is_early_close_day(self, yyyymmdd: str) -> bool:
+        """13:00 ET 조기폐장 여부. 전휴장일은 False."""
+        if not self.is_trading_day(yyyymmdd):
+            return False
+        d = self._parse(yyyymmdd)
+        if d.month == 7 and d.day == 3 and d.weekday() <= 3:
+            return True
+        if d == _nth_weekday(d.year, 11, 3, 4) + timedelta(days=1):
+            return True
+        if d.month == 12 and d.day == 24 and d.weekday() <= 3:
+            return True
+        return False
+
+    def get_close_time_str(self, yyyymmdd: str) -> str:
+        """해당 거래일의 정규장 마감 시각 (ET, "HH:MM"). Phase 5 EOD 청산 판단용."""
+        return "13:00" if self.is_early_close_day(yyyymmdd) else "16:00"
+
+    async def get_latest_trading_date(self) -> Optional[str]:
+        """US 클럭 기준 오늘 포함 가장 최근 거래일 (YYYYMMDD).
+
+        AfterMarketLoop / TimeDispatcher 의 mcs 인터페이스 호환 (async).
+        """
+        today_str = self._market_clock.get_current_kst_date_str()
+        if not today_str:
+            return None
+        d = self._parse(today_str)
+        for _ in range(15):  # 연말 연휴+주말 최장 조합도 커버
+            candidate = d.strftime(_DATE_FMT)
+            if self.is_trading_day(candidate):
+                return candidate
+            d -= timedelta(days=1)
+        self._logger.warning(f"USMarketCalendar: {today_str} 기준 최근 거래일 탐색 실패")
+        return None

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -6,11 +6,10 @@ OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 after-market
 
 트리거는 미국장 전용 TimeDispatcher(time_dispatcher_us)가 담당한다 — NY 정규장
 마감(16:00 ET) 감지 후 task delay(30분)만큼 대기해 16:30 ET 효과로 티켓을 발행하면
-WorkerPool 이 execute() 를 호출한다(Ticket-driven, worker_pool 주입). 한국 거래
-캘린더(mcs)는 미국장에 적용되지 않으므로 dispatcher 에 미주입(None)하며, NY 주말
-필터 + 클럭 날짜로 거래일을 식별한다. 미국 공휴일에는 직전 완성봉을 재평가할 수
-있으나 dry-run 이라 무해하다. (_loop_* 프로퍼티는 시스템 상태 화면의 트리거 표기용
-메타데이터로 유지된다.)
+WorkerPool 이 execute() 를 호출한다(Ticket-driven, worker_pool 주입). O-1: dispatcher
+와 이 태스크에 규칙 기반 NYSE 캘린더(`USMarketCalendarService`)가 주입되어 미국
+휴장일에는 latest_trading_date 가 직전 거래일로 유지되고 중복 발행이 차단된다.
+(_loop_* 프로퍼티는 시스템 상태 화면의 트리거 표기용 메타데이터로 유지된다.)
 
 **주문 경로 없음** — OverseasVBODryRunService 가 order_execution 의존을 갖지 않아
 실주문이 발생하지 않는다.

--- a/tests/unit_test/services/test_us_market_calendar_service.py
+++ b/tests/unit_test/services/test_us_market_calendar_service.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+
+from services.us_market_calendar_service import USMarketCalendarService
+
+
+def _svc(clock_date: str = "20260703") -> USMarketCalendarService:
+    clock = MagicMock()
+    clock.get_current_kst_date_str.return_value = clock_date
+    return USMarketCalendarService(market_clock=clock, logger=MagicMock())
+
+
+class TestFullHolidays2026:
+    """2026년 NYSE 전휴장일 규칙 검증."""
+
+    def test_2026_full_holiday_set(self):
+        svc = _svc()
+        expected_holidays = [
+            "20260101",  # 신정 (목)
+            "20260119",  # MLK — 1월 3째 월요일
+            "20260216",  # 워싱턴 탄생일 — 2월 3째 월요일
+            "20260403",  # 성금요일 (부활절 2026-04-05 - 2일)
+            "20260525",  # 메모리얼 — 5월 마지막 월요일
+            "20260619",  # 준틴스 (금)
+            "20260703",  # 독립기념일 관측 (7/4 토 → 금)
+            "20260907",  # 노동절 — 9월 1째 월요일
+            "20261126",  # 추수감사절 — 11월 4째 목요일
+            "20261225",  # 크리스마스 (금)
+        ]
+        for d in expected_holidays:
+            assert svc.is_trading_day(d) is False, f"{d} 는 휴장이어야 함"
+
+    def test_2026_normal_weekdays_are_trading_days(self):
+        svc = _svc()
+        for d in ("20260702", "20260706", "20261127", "20261224"):
+            assert svc.is_trading_day(d) is True, f"{d} 는 거래일이어야 함"
+
+    def test_weekends_are_not_trading_days(self):
+        svc = _svc()
+        assert svc.is_trading_day("20260704") is False  # 토
+        assert svc.is_trading_day("20260705") is False  # 일
+
+
+class TestObservanceRules:
+    def test_new_years_on_saturday_is_not_observed_on_friday(self):
+        # 2022-01-01(토) — NYSE 규칙상 전년 12/31(금)로 이동하지 않는다 (2021-12-31 개장).
+        svc = _svc()
+        assert svc.is_trading_day("20211231") is True
+
+    def test_sunday_holidays_observed_on_monday(self):
+        svc = _svc()
+        assert svc.is_trading_day("20210705") is False  # 7/4(일) → 월요일 관측
+        assert svc.is_trading_day("20221226") is False  # 12/25(일) → 월요일 관측
+
+    def test_good_friday_computus(self):
+        svc = _svc()
+        assert svc.is_trading_day("20250418") is False  # 부활절 2025-04-20
+        assert svc.is_trading_day("20260403") is False  # 부활절 2026-04-05
+
+
+class TestEarlyClose:
+    def test_early_close_days(self):
+        svc = _svc()
+        assert svc.is_early_close_day("20261127") is True  # 추수감사절 다음날(금)
+        assert svc.is_early_close_day("20261224") is True  # 크리스마스 이브(목)
+        assert svc.is_early_close_day("20250703") is True  # 7/3(목), 7/4(금) 휴장
+
+    def test_full_holiday_is_not_early_close(self):
+        svc = _svc()
+        # 2026-07-03 은 관측 전휴장이므로 조기폐장이 아니다.
+        assert svc.is_early_close_day("20260703") is False
+
+    def test_normal_day_is_not_early_close(self):
+        svc = _svc()
+        assert svc.is_early_close_day("20260702") is False
+
+    def test_close_time_str(self):
+        svc = _svc()
+        assert svc.get_close_time_str("20261127") == "13:00"
+        assert svc.get_close_time_str("20260702") == "16:00"
+
+
+class TestLatestTradingDate:
+    async def test_holiday_returns_previous_trading_day(self):
+        # 2026-07-03(금, 관측휴장) → 7/2(목)
+        svc = _svc(clock_date="20260703")
+        assert await svc.get_latest_trading_date() == "20260702"
+
+    async def test_weekend_walks_back_to_friday_unless_holiday(self):
+        # 2026-06-20(토) → 6/19 준틴스 휴장 → 6/18(목)
+        svc = _svc(clock_date="20260620")
+        assert await svc.get_latest_trading_date() == "20260618"
+
+    async def test_trading_day_returns_itself(self):
+        svc = _svc(clock_date="20260702")
+        assert await svc.get_latest_trading_date() == "20260702"

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -29,7 +29,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OneilUniverseService", "NaverFinanceScraperService",
     "StockClassificationRepository", "ThemeLeaderService", "ThemeDailyLeaderService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
-    "MarketCapGapService", "MarketCapGapReportTask",
+    "MarketCapGapService", "MarketCapGapReportTask", "USMarketCalendarService",
     "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
@@ -398,21 +398,23 @@ def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service
         ServiceContainer(ctx).run()
 
     task_kwargs = task_cls.call_args.kwargs
-    # 한국 거래 캘린더는 미국장에 적용되지 않으므로 미주입
-    assert task_kwargs["market_calendar_service"] is None
+    # O-1: 규칙 기반 NYSE 캘린더가 주입된다 (미국 휴장일 스킵).
+    us_calendar = patched_service_container_deps["USMarketCalendarService"].return_value
+    assert task_kwargs["market_calendar_service"] is us_calendar
     # 미국 정규장 클럭 주입 (America/New_York)
     assert task_kwargs["market_clock"].timezone_name == "America/New_York"
     # Ticket-driven 전환: 미국장 TimeDispatcher(time_dispatcher_us)가 NY 마감 후
     # delay 만큼 대기 뒤 티켓을 발행 → WorkerPool 이 execute() 를 호출한다.
     assert task_kwargs["worker_pool"] is ctx.worker_pool
     assert task_kwargs["notification_service"] is ctx.notification_service
-    # 미국장 전용 TimeDispatcher 가 mcs=None + 미국장 클럭으로 생성된다.
+    # 미국장 전용 TimeDispatcher 가 NYSE 캘린더(mcs) + 미국장 클럭으로 생성된다.
     assert ctx.time_dispatcher_us is not None
     td_us_calls = [
         c for c in patched_service_container_deps["TimeDispatcher"].call_args_list
-        if c.kwargs.get("mcs") is None
+        if c.kwargs.get("db_path") == "data/time_dispatcher_state_us.db"
     ]
     assert len(td_us_calls) == 1
+    assert td_us_calls[0].kwargs["mcs"] is us_calendar
     assert td_us_calls[0].kwargs["market_clock"].timezone_name == "America/New_York"
 
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -43,6 +43,7 @@ from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
 from services.oneil_universe_service import OneilUniverseService
 from services.theme_classification_collector_service import ThemeClassificationCollectorService
+from services.us_market_calendar_service import USMarketCalendarService
 from services.theme_daily_leader_service import ThemeDailyLeaderService
 from services.theme_leader_service import ThemeLeaderService
 from task.background.after_market.theme_classification_task import ThemeClassificationTask
@@ -266,13 +267,15 @@ class ServiceContainer:
             )
             # 미국장 배치(해외 dry-run 등)를 위한 별도 TimeDispatcher. KST dispatcher와
             # 동일한 MessageBroker/WorkerPool 을 공유하며, 미국장 클럭으로 NY 마감을 감지한다.
-            # 거래 캘린더(mcs)는 미주입 → clock 날짜를 거래일 식별자로 사용(주말 필터만 적용).
+            # O-1: 규칙 기반 NYSE 캘린더(mcs) 주입 → 휴장일에는 latest_trading_date가
+            # 직전 거래일로 유지되어 중복 발행이 차단된다 (주말 필터만 있던 기존 한계 해소).
             ctx.time_dispatcher_us = None
             if is_market_enabled(ctx, "overseas_us"):
+                us_clock = MarketClock.for_us_equities(logger=ctx.logger)
                 ctx.time_dispatcher_us = TimeDispatcher(
                     broker=ctx.message_broker,
-                    market_clock=MarketClock.for_us_equities(logger=ctx.logger),
-                    mcs=None,
+                    market_clock=us_clock,
+                    mcs=USMarketCalendarService(market_clock=us_clock, logger=ctx.logger),
                     logger=ctx.logger,
                     db_path="data/time_dispatcher_state_us.db",
                 )
@@ -328,13 +331,17 @@ class ServiceContainer:
                         scheduler_store=gap_report_store,
                         logger=ctx.logger,
                     ) if kr_gap_enabled else None
+                    # O-1: NYSE 캘린더 주입 — 미국 휴장일에 us_close 리포트 스킵.
+                    us_gap_clock = MarketClock.for_us_equities(logger=ctx.logger)
                     ctx.market_cap_gap_report_us_task = MarketCapGapReportTask(
                         market_cap_gap_service=ctx.market_cap_gap_service,
                         telegram_reporter=getattr(ctx, "telegram_reporter", None),
                         notification_service=ctx.notification_service,
                         session="us_close",
-                        market_calendar_service=None,
-                        market_clock=MarketClock.for_us_equities(logger=ctx.logger),
+                        market_calendar_service=USMarketCalendarService(
+                            market_clock=us_gap_clock, logger=ctx.logger,
+                        ),
+                        market_clock=us_gap_clock,
                         scheduler_store=gap_report_store,
                         logger=ctx.logger,
                     ) if us_gap_enabled else None
@@ -905,13 +912,16 @@ class ServiceContainer:
             position_sizing_service=overseas_position_sizing_service,
             fx_provider=_overseas_fx_provider,
         )
-        # 미국 정규장 마감(16:00 ET) 직후 트리거. 한국 거래 캘린더(mcs)는
-        # 미국장에 적용되지 않으므로 미주입(None)하고, 미국장 클럭을 주입한다.
+        # 미국 정규장 마감(16:00 ET) 직후 트리거. O-1: 규칙 기반 NYSE 캘린더를
+        # 주입해 미국 휴장일에는 실행을 스킵한다 (기존: 주말 필터만).
+        dryrun_us_clock = MarketClock.for_us_equities(logger=ctx.logger)
         ctx.overseas_dryrun_task = OverseasDryRunTask(
             dryrun_service=ctx.overseas_vbo_dryrun_service,
             shadow_journal=ctx.event_shadow_journal_service,
-            market_calendar_service=None,
-            market_clock=MarketClock.for_us_equities(logger=ctx.logger),
+            market_calendar_service=USMarketCalendarService(
+                market_clock=dryrun_us_clock, logger=ctx.logger,
+            ),
+            market_clock=dryrun_us_clock,
             logger=ctx.logger,
             notification_service=ctx.notification_service,
             # Ticket-driven: 미국장 TimeDispatcher(time_dispatcher_us)가 NY 마감 후


### PR DESCRIPTION
## 배경 (todo O-1 — 해외 Phase 5/라이브 전환 전 필수 게이트)

미국장 태스크(해외 VBO dry-run, 시총갭 us_close 리포트)는 "cron mon-fri + NY 클럭 날짜"만으로 거래일을 식별해 **미국 공휴일에 헛돈다**. 이 PR 작성일(2026-07-03)이 바로 독립기념일 관측 휴장(7/4 토→금)으로 실사례. 라이브 전환 시에는 조기폐장일(13:00 ET) EOD 청산 미스 = 의도치 않은 오버나이트로 직결되므로 Phase 5 전제 게이트다.

KIS Open API에는 해외 휴장일 조회 TR이 없어(국내 `CTCA0903R`만 존재) **NYSE 공식 규칙을 로컬 계산**하는 방식을 택했다.

## 변경 내용

**`USMarketCalendarService` 신설** (`services/us_market_calendar_service.py`)
- 전휴장 10종: 신정(일→월 관측, **토는 무관측** — NYSE 규칙), MLK, 워싱턴 탄생일, 성금요일(Gregorian computus), 메모리얼, 준틴스(2022~), 독립기념일, 노동절, 추수감사절, 크리스마스 (고정일은 토→금/일→월 관측)
- 조기폐장(13:00 ET) 3종: 7/3(월~목), 추수감사절 익일(금), 12/24(월~목) — `get_close_time_str()`로 Phase 5 EOD 청산 시각 판단에 소비 가능
- `async get_latest_trading_date()` — 기존 `AfterMarketLoop`/`TimeDispatcher`의 mcs 인터페이스와 호환. 휴장일엔 latest가 직전 거래일로 유지 → dispatcher dedup이 중복 발행을 차단하고, AfterMarketLoop은 `latest != today` 스킵이 작동
- 한계: 국장(國葬) 등 임시 특별휴장 미반영 (docstring 명시)

**주입 3곳** (`service_container.py`)
- `time_dispatcher_us`: `mcs=None` → NYSE 캘린더
- `OverseasDryRunTask`: `market_calendar_service=None` → NYSE 캘린더 (폴백 루프 경로 정합)
- `MarketCapGapReportTask(us_close)`: 동일

## 검증 시나리오 (오늘 밤)

미국 휴장일인 오늘, `latest_trading_date`가 20260702로 유지되어 어제 발행분과 dedup — dry-run/us 리포트가 스킵되어야 한다.

## 테스트 (TDD)

- 신규 13건: 2026년 전 휴장일 검증(7/3 관측휴장 포함), 관측 에지(2022-01-01 토 → 2021-12-31 **개장**, 일→월 관측 2건), computus 2건, 조기폐장 4건(2026-07-03은 조기폐장 아님 확인), latest 역탐색 3건(휴장 금→목, 주말+준틴스 연쇄)
- 컨테이너 테스트: `mcs=None` 단정 → 캘린더 주입 단정으로 갱신 (US dispatcher 식별자를 mcs→db_path로 변경)
- **단위 6,588 / 통합 245 전체 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)