### PR TITLE
Report standard journal accumulation

### DIFF
--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -230,6 +230,18 @@ def _normalize_strategy_metric_records(records: List[Mapping[str, Any]]) -> List
     return normalized
 
 
+def _journal_source(record: Mapping[str, Any]) -> str:
+    source = str(record.get("source") or "").strip()
+    if source:
+        return source
+    metadata = record.get("metadata")
+    if isinstance(metadata, Mapping):
+        signal_source = str(metadata.get("signal_source") or "").strip()
+        if signal_source:
+            return signal_source
+    return "unknown"
+
+
 def _strategy_display_label(value: Any) -> str:
     return STRATEGY_IDENTITY_RESOLVER.to_display(str(value or ""))
 
@@ -1024,6 +1036,74 @@ class StrategyLogReportService:
             if reasons:
                 reason_text = ", ".join(_profitability_gate_reason_label(r) for r in reasons)
                 lines.append(f"  - 차단 사유: {_esc(reason_text)}")
+        return "\n".join(lines)
+
+    def _build_standard_journal_accumulation_section(self, target_date: str) -> Optional[str]:
+        """shadow/paper/canary journal 축적량을 일일 리포트에 노출한다 (P1 1-6).
+
+        profitability gate 는 표본이 부족하면 차단 사유만 보여주므로, 이 섹션은
+        운영자가 소스별/전략별 표본 축적 속도를 별도로 확인하기 위한 요약이다.
+        """
+        if not self._virtual_trade_service:
+            return None
+        try:
+            records = self._virtual_trade_service.get_standard_journal_records() or []
+        except Exception:
+            return None
+        if not records:
+            return None
+
+        normalized_records = _normalize_strategy_metric_records(records)
+        status_counts = Counter(
+            str(record.get("status") or "UNKNOWN").upper()
+            for record in records
+        )
+        source_counts = Counter(_journal_source(record) for record in records)
+        sold_by_strategy = Counter(
+            str(record.get("strategy") or "")
+            for record in normalized_records
+            if str(record.get("status") or "").upper() == "SOLD"
+        )
+        total_by_strategy = Counter(
+            str(record.get("strategy") or "")
+            for record in normalized_records
+        )
+
+        sold_count = status_counts.get("SOLD", 0)
+        open_count = sum(
+            count for status, count in status_counts.items()
+            if status != "SOLD"
+        )
+        source_text = ", ".join(
+            f"{_esc(source)} {count}건"
+            for source, count in sorted(
+                source_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        )
+        cfg = self._profitability_gate_cfg()
+        lines = [
+            "<b>📒 표준 journal 축적 현황</b>",
+            f"• 전체 {len(records)}건 / SOLD {sold_count}건 / 진행중 {open_count}건",
+        ]
+        if source_text:
+            lines.append(f"• source: {source_text}")
+
+        strategy_names = sorted(
+            total_by_strategy,
+            key=lambda name: (-sold_by_strategy.get(name, 0), name),
+        )[:5]
+        for name in strategy_names:
+            strategy = _esc(_strategy_display_label(name))
+            sold = sold_by_strategy.get(name, 0)
+            total = total_by_strategy.get(name, 0)
+            lines.append(
+                f"• {strategy}: SOLD {sold}/{int(cfg.min_trades)}건 "
+                f"(전체 {total}건)"
+            )
+        remaining = len(total_by_strategy) - len(strategy_names)
+        if remaining > 0:
+            lines.append(f"  …외 {remaining}개 전략")
         return "\n".join(lines)
 
     def _build_multiple_testing_section(self, target_date: str) -> Optional[str]:
@@ -1988,6 +2068,7 @@ class StrategyLogReportService:
         execution_quality_section = self._build_execution_quality_section(execution_quality_records)
         divergence_section = self._build_backtest_live_divergence_section(target_date)
         degradation_section = self._build_strategy_degradation_section(target_date)
+        journal_accumulation_section = self._build_standard_journal_accumulation_section(target_date)
         profitability_gate_section = self._build_profitability_gate_section(target_date)
         volatility_section = self._build_volatility_section(strategy_summaries)
         signal_metadata_section = self._build_signal_metadata_section(strategy_summaries)
@@ -2005,6 +2086,7 @@ class StrategyLogReportService:
                     portfolio_summary,
                     divergence_section,
                     degradation_section,
+                    journal_accumulation_section,
                     profitability_gate_section,
                     execution_quality_section,
                     volatility_section,
@@ -2032,6 +2114,8 @@ class StrategyLogReportService:
             body += f"\n\n{divergence_section}"
         if degradation_section:
             body += f"\n\n{degradation_section}"
+        if journal_accumulation_section:
+            body += f"\n\n{journal_accumulation_section}"
         if profitability_gate_section:
             body += f"\n\n{profitability_gate_section}"
         if execution_quality_section:

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1049,6 +1049,64 @@ async def test_report_matches_virtual_trade_strategy_id_to_vbo_log_section(log_d
 
 
 @pytest.mark.asyncio
+async def test_report_includes_standard_journal_accumulation_section(log_dir):
+    """표준 journal 축적 현황을 일일 리포트에 노출한다."""
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return []
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+        def get_standard_journal_records(self):
+            return [
+                {
+                    "source": "paper",
+                    "strategy": "S1",
+                    "code": "000001",
+                    "status": "SOLD",
+                    "signal_time": "2026-04-15 10:00:00",
+                    "net_pnl": 100.0,
+                    "net_return": 1.0,
+                },
+                {
+                    "source": "paper",
+                    "strategy": "S1",
+                    "code": "000002",
+                    "status": "HOLD",
+                    "signal_time": "2026-04-18 10:00:00",
+                },
+                {
+                    "source": "event_shadow",
+                    "strategy": "S2",
+                    "code": "000003",
+                    "status": "SIGNAL",
+                    "signal_time": "2026-04-18 09:30:00",
+                    "metadata": {"signal_source": "event_shadow"},
+                },
+            ]
+
+    scan_entry = _make_entry("scan_with_watchlist", "", "", date="2026-04-18")
+    scan_entry["data"]["count"] = 2
+    _write_log(os.path.join(log_dir, "20260418_093000_FirstPullback.log.json"), [scan_entry])
+
+    svc = StrategyLogReportService(
+        log_dir=log_dir,
+        virtual_trade_service=DummyVirtualTradeService(),
+        profitability_gate_config=SimpleNamespace(min_trades=3),
+    )
+    report = await svc.generate_report("20260418")
+
+    assert "표준 journal 축적 현황" in report
+    assert "전체 3건 / SOLD 1건 / 진행중 2건" in report
+    assert "source: paper 2건, event_shadow 1건" in report
+    assert "S1: SOLD 1/3건" in report
+
+
+@pytest.mark.asyncio
 async def test_report_includes_strategy_regime_decomposition_section(log_dir):
     """일일 리포트 본문에 전략별 regime 분해 섹션을 포함한다."""
     class DummyVirtualTradeService:

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (O-2 해외 dry-run 비용/진입가 가정 보정 — 왕복 비용 기본값 0.5% 및 리포트 주의문 추가)
+최종 업데이트: 2026-07-04 (O-2 해외 dry-run 비용/진입가 가정 보정 + 1-6 표준 journal 축적 현황 리포트 추가)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -65,6 +65,7 @@
 ### 1-6. 실전 수익성 데이터 확보와 profitability gate 운영 [라이브 축적 — 코드 착수 가능]
 
 - [ ] shadow / paper / 소액 canary journal을 표준 포맷으로 누적하고, 전략별 profitability gate 통과 근거를 리포트한다. (journal은 `virtual_trade_service.get_standard_journal_records` ← polling scan + REST 가격 경로로 채워져 WS 틱 비의존 — 무틱 블로커와 독립적으로 축적 가능. shadow 하위 요소만 2-4와 동일 의존. 라이브 런타임 시간만 필요.)
+  - 표준 journal 축적 현황 리포트 추가 (2026-07-04): 일일 전략 리포트에 source별 레코드 수, SOLD/진행중 status, 전략별 SOLD 표본 진행률(`min_trades` 대비)을 노출해 paper/canary 데이터가 gate 해제 기준까지 얼마나 쌓였는지 확인 가능.
   - 최소 유지 기준: 실전 override `min_trades=100`, `profit_factor>=1.3`, `payoff_ratio>=1.2`, `win_rate>=40%`, `max_drawdown<=12%`, regime별 최소 거래 30. parameter stability·Monte Carlo·regime balance·multiple testing 보정을 운영 편의로 낮추지 않는다.
 
 주요 파일: `services/strategy_live_expansion_gate_service.py`, `services/strategy_profitability_gate_service.py`, `scheduler/strategy_scheduler.py`, `services/strategy_log_report_service.py`


### PR DESCRIPTION
## Summary
- Add a standard journal accumulation section to the daily strategy report
- Show source/status counts and per-strategy SOLD sample progress against profitability min_trades
- Update todo_list.md with the 1-6 reporting progress

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_strategy_log_report_service.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v

Note: integration tests passed with an existing asyncio pending-task warning from LarryWilliamsChannelBreakoutStrategy._load_state_async after pytest completed.