### PR TITLE
1-5 체결강도 장중 시계열 캡처 — WS 체결 틱 샘플링 → es_db 소스 소비

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -163,6 +163,9 @@ microstructure_capture_enabled: true
 # 장중 캡처 후보 종목 프로그램매매 WS 구독 (pt_history 장중 시계열 축적, LOW 우선순위 — 트레이딩 구독 비간섭)
 program_capture_subscription_enabled: true
 
+# 장중 체결강도 시계열 축적 (기존 PRICE 틱 무임승차 — es_history DB, 장마감 캡처가 es_db 소스로 소비)
+execution_strength_capture_enabled: true
+
 # 체결 품질 리포트 경고 기준 (사후 평가용, 자동 비활성화는 기본 OFF)
 execution_quality_report:
   enabled: true

--- a/repositories/execution_strength_repo.py
+++ b/repositories/execution_strength_repo.py
@@ -1,0 +1,164 @@
+"""체결강도 장중 시계열 SQLite 저장소."""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import Optional
+
+
+class ExecutionStrengthRepository:
+    """WS 체결 틱(H0STCNT0)의 체결강도를 종목당 샘플링해 SQLite에 축적한다.
+
+    todo 1-5: 체결강도는 EOD REST 스칼라 1개/종목만 확보 가능해 "체결강도 ≥120%"
+    장중 게이트의 리플레이가 불가능했다 — 기존 PRICE 틱에 포함된 체결강도를
+    장중에 샘플링 저장해 microstructure 캡처(es_db 소스)가 소비한다.
+
+    설계:
+      - 신규 WS 구독 없음 — PriceStreamService.on_price_tick 경로에 무임승차.
+        (커버리지는 PRICE 구독 + 유틱 종목으로 제한 — 무틱 종목은 캡처 단계에서
+         기존 REST 스칼라로 폴백)
+      - 백그라운드 태스크/스레드 없음 — 틱 경로에서 버퍼 flush를 amortize한다.
+        프로세스 종료 시 마지막 flush 이후 버퍼(샘플링 주기상 종목당 최대 1행
+        수준)는 유실될 수 있다.
+    """
+
+    DEFAULT_BASE_DIR = "data/execution_strength"
+    SAMPLE_INTERVAL_SEC = 60.0
+    FLUSH_INTERVAL_SEC = 30.0
+    FLUSH_BUFFER_SIZE = 20
+    RETENTION_DAYS = 30
+
+    def __init__(
+        self,
+        base_dir: str = DEFAULT_BASE_DIR,
+        logger=None,
+        sample_interval_sec: Optional[float] = None,
+        retention_days: Optional[int] = None,
+    ):
+        self._logger = logger or logging.getLogger(__name__)
+        self._base_dir = base_dir
+        self._db_path = os.path.join(base_dir, "execution_strength.db")
+        self._sample_interval_sec = (
+            sample_interval_sec if sample_interval_sec is not None else self.SAMPLE_INTERVAL_SEC
+        )
+        self._retention_days = retention_days if retention_days is not None else self.RETENTION_DAYS
+
+        self._conn: Optional[sqlite3.Connection] = None
+        self._buffer: list = []
+        self._buffer_lock = threading.Lock()
+        self._last_sampled: dict[str, float] = {}
+        self._last_flush = time.time()
+
+        os.makedirs(self._base_dir, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        try:
+            self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            with self._conn:
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS es_history (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        code TEXT NOT NULL,
+                        trade_date TEXT NOT NULL,
+                        trade_time TEXT NOT NULL,
+                        strength REAL NOT NULL,
+                        created_at REAL NOT NULL
+                    )
+                    """
+                )
+                self._conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_es_history_code_date"
+                    " ON es_history(code, trade_date)"
+                )
+                cutoff = time.time() - self._retention_days * 86400
+                self._conn.execute("DELETE FROM es_history WHERE created_at < ?", (cutoff,))
+        except sqlite3.Error as exc:
+            self._logger.error(f"ExecutionStrengthRepository DB 초기화 실패: {exc}")
+            self._conn = None
+
+    def record_tick(
+        self,
+        code: str,
+        strength_raw,
+        trade_time_raw,
+        trade_date_raw=None,
+        now: Optional[float] = None,
+    ) -> bool:
+        """틱 1건을 샘플링 기록한다. 버퍼에 채택되면 True.
+
+        종목당 SAMPLE_INTERVAL_SEC 이내 중복 틱과 파싱 불가 값은 조용히 skip한다.
+        """
+        if self._conn is None or not code:
+            return False
+        strength = self._parse_float(strength_raw)
+        if strength is None:
+            return False
+        trade_time = self._normalize_digits(trade_time_raw, 6)
+        if trade_time is None:
+            return False
+        if now is None:
+            now = time.time()
+        last = self._last_sampled.get(code)
+        if last is not None and (now - last) < self._sample_interval_sec:
+            return False
+        trade_date = self._normalize_digits(trade_date_raw, 8) or time.strftime(
+            "%Y%m%d", time.localtime(now)
+        )
+        self._last_sampled[code] = now
+        with self._buffer_lock:
+            self._buffer.append((code, trade_date, trade_time, strength, now))
+            should_flush = (
+                len(self._buffer) >= self.FLUSH_BUFFER_SIZE
+                or (now - self._last_flush) >= self.FLUSH_INTERVAL_SEC
+            )
+        if should_flush:
+            self.flush()
+        return True
+
+    def flush(self) -> None:
+        """버퍼를 DB에 일괄 저장한다."""
+        if self._conn is None:
+            return
+        with self._buffer_lock:
+            batch = self._buffer
+            self._buffer = []
+            self._last_flush = time.time()
+        if not batch:
+            return
+        try:
+            with self._conn:
+                self._conn.executemany(
+                    "INSERT INTO es_history (code, trade_date, trade_time, strength, created_at)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    batch,
+                )
+        except sqlite3.Error as exc:
+            self._logger.error(f"ExecutionStrengthRepository flush 실패: {exc}")
+
+    def close(self) -> None:
+        self.flush()
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    @staticmethod
+    def _parse_float(value) -> Optional[float]:
+        try:
+            return float(value) if value not in (None, "", "N/A") else None
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _normalize_digits(value, length: int) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if len(text) == length and text.isdigit():
+            return text
+        return None

--- a/scripts/analyze_backtest_microstructure_quality.py
+++ b/scripts/analyze_backtest_microstructure_quality.py
@@ -53,6 +53,7 @@ def compute_quality_report(
     min_intraday_coverage_pct: float = 80.0,
     min_program_overlay_coverage_pct: float = 80.0,
     min_program_db_coverage_pct: float = 50.0,
+    min_execution_strength_db_coverage_pct: float = 30.0,
     max_stale_rows: int = 0,
 ) -> Dict[str, Any]:
     """Compute daily and aggregate quality metrics."""
@@ -61,6 +62,7 @@ def compute_quality_report(
         min_intraday_coverage_pct=min_intraday_coverage_pct,
         min_program_overlay_coverage_pct=min_program_overlay_coverage_pct,
         min_program_db_coverage_pct=min_program_db_coverage_pct,
+        min_execution_strength_db_coverage_pct=min_execution_strength_db_coverage_pct,
         max_stale_rows=max_stale_rows,
     )
     for payload in payloads:
@@ -87,6 +89,14 @@ def compute_quality_report(
         row["program_db_available"] or 0 for row in by_date.values()
         if row["program_db_coverage_pct"] is not None
     )
+    es_db_denominator = sum(
+        row["codes"] for row in by_date.values()
+        if row["execution_strength_db_coverage_pct"] is not None
+    )
+    es_db_available = sum(
+        row["execution_strength_db_available"] or 0 for row in by_date.values()
+        if row["execution_strength_db_coverage_pct"] is not None
+    )
     stale_rows = sum(row["stale_minute_rows_dropped"] for row in by_date.values())
     fallback_count = sum(len(row["program_fallback_codes"]) for row in by_date.values())
 
@@ -112,6 +122,11 @@ def compute_quality_report(
         ),
         "program_fallback_count": fallback_count,
         "program_fallback_pct": coverage_pct(fallback_count, total_codes),
+        "execution_strength_db_available": es_db_available,
+        "execution_strength_db_coverage_pct": (
+            coverage_pct(es_db_available, es_db_denominator)
+            if es_db_denominator > 0 else None
+        ),
         "stale_minute_rows_dropped": stale_rows,
         "quality_gate_passed": gate_passed,
         "daily_failures": daily_failures,
@@ -124,6 +139,7 @@ def compute_quality_report(
             "min_intraday_coverage_pct": min_intraday_coverage_pct,
             "min_program_overlay_coverage_pct": min_program_overlay_coverage_pct,
             "min_program_db_coverage_pct": min_program_db_coverage_pct,
+            "min_execution_strength_db_coverage_pct": min_execution_strength_db_coverage_pct,
             "max_stale_rows": max_stale_rows,
         },
         "totals": totals,
@@ -150,14 +166,15 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
         f"| execution_strength_coverage | {_fmt_pct(totals.get('execution_strength_coverage_pct'))} |",
         f"| program_overlay_coverage | {_fmt_pct(totals.get('program_overlay_coverage_pct'))} |",
         f"| program_db_coverage | {_fmt_pct(totals.get('program_db_coverage_pct'))} |",
+        f"| execution_strength_db_coverage | {_fmt_pct(totals.get('execution_strength_db_coverage_pct'))} |",
         f"| program_fallback_count | {totals.get('program_fallback_count', 0)} |",
         f"| stale_minute_rows_dropped | {totals.get('stale_minute_rows_dropped', 0)} |",
         f"| quality_gate_passed | {totals.get('quality_gate_passed', False)} |",
         "",
         "## By Date",
         "",
-        "| date | codes | intraday | exec_strength | program | program_db | stale | issues |",
-        "|---|---:|---:|---:|---:|---:|---:|---|",
+        "| date | codes | intraday | exec_strength | program | program_db | es_db | stale | issues |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for date, row in sorted((report.get("by_date") or {}).items()):
         issues = ", ".join(row.get("issues") or []) or "-"
@@ -167,6 +184,7 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
             f"{_fmt_pct(row.get('execution_strength_coverage_pct'))} | "
             f"{_fmt_pct(row.get('program_overlay_coverage_pct'))} | "
             f"{_fmt_pct(row.get('program_db_coverage_pct'))} | "
+            f"{_fmt_pct(row.get('execution_strength_db_coverage_pct'))} | "
             f"{row.get('stale_minute_rows_dropped', 0)} | {issues} |"
         )
     lines.append("")
@@ -183,6 +201,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-intraday-coverage-pct", type=float, default=80.0)
     parser.add_argument("--min-program-overlay-coverage-pct", type=float, default=80.0)
     parser.add_argument("--min-program-db-coverage-pct", type=float, default=50.0)
+    parser.add_argument("--min-execution-strength-db-coverage-pct", type=float, default=30.0)
     parser.add_argument("--max-stale-rows", type=int, default=0)
     parser.add_argument("--output-json", default=None)
     parser.add_argument("--output-markdown", default=None)
@@ -206,6 +225,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         min_intraday_coverage_pct=args.min_intraday_coverage_pct,
         min_program_overlay_coverage_pct=args.min_program_overlay_coverage_pct,
         min_program_db_coverage_pct=args.min_program_db_coverage_pct,
+        min_execution_strength_db_coverage_pct=args.min_execution_strength_db_coverage_pct,
         max_stale_rows=args.max_stale_rows,
     )
     report["config"].update({

--- a/scripts/capture_backtest_microstructure.py
+++ b/scripts/capture_backtest_microstructure.py
@@ -34,6 +34,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--program-db-path",
         default="data/program_subscribe/program_trading.db",
     )
+    parser.add_argument(
+        "--execution-strength-source",
+        choices=("rest_scalar", "es_db"),
+        default="rest_scalar",
+        help="체결강도 출처: rest_scalar=EOD REST 스칼라, es_db=장중 WS 샘플링 DB(미스 종목은 스칼라 폴백)",
+    )
+    parser.add_argument(
+        "--execution-strength-db-path",
+        default="data/execution_strength/execution_strength.db",
+    )
     parser.add_argument("--output-dir", default="data/backtest_microstructure")
     parser.add_argument("--paper", action="store_true", default=False)
     parser.add_argument("--no-intraday", action="store_true", default=False)
@@ -56,6 +66,7 @@ async def _run(args: argparse.Namespace) -> int:
         stock_query_service=sqs,
         program_provider=_get_program_provider(sqs),
         program_db_path=args.program_db_path,
+        execution_strength_db_path=args.execution_strength_db_path,
     )
     payload = await service.capture(
         codes=_parse_codes(args.codes),
@@ -66,6 +77,7 @@ async def _run(args: argparse.Namespace) -> int:
         include_intraday=not args.no_intraday,
         include_execution_strength=not args.no_execution_strength,
         program_source=args.program_source,
+        execution_strength_source=args.execution_strength_source,
     )
     paths = _write_output_files(payload, Path(args.output_dir))
     for label, path in paths.items():

--- a/services/backtest_microstructure_capture.py
+++ b/services/backtest_microstructure_capture.py
@@ -18,10 +18,12 @@ class BacktestMicrostructureCaptureService:
         stock_query_service: Any,
         program_provider: Any | None = None,
         program_db_path: str | Path = "data/program_subscribe/program_trading.db",
+        execution_strength_db_path: str | Path = "data/execution_strength/execution_strength.db",
     ) -> None:
         self._sqs = stock_query_service
         self._program_provider = program_provider
         self._program_db_path = Path(program_db_path)
+        self._execution_strength_db_path = Path(execution_strength_db_path)
 
     async def capture(
         self,
@@ -34,6 +36,7 @@ class BacktestMicrostructureCaptureService:
         include_intraday: bool = True,
         include_execution_strength: bool = True,
         program_source: str = "daily_rest",
+        execution_strength_source: str = "rest_scalar",
     ) -> dict[str, Any]:
         selected_codes = [code.strip() for code in codes if code.strip()]
         intraday, stale_minute_rows_dropped = await self._capture_intraday(
@@ -46,6 +49,15 @@ class BacktestMicrostructureCaptureService:
         execution_strength = await self._capture_execution_strength(
             selected_codes
         ) if include_execution_strength else {code: None for code in selected_codes}
+        execution_strength_intraday, execution_strength_fallback_codes = (
+            self._capture_execution_strength_intraday(
+                selected_codes,
+                date_ymd=date_ymd,
+                source=execution_strength_source,
+                start_hhmmss=start_hhmmss,
+                end_hhmmss=end_hhmmss,
+            )
+        )
         program_trades, program_fallback_codes = await self._capture_program_trades(
             selected_codes,
             date_ymd=date_ymd,
@@ -69,6 +81,8 @@ class BacktestMicrostructureCaptureService:
                 "session": session,
                 "program_source": program_source,
                 "program_fallback_codes": program_fallback_codes,
+                "execution_strength_source": execution_strength_source,
+                "execution_strength_fallback_codes": execution_strength_fallback_codes,
                 "quality": {
                     "empty_minute_codes": empty_minute_codes,
                     "stale_minute_rows_dropped": stale_minute_rows_dropped,
@@ -79,6 +93,9 @@ class BacktestMicrostructureCaptureService:
                         1 for value in execution_strength.values()
                         if value is not None
                     ),
+                    "execution_strength_intraday_rows": sum(
+                        len(rows) for rows in execution_strength_intraday.values()
+                    ),
                     "program_trades": sum(
                         1 for value in program_trades.values()
                         if value is not None
@@ -87,6 +104,7 @@ class BacktestMicrostructureCaptureService:
             },
             "intraday_minutes": intraday,
             "execution_strength": execution_strength,
+            "execution_strength_intraday": execution_strength_intraday,
             "program_trades": program_trades,
         }
 
@@ -137,6 +155,43 @@ class BacktestMicrostructureCaptureService:
                 continue
             result[code] = _extract_execution_strength(resp)
         return result
+
+    def _capture_execution_strength_intraday(
+        self,
+        codes: list[str],
+        *,
+        date_ymd: str,
+        source: str,
+        start_hhmmss: str,
+        end_hhmmss: str,
+    ) -> tuple[dict[str, list[dict]], list[str]]:
+        if source not in ("rest_scalar", "es_db"):
+            raise ValueError(f"unsupported execution_strength_source: {source}")
+        result: dict[str, list[dict]] = {code: [] for code in codes}
+        if source == "rest_scalar":
+            return result, []
+        # es_db: 장중 WS 틱 샘플링 DB(es_history). 미스 종목(무틱/미구독)은
+        # 기존 REST 스칼라(execution_strength)가 폴백 역할을 한다.
+        if self._execution_strength_db_path.exists():
+            with sqlite3.connect(self._execution_strength_db_path) as conn:
+                for code in codes:
+                    rows = conn.execute(
+                        """
+                        SELECT trade_time, strength
+                        FROM es_history
+                        WHERE code = ?
+                          AND trade_date = ?
+                          AND trade_time >= ?
+                          AND trade_time <= ?
+                        ORDER BY trade_time ASC, id ASC
+                        """,
+                        (code, date_ymd, start_hhmmss, end_hhmmss),
+                    ).fetchall()
+                    result[code] = [
+                        {"time": row[0], "strength": row[1]} for row in rows
+                    ]
+        fallback_codes = [code for code in codes if not result[code]]
+        return result, fallback_codes
 
     async def _capture_program_trades(
         self,
@@ -234,17 +289,25 @@ class BacktestMicrostructureCaptureService:
         trade_date = payload["metadata"]["trade_date"]
         capture_path = output_dir / f"replay_microstructure_{trade_date}.json"
         execution_strength_path = output_dir / f"replay_execution_strength_{trade_date}.json"
+        execution_strength_intraday_path = (
+            output_dir / f"replay_execution_strength_intraday_{trade_date}.json"
+        )
         program_trades_path = output_dir / f"replay_program_trades_{trade_date}.json"
         intraday_path = output_dir / f"replay_intraday_minutes_{trade_date}.json"
 
         _write_json(capture_path, payload)
         _write_json(execution_strength_path, payload.get("execution_strength", {}))
+        _write_json(
+            execution_strength_intraday_path,
+            payload.get("execution_strength_intraday", {}),
+        )
         _write_json(program_trades_path, _flatten_program_trades(payload.get("program_trades", {})))
         _write_json(intraday_path, payload.get("intraday_minutes", {}))
 
         return {
             "capture": capture_path,
             "execution_strength": execution_strength_path,
+            "execution_strength_intraday": execution_strength_intraday_path,
             "program_trades": program_trades_path,
             "intraday_minutes": intraday_path,
         }

--- a/services/backtest_microstructure_quality.py
+++ b/services/backtest_microstructure_quality.py
@@ -9,6 +9,8 @@ class MicrostructureQualityThresholds:
     min_intraday_coverage_pct: float = 80.0
     min_program_overlay_coverage_pct: float = 80.0
     min_program_db_coverage_pct: float = 50.0
+    # 무틱 ~55%(P2 2-4) + PRICE 미구독 후보를 감안한 보수 임계 — 배선 전손 감지용
+    min_execution_strength_db_coverage_pct: float = 30.0
     max_stale_rows: int = 0
 
 
@@ -51,6 +53,18 @@ def summarize_capture_quality(
         program_db_available = max(0, program_overlay_available - len(program_fallback_codes))
         program_db_coverage_pct = coverage_pct(program_db_available, code_count)
 
+    execution_strength_source = str(metadata.get("execution_strength_source") or "")
+    execution_strength_intraday = payload.get("execution_strength_intraday") or {}
+    execution_strength_db_available: Optional[int] = None
+    execution_strength_db_coverage_pct: Optional[float] = None
+    if execution_strength_source == "es_db":
+        execution_strength_db_available = sum(
+            1 for code in codes if execution_strength_intraday.get(code)
+        )
+        execution_strength_db_coverage_pct = coverage_pct(
+            execution_strength_db_available, code_count
+        )
+
     intraday_coverage_pct = coverage_pct(intraday_available, code_count)
     execution_strength_coverage_pct = coverage_pct(
         execution_strength_available, code_count
@@ -69,6 +83,12 @@ def summarize_capture_quality(
         and program_db_coverage_pct < thresholds.min_program_db_coverage_pct
     ):
         issues.append("program_db_coverage_below_threshold")
+    if (
+        execution_strength_db_coverage_pct is not None
+        and execution_strength_db_coverage_pct
+        < thresholds.min_execution_strength_db_coverage_pct
+    ):
+        issues.append("execution_strength_db_coverage_below_threshold")
     if stale_rows > thresholds.max_stale_rows:
         issues.append("stale_minute_rows_present")
 
@@ -86,6 +106,9 @@ def summarize_capture_quality(
         "program_fallback_pct": coverage_pct(len(program_fallback_codes), code_count),
         "program_db_available": program_db_available,
         "program_db_coverage_pct": program_db_coverage_pct,
+        "execution_strength_source": execution_strength_source,
+        "execution_strength_db_available": execution_strength_db_available,
+        "execution_strength_db_coverage_pct": execution_strength_db_coverage_pct,
         "empty_minute_codes": quality.get("empty_minute_codes") or [],
         "stale_minute_rows_dropped": stale_rows,
         "issues": issues,

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -36,12 +36,14 @@ class PriceStreamService:
         data_quality_service=None,
         notification_service=None,
         event_router=None,
+        execution_strength_recorder=None,
     ):
         self._stock_repo = stock_repo
         self._logger = logger or logging.getLogger(__name__)
         self._data_quality_service = data_quality_service
         self._notification_service = notification_service
         self._event_router = event_router
+        self._execution_strength_recorder = execution_strength_recorder
         self._latest_prices: Dict[str, dict] = {}
         self._latest_conclusions: Dict[str, dict] = {}  # code → conclusion snapshot dict
         self._sse_queues: Dict[str, List[asyncio.Queue]] = {}  # code → SSE 구독 큐 목록
@@ -136,6 +138,18 @@ class PriceStreamService:
 
         self._last_tick_ts[stock_code] = now_ts
         self._last_any_tick_ts = now_ts
+
+        if self._execution_strength_recorder is not None:
+            # todo 1-5: 체결강도 장중 시계열 축적 (샘플링/파싱은 recorder 책임)
+            try:
+                self._execution_strength_recorder.record_tick(
+                    stock_code,
+                    realtime_data.get('체결강도'),
+                    realtime_data.get('주식체결시간'),
+                    realtime_data.get('영업일자'),
+                )
+            except Exception as e:
+                self._logger.warning(f"체결강도 기록 실패: code={stock_code}, error={e}")
 
         cum_vol = realtime_data.get('누적거래량', '0')
         try:

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -31,6 +31,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
         scheduler_store=None,
         output_dir: str | Path = "data/backtest_microstructure",
         program_db_path: str | Path = "data/program_subscribe/program_trading.db",
+        execution_strength_db_path: str | Path = "data/execution_strength/execution_strength.db",
         max_codes: int = 40,
         logger=None,
         notification_service=None,
@@ -46,6 +47,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
         self._virtual_trade_service = virtual_trade_service
         self._output_dir = Path(output_dir)
         self._program_db_path = Path(program_db_path)
+        self._execution_strength_db_path = Path(execution_strength_db_path)
         self._max_codes = max_codes
         self._notification_service = notification_service
         # 재시작 시 catch-up 중복 캡처 방지를 위해 "마지막 캡처 날짜"를 영속화한다.
@@ -122,12 +124,16 @@ class MicrostructureCaptureTask(AfterMarketTask):
         program_source = (
             "program_db" if self._program_db_path.exists() else "daily_rest"
         )
+        execution_strength_source = (
+            "es_db" if self._execution_strength_db_path.exists() else "rest_scalar"
+        )
         self._progress["running"] = True
         try:
             payload = await self._service.capture(
                 codes=codes,
                 date_ymd=latest_trading_date,
                 program_source=program_source,
+                execution_strength_source=execution_strength_source,
             )
             self._service.write_overlay_files(payload, self._output_dir)
             self._last_captured_date = latest_trading_date
@@ -136,6 +142,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
             metadata = payload.get("metadata") or {}
             quality = metadata.get("quality") or {}
             program_fallback_codes = metadata.get("program_fallback_codes") or []
+            execution_strength_fallback_codes = (
+                metadata.get("execution_strength_fallback_codes") or []
+            )
             quality_summary = summarize_capture_quality(
                 payload,
                 fallback_codes=codes,
@@ -152,6 +161,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 "execution_strength_coverage_pct": quality_summary["execution_strength_coverage_pct"],
                 "program_overlay_coverage_pct": quality_summary["program_overlay_coverage_pct"],
                 "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
+                "execution_strength_source": execution_strength_source,
+                "execution_strength_fallback_codes": execution_strength_fallback_codes,
+                "execution_strength_db_coverage_pct": quality_summary["execution_strength_db_coverage_pct"],
             }
             if not quality_summary["quality_gate_passed"]:
                 self._logger.warning(
@@ -166,6 +178,8 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 f"{self.task_name}: {latest_trading_date} 캡처 완료 "
                 f"(codes={len(codes)}, program_source={program_source}, "
                 f"program_fallback={len(program_fallback_codes)}, "
+                f"execution_strength_source={execution_strength_source}, "
+                f"execution_strength_fallback={len(execution_strength_fallback_codes)}, "
                 f"empty_minutes={len(quality.get('empty_minute_codes') or [])})"
             )
         except Exception as exc:

--- a/tests/unit_test/repositories/test_execution_strength_repo.py
+++ b/tests/unit_test/repositories/test_execution_strength_repo.py
@@ -1,0 +1,142 @@
+import sqlite3
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from repositories.execution_strength_repo import ExecutionStrengthRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    instance = ExecutionStrengthRepository(
+        base_dir=str(tmp_path / "es_repo"), logger=MagicMock()
+    )
+    yield instance
+    instance.close()
+
+
+def _rows(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT code, trade_date, trade_time, strength FROM es_history ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def test_init_creates_db_and_table(repo):
+    tables = {
+        row[0]
+        for row in sqlite3.connect(repo._db_path).execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    assert "es_history" in tables
+
+
+def test_record_tick_persists_after_flush(repo):
+    now = time.time()
+    assert repo.record_tick("005930", "123.45", "091001", "20260704", now=now) is True
+
+    repo.flush()
+
+    assert _rows(repo._db_path) == [("005930", "20260704", "091001", 123.45)]
+
+
+def test_record_tick_samples_per_code(repo):
+    base = time.time()
+    assert repo.record_tick("005930", "100.0", "090001", "20260704", now=base) is True
+    # 같은 종목 60초 이내 → skip
+    assert repo.record_tick("005930", "101.0", "090031", "20260704", now=base + 30) is False
+    # 다른 종목은 독립 샘플링
+    assert repo.record_tick("000660", "90.0", "090031", "20260704", now=base + 30) is True
+    # 같은 종목 60초 경과 → 기록
+    assert repo.record_tick("005930", "102.0", "090101", "20260704", now=base + 61) is True
+
+    repo.flush()
+
+    assert [(r[0], r[3]) for r in _rows(repo._db_path)] == [
+        ("005930", 100.0),
+        ("000660", 90.0),
+        ("005930", 102.0),
+    ]
+
+
+def test_record_tick_skips_invalid_values(repo):
+    now = time.time()
+    assert repo.record_tick("", "100.0", "090001", "20260704", now=now) is False
+    assert repo.record_tick("005930", "N/A", "090001", "20260704", now=now) is False
+    assert repo.record_tick("005930", None, "090001", "20260704", now=now) is False
+    assert repo.record_tick("005930", "100.0", "9:01", "20260704", now=now) is False
+    assert repo.record_tick("005930", "100.0", None, "20260704", now=now) is False
+
+    repo.flush()
+
+    assert _rows(repo._db_path) == []
+
+
+def test_record_tick_falls_back_to_local_date(repo):
+    now = time.time()
+    assert repo.record_tick("005930", "110.5", "091001", None, now=now) is True
+
+    repo.flush()
+
+    expected_date = time.strftime("%Y%m%d", time.localtime(now))
+    assert _rows(repo._db_path) == [("005930", expected_date, "091001", 110.5)]
+
+
+def test_buffer_flushes_on_size_threshold(repo):
+    now = time.time()
+    for i in range(ExecutionStrengthRepository.FLUSH_BUFFER_SIZE):
+        assert repo.record_tick(f"{i:06d}", "100.0", "090001", "20260704", now=now) is True
+
+    # 명시적 flush 없이 버퍼 임계 도달로 이미 저장됨
+    assert len(_rows(repo._db_path)) == ExecutionStrengthRepository.FLUSH_BUFFER_SIZE
+
+
+def test_flush_interval_triggers_flush(repo):
+    now = time.time() + ExecutionStrengthRepository.FLUSH_INTERVAL_SEC + 1
+    assert repo.record_tick("005930", "100.0", "090001", "20260704", now=now) is True
+
+    # 마지막 flush 이후 FLUSH_INTERVAL_SEC 경과 → 즉시 flush
+    assert len(_rows(repo._db_path)) == 1
+
+
+def test_retention_cleanup_on_init(tmp_path):
+    base_dir = str(tmp_path / "es_repo")
+    first = ExecutionStrengthRepository(base_dir=base_dir, logger=MagicMock())
+    old_ts = time.time() - (ExecutionStrengthRepository.RETENTION_DAYS + 10) * 86400
+    with first._conn:
+        first._conn.execute(
+            "INSERT INTO es_history (code, trade_date, trade_time, strength, created_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("005930", "20260501", "090001", 100.0, old_ts),
+        )
+        first._conn.execute(
+            "INSERT INTO es_history (code, trade_date, trade_time, strength, created_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("005930", "20260704", "090001", 101.0, time.time()),
+        )
+    first.close()
+
+    second = ExecutionStrengthRepository(base_dir=base_dir, logger=MagicMock())
+    second.close()
+
+    assert _rows(second._db_path) == [("005930", "20260704", "090001", 101.0)]
+
+
+def test_init_db_failure_logs_error_and_record_returns_false(tmp_path):
+    logger = MagicMock()
+
+    with patch(
+        "repositories.execution_strength_repo.sqlite3.connect",
+        side_effect=sqlite3.Error("boom"),
+    ):
+        repo = ExecutionStrengthRepository(base_dir=str(tmp_path / "es_repo"), logger=logger)
+
+    logger.error.assert_called_once()
+    assert repo.record_tick("005930", "100.0", "090001", "20260704") is False
+    repo.flush()  # no-op이어야 하며 예외가 나지 않는다
+    repo.close()

--- a/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
+++ b/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
@@ -211,3 +211,44 @@ def test_main_fail_on_gate_returns_nonzero_for_bad_quality(tmp_path):
     ])
 
     assert rc == 1
+
+
+def test_compute_quality_report_aggregates_execution_strength_db_coverage():
+    report = compute_quality_report([
+        {
+            "metadata": {
+                "trade_date": "20260703",
+                "codes": ["A", "B"],
+                "execution_strength_source": "es_db",
+            },
+            "intraday_minutes": {"A": [{"r": 1}], "B": [{"r": 1}]},
+            "execution_strength": {"A": 1.0, "B": 1.0},
+            "execution_strength_intraday": {
+                "A": [{"time": "090001", "strength": 1.0}],
+                "B": [],
+            },
+            "program_trades": {"A": {"q": 1}, "B": {"q": 1}},
+        },
+    ])
+
+    assert report["totals"]["execution_strength_db_coverage_pct"] == pytest.approx(50.0)
+    assert report["by_date"]["20260703"][
+        "execution_strength_db_coverage_pct"
+    ] == pytest.approx(50.0)
+
+    md = format_markdown_report(report)
+    assert "execution_strength_db_coverage" in md
+
+
+def test_execution_strength_db_coverage_absent_for_rest_scalar_payloads():
+    report = compute_quality_report([
+        _payload(
+            date="20260701",
+            codes=["A"],
+            intraday_minutes={"A": [{"r": 1}]},
+            execution_strength={"A": 1.0},
+            program_trades={"A": {"q": 1}},
+        ),
+    ])
+
+    assert report["totals"]["execution_strength_db_coverage_pct"] is None

--- a/tests/unit_test/scripts/test_capture_backtest_microstructure.py
+++ b/tests/unit_test/scripts/test_capture_backtest_microstructure.py
@@ -1,6 +1,27 @@
 import json
 
-from scripts.capture_backtest_microstructure import _write_output_files
+from scripts.capture_backtest_microstructure import _write_output_files, build_parser
+
+
+def test_build_parser_execution_strength_defaults():
+    args = build_parser().parse_args(["--date", "20260512", "--codes", "000001"])
+
+    assert args.execution_strength_source == "rest_scalar"
+    assert args.execution_strength_db_path == "data/execution_strength/execution_strength.db"
+
+
+def test_build_parser_execution_strength_es_db():
+    args = build_parser().parse_args(
+        [
+            "--date", "20260512",
+            "--codes", "000001",
+            "--execution-strength-source", "es_db",
+            "--execution-strength-db-path", "custom/es.db",
+        ]
+    )
+
+    assert args.execution_strength_source == "es_db"
+    assert args.execution_strength_db_path == "custom/es.db"
 
 
 def test_write_output_files_creates_overlay_and_intraday_files(tmp_path):

--- a/tests/unit_test/services/test_backtest_microstructure_capture.py
+++ b/tests/unit_test/services/test_backtest_microstructure_capture.py
@@ -45,6 +45,7 @@ async def test_capture_collects_intraday_execution_strength_and_daily_program_ov
     assert payload["metadata"]["row_counts"] == {
         "intraday_minutes": 2,
         "execution_strength": 2,
+        "execution_strength_intraday_rows": 0,
         "program_trades": 2,
     }
     assert payload["intraday_minutes"]["000001"][0]["stck_prpr"] == "10000"
@@ -375,4 +376,149 @@ def test_write_overlay_files_creates_four_fixture_files(tmp_path):
         "000001": [{"stck_cntg_hour": "090000"}],
     }
     assert paths["capture"].name == "replay_microstructure_20260702.json"
+
+
+def _seed_es_db(tmp_path):
+    db_path = tmp_path / "execution_strength.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE es_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT NOT NULL,
+                trade_date TEXT NOT NULL,
+                trade_time TEXT NOT NULL,
+                strength REAL NOT NULL,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO es_history (code, trade_date, trade_time, strength, created_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                ("000001", "20260512", "090001", 110.0, 1.0),
+                ("000001", "20260512", "091001", 125.5, 2.0),
+                ("000001", "20260511", "090001", 90.0, 0.5),  # 다른 거래일 — 제외
+                ("000001", "20260512", "154000", 99.0, 3.0),  # 마감 이후 — 제외
+                ("000002", "20260512", "090001", 80.0, 1.5),
+            ],
+        )
+    return db_path
+
+
+@pytest.mark.asyncio
+async def test_capture_execution_strength_intraday_from_es_db(tmp_path):
+    db_path = _seed_es_db(tmp_path)
+    sqs = AsyncMock()
+    sqs.get_stock_conclusion.side_effect = [
+        _response({"output": [{"tday_rltv": "145.5"}]}),
+        _response({"output": [{"tday_rltv": "132.0"}]}),
+        _response({"output": [{"tday_rltv": "120.0"}]}),
+    ]
+    service = BacktestMicrostructureCaptureService(
+        stock_query_service=sqs,
+        execution_strength_db_path=db_path,
+    )
+
+    payload = await service.capture(
+        codes=["000001", "000002", "000003"],
+        date_ymd="20260512",
+        include_intraday=False,
+        program_source="none",
+        execution_strength_source="es_db",
+    )
+
+    assert payload["execution_strength_intraday"] == {
+        "000001": [
+            {"time": "090001", "strength": 110.0},
+            {"time": "091001", "strength": 125.5},
+        ],
+        "000002": [{"time": "090001", "strength": 80.0}],
+        "000003": [],
+    }
+    assert payload["metadata"]["execution_strength_source"] == "es_db"
+    # DB 미스 종목만 fallback — REST 스칼라는 전 종목 그대로 캡처된다
+    assert payload["metadata"]["execution_strength_fallback_codes"] == ["000003"]
+    assert payload["metadata"]["row_counts"]["execution_strength_intraday_rows"] == 3
+    assert payload["execution_strength"] == {
+        "000001": 145.5,
+        "000002": 132.0,
+        "000003": 120.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_execution_strength_rest_scalar_has_empty_intraday():
+    sqs = AsyncMock()
+    sqs.get_stock_conclusion.return_value = _response({"output": [{"tday_rltv": "100.0"}]})
+
+    payload = await _service(sqs=sqs).capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        program_source="none",
+    )
+
+    assert payload["metadata"]["execution_strength_source"] == "rest_scalar"
+    assert payload["execution_strength_intraday"] == {"000001": []}
+    assert payload["metadata"]["execution_strength_fallback_codes"] == []
+
+
+@pytest.mark.asyncio
+async def test_capture_execution_strength_es_db_missing_file_marks_all_fallback(tmp_path):
+    sqs = AsyncMock()
+    sqs.get_stock_conclusion.return_value = _response({"output": [{"tday_rltv": "100.0"}]})
+    service = BacktestMicrostructureCaptureService(
+        stock_query_service=sqs,
+        execution_strength_db_path=tmp_path / "missing.db",
+    )
+
+    payload = await service.capture(
+        codes=["000001"],
+        date_ymd="20260512",
+        include_intraday=False,
+        program_source="none",
+        execution_strength_source="es_db",
+    )
+
+    assert payload["execution_strength_intraday"] == {"000001": []}
+    assert payload["metadata"]["execution_strength_fallback_codes"] == ["000001"]
+
+
+@pytest.mark.asyncio
+async def test_capture_rejects_unknown_execution_strength_source():
+    with pytest.raises(ValueError):
+        await _service().capture(
+            codes=["000001"],
+            date_ymd="20260512",
+            include_intraday=False,
+            include_execution_strength=False,
+            program_source="none",
+            execution_strength_source="bogus",
+        )
+
+
+def test_write_overlay_files_includes_execution_strength_intraday(tmp_path):
+    import json
+
+    payload = {
+        "metadata": {"trade_date": "20260512", "codes": ["000001"]},
+        "intraday_minutes": {},
+        "execution_strength": {"000001": 100.0},
+        "execution_strength_intraday": {
+            "000001": [{"time": "090001", "strength": 100.0}],
+        },
+        "program_trades": {},
+    }
+
+    paths = BacktestMicrostructureCaptureService.write_overlay_files(payload, tmp_path / "out")
+
+    assert (
+        paths["execution_strength_intraday"].name
+        == "replay_execution_strength_intraday_20260512.json"
+    )
+    assert json.loads(
+        paths["execution_strength_intraday"].read_text(encoding="utf-8")
+    ) == {"000001": [{"time": "090001", "strength": 100.0}]}
 

--- a/tests/unit_test/services/test_backtest_microstructure_quality.py
+++ b/tests/unit_test/services/test_backtest_microstructure_quality.py
@@ -78,3 +78,57 @@ def test_summarize_capture_quality_falls_back_to_resolved_codes_when_metadata_mi
 def test_format_optional_pct_formats_numbers_and_missing_values():
     assert format_optional_pct(12.345) == "12.3%"
     assert format_optional_pct(None) == "-"
+
+
+def _es_payload(intraday_by_code):
+    codes = list(intraday_by_code)
+    return {
+        "metadata": {
+            "trade_date": "20260704",
+            "codes": codes,
+            "execution_strength_source": "es_db",
+        },
+        "intraday_minutes": {code: [{"row": 1}] for code in codes},
+        "execution_strength": {code: 100.0 for code in codes},
+        "execution_strength_intraday": intraday_by_code,
+        "program_trades": {code: {"program_net_buy_qty": 1} for code in codes},
+    }
+
+
+def test_execution_strength_db_coverage_computed_for_es_db_source():
+    summary = summarize_capture_quality(
+        _es_payload({
+            "A": [{"time": "090001", "strength": 110.0}],
+            "B": [],
+        })
+    )
+
+    assert summary["execution_strength_source"] == "es_db"
+    assert summary["execution_strength_db_available"] == 1
+    assert summary["execution_strength_db_coverage_pct"] == 50.0
+    assert "execution_strength_db_coverage_below_threshold" not in summary["issues"]
+
+
+def test_execution_strength_db_coverage_below_threshold_flags_issue():
+    summary = summarize_capture_quality(_es_payload({"A": [], "B": []}))
+
+    assert summary["execution_strength_db_coverage_pct"] == 0.0
+    assert "execution_strength_db_coverage_below_threshold" in summary["issues"]
+    assert summary["quality_gate_passed"] is False
+
+
+def test_execution_strength_db_coverage_absent_for_non_es_db_payload():
+    # 구 payload(소스 메타 없음) 하위호환 — 커버리지 미계산, issue 없음
+    payload = {
+        "metadata": {"trade_date": "20260702", "codes": ["A"]},
+        "intraday_minutes": {"A": [{"row": 1}]},
+        "execution_strength": {"A": 100.0},
+        "program_trades": {"A": {"program_net_buy_qty": 1}},
+    }
+
+    summary = summarize_capture_quality(payload)
+
+    assert summary["execution_strength_source"] == ""
+    assert summary["execution_strength_db_available"] is None
+    assert summary["execution_strength_db_coverage_pct"] is None
+    assert "execution_strength_db_coverage_below_threshold" not in summary["issues"]

--- a/tests/unit_test/services/test_price_stream_service_execution_strength.py
+++ b/tests/unit_test/services/test_price_stream_service_execution_strength.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.data_quality_service import DataQualityResult
+from services.price_stream_service import PriceStreamService
+
+
+def _tick(code="005930"):
+    return {
+        '유가증권단축종목코드': code,
+        '주식현재가': '75000',
+        '누적거래량': '1500000',
+        '체결강도': '123.45',
+        '주식체결시간': '091001',
+        '영업일자': '20260704',
+    }
+
+
+@pytest.fixture
+def recorder():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(recorder):
+    return PriceStreamService(
+        stock_repo=MagicMock(),
+        logger=MagicMock(),
+        execution_strength_recorder=recorder,
+    )
+
+
+def test_on_price_tick_records_execution_strength(service, recorder):
+    service.on_price_tick(_tick())
+
+    recorder.record_tick.assert_called_once_with(
+        '005930', '123.45', '091001', '20260704'
+    )
+
+
+def test_recorder_error_does_not_break_tick_path(service, recorder):
+    recorder.record_tick.side_effect = RuntimeError("boom")
+
+    service.on_price_tick(_tick())
+
+    # recorder 실패에도 틱 처리(캐시 갱신)는 지속되어야 한다
+    assert service.get_cached_price('005930') is not None
+
+
+def test_no_recorder_is_noop():
+    service = PriceStreamService(stock_repo=MagicMock(), logger=MagicMock())
+
+    service.on_price_tick(_tick())
+
+    assert service.get_cached_price('005930') is not None
+
+
+def test_quality_rejected_tick_not_recorded(recorder):
+    dq = MagicMock()
+    dq.validate_price_tick.return_value = DataQualityResult(
+        ok=False, severity="error", reason="invalid_tick", code="005930"
+    )
+    service = PriceStreamService(
+        stock_repo=MagicMock(),
+        logger=MagicMock(),
+        data_quality_service=dq,
+        execution_strength_recorder=recorder,
+    )
+
+    service.on_price_tick(_tick())
+
+    recorder.record_tick.assert_not_called()

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -59,6 +59,7 @@ def _make_task(capture_service, tmp_path, **kwargs):
         capture_service=capture_service,
         output_dir=tmp_path / "out",
         program_db_path=tmp_path / "program_trading.db",
+        execution_strength_db_path=tmp_path / "execution_strength.db",
         logger=MagicMock(),
     )
     defaults.update(kwargs)
@@ -392,3 +393,66 @@ def test_write_output_dir_passed_through(capture_service, tmp_path):
     task = _make_task(capture_service, tmp_path)
     assert task.task_name == "microstructure_capture"
     assert task.get_progress()["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_execution_strength_source_auto_selects_es_db_when_db_exists(
+    capture_service, universe_service, tmp_path
+):
+    es_db = tmp_path / "execution_strength.db"
+    es_db.write_bytes(b"")
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        execution_strength_db_path=es_db,
+    )
+
+    await task._on_market_closed("20260702")
+
+    kwargs = capture_service.capture.await_args.kwargs
+    assert kwargs["execution_strength_source"] == "es_db"
+    assert task.get_progress()["last_result"]["execution_strength_source"] == "es_db"
+
+
+@pytest.mark.asyncio
+async def test_execution_strength_source_falls_back_to_rest_scalar_without_db(
+    capture_service, universe_service, tmp_path
+):
+    task = _make_task(capture_service, tmp_path, universe_service=universe_service)
+
+    await task._on_market_closed("20260702")
+
+    kwargs = capture_service.capture.await_args.kwargs
+    assert kwargs["execution_strength_source"] == "rest_scalar"
+    assert (
+        task.get_progress()["last_result"]["execution_strength_source"]
+        == "rest_scalar"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_strength_metrics_exposed_in_last_result(
+    capture_service, universe_service, tmp_path
+):
+    payload = _payload()
+    payload["metadata"]["codes"] = ["005930", "000660"]
+    payload["metadata"]["execution_strength_source"] = "es_db"
+    payload["metadata"]["execution_strength_fallback_codes"] = ["000660"]
+    payload["execution_strength_intraday"] = {
+        "005930": [{"time": "090001", "strength": 110.0}],
+        "000660": [],
+    }
+    capture_service.capture = AsyncMock(return_value=payload)
+    es_db = tmp_path / "execution_strength.db"
+    es_db.write_bytes(b"")
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        execution_strength_db_path=es_db,
+    )
+
+    await task._on_market_closed("20260702")
+
+    last_result = task.get_progress()["last_result"]
+    assert last_result["execution_strength_fallback_codes"] == ["000660"]
+    assert last_result["execution_strength_db_coverage_pct"] == 50.0

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -22,6 +22,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "WorkerPool", "TimeDispatcher", "DataQualityService", "RankingTask",
     "StockQueryService", "MinerviniStageService", "MinerviniUpdateTask",
     "StreamingService", "PriceStreamService", "StreamingStockRepo",
+    "ExecutionStrengthRepository",
     "PriceSubscriptionService", "WebSocketWatchdogTask", "PreMarketHealthCheckTask",
     "DailyPriceCollectorTask", "OhlcvUpdateTask", "AccountSnapshotCache",
     "PositionSizingService", "RiskGateService", "ExecutionFlowService",
@@ -478,3 +479,31 @@ async def test_overseas_fx_provider_extracts_rate_from_balance(patched_service_c
     # 잔고 조회 실패 시 None → KRW 환산 생략
     ctx.broker.get_overseas_balance = AsyncMock(side_effect=RuntimeError("boom"))
     assert await fx_provider() is None
+
+
+def test_service_container_wires_execution_strength_recorder(patched_service_container_deps):
+    """체결강도 recorder(repo)가 생성되어 PriceStreamService에 주입된다 (todo 1-5)."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ServiceContainer(ctx).run()
+
+    es_repo = patched_service_container_deps["ExecutionStrengthRepository"].return_value
+    assert ctx.execution_strength_repo is es_repo
+    kwargs = patched_service_container_deps["PriceStreamService"].call_args.kwargs
+    assert kwargs["execution_strength_recorder"] is es_repo
+
+
+def test_service_container_disables_execution_strength_capture_via_config(
+    patched_service_container_deps,
+):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {"execution_strength_capture_enabled": False}
+    ServiceContainer(ctx).run()
+
+    patched_service_container_deps["ExecutionStrengthRepository"].assert_not_called()
+    assert ctx.execution_strength_repo is None
+    kwargs = patched_service_container_deps["PriceStreamService"].call_args.kwargs
+    assert kwargs["execution_strength_recorder"] is None

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (O-2 해외 dry-run 비용/진입가 가정 보정 + 1-6 표준 journal 축적 현황 리포트 추가)
+최종 업데이트: 2026-07-04 (1-5 체결강도 장중 시계열 캡처 배선 + O-1 완료 반영)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -20,17 +20,16 @@
 리뷰 핵심 판단: 운영 인프라·리스크 규율(킬스위치 영속화·RiskGate·tiered force-exit·profitability gate·캐너리 사이징)은 갖춰졌다. 남은 크리티컬 패스는 **엣지(수익성) 입증**이다. 엣지의 원천으로 삼는 수급 필터(체결강도·프로그램매매)가 장중 히스토리 부재로 백테스트 검증 불가능한 상태이므로, 검증 데이터 축적을 지금 시작하는 것이 최우선이다.
 
 1. **[즉시 착수 — 엣지 검증 크리티컬 패스]**
-   - 1-5 장중 microstructure 캡처 **상시 가동** (blocked 해제 단계 자체가 착수 항목) — 태스크 배선 완료(#618), 코퍼스 축적 중, 1일차 품질 결함 보정 완료(2026-07-04)
+   - 1-5 장중 microstructure 캡처 **상시 가동** (blocked 해제 단계 자체가 착수 항목) — 태스크 배선 완료(#618), 코퍼스 축적 중, 1일차 품질 결함 보정 + 체결강도 장중 시계열 배선 완료(2026-07-04)
    - 1-6 shadow/paper/소액 canary journal 축적 (운영 상시 — 무틱 블로커와 독립)
 2. **[외부 블로커 — 병행 진행]**
    - 2-4 WebSocket 무틱 — KIS 에스컬레이션 (무틱 보통주만; ETF/우선주는 무틱 수용으로 종결)
 3. **[확대·전환 전 필수 게이트]**
-   - O-1 미국 휴장일/조기폐장 캘린더 (신규 — 해외 Phase 5/라이브 전환 전 필수)
    - M-1 포지션 사이징 단일화 (신규 — canary→자금 확대 전 필수)
    - 0-1 실전 체결필드 fixture · 2-2 KIS 유량 한도 실측 (실전 전환 직전, 외부 의존)
 4. **[데이터·정책 대기]**
    - 1-8 백테스트 재실행 (CLI 노출 완료 #619 — PIT 후보 부재로 blocked, 2026-07-03 파일럿 판정)
-   - 1-7 DSR hard threshold (canary 데이터 후) · R-2 Phase 4 (베어 paper 데이터 후) · 해외 Phase 5 (dry-run 검증 + O-1/O-2 후)
+   - 1-7 DSR hard threshold (canary 데이터 후) · R-2 Phase 4 (베어 paper 데이터 후) · 해외 Phase 5 (dry-run 검증 후 — O-1 #621/O-2 완료)
 5. **[조건부·저위험 상시]**
    - Pool B 완화 (**재발 확인 2026-07-02 — 정책 결정 대기**) · 2-6 핫패스 (보류) · 3-4 lifecycle 분해 (정책 합의 시) · M-2 문서 동기화 · T-0/R-6 (선택/관찰)
 
@@ -45,11 +44,12 @@
   - 프로그램 장중 시계열 캡처 경로 배선 완료 (2026-07-04): `ProgramCaptureSubscriptionTask`(intraday)가 장중에 캡처 후보(보유+워치리스트)를 LOW 우선순위 `PROGRAM_TRADING` 구독(cap 10종목, PT=2슬롯)으로 동기화해 `pt_history`에 장중 순매수 시계열을 축적 → 장마감 캡처가 program_db 소스로 소비(미커버 종목만 daily_rest 폴백). 수동 UI PT 구독은 제외, 슬롯 압박 시 트레이딩 구독이 아닌 이 카테고리가 먼저 해지됨. 구독 목록 영속화로 크래시 잔재는 재시작 시 자동 정리. `program_capture_subscription_enabled`(기본 on).
   - 캡처 QC 리포트 추가 (2026-07-04): `scripts/analyze_backtest_microstructure_quality.py`로 `replay_microstructure_*.json`의 intraday/execution_strength/program overlay 커버리지, stale row, program DB/fallback 비율을 날짜별 집계하고 `--fail-on-gate`로 품질 게이트를 자동 판정한다.
   - 캡처 태스크 QC 노출 추가 (2026-07-04): `MicrostructureCaptureTask.last_result`에 `quality_gate_passed`, `quality_issues`, intraday/execution_strength/program/program_db coverage를 노출하고, 게이트 실패 시 warning 로그와 BACKGROUND/WARNING notification을 남긴다.
-  - ※ 남은 구조적 한계: 체결강도는 EOD 스칼라 1개/종목만 확보 가능(장중 시계열 REST API 없음) — "체결강도 ≥120%" 장중 게이트의 충실한 리플레이는 여전히 불가. 남은 것: quality 플래그·PT 커버리지(`program_fallback_codes` 감소 여부) 일일 관찰 + 체결강도 장중 시계열 확보 방안 검토(WS 체결 스트림 기반 — 무틱 2-4와 연관).
+  - 체결강도 장중 시계열 캡처 배선 완료 (2026-07-04): WS 체결 틱(H0STCNT0)에 포함된 `체결강도`를 `PriceStreamService.on_price_tick`에서 종목당 60초 샘플링해 `es_history` SQLite(`data/execution_strength/`, `ExecutionStrengthRepository`)에 축적 — **신규 WS 구독 없음**(기존 PRICE 틱 무임승차, 슬롯 비간섭). 장마감 캡처가 `execution_strength_source=es_db`로 소비하고 DB 미스 종목은 기존 REST 스칼라 유지 + `metadata.execution_strength_fallback_codes` 기록. QC에 `execution_strength_db_coverage_pct`(임계 30% — 배선 전손 감지용) 노출, overlay 파일 `replay_execution_strength_intraday_*.json` 추가. `execution_strength_capture_enabled`(기본 on).
+  - ※ 남은 한계: 체결강도 시계열 커버리지가 "PRICE 구독 중 + 유틱" 종목으로 제한(무틱 ~55% — 2-4 해소 시 개선, 미커버는 EOD 스칼라 폴백). 남은 것: quality 플래그·PT/ES 커버리지(`program_fallback_codes`·`execution_strength_fallback_codes` 감소 여부) 일일 관찰.
 - [blocked — 캡처 코퍼스 축적 후] 실제 replay fixture를 통과 케이스까지 확장 → replay overlay.
 - [ ] 한국장 실전 microstructure fixture(bid/ask book·잔량·체결강도·프로그램매매 overlay)로 체결 모델 보정 + 시장가/최유리/지정가별 fill quality가 live journal과 얼마나 벌어지는지 리포트.
 
-주요 파일: `services/backtest_execution_simulator.py`, `services/backtest_replay_context.py`, `scripts/run_backtest.py`, `tests/fixtures/backtest/`
+주요 파일: `services/backtest_execution_simulator.py`, `services/backtest_replay_context.py`, `services/backtest_microstructure_capture.py`, `repositories/execution_strength_repo.py`, `scripts/run_backtest.py`, `tests/fixtures/backtest/`
 
 ### 1-8. 현행 전략 버전 백테스트 재실행 [blocked — PIT 후보 부재, 2026-07-03 파일럿 판정]
 
@@ -128,11 +128,11 @@
 
 결론: 일봉 셋업형 전략만 적용 가능(해외 일봉 API 존재), 장중/실시간 전략은 불가. 첫 대상 = `LarryWilliamsVBOStrategy`. 제약: **해외 주문 TR은 실전(TTTS6036U 등)만, 모의 주문 TR 없음** → dry-run 검증 전 실주문 배선 금지. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
 
-### O-1. 미국 휴장일/조기폐장 캘린더 [신규 — Phase 5/라이브 전환 전 필수]
+### O-1. 미국 휴장일/조기폐장 캘린더 [완료 — #621, 2026-07-03]
 
-- [ ] NY 휴장일(추수감사절·독립기념일 등)과 조기폐장일(13:00 ET 마감, 연 3~4회) 캘린더를 추가한다. 현재 "cron mon-fri + NY 클럭"으로 대체 운영 중 — dry-run 단계는 휴장일 노이즈로 끝나지만, 라이브 전환 시 조기폐장일 EOD 청산 미스 = 의도치 않은 오버나이트 포지션으로 직결. Phase 5(`live_enabled=True`) 전환의 전제 게이트. (2026-07-02 리뷰)
+- [x] 규칙 기반 NYSE 캘린더 `USMarketCalendarService` 추가 — 전휴장 10종(신정 토요일 무관측·성금요일 computus·준틴스 2022~) + 조기폐장(13:00 ET) 3종(7/3·추수감사절 익일·12/24) + `get_close_time_str()`(Phase 5 EOD 청산 소비용). `time_dispatcher_us`/`OverseasDryRunTask`/`MarketCapGapReportTask` 3곳 주입. KIS에 해외 휴장일 TR이 없어 로컬 규칙 계산. 한계: 임시 특별휴장 미반영(docstring 명시).
 
-주요 파일: `core/market_clock.py`, `scheduler/after_market_loop.py`, `task/background/after_market/overseas_dryrun_task.py`
+주요 파일: `services/us_market_calendar_service.py`, `task/background/after_market/overseas_dryrun_task.py`, `view/web/bootstrap/service_container.py`
 
 ### O-2. dry-run 비용/진입가 가정 보정 [신규]
 
@@ -141,7 +141,7 @@
 
 주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_vbo_dryrun_service.py`
 
-### Phase 5. 안전/canary [dry-run 검증 + O-1/O-2 후]
+### Phase 5. 안전/canary [dry-run 검증 후 — O-1/O-2 완료]
 
 - [ ] **Phase 5 안전/canary**: `get_overseas_balance`/`ccnl` reconcile(`OverseasReconcileService` scaffolding 존재), risk gate/kill switch/canary USD 확장, 실전 소액 canary, canary auto-fire 배선 + `live_enabled=True` 전환 — dry-run 검증 + canary 게이팅.
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -22,6 +22,7 @@ from core.account_snapshot import AccountSnapshotCache
 from core.cache.cache_store import CacheStore
 from core.market_clock import MarketClock
 from core.performance_profiler import PerformanceProfiler
+from repositories.execution_strength_repo import ExecutionStrengthRepository
 from repositories.rs_rating_repository import RSRatingRepository
 from repositories.stock_classification_repository import StockClassificationRepository
 from repositories.stock_repository import StockRepository
@@ -428,12 +429,22 @@ class ServiceContainer:
                     signal_debounce_sec=0.5,  # Q5: 같은 (strategy, code) 중복 publish 차단.
                     signal_sink=None,  # PR-3 본 작업에서 live consumer 주입 예정. shadow 운영은 None 유지.
                 )
+                # todo 1-5: 체결강도 장중 시계열 축적 — 기존 PRICE 틱에 무임승차 (신규 구독 없음).
+                # 장마감 microstructure 캡처가 es_db 소스로 소비한다.
+                es_capture_enabled = config_dict.get(
+                    "execution_strength_capture_enabled", True
+                )
+                ctx.execution_strength_repo = (
+                    ExecutionStrengthRepository(logger=ctx.logger)
+                    if es_capture_enabled else None
+                )
                 ctx.price_stream_service = PriceStreamService(
                     stock_repo=ctx.stock_repository,
                     logger=ctx.logger,
                     data_quality_service=ctx.data_quality_service,
                     notification_service=ctx.notification_service,
                     event_router=ctx.strategy_event_router,
+                    execution_strength_recorder=ctx.execution_strength_repo,
                 )
                 # NOTE: data_quality / streaming / stock_query <-> price_stream wiring is performed by WiringPhase.
                 ctx.streaming_stock_repo = StreamingStockRepo(logger=ctx.logger)
@@ -474,6 +485,7 @@ class ServiceContainer:
                 ctx.streaming_service = None
                 ctx.event_shadow_journal_service = None
                 ctx.strategy_event_router = None
+                ctx.execution_strength_repo = None
                 ctx.price_stream_service = None
                 ctx.streaming_stock_repo = None
                 ctx.price_subscription_service = None


### PR DESCRIPTION
## 배경 (todo 1-5 남은 구조적 한계)

캡처 코퍼스의 체결강도가 EOD REST 스칼라 1개/종목뿐이라 VBO/OSB의 **"체결강도 ≥120%" 장중 게이트를 충실하게 리플레이할 수 없었다**. 장중 시계열 REST API는 없지만, WS 체결 틱(H0STCNT0)에는 `체결강도` 필드가 이미 파싱되어 `PriceStreamService.on_price_tick`으로 들어온다 — 이를 장중에 샘플링 축적하고 장마감 캡처가 소비하게 한다.

#623의 프로그램매매 캡처(`ProgramCaptureSubscriptionTask` → `pt_history` → `program_db` 소스)와 동일한 구조를 체결강도에 적용하되, **신규 WS 구독이 전혀 필요 없다**(체결강도는 이미 구독 중인 PRICE 틱에 포함 — 슬롯 비간섭).

## 변경 내용

- **`ExecutionStrengthRepository` 신설** (`repositories/execution_strength_repo.py`)
  - `on_price_tick` 경로에서 종목당 60초 샘플링 → `data/execution_strength/execution_strength.db`의 `es_history` 테이블에 버퍼 저장 (20건 또는 30초 경과 시 flush)
  - 백그라운드 태스크/스레드 없음 (테스트 hang 리스크 회피), 30일 retention, 파싱 실패 틱은 조용히 skip
- **`PriceStreamService`**: `execution_strength_recorder` 주입 + 품질검증 통과 틱만 기록. recorder 예외는 틱 경로를 깨지 않음 (try/except 가드)
- **캡처 서비스**: `execution_strength_source="es_db"` — DB 시계열을 `execution_strength_intraday`로 소비, 미스 종목(무틱/미구독)은 기존 REST 스칼라 유지 + `metadata.execution_strength_fallback_codes` 기록 (program_db/daily_rest 폴백 패턴 미러). overlay 파일 `replay_execution_strength_intraday_*.json` 추가 — **기존 4파일 스키마 불변**
- **QC 계층**: `execution_strength_db_coverage_pct` 임계 30% (무틱 ~55% 감안 — 정상 커버리지 저하가 아닌 배선 전손 감지용) — quality 모듈 issue + 캡처 태스크 `last_result` + `analyze_backtest_microstructure_quality.py` es_db 컬럼 노출
- **캡처 태스크/CLI**: es_history DB 존재 시 `es_db` 자동 선택 / `--execution-strength-source` 인자
- **배선**: `execution_strength_capture_enabled`(기본 on) — service_container에서 recorder 생성·주입
- **todo_list.md**: O-1 완료(#621) 반영 + 1-5 체결강도 배선 기록

## 남은 한계 (todo에 기록)

- 커버리지는 "PRICE 구독 중 + 유틱" 종목으로 제한 — 무틱 ~55%(P2 2-4)는 KIS 에스컬레이션으로 병행 추적, 미커버 종목은 EOD 스칼라 폴백
- 관찰 항목: `execution_strength_fallback_codes` 감소 여부 일일 관찰 (QC 리포트 es_db 컬럼)

## 테스트

- 단위 6,645 / 통합 246 **전체 통과**
- 신규: repo 9 (샘플링·flush·retention·파싱 실패·날짜 폴백), price_stream 4 (호출 필드·예외 격리·품질 reject 시 미기록), 캡처 5 (es_db seed·폴백·스키마·ValueError·overlay 파일), QC 3, 태스크 3 (소스 자동 선택·last_result), 컨테이너 2 (flag on/off), CLI 2, 분석 스크립트 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)