### PR TITLE
Fix overseas dry-run US holiday handling

### DIFF
--- a/scheduler/dispatcher/time_dispatcher.py
+++ b/scheduler/dispatcher/time_dispatcher.py
@@ -48,6 +48,7 @@ class TimeDispatcher:
         self._task_schedule: Dict[str, int] = {}   # task_name → priority
         self._task_delays: Dict[str, int] = {}     # task_name → delay_sec
         self._task_dispatched_dates: Dict[str, Optional[str]] = {}  # task_name → last dispatched date
+        self._last_non_trading_log_key: Optional[str] = None
         self._running = False
         self._sleep_task: Optional[asyncio.Task] = None
         self._pending_publish_tasks: Set[asyncio.Task] = set()
@@ -83,7 +84,7 @@ class TimeDispatcher:
 
     def _is_after_market_close(self) -> bool:
         """현재 시각이 당일 장 마감(15:40) 이후인지 확인한다.
-        주말은 항상 True(직전 거래일 기준 발행 허용), 평일은 마감 후에만 True."""
+        주말은 항상 True로 보되, mcs 주입 시 비거래일 발행 여부는 _maybe_dispatch가 다시 막는다."""
         now = self._market_clock.get_current_kst_time()
         if now.weekday() >= 5:  # 주말
             return True
@@ -137,13 +138,24 @@ class TimeDispatcher:
         if not self._is_after_market_close():
             return
 
+        today_str = self._market_clock.get_current_kst_date_str()
         if self._mcs is not None:
             latest_trading_date = await self._mcs.get_latest_trading_date()
+            if not latest_trading_date:
+                return
+            if today_str and latest_trading_date != today_str:
+                log_key = f"{today_str}:{latest_trading_date}"
+                if self._last_non_trading_log_key != log_key:
+                    self._logger.info(
+                        f"[TimeDispatcher] 오늘({today_str})은 휴장일/비거래일입니다 — "
+                        f"티켓 발행 스킵 (최근 거래일={latest_trading_date})"
+                    )
+                    self._last_non_trading_log_key = log_key
+                return
         else:
             # 거래 캘린더 미주입(해외장 등): clock 날짜를 거래일 식별자로 사용한다.
-            # 주말 발행 차단은 _is_after_market_close()의 weekday 필터가 담당하며,
-            # 공휴일은 미반영(현행 AfterMarketLoop mcs=None 동작과 동일한 한계).
-            latest_trading_date = self._market_clock.get_current_kst_date_str()
+            # 주말/공휴일은 미반영(현행 AfterMarketLoop mcs=None 동작과 동일한 한계).
+            latest_trading_date = today_str
         if not latest_trading_date:
             return
 

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -85,10 +85,25 @@ class OverseasDryRunTask(AfterMarketTask):
     def get_progress(self) -> dict:
         return {"last_run_date": self._last_run_date}
 
+    @staticmethod
+    def _format_market_date(yyyymmdd: str) -> str:
+        if len(yyyymmdd) == 8 and yyyymmdd.isdigit():
+            return f"{yyyymmdd[:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]}"
+        return yyyymmdd
+
     async def _on_market_closed(self, latest_trading_date: str) -> None:
+        market_date_text = self._format_market_date(latest_trading_date)
+        exchange_value = self._exchange.value
         if self._last_run_date == latest_trading_date:
             self._logger.info(
-                {"event": "overseas_dryrun_skip", "date": latest_trading_date, "reason": "already_run"}
+                {
+                    "event": "overseas_dryrun_skip",
+                    "market_date": latest_trading_date,
+                    "market_date_text": market_date_text,
+                    "exchange": exchange_value,
+                    "reason": "already_run",
+                    "reason_text": "이미 처리한 미국 거래일이므로 dry-run을 스킵합니다.",
+                }
             )
             return
         try:
@@ -96,19 +111,32 @@ class OverseasDryRunTask(AfterMarketTask):
             if self._journal is not None:
                 self._journal.flush_to_file(latest_trading_date)
             self._logger.info(
-                {"event": "overseas_dryrun_done", "date": latest_trading_date, "signals": len(signals or [])}
+                {
+                    "event": "overseas_dryrun_done",
+                    "market_date": latest_trading_date,
+                    "market_date_text": market_date_text,
+                    "exchange": exchange_value,
+                    "signals": len(signals or []),
+                }
             )
             if self._notification_service:
                 await self._notification_service.emit(
                     NotificationCategory.BACKGROUND,
                     NotificationLevel.INFO,
                     "해외 VBO dry-run 완료",
-                    f"{latest_trading_date} 기준 {len(signals or [])}개 신호",
+                    f"미국 거래일 {market_date_text} 기준 dry-run 리포트: {len(signals or [])}개 신호",
                 )
             self._last_run_date = latest_trading_date  # 성공 시에만 dedup 마킹 → 실패 시 재시도
         except Exception as e:
             self._logger.error(
-                {"event": "overseas_dryrun_error", "date": latest_trading_date, "error": str(e)}, exc_info=True
+                {
+                    "event": "overseas_dryrun_error",
+                    "market_date": latest_trading_date,
+                    "market_date_text": market_date_text,
+                    "exchange": exchange_value,
+                    "error": str(e),
+                },
+                exc_info=True,
             )
             if self._notification_service:
                 await self._notification_service.emit(

--- a/tests/unit_test/scheduler/test_time_dispatcher.py
+++ b/tests/unit_test/scheduler/test_time_dispatcher.py
@@ -40,15 +40,18 @@ def _make_dispatcher(
     *,
     is_after_close: bool = True,
     weekday: int = 1,
+    date_str: str = "20250417",
 ):
     broker = MessageBroker()
     market_clock = _make_clock(
-        is_operating=is_operating, is_after_close=is_after_close, weekday=weekday
+        is_operating=is_operating, is_after_close=is_after_close,
+        weekday=weekday, date_str=date_str,
     )
     mcs = MagicMock()
     mcs.get_latest_trading_date = AsyncMock(return_value=latest_date)
+    logger = MagicMock()
     dispatcher = TimeDispatcher(
-        broker=broker, market_clock=market_clock, mcs=mcs, db_path=db_path
+        broker=broker, market_clock=market_clock, mcs=mcs, logger=logger, db_path=db_path
     )
     return dispatcher, broker
 
@@ -130,18 +133,62 @@ async def test_stop_exits_run_loop(db_path):
 
 # ── 장전 오전 실행 방지 TC ───────────────────────────────────────────────────
 
-async def test_ticket_allowed_on_weekend(db_path):
-    """주말에는 장 마감 시각 체크 없이 직전 거래일 티켓 발행이 허용된다."""
+async def test_no_ticket_on_non_trading_day_even_if_previous_trading_date_missing(db_path):
+    """mcs 주입 시 주말/휴장일에는 직전 거래일 티켓을 새로 발행하지 않는다."""
     dispatcher, broker = _make_dispatcher(
         is_operating=False, latest_date="20250418", db_path=db_path,
-        is_after_close=False, weekday=5,  # 토요일
+        is_after_close=False, weekday=5, date_str="20250419",  # 토요일
     )
     dispatcher.register_task("RANKING_UPDATE", priority=100)
 
     await dispatcher._maybe_dispatch()
     await _drain(dispatcher)
 
+    assert broker.empty is True
+
+
+async def test_us_holiday_20260703_skips_ticket_and_logs_clear_reason(db_path):
+    """2026-07-03 미국 독립기념일 관측휴장에는 7/2 기준 dry-run을 발행하지 않는다."""
+    dispatcher, broker = _make_dispatcher(
+        is_operating=False,
+        latest_date="20260702",
+        db_path=db_path,
+        is_after_close=True,
+        weekday=4,  # 금요일
+        date_str="20260703",
+    )
+    dispatcher.register_task("overseas_vbo_dryrun", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
+    assert broker.empty is True
+    dispatcher._logger.info.assert_any_call(
+        "[TimeDispatcher] 오늘(20260703)은 휴장일/비거래일입니다 — "
+        "티켓 발행 스킵 (최근 거래일=20260702)"
+    )
+
+
+async def test_us_resume_20260706_dispatches_new_market_date(db_path):
+    """2026-07-06 미국장 재개일에는 새 거래일로 dry-run 티켓을 발행한다."""
+    dispatcher, broker = _make_dispatcher(
+        is_operating=False,
+        latest_date="20260706",
+        db_path=db_path,
+        is_after_close=True,
+        weekday=0,  # 월요일
+        date_str="20260706",
+    )
+    dispatcher.register_task("overseas_vbo_dryrun", priority=100)
+
+    await dispatcher._maybe_dispatch()
+    await _drain(dispatcher)
+
     assert broker.qsize == 1
+    ticket = await broker.consume()
+    broker.task_done()
+    assert ticket.task_name == "overseas_vbo_dryrun"
+    assert ticket.payload["date"] == "20260706"
 
 
 # ── SQLite 영속화 TC ─────────────────────────────────────────────────────────

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -16,21 +16,22 @@ def _make_task(exchange=OverseasExchange.NASD):
     dryrun = MagicMock()
     dryrun.scan_dry_run = AsyncMock(return_value=[{"code": "AAA", "action": "BUY"}])
     journal = MagicMock()
+    logger = MagicMock()
     notification_service = AsyncMock()
     task = OverseasDryRunTask(
         dryrun_service=dryrun,
         shadow_journal=journal,
         market_calendar_service=MagicMock(),
         market_clock=MagicMock(),
-        logger=MagicMock(),
+        logger=logger,
         notification_service=notification_service,
         exchange=exchange,
     )
-    return task, dryrun, journal, notification_service
+    return task, dryrun, journal, notification_service, logger
 
 
 def test_task_metadata():
-    task, _, _, _ = _make_task()
+    task, _, _, _, _ = _make_task()
     assert task.task_name == "overseas_vbo_dryrun"
     assert task._scheduler_label == "OverseasVBODryRun"
     assert task.priority == TaskPriority.LOW
@@ -42,7 +43,7 @@ def test_loop_triggers_on_us_market_close():
     KST 15:41 하드코딩이 아니라 America/New_York 16:30 으로 트리거되도록
     AfterMarketLoop 파라미터 훅을 오버라이드한다.
     """
-    task, _, _, _ = _make_task()
+    task, _, _, _, _ = _make_task()
     assert task._loop_timezone == "America/New_York"
     assert task._loop_cron_hour == 16
     assert task._loop_cron_minute == 30
@@ -50,35 +51,54 @@ def test_loop_triggers_on_us_market_close():
 
 @pytest.mark.asyncio
 async def test_on_market_closed_runs_scan_and_flushes():
-    task, dryrun, journal, notification_service = _make_task(OverseasExchange.NASD)
+    task, dryrun, journal, notification_service, logger = _make_task(OverseasExchange.NASD)
 
-    await task._on_market_closed("20260615")
+    await task._on_market_closed("20260706")
 
     dryrun.scan_dry_run.assert_awaited_once()
     args, kwargs = dryrun.scan_dry_run.await_args
     assert (kwargs.get("exchange") == OverseasExchange.NASD) or (args and args[0] == OverseasExchange.NASD)
-    journal.flush_to_file.assert_called_once_with("20260615")
+    journal.flush_to_file.assert_called_once_with("20260706")
+    logger.info.assert_any_call(
+        {
+            "event": "overseas_dryrun_done",
+            "market_date": "20260706",
+            "market_date_text": "2026-07-06",
+            "exchange": "NASD",
+            "signals": 1,
+        }
+    )
     notification_service.emit.assert_awaited_once_with(
         NotificationCategory.BACKGROUND,
         NotificationLevel.INFO,
         "해외 VBO dry-run 완료",
-        "20260615 기준 1개 신호",
+        "미국 거래일 2026-07-06 기준 dry-run 리포트: 1개 신호",
     )
 
 
 @pytest.mark.asyncio
 async def test_dedup_same_date_skips_second_run():
-    task, dryrun, journal, _ = _make_task()
+    task, dryrun, journal, _, logger = _make_task()
 
     await task._on_market_closed("20260615")
     await task._on_market_closed("20260615")
 
     assert dryrun.scan_dry_run.await_count == 1
+    logger.info.assert_any_call(
+        {
+            "event": "overseas_dryrun_skip",
+            "market_date": "20260615",
+            "market_date_text": "2026-06-15",
+            "exchange": "NASD",
+            "reason": "already_run",
+            "reason_text": "이미 처리한 미국 거래일이므로 dry-run을 스킵합니다.",
+        }
+    )
 
 
 @pytest.mark.asyncio
 async def test_failure_does_not_mark_date_done_allowing_retry():
-    task, dryrun, journal, _ = _make_task()
+    task, dryrun, journal, _, _ = _make_task()
     dryrun.scan_dry_run = AsyncMock(side_effect=RuntimeError("boom"))
 
     await task._on_market_closed("20260615")  # 예외 삼킴
@@ -89,6 +109,6 @@ async def test_failure_does_not_mark_date_done_allowing_retry():
 
 
 def test_task_has_no_order_dependency():
-    task, _, _, _ = _make_task()
+    task, _, _, _, _ = _make_task()
     assert not hasattr(task, "_order_execution_service")
     assert not hasattr(task, "_order_service")


### PR DESCRIPTION
## Summary
- skip TimeDispatcher ticket publishing on US non-trading days so 2026-07-03 does not emit a stale 2026-07-02 dry-run
- make overseas dry-run logs and notifications explicitly reference the US market date
- add regressions for 2026-07-03 holiday skip and 2026-07-06 market resume

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v