### PR TITLE
[codex] Add OpenAI leading stock analysis service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pykrx
 aiohttp
 beautifulsoup4
 python-telegram-bot>=13.15
+openai
 pyinstrument>=4.6.0
 debugpy>=1.8.20
 finance-datareader>=0.9.110

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ aiohttp
 beautifulsoup4
 python-telegram-bot>=13.15
 openai
+google-genai
 pyinstrument>=4.6.0
 debugpy>=1.8.20
 finance-datareader>=0.9.110

--- a/services/ai_analysis_service.py
+++ b/services/ai_analysis_service.py
@@ -1,15 +1,17 @@
-"""OpenAI Responses API 기반 얇은 분석 서비스."""
+"""AI provider 기반 얇은 분석 서비스."""
 from __future__ import annotations
 
 import inspect
 import json
 import logging
 import os
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Protocol, Sequence
 
 from common.types import ErrorCode, ResCommonResponse
 
 
+DEFAULT_AI_ANALYSIS_PROVIDER = "gemini"
+DEFAULT_GEMINI_ANALYSIS_MODEL = "gemini-3.1-flash-lite"
 DEFAULT_OPENAI_ANALYSIS_MODEL = "gpt-5.5"
 
 _LEADING_STOCK_INSTRUCTIONS = """
@@ -21,17 +23,117 @@ _LEADING_STOCK_INSTRUCTIONS = """
 """.strip()
 
 
+class AITextProvider(Protocol):
+    name: str
+    model: str
+
+    async def generate_analysis(self, instructions: str, input_text: str) -> str:
+        """분석 지침과 입력 텍스트를 받아 분석 결과 텍스트를 반환한다."""
+
+
+class OpenAIAnalysisProvider:
+    """OpenAI Responses API provider."""
+
+    name = "openai"
+
+    def __init__(self, client: Any | None = None, model: str | None = None):
+        self._client = client or self._create_default_client()
+        self.model = (
+            model
+            or os.getenv("AI_ANALYSIS_MODEL")
+            or os.getenv("OPENAI_ANALYSIS_MODEL")
+            or DEFAULT_OPENAI_ANALYSIS_MODEL
+        )
+
+    async def generate_analysis(self, instructions: str, input_text: str) -> str:
+        result = self._client.responses.create(
+            model=self.model,
+            instructions=instructions,
+            input=input_text,
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return self._extract_output_text(result)
+
+    @staticmethod
+    def _extract_output_text(response: Any) -> str:
+        output_text = getattr(response, "output_text", None)
+        if output_text:
+            return str(output_text).strip()
+        return ""
+
+    @staticmethod
+    def _create_default_client() -> Any:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as e:
+            raise RuntimeError("openai 패키지가 필요합니다. requirements.txt를 설치하세요.") from e
+        return AsyncOpenAI()
+
+
+class GeminiAnalysisProvider:
+    """Google GenAI SDK 기반 Gemini provider."""
+
+    name = "gemini"
+
+    def __init__(self, client: Any | None = None, model: str | None = None):
+        self._client = client or self._create_default_client()
+        self.model = (
+            model
+            or os.getenv("AI_ANALYSIS_MODEL")
+            or os.getenv("GEMINI_ANALYSIS_MODEL")
+            or DEFAULT_GEMINI_ANALYSIS_MODEL
+        )
+
+    async def generate_analysis(self, instructions: str, input_text: str) -> str:
+        result = self._client.aio.models.generate_content(
+            model=self.model,
+            contents=input_text,
+            config={"system_instruction": instructions},
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return self._extract_output_text(result)
+
+    @staticmethod
+    def _extract_output_text(response: Any) -> str:
+        output_text = getattr(response, "text", None)
+        if output_text:
+            return str(output_text).strip()
+        return ""
+
+    @staticmethod
+    def _create_default_client() -> Any:
+        try:
+            from google import genai
+        except ImportError as e:
+            raise RuntimeError("google-genai 패키지가 필요합니다. requirements.txt를 설치하세요.") from e
+
+        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if api_key:
+            return genai.Client(api_key=api_key)
+        return genai.Client()
+
+
 class AIAnalysisService:
     """정량 스캐너 결과를 AI 분석 텍스트로 변환하는 얇은 어댑터."""
 
     def __init__(
         self,
+        provider: AITextProvider | None = None,
         client: Any | None = None,
         model: str | None = None,
+        provider_name: str | None = None,
         logger=None,
     ):
-        self._client = client or self._create_default_client()
-        self._model = model or os.getenv("OPENAI_ANALYSIS_MODEL") or DEFAULT_OPENAI_ANALYSIS_MODEL
+        self._provider = provider or self._create_provider(
+            provider_name=self.resolve_provider_name(
+                provider_name=provider_name,
+                default_to_openai=client is not None,
+            ),
+            client=client,
+            model=model,
+        )
         self._logger = logger or logging.getLogger(__name__)
 
     async def analyze_leading_stocks(
@@ -60,19 +162,14 @@ class AIAnalysisService:
         input_text = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
 
         try:
-            result = self._client.responses.create(
-                model=self._model,
-                instructions=_LEADING_STOCK_INSTRUCTIONS,
-                input=input_text,
+            output_text = await self._provider.generate_analysis(
+                _LEADING_STOCK_INSTRUCTIONS,
+                input_text,
             )
-            if inspect.isawaitable(result):
-                result = await result
-
-            output_text = self._extract_output_text(result)
             if not output_text:
                 return ResCommonResponse(
                     rt_cd=ErrorCode.API_ERROR.value,
-                    msg1="OpenAI 응답에서 분석 텍스트를 찾을 수 없습니다.",
+                    msg1="AI 응답에서 분석 텍스트를 찾을 수 없습니다.",
                     data=None,
                 )
 
@@ -81,7 +178,8 @@ class AIAnalysisService:
                 msg1="AI 분석 성공",
                 data={
                     "analysis": output_text,
-                    "model": self._model,
+                    "provider": self._provider.name,
+                    "model": self._provider.model,
                     "candidate_count": len(limited_candidates),
                 },
             )
@@ -94,16 +192,27 @@ class AIAnalysisService:
             )
 
     @staticmethod
-    def _extract_output_text(response: Any) -> str:
-        output_text = getattr(response, "output_text", None)
-        if output_text:
-            return str(output_text).strip()
-        return ""
+    def resolve_provider_name(
+        provider_name: str | None = None,
+        *,
+        default_to_openai: bool = False,
+    ) -> str:
+        raw = provider_name or os.getenv("AI_ANALYSIS_PROVIDER")
+        if raw:
+            return raw.strip().lower()
+        if default_to_openai:
+            return "openai"
+        return DEFAULT_AI_ANALYSIS_PROVIDER
 
     @staticmethod
-    def _create_default_client() -> Any:
-        try:
-            from openai import AsyncOpenAI
-        except ImportError as e:
-            raise RuntimeError("openai 패키지가 필요합니다. requirements.txt를 설치하세요.") from e
-        return AsyncOpenAI()
+    def _create_provider(
+        *,
+        provider_name: str,
+        client: Any | None = None,
+        model: str | None = None,
+    ) -> AITextProvider:
+        if provider_name == "openai":
+            return OpenAIAnalysisProvider(client=client, model=model)
+        if provider_name == "gemini":
+            return GeminiAnalysisProvider(client=client, model=model)
+        raise ValueError(f"지원하지 않는 AI 분석 provider입니다: {provider_name}")

--- a/services/ai_analysis_service.py
+++ b/services/ai_analysis_service.py
@@ -1,0 +1,109 @@
+"""OpenAI Responses API 기반 얇은 분석 서비스."""
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import os
+from typing import Any, Mapping, Sequence
+
+from common.types import ErrorCode, ResCommonResponse
+
+
+DEFAULT_OPENAI_ANALYSIS_MODEL = "gpt-5.5"
+
+_LEADING_STOCK_INSTRUCTIONS = """
+너는 한국 주식 자동매매 시스템의 주도주 후보 분석 보조자다.
+제공된 데이터만 근거로 판단하고, 데이터에 없는 뉴스/재무/수급을 추측하지 않는다.
+매수/매도 지시가 아니라 후보 해설, 강한 근거, 약한 근거, 리스크, 추가 확인 포인트만 작성한다.
+불확실하거나 데이터가 부족하면 그 사실을 명확히 말한다.
+응답은 한국어로 간결하게 작성한다.
+""".strip()
+
+
+class AIAnalysisService:
+    """정량 스캐너 결과를 AI 분석 텍스트로 변환하는 얇은 어댑터."""
+
+    def __init__(
+        self,
+        client: Any | None = None,
+        model: str | None = None,
+        logger=None,
+    ):
+        self._client = client or self._create_default_client()
+        self._model = model or os.getenv("OPENAI_ANALYSIS_MODEL") or DEFAULT_OPENAI_ANALYSIS_MODEL
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def analyze_leading_stocks(
+        self,
+        candidates: Sequence[Mapping[str, Any]],
+        *,
+        market_context: Mapping[str, Any] | None = None,
+        max_candidates: int = 20,
+    ) -> ResCommonResponse:
+        """주도주 후보 목록을 OpenAI Responses API로 해설한다."""
+        candidate_list = [dict(item) for item in candidates or []]
+        if not candidate_list:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.EMPTY_VALUES.value,
+                msg1="AI 분석 대상 후보가 없습니다.",
+                data=None,
+            )
+
+        limited_candidates = candidate_list[:max(1, max_candidates)]
+        payload = {
+            "analysis_type": "leading_stock_candidates",
+            "candidate_count": len(limited_candidates),
+            "market_context": dict(market_context or {}),
+            "candidates": limited_candidates,
+        }
+        input_text = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+
+        try:
+            result = self._client.responses.create(
+                model=self._model,
+                instructions=_LEADING_STOCK_INSTRUCTIONS,
+                input=input_text,
+            )
+            if inspect.isawaitable(result):
+                result = await result
+
+            output_text = self._extract_output_text(result)
+            if not output_text:
+                return ResCommonResponse(
+                    rt_cd=ErrorCode.API_ERROR.value,
+                    msg1="OpenAI 응답에서 분석 텍스트를 찾을 수 없습니다.",
+                    data=None,
+                )
+
+            return ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="AI 분석 성공",
+                data={
+                    "analysis": output_text,
+                    "model": self._model,
+                    "candidate_count": len(limited_candidates),
+                },
+            )
+        except Exception as e:
+            self._logger.exception(f"AIAnalysisService.analyze_leading_stocks 오류: {e}")
+            return ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1=str(e),
+                data=None,
+            )
+
+    @staticmethod
+    def _extract_output_text(response: Any) -> str:
+        output_text = getattr(response, "output_text", None)
+        if output_text:
+            return str(output_text).strip()
+        return ""
+
+    @staticmethod
+    def _create_default_client() -> Any:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as e:
+            raise RuntimeError("openai 패키지가 필요합니다. requirements.txt를 설치하세요.") from e
+        return AsyncOpenAI()

--- a/tests/unit_test/services/test_ai_analysis_service.py
+++ b/tests/unit_test/services/test_ai_analysis_service.py
@@ -1,0 +1,94 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from common.types import ErrorCode
+from services.ai_analysis_service import AIAnalysisService
+
+
+class _FakeResponses:
+    def __init__(self, output_text="분석 결과"):
+        self.output_text = output_text
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(output_text=self.output_text)
+
+
+class _FakeClient:
+    def __init__(self, output_text="분석 결과"):
+        self.responses = _FakeResponses(output_text=output_text)
+
+
+@pytest.mark.asyncio
+async def test_analyze_leading_stocks_sends_compact_json_to_responses_api():
+    client = _FakeClient(output_text="삼성전자는 거래대금과 RS가 강합니다.")
+    service = AIAnalysisService(client=client, model="gpt-test")
+
+    resp = await service.analyze_leading_stocks(
+        candidates=[
+            {
+                "code": "005930",
+                "name": "삼성전자",
+                "change_rate": 4.2,
+                "rs_rating": 92,
+                "trading_value_rank": 3,
+            }
+        ],
+        market_context={"trade_date": "20260707", "market": "KRX"},
+    )
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data["analysis"] == "삼성전자는 거래대금과 RS가 강합니다."
+    assert resp.data["model"] == "gpt-test"
+    assert resp.data["candidate_count"] == 1
+
+    call = client.responses.calls[0]
+    assert call["model"] == "gpt-test"
+    assert "제공된 데이터만" in call["instructions"]
+
+    payload = json.loads(call["input"])
+    assert payload["analysis_type"] == "leading_stock_candidates"
+    assert payload["market_context"]["trade_date"] == "20260707"
+    assert payload["candidates"][0]["code"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_analyze_leading_stocks_limits_candidates_before_api_call():
+    client = _FakeClient()
+    service = AIAnalysisService(client=client, model="gpt-test")
+
+    candidates = [
+        {"code": "000001", "name": "A"},
+        {"code": "000002", "name": "B"},
+        {"code": "000003", "name": "C"},
+    ]
+    resp = await service.analyze_leading_stocks(candidates, max_candidates=2)
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    payload = json.loads(client.responses.calls[0]["input"])
+    assert [item["code"] for item in payload["candidates"]] == ["000001", "000002"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_leading_stocks_returns_empty_values_without_candidates():
+    client = _FakeClient()
+    service = AIAnalysisService(client=client, model="gpt-test")
+
+    resp = await service.analyze_leading_stocks([])
+
+    assert resp.rt_cd == ErrorCode.EMPTY_VALUES.value
+    assert client.responses.calls == []
+
+
+@pytest.mark.asyncio
+async def test_analyze_leading_stocks_returns_api_error_when_output_text_missing():
+    client = _FakeClient(output_text="")
+    service = AIAnalysisService(client=client, model="gpt-test")
+
+    resp = await service.analyze_leading_stocks([{"code": "005930", "name": "삼성전자"}])
+
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+    assert resp.data is None

--- a/tests/unit_test/services/test_ai_analysis_service.py
+++ b/tests/unit_test/services/test_ai_analysis_service.py
@@ -4,10 +4,27 @@ from types import SimpleNamespace
 import pytest
 
 from common.types import ErrorCode
-from services.ai_analysis_service import AIAnalysisService
+from services.ai_analysis_service import (
+    AIAnalysisService,
+    GeminiAnalysisProvider,
+    OpenAIAnalysisProvider,
+)
 
 
-class _FakeResponses:
+class _FakeProvider:
+    name = "fake"
+    model = "fake-model"
+
+    def __init__(self, output_text="분석 결과"):
+        self.output_text = output_text
+        self.calls = []
+
+    async def generate_analysis(self, instructions: str, input_text: str) -> str:
+        self.calls.append({"instructions": instructions, "input_text": input_text})
+        return self.output_text
+
+
+class _FakeOpenAIResponses:
     def __init__(self, output_text="분석 결과"):
         self.output_text = output_text
         self.calls = []
@@ -17,15 +34,35 @@ class _FakeResponses:
         return SimpleNamespace(output_text=self.output_text)
 
 
-class _FakeClient:
+class _FakeOpenAIClient:
     def __init__(self, output_text="분석 결과"):
-        self.responses = _FakeResponses(output_text=output_text)
+        self.responses = _FakeOpenAIResponses(output_text=output_text)
+
+
+class _FakeGeminiModels:
+    def __init__(self, output_text="분석 결과"):
+        self.output_text = output_text
+        self.calls = []
+
+    async def generate_content(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(text=self.output_text)
+
+
+class _FakeGeminiAio:
+    def __init__(self, output_text="분석 결과"):
+        self.models = _FakeGeminiModels(output_text=output_text)
+
+
+class _FakeGeminiClient:
+    def __init__(self, output_text="분석 결과"):
+        self.aio = _FakeGeminiAio(output_text=output_text)
 
 
 @pytest.mark.asyncio
-async def test_analyze_leading_stocks_sends_compact_json_to_responses_api():
-    client = _FakeClient(output_text="삼성전자는 거래대금과 RS가 강합니다.")
-    service = AIAnalysisService(client=client, model="gpt-test")
+async def test_analyze_leading_stocks_sends_compact_json_to_provider():
+    provider = _FakeProvider(output_text="삼성전자는 거래대금과 RS가 강합니다.")
+    service = AIAnalysisService(provider=provider)
 
     resp = await service.analyze_leading_stocks(
         candidates=[
@@ -42,14 +79,14 @@ async def test_analyze_leading_stocks_sends_compact_json_to_responses_api():
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
     assert resp.data["analysis"] == "삼성전자는 거래대금과 RS가 강합니다."
-    assert resp.data["model"] == "gpt-test"
+    assert resp.data["model"] == "fake-model"
+    assert resp.data["provider"] == "fake"
     assert resp.data["candidate_count"] == 1
 
-    call = client.responses.calls[0]
-    assert call["model"] == "gpt-test"
+    call = provider.calls[0]
     assert "제공된 데이터만" in call["instructions"]
 
-    payload = json.loads(call["input"])
+    payload = json.loads(call["input_text"])
     assert payload["analysis_type"] == "leading_stock_candidates"
     assert payload["market_context"]["trade_date"] == "20260707"
     assert payload["candidates"][0]["code"] == "005930"
@@ -57,8 +94,8 @@ async def test_analyze_leading_stocks_sends_compact_json_to_responses_api():
 
 @pytest.mark.asyncio
 async def test_analyze_leading_stocks_limits_candidates_before_api_call():
-    client = _FakeClient()
-    service = AIAnalysisService(client=client, model="gpt-test")
+    provider = _FakeProvider()
+    service = AIAnalysisService(provider=provider)
 
     candidates = [
         {"code": "000001", "name": "A"},
@@ -68,27 +105,73 @@ async def test_analyze_leading_stocks_limits_candidates_before_api_call():
     resp = await service.analyze_leading_stocks(candidates, max_candidates=2)
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
-    payload = json.loads(client.responses.calls[0]["input"])
+    payload = json.loads(provider.calls[0]["input_text"])
     assert [item["code"] for item in payload["candidates"]] == ["000001", "000002"]
 
 
 @pytest.mark.asyncio
 async def test_analyze_leading_stocks_returns_empty_values_without_candidates():
-    client = _FakeClient()
-    service = AIAnalysisService(client=client, model="gpt-test")
+    provider = _FakeProvider()
+    service = AIAnalysisService(provider=provider)
 
     resp = await service.analyze_leading_stocks([])
 
     assert resp.rt_cd == ErrorCode.EMPTY_VALUES.value
-    assert client.responses.calls == []
+    assert provider.calls == []
 
 
 @pytest.mark.asyncio
 async def test_analyze_leading_stocks_returns_api_error_when_output_text_missing():
-    client = _FakeClient(output_text="")
-    service = AIAnalysisService(client=client, model="gpt-test")
+    provider = _FakeProvider(output_text="")
+    service = AIAnalysisService(provider=provider)
 
     resp = await service.analyze_leading_stocks([{"code": "005930", "name": "삼성전자"}])
 
     assert resp.rt_cd == ErrorCode.API_ERROR.value
     assert resp.data is None
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_uses_responses_api():
+    client = _FakeOpenAIClient(output_text="OpenAI 분석")
+    provider = OpenAIAnalysisProvider(client=client, model="gpt-test")
+
+    result = await provider.generate_analysis("지침", "입력")
+
+    assert result == "OpenAI 분석"
+    assert provider.name == "openai"
+    assert provider.model == "gpt-test"
+    assert client.responses.calls == [{
+        "model": "gpt-test",
+        "instructions": "지침",
+        "input": "입력",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_gemini_provider_uses_generate_content_with_system_instruction():
+    client = _FakeGeminiClient(output_text="Gemini 분석")
+    provider = GeminiAnalysisProvider(client=client, model="gemini-test")
+
+    result = await provider.generate_analysis("지침", "입력")
+
+    assert result == "Gemini 분석"
+    assert provider.name == "gemini"
+    assert provider.model == "gemini-test"
+
+    call = client.aio.models.calls[0]
+    assert call["model"] == "gemini-test"
+    assert call["contents"] == "입력"
+    assert call["config"]["system_instruction"] == "지침"
+
+
+def test_default_provider_is_gemini(monkeypatch):
+    monkeypatch.delenv("AI_ANALYSIS_PROVIDER", raising=False)
+
+    assert AIAnalysisService.resolve_provider_name() == "gemini"
+
+
+def test_provider_name_can_be_overridden_by_env(monkeypatch):
+    monkeypatch.setenv("AI_ANALYSIS_PROVIDER", "openai")
+
+    assert AIAnalysisService.resolve_provider_name() == "openai"


### PR DESCRIPTION
## Summary
- Add a thin `AIAnalysisService` for OpenAI Responses API-based leading stock candidate analysis.
- Send scanner-selected candidates as compact JSON and constrain the prompt to provided data only.
- Add unit coverage with an injected fake OpenAI client and add the `openai` SDK dependency.

## Validation
- `python -m pytest tests/unit_test/services/test_ai_analysis_service.py -v -n0`
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`