### PR TITLE
Adjust overseas dry-run cost assumptions

### DIFF
--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -30,6 +30,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 _SIGNAL_SOURCE = "overseas_dryrun"
+DEFAULT_ROUND_TRIP_COST_PCT = 0.5
+DEFAULT_COST_MODEL = "commission_only"
+DEFAULT_ENTRY_PRICE_ASSUMPTION = "daily_breakout_target"
 
 
 def _to_float(value: Any) -> Optional[float]:
@@ -352,6 +355,22 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
             f"signal_source: `{cfg.get('signal_source', '')}`  "
             f"shadow_dir: `{cfg.get('shadow_dir', '')}`"
         )
+        cost_pct = cfg.get("round_trip_cost_pct")
+        lines.append("")
+        lines.append("## 가정/주의")
+        lines.append("")
+        if isinstance(cost_pct, (int, float)):
+            lines.append(
+                f"- 왕복 비용 {float(cost_pct):.3f}% "
+                f"(`{cfg.get('cost_model', DEFAULT_COST_MODEL)}`): "
+                "미국주식 온라인 기본 수수료 0.25%/side를 왕복으로 반영한 값이며, "
+                "환전 스프레드·SEC/TAF 등 매도 제비용은 별도입니다."
+            )
+        lines.append(
+            "- 일봉 기반 would-be 진입가: 당일 intraday 체결 경로가 아니라 "
+            "`open + K * prev_range` 목표가 체결을 가정하므로 실제 장중 체결가보다 "
+            "낙관적일 수 있습니다."
+        )
         lines.append("")
 
     def _fmt(v: Optional[float], suffix: str = "") -> str:
@@ -444,8 +463,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="멀티데이 trailing stop %% (회고 가정값)")
     parser.add_argument("--time-stop-days", type=int, default=20,
                         help="멀티데이 time stop 보유일수(회고 가정값)")
-    parser.add_argument("--cost-pct", type=float, default=0.2,
-                        help="멀티데이 왕복 비용 %% (net 산출)")
+    parser.add_argument("--cost-pct", type=float, default=DEFAULT_ROUND_TRIP_COST_PCT,
+                        help="멀티데이 왕복 비용 %% (net 산출). 기본값 0.5%%는 미국주식 온라인 수수료 0.25%%/side 왕복 가정.")
     parser.add_argument("--output-json", default=None)
     parser.add_argument("--output-markdown", default=None)
     return parser
@@ -466,6 +485,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         "date_to": args.date_to,
         "signal_source": args.signal_source,
         "shadow_dir": str(args.shadow_dir),
+        "round_trip_cost_pct": args.cost_pct,
+        "cost_model": DEFAULT_COST_MODEL,
+        "entry_price_assumption": DEFAULT_ENTRY_PRICE_ASSUMPTION,
     }
 
     if args.ohlcv_dir:

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from scripts.analyze_overseas_dryrun import (
+    build_parser,
     compute_dryrun_report,
     compute_multiday_report,
     format_markdown_report,
@@ -183,9 +184,23 @@ def test_format_markdown_smoke():
         {"code": "AAA", "exchange": "NASD", "trade_date": "20260601",
          "realized_pct": 5.0, "exit_reason": "eod", "qty": 9, "notional_usd": 945.0},
     ])
+    report["config"] = {
+        "round_trip_cost_pct": 0.5,
+        "cost_model": "commission_only",
+        "entry_price_assumption": "daily_breakout_target",
+    }
     md = format_markdown_report(report)
     assert "Overseas VBO Dry-run" in md
     assert "win_rate" in md
+    assert "가정/주의" in md
+    assert "왕복 비용 0.500%" in md
+    assert "일봉 기반 would-be 진입가" in md
+
+
+def test_parser_defaults_to_us_online_round_trip_commission():
+    args = build_parser().parse_args(["--date-from", "20260601", "--date-to", "20260605"])
+
+    assert args.cost_pct == pytest.approx(0.5)
 
 
 # ── multiday 회고 재구성 ─────────────────────────────────────────────────────

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (1-5 microstructure QC 태스크 알림 추가 — 캡처 품질 게이트 실패를 last_result/log/notification에서 확인 가능)
+최종 업데이트: 2026-07-04 (O-2 해외 dry-run 비용/진입가 가정 보정 — 왕복 비용 기본값 0.5% 및 리포트 주의문 추가)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -135,8 +135,8 @@
 
 ### O-2. dry-run 비용/진입가 가정 보정 [신규]
 
-- [ ] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 실계약 KIS 해외 요율 기반으로 교체 — 편도 수수료 0.25% 수준이면 0.2%는 낙관적. (2026-07-02 리뷰)
-- [ ] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run 리포트에 명시해 성과 해석 시 참고하도록 한다.
+- [x] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 미국주식 온라인 기본 수수료 0.25%/side 기준 0.5%로 보정 (2026-07-04). 환전 스프레드·SEC/TAF 등 매도 제비용은 별도이므로 리포트에 `commission_only` 가정으로 명시.
+- [x] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run Markdown 리포트 `가정/주의` 섹션에 명시.
 
 주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_vbo_dryrun_service.py`
 


### PR DESCRIPTION
## Summary
- Raise overseas dry-run multiday round-trip cost default from 0.2% to 0.5%
- Add report config/Markdown assumptions for commission-only cost and daily target-entry optimism
- Mark O-2 complete in todo_list.md

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/scripts/test_analyze_overseas_dryrun.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v

## Reference
- KIS official overseas stock fee page/search result indicates US online stock commission at 0.25% per side; this PR uses 0.5% round-trip as commission-only default and leaves FX spread/SEC/TAF costs explicit as excluded assumptions.