### PR TITLE
성능계측 공백 보강: WorkerPool 태스크 타이머 + BudgetSnapshot 주기 로깅

### DIFF
--- a/scheduler/background_scheduler.py
+++ b/scheduler/background_scheduler.py
@@ -30,11 +30,15 @@ class BackgroundScheduler:
         worker_pool=None,
         time_dispatcher=None,
         time_dispatchers=None,
+        api_budget_limiter=None,
+        budget_snapshot_interval_sec: float = 60.0,
     ):
         self._logger = logger or logging.getLogger(__name__)
         self._pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._tasks: Dict[str, SchedulableTask] = {}  # name -> task
         self._worker_pool = worker_pool
+        self._api_budget_limiter = api_budget_limiter
+        self._budget_snapshot_interval_sec = budget_snapshot_interval_sec
         # 시장별 TimeDispatcher 복수 지원: 단수 time_dispatcher 와 복수 time_dispatchers 를
         # 함께 받아 하나의 리스트로 정규화한다 (KR + US 동시 구동).
         self._time_dispatchers = list(time_dispatchers or [])
@@ -109,6 +113,10 @@ class BackgroundScheduler:
             self._logger.info(
                 f"[BackgroundScheduler] TimeDispatcher {len(self._time_dispatchers)}개 시작 완료"
             )
+        if self._api_budget_limiter is not None and self._pm.enabled:
+            t = asyncio.create_task(self._budget_snapshot_loop(), name="budget-snapshot-logger")
+            self._infra_tasks.append(t)
+            self._logger.info("[BackgroundScheduler] BudgetSnapshot 로거 시작")
 
         for name, task in self._tasks.items():
             if task.state == TaskState.SUSPENDED:
@@ -124,6 +132,36 @@ class BackgroundScheduler:
                 except Exception as e:
                     self._logger.error(f"[BackgroundScheduler] '{name}' 시작 실패: {e}", exc_info=True)
         self._pm.log_timer("BackgroundScheduler.start_all", t_start)
+
+    async def _budget_snapshot_loop(self) -> None:
+        """ApiBudgetLimiter 상태를 주기적으로 성능 로그에 남긴다.
+
+        [Performance] 타이머는 threshold(기본 1.0s) 미만 호출을 걷어내 실제 호출량을
+        가려버린다. acquired_total/rate_wait_seconds_total 같은 누적 카운터를 주기
+        스냅샷으로 남겨 그 공백(실호출량, 검열 없는 총 대기시간)을 메운다.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self._budget_snapshot_interval_sec)
+                self._log_budget_snapshot()
+        except asyncio.CancelledError:
+            pass
+
+    def _log_budget_snapshot(self) -> None:
+        snapshot = self._api_budget_limiter.snapshot()
+        for category, lane in snapshot.items():
+            self._emit_budget_snapshot_line(category, lane)
+            emergency = lane.get("emergency")
+            if emergency:
+                self._emit_budget_snapshot_line(f"{category}(emergency)", emergency)
+
+    def _emit_budget_snapshot_line(self, category: str, lane: dict) -> None:
+        msg = (
+            f"[Performance] BudgetSnapshot.{category}: {lane['rate_wait_seconds_total']:.4f}s "
+            f"(active={lane['active']}, limit={lane['limit']}, acquired_total={lane['acquired_total']}, "
+            f"rate_wait_total={lane['rate_wait_total']}, max_observed_active={lane['max_observed_active']})"
+        )
+        self._pm.logger.info(msg)
 
     async def shutdown(self) -> None:
         """등록된 모든 태스크를 정상 종료한다.

--- a/scheduler/worker/worker_pool.py
+++ b/scheduler/worker/worker_pool.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from typing import Awaitable, Callable, Dict, List, Optional
 
 from scheduler.ticket_queue.ticket import Ticket, POISON_PRIORITY
 from scheduler.ticket_queue.message_broker import MessageBroker
 from scheduler.ticket_queue.dlq_manager import DlqManager
 from core.loggers.trace_context import trace_scope
+from core.performance_profiler import PerformanceProfiler
 
 
 Handler = Callable[[dict], Awaitable[None]]
@@ -32,11 +34,13 @@ class WorkerPool:
         dlq_manager: DlqManager,
         logger: Optional[logging.Logger] = None,
         num_workers: int = 2,
+        performance_profiler: Optional[PerformanceProfiler] = None,
     ) -> None:
         self._broker = broker
         self._dlq = dlq_manager
         self._logger = logger or logging.getLogger(__name__)
         self._num_workers = num_workers
+        self._pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._registry: Dict[str, Handler] = {}
         self._worker_tasks: List[asyncio.Task] = []
         self._resume_event = asyncio.Event()
@@ -109,20 +113,31 @@ class WorkerPool:
         if not handler:
             self._logger.warning(f"[Worker-{worker_id}] 등록되지 않은 태스크: {ticket.task_name}")
             return
+        if self._pm.enabled:
+            # 발행(publish) → 실행 시작까지의 큐 대기시간. created_at은 UTC epoch 기준이라
+            # time.time()과 직접 뺄셈 가능 (log_timer(name, start_time)와 동일한 계산식).
+            self._pm.log_timer(
+                f"AfterMarketTask.{ticket.task_name}(queue_wait)",
+                datetime.fromisoformat(ticket.created_at).timestamp(),
+            )
+        t_exec = self._pm.start_timer()
         try:
-            with trace_scope(ticket.trace_id):
-                await handler(ticket.payload)
-        except Exception as e:
-            with trace_scope(ticket.trace_id):
-                self._logger.error(
-                    f"[Worker-{worker_id}] 작업 실패: {ticket.task_name} (시도 {ticket.attempt + 1}/{self.MAX_RETRIES}) — {e}",
-                    exc_info=True,
-                )
-            ticket.attempt += 1
-            if ticket.attempt < self.MAX_RETRIES:
-                delay = self.BASE_DELAY * ticket.attempt
-                self._logger.info(f"[Worker-{worker_id}] {delay:.0f}s 후 재시도: {ticket.task_name}")
-                await asyncio.sleep(delay)
-                await self._broker.publish(ticket)
-            else:
-                await self._dlq.handle_failed_ticket(ticket, str(e))
+            try:
+                with trace_scope(ticket.trace_id):
+                    await handler(ticket.payload)
+            except Exception as e:
+                with trace_scope(ticket.trace_id):
+                    self._logger.error(
+                        f"[Worker-{worker_id}] 작업 실패: {ticket.task_name} (시도 {ticket.attempt + 1}/{self.MAX_RETRIES}) — {e}",
+                        exc_info=True,
+                    )
+                ticket.attempt += 1
+                if ticket.attempt < self.MAX_RETRIES:
+                    delay = self.BASE_DELAY * ticket.attempt
+                    self._logger.info(f"[Worker-{worker_id}] {delay:.0f}s 후 재시도: {ticket.task_name}")
+                    await asyncio.sleep(delay)
+                    await self._broker.publish(ticket)
+                else:
+                    await self._dlq.handle_failed_ticket(ticket, str(e))
+        finally:
+            self._pm.log_timer(f"AfterMarketTask.{ticket.task_name}", t_exec)

--- a/tests/unit_test/scheduler/test_background_scheduler.py
+++ b/tests/unit_test/scheduler/test_background_scheduler.py
@@ -438,3 +438,55 @@ async def test_shutdown_sequential_repeat_is_noop(scheduler):
 
     t1.stop.assert_awaited_once()
     scheduler._logger.warning.assert_any_call("[BackgroundScheduler] 이미 종료됨 — shutdown 호출 무시")
+
+
+@pytest.mark.asyncio
+async def test_start_all_without_api_budget_limiter_skips_snapshot_task():
+    """api_budget_limiter 미주입 시 스냅샷 태스크가 생성되지 않는다 (기존 동작 유지)."""
+    scheduler = BackgroundScheduler(logger=MagicMock())
+
+    await scheduler.start_all()
+    assert scheduler._infra_tasks == []
+
+    await scheduler.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_start_all_with_api_budget_limiter_but_pm_disabled_skips_snapshot_task():
+    """pm이 비활성화면 limiter가 있어도 스냅샷 태스크를 만들지 않는다."""
+    from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
+
+    limiter = ApiBudgetLimiter({"quotation": 2})
+    scheduler = BackgroundScheduler(logger=MagicMock(), api_budget_limiter=limiter)
+
+    await scheduler.start_all()
+    assert scheduler._infra_tasks == []
+
+    await scheduler.shutdown()
+
+
+@pytest.mark.real_sleep
+@pytest.mark.asyncio
+async def test_start_all_with_api_budget_limiter_logs_snapshot_periodically():
+    """api_budget_limiter 주입 + pm 활성화 시 주기적으로 BudgetSnapshot 로그를 남긴다."""
+    from core.performance_profiler import PerformanceProfiler
+    from core.retry_queue.api_budget_limiter import ApiBudgetLimiter
+
+    fake_logger = MagicMock()
+    pm = PerformanceProfiler(logger=fake_logger, enabled=True, threshold=0.0)
+    limiter = ApiBudgetLimiter({"quotation": 2})
+
+    scheduler = BackgroundScheduler(
+        logger=MagicMock(),
+        performance_profiler=pm,
+        api_budget_limiter=limiter,
+        budget_snapshot_interval_sec=0.02,
+    )
+
+    await scheduler.start_all()
+    await asyncio.sleep(0.08)
+    await scheduler.shutdown()
+
+    logged = [c.args[0] for c in fake_logger.info.call_args_list]
+    assert any("[Performance] BudgetSnapshot.quotation:" in m for m in logged)
+    assert scheduler._infra_tasks == []

--- a/tests/unit_test/scheduler/test_worker_pool.py
+++ b/tests/unit_test/scheduler/test_worker_pool.py
@@ -156,3 +156,53 @@ async def test_no_trace_id_ticket_handler_gets_none():
     await pool.shutdown()
 
     assert captured == [None]
+
+
+async def test_handle_logs_perf_timers_when_profiler_enabled():
+    """profiler 활성화 시 큐 대기시간과 실행시간을 [Performance] 로그로 남긴다."""
+    from core.performance_profiler import PerformanceProfiler
+
+    fake_logger = MagicMock()
+    pm = PerformanceProfiler(logger=fake_logger, enabled=True, threshold=0.0)
+    broker = MessageBroker()
+    dlq = MagicMock(spec=DlqManager)
+    pool = WorkerPool(broker=broker, dlq_manager=dlq, performance_profiler=pm, num_workers=1)
+
+    async def handler(payload):
+        pass
+
+    pool.register("PERF_TASK", handler)
+    await pool.start()
+    await broker.publish(Ticket(priority=50, task_name="PERF_TASK", payload={}))
+    await broker.join()
+    await pool.shutdown()
+
+    logged = [c.args[0] for c in fake_logger.info.call_args_list]
+    assert any("AfterMarketTask.PERF_TASK(queue_wait):" in m for m in logged)
+    assert any(m.startswith("[Performance] AfterMarketTask.PERF_TASK:") for m in logged)
+
+
+async def test_handle_logs_execution_timer_even_on_failure():
+    """실행 중 예외가 발생해도 실행시간 타이머는 매 시도마다 기록된다."""
+    from core.performance_profiler import PerformanceProfiler
+
+    fake_logger = MagicMock()
+    pm = PerformanceProfiler(logger=fake_logger, enabled=True, threshold=0.0)
+    broker = MessageBroker()
+    dlq = MagicMock(spec=DlqManager)
+    dlq.handle_failed_ticket = AsyncMock()
+    pool = WorkerPool(broker=broker, dlq_manager=dlq, performance_profiler=pm, num_workers=1)
+    pool.BASE_DELAY = 0
+
+    async def always_fail(payload):
+        raise RuntimeError("boom")
+
+    pool.register("FAIL_TASK", always_fail)
+    await pool.start()
+    await broker.publish(Ticket(priority=50, task_name="FAIL_TASK", payload={}))
+    await broker.join()
+    await pool.shutdown()
+
+    logged = [c.args[0] for c in fake_logger.info.call_args_list]
+    exec_logs = [m for m in logged if m.startswith("[Performance] AfterMarketTask.FAIL_TASK:")]
+    assert len(exec_logs) == pool.MAX_RETRIES

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -71,6 +71,7 @@ class SchedulerBootstrap:
             performance_profiler=ctx.pm,
             worker_pool=ctx.worker_pool,
             time_dispatchers=dispatchers,
+            api_budget_limiter=getattr(ctx, "api_budget_limiter", None),
         )
 
     def _create_foreground_scheduler(self) -> None:

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -260,6 +260,7 @@ class ServiceContainer:
                 dlq_manager=ctx.dlq_manager,
                 logger=ctx.logger,
                 num_workers=1,  # after_market 태스크는 API 레이트 리밋 고려해 순차 실행
+                performance_profiler=ctx.pm,
             )
             ctx.time_dispatcher = TimeDispatcher(
                 broker=ctx.message_broker,


### PR DESCRIPTION
## Summary
- 지난주(06-29~07-03) 성능로그 리뷰에서 확인된 계측 공백 2곳을 메운다.
- `WorkerPool._handle`: after-market 태스크별 `AfterMarketTask.{task_name}(queue_wait)` / `AfterMarketTask.{task_name}` 타이머를 추가해 실행시간을 개별 귀속 가능하게 함 (이전엔 심야 로그 클러스터 추론에 의존).
- `BackgroundScheduler`: `ApiBudgetLimiter.snapshot()`의 기존 누적 카운터(acquired_total/rate_wait_seconds_total 등)를 주기적으로 `[Performance] BudgetSnapshot.{category}` 로그로 남겨, threshold(1.0s) 게이트로 가려진 실제 호출량/총 대기시간을 확보.
- 두 계측 모두 `performance_profiler` 미주입/비활성 시 기존 동작 그대로(no-op).

## Test plan
- [x] TDD: 신규 동작마다 실패 테스트 선작성 → 구현 → 통과 확인
- [x] `pytest tests/unit_test -v` — 6652 passed
- [x] `pytest tests/integration_test -v` — 246 passed
- [x] `BackgroundScheduler._budget_snapshot_loop` 검증 테스트는 `@pytest.mark.real_sleep` 적용 (conftest의 autouse `asyncio.sleep` 목킹이 `while True` 루프를 영구 점유시키는 hang 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)