### PR TITLE
Improve daily theme ranking score

### DIFF
--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -319,9 +319,16 @@ class TelegramReporter:
             trading_value = self._format_won_100m(theme.get("trading_value_sum_won"))
             advancing_ratio = self._format_signed_pct(theme.get("advancing_ratio"), digits=1).replace("+", "")
             flow_ratio = self._format_signed_pct(theme.get("flow_ratio"), digits=2)
+            theme_score = theme.get("theme_score")
+            score_text = ""
+            if theme_score is not None:
+                try:
+                    score_text = f" | 종합점수 {float(theme_score):.2f}"
+                except (TypeError, ValueError):
+                    score_text = ""
             lines = [
                 f"<b>{rank}. {theme_name}</b>  {avg_rate}  {trading_value}",
-                f"상승비율 {advancing_ratio} | 수급비중 {flow_ratio}",
+                f"상승비율 {advancing_ratio} | 수급비중 {flow_ratio}{score_text}",
                 "<pre>",
             ]
             for leader in (theme.get("leaders") or [])[:3]:

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -1,5 +1,6 @@
 """당일 랭킹 데이터 기반 주도 테마 리포트 서비스."""
 import logging
+import math
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from common.types import ErrorCode, ResCommonResponse
@@ -106,26 +107,39 @@ class ThemeDailyLeaderService:
                     round(((fi_net_sum + program_net_sum) / trading_value_sum) * 100, 2)
                     if trading_value_sum else 0.0
                 )
+                leader_avg_change_rate = round(
+                    sum(item["change_rate"] for item in leaders) / len(leaders), 2
+                )
+                score_info = self._build_theme_score(
+                    scored=scored,
+                    leader_avg_change_rate=leader_avg_change_rate,
+                    advancing_ratio=round(advance_count / len(scored) * 100, 1),
+                    trading_value_sum_won=trading_value_sum,
+                    flow_ratio=flow_ratio,
+                )
 
                 themes.append({
                     "normalized_name": normalized_name,
                     "sources": group.get("sources", []),
                     "report_date": report_date,
                     "scored_member_count": len(scored),
-                    "leader_avg_change_rate": round(
-                        sum(item["change_rate"] for item in leaders) / len(leaders), 2
-                    ),
+                    "leader_avg_change_rate": leader_avg_change_rate,
                     "advance_count": advance_count,
-                    "advancing_ratio": round(advance_count / len(scored) * 100, 1),
+                    "advancing_ratio": score_info["advancing_ratio"],
                     "trading_value_sum_won": trading_value_sum,
                     "fi_net_buy_won": fi_net_sum,
                     "program_net_buy_won": program_net_sum,
                     "flow_ratio": flow_ratio,
+                    "value_weighted_change_rate": score_info["value_weighted_change_rate"],
+                    "zero_trading_value_ratio": score_info["zero_trading_value_ratio"],
+                    "negative_trading_value_ratio": score_info["negative_trading_value_ratio"],
+                    "theme_score": score_info["theme_score"],
                     "leaders": leaders,
                 })
 
             themes.sort(
                 key=lambda item: (
+                    item["theme_score"],
                     item["leader_avg_change_rate"],
                     item["advancing_ratio"],
                     item["trading_value_sum_won"],
@@ -178,6 +192,54 @@ class ThemeDailyLeaderService:
             if code:
                 out[str(code)] = _to_int(_get(stock, "whol_smtn_ntby_tr_pbmn"))
         return out
+
+    @staticmethod
+    def _build_theme_score(
+        scored: List[Dict[str, Any]],
+        leader_avg_change_rate: float,
+        advancing_ratio: float,
+        trading_value_sum_won: int,
+        flow_ratio: float,
+    ) -> Dict[str, float]:
+        total_count = len(scored)
+        zero_trading_value_count = sum(1 for item in scored if item["trading_value_won"] <= 0)
+        negative_trading_value_sum = sum(
+            item["trading_value_won"] for item in scored if item["change_rate"] < 0
+        )
+        if trading_value_sum_won > 0:
+            value_weighted_change_rate = (
+                sum(item["change_rate"] * item["trading_value_won"] for item in scored)
+                / trading_value_sum_won
+            )
+            trading_value_score = min(math.log10(trading_value_sum_won / 100_000_000), 5.0)
+            negative_trading_value_ratio = negative_trading_value_sum / trading_value_sum_won * 100
+        else:
+            value_weighted_change_rate = (
+                sum(item["change_rate"] for item in scored) / total_count if total_count else 0.0
+            )
+            trading_value_score = 0.0
+            negative_trading_value_ratio = 0.0
+
+        zero_trading_value_ratio = (
+            zero_trading_value_count / total_count * 100 if total_count else 0.0
+        )
+        clipped_flow_ratio = max(min(flow_ratio, 20.0), -20.0)
+        theme_score = (
+            leader_avg_change_rate * 0.45
+            + value_weighted_change_rate * 0.20
+            + advancing_ratio * 0.03
+            + trading_value_score * 2.0
+            + clipped_flow_ratio * 0.10
+            - zero_trading_value_ratio * 0.05
+            - negative_trading_value_ratio * 0.04
+        )
+        return {
+            "advancing_ratio": advancing_ratio,
+            "value_weighted_change_rate": round(value_weighted_change_rate, 2),
+            "zero_trading_value_ratio": round(zero_trading_value_ratio, 2),
+            "negative_trading_value_ratio": round(negative_trading_value_ratio, 2),
+            "theme_score": round(theme_score, 2),
+        }
 
     @staticmethod
     def _build_member_score(member: Dict[str, Any], stock: Any, program_net_won: int) -> Dict[str, Any]:

--- a/task/background/intraday/theme_intraday_leader_alert_task.py
+++ b/task/background/intraday/theme_intraday_leader_alert_task.py
@@ -1,4 +1,4 @@
-"""장중 주도테마 리포트를 30분 슬롯마다 발송하는 태스크."""
+"""장중 주도테마 리포트를 1시간 슬롯마다 발송하는 태스크."""
 from __future__ import annotations
 
 import asyncio
@@ -19,7 +19,9 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
     """기본 랭킹 캐시를 갱신해 장중 주도테마 리포트를 주기적으로 보낸다."""
 
     CHECK_INTERVAL_SEC = 60
-    ALERT_INTERVAL_SEC = 30 * 60
+    ALERT_INTERVAL_SEC = 60 * 60
+    ALERT_START_HOUR = 9
+    ALERT_START_MINUTE = 10
 
     def __init__(
         self,
@@ -113,6 +115,8 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
             return
         now = self._market_clock.get_current_kst_time()
         slot_label = self._slot_label(now)
+        if slot_label is None:
+            return
         if self._progress["last_report_slot"] == slot_label:
             return
         await self._send_report(slot_label)
@@ -132,11 +136,18 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
                 return False
         return True
 
-    def _slot_label(self, now: datetime) -> str:
-        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        elapsed = int((now - midnight).total_seconds())
+    def _slot_label(self, now: datetime) -> Optional[str]:
+        start = now.replace(
+            hour=self.ALERT_START_HOUR,
+            minute=self.ALERT_START_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+        if now < start:
+            return None
+        elapsed = int((now - start).total_seconds())
         slot_elapsed = elapsed - (elapsed % self._alert_interval_sec)
-        slot = midnight + timedelta(seconds=slot_elapsed)
+        slot = start + timedelta(seconds=slot_elapsed)
         return slot.strftime("%Y%m%d %H:%M")
 
     async def _send_report(self, slot_label: str) -> None:

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -837,6 +837,7 @@ async def test_send_daily_theme_report_formats_stockeasy_like_cards(telegram_rep
             "trading_value_sum_won": 380_100_000_000,
             "advancing_ratio": 75.0,
             "flow_ratio": 1.67,
+            "theme_score": 12.17,
             "leaders": [
                 {"name": "테스", "code": "A", "change_rate": 14.9, "trading_value_won": 193_000_000_000},
                 {"name": "유진테크", "code": "B", "change_rate": 12.6, "trading_value_won": 54_300_000_000},
@@ -853,6 +854,7 @@ async def test_send_daily_theme_report_formats_stockeasy_like_cards(telegram_rep
     assert "1. 반도체/소부장" in full
     assert "+12.33%" in full
     assert "3,801억" in full
+    assert "종합점수 12.17" in full
     assert "테스 +14.9% 1,930억" in full
 
 

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -109,7 +109,54 @@ async def test_builds_theme_report_from_ranking_data():
     assert semi["fi_net_buy_won"] == 350_000_000
     assert semi["program_net_buy_won"] == 6_000_000_000
     assert semi["flow_ratio"] == 1.67
+    assert semi["value_weighted_change_rate"] == 12.41
+    assert semi["zero_trading_value_ratio"] == 0.0
+    assert semi["negative_trading_value_ratio"] == 2.63
+    assert semi["theme_score"] == 17.5
     assert [leader["code"] for leader in semi["leaders"][:3]] == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+async def test_ranks_liquid_theme_above_thin_high_change_theme():
+    groups = {
+        "저유동성급등": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("A", "급등1"),
+                _member("B", "급등2"),
+                _member("C", "급등3"),
+            ],
+        },
+        "대금동반상승": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("D", "대금1"),
+                _member("E", "대금2"),
+                _member("F", "대금3"),
+            ],
+        },
+    }
+    svc, _ = _service(groups)
+    rankings = {
+        "all_stocks": [
+            _stock("A", "급등1", 10.0, 200_000_000),
+            _stock("B", "급등2", 9.0, 0),
+            _stock("C", "급등3", 8.0, 0),
+            _stock("D", "대금1", 5.0, 300_000_000_000),
+            _stock("E", "대금2", 4.0, 250_000_000_000),
+            _stock("F", "대금3", 3.0, 200_000_000_000),
+        ],
+        "program_all_stocks": [],
+    }
+
+    resp = await svc.build_daily_theme_report(rankings, "20260630")
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [item["normalized_name"] for item in resp.data] == ["대금동반상승", "저유동성급등"]
+    liquid, thin = resp.data
+    assert liquid["leader_avg_change_rate"] < thin["leader_avg_change_rate"]
+    assert liquid["theme_score"] > thin["theme_score"]
+    assert thin["zero_trading_value_ratio"] == 66.67
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -34,7 +34,7 @@ def _make_response(data):
 
 
 def _make_task(*, now=None, open_now=True, basic_rankings=None, service_response=None):
-    clock = _Clock(now or datetime(2026, 7, 6, 10, 3, 0), open_now=open_now)
+    clock = _Clock(now or datetime(2026, 7, 6, 10, 10, 0), open_now=open_now)
     ranking_task = MagicMock()
     ranking_task.refresh_basic_ranking = AsyncMock()
     basic_rankings = basic_rankings if basic_rankings is not None else {
@@ -94,7 +94,7 @@ def _make_task(*, now=None, open_now=True, basic_rankings=None, service_response
 
 
 @pytest.mark.asyncio
-async def test_open_tick_sends_intraday_theme_report_for_current_30m_slot():
+async def test_open_tick_sends_intraday_theme_report_for_current_hourly_slot():
     deps = _make_task()
 
     await deps.task._tick()
@@ -107,37 +107,47 @@ async def test_open_tick_sends_intraday_theme_report_for_current_30m_slot():
     samsung = next(item for item in rankings["all_stocks"] if item["stck_shrn_iscd"] == "005930")
     assert samsung["acml_tr_pbmn"] == "80000000"
     deps.theme_service.build_daily_theme_report.assert_awaited_once()
-    assert deps.theme_service.build_daily_theme_report.await_args.kwargs["report_date"] == "20260706 10:00"
+    assert deps.theme_service.build_daily_theme_report.await_args.kwargs["report_date"] == "20260706 10:10"
     deps.telegram_reporter.send_daily_theme_report.assert_awaited_once_with(
         [{"normalized_name": "반도체", "leaders": []}],
-        report_date="20260706 10:00",
+        report_date="20260706 10:10",
     )
     progress = deps.task.get_progress()
-    assert progress["last_report_slot"] == "20260706 10:00"
+    assert progress["last_report_slot"] == "20260706 10:10"
     assert progress["sent_count"] == 1
 
 
 @pytest.mark.asyncio
-async def test_same_30m_slot_does_not_send_twice():
+async def test_same_hourly_slot_does_not_send_twice():
     deps = _make_task()
 
     await deps.task._tick()
-    deps.clock.now = datetime(2026, 7, 6, 10, 29, 0)
+    deps.clock.now = datetime(2026, 7, 6, 11, 9, 0)
     await deps.task._tick()
 
     deps.telegram_reporter.send_daily_theme_report.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_next_30m_slot_sends_again():
+async def test_next_hourly_slot_sends_again():
     deps = _make_task()
 
     await deps.task._tick()
-    deps.clock.now = datetime(2026, 7, 6, 10, 30, 0)
+    deps.clock.now = datetime(2026, 7, 6, 11, 10, 0)
     await deps.task._tick()
 
     assert deps.telegram_reporter.send_daily_theme_report.await_count == 2
-    assert deps.task.get_progress()["last_report_slot"] == "20260706 10:30"
+    assert deps.task.get_progress()["last_report_slot"] == "20260706 11:10"
+
+
+@pytest.mark.asyncio
+async def test_before_0910_skips_alert():
+    deps = _make_task(now=datetime(2026, 7, 6, 9, 9, 0))
+
+    await deps.task._tick()
+
+    deps.theme_service.build_daily_theme_report.assert_not_called()
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Rank daily themes by composite score instead of leader average change alone
- Add liquidity, value-weighted change, flow, and low-liquidity/downside-trading penalties to theme report data
- Show the composite score in the Telegram daily theme report

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_test -v