### PR TITLE
[codex] Show virtual chart trade counts

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_virtual.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_virtual.py
@@ -178,6 +178,43 @@ async def test_get_strategy_chart_selected_strategies_use_selected_date_range(we
 
 
 @pytest.mark.asyncio
+async def test_get_strategy_chart_includes_trade_counts_for_chart_period(web_client, mock_web_ctx):
+    """차트 응답은 각 전략 차트 기간 안의 매수/매도 횟수를 함께 반환한다."""
+    history_map = {
+        "StrategyB": [
+            {"date": "2025-04-24", "return_rate": 0.5},
+            {"date": "2025-04-25", "return_rate": 0.1},
+        ],
+        "StrategyC": [{"date": "2025-04-25", "return_rate": -0.2}],
+    }
+    mock_web_ctx.virtual_trade_service.get_strategy_return_history.side_effect = lambda name: history_map[name]
+    mock_web_ctx.virtual_trade_service.get_all_trades.return_value = [
+        mock_trade(strategy="StrategyB", buy_date="2025-04-23 09:00:00", sell_date="2025-04-24 15:00:00", status="SOLD"),
+        mock_trade(strategy="StrategyB", buy_date="2025-04-24 09:00:00", status="HOLD"),
+        mock_trade(strategy="StrategyB", buy_date="2025-04-25 09:00:00", sell_date="2025-04-26 15:00:00", status="SOLD"),
+        mock_trade(strategy="StrategyC", buy_date="2025-04-25 09:00:00", sell_date="2025-04-25 15:00:00", status="SOLD"),
+        mock_trade(strategy="Other", buy_date="2025-04-24 09:00:00", sell_date="2025-04-24 15:00:00", status="SOLD"),
+    ]
+    mock_web_ctx.stock_query_service.get_ohlcv_range = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd="0",
+            msg1="Success",
+            data=[
+                {"date": "20250424", "close": 30000},
+                {"date": "20250425", "close": 30300},
+            ],
+        )
+    )
+
+    response = web_client.get("/api/virtual/chart/ALL?strategies=StrategyB,StrategyC")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["chart_counts"]["StrategyB"] == {"buy": 2, "sell": 1}
+    assert data["chart_counts"]["StrategyC"] == {"buy": 1, "sell": 1}
+
+
+@pytest.mark.asyncio
 async def test_calculate_benchmark_zero_base_price(web_client, mock_web_ctx):
     """_calculate_benchmark 기준가 0일 때 테스트"""
     mock_web_ctx.virtual_trade_service.get_all_strategies.return_value = ["StratA"]

--- a/view/web/routes/virtual.py
+++ b/view/web/routes/virtual.py
@@ -105,6 +105,60 @@ def _build_reference_history(histories: dict[str, list], strategy_names: list[st
     return [{"date": date} for date in sorted(date_set)]
 
 
+def _date_prefix(value) -> str | None:
+    text = str(value or "")[:10]
+    if len(text) == 10 and text[4] == "-" and text[7] == "-":
+        return text
+    return None
+
+
+def _build_chart_trade_counts(vm, histories: dict[str, list], strategy_names: list[str]) -> dict[str, dict[str, int]]:
+    """각 전략 차트 날짜 범위 안에 포함된 매수/매도 횟수를 계산한다."""
+    try:
+        trades = vm.get_all_trades(apply_cost=False)
+    except TypeError:
+        trades = vm.get_all_trades()
+    except Exception as e:
+        logger.error(f"[WebAPI] virtual/chart 거래 카운트 조회 오류: {e}")
+        return {}
+
+    if not isinstance(trades, list):
+        return {}
+
+    selected_names = set(strategy_names or [])
+    counts = {}
+    for name, history in histories.items():
+        dates = sorted(entry.get("date") for entry in history if entry.get("date"))
+        if not dates:
+            continue
+
+        start_date, end_date = dates[0], dates[-1]
+        buy_count = 0
+        sell_count = 0
+        for trade in trades:
+            if not isinstance(trade, dict) or trade.get("status") == "FAILED":
+                continue
+
+            trade_strategy = trade.get("strategy")
+            if name == "ALL":
+                if selected_names and trade_strategy not in selected_names:
+                    continue
+            elif trade_strategy != name:
+                continue
+
+            buy_date = _date_prefix(trade.get("buy_date"))
+            if buy_date and start_date <= buy_date <= end_date:
+                buy_count += 1
+
+            sell_date = _date_prefix(trade.get("sell_date"))
+            if sell_date and start_date <= sell_date <= end_date:
+                sell_count += 1
+
+        counts[name] = {"buy": buy_count, "sell": sell_count}
+
+    return counts
+
+
 @router.get("/virtual/chart/{strategy_name}")
 async def get_strategy_chart(strategy_name: str, strategies: str | None = None):
     """특정 전략의 수익률 히스토리(차트용) 반환 + 벤치마크(KOSPI200, KOSDAQ150) 포함"""
@@ -113,7 +167,7 @@ async def get_strategy_chart(strategy_name: str, strategies: str | None = None):
         t_start = ctx.pm.start_timer()
         vm = _sync_virtual_trade_state(ctx)
         if vm is None:
-            return {"histories": {}, "benchmarks": {}}
+            return {"histories": {}, "benchmarks": {}, "chart_counts": {}}
 
         # 1. 히스토리 데이터 수집
         if strategy_name == "ALL":
@@ -148,10 +202,11 @@ async def get_strategy_chart(strategy_name: str, strategies: str | None = None):
         )
 
         if not ref_history:
-            return {"histories": {}, "benchmarks": {}}
+            return {"histories": {}, "benchmarks": {}, "chart_counts": {}}
 
         start_date = ref_history[0]['date'].replace('-', '')
         end_date = ref_history[-1]['date'].replace('-', '')
+        chart_counts = _build_chart_trade_counts(vm, histories, selected_strategy_names)
 
         # 벤치마크 데이터 (KOSPI 200, KOSDAQ 150)
         kospi_benchmark, kosdaq_benchmark = await asyncio.gather(
@@ -165,7 +220,7 @@ async def get_strategy_chart(strategy_name: str, strategies: str | None = None):
         }
 
         ctx.pm.log_timer(f"get_strategy_chart({strategy_name})", t_start)
-        return {"histories": histories, "benchmarks": benchmarks}
+        return {"histories": histories, "benchmarks": benchmarks, "chart_counts": chart_counts}
 
 
 def _sanitize_for_json(obj):

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -386,6 +386,8 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 }
 
 .virtual-mini-chart-header h3 {
+    flex: 1 1 auto;
+    min-width: 0;
     margin: 0;
     color: var(--text-primary);
     font-size: 0.95rem;
@@ -399,6 +401,7 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     flex: 0 0 auto;
     color: var(--text-secondary);
     font-size: 0.75rem;
+    white-space: nowrap;
 }
 
 .virtual-mini-chart-canvas {

--- a/view/web/static/js/virtual_chart.js
+++ b/view/web/static/js/virtual_chart.js
@@ -113,7 +113,13 @@ function setVirtualChartMessage(message) {
     grid.appendChild(empty);
 }
 
-function createVirtualChartCard(strategyName) {
+function formatVirtualChartTradeCounts(counts) {
+    const buyCount = Number(counts?.buy ?? 0);
+    const sellCount = Number(counts?.sell ?? 0);
+    return `기간 매수 ${buyCount} / 매도 ${sellCount}`;
+}
+
+function createVirtualChartCard(strategyName, tradeCounts) {
     const card = document.createElement('div');
     card.className = 'virtual-mini-chart-card';
 
@@ -124,7 +130,7 @@ function createVirtualChartCard(strategyName) {
     title.textContent = strategyName === 'ALL' ? '전체(ALL)' : strategyName;
 
     const legend = document.createElement('span');
-    legend.textContent = 'KOSPI200 / KOSDAQ150 비교';
+    legend.textContent = formatVirtualChartTradeCounts(tradeCounts);
 
     header.appendChild(title);
     header.appendChild(legend);
@@ -374,12 +380,12 @@ function getDisplayStrategies(selectedStrategies, allHistories) {
     return selectedStrategies.filter(name => allHistories[name]?.length > 0);
 }
 
-function renderMiniChart(grid, strategyName, strategyHistory, benchmarks) {
+function renderMiniChart(grid, strategyName, strategyHistory, benchmarks, tradeCounts) {
     const activeDates = strategyHistory.map(h => h.date).filter(Boolean);
     if (activeDates.length === 0) return;
 
     const labels = activeDates.map(d => d.substring(5));
-    const { card, canvas } = createVirtualChartCard(strategyName);
+    const { card, canvas } = createVirtualChartCard(strategyName, tradeCounts);
     grid.appendChild(card);
 
     const chart = new Chart(canvas.getContext('2d'), {
@@ -415,6 +421,7 @@ window.refreshVirtualChart = async function(selectedStrategies) {
 
         const allHistories = data.histories;
         const benchmarks = data.benchmarks || {};
+        const chartCounts = data.chart_counts || {};
         const allStrategyNames = Object.keys(allHistories).filter(name => name !== 'ALL');
         allStrategyNames.forEach(name => getStrategyColor(name));
 
@@ -427,7 +434,7 @@ window.refreshVirtualChart = async function(selectedStrategies) {
         destroyVirtualCharts();
         grid.innerHTML = '';
         displayStrategies.forEach(name => {
-            renderMiniChart(grid, name, allHistories[name], benchmarks);
+            renderMiniChart(grid, name, allHistories[name], benchmarks, chartCounts[name]);
         });
     } catch (error) {
         console.error('[VirtualChart] 업데이트 실패:', error);


### PR DESCRIPTION
﻿## What changed
- Replaced the virtual mini-chart header message with chart-period buy/sell counts.
- Added `chart_counts` to `/api/virtual/chart/{strategy_name}` based on each strategy chart's actual date range.
- Added a route test covering in-range and out-of-range buy/sell counting.

## Why
The chart cards should explain how many trades produced the displayed strategy curve, rather than repeating the KOSPI200/KOSDAQ150 comparison label.

## Validation
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`
