### PR TITLE
Expose microstructure capture quality gate

### DIFF
--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from task.background.after_market.after_market_task_base import AfterMarketTask
 from task.background.capture_candidates import resolve_capture_codes
+
+
+_MIN_INTRADAY_COVERAGE_PCT = 80.0
+_MIN_PROGRAM_OVERLAY_COVERAGE_PCT = 80.0
+_MIN_PROGRAM_DB_COVERAGE_PCT = 50.0
+_MAX_STALE_ROWS = 0
 
 
 class MicrostructureCaptureTask(AfterMarketTask):
@@ -129,13 +135,31 @@ class MicrostructureCaptureTask(AfterMarketTask):
             metadata = payload.get("metadata") or {}
             quality = metadata.get("quality") or {}
             program_fallback_codes = metadata.get("program_fallback_codes") or []
+            quality_summary = _summarize_capture_quality(
+                payload,
+                fallback_codes=codes,
+            )
             self._progress["last_result"] = {
                 "codes": len(codes),
                 "program_source": program_source,
                 "row_counts": metadata.get("row_counts"),
                 "program_fallback_codes": program_fallback_codes,
                 "quality": quality,
+                "quality_gate_passed": quality_summary["quality_gate_passed"],
+                "quality_issues": quality_summary["issues"],
+                "intraday_coverage_pct": quality_summary["intraday_coverage_pct"],
+                "execution_strength_coverage_pct": quality_summary["execution_strength_coverage_pct"],
+                "program_overlay_coverage_pct": quality_summary["program_overlay_coverage_pct"],
+                "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
             }
+            if not quality_summary["quality_gate_passed"]:
+                self._logger.warning(
+                    f"{self.task_name}: {latest_trading_date} 캡처 품질 게이트 실패 "
+                    f"(issues={quality_summary['issues']}, "
+                    f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
+                    f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
+                    f"program_db={_format_optional_pct(quality_summary['program_db_coverage_pct'])})"
+                )
             self._logger.info(
                 f"{self.task_name}: {latest_trading_date} 캡처 완료 "
                 f"(codes={len(codes)}, program_source={program_source}, "
@@ -147,3 +171,86 @@ class MicrostructureCaptureTask(AfterMarketTask):
             self._progress["last_result"] = {"error": str(exc)}
         finally:
             self._progress["running"] = False
+
+
+def _summarize_capture_quality(
+    payload: dict[str, Any],
+    *,
+    fallback_codes: list[str],
+) -> dict[str, Any]:
+    metadata = payload.get("metadata") or {}
+    codes = [str(code) for code in (metadata.get("codes") or fallback_codes or [])]
+    code_set = set(codes)
+    code_count = len(codes)
+    intraday = payload.get("intraday_minutes") or {}
+    execution_strength = payload.get("execution_strength") or {}
+    program_trades = payload.get("program_trades") or {}
+    quality = metadata.get("quality") or {}
+    program_fallback_codes = [
+        str(code) for code in (metadata.get("program_fallback_codes") or [])
+        if str(code) in code_set
+    ]
+    stale_rows = sum(
+        _to_int(value)
+        for value in (quality.get("stale_minute_rows_dropped") or {}).values()
+    )
+
+    intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
+    execution_strength_available = sum(
+        1 for code in codes if execution_strength.get(code) is not None
+    )
+    program_overlay_available = sum(
+        1 for code in codes if program_trades.get(code) is not None
+    )
+    program_source = str(metadata.get("program_source") or "")
+    program_db_coverage_pct = None
+    if program_source == "program_db":
+        program_db_available = max(0, program_overlay_available - len(program_fallback_codes))
+        program_db_coverage_pct = _pct(program_db_available, code_count)
+
+    intraday_coverage_pct = _pct(intraday_available, code_count)
+    execution_strength_coverage_pct = _pct(execution_strength_available, code_count)
+    program_overlay_coverage_pct = _pct(program_overlay_available, code_count)
+
+    issues: list[str] = []
+    if code_count == 0:
+        issues.append("no_codes")
+    if intraday_coverage_pct < _MIN_INTRADAY_COVERAGE_PCT:
+        issues.append("intraday_coverage_below_threshold")
+    if program_overlay_coverage_pct < _MIN_PROGRAM_OVERLAY_COVERAGE_PCT:
+        issues.append("program_overlay_coverage_below_threshold")
+    if (
+        program_db_coverage_pct is not None
+        and program_db_coverage_pct < _MIN_PROGRAM_DB_COVERAGE_PCT
+    ):
+        issues.append("program_db_coverage_below_threshold")
+    if stale_rows > _MAX_STALE_ROWS:
+        issues.append("stale_minute_rows_present")
+
+    return {
+        "quality_gate_passed": not issues,
+        "issues": issues,
+        "intraday_coverage_pct": intraday_coverage_pct,
+        "execution_strength_coverage_pct": execution_strength_coverage_pct,
+        "program_overlay_coverage_pct": program_overlay_coverage_pct,
+        "program_db_coverage_pct": program_db_coverage_pct,
+    }
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator * 100.0
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _format_optional_pct(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.1f}%"
+    return "-"

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
+from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.after_market_task_base import AfterMarketTask
 from task.background.capture_candidates import resolve_capture_codes
 
@@ -34,6 +35,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
         program_db_path: str | Path = "data/program_subscribe/program_trading.db",
         max_codes: int = 40,
         logger=None,
+        notification_service=None,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -47,6 +49,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
         self._output_dir = Path(output_dir)
         self._program_db_path = Path(program_db_path)
         self._max_codes = max_codes
+        self._notification_service = notification_service
         # 재시작 시 catch-up 중복 캡처 방지를 위해 "마지막 캡처 날짜"를 영속화한다.
         self._scheduler_store = scheduler_store
         self._state_key = "microstructure_capture_last_date"
@@ -160,6 +163,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
                     f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
                     f"program_db={_format_optional_pct(quality_summary['program_db_coverage_pct'])})"
                 )
+                await self._emit_quality_gate_warning(latest_trading_date, quality_summary)
             self._logger.info(
                 f"{self.task_name}: {latest_trading_date} 캡처 완료 "
                 f"(codes={len(codes)}, program_source={program_source}, "
@@ -171,6 +175,33 @@ class MicrostructureCaptureTask(AfterMarketTask):
             self._progress["last_result"] = {"error": str(exc)}
         finally:
             self._progress["running"] = False
+
+    async def _emit_quality_gate_warning(
+        self,
+        latest_trading_date: str,
+        quality_summary: dict[str, Any],
+    ) -> None:
+        if not self._notification_service:
+            return
+        await self._notification_service.emit(
+            NotificationCategory.BACKGROUND,
+            NotificationLevel.WARNING,
+            "Microstructure 캡처 품질 게이트 실패",
+            f"{latest_trading_date}: "
+            f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
+            f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
+            f"program_db={_format_optional_pct(quality_summary['program_db_coverage_pct'])}",
+            metadata={
+                "alert_type": "microstructure_capture_quality_gate",
+                "trade_date": latest_trading_date,
+                "codes": quality_summary["codes"],
+                "issues": quality_summary["issues"],
+                "intraday_coverage_pct": quality_summary["intraday_coverage_pct"],
+                "execution_strength_coverage_pct": quality_summary["execution_strength_coverage_pct"],
+                "program_overlay_coverage_pct": quality_summary["program_overlay_coverage_pct"],
+                "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
+            },
+        )
 
 
 def _summarize_capture_quality(
@@ -229,6 +260,7 @@ def _summarize_capture_quality(
 
     return {
         "quality_gate_passed": not issues,
+        "codes": code_count,
         "issues": issues,
         "intraday_coverage_pct": intraday_coverage_pct,
         "execution_strength_coverage_pct": execution_strength_coverage_pct,

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -206,6 +206,100 @@ async def test_quality_and_fallback_exposed_in_last_result(
     assert last_result["quality"]["empty_minute_codes"] == ["005930"]
 
 
+@pytest.mark.asyncio
+async def test_quality_gate_metrics_exposed_and_warned_when_capture_quality_fails(
+    capture_service, universe_service, tmp_path
+):
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930", "000660"],
+            "program_source": "program_db",
+            "program_fallback_codes": [],
+            "quality": {
+                "empty_minute_codes": ["000660"],
+                "stale_minute_rows_dropped": {"005930": 2},
+            },
+            "row_counts": {"intraday_minutes": 1, "execution_strength": 2, "program_trades": 0},
+        },
+        "intraday_minutes": {"005930": [{"stck_cntg_hour": "090000"}], "000660": []},
+        "execution_strength": {"005930": 120.0, "000660": 130.0},
+        "program_trades": {"005930": None, "000660": None},
+    }
+    capture_service.capture = AsyncMock(return_value=payload)
+    logger = MagicMock()
+    db_path = tmp_path / "program_trading.db"
+    db_path.write_bytes(b"")
+    task = _make_task(
+        capture_service,
+        tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+        logger=logger,
+    )
+
+    await task._on_market_closed("20260702")
+
+    last_result = task.get_progress()["last_result"]
+    assert last_result["quality_gate_passed"] is False
+    assert last_result["quality_issues"] == [
+        "intraday_coverage_below_threshold",
+        "program_overlay_coverage_below_threshold",
+        "program_db_coverage_below_threshold",
+        "stale_minute_rows_present",
+    ]
+    assert last_result["intraday_coverage_pct"] == 50.0
+    assert last_result["program_overlay_coverage_pct"] == 0.0
+    assert last_result["program_db_coverage_pct"] == 0.0
+    logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_quality_gate_passes_without_warning_when_capture_quality_is_good(
+    capture_service, universe_service, tmp_path
+):
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930", "000660"],
+            "program_source": "program_db",
+            "program_fallback_codes": [],
+            "quality": {
+                "empty_minute_codes": [],
+                "stale_minute_rows_dropped": {},
+            },
+            "row_counts": {"intraday_minutes": 2, "execution_strength": 2, "program_trades": 2},
+        },
+        "intraday_minutes": {"005930": [{}], "000660": [{}]},
+        "execution_strength": {"005930": 120.0, "000660": 130.0},
+        "program_trades": {
+            "005930": {"program_net_buy_qty": 1},
+            "000660": {"program_net_buy_qty": -1},
+        },
+    }
+    capture_service.capture = AsyncMock(return_value=payload)
+    logger = MagicMock()
+    db_path = tmp_path / "program_trading.db"
+    db_path.write_bytes(b"")
+    task = _make_task(
+        capture_service,
+        tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+        logger=logger,
+    )
+
+    await task._on_market_closed("20260702")
+
+    last_result = task.get_progress()["last_result"]
+    assert last_result["quality_gate_passed"] is True
+    assert last_result["quality_issues"] == []
+    assert last_result["intraday_coverage_pct"] == 100.0
+    assert last_result["program_overlay_coverage_pct"] == 100.0
+    assert last_result["program_db_coverage_pct"] == 100.0
+    logger.warning.assert_not_called()
+
+
 def test_write_output_dir_passed_through(capture_service, tmp_path):
     task = _make_task(capture_service, tmp_path)
     assert task.task_name == "microstructure_capture"

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.microstructure_capture_task import MicrostructureCaptureTask
 
 
@@ -255,6 +256,58 @@ async def test_quality_gate_metrics_exposed_and_warned_when_capture_quality_fail
 
 
 @pytest.mark.asyncio
+async def test_quality_gate_failure_emits_background_warning_notification(
+    capture_service, universe_service, tmp_path
+):
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930", "000660"],
+            "program_source": "program_db",
+            "program_fallback_codes": [],
+            "quality": {
+                "empty_minute_codes": ["000660"],
+                "stale_minute_rows_dropped": {},
+            },
+            "row_counts": {"intraday_minutes": 1, "execution_strength": 2, "program_trades": 0},
+        },
+        "intraday_minutes": {"005930": [{}], "000660": []},
+        "execution_strength": {"005930": 120.0, "000660": 130.0},
+        "program_trades": {"005930": None, "000660": None},
+    }
+    capture_service.capture = AsyncMock(return_value=payload)
+    notification_service = MagicMock()
+    notification_service.emit = AsyncMock()
+    db_path = tmp_path / "program_trading.db"
+    db_path.write_bytes(b"")
+    task = _make_task(
+        capture_service,
+        tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+        notification_service=notification_service,
+    )
+
+    await task._on_market_closed("20260702")
+
+    notification_service.emit.assert_awaited_once()
+    args = notification_service.emit.await_args.args
+    kwargs = notification_service.emit.await_args.kwargs
+    assert args[:4] == (
+        NotificationCategory.BACKGROUND,
+        NotificationLevel.WARNING,
+        "Microstructure 캡처 품질 게이트 실패",
+        "20260702: intraday=50.0%, program=0.0%, program_db=0.0%",
+    )
+    assert kwargs["metadata"]["issues"] == [
+        "intraday_coverage_below_threshold",
+        "program_overlay_coverage_below_threshold",
+        "program_db_coverage_below_threshold",
+    ]
+    assert kwargs["metadata"]["codes"] == 2
+
+
+@pytest.mark.asyncio
 async def test_quality_gate_passes_without_warning_when_capture_quality_is_good(
     capture_service, universe_service, tmp_path
 ):
@@ -298,6 +351,41 @@ async def test_quality_gate_passes_without_warning_when_capture_quality_is_good(
     assert last_result["program_overlay_coverage_pct"] == 100.0
     assert last_result["program_db_coverage_pct"] == 100.0
     logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_quality_gate_success_does_not_emit_notification(
+    capture_service, universe_service, tmp_path
+):
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930"],
+            "program_source": "daily_rest",
+            "program_fallback_codes": [],
+            "quality": {
+                "empty_minute_codes": [],
+                "stale_minute_rows_dropped": {},
+            },
+            "row_counts": {"intraday_minutes": 1, "execution_strength": 1, "program_trades": 1},
+        },
+        "intraday_minutes": {"005930": [{}]},
+        "execution_strength": {"005930": 120.0},
+        "program_trades": {"005930": {"program_net_buy_qty": 1}},
+    }
+    capture_service.capture = AsyncMock(return_value=payload)
+    notification_service = MagicMock()
+    notification_service.emit = AsyncMock()
+    task = _make_task(
+        capture_service,
+        tmp_path,
+        universe_service=universe_service,
+        notification_service=notification_service,
+    )
+
+    await task._on_market_closed("20260702")
+
+    notification_service.emit.assert_not_awaited()
 
 
 def test_write_output_dir_passed_through(capture_service, tmp_path):

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (1-5 microstructure QC 리포트 스크립트 추가 — 캡처 품질/커버리지 게이트 확인 가능)
+최종 업데이트: 2026-07-04 (1-5 microstructure QC 태스크 노출 추가 — 캡처 품질 게이트를 last_result/log에서 확인 가능)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -44,6 +44,7 @@
   - 가동 확인 + 1일차(20260703, 후보 10종목) 산출물 검증에서 품질 결함 3건 발견·보정 (2026-07-04): ① 프로그램 overlay 전량 null — 태스크가 DB 파일 존재만으로 `program_db` 소스 확정하는데 `pt_subscriptions`가 고정 4종목뿐이라 후보 행 없음 → DB 미스 종목만 daily_rest per-code 폴백 + `metadata.program_fallback_codes` 기록. ② 무거래/정지 종목에 직전 거래일 분봉 유입(033160에 2025-12-30 행 57건) → `trade_date` 불일치 행 필터. ③ 분봉 0건 종목 무플래그 → `metadata.quality`(empty_minute_codes·stale_minute_rows_dropped) + 태스크 last_result/로그 노출.
   - 프로그램 장중 시계열 캡처 경로 배선 완료 (2026-07-04): `ProgramCaptureSubscriptionTask`(intraday)가 장중에 캡처 후보(보유+워치리스트)를 LOW 우선순위 `PROGRAM_TRADING` 구독(cap 10종목, PT=2슬롯)으로 동기화해 `pt_history`에 장중 순매수 시계열을 축적 → 장마감 캡처가 program_db 소스로 소비(미커버 종목만 daily_rest 폴백). 수동 UI PT 구독은 제외, 슬롯 압박 시 트레이딩 구독이 아닌 이 카테고리가 먼저 해지됨. 구독 목록 영속화로 크래시 잔재는 재시작 시 자동 정리. `program_capture_subscription_enabled`(기본 on).
   - 캡처 QC 리포트 추가 (2026-07-04): `scripts/analyze_backtest_microstructure_quality.py`로 `replay_microstructure_*.json`의 intraday/execution_strength/program overlay 커버리지, stale row, program DB/fallback 비율을 날짜별 집계하고 `--fail-on-gate`로 품질 게이트를 자동 판정한다.
+  - 캡처 태스크 QC 노출 추가 (2026-07-04): `MicrostructureCaptureTask.last_result`에 `quality_gate_passed`, `quality_issues`, intraday/execution_strength/program/program_db coverage를 노출하고, 게이트 실패 시 warning 로그를 남긴다.
   - ※ 남은 구조적 한계: 체결강도는 EOD 스칼라 1개/종목만 확보 가능(장중 시계열 REST API 없음) — "체결강도 ≥120%" 장중 게이트의 충실한 리플레이는 여전히 불가. 남은 것: quality 플래그·PT 커버리지(`program_fallback_codes` 감소 여부) 일일 관찰 + 체결강도 장중 시계열 확보 방안 검토(WS 체결 스트림 기반 — 무틱 2-4와 연관).
 - [blocked — 캡처 코퍼스 축적 후] 실제 replay fixture를 통과 케이스까지 확장 → replay overlay.
 - [ ] 한국장 실전 microstructure fixture(bid/ask book·잔량·체결강도·프로그램매매 overlay)로 체결 모델 보정 + 시장가/최유리/지정가별 fill quality가 live journal과 얼마나 벌어지는지 리포트.

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (1-5 microstructure QC 태스크 노출 추가 — 캡처 품질 게이트를 last_result/log에서 확인 가능)
+최종 업데이트: 2026-07-04 (1-5 microstructure QC 태스크 알림 추가 — 캡처 품질 게이트 실패를 last_result/log/notification에서 확인 가능)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -44,7 +44,7 @@
   - 가동 확인 + 1일차(20260703, 후보 10종목) 산출물 검증에서 품질 결함 3건 발견·보정 (2026-07-04): ① 프로그램 overlay 전량 null — 태스크가 DB 파일 존재만으로 `program_db` 소스 확정하는데 `pt_subscriptions`가 고정 4종목뿐이라 후보 행 없음 → DB 미스 종목만 daily_rest per-code 폴백 + `metadata.program_fallback_codes` 기록. ② 무거래/정지 종목에 직전 거래일 분봉 유입(033160에 2025-12-30 행 57건) → `trade_date` 불일치 행 필터. ③ 분봉 0건 종목 무플래그 → `metadata.quality`(empty_minute_codes·stale_minute_rows_dropped) + 태스크 last_result/로그 노출.
   - 프로그램 장중 시계열 캡처 경로 배선 완료 (2026-07-04): `ProgramCaptureSubscriptionTask`(intraday)가 장중에 캡처 후보(보유+워치리스트)를 LOW 우선순위 `PROGRAM_TRADING` 구독(cap 10종목, PT=2슬롯)으로 동기화해 `pt_history`에 장중 순매수 시계열을 축적 → 장마감 캡처가 program_db 소스로 소비(미커버 종목만 daily_rest 폴백). 수동 UI PT 구독은 제외, 슬롯 압박 시 트레이딩 구독이 아닌 이 카테고리가 먼저 해지됨. 구독 목록 영속화로 크래시 잔재는 재시작 시 자동 정리. `program_capture_subscription_enabled`(기본 on).
   - 캡처 QC 리포트 추가 (2026-07-04): `scripts/analyze_backtest_microstructure_quality.py`로 `replay_microstructure_*.json`의 intraday/execution_strength/program overlay 커버리지, stale row, program DB/fallback 비율을 날짜별 집계하고 `--fail-on-gate`로 품질 게이트를 자동 판정한다.
-  - 캡처 태스크 QC 노출 추가 (2026-07-04): `MicrostructureCaptureTask.last_result`에 `quality_gate_passed`, `quality_issues`, intraday/execution_strength/program/program_db coverage를 노출하고, 게이트 실패 시 warning 로그를 남긴다.
+  - 캡처 태스크 QC 노출 추가 (2026-07-04): `MicrostructureCaptureTask.last_result`에 `quality_gate_passed`, `quality_issues`, intraday/execution_strength/program/program_db coverage를 노출하고, 게이트 실패 시 warning 로그와 BACKGROUND/WARNING notification을 남긴다.
   - ※ 남은 구조적 한계: 체결강도는 EOD 스칼라 1개/종목만 확보 가능(장중 시계열 REST API 없음) — "체결강도 ≥120%" 장중 게이트의 충실한 리플레이는 여전히 불가. 남은 것: quality 플래그·PT 커버리지(`program_fallback_codes` 감소 여부) 일일 관찰 + 체결강도 장중 시계열 확보 방안 검토(WS 체결 스트림 기반 — 무틱 2-4와 연관).
 - [blocked — 캡처 코퍼스 축적 후] 실제 replay fixture를 통과 케이스까지 확장 → replay overlay.
 - [ ] 한국장 실전 microstructure fixture(bid/ask book·잔량·체결강도·프로그램매매 overlay)로 체결 모델 보정 + 시장가/최유리/지정가별 fill quality가 live journal과 얼마나 벌어지는지 리포트.

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -800,6 +800,7 @@ class ServiceContainer:
                     market_clock=ctx.market_clock,
                     scheduler_store=StrategySchedulerStore(logger=ctx.logger),
                     logger=ctx.logger,
+                    notification_service=ctx.notification_service,
                 ) if microstructure_enabled else None
                 # todo 1-5: 장중 캡처 후보 프로그램매매 WS 구독 (pt_history 장중 시계열 축적).
                 # LOW 우선순위 — 트레이딩용 price 구독을 밀어내지 않는다.


### PR DESCRIPTION
## Summary
- expose microstructure capture QC gate metrics in MicrostructureCaptureTask last_result
- emit a warning log when capture quality falls below coverage/stale-row thresholds
- add unit coverage for passing and failing QC gate outcomes
- update todo_list with the task-level QC visibility step

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/task/background/after_market/test_microstructure_capture_task.py tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py tests/unit_test/scripts/test_capture_backtest_microstructure.py tests/unit_test/services/test_backtest_microstructure_capture.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v