### PR TITLE
Add microstructure capture quality report

### DIFF
--- a/scripts/analyze_backtest_microstructure_quality.py
+++ b/scripts/analyze_backtest_microstructure_quality.py
@@ -1,0 +1,324 @@
+"""CLI: summarize replay microstructure capture quality.
+
+The analyzer reads ``replay_microstructure_YYYYMMDD.json`` files produced by
+``scripts.capture_backtest_microstructure`` and turns their metadata into a
+small daily QC report. It does not call broker APIs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator * 100.0
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_present(value: Any) -> bool:
+    return value is not None
+
+
+def load_capture_payloads(
+    input_dir: Path | str,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Load capture payloads sorted by filename date."""
+    input_dir = Path(input_dir)
+    if not input_dir.exists():
+        return []
+
+    payloads: List[Dict[str, Any]] = []
+    for path in sorted(input_dir.glob("replay_microstructure_*.json")):
+        stem_date = path.stem.replace("replay_microstructure_", "", 1)
+        if len(stem_date) != 8 or not stem_date.isdigit():
+            continue
+        if date_from and stem_date < date_from:
+            continue
+        if date_to and stem_date > date_to:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _daily_quality(
+    payload: Dict[str, Any],
+    *,
+    min_intraday_coverage_pct: float,
+    min_program_overlay_coverage_pct: float,
+    min_program_db_coverage_pct: float,
+    max_stale_rows: int,
+) -> Dict[str, Any]:
+    metadata = payload.get("metadata") or {}
+    codes = [str(code) for code in (metadata.get("codes") or [])]
+    code_count = len(codes)
+    intraday = payload.get("intraday_minutes") or {}
+    execution_strength = payload.get("execution_strength") or {}
+    program_trades = payload.get("program_trades") or {}
+    quality = metadata.get("quality") or {}
+    fallback_codes = [
+        str(code) for code in (metadata.get("program_fallback_codes") or [])
+        if str(code) in set(codes)
+    ]
+    stale_by_code = quality.get("stale_minute_rows_dropped") or {}
+    stale_rows = sum(_to_int(v) for v in stale_by_code.values())
+
+    intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
+    execution_strength_available = sum(
+        1 for code in codes if _is_present(execution_strength.get(code))
+    )
+    program_overlay_available = sum(
+        1 for code in codes if _is_present(program_trades.get(code))
+    )
+    program_source = str(metadata.get("program_source") or "")
+    program_db_available: Optional[int] = None
+    program_db_coverage_pct: Optional[float] = None
+    if program_source == "program_db":
+        program_db_available = max(0, program_overlay_available - len(fallback_codes))
+        program_db_coverage_pct = _pct(program_db_available, code_count)
+
+    intraday_coverage_pct = _pct(intraday_available, code_count)
+    execution_strength_coverage_pct = _pct(execution_strength_available, code_count)
+    program_overlay_coverage_pct = _pct(program_overlay_available, code_count)
+
+    issues: List[str] = []
+    if code_count == 0:
+        issues.append("no_codes")
+    if intraday_coverage_pct < min_intraday_coverage_pct:
+        issues.append("intraday_coverage_below_threshold")
+    if program_overlay_coverage_pct < min_program_overlay_coverage_pct:
+        issues.append("program_overlay_coverage_below_threshold")
+    if (
+        program_db_coverage_pct is not None
+        and program_db_coverage_pct < min_program_db_coverage_pct
+    ):
+        issues.append("program_db_coverage_below_threshold")
+    if stale_rows > max_stale_rows:
+        issues.append("stale_minute_rows_present")
+
+    return {
+        "trade_date": str(metadata.get("trade_date") or ""),
+        "codes": code_count,
+        "intraday_available": intraday_available,
+        "intraday_coverage_pct": intraday_coverage_pct,
+        "execution_strength_available": execution_strength_available,
+        "execution_strength_coverage_pct": execution_strength_coverage_pct,
+        "program_overlay_available": program_overlay_available,
+        "program_overlay_coverage_pct": program_overlay_coverage_pct,
+        "program_source": program_source,
+        "program_fallback_codes": fallback_codes,
+        "program_fallback_pct": _pct(len(fallback_codes), code_count),
+        "program_db_available": program_db_available,
+        "program_db_coverage_pct": program_db_coverage_pct,
+        "empty_minute_codes": quality.get("empty_minute_codes") or [],
+        "stale_minute_rows_dropped": stale_rows,
+        "issues": issues,
+        "quality_gate_passed": not issues,
+    }
+
+
+def compute_quality_report(
+    payloads: List[Dict[str, Any]],
+    *,
+    min_intraday_coverage_pct: float = 80.0,
+    min_program_overlay_coverage_pct: float = 80.0,
+    min_program_db_coverage_pct: float = 50.0,
+    max_stale_rows: int = 0,
+) -> Dict[str, Any]:
+    """Compute daily and aggregate quality metrics."""
+    by_date: Dict[str, Dict[str, Any]] = {}
+    for payload in payloads:
+        daily = _daily_quality(
+            payload,
+            min_intraday_coverage_pct=min_intraday_coverage_pct,
+            min_program_overlay_coverage_pct=min_program_overlay_coverage_pct,
+            min_program_db_coverage_pct=min_program_db_coverage_pct,
+            max_stale_rows=max_stale_rows,
+        )
+        key = daily["trade_date"] or f"unknown_{len(by_date) + 1}"
+        by_date[key] = daily
+
+    total_codes = sum(row["codes"] for row in by_date.values())
+    intraday_available = sum(row["intraday_available"] for row in by_date.values())
+    execution_strength_available = sum(
+        row["execution_strength_available"] for row in by_date.values()
+    )
+    program_overlay_available = sum(
+        row["program_overlay_available"] for row in by_date.values()
+    )
+    program_db_denominator = sum(
+        row["codes"] for row in by_date.values()
+        if row["program_db_coverage_pct"] is not None
+    )
+    program_db_available = sum(
+        row["program_db_available"] or 0 for row in by_date.values()
+        if row["program_db_coverage_pct"] is not None
+    )
+    stale_rows = sum(row["stale_minute_rows_dropped"] for row in by_date.values())
+    fallback_count = sum(len(row["program_fallback_codes"]) for row in by_date.values())
+
+    daily_failures = {
+        date: row["issues"] for date, row in by_date.items()
+        if row["issues"]
+    }
+    gate_passed = bool(payloads) and not daily_failures
+    totals = {
+        "capture_files": len(payloads),
+        "trading_days": len(by_date),
+        "total_codes": total_codes,
+        "intraday_available": intraday_available,
+        "intraday_coverage_pct": _pct(intraday_available, total_codes),
+        "execution_strength_available": execution_strength_available,
+        "execution_strength_coverage_pct": _pct(execution_strength_available, total_codes),
+        "program_overlay_available": program_overlay_available,
+        "program_overlay_coverage_pct": _pct(program_overlay_available, total_codes),
+        "program_db_available": program_db_available,
+        "program_db_coverage_pct": (
+            _pct(program_db_available, program_db_denominator)
+            if program_db_denominator > 0 else None
+        ),
+        "program_fallback_count": fallback_count,
+        "program_fallback_pct": _pct(fallback_count, total_codes),
+        "stale_minute_rows_dropped": stale_rows,
+        "quality_gate_passed": gate_passed,
+        "daily_failures": daily_failures,
+    }
+    if not payloads:
+        totals["daily_failures"] = {"all": ["no_capture_files"]}
+
+    return {
+        "config": {
+            "min_intraday_coverage_pct": min_intraday_coverage_pct,
+            "min_program_overlay_coverage_pct": min_program_overlay_coverage_pct,
+            "min_program_db_coverage_pct": min_program_db_coverage_pct,
+            "max_stale_rows": max_stale_rows,
+        },
+        "totals": totals,
+        "by_date": by_date,
+    }
+
+
+def _fmt_pct(value: Any) -> str:
+    return f"{value:.1f}%" if isinstance(value, (int, float)) else "-"
+
+
+def format_markdown_report(report: Dict[str, Any]) -> str:
+    totals = report.get("totals", {})
+    lines: List[str] = [
+        "# Microstructure Capture Quality",
+        "",
+        "## Summary",
+        "",
+        "| metric | value |",
+        "|---|---:|",
+        f"| capture_files | {totals.get('capture_files', 0)} |",
+        f"| total_codes | {totals.get('total_codes', 0)} |",
+        f"| intraday_coverage | {_fmt_pct(totals.get('intraday_coverage_pct'))} |",
+        f"| execution_strength_coverage | {_fmt_pct(totals.get('execution_strength_coverage_pct'))} |",
+        f"| program_overlay_coverage | {_fmt_pct(totals.get('program_overlay_coverage_pct'))} |",
+        f"| program_db_coverage | {_fmt_pct(totals.get('program_db_coverage_pct'))} |",
+        f"| program_fallback_count | {totals.get('program_fallback_count', 0)} |",
+        f"| stale_minute_rows_dropped | {totals.get('stale_minute_rows_dropped', 0)} |",
+        f"| quality_gate_passed | {totals.get('quality_gate_passed', False)} |",
+        "",
+        "## By Date",
+        "",
+        "| date | codes | intraday | exec_strength | program | program_db | stale | issues |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for date, row in sorted((report.get("by_date") or {}).items()):
+        issues = ", ".join(row.get("issues") or []) or "-"
+        lines.append(
+            f"| {date} | {row.get('codes', 0)} | "
+            f"{_fmt_pct(row.get('intraday_coverage_pct'))} | "
+            f"{_fmt_pct(row.get('execution_strength_coverage_pct'))} | "
+            f"{_fmt_pct(row.get('program_overlay_coverage_pct'))} | "
+            f"{_fmt_pct(row.get('program_db_coverage_pct'))} | "
+            f"{row.get('stale_minute_rows_dropped', 0)} | {issues} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analyze replay microstructure capture quality.",
+    )
+    parser.add_argument("--input-dir", default="data/backtest_microstructure")
+    parser.add_argument("--date-from", default=None, help="YYYYMMDD")
+    parser.add_argument("--date-to", default=None, help="YYYYMMDD")
+    parser.add_argument("--min-intraday-coverage-pct", type=float, default=80.0)
+    parser.add_argument("--min-program-overlay-coverage-pct", type=float, default=80.0)
+    parser.add_argument("--min-program-db-coverage-pct", type=float, default=50.0)
+    parser.add_argument("--max-stale-rows", type=int, default=0)
+    parser.add_argument("--output-json", default=None)
+    parser.add_argument("--output-markdown", default=None)
+    parser.add_argument(
+        "--fail-on-gate",
+        action="store_true",
+        help="Return exit code 1 when the quality gate fails.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    payloads = load_capture_payloads(
+        args.input_dir,
+        date_from=args.date_from,
+        date_to=args.date_to,
+    )
+    report = compute_quality_report(
+        payloads,
+        min_intraday_coverage_pct=args.min_intraday_coverage_pct,
+        min_program_overlay_coverage_pct=args.min_program_overlay_coverage_pct,
+        min_program_db_coverage_pct=args.min_program_db_coverage_pct,
+        max_stale_rows=args.max_stale_rows,
+    )
+    report["config"].update({
+        "input_dir": str(args.input_dir),
+        "date_from": args.date_from,
+        "date_to": args.date_to,
+    })
+
+    if args.output_json:
+        out_json = Path(args.output_json)
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"[INFO] JSON report: {out_json}")
+    if args.output_markdown:
+        out_md = Path(args.output_markdown)
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(format_markdown_report(report), encoding="utf-8")
+        print(f"[INFO] Markdown report: {out_md}")
+
+    if not (args.output_json or args.output_markdown):
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    if args.fail_on_gate and not report["totals"]["quality_gate_passed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
+++ b/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
@@ -1,0 +1,213 @@
+import json
+
+import pytest
+
+from scripts.analyze_backtest_microstructure_quality import (
+    compute_quality_report,
+    format_markdown_report,
+    load_capture_payloads,
+    main,
+)
+
+
+def _payload(
+    *,
+    date: str,
+    codes: list[str],
+    intraday_minutes: dict,
+    execution_strength: dict,
+    program_trades: dict,
+    program_source: str = "program_db",
+    fallback_codes: list[str] | None = None,
+    empty_codes: list[str] | None = None,
+    stale_dropped: dict | None = None,
+):
+    return {
+        "metadata": {
+            "trade_date": date,
+            "codes": codes,
+            "program_source": program_source,
+            "program_fallback_codes": fallback_codes or [],
+            "quality": {
+                "empty_minute_codes": empty_codes or [],
+                "stale_minute_rows_dropped": stale_dropped or {},
+            },
+        },
+        "intraday_minutes": intraday_minutes,
+        "execution_strength": execution_strength,
+        "program_trades": program_trades,
+    }
+
+
+def _write_capture(path, payload):
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_load_capture_payloads_filters_replay_files_and_date_range(tmp_path):
+    _write_capture(
+        tmp_path / "replay_microstructure_20260701.json",
+        _payload(
+            date="20260701",
+            codes=["000001"],
+            intraday_minutes={"000001": [{}]},
+            execution_strength={"000001": 120.0},
+            program_trades={"000001": {"program_net_buy_qty": 1}},
+        ),
+    )
+    _write_capture(
+        tmp_path / "replay_microstructure_20260702.json",
+        _payload(
+            date="20260702",
+            codes=["000002"],
+            intraday_minutes={"000002": [{}]},
+            execution_strength={"000002": 130.0},
+            program_trades={"000002": {"program_net_buy_qty": 1}},
+        ),
+    )
+    _write_capture(tmp_path / "replay_program_trades_20260702.json", {"000002": 1})
+
+    payloads = load_capture_payloads(tmp_path, date_from="20260702", date_to="20260702")
+
+    assert [p["metadata"]["trade_date"] for p in payloads] == ["20260702"]
+
+
+def test_compute_quality_report_flags_stale_rows_and_low_coverage():
+    payloads = [
+        _payload(
+            date="20260701",
+            codes=["000001", "000002"],
+            intraday_minutes={"000001": [{}], "000002": [{}]},
+            execution_strength={"000001": 120.0, "000002": 130.0},
+            program_trades={
+                "000001": {"program_net_buy_qty": 100},
+                "000002": {"program_net_buy_qty": -50},
+            },
+        ),
+        _payload(
+            date="20260702",
+            codes=["000001", "000002", "000003", "000004"],
+            intraday_minutes={"000001": [{}], "000002": [], "000003": [], "000004": [{}]},
+            execution_strength={"000001": 120.0, "000002": None, "000003": None, "000004": 99.0},
+            program_trades={
+                "000001": {"program_net_buy_qty": 100},
+                "000002": None,
+                "000003": {"program_net_buy_qty": -20},
+                "000004": None,
+            },
+            fallback_codes=["000003"],
+            empty_codes=["000002", "000003"],
+            stale_dropped={"000004": 3},
+        ),
+    ]
+
+    report = compute_quality_report(
+        payloads,
+        min_intraday_coverage_pct=80.0,
+        min_program_overlay_coverage_pct=80.0,
+        min_program_db_coverage_pct=50.0,
+        max_stale_rows=0,
+    )
+
+    assert report["totals"]["capture_files"] == 2
+    assert report["totals"]["total_codes"] == 6
+    assert report["totals"]["intraday_coverage_pct"] == pytest.approx(4 / 6 * 100)
+    assert report["totals"]["program_overlay_coverage_pct"] == pytest.approx(4 / 6 * 100)
+    assert report["totals"]["program_db_coverage_pct"] == pytest.approx(3 / 6 * 100)
+    assert report["totals"]["stale_minute_rows_dropped"] == 3
+    assert report["totals"]["quality_gate_passed"] is False
+
+    bad_day = report["by_date"]["20260702"]
+    assert bad_day["intraday_coverage_pct"] == pytest.approx(50.0)
+    assert bad_day["program_overlay_coverage_pct"] == pytest.approx(50.0)
+    assert bad_day["program_db_coverage_pct"] == pytest.approx(25.0)
+    assert bad_day["stale_minute_rows_dropped"] == 3
+    assert "intraday_coverage_below_threshold" in bad_day["issues"]
+    assert "program_overlay_coverage_below_threshold" in bad_day["issues"]
+    assert "program_db_coverage_below_threshold" in bad_day["issues"]
+    assert "stale_minute_rows_present" in bad_day["issues"]
+
+
+def test_compute_quality_report_passes_when_payloads_meet_thresholds():
+    report = compute_quality_report([
+        _payload(
+            date="20260701",
+            codes=["000001", "000002"],
+            intraday_minutes={"000001": [{}], "000002": [{}]},
+            execution_strength={"000001": 120.0, "000002": 130.0},
+            program_trades={
+                "000001": {"program_net_buy_qty": 100},
+                "000002": {"program_net_buy_qty": -50},
+            },
+        ),
+    ])
+
+    assert report["totals"]["quality_gate_passed"] is True
+    assert report["by_date"]["20260701"]["issues"] == []
+
+
+def test_format_markdown_report_contains_gate_and_date_rows():
+    report = compute_quality_report([
+        _payload(
+            date="20260701",
+            codes=["000001"],
+            intraday_minutes={"000001": [{}]},
+            execution_strength={"000001": 120.0},
+            program_trades={"000001": {"program_net_buy_qty": 100}},
+        ),
+    ])
+
+    md = format_markdown_report(report)
+
+    assert "Microstructure Capture Quality" in md
+    assert "quality_gate_passed" in md
+    assert "20260701" in md
+
+
+def test_main_writes_json_and_markdown(tmp_path):
+    _write_capture(
+        tmp_path / "replay_microstructure_20260701.json",
+        _payload(
+            date="20260701",
+            codes=["000001"],
+            intraday_minutes={"000001": [{}]},
+            execution_strength={"000001": 120.0},
+            program_trades={"000001": {"program_net_buy_qty": 100}},
+        ),
+    )
+    out_json = tmp_path / "reports" / "quality.json"
+    out_md = tmp_path / "reports" / "quality.md"
+
+    rc = main([
+        "--input-dir", str(tmp_path),
+        "--date-from", "20260701",
+        "--date-to", "20260701",
+        "--output-json", str(out_json),
+        "--output-markdown", str(out_md),
+    ])
+
+    assert rc == 0
+    assert json.loads(out_json.read_text(encoding="utf-8"))["totals"]["capture_files"] == 1
+    assert "20260701" in out_md.read_text(encoding="utf-8")
+
+
+def test_main_fail_on_gate_returns_nonzero_for_bad_quality(tmp_path):
+    _write_capture(
+        tmp_path / "replay_microstructure_20260701.json",
+        _payload(
+            date="20260701",
+            codes=["000001"],
+            intraday_minutes={"000001": []},
+            execution_strength={"000001": None},
+            program_trades={"000001": None},
+            empty_codes=["000001"],
+        ),
+    )
+
+    rc = main([
+        "--input-dir", str(tmp_path),
+        "--date-from", "20260701",
+        "--date-to", "20260701",
+        "--fail-on-gate",
+    ])
+
+    assert rc == 1

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-03 (1-8 백테스트 재실행 파일럿 판정 반영 — PIT 후보 부재로 blocked, Pool B 후보 부족 재발 확인)
+최종 업데이트: 2026-07-04 (1-5 microstructure QC 리포트 스크립트 추가 — 캡처 품질/커버리지 게이트 확인 가능)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -43,6 +43,7 @@
 - [~] **(최우선) 장중 microstructure 캡처 파이프라인 상시 가동** — `scripts.capture_backtest_microstructure`를 장중 운영 루틴으로 돌려 후보 종목 bid/ask·잔량·체결강도·프로그램매매 리플레이 코퍼스 축적을 시작한다. VBO/OSB의 수급 게이트(체결강도 ≥120%, 프로그램 순매수 ≥ 거래대금 10%)가 현재 백테스트로 검증 불가능한 상태 — 백테스트가 검증하는 전략과 라이브가 거래하는 전략이 다르다. 이 캡처가 엣지 판별의 크리티컬 패스. (2026-07-02 리뷰)
   - 가동 확인 + 1일차(20260703, 후보 10종목) 산출물 검증에서 품질 결함 3건 발견·보정 (2026-07-04): ① 프로그램 overlay 전량 null — 태스크가 DB 파일 존재만으로 `program_db` 소스 확정하는데 `pt_subscriptions`가 고정 4종목뿐이라 후보 행 없음 → DB 미스 종목만 daily_rest per-code 폴백 + `metadata.program_fallback_codes` 기록. ② 무거래/정지 종목에 직전 거래일 분봉 유입(033160에 2025-12-30 행 57건) → `trade_date` 불일치 행 필터. ③ 분봉 0건 종목 무플래그 → `metadata.quality`(empty_minute_codes·stale_minute_rows_dropped) + 태스크 last_result/로그 노출.
   - 프로그램 장중 시계열 캡처 경로 배선 완료 (2026-07-04): `ProgramCaptureSubscriptionTask`(intraday)가 장중에 캡처 후보(보유+워치리스트)를 LOW 우선순위 `PROGRAM_TRADING` 구독(cap 10종목, PT=2슬롯)으로 동기화해 `pt_history`에 장중 순매수 시계열을 축적 → 장마감 캡처가 program_db 소스로 소비(미커버 종목만 daily_rest 폴백). 수동 UI PT 구독은 제외, 슬롯 압박 시 트레이딩 구독이 아닌 이 카테고리가 먼저 해지됨. 구독 목록 영속화로 크래시 잔재는 재시작 시 자동 정리. `program_capture_subscription_enabled`(기본 on).
+  - 캡처 QC 리포트 추가 (2026-07-04): `scripts/analyze_backtest_microstructure_quality.py`로 `replay_microstructure_*.json`의 intraday/execution_strength/program overlay 커버리지, stale row, program DB/fallback 비율을 날짜별 집계하고 `--fail-on-gate`로 품질 게이트를 자동 판정한다.
   - ※ 남은 구조적 한계: 체결강도는 EOD 스칼라 1개/종목만 확보 가능(장중 시계열 REST API 없음) — "체결강도 ≥120%" 장중 게이트의 충실한 리플레이는 여전히 불가. 남은 것: quality 플래그·PT 커버리지(`program_fallback_codes` 감소 여부) 일일 관찰 + 체결강도 장중 시계열 확보 방안 검토(WS 체결 스트림 기반 — 무틱 2-4와 연관).
 - [blocked — 캡처 코퍼스 축적 후] 실제 replay fixture를 통과 케이스까지 확장 → replay overlay.
 - [ ] 한국장 실전 microstructure fixture(bid/ask book·잔량·체결강도·프로그램매매 overlay)로 체결 모델 보정 + 시장가/최유리/지정가별 fill quality가 live journal과 얼마나 벌어지는지 리포트.


### PR DESCRIPTION
## Summary
- add a replay microstructure QC analyzer for coverage, stale rows, and program DB/fallback metrics
- add unit coverage for loader, gate calculation, markdown output, and CLI exit behavior
- update todo_list with the new QC reporting step

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py tests/unit_test/scripts/test_capture_backtest_microstructure.py tests/unit_test/services/test_backtest_microstructure_capture.py tests/unit_test/task/background/after_market/test_microstructure_capture_task.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v