### PR TITLE
Add new-high strategy coverage backtest

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -19,6 +19,7 @@ after_market_tasks:
     daily_price_collector: 10      # DailyPriceCollectorTask — 장 마감 10분 후
     ohlcv_update: 20             # OhlcvUpdateTask — 장 마감 20분 후
     post_market_replay_audit: 30  # PostMarketReplayAuditTask — live 후보군 missed-signal 감사
+    newhigh_strategy_coverage_backtest: 35  # NewHighStrategyCoverageBacktestTask — 신고가 전략 미매수 비율 백테스트
     newhigh: 21                  # NewHighTask — daily_price_collector 완료(21분) + 여유
     minervini_update: 21        # MinerviniUpdateTask — 장 마감 21분 후
     전일기준주도주_생성: 50        # PremiumWatchlistGeneratorTask — 장 마감 50분 후

--- a/services/backtest_microstructure_quality.py
+++ b/services/backtest_microstructure_quality.py
@@ -89,9 +89,6 @@ def summarize_capture_quality(
         < thresholds.min_execution_strength_db_coverage_pct
     ):
         issues.append("execution_strength_db_coverage_below_threshold")
-    if stale_rows > thresholds.max_stale_rows:
-        issues.append("stale_minute_rows_present")
-
     return {
         "trade_date": str(metadata.get("trade_date") or ""),
         "codes": code_count,

--- a/services/newhigh_strategy_coverage_backtest_service.py
+++ b/services/newhigh_strategy_coverage_backtest_service.py
@@ -1,0 +1,413 @@
+"""Backtest strategy coverage for daily new-high stocks."""
+from __future__ import annotations
+
+import logging
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from common.trade_journal_schema import normalize_backtest_decision
+from services.backtest_replay_adapter import StockQueryBacktestReplayService
+from services.backtest_replay_context import BacktestMarketClock
+from strategies.debug.strategy_debug_runner import StrategyDebugRunner
+
+
+_DEFAULT_STRATEGY_KEYS = (
+    "oneil_pocket_pivot",
+    "oneil_squeeze_breakout",
+    "high_tight_flag",
+    "first_pullback",
+    "larry_williams_vbo",
+    "rsi2_pullback",
+    "larry_williams_channel_breakout",
+)
+
+
+@dataclass
+class StrategyCoverageSummary:
+    strategy_key: str
+    strategy_name: str
+    candidate_count: int
+    bought_count: int = 0
+    not_bought_count: int = 0
+    rejected_count: int = 0
+    missing_from_universe_count: int = 0
+    no_signal_count: int = 0
+    data_unavailable_count: int = 0
+    not_bought_rate: float = 0.0
+    evaluable_not_bought_rate: float = 0.0
+    saved_run: dict[str, Any] | None = None
+
+
+@dataclass
+class NewHighStrategyCoverageBacktestResult:
+    target_date: str
+    skipped: bool = False
+    skip_reason: str = ""
+    newhigh_count: int = 0
+    strategy_count: int = 0
+    all_strategy_missed_count: int = 0
+    all_strategy_missed_rate: float = 0.0
+    strategy_summaries: list[StrategyCoverageSummary] = field(default_factory=list)
+    saved_runs: list[dict[str, Any]] = field(default_factory=list)
+
+
+class NewHighStrategyCoverageBacktestService:
+    """Run active backtest strategies against only the day's new-high universe."""
+
+    def __init__(
+        self,
+        *,
+        stock_repository: Any,
+        stock_query_service: Any,
+        universe_service: Any,
+        indicator_service: Any,
+        market_clock: Any,
+        backtest_journal_repository: Any,
+        program_provider: Any | None = None,
+        strategy_factory: Callable[..., Any] | None = None,
+        env: Any | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._stock_repository = stock_repository
+        self._sqs = stock_query_service
+        self._universe_service = universe_service
+        self._indicator_service = indicator_service
+        self._market_clock = market_clock
+        self._repo = backtest_journal_repository
+        self._program_provider = program_provider
+        self._strategy_factory = strategy_factory or self._default_strategy_factory
+        self._env = env
+        self._logger = logger or logging.getLogger(__name__)
+        self._debug_logger = logger if isinstance(logger, logging.Logger) else logging.getLogger(__name__)
+
+    async def run(
+        self,
+        target_date: str,
+        *,
+        strategy_keys: list[str] | tuple[str, ...] | None = None,
+        backtest_time: str = "15:30:00",
+    ) -> NewHighStrategyCoverageBacktestResult:
+        target_date = str(target_date)
+        result = NewHighStrategyCoverageBacktestResult(target_date=target_date)
+        if self._is_paper_mode():
+            result.skipped = True
+            result.skip_reason = "historical_intraday_unavailable_in_paper"
+            return result
+
+        newhigh_rows = await self._stock_repository.get_newhigh_stocks(target_date)
+        candidate_codes = _extract_codes(newhigh_rows)
+        result.newhigh_count = len(candidate_codes)
+        if not candidate_codes:
+            result.skipped = True
+            result.skip_reason = "no_newhigh_stocks"
+            return result
+
+        selected_strategy_keys = list(strategy_keys or _DEFAULT_STRATEGY_KEYS)
+        backtest_clock = BacktestMarketClock.from_clock(
+            self._market_clock,
+            default_time=backtest_time,
+        )
+        replay_sqs = StockQueryBacktestReplayService(
+            self._sqs,
+            program_provider=self._program_provider,
+            market_clock=backtest_clock,
+        )
+        signal_time = _signal_time(target_date, backtest_time)
+        all_bought_codes: set[str] = set()
+
+        with tempfile.TemporaryDirectory(prefix="newhigh_strategy_coverage_") as tmp_dir:
+            for strategy_key in selected_strategy_keys:
+                summary, bought_codes = await self._run_strategy_coverage(
+                    strategy_key=strategy_key,
+                    target_date=target_date,
+                    signal_time=signal_time,
+                    candidate_codes=candidate_codes,
+                    replay_sqs=replay_sqs,
+                    backtest_clock=backtest_clock,
+                    state_dir=tmp_dir,
+                )
+                result.strategy_summaries.append(summary)
+                result.saved_runs.append(summary.saved_run or {})
+                all_bought_codes.update(bought_codes)
+
+        result.strategy_count = len(result.strategy_summaries)
+        result.all_strategy_missed_count = len(set(candidate_codes) - all_bought_codes)
+        result.all_strategy_missed_rate = _ratio(result.all_strategy_missed_count, result.newhigh_count)
+        return result
+
+    async def _run_strategy_coverage(
+        self,
+        *,
+        strategy_key: str,
+        target_date: str,
+        signal_time: str,
+        candidate_codes: list[str],
+        replay_sqs: StockQueryBacktestReplayService,
+        backtest_clock: BacktestMarketClock,
+        state_dir: str,
+    ) -> tuple[StrategyCoverageSummary, set[str]]:
+        replay_sqs.set_backtest_date(target_date)
+        backtest_clock.set_backtest_date(target_date)
+        strategy_name = strategy_key
+        try:
+            strategy = self._strategy_factory(
+                strategy_key=strategy_key,
+                replay_sqs=replay_sqs,
+                universe_service=self._universe_service,
+                indicator_service=self._indicator_service,
+                backtest_clock=backtest_clock,
+                state_dir=state_dir,
+                logger=self._debug_logger,
+            )
+            strategy_name = str(getattr(strategy, "name", strategy_key) or strategy_key)
+            report = await StrategyDebugRunner(
+                strategy,
+                self._debug_logger,
+                target_date=target_date,
+                target_signal_time=signal_time,
+            ).run(candidate_codes=candidate_codes)
+            records = self._annotate_and_fill_records(
+                records=report.journal_records,
+                candidate_codes=candidate_codes,
+                strategy_key=strategy_key,
+                strategy_name=strategy_name,
+                signal_time=signal_time,
+                target_date=target_date,
+            )
+        except Exception as exc:
+            self._logger.warning(
+                "new-high strategy coverage failed: strategy=%s date=%s error=%s",
+                strategy_key,
+                target_date,
+                exc,
+                exc_info=True,
+            )
+            records = [
+                self._synthetic_record(
+                    code=code,
+                    strategy=strategy_name,
+                    signal_time=signal_time,
+                    target_date=target_date,
+                    strategy_key=strategy_key,
+                    rejected_reason=f"data_unavailable:{exc}",
+                    coverage_status="data_unavailable",
+                )
+                for code in candidate_codes
+            ]
+
+        summary, bought_codes = self._summarize_records(
+            records,
+            strategy_key=strategy_key,
+            strategy_name=strategy_name,
+            candidate_count=len(candidate_codes),
+        )
+        saved = self._repo.save_run(
+            records,
+            run_id=f"newhigh_coverage_{strategy_key}_{target_date}",
+            strategy=strategy_name,
+            target_date=target_date,
+            metadata={
+                "audit_type": "newhigh_strategy_coverage",
+                "strategy_key": strategy_key,
+                "candidate_count": summary.candidate_count,
+                "bought_count": summary.bought_count,
+                "not_bought_count": summary.not_bought_count,
+                "rejected_count": summary.rejected_count,
+                "missing_from_universe_count": summary.missing_from_universe_count,
+                "no_signal_count": summary.no_signal_count,
+                "data_unavailable_count": summary.data_unavailable_count,
+                "not_bought_rate": summary.not_bought_rate,
+                "evaluable_not_bought_rate": summary.evaluable_not_bought_rate,
+            },
+        )
+        summary.saved_run = saved
+        return summary, bought_codes
+
+    def _annotate_and_fill_records(
+        self,
+        *,
+        records: list[dict],
+        candidate_codes: list[str],
+        strategy_key: str,
+        strategy_name: str,
+        signal_time: str,
+        target_date: str,
+    ) -> list[dict]:
+        annotated: list[dict] = []
+        seen_codes: set[str] = set()
+        candidate_set = set(candidate_codes)
+        for record in records:
+            code = _normalize_code(record.get("code"))
+            if not code or code not in candidate_set:
+                continue
+            seen_codes.add(code)
+            annotated.append(
+                self._with_coverage_metadata(
+                    record,
+                    target_date=target_date,
+                    strategy_key=strategy_key,
+                    coverage_status=_coverage_status(record),
+                )
+            )
+
+        for code in candidate_codes:
+            if code in seen_codes:
+                continue
+            annotated.append(
+                self._synthetic_record(
+                    code=code,
+                    strategy=strategy_name,
+                    signal_time=signal_time,
+                    target_date=target_date,
+                    strategy_key=strategy_key,
+                    rejected_reason="no_signal",
+                    coverage_status="no_signal",
+                )
+            )
+        return annotated
+
+    def _summarize_records(
+        self,
+        records: list[dict],
+        *,
+        strategy_key: str,
+        strategy_name: str,
+        candidate_count: int,
+    ) -> tuple[StrategyCoverageSummary, set[str]]:
+        bought_codes = {
+            str(record.get("code") or "")
+            for record in records
+            if _coverage_status(record) == "bought"
+        }
+        rejected_count = sum(1 for record in records if _coverage_status(record) == "rejected")
+        missing_count = sum(1 for record in records if _coverage_status(record) == "missing_from_universe")
+        no_signal_count = sum(1 for record in records if _coverage_status(record) == "no_signal")
+        data_unavailable_count = sum(1 for record in records if _coverage_status(record) == "data_unavailable")
+        not_bought_count = rejected_count + missing_count + no_signal_count
+        evaluable_count = max(candidate_count - data_unavailable_count, 0)
+        return (
+            StrategyCoverageSummary(
+                strategy_key=strategy_key,
+                strategy_name=strategy_name,
+                candidate_count=candidate_count,
+                bought_count=len(bought_codes),
+                not_bought_count=not_bought_count,
+                rejected_count=rejected_count,
+                missing_from_universe_count=missing_count,
+                no_signal_count=no_signal_count,
+                data_unavailable_count=data_unavailable_count,
+                not_bought_rate=_ratio(not_bought_count, candidate_count),
+                evaluable_not_bought_rate=_ratio(not_bought_count, evaluable_count),
+            ),
+            bought_codes,
+        )
+
+    @staticmethod
+    def _with_coverage_metadata(
+        record: dict,
+        *,
+        target_date: str,
+        strategy_key: str,
+        coverage_status: str,
+    ) -> dict:
+        copied = dict(record)
+        metadata = dict(copied.get("metadata") or {})
+        metadata["audit_type"] = "newhigh_strategy_coverage"
+        metadata["newhigh_coverage_status"] = coverage_status
+        metadata["target_date"] = target_date
+        metadata["strategy_key"] = strategy_key
+        copied["metadata"] = metadata
+        return copied
+
+    def _synthetic_record(
+        self,
+        *,
+        code: str,
+        strategy: str,
+        signal_time: str,
+        target_date: str,
+        strategy_key: str,
+        rejected_reason: str,
+        coverage_status: str,
+    ) -> dict:
+        record = normalize_backtest_decision(
+            {
+                "signal_time": signal_time,
+                "rejected_reason": rejected_reason,
+                "strategy": strategy,
+            },
+            stock_code=code,
+            strategy=strategy,
+            accepted=False,
+        )
+        return self._with_coverage_metadata(
+            record,
+            target_date=target_date,
+            strategy_key=strategy_key,
+            coverage_status=coverage_status,
+        )
+
+    def _default_strategy_factory(self, **kwargs):
+        from scripts.run_backtest import _build_backtest_strategy
+
+        return _build_backtest_strategy(
+            strategy_key=kwargs["strategy_key"],
+            replay_sqs=kwargs["replay_sqs"],
+            universe_service=kwargs["universe_service"],
+            indicator_service=kwargs.get("indicator_service"),
+            backtest_clock=kwargs["backtest_clock"],
+            state_dir=kwargs["state_dir"],
+            logger=kwargs.get("logger"),
+        )
+
+    def _is_paper_mode(self) -> bool:
+        return bool(getattr(self._env, "is_paper_trading", False))
+
+
+def _extract_codes(rows: Any) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for row in rows or []:
+        code = _normalize_code(row.get("code") if isinstance(row, dict) else row)
+        if not code or code in seen:
+            continue
+        seen.add(code)
+        result.append(code)
+    return result
+
+
+def _normalize_code(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.isdigit() and len(text) < 6:
+        return text.zfill(6)
+    return text
+
+
+def _coverage_status(record: dict) -> str:
+    metadata = record.get("metadata") if isinstance(record, dict) else None
+    if isinstance(metadata, dict) and metadata.get("newhigh_coverage_status"):
+        return str(metadata.get("newhigh_coverage_status"))
+    status = str(record.get("status") or "").upper()
+    side = str(record.get("side") or "").upper()
+    rejected_reason = str(record.get("rejected_reason") or "")
+    if status == "SIGNAL" or side == "BUY":
+        return "bought"
+    if rejected_reason.startswith("data_unavailable"):
+        return "data_unavailable"
+    if rejected_reason == "missing_from_universe":
+        return "missing_from_universe"
+    if rejected_reason == "no_signal":
+        return "no_signal"
+    return "rejected"
+
+
+def _signal_time(target_date: str, backtest_time: str) -> str:
+    return (
+        f"{target_date[:4]}-{target_date[4:6]}-{target_date[6:8]} "
+        f"{str(backtest_time or '15:30:00')[:8]}"
+    )
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return float(numerator) / float(denominator) if denominator else 0.0

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -195,6 +195,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
     ) -> None:
         if not self._notification_service:
             return
+        empty_minute_codes = quality_summary.get("empty_minute_codes") or []
+        stale_minute_rows_dropped = quality_summary.get("stale_minute_rows_dropped") or 0
+        program_fallback_codes = quality_summary.get("program_fallback_codes") or []
         await self._notification_service.emit(
             NotificationCategory.BACKGROUND,
             NotificationLevel.WARNING,
@@ -202,7 +205,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
             f"{latest_trading_date}: "
             f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
             f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
-            f"program_db={format_optional_pct(quality_summary['program_db_coverage_pct'])}",
+            f"program_db={format_optional_pct(quality_summary['program_db_coverage_pct'])}, "
+            f"empty_minutes={len(empty_minute_codes)}, "
+            f"stale_dropped={stale_minute_rows_dropped}",
             metadata={
                 "alert_type": "microstructure_capture_quality_gate",
                 "trade_date": latest_trading_date,
@@ -212,5 +217,8 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 "execution_strength_coverage_pct": quality_summary["execution_strength_coverage_pct"],
                 "program_overlay_coverage_pct": quality_summary["program_overlay_coverage_pct"],
                 "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
+                "empty_minute_codes": empty_minute_codes,
+                "stale_minute_rows_dropped": stale_minute_rows_dropped,
+                "program_fallback_codes": program_fallback_codes,
             },
         )

--- a/task/background/after_market/newhigh_strategy_coverage_backtest_task.py
+++ b/task/background/after_market/newhigh_strategy_coverage_backtest_task.py
@@ -1,0 +1,83 @@
+"""장 마감 후 신고가 종목 전략 커버리지 백테스트 태스크."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+    from scheduler.worker.worker_pool import WorkerPool
+
+
+class NewHighStrategyCoverageBacktestTask(AfterMarketTask):
+    def __init__(
+        self,
+        coverage_service,
+        mcs: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        logger=None,
+        worker_pool: Optional["WorkerPool"] = None,
+    ) -> None:
+        super().__init__(
+            mcs=mcs,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._coverage_service = coverage_service
+        self._last_result = None
+
+    @property
+    def task_name(self) -> str:
+        return "newhigh_strategy_coverage_backtest"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "NewHighStrategyCoverageBacktestTask"
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        self._logger.info(f"newhigh strategy coverage backtest 시작: {latest_trading_date}")
+        try:
+            self._last_result = await self._coverage_service.run(latest_trading_date)
+        except Exception as e:
+            self._logger.error(f"newhigh strategy coverage backtest 실패: {e}", exc_info=True)
+            return
+        self._logger.info(f"newhigh strategy coverage backtest 완료: {latest_trading_date}")
+
+    async def force_run(self) -> None:
+        self._logger.info("NewHighStrategyCoverageBacktestTask 강제 실행 요청")
+        async with self._running_state():
+            target_date: Optional[str] = None
+            if self._mcs:
+                try:
+                    target_date = await self._mcs.get_latest_trading_date()
+                except Exception as e:
+                    self._logger.warning(f"최근 거래일 조회 실패 — 오늘 날짜로 대체: {e}")
+            if not target_date:
+                target_date = datetime.now().strftime("%Y%m%d")
+            await self._on_market_closed(target_date)
+
+    def get_progress(self) -> dict:
+        last_result = None
+        if self._last_result is not None:
+            last_result = {
+                "target_date": getattr(self._last_result, "target_date", ""),
+                "skipped": bool(getattr(self._last_result, "skipped", False)),
+                "skip_reason": getattr(self._last_result, "skip_reason", ""),
+                "newhigh_count": int(getattr(self._last_result, "newhigh_count", 0)),
+                "strategy_count": int(getattr(self._last_result, "strategy_count", 0)),
+                "all_strategy_missed_count": int(
+                    getattr(self._last_result, "all_strategy_missed_count", 0)
+                ),
+                "all_strategy_missed_rate": float(
+                    getattr(self._last_result, "all_strategy_missed_rate", 0.0)
+                ),
+            }
+        return {
+            "running": self._state.value == "running",
+            "last_result": last_result,
+        }

--- a/task/background/intraday/theme_intraday_leader_alert_task.py
+++ b/task/background/intraday/theme_intraday_leader_alert_task.py
@@ -1,0 +1,241 @@
+"""장중 주도테마 리포트를 30분 슬롯마다 발송하는 태스크."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from common.types import ErrorCode
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+
+if TYPE_CHECKING:
+    from core.market_clock import MarketClock
+    from services.market_calendar_service import MarketCalendarService
+
+
+class ThemeIntradayLeaderAlertTask(SchedulableTask):
+    """기본 랭킹 캐시를 갱신해 장중 주도테마 리포트를 주기적으로 보낸다."""
+
+    CHECK_INTERVAL_SEC = 60
+    ALERT_INTERVAL_SEC = 30 * 60
+
+    def __init__(
+        self,
+        *,
+        ranking_task,
+        theme_daily_leader_service,
+        telegram_reporter=None,
+        market_calendar_service: Optional["MarketCalendarService"] = None,
+        market_clock: Optional["MarketClock"] = None,
+        check_interval_sec: Optional[int] = None,
+        alert_interval_sec: Optional[int] = None,
+        logger=None,
+    ) -> None:
+        self._ranking_task = ranking_task
+        self._theme_daily_leader_service = theme_daily_leader_service
+        self._telegram_reporter = telegram_reporter
+        self._mcs = market_calendar_service
+        self._market_clock = market_clock
+        self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
+        self._alert_interval_sec = alert_interval_sec or self.ALERT_INTERVAL_SEC
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._progress: Dict = {
+            "running": False,
+            "last_report_slot": None,
+            "sent_count": 0,
+            "last_error": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "intraday_theme_leader_alert"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    def get_progress(self) -> Dict:
+        return dict(self._progress)
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                if self._state != TaskState.SUSPENDED:
+                    self._state = TaskState.RUNNING
+                    self._progress["running"] = True
+                    try:
+                        await self._tick()
+                    finally:
+                        if self._state == TaskState.RUNNING:
+                            self._state = TaskState.IDLE
+                        self._progress["running"] = False
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._progress["last_error"] = str(exc)
+                self._logger.error(f"{self.task_name}: loop error — {exc}", exc_info=True)
+            await asyncio.sleep(self._check_interval_sec)
+
+    async def _tick(self) -> None:
+        if not await self._is_market_open_now():
+            return
+        now = self._market_clock.get_current_kst_time()
+        slot_label = self._slot_label(now)
+        if self._progress["last_report_slot"] == slot_label:
+            return
+        await self._send_report(slot_label)
+
+    async def _is_market_open_now(self) -> bool:
+        if self._market_clock is None:
+            return False
+        now = self._market_clock.get_current_kst_time()
+        if not self._market_clock.is_market_operating_hours(now):
+            return False
+        if self._mcs is not None:
+            try:
+                if not await self._mcs.is_business_day(now.strftime("%Y%m%d")):
+                    return False
+            except Exception as exc:
+                self._logger.warning(f"{self.task_name}: 영업일 확인 실패 — {exc}")
+                return False
+        return True
+
+    def _slot_label(self, now: datetime) -> str:
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        elapsed = int((now - midnight).total_seconds())
+        slot_elapsed = elapsed - (elapsed % self._alert_interval_sec)
+        slot = midnight + timedelta(seconds=slot_elapsed)
+        return slot.strftime("%Y%m%d %H:%M")
+
+    async def _send_report(self, slot_label: str) -> None:
+        self._progress["last_error"] = None
+        rankings = await self._build_intraday_rankings(slot_label)
+        if not rankings or not rankings.get("all_stocks"):
+            self._progress["last_error"] = "intraday_ranking_empty"
+            self._logger.info(f"{self.task_name}: 장중 기본 랭킹 없음 — {slot_label} 스킵")
+            return
+
+        theme_resp = await self._theme_daily_leader_service.build_daily_theme_report(
+            rankings,
+            report_date=slot_label,
+        )
+        if not theme_resp or theme_resp.rt_cd != ErrorCode.SUCCESS.value:
+            msg = getattr(theme_resp, "msg1", "") if theme_resp else "응답 없음"
+            self._progress["last_error"] = f"theme_service_error:{msg}"
+            self._logger.warning(f"{self.task_name}: 주도테마 생성 실패 — {msg}")
+            return
+
+        theme_data = theme_resp.data or []
+        if self._telegram_reporter:
+            await self._telegram_reporter.send_daily_theme_report(
+                theme_data,
+                report_date=slot_label,
+            )
+        self._progress["last_report_slot"] = slot_label
+        self._progress["sent_count"] = len(theme_data)
+        self._logger.info(
+            f"{self.task_name}: {slot_label} 장중 주도테마 알림 발송 완료 "
+            f"({len(theme_data)}개 테마)"
+        )
+
+    async def _build_intraday_rankings(self, slot_label: str) -> Dict[str, Any]:
+        refresh = getattr(self._ranking_task, "refresh_basic_ranking", None)
+        if callable(refresh):
+            result = refresh()
+            if inspect.isawaitable(result):
+                await result
+
+        stocks: Dict[str, Dict] = {}
+        for category in ("rise", "trading_value", "volume"):
+            for item in self._get_basic_ranking_items(category):
+                stock = self._normalize_stock(item)
+                code = stock.get("stck_shrn_iscd") or stock.get("mksc_shrn_iscd")
+                if not code:
+                    continue
+                existing = stocks.setdefault(code, {})
+                for key, value in stock.items():
+                    if value not in (None, "") or key not in existing:
+                        existing[key] = value
+                existing["stck_shrn_iscd"] = code
+                existing.setdefault("mksc_shrn_iscd", code)
+
+        return {
+            "all_stocks": list(stocks.values()),
+            "program_all_stocks": [],
+            "report_date": slot_label[:8],
+        }
+
+    def _get_basic_ranking_items(self, category: str) -> List[Any]:
+        getter = getattr(self._ranking_task, "get_basic_ranking_cache", None)
+        if not callable(getter):
+            return []
+        resp = getter(category)
+        if not resp or getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return []
+        data = getattr(resp, "data", None)
+        if isinstance(data, dict):
+            data = data.get("output", [])
+        return list(data or [])
+
+    def _normalize_stock(self, item: Any) -> Dict:
+        stock = item.to_dict() if hasattr(item, "to_dict") else dict(item or {})
+        code = (
+            stock.get("stck_shrn_iscd")
+            or stock.get("mksc_shrn_iscd")
+            or stock.get("iscd")
+            or stock.get("code")
+            or ""
+        )
+        if code:
+            stock["stck_shrn_iscd"] = code
+            stock.setdefault("mksc_shrn_iscd", code)
+        if "hts_kor_isnm" not in stock and stock.get("name"):
+            stock["hts_kor_isnm"] = stock["name"]
+        stock.setdefault("frgn_ntby_tr_pbmn", "0")
+        stock.setdefault("orgn_ntby_tr_pbmn", "0")
+        stock.setdefault("prsn_ntby_tr_pbmn", "0")
+        if not stock.get("acml_tr_pbmn"):
+            price = self._to_int(stock.get("stck_prpr"))
+            volume = self._to_int(stock.get("acml_vol"))
+            if price and volume:
+                stock["acml_tr_pbmn"] = str(price * volume)
+        return stock
+
+    @staticmethod
+    def _to_int(value: Any) -> int:
+        try:
+            return int(str(value or "0").replace(",", ""))
+        except (TypeError, ValueError):
+            return 0

--- a/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
+++ b/tests/unit_test/scripts/test_analyze_backtest_microstructure_quality.py
@@ -124,7 +124,7 @@ def test_compute_quality_report_flags_stale_rows_and_low_coverage():
     assert "intraday_coverage_below_threshold" in bad_day["issues"]
     assert "program_overlay_coverage_below_threshold" in bad_day["issues"]
     assert "program_db_coverage_below_threshold" in bad_day["issues"]
-    assert "stale_minute_rows_present" in bad_day["issues"]
+    assert "stale_minute_rows_present" not in bad_day["issues"]
 
 
 def test_compute_quality_report_passes_when_payloads_meet_thresholds():

--- a/tests/unit_test/services/test_backtest_microstructure_quality.py
+++ b/tests/unit_test/services/test_backtest_microstructure_quality.py
@@ -56,8 +56,36 @@ def test_summarize_capture_quality_uses_metadata_codes_and_program_db_fallbacks(
     assert summary["issues"] == [
         "intraday_coverage_below_threshold",
         "program_overlay_coverage_below_threshold",
-        "stale_minute_rows_present",
     ]
+
+
+def test_summarize_capture_quality_keeps_stale_rows_as_diagnostic_only():
+    payload = {
+        "metadata": {
+            "trade_date": "20260702",
+            "codes": ["005930", "000660"],
+            "program_source": "program_db",
+            "quality": {
+                "empty_minute_codes": [],
+                "stale_minute_rows_dropped": {"005930": 57},
+            },
+        },
+        "intraday_minutes": {"005930": [{}], "000660": [{}]},
+        "execution_strength": {"005930": 120.0, "000660": 130.0},
+        "program_trades": {
+            "005930": {"program_net_buy_qty": 1},
+            "000660": {"program_net_buy_qty": -1},
+        },
+    }
+
+    summary = summarize_capture_quality(
+        payload,
+        thresholds=MicrostructureQualityThresholds(max_stale_rows=0),
+    )
+
+    assert summary["stale_minute_rows_dropped"] == 57
+    assert "stale_minute_rows_present" not in summary["issues"]
+    assert summary["quality_gate_passed"] is True
 
 
 def test_summarize_capture_quality_falls_back_to_resolved_codes_when_metadata_missing():

--- a/tests/unit_test/services/test_newhigh_strategy_coverage_backtest_service.py
+++ b/tests/unit_test/services/test_newhigh_strategy_coverage_backtest_service.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import TradeSignal
+from core.market_clock import MarketClock
+from services.newhigh_strategy_coverage_backtest_service import (
+    NewHighStrategyCoverageBacktestService,
+)
+
+
+def _fake_strategy_factory(**kwargs):
+    strategy_key = kwargs["strategy_key"]
+    universe = MagicMock()
+    universe.get_watchlist = AsyncMock(
+        return_value={"005930": object(), "000660": object(), "035720": object()}
+    )
+
+    class FakeStrategy:
+        name = strategy_key
+        _universe = universe
+
+        async def scan(self):
+            watchlist = await self._universe.get_watchlist()
+            if strategy_key != "buy_strategy" or "005930" not in watchlist:
+                return []
+            return [
+                TradeSignal(
+                    code="005930",
+                    name="삼성전자",
+                    action="BUY",
+                    price=70_000,
+                    qty=1,
+                    reason="replay_signal",
+                    strategy_name=strategy_key,
+                )
+            ]
+
+    return FakeStrategy()
+
+
+def _make_service(*, stock_repository=None, repo=None, strategy_factory=_fake_strategy_factory, env=None):
+    if stock_repository is None:
+        stock_repository = MagicMock()
+        stock_repository.get_newhigh_stocks = AsyncMock(
+            return_value=[
+                {"code": "005930", "name": "삼성전자"},
+                {"code": "000660", "name": "SK하이닉스"},
+                {"code": "035720", "name": "카카오"},
+            ]
+        )
+    repo = repo or MagicMock()
+    repo.save_run.return_value = {"run_id": "saved"}
+    return NewHighStrategyCoverageBacktestService(
+        stock_repository=stock_repository,
+        stock_query_service=AsyncMock(),
+        universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MarketClock(),
+        backtest_journal_repository=repo,
+        strategy_factory=strategy_factory,
+        env=env or SimpleNamespace(is_paper_trading=False),
+        logger=MagicMock(),
+    ), stock_repository, repo
+
+
+@pytest.mark.asyncio
+async def test_run_calculates_not_bought_rates_and_saves_journals():
+    service, stock_repository, repo = _make_service()
+
+    result = await service.run("20260505", strategy_keys=["buy_strategy", "miss_strategy"])
+
+    assert result.skipped is False
+    assert result.newhigh_count == 3
+    assert result.strategy_count == 2
+    assert result.all_strategy_missed_count == 2
+    assert result.all_strategy_missed_rate == pytest.approx(2 / 3)
+    stock_repository.get_newhigh_stocks.assert_awaited_once_with("20260505")
+
+    by_strategy = {row.strategy_key: row for row in result.strategy_summaries}
+    assert by_strategy["buy_strategy"].bought_count == 1
+    assert by_strategy["buy_strategy"].not_bought_count == 2
+    assert by_strategy["buy_strategy"].not_bought_rate == pytest.approx(2 / 3)
+    assert by_strategy["buy_strategy"].no_signal_count == 2
+    assert by_strategy["miss_strategy"].bought_count == 0
+    assert by_strategy["miss_strategy"].not_bought_count == 3
+
+    assert repo.save_run.call_count == 2
+    first_records = repo.save_run.call_args_list[0].args[0]
+    by_code = {record["code"]: record for record in first_records}
+    assert by_code["005930"]["metadata"]["newhigh_coverage_status"] == "bought"
+    assert by_code["000660"]["rejected_reason"] == "no_signal"
+    assert by_code["000660"]["metadata"]["newhigh_coverage_status"] == "no_signal"
+
+    first_kwargs = repo.save_run.call_args_list[0].kwargs
+    assert first_kwargs["run_id"] == "newhigh_coverage_buy_strategy_20260505"
+    assert first_kwargs["metadata"]["audit_type"] == "newhigh_strategy_coverage"
+    assert first_kwargs["metadata"]["not_bought_rate"] == pytest.approx(2 / 3)
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_no_newhigh_stocks():
+    stock_repository = MagicMock()
+    stock_repository.get_newhigh_stocks = AsyncMock(return_value=[])
+    service, _, repo = _make_service(stock_repository=stock_repository)
+
+    result = await service.run("20260505", strategy_keys=["buy_strategy"])
+
+    assert result.skipped is True
+    assert result.skip_reason == "no_newhigh_stocks"
+    repo.save_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_marks_data_unavailable_when_strategy_fails():
+    def raising_factory(**_kwargs):
+        raise RuntimeError("replay data missing")
+
+    service, _, repo = _make_service(strategy_factory=raising_factory)
+
+    result = await service.run("20260505", strategy_keys=["broken_strategy"])
+
+    summary = result.strategy_summaries[0]
+    assert summary.data_unavailable_count == 3
+    assert summary.not_bought_count == 0
+    records = repo.save_run.call_args.args[0]
+    assert {record["metadata"]["newhigh_coverage_status"] for record in records} == {
+        "data_unavailable"
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_skips_paper_mode():
+    service, _, repo = _make_service(env=SimpleNamespace(is_paper_trading=True))
+
+    result = await service.run("20260505", strategy_keys=["buy_strategy"])
+
+    assert result.skipped is True
+    assert result.skip_reason == "historical_intraday_unavailable_in_paper"
+    repo.save_run.assert_not_called()

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -248,7 +248,6 @@ async def test_quality_gate_metrics_exposed_and_warned_when_capture_quality_fail
         "intraday_coverage_below_threshold",
         "program_overlay_coverage_below_threshold",
         "program_db_coverage_below_threshold",
-        "stale_minute_rows_present",
     ]
     assert last_result["intraday_coverage_pct"] == 50.0
     assert last_result["program_overlay_coverage_pct"] == 0.0
@@ -268,7 +267,7 @@ async def test_quality_gate_failure_emits_background_warning_notification(
             "program_fallback_codes": [],
             "quality": {
                 "empty_minute_codes": ["000660"],
-                "stale_minute_rows_dropped": {},
+                "stale_minute_rows_dropped": {"005930": 2},
             },
             "row_counts": {"intraday_minutes": 1, "execution_strength": 2, "program_trades": 0},
         },
@@ -298,7 +297,7 @@ async def test_quality_gate_failure_emits_background_warning_notification(
         NotificationCategory.BACKGROUND,
         NotificationLevel.WARNING,
         "Microstructure 캡처 품질 게이트 실패",
-        "20260702: intraday=50.0%, program=0.0%, program_db=0.0%",
+        "20260702: intraday=50.0%, program=0.0%, program_db=0.0%, empty_minutes=1, stale_dropped=2",
     )
     assert kwargs["metadata"]["issues"] == [
         "intraday_coverage_below_threshold",
@@ -306,6 +305,9 @@ async def test_quality_gate_failure_emits_background_warning_notification(
         "program_db_coverage_below_threshold",
     ]
     assert kwargs["metadata"]["codes"] == 2
+    assert kwargs["metadata"]["empty_minute_codes"] == ["000660"]
+    assert kwargs["metadata"]["stale_minute_rows_dropped"] == 2
+    assert kwargs["metadata"]["program_fallback_codes"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/after_market/test_newhigh_strategy_coverage_backtest_task.py
+++ b/tests/unit_test/task/background/after_market/test_newhigh_strategy_coverage_backtest_task.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from interfaces.schedulable_task import TaskState
+from task.background.after_market.newhigh_strategy_coverage_backtest_task import (
+    NewHighStrategyCoverageBacktestTask,
+)
+
+
+def _make_task(service=None, mcs=None):
+    service = service or MagicMock()
+    service.run = AsyncMock()
+    return NewHighStrategyCoverageBacktestTask(
+        coverage_service=service,
+        mcs=mcs,
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+async def test_on_market_closed_runs_coverage_service():
+    service = MagicMock()
+    service.run = AsyncMock()
+    task = _make_task(service=service)
+
+    await task._on_market_closed("20260505")
+
+    service.run.assert_awaited_once_with("20260505")
+
+
+async def test_force_run_uses_market_calendar_date():
+    service = MagicMock()
+    service.run = AsyncMock()
+    mcs = MagicMock()
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260502")
+    task = _make_task(service=service, mcs=mcs)
+
+    await task.force_run()
+
+    service.run.assert_awaited_once_with("20260502")
+    assert task.state == TaskState.IDLE
+
+
+async def test_force_run_falls_back_to_today_when_calendar_fails():
+    service = MagicMock()
+    service.run = AsyncMock()
+    mcs = MagicMock()
+    mcs.get_latest_trading_date = AsyncMock(side_effect=RuntimeError("calendar down"))
+    task = _make_task(service=service, mcs=mcs)
+
+    with patch("task.background.after_market.newhigh_strategy_coverage_backtest_task.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "20260505"
+        await task.force_run()
+
+    service.run.assert_awaited_once_with("20260505")
+    task._logger.warning.assert_called_once()
+
+
+def test_task_name_and_scheduler_label():
+    task = _make_task()
+    assert task.task_name == "newhigh_strategy_coverage_backtest"
+    assert task._scheduler_label == "NewHighStrategyCoverageBacktestTask"
+
+
+async def test_on_market_closed_swallows_exception():
+    task = _make_task()
+    task._coverage_service.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await task._on_market_closed("20260505")
+
+    task._logger.error.assert_called_once()
+    assert task._last_result is None
+
+
+def test_get_progress_with_result():
+    task = _make_task()
+    task._last_result = SimpleNamespace(
+        target_date="20260505",
+        skipped=False,
+        skip_reason="",
+        newhigh_count=10,
+        strategy_count=2,
+        all_strategy_missed_count=3,
+        all_strategy_missed_rate=0.3,
+    )
+
+    progress = task.get_progress()
+
+    assert progress["last_result"] == {
+        "target_date": "20260505",
+        "skipped": False,
+        "skip_reason": "",
+        "newhigh_count": 10,
+        "strategy_count": 2,
+        "all_strategy_missed_count": 3,
+        "all_strategy_missed_rate": 0.3,
+    }

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -1,0 +1,169 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from task.background.intraday.theme_intraday_leader_alert_task import (
+    ThemeIntradayLeaderAlertTask,
+)
+
+
+class _Clock:
+    def __init__(self, now: datetime, open_now: bool = True):
+        self.now = now
+        self.open_now = open_now
+
+    def get_current_kst_time(self):
+        return self.now
+
+    def get_current_kst_date_str(self):
+        return self.now.strftime("%Y%m%d")
+
+    def is_market_operating_hours(self, _now):
+        return self.open_now
+
+
+def _make_response(data):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="성공",
+        data=data,
+    )
+
+
+def _make_task(*, now=None, open_now=True, basic_rankings=None, service_response=None):
+    clock = _Clock(now or datetime(2026, 7, 6, 10, 3, 0), open_now=open_now)
+    ranking_task = MagicMock()
+    ranking_task.refresh_basic_ranking = AsyncMock()
+    basic_rankings = basic_rankings if basic_rankings is not None else {
+        "rise": [
+            {
+                "stck_shrn_iscd": "005930",
+                "hts_kor_isnm": "삼성전자",
+                "stck_prpr": "80000",
+                "prdy_ctrt": "3.1",
+                "acml_vol": "1000",
+            }
+        ],
+        "trading_value": [
+            {
+                "mksc_shrn_iscd": "000660",
+                "hts_kor_isnm": "SK하이닉스",
+                "stck_prpr": "200000",
+                "prdy_ctrt": "2.5",
+                "acml_tr_pbmn": "500000000",
+            }
+        ],
+        "volume": [],
+    }
+
+    def _basic_cache(category):
+        return _make_response(basic_rankings.get(category, []))
+
+    ranking_task.get_basic_ranking_cache.side_effect = _basic_cache
+    theme_service = MagicMock()
+    theme_service.build_daily_theme_report = AsyncMock(
+        return_value=service_response or ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="성공",
+            data=[{"normalized_name": "반도체", "leaders": []}],
+        )
+    )
+    telegram_reporter = MagicMock()
+    telegram_reporter.send_daily_theme_report = AsyncMock()
+    mcs = MagicMock()
+    mcs.is_business_day = AsyncMock(return_value=True)
+    task = ThemeIntradayLeaderAlertTask(
+        ranking_task=ranking_task,
+        theme_daily_leader_service=theme_service,
+        telegram_reporter=telegram_reporter,
+        market_calendar_service=mcs,
+        market_clock=clock,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(
+        task=task,
+        clock=clock,
+        ranking_task=ranking_task,
+        theme_service=theme_service,
+        telegram_reporter=telegram_reporter,
+        mcs=mcs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_tick_sends_intraday_theme_report_for_current_30m_slot():
+    deps = _make_task()
+
+    await deps.task._tick()
+
+    deps.ranking_task.refresh_basic_ranking.assert_awaited_once()
+    rankings = deps.theme_service.build_daily_theme_report.await_args.args[0]
+    assert rankings["report_date"] == "20260706"
+    assert rankings["program_all_stocks"] == []
+    assert {item["stck_shrn_iscd"] for item in rankings["all_stocks"]} == {"005930", "000660"}
+    samsung = next(item for item in rankings["all_stocks"] if item["stck_shrn_iscd"] == "005930")
+    assert samsung["acml_tr_pbmn"] == "80000000"
+    deps.theme_service.build_daily_theme_report.assert_awaited_once()
+    assert deps.theme_service.build_daily_theme_report.await_args.kwargs["report_date"] == "20260706 10:00"
+    deps.telegram_reporter.send_daily_theme_report.assert_awaited_once_with(
+        [{"normalized_name": "반도체", "leaders": []}],
+        report_date="20260706 10:00",
+    )
+    progress = deps.task.get_progress()
+    assert progress["last_report_slot"] == "20260706 10:00"
+    assert progress["sent_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_same_30m_slot_does_not_send_twice():
+    deps = _make_task()
+
+    await deps.task._tick()
+    deps.clock.now = datetime(2026, 7, 6, 10, 29, 0)
+    await deps.task._tick()
+
+    deps.telegram_reporter.send_daily_theme_report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_next_30m_slot_sends_again():
+    deps = _make_task()
+
+    await deps.task._tick()
+    deps.clock.now = datetime(2026, 7, 6, 10, 30, 0)
+    await deps.task._tick()
+
+    assert deps.telegram_reporter.send_daily_theme_report.await_count == 2
+    assert deps.task.get_progress()["last_report_slot"] == "20260706 10:30"
+
+
+@pytest.mark.asyncio
+async def test_market_closed_skips_alert():
+    deps = _make_task(open_now=False)
+
+    await deps.task._tick()
+
+    deps.theme_service.build_daily_theme_report.assert_not_called()
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_ranking_cache_skips_without_marking_slot_sent():
+    deps = _make_task(basic_rankings={"rise": [], "trading_value": [], "volume": []})
+
+    await deps.task._tick()
+
+    deps.theme_service.build_daily_theme_report.assert_not_called()
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+    assert deps.task.get_progress()["last_error"] == "intraday_ranking_empty"
+    assert deps.task.get_progress()["last_report_slot"] is None
+
+
+def test_task_identity_and_initial_progress():
+    deps = _make_task()
+
+    assert deps.task.task_name == "intraday_theme_leader_alert"
+    assert deps.task.get_progress()["running"] is False

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -6,7 +6,7 @@ TimeDispatcher 태스크 등록, BackgroundScheduler / ForegroundScheduler 생�
 
 또한 `WebAppContext.runtime_mode` 별로 task 등록이 그룹 단위로 분기되는지
 검증한다. StrategySchedulerTaskAdapter 는 StrategyFactory 책임이라 여기서
-다루지 않는다 (총 15개 = SchedulerBootstrap 등록 분, 16번째 adapter 는 별도).
+다루지 않는다.
 """
 import contextlib
 from types import SimpleNamespace
@@ -47,7 +47,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "log_cleanup_task", "strategy_log_report_task", "theme_classification_task",
         "theme_daily_leader_report_task",
         "opening_position_reconcile_task", "after_market_reconcile_task",
-        "post_market_replay_audit_task",
+        "post_market_replay_audit_task", "newhigh_strategy_coverage_backtest_task",
         "websocket_watchdog_task", "pre_market_health_check_task",
         "cache_warmup_task", "notification_queue_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
@@ -90,17 +90,17 @@ def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
 
 # ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
 
-def test_all_mode_registers_16_tasks_to_background(patched_scheduler_deps):
+def test_all_mode_registers_22_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 21
+    assert bg.register.call_count == 22
 
 
-def test_all_mode_registers_12_tasks_to_time_dispatcher(patched_scheduler_deps):
+def test_all_mode_registers_14_tasks_to_time_dispatcher(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
-    assert ctx.time_dispatcher.register_task.call_count == 13
+    assert ctx.time_dispatcher.register_task.call_count == 14
 
 
 # ---------- mode 별 task 등록 ----------
@@ -181,6 +181,7 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
         "ranking_task", "minervini_update_task", "daily_price_collector_task",
         "ohlcv_update_task", "premium_watchlist_generator_task", "newhigh_task",
         "log_cleanup_task", "post_market_replay_audit_task",
+        "newhigh_strategy_coverage_backtest_task",
         "strategy_log_report_task", "after_market_reconcile_task",
         "theme_classification_task", "theme_daily_leader_report_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
@@ -233,6 +234,6 @@ def test_skips_none_tasks(patched_scheduler_deps):
     _run(ctx)
     # opening_position_reconcile_task 는 TRADING 그룹 + TimeDispatcher 등록 대상이었으므로
     # 둘 다 -1 감소한다.
-    assert ctx.time_dispatcher.register_task.call_count == 12
+    assert ctx.time_dispatcher.register_task.call_count == 13
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 20
+    assert bg.register.call_count == 21

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -52,6 +52,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "cache_warmup_task", "notification_queue_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
         "microstructure_capture_task", "program_capture_subscription_task",
+        "theme_intraday_leader_alert_task",
     ]:
         task = MagicMock()
         task.task_name = name
@@ -90,11 +91,11 @@ def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
 
 # ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
 
-def test_all_mode_registers_22_tasks_to_background(patched_scheduler_deps):
+def test_all_mode_registers_23_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 22
+    assert bg.register.call_count == 23
 
 
 def test_all_mode_registers_14_tasks_to_time_dispatcher(patched_scheduler_deps):
@@ -169,6 +170,7 @@ def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):
         "pre_market_health_check_task",
         "opening_position_reconcile_task",
         "cache_warmup_task",
+        "theme_intraday_leader_alert_task",
         "websocket_watchdog_task",
     }
 
@@ -236,4 +238,4 @@ def test_skips_none_tasks(patched_scheduler_deps):
     # 둘 다 -1 감소한다.
     assert ctx.time_dispatcher.register_task.call_count == 13
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 21
+    assert bg.register.call_count == 22

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -30,6 +30,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OneilUniverseService", "NaverFinanceScraperService",
     "StockClassificationRepository", "ThemeLeaderService", "ThemeDailyLeaderService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
+    "ThemeIntradayLeaderAlertTask",
     "MarketCapGapService", "MarketCapGapReportTask", "USMarketCalendarService",
     "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
@@ -240,6 +241,7 @@ def test_service_container_web_mode_keeps_realtime_and_skips_trading_batch_tasks
     patched_service_container_deps["OhlcvUpdateTask"].assert_not_called()
     patched_service_container_deps["AfterMarketReconcileTask"].assert_not_called()
     patched_service_container_deps["ThemeDailyLeaderReportTask"].assert_not_called()
+    patched_service_container_deps["ThemeIntradayLeaderAlertTask"].assert_not_called()
     patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
 
     assert ctx.pre_market_health_check_task is None
@@ -248,6 +250,7 @@ def test_service_container_web_mode_keeps_realtime_and_skips_trading_batch_tasks
     assert ctx.daily_price_collector_task is None
     assert ctx.ohlcv_update_task is None
     assert ctx.after_market_reconcile_task is None
+    assert ctx.theme_intraday_leader_alert_task is None
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
 
 
@@ -266,6 +269,9 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     assert ctx.pre_market_health_check_task is patched_service_container_deps["PreMarketHealthCheckTask"].return_value
     assert ctx.opening_position_reconcile_task is patched_service_container_deps["OpeningPositionReconcileTask"].return_value
     assert ctx.cache_warmup_task is patched_service_container_deps["CacheWarmupTask"].return_value
+    assert ctx.theme_intraday_leader_alert_task is patched_service_container_deps[
+        "ThemeIntradayLeaderAlertTask"
+    ].return_value
 
     patched_service_container_deps["NotificationQueueTask"].assert_not_called()
     patched_service_container_deps["MinerviniUpdateTask"].assert_not_called()
@@ -283,6 +289,9 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     assert ctx.ohlcv_update_task is None
     assert ctx.after_market_reconcile_task is None
     assert ctx.theme_daily_leader_report_task is None
+    assert ctx.theme_intraday_leader_alert_task is patched_service_container_deps[
+        "ThemeIntradayLeaderAlertTask"
+    ].return_value
     assert ctx.strategy_log_report_task is None
     assert ctx.post_market_replay_audit_task is None
     assert ctx.newhigh_strategy_coverage_backtest_task is None
@@ -307,6 +316,14 @@ def test_service_container_creates_universe_and_tasks(patched_service_container_
     theme_report_kwargs = patched_service_container_deps["ThemeDailyLeaderReportTask"].call_args.kwargs
     assert theme_report_kwargs["ranking_task"] is ctx.ranking_task
     assert theme_report_kwargs["theme_daily_leader_service"] is ctx.theme_daily_leader_service
+    assert ctx.theme_intraday_leader_alert_task is patched_service_container_deps[
+        "ThemeIntradayLeaderAlertTask"
+    ].return_value
+    intraday_theme_kwargs = patched_service_container_deps[
+        "ThemeIntradayLeaderAlertTask"
+    ].call_args.kwargs
+    assert intraday_theme_kwargs["ranking_task"] is ctx.ranking_task
+    assert intraday_theme_kwargs["theme_daily_leader_service"] is ctx.theme_daily_leader_service
     assert ctx.strategy_log_report_task is patched_service_container_deps["StrategyLogReportTask"].return_value
     assert ctx.market_cap_gap_service is patched_service_container_deps["MarketCapGapService"].return_value
     assert patched_service_container_deps["MarketCapGapReportTask"].call_count == 2

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -38,6 +38,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
     "OpeningPositionReconcileService", "PerformanceProfiler",
     "PostMarketReplayAuditService", "PostMarketReplayAuditTask",
+    "NewHighStrategyCoverageBacktestService", "NewHighStrategyCoverageBacktestTask",
 ]
 
 
@@ -211,6 +212,9 @@ def test_service_container_batch_mode_skips_streaming_and_intraday_web_tasks(pat
     assert ctx.notification_queue_task is None
     assert ctx.after_market_reconcile_task is patched_service_container_deps["AfterMarketReconcileTask"].return_value
     assert ctx.post_market_replay_audit_task is patched_service_container_deps["PostMarketReplayAuditTask"].return_value
+    assert ctx.newhigh_strategy_coverage_backtest_task is patched_service_container_deps[
+        "NewHighStrategyCoverageBacktestTask"
+    ].return_value
     assert ctx.daily_price_collector_task is patched_service_container_deps["DailyPriceCollectorTask"].return_value
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
 
@@ -271,6 +275,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     patched_service_container_deps["ThemeDailyLeaderReportTask"].assert_not_called()
     patched_service_container_deps["StrategyLogReportTask"].assert_not_called()
     patched_service_container_deps["PostMarketReplayAuditTask"].assert_not_called()
+    patched_service_container_deps["NewHighStrategyCoverageBacktestTask"].assert_not_called()
 
     assert ctx.notification_queue_task is None
     assert ctx.minervini_update_task is None
@@ -280,6 +285,7 @@ def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_ba
     assert ctx.theme_daily_leader_report_task is None
     assert ctx.strategy_log_report_task is None
     assert ctx.post_market_replay_audit_task is None
+    assert ctx.newhigh_strategy_coverage_backtest_task is None
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
     assert ctx.oneil_universe_service is patched_service_container_deps["OneilUniverseService"].return_value
 

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -617,6 +617,25 @@ def test_get_background_status_daily_theme_leader_report_is_after_market(web_cli
     assert item["schedule_type"] == "after_market"
 
 
+def test_get_background_status_intraday_theme_leader_alert_is_intraday(web_client, mock_web_ctx):
+    """장중 주도테마 알림 태스크는 intraday 로 분류된다."""
+    mock_task = MagicMock()
+    mock_task.get_progress.return_value = {"running": False}
+
+    mock_web_ctx.background_scheduler = MagicMock()
+    mock_web_ctx.background_scheduler.get_all_status.return_value = [
+        {"name": "intraday_theme_leader_alert", "state": "idle", "priority": 100},
+    ]
+    mock_web_ctx.background_scheduler.get_task.return_value = mock_task
+
+    response = web_client.get("/api/background/status")
+
+    assert response.status_code == 200
+    item = response.json()["data"][0]
+    assert item["name"] == "intraday_theme_leader_alert"
+    assert item["schedule_type"] == "intraday"
+
+
 def test_get_background_status_pre_market_health_check_schedule_type(web_client, mock_web_ctx):
     """pre_market_health_check는 IDLE이어도 실제 점검 progress를 반환한다."""
     class PreMarketTask:

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -968,6 +968,41 @@ async def test_force_newhigh_update_not_init(web_client, mock_web_ctx):
     assert response.status_code == 503
 
 
+@pytest.mark.asyncio
+async def test_force_newhigh_strategy_coverage_success_running_and_not_init(
+    web_client,
+    mock_web_ctx,
+    monkeypatch,
+):
+    from view.web.routes import system
+
+    mock_web_ctx.newhigh_strategy_coverage_backtest_task = None
+    response = web_client.post("/api/background/newhigh-strategy-coverage/force-update")
+    assert response.status_code == 503
+
+    running_task = MagicMock()
+    running_task.get_progress.return_value = {"running": True}
+    mock_web_ctx.newhigh_strategy_coverage_backtest_task = running_task
+    response = web_client.post("/api/background/newhigh-strategy-coverage/force-update")
+    assert response.status_code == 409
+
+    task = MagicMock()
+    task.get_progress.return_value = {"running": False}
+    task.force_run = AsyncMock()
+    mock_web_ctx.newhigh_strategy_coverage_backtest_task = task
+
+    def fake_create_task(coro):
+        coro.close()
+        return MagicMock()
+
+    monkeypatch.setattr(system.asyncio, "create_task", fake_create_task)
+    response = web_client.post("/api/background/newhigh-strategy-coverage/force-update")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    task.force_run.assert_called_once()
+
+
 # ── POST /api/background/theme-classification/force-update ─────────────
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -43,6 +43,8 @@ def mock_deps():
         ("tr", patch("view.web.bootstrap.config_bootstrap.TelegramReporter", autospec=True)),
         ("strategy_log_report_task", patch("view.web.bootstrap.service_container.StrategyLogReportTask", autospec=True)),
         ("strategy_log_report_service", patch("view.web.bootstrap.service_container.StrategyLogReportService", autospec=True)),
+        ("newhigh_coverage_service", patch("view.web.bootstrap.service_container.NewHighStrategyCoverageBacktestService", autospec=True)),
+        ("newhigh_coverage_task", patch("view.web.bootstrap.service_container.NewHighStrategyCoverageBacktestTask", autospec=True)),
     ]
 
     with contextlib.ExitStack() as stack:

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -128,6 +128,7 @@ class SchedulerBootstrap:
         self._register(self._optional_task("theme_daily_leader_report_task"), TaskPriority.LOW)
         self._register(ctx.log_cleanup_task, TaskPriority.MAINTENANCE)
         self._register(ctx.post_market_replay_audit_task, TaskPriority.LOW)
+        self._register(self._optional_task("newhigh_strategy_coverage_backtest_task"), TaskPriority.LOW)
         self._register(ctx.strategy_log_report_task, TaskPriority.LOW)
         self._register(ctx.after_market_reconcile_task, TaskPriority.LOW)
         # 자체 AfterMarketLoop 사용 (KST 16:05): market_cap_gap 과 동일 패턴.

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -111,6 +111,7 @@ class SchedulerBootstrap:
         self._register(ctx.pre_market_health_check_task)
         self._register(ctx.opening_position_reconcile_task, TaskPriority.HIGH)
         self._register(ctx.cache_warmup_task)
+        self._register(self._optional_task("theme_intraday_leader_alert_task"))
 
     def _register_batch_tasks(self) -> None:
         ctx = self._ctx

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -43,6 +43,7 @@ from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
 from services.oneil_universe_service import OneilUniverseService
+from services.newhigh_strategy_coverage_backtest_service import NewHighStrategyCoverageBacktestService
 from services.theme_classification_collector_service import ThemeClassificationCollectorService
 from services.us_market_calendar_service import USMarketCalendarService
 from services.theme_daily_leader_service import ThemeDailyLeaderService
@@ -79,6 +80,7 @@ from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
 from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
+from task.background.after_market.newhigh_strategy_coverage_backtest_task import NewHighStrategyCoverageBacktestTask
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
@@ -641,6 +643,7 @@ class ServiceContainer:
                 ctx.newhigh_service = None
                 ctx.strategy_log_report_task = None
                 ctx.post_market_replay_audit_task = None
+                ctx.newhigh_strategy_coverage_backtest_task = None
                 ctx.after_market_reconcile_task = None
                 ctx.opening_position_reconcile_task = None
                 ctx.microstructure_capture_task = None
@@ -791,6 +794,23 @@ class ServiceContainer:
                     logger=ctx.logger,
                     worker_pool=ctx.worker_pool,
                 )
+                ctx.newhigh_strategy_coverage_backtest_task = NewHighStrategyCoverageBacktestTask(
+                    coverage_service=NewHighStrategyCoverageBacktestService(
+                        stock_repository=ctx.stock_repository,
+                        stock_query_service=ctx.stock_query_service,
+                        universe_service=ctx.oneil_universe_service,
+                        indicator_service=ctx.indicator_service,
+                        market_clock=ctx.market_clock,
+                        backtest_journal_repository=ctx.backtest_journal_repository,
+                        program_provider=getattr(ctx.broker, "_client", ctx.broker),
+                        env=ctx.env,
+                        logger=ctx.logger,
+                    ),
+                    mcs=ctx._mcs,
+                    market_clock=ctx.market_clock,
+                    logger=ctx.logger,
+                    worker_pool=ctx.worker_pool,
+                )
                 ctx.after_market_reconcile_task = AfterMarketReconcileTask(
                     order_execution_service=ctx.order_execution_service,
                     notification_service=ctx.notification_service,
@@ -840,6 +860,7 @@ class ServiceContainer:
                 ctx.theme_daily_leader_report_task = None
                 ctx.strategy_log_report_task = None
                 ctx.post_market_replay_audit_task = None
+                ctx.newhigh_strategy_coverage_backtest_task = None
                 ctx.after_market_reconcile_task = None
                 ctx.microstructure_capture_task = None
                 ctx.program_capture_subscription_task = None

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -86,6 +86,7 @@ from task.background.always_on.notification_queue_task import NotificationQueueT
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
+from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.market_mode_utils import is_market_enabled
@@ -647,6 +648,7 @@ class ServiceContainer:
                 ctx.after_market_reconcile_task = None
                 ctx.opening_position_reconcile_task = None
                 ctx.microstructure_capture_task = None
+                ctx.theme_intraday_leader_alert_task = None
                 if needs_web:
                     ctx.notification_queue_task = NotificationQueueTask(
                         notification_service=ctx.notification_service,
@@ -864,6 +866,20 @@ class ServiceContainer:
                 ctx.after_market_reconcile_task = None
                 ctx.microstructure_capture_task = None
                 ctx.program_capture_subscription_task = None
+                ctx.theme_intraday_leader_alert_task = None
+
+            ctx.theme_intraday_leader_alert_task = ThemeIntradayLeaderAlertTask(
+                ranking_task=ctx.ranking_task,
+                theme_daily_leader_service=ctx.theme_daily_leader_service,
+                telegram_reporter=getattr(ctx, 'telegram_reporter', None),
+                market_calendar_service=ctx._mcs,
+                market_clock=ctx.market_clock,
+                logger=ctx.logger,
+            ) if (
+                needs_trading
+                and ctx.ranking_task is not None
+                and ctx.theme_daily_leader_service is not None
+            ) else None
 
             if needs_web:
                 ctx.notification_queue_task = NotificationQueueTask(

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -37,6 +37,7 @@ _SCHEDULE_TYPES = {
     "overseas_vbo_dryrun": "after_market",
     "after_market_reconcile": "after_market",
     "post_market_replay_audit": "after_market",
+    "newhigh_strategy_coverage_backtest": "after_market",
     "strategy_log_report": "after_market",
     "log_cleanup": "after_market",
     "notification_queue_task":  "always_on",
@@ -807,6 +808,25 @@ async def force_newhigh_update():
 
     asyncio.create_task(task.force_run())
     return {"success": True, "message": "52주 신고가 강제 탐색이 시작되었습니다."}
+
+
+@router.post("/background/newhigh-strategy-coverage/force-update")
+async def force_newhigh_strategy_coverage_backtest():
+    """신고가 종목 대상 전략별 미매수 비율 백테스트를 강제 실행한다."""
+    ctx = _get_ctx()
+    task = getattr(ctx, "newhigh_strategy_coverage_backtest_task", None)
+    if not task:
+        raise HTTPException(
+            status_code=503,
+            detail="NewHighStrategyCoverageBacktestTask가 초기화되지 않았습니다",
+        )
+
+    progress = task.get_progress()
+    if progress.get("running"):
+        raise HTTPException(status_code=409, detail="이미 백테스트가 진행 중입니다")
+
+    asyncio.create_task(task.force_run())
+    return {"success": True, "message": "신고가 전략 커버리지 백테스트가 시작되었습니다."}
 
 
 @router.post("/background/theme-classification/force-update")

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -24,6 +24,7 @@ _SCHEDULE_TYPES = {
     "websocket_watchdog":  "intraday",
     "cache_warmup":       "pre_market",
     "strategy_scheduler":  "intraday",
+    "intraday_theme_leader_alert": "intraday",
     "ranking_refresh":     "after_market",
     "daily_price_collector": "after_market",
     "minervini_update":     "after_market",

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -527,6 +527,7 @@ const FORCE_UPDATE_CONFIG = {
     '전일기준주도주_생성': { endpoint: '/api/background/watchlist/force-update',        label: '강제 생성' },
     cache_warmup:         { endpoint: '/api/background/cache-warmup/force-update',     label: '강제 웜업' },
     newhigh:              { endpoint: '/api/background/newhigh/force-update',          label: '강제 수집' },
+    newhigh_strategy_coverage_backtest: { endpoint: '/api/background/newhigh-strategy-coverage/force-update', label: '강제 실행' },
     theme_classification:  { endpoint: '/api/background/theme-classification/force-update', label: '강제 수집' },
     daily_theme_leader_report: { endpoint: '/api/background/daily-theme-leader-report/force-update', label: '강제 발송' },
     minervini_update:     { endpoint: '/api/background/minervini/force-update',         label: '강제 수집' },

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -153,6 +153,7 @@ class WebAppContext:
         self.theme_leader_service = None
         self.theme_daily_leader_service = None
         self.theme_daily_leader_report_task = None
+        self.theme_intraday_leader_alert_task = None
         self.strategy_log_report_task: StrategyLogReportTask = None
         self.post_market_replay_audit_task: PostMarketReplayAuditTask = None
         self.newhigh_strategy_coverage_backtest_task: NewHighStrategyCoverageBacktestTask = None

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -48,6 +48,7 @@ from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
 from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
+from task.background.after_market.newhigh_strategy_coverage_backtest_task import NewHighStrategyCoverageBacktestTask
 from services.strategy_log_report_service import StrategyLogReportService, _REASON_KR
 from services.rejection_distribution_service import RejectionDistributionService
 from task.background.always_on.notification_queue_task import NotificationQueueTask
@@ -154,6 +155,7 @@ class WebAppContext:
         self.theme_daily_leader_report_task = None
         self.strategy_log_report_task: StrategyLogReportTask = None
         self.post_market_replay_audit_task: PostMarketReplayAuditTask = None
+        self.newhigh_strategy_coverage_backtest_task: NewHighStrategyCoverageBacktestTask = None
         self.stock_repository: StockRepository = None
         self.background_scheduler: BackgroundScheduler = None
         self.foreground_scheduler: ForegroundScheduler = None


### PR DESCRIPTION
## Summary
- add a new-high strategy coverage backtest service that replays active backtest strategies against daily new-high candidates
- save per-strategy coverage journals with bought, no-signal, rejection, missing-universe, and data-unavailable counts
- wire the task into after-market scheduling, background status, and force-run API/UI mapping

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v