### PR TITLE
당일 성능 분석: budget 계측 공백 보강 + RankingTask 중복 스로틀 제거

### DIFF
--- a/core/retry_queue/api_budget_limiter.py
+++ b/core/retry_queue/api_budget_limiter.py
@@ -69,6 +69,8 @@ class _LaneState:
     max_observed_active: int = 0
     rate_wait_total: int = 0
     rate_wait_seconds_total: float = 0.0
+    semaphore_wait_total: int = 0
+    semaphore_wait_seconds_total: float = 0.0
 
 
 @dataclass
@@ -140,7 +142,13 @@ class ApiBudgetLimiter:
         lane = self._lane_for(budget, priority)
         await self._wait_for_rate_slot(self._global_lane_for(priority))
         await self._wait_for_rate_slot(lane)
+        will_wait_for_semaphore = lane.active >= lane.limit
+        if will_wait_for_semaphore:
+            semaphore_wait_start = self._monotonic()
         await lane.semaphore.acquire()
+        if will_wait_for_semaphore:
+            lane.semaphore_wait_total += 1
+            lane.semaphore_wait_seconds_total += self._monotonic() - semaphore_wait_start
         lane.active += 1
         lane.acquired_total += 1
         lane.max_observed_active = max(lane.max_observed_active, lane.active)
@@ -171,6 +179,8 @@ class ApiBudgetLimiter:
             "max_observed_active": lane.max_observed_active,
             "rate_wait_total": lane.rate_wait_total,
             "rate_wait_seconds_total": lane.rate_wait_seconds_total,
+            "semaphore_wait_total": lane.semaphore_wait_total,
+            "semaphore_wait_seconds_total": lane.semaphore_wait_seconds_total,
         }
 
     def _budget_for(self, category: str) -> _CategoryBudget:

--- a/scheduler/background_scheduler.py
+++ b/scheduler/background_scheduler.py
@@ -159,7 +159,9 @@ class BackgroundScheduler:
         msg = (
             f"[Performance] BudgetSnapshot.{category}: {lane['rate_wait_seconds_total']:.4f}s "
             f"(active={lane['active']}, limit={lane['limit']}, acquired_total={lane['acquired_total']}, "
-            f"rate_wait_total={lane['rate_wait_total']}, max_observed_active={lane['max_observed_active']})"
+            f"rate_wait_total={lane['rate_wait_total']}, max_observed_active={lane['max_observed_active']}, "
+            f"semaphore_wait_total={lane['semaphore_wait_total']}, "
+            f"semaphore_wait_seconds_total={lane['semaphore_wait_seconds_total']:.4f})"
         )
         self._pm.logger.info(msg)
 

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -40,9 +40,8 @@ _ETF_PREFIXES = (
 class RankingTask(AfterMarketTask):
     """랭킹 데이터를 수집·캐시하는 백그라운드 태스크."""
 
-    # 청크 크기 및 레이트 리밋
+    # 청크 크기 (API 호출 페이싱은 ApiBudgetLimiter가 중앙에서 담당)
     API_CHUNK_SIZE = 8
-    CHUNK_SLEEP_SEC = 1.1
 
     def __init__(
         self,
@@ -423,14 +422,6 @@ class RankingTask(AfterMarketTask):
                         f"투자자 랭킹 진행: {processed}/{total} ({processed/total*100:.1f}%) "
                         f"| 수집: {len(results)} | 프로그램: {len(program_results)} | 소요: {elapsed:.1f}s"
                     )
-
-                # 전체 캐시 HIT면 sleep 불필요, 실제 API 호출이 있었으면 rate limit sleep
-                all_cache_hit = all(
-                    getattr(r, '_cache_hit', False)
-                    for r in all_responses if not isinstance(r, Exception)
-                )
-                if not all_cache_hit:
-                    await asyncio.sleep(self.CHUNK_SLEEP_SEC)
 
             # 2-1. 프로그램 데이터의 acml_tr_pbmn으로 투자자 결과 보정
             prog_tr_map = {r["stck_shrn_iscd"]: r["acml_tr_pbmn"] for r in program_results}

--- a/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
+++ b/tests/unit_test/core/retry_queue/test_api_budget_limiter.py
@@ -244,6 +244,47 @@ async def test_emergency_global_rate_bucket_is_independent_from_normal_global_bu
 
 
 @pytest.mark.real_sleep
+async def test_limiter_tracks_semaphore_wait_seconds_when_concurrency_limit_saturated():
+    """rate 대기와 별개로, concurrency semaphore 대기(동시성 한도 포화)도 누적 계측한다."""
+    limiter = ApiBudgetLimiter(
+        {"quotation_price": 1},
+        rate_limits_per_sec={"quotation_price": 100.0},
+        global_rate_limit_per_sec=100.0,
+        emergency_global_rate_limit_per_sec=100.0,
+    )
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    second_waiting = asyncio.Event()
+
+    async def run_first():
+        async with limiter.acquire("quotation_price"):
+            first_started.set()
+            await release_first.wait()
+
+    async def run_second():
+        second_waiting.set()
+        async with limiter.acquire("quotation_price"):
+            second_started.set()
+
+    first_task = asyncio.create_task(run_first())
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    second_task = asyncio.create_task(run_second())
+    await asyncio.wait_for(second_waiting.wait(), timeout=1)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(second_started.wait(), timeout=0.05)
+
+    release_first.set()
+    await asyncio.wait_for(second_started.wait(), timeout=1)
+    await asyncio.gather(first_task, second_task)
+
+    snapshot = limiter.snapshot()
+    assert snapshot["quotation_price"]["semaphore_wait_total"] == 1
+    assert snapshot["quotation_price"]["semaphore_wait_seconds_total"] > 0.0
+
+
+@pytest.mark.real_sleep
 async def test_account_reconciliation_budget_is_independent_from_quotation_scan_budget():
     limiter = ApiBudgetLimiter(
         {"quotation_price": 1, "account_reconciliation": 1},

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -773,6 +773,22 @@ async def test_refresh_investor_ranking_optimization(bg_service, mock_deps):
 
 
 @pytest.mark.asyncio
+async def test_refresh_investor_ranking_does_not_sleep_between_chunks(bg_service, mock_deps, disable_asyncio_sleep):
+    """중앙 ApiBudgetLimiter가 이미 API 호출 페이싱을 담당하므로, 청크 사이 수동 sleep은 없어야 한다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([
+        (f"{i:05d}0", f"종목{i}", "KOSPI") for i in range(9)
+    ])
+    broker.get_investor_trade_by_stock_daily = AsyncMock(
+        return_value=_make_investor_response(100)
+    )
+
+    await bg_service.refresh_investor_ranking()
+
+    disable_asyncio_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_refresh_investor_ranking_skipped_during_market_open(bg_service, mock_deps):
     """장 중에는 투자자 랭킹 갱신(직접 호출)을 스킵해야 한다."""
     broker, _, _, logger, market_clock, market_calendar_service = mock_deps


### PR DESCRIPTION
## Summary
- 당일(2026-07-06) 성능 로그 분석에서 발견한 두 가지를 함께 처리

**1. ApiBudgetLimiter concurrency semaphore 대기시간 계측 공백**
- rate-limit 대기(`rate_wait_seconds_total`)는 누적되고 있었지만, concurrency semaphore 포화로 인한 대기는 전혀 계측되지 않았음
- `quotation_price`/`quotation` 레인이 오늘 실제로 한도(4/4)까지 포화됐던 기록(`max_observed_active`)이 있었지만, 그 대기시간은 로그로 알 수 없었음
- `_LaneState`에 `semaphore_wait_total`/`semaphore_wait_seconds_total` 추가, lane이 한도만큼 점유 중일 때만 대기시간 측정. `BudgetSnapshot` 로그 라인에도 노출

**2. RankingTask 청크당 수동 rate-limit sleep 제거 (ApiBudgetLimiter와 중복)**
- `CHUNK_SLEEP_SEC`(1.1s)는 중앙 `ApiBudgetLimiter` 도입(#436) 이전부터 있던 수동 스로틀로, 현재는 budget limiter가 이미 API 호출 페이싱을 담당해 이중으로 겹쳐 있었음
- 오늘 성능 로그 기준 `refresh_investor_ranking` 1088초 중 약 300청크 x 1.1초(약 330초, 30%)가 이 sleep 하나에서 소비됨을 확인 후 제거
- KIS 호출 페이싱은 여전히 중앙 budget limiter(global 8/sec)가 담당하므로 호출 한도 위반 리스크는 늘지 않음

## Test plan
- [x] `pytest tests/unit_test/core/retry_queue/test_api_budget_limiter.py -v` — 신규 테스트 포함 22개 통과
- [x] `pytest tests/unit_test/task/background/after_market/test_ranking_task.py -v` — 신규 테스트 포함 82개 통과
- [x] `pytest tests/unit_test -q` — 6676 passed
- [x] `pytest tests/integration_test -q` — 246 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)