### PR TITLE
Share microstructure quality gate helper

### DIFF
--- a/scripts/analyze_backtest_microstructure_quality.py
+++ b/scripts/analyze_backtest_microstructure_quality.py
@@ -12,22 +12,11 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-
-def _pct(numerator: int, denominator: int) -> float:
-    if denominator <= 0:
-        return 0.0
-    return numerator / denominator * 100.0
-
-
-def _to_int(value: Any) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _is_present(value: Any) -> bool:
-    return value is not None
+from services.backtest_microstructure_quality import (
+    MicrostructureQualityThresholds,
+    coverage_pct,
+    summarize_capture_quality,
+)
 
 
 def load_capture_payloads(
@@ -58,82 +47,6 @@ def load_capture_payloads(
     return payloads
 
 
-def _daily_quality(
-    payload: Dict[str, Any],
-    *,
-    min_intraday_coverage_pct: float,
-    min_program_overlay_coverage_pct: float,
-    min_program_db_coverage_pct: float,
-    max_stale_rows: int,
-) -> Dict[str, Any]:
-    metadata = payload.get("metadata") or {}
-    codes = [str(code) for code in (metadata.get("codes") or [])]
-    code_count = len(codes)
-    intraday = payload.get("intraday_minutes") or {}
-    execution_strength = payload.get("execution_strength") or {}
-    program_trades = payload.get("program_trades") or {}
-    quality = metadata.get("quality") or {}
-    fallback_codes = [
-        str(code) for code in (metadata.get("program_fallback_codes") or [])
-        if str(code) in set(codes)
-    ]
-    stale_by_code = quality.get("stale_minute_rows_dropped") or {}
-    stale_rows = sum(_to_int(v) for v in stale_by_code.values())
-
-    intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
-    execution_strength_available = sum(
-        1 for code in codes if _is_present(execution_strength.get(code))
-    )
-    program_overlay_available = sum(
-        1 for code in codes if _is_present(program_trades.get(code))
-    )
-    program_source = str(metadata.get("program_source") or "")
-    program_db_available: Optional[int] = None
-    program_db_coverage_pct: Optional[float] = None
-    if program_source == "program_db":
-        program_db_available = max(0, program_overlay_available - len(fallback_codes))
-        program_db_coverage_pct = _pct(program_db_available, code_count)
-
-    intraday_coverage_pct = _pct(intraday_available, code_count)
-    execution_strength_coverage_pct = _pct(execution_strength_available, code_count)
-    program_overlay_coverage_pct = _pct(program_overlay_available, code_count)
-
-    issues: List[str] = []
-    if code_count == 0:
-        issues.append("no_codes")
-    if intraday_coverage_pct < min_intraday_coverage_pct:
-        issues.append("intraday_coverage_below_threshold")
-    if program_overlay_coverage_pct < min_program_overlay_coverage_pct:
-        issues.append("program_overlay_coverage_below_threshold")
-    if (
-        program_db_coverage_pct is not None
-        and program_db_coverage_pct < min_program_db_coverage_pct
-    ):
-        issues.append("program_db_coverage_below_threshold")
-    if stale_rows > max_stale_rows:
-        issues.append("stale_minute_rows_present")
-
-    return {
-        "trade_date": str(metadata.get("trade_date") or ""),
-        "codes": code_count,
-        "intraday_available": intraday_available,
-        "intraday_coverage_pct": intraday_coverage_pct,
-        "execution_strength_available": execution_strength_available,
-        "execution_strength_coverage_pct": execution_strength_coverage_pct,
-        "program_overlay_available": program_overlay_available,
-        "program_overlay_coverage_pct": program_overlay_coverage_pct,
-        "program_source": program_source,
-        "program_fallback_codes": fallback_codes,
-        "program_fallback_pct": _pct(len(fallback_codes), code_count),
-        "program_db_available": program_db_available,
-        "program_db_coverage_pct": program_db_coverage_pct,
-        "empty_minute_codes": quality.get("empty_minute_codes") or [],
-        "stale_minute_rows_dropped": stale_rows,
-        "issues": issues,
-        "quality_gate_passed": not issues,
-    }
-
-
 def compute_quality_report(
     payloads: List[Dict[str, Any]],
     *,
@@ -144,13 +57,16 @@ def compute_quality_report(
 ) -> Dict[str, Any]:
     """Compute daily and aggregate quality metrics."""
     by_date: Dict[str, Dict[str, Any]] = {}
+    thresholds = MicrostructureQualityThresholds(
+        min_intraday_coverage_pct=min_intraday_coverage_pct,
+        min_program_overlay_coverage_pct=min_program_overlay_coverage_pct,
+        min_program_db_coverage_pct=min_program_db_coverage_pct,
+        max_stale_rows=max_stale_rows,
+    )
     for payload in payloads:
-        daily = _daily_quality(
+        daily = summarize_capture_quality(
             payload,
-            min_intraday_coverage_pct=min_intraday_coverage_pct,
-            min_program_overlay_coverage_pct=min_program_overlay_coverage_pct,
-            min_program_db_coverage_pct=min_program_db_coverage_pct,
-            max_stale_rows=max_stale_rows,
+            thresholds=thresholds,
         )
         key = daily["trade_date"] or f"unknown_{len(by_date) + 1}"
         by_date[key] = daily
@@ -184,18 +100,18 @@ def compute_quality_report(
         "trading_days": len(by_date),
         "total_codes": total_codes,
         "intraday_available": intraday_available,
-        "intraday_coverage_pct": _pct(intraday_available, total_codes),
+        "intraday_coverage_pct": coverage_pct(intraday_available, total_codes),
         "execution_strength_available": execution_strength_available,
-        "execution_strength_coverage_pct": _pct(execution_strength_available, total_codes),
+        "execution_strength_coverage_pct": coverage_pct(execution_strength_available, total_codes),
         "program_overlay_available": program_overlay_available,
-        "program_overlay_coverage_pct": _pct(program_overlay_available, total_codes),
+        "program_overlay_coverage_pct": coverage_pct(program_overlay_available, total_codes),
         "program_db_available": program_db_available,
         "program_db_coverage_pct": (
-            _pct(program_db_available, program_db_denominator)
+            coverage_pct(program_db_available, program_db_denominator)
             if program_db_denominator > 0 else None
         ),
         "program_fallback_count": fallback_count,
-        "program_fallback_pct": _pct(fallback_count, total_codes),
+        "program_fallback_pct": coverage_pct(fallback_count, total_codes),
         "stale_minute_rows_dropped": stale_rows,
         "quality_gate_passed": gate_passed,
         "daily_failures": daily_failures,

--- a/services/backtest_microstructure_quality.py
+++ b/services/backtest_microstructure_quality.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class MicrostructureQualityThresholds:
+    min_intraday_coverage_pct: float = 80.0
+    min_program_overlay_coverage_pct: float = 80.0
+    min_program_db_coverage_pct: float = 50.0
+    max_stale_rows: int = 0
+
+
+def summarize_capture_quality(
+    payload: dict[str, Any],
+    *,
+    fallback_codes: Optional[list[str]] = None,
+    thresholds: Optional[MicrostructureQualityThresholds] = None,
+) -> dict[str, Any]:
+    thresholds = thresholds or MicrostructureQualityThresholds()
+    metadata = payload.get("metadata") or {}
+    codes = [
+        str(code)
+        for code in (metadata.get("codes") or fallback_codes or [])
+    ]
+    code_set = set(codes)
+    code_count = len(codes)
+    intraday = payload.get("intraday_minutes") or {}
+    execution_strength = payload.get("execution_strength") or {}
+    program_trades = payload.get("program_trades") or {}
+    quality = metadata.get("quality") or {}
+    program_fallback_codes = [
+        str(code) for code in (metadata.get("program_fallback_codes") or [])
+        if str(code) in code_set
+    ]
+    stale_by_code = quality.get("stale_minute_rows_dropped") or {}
+    stale_rows = sum(_to_int(value) for value in stale_by_code.values())
+
+    intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
+    execution_strength_available = sum(
+        1 for code in codes if execution_strength.get(code) is not None
+    )
+    program_overlay_available = sum(
+        1 for code in codes if program_trades.get(code) is not None
+    )
+    program_source = str(metadata.get("program_source") or "")
+    program_db_available: Optional[int] = None
+    program_db_coverage_pct: Optional[float] = None
+    if program_source == "program_db":
+        program_db_available = max(0, program_overlay_available - len(program_fallback_codes))
+        program_db_coverage_pct = coverage_pct(program_db_available, code_count)
+
+    intraday_coverage_pct = coverage_pct(intraday_available, code_count)
+    execution_strength_coverage_pct = coverage_pct(
+        execution_strength_available, code_count
+    )
+    program_overlay_coverage_pct = coverage_pct(program_overlay_available, code_count)
+
+    issues: list[str] = []
+    if code_count == 0:
+        issues.append("no_codes")
+    if intraday_coverage_pct < thresholds.min_intraday_coverage_pct:
+        issues.append("intraday_coverage_below_threshold")
+    if program_overlay_coverage_pct < thresholds.min_program_overlay_coverage_pct:
+        issues.append("program_overlay_coverage_below_threshold")
+    if (
+        program_db_coverage_pct is not None
+        and program_db_coverage_pct < thresholds.min_program_db_coverage_pct
+    ):
+        issues.append("program_db_coverage_below_threshold")
+    if stale_rows > thresholds.max_stale_rows:
+        issues.append("stale_minute_rows_present")
+
+    return {
+        "trade_date": str(metadata.get("trade_date") or ""),
+        "codes": code_count,
+        "intraday_available": intraday_available,
+        "intraday_coverage_pct": intraday_coverage_pct,
+        "execution_strength_available": execution_strength_available,
+        "execution_strength_coverage_pct": execution_strength_coverage_pct,
+        "program_overlay_available": program_overlay_available,
+        "program_overlay_coverage_pct": program_overlay_coverage_pct,
+        "program_source": program_source,
+        "program_fallback_codes": program_fallback_codes,
+        "program_fallback_pct": coverage_pct(len(program_fallback_codes), code_count),
+        "program_db_available": program_db_available,
+        "program_db_coverage_pct": program_db_coverage_pct,
+        "empty_minute_codes": quality.get("empty_minute_codes") or [],
+        "stale_minute_rows_dropped": stale_rows,
+        "issues": issues,
+        "quality_gate_passed": not issues,
+    }
+
+
+def coverage_pct(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator * 100.0
+
+
+def format_optional_pct(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.1f}%"
+    return "-"
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -4,15 +4,13 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
+from services.backtest_microstructure_quality import (
+    format_optional_pct,
+    summarize_capture_quality,
+)
 from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.after_market_task_base import AfterMarketTask
 from task.background.capture_candidates import resolve_capture_codes
-
-
-_MIN_INTRADAY_COVERAGE_PCT = 80.0
-_MIN_PROGRAM_OVERLAY_COVERAGE_PCT = 80.0
-_MIN_PROGRAM_DB_COVERAGE_PCT = 50.0
-_MAX_STALE_ROWS = 0
 
 
 class MicrostructureCaptureTask(AfterMarketTask):
@@ -138,7 +136,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
             metadata = payload.get("metadata") or {}
             quality = metadata.get("quality") or {}
             program_fallback_codes = metadata.get("program_fallback_codes") or []
-            quality_summary = _summarize_capture_quality(
+            quality_summary = summarize_capture_quality(
                 payload,
                 fallback_codes=codes,
             )
@@ -161,7 +159,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
                     f"(issues={quality_summary['issues']}, "
                     f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
                     f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
-                    f"program_db={_format_optional_pct(quality_summary['program_db_coverage_pct'])})"
+                    f"program_db={format_optional_pct(quality_summary['program_db_coverage_pct'])})"
                 )
                 await self._emit_quality_gate_warning(latest_trading_date, quality_summary)
             self._logger.info(
@@ -190,7 +188,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
             f"{latest_trading_date}: "
             f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
             f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
-            f"program_db={_format_optional_pct(quality_summary['program_db_coverage_pct'])}",
+            f"program_db={format_optional_pct(quality_summary['program_db_coverage_pct'])}",
             metadata={
                 "alert_type": "microstructure_capture_quality_gate",
                 "trade_date": latest_trading_date,
@@ -202,87 +200,3 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
             },
         )
-
-
-def _summarize_capture_quality(
-    payload: dict[str, Any],
-    *,
-    fallback_codes: list[str],
-) -> dict[str, Any]:
-    metadata = payload.get("metadata") or {}
-    codes = [str(code) for code in (metadata.get("codes") or fallback_codes or [])]
-    code_set = set(codes)
-    code_count = len(codes)
-    intraday = payload.get("intraday_minutes") or {}
-    execution_strength = payload.get("execution_strength") or {}
-    program_trades = payload.get("program_trades") or {}
-    quality = metadata.get("quality") or {}
-    program_fallback_codes = [
-        str(code) for code in (metadata.get("program_fallback_codes") or [])
-        if str(code) in code_set
-    ]
-    stale_rows = sum(
-        _to_int(value)
-        for value in (quality.get("stale_minute_rows_dropped") or {}).values()
-    )
-
-    intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
-    execution_strength_available = sum(
-        1 for code in codes if execution_strength.get(code) is not None
-    )
-    program_overlay_available = sum(
-        1 for code in codes if program_trades.get(code) is not None
-    )
-    program_source = str(metadata.get("program_source") or "")
-    program_db_coverage_pct = None
-    if program_source == "program_db":
-        program_db_available = max(0, program_overlay_available - len(program_fallback_codes))
-        program_db_coverage_pct = _pct(program_db_available, code_count)
-
-    intraday_coverage_pct = _pct(intraday_available, code_count)
-    execution_strength_coverage_pct = _pct(execution_strength_available, code_count)
-    program_overlay_coverage_pct = _pct(program_overlay_available, code_count)
-
-    issues: list[str] = []
-    if code_count == 0:
-        issues.append("no_codes")
-    if intraday_coverage_pct < _MIN_INTRADAY_COVERAGE_PCT:
-        issues.append("intraday_coverage_below_threshold")
-    if program_overlay_coverage_pct < _MIN_PROGRAM_OVERLAY_COVERAGE_PCT:
-        issues.append("program_overlay_coverage_below_threshold")
-    if (
-        program_db_coverage_pct is not None
-        and program_db_coverage_pct < _MIN_PROGRAM_DB_COVERAGE_PCT
-    ):
-        issues.append("program_db_coverage_below_threshold")
-    if stale_rows > _MAX_STALE_ROWS:
-        issues.append("stale_minute_rows_present")
-
-    return {
-        "quality_gate_passed": not issues,
-        "codes": code_count,
-        "issues": issues,
-        "intraday_coverage_pct": intraday_coverage_pct,
-        "execution_strength_coverage_pct": execution_strength_coverage_pct,
-        "program_overlay_coverage_pct": program_overlay_coverage_pct,
-        "program_db_coverage_pct": program_db_coverage_pct,
-    }
-
-
-def _pct(numerator: int, denominator: int) -> float:
-    if denominator <= 0:
-        return 0.0
-    return numerator / denominator * 100.0
-
-
-def _to_int(value: Any) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _format_optional_pct(value: Any) -> str:
-    if isinstance(value, (int, float)):
-        return f"{value:.1f}%"
-    return "-"

--- a/tests/unit_test/services/test_backtest_microstructure_quality.py
+++ b/tests/unit_test/services/test_backtest_microstructure_quality.py
@@ -1,0 +1,80 @@
+import pytest
+
+from services.backtest_microstructure_quality import (
+    MicrostructureQualityThresholds,
+    format_optional_pct,
+    summarize_capture_quality,
+)
+
+
+def test_summarize_capture_quality_uses_metadata_codes_and_program_db_fallbacks():
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930", "000660", "035420", "068270"],
+            "program_source": "program_db",
+            "program_fallback_codes": ["035420", "999999"],
+            "quality": {
+                "empty_minute_codes": ["068270"],
+                "stale_minute_rows_dropped": {"005930": "2", "000660": None},
+            },
+        },
+        "intraday_minutes": {
+            "005930": [{}],
+            "000660": [{}],
+            "035420": [],
+            "068270": [{}],
+        },
+        "execution_strength": {
+            "005930": 120.0,
+            "000660": 130.0,
+            "035420": None,
+            "068270": 110.0,
+        },
+        "program_trades": {
+            "005930": {"program_net_buy_qty": 1},
+            "000660": {"program_net_buy_qty": -1},
+            "035420": {"program_net_buy_qty": 0},
+            "068270": None,
+        },
+    }
+
+    summary = summarize_capture_quality(
+        payload,
+        thresholds=MicrostructureQualityThresholds(max_stale_rows=0),
+    )
+
+    assert summary["trade_date"] == "20260702"
+    assert summary["codes"] == 4
+    assert summary["intraday_coverage_pct"] == pytest.approx(75.0)
+    assert summary["execution_strength_coverage_pct"] == pytest.approx(75.0)
+    assert summary["program_overlay_coverage_pct"] == pytest.approx(75.0)
+    assert summary["program_db_available"] == 2
+    assert summary["program_db_coverage_pct"] == pytest.approx(50.0)
+    assert summary["program_fallback_codes"] == ["035420"]
+    assert summary["stale_minute_rows_dropped"] == 2
+    assert summary["issues"] == [
+        "intraday_coverage_below_threshold",
+        "program_overlay_coverage_below_threshold",
+        "stale_minute_rows_present",
+    ]
+
+
+def test_summarize_capture_quality_falls_back_to_resolved_codes_when_metadata_missing():
+    summary = summarize_capture_quality(
+        {
+            "metadata": {"program_source": "daily_rest"},
+            "intraday_minutes": {"005930": [{}]},
+            "execution_strength": {"005930": 120.0},
+            "program_trades": {"005930": {"program_net_buy_qty": 1}},
+        },
+        fallback_codes=["005930"],
+    )
+
+    assert summary["codes"] == 1
+    assert summary["quality_gate_passed"] is True
+
+
+def test_format_optional_pct_formats_numbers_and_missing_values():
+    assert format_optional_pct(12.345) == "12.3%"
+    assert format_optional_pct(None) == "-"


### PR DESCRIPTION
## Summary
- Extract shared microstructure capture quality gate calculation into services/backtest_microstructure_quality.py
- Reuse the shared helper from the CLI analyzer and after-market capture task
- Add direct unit coverage for the shared helper

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_backtest_microstructure_quality.py tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py tests/unit_test/task/background/after_market/test_microstructure_capture_task.py tests/unit_test/view/web/bootstrap/test_service_container.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v