### PR TITLE
Prepare KIS no-tick escalation package

### DIFF
--- a/reports/kis_no_tick_common_stock_escalation_20260705.md
+++ b/reports/kis_no_tick_common_stock_escalation_20260705.md
@@ -1,0 +1,109 @@
+# KIS WebSocket Common-Stock No-Tick Escalation Package
+
+작성일: 2026-07-05 KST
+
+## 목적
+
+한국투자증권 Open API 국내주식 실시간 체결가 WebSocket에서 일부 보통주가 구독 성공 및 ACK 성공 후에도 체결가 프레임을 전혀 수신하지 않는 현상을 KIS에 문의한다.
+
+이 패키지는 ETF/우선주 무틱 이슈를 제외하고, **보통주 단독 구독에서도 0프레임이 재현된 C군 결과**만 에스컬레이션 대상으로 삼는다.
+
+## 핵심 문의
+
+아래 보통주 3종에 대해 `H0UNCNT0` 실시간 체결가 구독 요청이 `SUBSCRIBE SUCCESS`로 처리되고 ACK도 확인되었으나, 장중 180초 관찰 동안 체결가 프레임이 0건이었다.
+
+KIS 서버/계정/종목 단위에서 해당 종목의 국내주식 실시간 체결가 WebSocket 프레임 송신 제한, 미지원, 라우팅 누락, 권한/계정 설정 문제가 있는지 확인 요청한다.
+
+| 종목코드 | 종목명 | 상품군 | 구독 성공 | ACK | 수신 프레임 delta | 품질 reject delta | dispatch delta |
+|---|---|---|---|---|---:|---:|---:|
+| 080220 | 제주반도체 | 보통주 | True | True | 0 | 0 | 0 |
+| 353200 | 대덕전자 | 보통주 | True | True | 0 | 0 | 0 |
+| 004710 | 한솔테크닉스 | 보통주 | True | True | 0 | 0 | 0 |
+
+## 재현 조건
+
+- 일시: 2026-06-22 09:12:16~09:15:18 KST
+- 모드: 실전 WebSocket 시세 구독
+- TR: 국내주식 실시간 체결가 `H0UNCNT0`
+- 구독 대상: 위 보통주 3종만 단독 구독
+- 관찰 시간: 180초
+- 주문/체결 경로 사용 여부: 없음, 시세 구독만 수행
+
+## 배제된 원인
+
+| 가설 | 판단 | 근거 |
+|---|---|---|
+| 구독 실패 | 배제 | C군 3종 모두 `subscribe_ok=True` |
+| ACK 실패 | 배제 | C군 3종 모두 `ack_ok=True` |
+| 클라이언트 품질 필터 탈락 | 배제 | `quality_reject_delta=0` |
+| 파싱 실패/비정상 payload | 배제 | `malformed_delta=0` |
+| ETF/우선주 상품군 문제 | 별도 이슈로 분리 | B군은 정책상 REST 폴백으로 수용, 이번 문의 대상에서 제외 |
+| 슬롯/대량 구독 컨텍스트 문제 | 가능성 낮음 | C군에서 보통주 3종만 단독 구독해도 0프레임 |
+| 재구독 refresh 복구 가능성 | 배제 | D군에서 refresh 후에도 대상 보통주 5종 0프레임 |
+
+## 비교 관찰
+
+A군 보통주-only 실험에서는 같은 `H0UNCNT0` 경로에서 일부 보통주는 정상 수신되었다. 따라서 WebSocket 연결 전체 또는 TR 전체 장애라기보다, 특정 보통주 또는 계정/종목 조합에서 프레임이 송신되지 않는 현상으로 판단한다.
+
+| 정상 수신 보통주 | 수신 프레임 delta |
+|---|---:|
+| 028260 삼성물산 | 729 |
+| 032830 삼성생명 | 524 |
+| 240810 원익IPS | 806 |
+| 034730 SK | 247 |
+| 298040 효성중공업 | 170 |
+
+## KIS 문의 문안
+
+제목:
+
+국내주식 실시간 체결가 WebSocket(H0UNCNT0) 일부 보통주 ACK 후 프레임 미수신 문의
+
+본문:
+
+안녕하세요. 한국투자증권 Open API 국내주식 실시간 체결가 WebSocket 사용 중 일부 보통주에서 구독 성공 및 ACK 성공 후에도 체결가 프레임이 전혀 수신되지 않는 현상이 반복되어 문의드립니다.
+
+2026-06-22 09:12:16~09:15:18 KST 장중에 보통주 3종(080220 제주반도체, 353200 대덕전자, 004710 한솔테크닉스)만 단독으로 `H0UNCNT0` 실시간 체결가를 구독했습니다. 각 종목은 모두 `SUBSCRIBE SUCCESS`와 ACK가 확인되었으나 180초 동안 수신 프레임이 0건이었습니다. 클라이언트 측 quality reject, malformed payload, dispatch 실패도 모두 0건입니다.
+
+같은 세션의 보통주-only 비교 실험에서는 028260, 032830, 240810, 034730, 298040 등 다른 보통주는 정상적으로 수백 건의 체결가 프레임을 수신했습니다. 따라서 WebSocket 연결 또는 TR 전체 장애가 아니라 특정 보통주 또는 계정/종목 조합에서 서버 프레임이 송신되지 않는 현상으로 보입니다.
+
+확인 요청드립니다.
+
+1. 위 3개 보통주가 국내주식 실시간 체결가 WebSocket `H0UNCNT0` 송신 대상에서 제외되거나 제한되는 조건이 있는지
+2. 계정/HTS ID/API 권한/실전 시세 권한 설정에 따라 특정 보통주 프레임이 송신되지 않을 수 있는지
+3. 서버 로그상 위 시간대에 해당 종목 구독 요청은 정상 등록되었는지, 이후 체결가 프레임 송신 시도가 있었는지
+4. 보통주임에도 WebSocket 실시간 체결가가 제공되지 않는 종목 목록 또는 별도 예외 정책이 있는지
+
+첨부 파일에는 실험 결과 JSON/Markdown과 종합 분석 리포트를 포함했습니다. 필요하시면 민감값을 제거한 원본 실행 로그도 추가로 제공하겠습니다.
+
+## 기본 첨부 파일
+
+- `reports/no_tick_operational_experiment_result_C_no_tick_common_solo_20260622_live.json`
+- `reports/no_tick_operational_experiment_result_C_no_tick_common_solo_20260622_live.md`
+- `reports/no_tick_operational_experiment_analysis_20260622_live.json`
+- `reports/no_tick_operational_experiment_analysis_20260622_live.md`
+- `reports/no_tick_diagnosis_20260619.json`
+- `reports/no_tick_diagnosis_20260619.md`
+
+## 보조 첨부 파일
+
+- `reports/no_tick_operational_experiment_result_A_common_stock_only_20260622_live.json`
+- `reports/no_tick_operational_experiment_result_A_common_stock_only_20260622_live.md`
+- `reports/no_tick_operational_experiment_result_D_refresh_observation_20260622_live.json`
+- `reports/no_tick_operational_experiment_result_D_refresh_observation_20260622_live.md`
+
+원본 로그 `reports/no_tick_live_20260622.log`는 HTS ID와 접속키 일부가 포함될 수 있고 인코딩이 깨져 있으므로 기본 첨부에서 제외한다. KIS가 요청할 때만 HTS ID, approval key, token, app key, 계좌 식별자 등을 제거한 sanitized 로그로 전달한다.
+
+## 완료 판정
+
+이 항목은 다음 중 하나가 확인되면 완료로 본다.
+
+- KIS가 해당 보통주의 WebSocket 미송신/권한/계정/종목 예외를 확인한다.
+- KIS가 서버 로그상 정상 송신을 확인하고, 클라이언트가 추가 재현 실험으로 수신 여부를 재검증한다.
+- KIS가 공식적으로 해당 종목군 또는 조건에서 WebSocket 체결가 미제공을 안내한다.
+
+완료 전까지 운영 정책은 유지한다.
+
+- ETF/우선주 무틱은 예상된 무틱으로 보고 REST 폴백 처리한다.
+- 보통주 무틱은 장중 quarantine + REST 폴백 대상으로 유지한다.
+- event-driven 전환은 보통주 WebSocket 수신 신뢰도가 확인될 때까지 shadow/parity 단계로 올리지 않는다.

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-04 (1-5 체결강도 장중 시계열 캡처 배선 + O-1 완료 반영)
+최종 업데이트: 2026-07-05 (2-4 KIS 보통주 무틱 에스컬레이션 패키지 작성)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -87,7 +87,7 @@
 - **[최우선 블로커] WebSocket price 피드 무틱 ≈55%**: 구독 종목 절반 이상이 종일 `subscribed_no_tick` → shadow parity 수집 불가 + 라이브 실시간 데이터 품질 문제. **이 레포의 코드 작업은 종결**(무틱 종목 격리 구현 완료). 진단 확정: 종목·상품군·계정 단위 **KIS측 프레임 미전송**(`a1_kis_no_send`).
   - 근거: 2026-06-19 로그 진단(`reports/no_tick_diagnosis_20260619.md`) + 2026-06-22 운영 실험 A~D(`reports/no_tick_operational_experiment_analysis_20260622_live.md`) — subscribe/ack/quality_reject 전부 0, received 5 vs no_tick 18. 보통주 일부만 0틱(종목 단위), ETF/우선주 전부 0틱(상품군 단위), 격리해도 0틱 지속(계정 단위), refresh 무효.
   - **정책 결정(2026-07-01)**: ETF/우선주는 WS tick 없음으로 **간주**(상품군 단위 무틱 수용) → B군 KIS 문의 **드롭**. REST 폴링 경로로 처리하고, 무틱 지표에서 ETF/우선주는 정상(예상된 무틱)으로 본다. 코드 변경 없음(사후 격리가 이미 churn 중단). ※ 실전 전략은 보통주 롱온리라 ETF/우선주 WS 구독은 부수적.
-  - **다음 액션(코드 아님)**: C군 — 무틱 **보통주**만 runner 출력 첨부해 KIS 에스컬레이션(계정/종목 단위 프레임 미전송 문의).
+  - **다음 액션(코드 아님)**: KIS 에스컬레이션 접수 준비 — 무틱 **보통주**만 대상으로 정리한 문의 패키지 `reports/kis_no_tick_common_stock_escalation_20260705.md`와 C군 runner 출력(`reports/no_tick_operational_experiment_result_C_no_tick_common_solo_20260622_live.{json,md}`) 첨부. 완료 판정은 KIS 답변으로 서버/권한/종목 예외 확인 또는 재현 실험 요청 수신.
   - ※ 폴링 지연(5분 scan + stagger + limiter)은 돌파 전략의 실질 슬리피지로 작용 — 무틱 해소 → event-driven 전환이 VBO 계열 수익성의 전제 조건이기도 하다. (2026-07-02 리뷰)
 - [ ] (블로커 해소 후) `event_shadow`/`event_shadow_exit` 5거래일 jsonl 수집 → `scripts/analyze_event_shadow_parity.py`로 entry/exit parity 리포트 → PR-3 진입 판정.
 - [ ] event-driven signal은 별도 승인 전 shadow/latency 측정용으로만 운영(실주문은 polling + full gate 경로만). VBO fast path는 execution strength/program-buy 생략.


### PR DESCRIPTION
## Summary
- add a KIS escalation package for common-stock WebSocket no-tick cases
- isolate the escalation target to C cohort common stocks and list supporting attachments
- update todo_list.md with the prepared external-action package

## Verification
- git diff --check
- verified all referenced attachment paths exist
- docs-only change; unit/integration tests skipped