### PR TITLE
[codex] 전략별 모의투자 성과 차트 분리

### DIFF
--- a/tests/frontend/run_virtual_chart_dom_tests.mjs
+++ b/tests/frontend/run_virtual_chart_dom_tests.mjs
@@ -1,0 +1,157 @@
+/*
+ * jsdom 기반 /virtual 성과 차트 회귀 테스트.
+ *
+ * 목적: ALL 성과 차트가 다시 단일 과밀 차트로 퇴행하지 않도록,
+ * 전략별 미니 차트 생성과 Chart.js 인스턴스 정리를 DOM 행위로 검증한다.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+
+const VIRTUAL_CHART_JS = resolve(import.meta.dirname, "../../view/web/static/js/virtual_chart.js");
+
+const SCAFFOLD = `
+<div id="section-virtual" class="section">
+  <div id="virtualYieldChartGrid" class="virtual-chart-grid">
+    <div class="virtual-chart-empty">차트 로딩 중...</div>
+  </div>
+</div>
+`;
+
+const SAMPLE_CHART_DATA = {
+  histories: {
+    ALL: [
+      { date: "2026-06-01", return_rate: 0 },
+      { date: "2026-06-02", return_rate: 1.5 },
+    ],
+    StrategyA: [
+      { date: "2026-06-01", return_rate: 0 },
+      { date: "2026-06-02", return_rate: 2.1 },
+    ],
+    StrategyB: [
+      { date: "2026-06-01", return_rate: 0 },
+      { date: "2026-06-02", return_rate: -1.2 },
+    ],
+  },
+  benchmarks: {
+    KOSPI200: [
+      { date: "2026-06-01", return_rate: 0 },
+      { date: "2026-06-02", return_rate: 0.3 },
+    ],
+    KOSDAQ150: [
+      { date: "2026-06-01", return_rate: 0 },
+      { date: "2026-06-02", return_rate: -0.4 },
+    ],
+  },
+};
+
+function makeWindow(fetchPayload = SAMPLE_CHART_DATA) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/virtual",
+    runScripts: "dangerously",
+  });
+  const { window } = dom;
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
+  window.currentCharts = [];
+  window.__charts = [];
+  window.fetch = async () => ({
+    ok: true,
+    json: async () => fetchPayload,
+  });
+  window.Chart = class MockChart {
+    static defaults = {
+      plugins: {
+        legend: {
+          labels: {
+            generateLabels: chart => chart.data.datasets.map((dataset, datasetIndex) => ({
+              datasetIndex,
+              text: dataset.label,
+            })),
+          },
+        },
+      },
+    };
+
+    constructor(ctx, config) {
+      this.ctx = ctx;
+      this.config = config;
+      this.data = config.data;
+      this.options = config.options;
+      this.destroyed = false;
+      window.__charts.push(this);
+    }
+
+    update() {}
+
+    destroy() {
+      this.destroyed = true;
+    }
+  };
+
+  const script = window.document.createElement("script");
+  script.textContent = readFileSync(VIRTUAL_CHART_JS, "utf8");
+  window.document.body.appendChild(script);
+  return window;
+}
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+test("ALL 선택 시 ALL 집계선이 아니라 전략별 미니 차트를 생성한다", async () => {
+  const window = makeWindow();
+
+  await window.refreshVirtualChart(["ALL"]);
+
+  const cards = [...window.document.querySelectorAll(".virtual-mini-chart-card")];
+  const titles = cards.map(card => card.querySelector("h3").textContent);
+  assert(cards.length === 2, `전략별 차트 2개가 필요함: ${cards.length}`);
+  assert(titles.includes("StrategyA"), "StrategyA 차트 누락");
+  assert(titles.includes("StrategyB"), "StrategyB 차트 누락");
+  assert(!titles.includes("전체(ALL)"), "ALL 집계 차트가 표시되면 안 됨");
+  assert(window.__charts.length === 2, "Chart 인스턴스는 전략별 1개씩 생성되어야 함");
+
+  const firstLabels = window.__charts[0].data.datasets.map(dataset => dataset.label);
+  assert(firstLabels.length === 3, "각 차트는 전략선과 벤치마크 2개만 가져야 함");
+  assert(firstLabels.includes("KOSPI200 %"), "KOSPI200 벤치마크 누락");
+  assert(firstLabels.includes("KOSDAQ150 %"), "KOSDAQ150 벤치마크 누락");
+});
+
+test("전략 선택 변경 시 이전 미니 차트를 정리하고 선택 전략만 렌더링한다", async () => {
+  const window = makeWindow();
+
+  await window.refreshVirtualChart(["ALL"]);
+  const oldCharts = window.__charts.slice();
+  await window.refreshVirtualChart(["StrategyB"]);
+
+  assert(oldCharts.every(chart => chart.destroyed), "선택 변경 전 Chart 인스턴스가 정리되어야 함");
+  const cards = [...window.document.querySelectorAll(".virtual-mini-chart-card")];
+  assert(cards.length === 1, "선택 전략 차트만 남아야 함");
+  assert(cards[0].querySelector("h3").textContent === "StrategyB", "StrategyB 차트만 표시되어야 함");
+  assert(window.currentCharts.length === 1, "전역 Chart 레지스트리에는 현재 차트만 남아야 함");
+});
+
+test("히스토리가 없으면 차트 대신 빈 상태 메시지를 표시한다", async () => {
+  const window = makeWindow({ histories: {}, benchmarks: {} });
+
+  await window.refreshVirtualChart(["ALL"]);
+
+  assert(window.document.querySelectorAll(".virtual-mini-chart-card").length === 0, "빈 데이터에서는 차트가 없어야 함");
+  assert(
+    window.document.querySelector(".virtual-chart-empty").textContent.includes("표시할 차트 데이터"),
+    "빈 데이터 메시지가 표시되어야 함",
+  );
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -355,6 +355,82 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     border: 1px solid #ddd;
 }
 
+.virtual-chart-panel {
+    margin-top: 16px;
+    background: rgba(255,255,255,0.05);
+    border-radius: 8px;
+    padding: 12px;
+    border: 1px solid var(--border);
+}
+
+.virtual-chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 12px;
+}
+
+.virtual-mini-chart-card {
+    min-width: 0;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.virtual-mini-chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.virtual-mini-chart-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.virtual-mini-chart-header span {
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+.virtual-mini-chart-canvas {
+    position: relative;
+    width: 100%;
+    height: 260px;
+}
+
+.virtual-chart-empty {
+    grid-column: 1 / -1;
+    padding: 24px;
+    color: var(--text-secondary);
+    text-align: center;
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+}
+
+@media (max-width: 520px) {
+    .virtual-chart-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .virtual-mini-chart-header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .virtual-mini-chart-header h3 {
+        white-space: normal;
+    }
+}
+
 .text-red { color: #e74c3c; }
 .text-blue { color: #3498db; }
 

--- a/view/web/static/js/virtual_chart.js
+++ b/view/web/static/js/virtual_chart.js
@@ -1,11 +1,10 @@
 /**
- * VirtualTradeRepository 데이터를 이용한 수익률 차트 관리
+ * VirtualTradeRepository 데이터를 이용한 전략별 수익률 미니 차트 관리
  * - 멀티셀렉트 전략 필터링 지원
  * - 전략별 고정 색상 매핑
- * - 전일/전주 기준선 annotation
+ * - 각 전략 차트에 KOSPI200/KOSDAQ150 벤치마크 표시
  */
-let yieldChart = null;
-let chartInitPromise = null;
+const yieldCharts = new Map();
 
 const STRATEGY_COLORS_PALETTE = [
     '#ff6b6b', '#51cf66', '#fcc419', '#ae3ec9',
@@ -88,123 +87,171 @@ async function waitForChartLibrary(timeoutMs = CHART_LIBRARY_WAIT_MS) {
     throw new Error('Chart.js library not loaded');
 }
 
-async function initVirtualChart() {
-    if (yieldChart) return yieldChart;
+function unregisterVirtualChart(chart) {
+    if (!window.currentCharts) return;
+    window.currentCharts = window.currentCharts.filter(item => item !== chart);
+}
 
-    const canvas = document.getElementById('virtualYieldChart');
-    if (!canvas) return;
+function destroyVirtualCharts() {
+    yieldCharts.forEach(chart => {
+        unregisterVirtualChart(chart);
+        try {
+            chart.destroy();
+        } catch (_) {}
+    });
+    yieldCharts.clear();
+}
 
-    await waitForChartLibrary();
+function setVirtualChartMessage(message) {
+    const grid = document.getElementById('virtualYieldChartGrid');
+    if (!grid) return;
+    destroyVirtualCharts();
+    grid.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'virtual-chart-empty';
+    empty.textContent = message;
+    grid.appendChild(empty);
+}
 
-    const ctx = canvas.getContext('2d');
-    yieldChart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: [], datasets: [] },
-        options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            animation: false,
-            scales: {
-                x: {
-                    grid: {
-                        display: true,
-                        drawOnChartArea: true,
-                        color: 'rgba(255,255,255,0.15)',
-                        lineWidth: 1,
-                        drawTicks: true
-                    },
-                    ticks: {
-                        color: '#868e96',
-                        maxRotation: 45,
-                        autoSkip: false,
-                        font: { size: 10 }
-                    }
+function createVirtualChartCard(strategyName) {
+    const card = document.createElement('div');
+    card.className = 'virtual-mini-chart-card';
+
+    const header = document.createElement('div');
+    header.className = 'virtual-mini-chart-header';
+
+    const title = document.createElement('h3');
+    title.textContent = strategyName === 'ALL' ? '전체(ALL)' : strategyName;
+
+    const legend = document.createElement('span');
+    legend.textContent = 'KOSPI200 / KOSDAQ150 비교';
+
+    header.appendChild(title);
+    header.appendChild(legend);
+
+    const canvasWrap = document.createElement('div');
+    canvasWrap.className = 'virtual-mini-chart-canvas';
+
+    const canvas = document.createElement('canvas');
+    canvas.id = `virtualYieldChart-${yieldCharts.size}`;
+    canvasWrap.appendChild(canvas);
+
+    card.appendChild(header);
+    card.appendChild(canvasWrap);
+    return { card, canvas };
+}
+
+function buildBaseChartOptions() {
+    return {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        interaction: {
+            mode: 'index',
+            intersect: false
+        },
+        scales: {
+            x: {
+                grid: {
+                    display: true,
+                    drawOnChartArea: true,
+                    color: 'rgba(255,255,255,0.12)',
+                    lineWidth: 1,
+                    drawTicks: true
                 },
-                y: {
-                    grid: {
-                        display: true,
-                        drawOnChartArea: true,
-                        color: 'rgba(255,255,255,0.15)',
-                        lineWidth: 1,
-                        drawTicks: true
-                    },
-                    ticks: {
-                        color: '#868e96',
-                        callback: value => value.toFixed(1) + '%',
-                        stepSize: 5
+                ticks: {
+                    color: '#868e96',
+                    maxRotation: 0,
+                    autoSkip: true,
+                    maxTicksLimit: 8,
+                    font: { size: 10 }
+                }
+            },
+            y: {
+                grid: {
+                    display: true,
+                    drawOnChartArea: true,
+                    color: 'rgba(255,255,255,0.12)',
+                    lineWidth: 1,
+                    drawTicks: true
+                },
+                ticks: {
+                    color: '#868e96',
+                    callback: value => value.toFixed(1) + '%',
+                    maxTicksLimit: 7
+                }
+            }
+        },
+        plugins: {
+            legend: {
+                display: true,
+                position: 'top',
+                labels: {
+                    color: '#a0a0b0',
+                    usePointStyle: true,
+                    pointStyle: 'line',
+                    boxWidth: 20,
+                    font: { size: 10 },
+                    generateLabels: function(chart) {
+                        const original = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+                        return original.map(item => {
+                            const dataset = chart.data.datasets[item.datasetIndex];
+                            item.pointStyle = 'line';
+                            if (dataset.borderDash && dataset.borderDash.length > 0) {
+                                item.lineDash = dataset.borderDash;
+                            }
+                            return item;
+                        });
                     }
                 }
             },
-            plugins: {
-                legend: {
-                    display: true,
-                    labels: {
-                        color: '#a0a0b0',
-                        usePointStyle: true,
-                        pointStyle: 'line',
-                        boxWidth: 20,
-                        font: { size: 11 },
-                        generateLabels: function(chart) {
-                            const original = Chart.defaults.plugins.legend.labels.generateLabels(chart);
-                            return original.map(item => {
-                                const dataset = chart.data.datasets[item.datasetIndex];
-                                item.pointStyle = 'line';
-                                if (dataset.borderDash && dataset.borderDash.length > 0) {
-                                    item.lineDash = dataset.borderDash;
-                                }
-                                return item;
-                            });
-                        }
-                    }
-                },
-                tooltip: { mode: 'index', intersect: false },
-                annotation: { annotations: {} }
-            }
+            tooltip: { mode: 'index', intersect: false },
+            annotation: { annotations: {} }
         }
-    });
-    window.currentCharts = window.currentCharts || [];
-    window.currentCharts.push(yieldChart);
+    };
 }
 
 /**
  * 전일/전주 기준 annotation 생성
  * @param {string[]} labels - MM-DD 포맷 라벨 배열
- * @param {string[]} globalDates - YYYY-MM-DD 원본 날짜 배열
- * @param {object} allHistories - { strategyName: [{date, return_rate}, ...] }
- * @param {string[]} displayStrategies - 현재 표시 중인 전략 목록
+ * @param {string[]} activeDates - YYYY-MM-DD 원본 날짜 배열
+ * @param {Array<{date: string, return_rate: number}>} strategyHistory
  */
-function buildAnnotations(labels, globalDates, allHistories, displayStrategies) {
-    const annotations = {};
-    if (globalDates.length < 2) return annotations;
+function buildAnnotations(labels, activeDates, strategyHistory) {
+    const annotations = {
+        zeroLine: {
+            type: 'line',
+            yMin: 0,
+            yMax: 0,
+            borderColor: 'rgba(255, 255, 255, 0.25)',
+            borderWidth: 1,
+            borderDash: [3, 3]
+        }
+    };
+    if (activeDates.length < 2) return annotations;
 
-    const todayIdx = globalDates.length - 1;
-    const todayDate = globalDates[todayIdx];
+    const todayIdx = activeDates.length - 1;
+    const todayDate = activeDates[todayIdx];
 
-    // 전일: 오늘 바로 이전 데이터 포인트
     const prevDayIdx = todayIdx - 1;
-    // 전주: 7일 이상 전인 가장 가까운 데이터 포인트
     const todayMs = new Date(todayDate).getTime();
     let prevWeekIdx = -1;
     for (let i = todayIdx - 1; i >= 0; i--) {
-        const diff = todayMs - new Date(globalDates[i]).getTime();
-        if (diff >= 6 * 24 * 60 * 60 * 1000) { // 6일 이상 (전주)
+        const diff = todayMs - new Date(activeDates[i]).getTime();
+        if (diff >= 6 * 24 * 60 * 60 * 1000) {
             prevWeekIdx = i;
             break;
         }
     }
 
-    // ALL 전략 기준 수익률 변동 계산
-    const refName = displayStrategies.includes('ALL') ? 'ALL' : displayStrategies[0];
-    const refHistory = allHistories[refName] || [];
     const refDateMap = {};
-    refHistory.forEach(h => { refDateMap[h.date] = h.return_rate; });
+    strategyHistory.forEach(h => { refDateMap[h.date] = h.return_rate; });
 
     const todayVal = refDateMap[todayDate];
     if (todayVal === undefined) return annotations;
 
-    // 전일 annotation (세로선 + 라벨)
     if (prevDayIdx >= 0) {
-        const prevDate = globalDates[prevDayIdx];
+        const prevDate = activeDates[prevDayIdx];
         const prevVal = refDateMap[prevDate];
         if (prevVal !== undefined) {
             const change = todayVal - prevVal;
@@ -217,21 +264,20 @@ function buildAnnotations(labels, globalDates, allHistories, displayStrategies) 
                 borderWidth: 2,
                 label: {
                     display: true,
-                    content: `전일 (${prevDate.substring(5)}) ${sign}${change.toFixed(2)}%`,
+                    content: `전일 ${sign}${change.toFixed(2)}%`,
                     position: 'start',
                     backgroundColor: 'rgba(255, 183, 77, 0.15)',
                     color: '#ffb74d',
-                    font: { size: 10, weight: 'bold' },
-                    padding: { top: 3, bottom: 3, left: 6, right: 6 },
+                    font: { size: 9, weight: 'bold' },
+                    padding: { top: 2, bottom: 2, left: 5, right: 5 },
                     borderRadius: 3
                 }
             };
         }
     }
 
-    // 전주 annotation (세로선 + 라벨)
     if (prevWeekIdx >= 0) {
-        const prevWeekDate = globalDates[prevWeekIdx];
+        const prevWeekDate = activeDates[prevWeekIdx];
         const prevWeekVal = refDateMap[prevWeekDate];
         if (prevWeekVal !== undefined) {
             const change = todayVal - prevWeekVal;
@@ -244,176 +290,164 @@ function buildAnnotations(labels, globalDates, allHistories, displayStrategies) 
                 borderWidth: 2,
                 label: {
                     display: true,
-                    content: `전주 (${prevWeekDate.substring(5)}) ${sign}${change.toFixed(2)}%`,
+                    content: `전주 ${sign}${change.toFixed(2)}%`,
                     position: 'start',
                     backgroundColor: 'rgba(129, 199, 132, 0.15)',
                     color: '#81c784',
-                    font: { size: 10, weight: 'bold' },
-                    padding: { top: 3, bottom: 3, left: 6, right: 6 },
+                    font: { size: 9, weight: 'bold' },
+                    padding: { top: 2, bottom: 2, left: 5, right: 5 },
                     borderRadius: 3,
-                    yAdjust: -20
+                    yAdjust: -18
                 }
             };
         }
     }
 
-    // 0% 기준 수평선
-    annotations.zeroLine = {
-        type: 'line',
-        yMin: 0,
-        yMax: 0,
-        borderColor: 'rgba(255, 255, 255, 0.25)',
-        borderWidth: 1,
-        borderDash: [3, 3]
-    };
-
     return annotations;
+}
+
+function alignHistoryToDates(history, activeDates) {
+    const dateMap = {};
+    history.forEach(h => { dateMap[h.date] = h.return_rate; });
+    return activeDates.map(date => {
+        const val = dateMap[date];
+        return val !== undefined ? val : null;
+    });
+}
+
+function buildStrategyDatasets(strategyName, strategyHistory, benchmarks, activeDates) {
+    const isAllLine = strategyName === 'ALL';
+    const isSparse = activeDates.length <= 2;
+    const datasets = [{
+        label: isAllLine ? '전체(ALL) %' : `${strategyName} %`,
+        data: alignHistoryToDates(strategyHistory, activeDates),
+        borderColor: getStrategyColor(strategyName),
+        backgroundColor: isAllLine ? 'rgba(77, 171, 247, 0.1)' : 'transparent',
+        borderWidth: isAllLine ? 3 : 2,
+        pointRadius: isSparse ? 4 : (isAllLine ? 3 : 0),
+        fill: isAllLine,
+        tension: 0.3
+    }];
+
+    if (benchmarks.KOSPI200 && benchmarks.KOSPI200.length > 0) {
+        datasets.push({
+            label: 'KOSPI200 %',
+            data: alignHistoryToDates(benchmarks.KOSPI200, activeDates),
+            borderColor: '#ff922b',
+            borderWidth: 1.8,
+            borderDash: [5, 5],
+            fill: false,
+            pointRadius: 0,
+            tension: 0.3
+        });
+    }
+    if (benchmarks.KOSDAQ150 && benchmarks.KOSDAQ150.length > 0) {
+        datasets.push({
+            label: 'KOSDAQ150 %',
+            data: alignHistoryToDates(benchmarks.KOSDAQ150, activeDates),
+            borderColor: '#8ce99a',
+            borderWidth: 1.8,
+            borderDash: [2, 2],
+            fill: false,
+            pointRadius: 0,
+            tension: 0.3
+        });
+    }
+
+    return datasets;
+}
+
+function getDisplayStrategies(selectedStrategies, allHistories) {
+    const isAll = !selectedStrategies || selectedStrategies.includes('ALL');
+    if (isAll) {
+        return Object.keys(allHistories).filter(name => name !== 'ALL' && allHistories[name]?.length > 0);
+    }
+    return selectedStrategies.filter(name => allHistories[name]?.length > 0);
+}
+
+function renderMiniChart(grid, strategyName, strategyHistory, benchmarks) {
+    const activeDates = strategyHistory.map(h => h.date).filter(Boolean);
+    if (activeDates.length === 0) return;
+
+    const labels = activeDates.map(d => d.substring(5));
+    const { card, canvas } = createVirtualChartCard(strategyName);
+    grid.appendChild(card);
+
+    const chart = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+            labels,
+            datasets: buildStrategyDatasets(strategyName, strategyHistory, benchmarks, activeDates)
+        },
+        options: buildBaseChartOptions()
+    });
+
+    chart.options.plugins.annotation.annotations = buildAnnotations(labels, activeDates, strategyHistory);
+    chart.update();
+
+    yieldCharts.set(strategyName, chart);
+    window.currentCharts = window.currentCharts || [];
+    window.currentCharts.push(chart);
 }
 
 window.refreshVirtualChart = async function(selectedStrategies) {
     if (!selectedStrategies) selectedStrategies = ['ALL'];
 
-    if (!yieldChart) {
-        try {
-            if (!chartInitPromise) {
-                chartInitPromise = initVirtualChart();
-            }
-            await chartInitPromise;
-            if (!yieldChart) return;
-        } catch (error) {
-            chartInitPromise = null;
-            console.error('[VirtualChart] init failed:', error);
-            return;
-        }
-    }
+    const grid = document.getElementById('virtualYieldChartGrid');
+    if (!grid) return;
 
     try {
+        await waitForChartLibrary();
         const data = await getChartData(selectedStrategies);
-        if (!data.histories || Object.keys(data.histories).length === 0) return;
+        if (!data.histories || Object.keys(data.histories).length === 0) {
+            setVirtualChartMessage('표시할 차트 데이터가 없습니다.');
+            return;
+        }
 
         const allHistories = data.histories;
         const benchmarks = data.benchmarks || {};
-        const isAll = selectedStrategies.includes('ALL');
-
-        // 색상 맵 초기화 — 전체 전략 순서대로 색상 할당 (필터 전에 호출)
-        const allStrategyNames = Object.keys(allHistories).filter(n => n !== 'ALL');
+        const allStrategyNames = Object.keys(allHistories).filter(name => name !== 'ALL');
         allStrategyNames.forEach(name => getStrategyColor(name));
 
-        const displayStrategies = isAll
-            ? Object.keys(allHistories)
-            : selectedStrategies.filter(s => allHistories[s]);
-
-        // X축 날짜: 선택된 전략들의 실제 날짜 합집합 (빈 날짜 제거)
-        let activeDates;
-        if (isAll) {
-            const refHistory = allHistories['ALL'] || Object.values(allHistories)[0] || [];
-            activeDates = refHistory.map(h => h.date);
-        } else {
-            const dateSet = new Set();
-            displayStrategies.forEach(name => {
-                (allHistories[name] || []).forEach(h => dateSet.add(h.date));
-            });
-            activeDates = [...dateSet].sort();
+        const displayStrategies = getDisplayStrategies(selectedStrategies, allHistories);
+        if (displayStrategies.length === 0) {
+            setVirtualChartMessage('표시할 전략 차트가 없습니다.');
+            return;
         }
-        if (activeDates.length === 0) return;
 
-        const labels = activeDates.map(d => d.substring(5));
-        yieldChart.data.labels = labels;
-
-        const newDatasets = [];
-        const isSparse = activeDates.length <= 2;
-
-        displayStrategies.forEach((name) => {
-            const isAllLine = (name === 'ALL');
-            const strategyHistory = allHistories[name];
-            if (!strategyHistory) return;
-
-            const dateMap = {};
-            strategyHistory.forEach(h => { dateMap[h.date] = h.return_rate; });
-
-            const alignedData = activeDates.map(date => {
-                const val = dateMap[date];
-                return val !== undefined ? val : null;
-            });
-
-            newDatasets.push({
-                label: isAllLine ? '전체(ALL) %' : `${name} %`,
-                data: alignedData,
-                borderColor: getStrategyColor(name),
-                backgroundColor: isAllLine ? 'rgba(77, 171, 247, 0.1)' : 'transparent',
-                borderWidth: isAllLine ? 3 : 1.5,
-                pointRadius: isSparse ? 4 : (isAllLine ? 3 : 0),
-                fill: isAllLine,
-                tension: 0.3
-            });
+        destroyVirtualCharts();
+        grid.innerHTML = '';
+        displayStrategies.forEach(name => {
+            renderMiniChart(grid, name, allHistories[name], benchmarks);
         });
-
-        // 벤치마크를 activeDates에 맞춰 align
-        function alignBenchmark(bmData) {
-            const bmMap = {};
-            bmData.forEach(b => { bmMap[b.date] = b.return_rate; });
-            return activeDates.map(date => {
-                const val = bmMap[date];
-                return val !== undefined ? val : null;
-            });
-        }
-
-        if (benchmarks.KOSPI200 && benchmarks.KOSPI200.length > 0) {
-            newDatasets.push({
-                label: '벤치마크(KOSPI200) %',
-                data: alignBenchmark(benchmarks.KOSPI200),
-                borderColor: '#ff922b',
-                borderWidth: 2,
-                borderDash: [5, 5],
-                fill: false,
-                pointRadius: 0,
-                tension: 0.3
-            });
-        }
-        if (benchmarks.KOSDAQ150 && benchmarks.KOSDAQ150.length > 0) {
-            newDatasets.push({
-                label: '벤치마크(KOSDAQ150) %',
-                data: alignBenchmark(benchmarks.KOSDAQ150),
-                borderColor: '#8ce99a',
-                borderWidth: 2,
-                borderDash: [2, 2],
-                fill: false,
-                pointRadius: 0,
-                tension: 0.3
-            });
-        }
-
-        yieldChart.data.datasets = newDatasets;
-
-        // annotation 업데이트
-        const annotations = buildAnnotations(labels, activeDates, allHistories, displayStrategies);
-        yieldChart.options.plugins.annotation.annotations = annotations;
-
-        yieldChart.update();
     } catch (error) {
         console.error('[VirtualChart] 업데이트 실패:', error);
+        setVirtualChartMessage('차트 업데이트 실패');
     }
-}
+};
 
 window.invalidateVirtualChartCache = function() {
     chartDataCache.clear();
     chartDataPromiseCache.clear();
-}
+};
 
 window.prefetchVirtualChart = function(selectedStrategies) {
     return getChartData(selectedStrategies).catch(error => {
         console.error('[VirtualChart] prefetch failed:', error);
     });
-}
+};
 
-document.addEventListener('DOMContentLoaded', initVirtualChart);
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('virtualYieldChartGrid')) {
+        waitForChartLibrary().catch(error => {
+            console.error('[VirtualChart] init failed:', error);
+        });
+    }
+});
 
 /* ── Pjax 재방문 시 차트 재초기화 ── */
-document.addEventListener('pjax:ready', async (e) => {
+document.addEventListener('pjax:ready', (e) => {
     if (e.detail?.path !== '/virtual') return;
-    // Pjax 클린업에서 destroy된 인스턴스 → null 리셋 후 재초기화
-    yieldChart = null;
-    chartInitPromise = null;
+    destroyVirtualCharts();
     window.invalidateVirtualChartCache();
-    await initVirtualChart();
 });

--- a/view/web/templates/virtual.html
+++ b/view/web/templates/virtual.html
@@ -17,8 +17,10 @@
                 <span>로딩 중...</span>
             </div>
 
-            <div style="margin-top: 16px; background: rgba(255,255,255,0.05); border-radius: 8px; padding: 12px; border: 1px solid var(--border);">
-                <canvas id="virtualYieldChart" style="width: 100%; height: 600px;"></canvas>
+            <div class="virtual-chart-panel">
+                <div id="virtualYieldChartGrid" class="virtual-chart-grid">
+                    <div class="virtual-chart-empty">차트 로딩 중...</div>
+                </div>
             </div>
             <div class="form-row" style="justify-content: flex-end; margin-top: 10px; align-items: center; gap: 10px;">
                 <label style="display: flex; align-items: center; gap: 5px; cursor: help; user-select: none; color: var(--text-primary);"
@@ -116,7 +118,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/virtual_chart.js?v=8"></script>
+<script src="/static/js/virtual_chart.js?v=9"></script>
 <script src="/static/js/stock.js?v=1"></script>
 <script src="/static/js/virtual.js?v=4"></script>
 <script>


### PR DESCRIPTION
## Summary
- Split the overcrowded virtual performance chart into per-strategy mini charts.
- Show each strategy with KOSPI200 and KOSDAQ150 benchmark lines.
- Add a jsdom regression runner for the virtual chart behavior.

## Validation
- node --check view/web/static/js/virtual_chart.js
- node tests/frontend/run_virtual_chart_dom_tests.mjs
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v