### PR TITLE
[codex] Combine market timing alerts

### DIFF
--- a/services/backtest_microstructure_quality.py
+++ b/services/backtest_microstructure_quality.py
@@ -38,6 +38,11 @@ def summarize_capture_quality(
     ]
     stale_by_code = quality.get("stale_minute_rows_dropped") or {}
     stale_rows = sum(_to_int(value) for value in stale_by_code.values())
+    stale_by_code = {
+        str(code): _to_int(value)
+        for code, value in stale_by_code.items()
+        if _to_int(value) > 0
+    }
 
     intraday_available = sum(1 for code in codes if bool(intraday.get(code)))
     execution_strength_available = sum(
@@ -108,6 +113,7 @@ def summarize_capture_quality(
         "execution_strength_db_coverage_pct": execution_strength_db_coverage_pct,
         "empty_minute_codes": quality.get("empty_minute_codes") or [],
         "stale_minute_rows_dropped": stale_rows,
+        "stale_minute_rows_dropped_by_code": stale_by_code,
         "issues": issues,
         "quality_gate_passed": not issues,
     }

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1009,6 +1009,8 @@ class OneilUniverseService:
 
     async def _update_market_timing(self, caller: str = "", logger: Optional[logging.Logger] = None):
         logger = logger or self._logger
+        notification_rows = []
+        overall_level = NotificationLevel.INFO
         for market, code in [("KOSDAQ", self._cfg.kosdaq_etf_code), ("KOSPI", self._cfg.kospi_etf_code)]:
             snap = await self._regime_svc.classify(market, logger=logger)
             is_rising = snap.is_rising
@@ -1024,28 +1026,33 @@ class OneilUniverseService:
             if self._notification_service:
                 status_text = "🟢 매수 적합 (우상향)" if is_rising else "🔴 매수 부적합 (추세 꺾임)"
                 level = NotificationLevel.INFO if is_rising else NotificationLevel.WARNING
+                if level == NotificationLevel.WARNING:
+                    overall_level = NotificationLevel.WARNING
 
                 ma_str = " ➔ ".join([f"{v:.2f}" for v in snap.ma_values])
                 msg = f"• 지수: {market} ({code})\n• 상태: {status_text}\n"
                 if not is_rising and snap.fail_detail:
                     msg += f"• 사유: {snap.fail_detail}\n"
                 msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"
+                notification_rows.append(msg)
 
-                title = f"마켓 타이밍 갱신 ({market})"
-                if caller:
-                    title = f"[{caller}] {title}"
+        if self._notification_service and notification_rows:
+            title = "마켓 타이밍 갱신"
+            if caller:
+                title = f"[{caller}] {title}"
 
-                await self._notification_service.emit(
-                    category=NotificationCategory.STRATEGY,
-                    level=level,
-                    title=title,
-                    message=msg,
-                    metadata={
-                        "force_external": True,
-                        "event": "market_timing_updated",
-                        "market": market,
-                    },
-                )
+            await self._notification_service.emit(
+                category=NotificationCategory.STRATEGY,
+                level=overall_level,
+                title=title,
+                message="\n\n".join(notification_rows),
+                metadata={
+                    "force_external": True,
+                    "event": "market_timing_updated",
+                    "market": "ALL",
+                    "markets": ["KOSDAQ", "KOSPI"],
+                },
+            )
 
     def _compute_rs_scores(
         self,

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -228,7 +228,7 @@ class ThemeDailyLeaderService:
             leader_avg_change_rate * 0.45
             + value_weighted_change_rate * 0.20
             + advancing_ratio * 0.03
-            + trading_value_score * 2.0
+            + trading_value_score * 0.8
             + clipped_flow_ratio * 0.10
             - zero_trading_value_ratio * 0.05
             - negative_trading_value_ratio * 0.04

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Optional
@@ -35,6 +36,8 @@ class MicrostructureCaptureTask(AfterMarketTask):
         max_codes: int = 40,
         logger=None,
         notification_service=None,
+        quality_retry_attempts: int = 1,
+        quality_retry_delay_sec: float = 15 * 60,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -50,6 +53,8 @@ class MicrostructureCaptureTask(AfterMarketTask):
         self._execution_strength_db_path = Path(execution_strength_db_path)
         self._max_codes = max_codes
         self._notification_service = notification_service
+        self._quality_retry_attempts = max(0, int(quality_retry_attempts))
+        self._quality_retry_delay_sec = max(0.0, float(quality_retry_delay_sec))
         # 재시작 시 catch-up 중복 캡처 방지를 위해 "마지막 캡처 날짜"를 영속화한다.
         self._scheduler_store = scheduler_store
         self._state_key = "microstructure_capture_last_date"
@@ -129,9 +134,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
         )
         self._progress["running"] = True
         try:
-            payload = await self._service.capture(
+            payload, quality_summary = await self._capture_with_quality_retry(
                 codes=codes,
-                date_ymd=latest_trading_date,
+                latest_trading_date=latest_trading_date,
                 program_source=program_source,
                 execution_strength_source=execution_strength_source,
             )
@@ -144,10 +149,6 @@ class MicrostructureCaptureTask(AfterMarketTask):
             program_fallback_codes = metadata.get("program_fallback_codes") or []
             execution_strength_fallback_codes = (
                 metadata.get("execution_strength_fallback_codes") or []
-            )
-            quality_summary = summarize_capture_quality(
-                payload,
-                fallback_codes=codes,
             )
             self._progress["last_result"] = {
                 "codes": len(codes),
@@ -188,6 +189,57 @@ class MicrostructureCaptureTask(AfterMarketTask):
         finally:
             self._progress["running"] = False
 
+    async def _capture_with_quality_retry(
+        self,
+        *,
+        codes: list[str],
+        latest_trading_date: str,
+        program_source: str,
+        execution_strength_source: str,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        payload = await self._capture_once(
+            codes=codes,
+            latest_trading_date=latest_trading_date,
+            program_source=program_source,
+            execution_strength_source=execution_strength_source,
+        )
+        quality_summary = summarize_capture_quality(payload, fallback_codes=codes)
+
+        for attempt in range(self._quality_retry_attempts):
+            if "intraday_coverage_below_threshold" not in quality_summary["issues"]:
+                break
+            self._logger.warning(
+                f"{self.task_name}: {latest_trading_date} intraday 분봉 품질 낮음 "
+                f"(intraday={quality_summary['intraday_coverage_pct']:.1f}%) — "
+                f"{self._quality_retry_delay_sec:.0f}초 후 재시도 "
+                f"({attempt + 1}/{self._quality_retry_attempts})"
+            )
+            await asyncio.sleep(self._quality_retry_delay_sec)
+            payload = await self._capture_once(
+                codes=codes,
+                latest_trading_date=latest_trading_date,
+                program_source=program_source,
+                execution_strength_source=execution_strength_source,
+            )
+            quality_summary = summarize_capture_quality(payload, fallback_codes=codes)
+
+        return payload, quality_summary
+
+    async def _capture_once(
+        self,
+        *,
+        codes: list[str],
+        latest_trading_date: str,
+        program_source: str,
+        execution_strength_source: str,
+    ) -> dict[str, Any]:
+        return await self._service.capture(
+            codes=codes,
+            date_ymd=latest_trading_date,
+            program_source=program_source,
+            execution_strength_source=execution_strength_source,
+        )
+
     async def _emit_quality_gate_warning(
         self,
         latest_trading_date: str,
@@ -197,7 +249,12 @@ class MicrostructureCaptureTask(AfterMarketTask):
             return
         empty_minute_codes = quality_summary.get("empty_minute_codes") or []
         stale_minute_rows_dropped = quality_summary.get("stale_minute_rows_dropped") or 0
+        stale_minute_rows_dropped_by_code = (
+            quality_summary.get("stale_minute_rows_dropped_by_code") or {}
+        )
         program_fallback_codes = quality_summary.get("program_fallback_codes") or []
+        empty_detail = _format_code_list(empty_minute_codes)
+        stale_detail = _format_stale_by_code(stale_minute_rows_dropped_by_code)
         await self._notification_service.emit(
             NotificationCategory.BACKGROUND,
             NotificationLevel.WARNING,
@@ -206,8 +263,8 @@ class MicrostructureCaptureTask(AfterMarketTask):
             f"intraday={quality_summary['intraday_coverage_pct']:.1f}%, "
             f"program={quality_summary['program_overlay_coverage_pct']:.1f}%, "
             f"program_db={format_optional_pct(quality_summary['program_db_coverage_pct'])}, "
-            f"empty_minutes={len(empty_minute_codes)}, "
-            f"stale_dropped={stale_minute_rows_dropped}",
+            f"empty_minutes={len(empty_minute_codes)}{empty_detail}, "
+            f"stale_dropped={stale_minute_rows_dropped}{stale_detail}",
             metadata={
                 "alert_type": "microstructure_capture_quality_gate",
                 "trade_date": latest_trading_date,
@@ -219,6 +276,24 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 "program_db_coverage_pct": quality_summary["program_db_coverage_pct"],
                 "empty_minute_codes": empty_minute_codes,
                 "stale_minute_rows_dropped": stale_minute_rows_dropped,
+                "stale_minute_rows_dropped_by_code": stale_minute_rows_dropped_by_code,
                 "program_fallback_codes": program_fallback_codes,
             },
         )
+
+
+def _format_code_list(codes: list[str], *, limit: int = 8) -> str:
+    if not codes:
+        return ""
+    visible = [str(code) for code in codes[:limit]]
+    suffix = "" if len(codes) <= limit else f", +{len(codes) - limit}"
+    return f" [{','.join(visible)}{suffix}]"
+
+
+def _format_stale_by_code(stale_by_code: dict[str, int], *, limit: int = 8) -> str:
+    if not stale_by_code:
+        return ""
+    items = list(stale_by_code.items())[:limit]
+    visible = [f"{code}:{count}" for code, count in items]
+    suffix = "" if len(stale_by_code) <= limit else f", +{len(stale_by_code) - limit}"
+    return f" [{','.join(visible)}{suffix}]"

--- a/task/background/intraday/theme_intraday_leader_alert_task.py
+++ b/task/background/intraday/theme_intraday_leader_alert_task.py
@@ -20,6 +20,7 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
 
     CHECK_INTERVAL_SEC = 60
     ALERT_INTERVAL_SEC = 60 * 60
+    ALERT_GRACE_SEC = 120
     ALERT_START_HOUR = 9
     ALERT_START_MINUTE = 10
 
@@ -33,6 +34,7 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
         market_clock: Optional["MarketClock"] = None,
         check_interval_sec: Optional[int] = None,
         alert_interval_sec: Optional[int] = None,
+        alert_grace_sec: Optional[int] = None,
         logger=None,
     ) -> None:
         self._ranking_task = ranking_task
@@ -42,6 +44,7 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
         self._market_clock = market_clock
         self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
         self._alert_interval_sec = alert_interval_sec or self.ALERT_INTERVAL_SEC
+        self._alert_grace_sec = alert_grace_sec or self.ALERT_GRACE_SEC
         self._logger = logger or logging.getLogger(__name__)
         self._state = TaskState.IDLE
         self._tasks: List[asyncio.Task] = []
@@ -147,6 +150,8 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
             return None
         elapsed = int((now - start).total_seconds())
         slot_elapsed = elapsed - (elapsed % self._alert_interval_sec)
+        if elapsed - slot_elapsed > self._alert_grace_sec:
+            return None
         slot = start + timedelta(seconds=slot_elapsed)
         return slot.strftime("%Y%m%d %H:%M")
 

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1763,7 +1763,7 @@ async def test_analyze_surge_candidate_filter_branches_after_candle_merge(mock_d
 
 @pytest.mark.asyncio
 async def test_update_market_timing_emits_notifications(mock_deps):
-    """마켓 타이밍 갱신 시 상승/하락 모두 알림을 발행한다."""
+    """마켓 타이밍 갱신 시 KOSDAQ/KOSPI를 하나의 알림에 함께 담아 발행한다."""
     _, sqs, indicator, mapper, tm, logger = mock_deps
     notification = AsyncMock()
     service = OneilUniverseService(sqs, indicator, mapper, tm, logger=logger, notification_service=notification)
@@ -1784,14 +1784,19 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     ])
     await service._update_market_timing(caller="tester", logger=logger)
 
-    assert notification.emit.await_count == 2
-    first_call = notification.emit.await_args_list[0].kwargs
-    second_call = notification.emit.await_args_list[1].kwargs
-    assert first_call["level"] == service._notification_service.emit.await_args_list[0].kwargs["level"]
-    assert "[tester] 마켓 타이밍 갱신 (KOSDAQ)" == first_call["title"]
-    assert first_call["metadata"] == {"force_external": True, "event": "market_timing_updated", "market": "KOSDAQ"}
-    assert second_call["metadata"] == {"force_external": True, "event": "market_timing_updated", "market": "KOSPI"}
-    assert "MA decline" in second_call["message"]
+    notification.emit.assert_awaited_once()
+    call_kwargs = notification.emit.await_args.kwargs
+    assert call_kwargs["level"].value == "warning"
+    assert "[tester] 마켓 타이밍 갱신" == call_kwargs["title"]
+    assert call_kwargs["metadata"] == {
+        "force_external": True,
+        "event": "market_timing_updated",
+        "market": "ALL",
+        "markets": ["KOSDAQ", "KOSPI"],
+    }
+    assert "KOSDAQ" in call_kwargs["message"]
+    assert "KOSPI" in call_kwargs["message"]
+    assert "MA decline" in call_kwargs["message"]
 
 
 def test_compute_rs_scores_rating_mode(mock_deps):

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -98,9 +98,9 @@ async def test_builds_theme_report_from_ranking_data():
     resp = await svc.build_daily_theme_report(rankings, "20260630")
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
-    assert [item["normalized_name"] for item in resp.data] == ["반도체/소부장", "우주항공"]
+    assert [item["normalized_name"] for item in resp.data] == ["우주항공", "반도체/소부장"]
 
-    semi = resp.data[0]
+    semi = next(item for item in resp.data if item["normalized_name"] == "반도체/소부장")
     assert semi["scored_member_count"] == 4
     assert semi["advance_count"] == 3
     assert semi["advancing_ratio"] == 75.0
@@ -112,7 +112,7 @@ async def test_builds_theme_report_from_ranking_data():
     assert semi["value_weighted_change_rate"] == 12.41
     assert semi["zero_trading_value_ratio"] == 0.0
     assert semi["negative_trading_value_ratio"] == 2.63
-    assert semi["theme_score"] == 17.5
+    assert semi["theme_score"] == 13.21
     assert [leader["code"] for leader in semi["leaders"][:3]] == ["A", "B", "C"]
 
 
@@ -157,6 +157,48 @@ async def test_ranks_liquid_theme_above_thin_high_change_theme():
     assert liquid["leader_avg_change_rate"] < thin["leader_avg_change_rate"]
     assert liquid["theme_score"] > thin["theme_score"]
     assert thin["zero_trading_value_ratio"] == 66.67
+
+
+@pytest.mark.asyncio
+async def test_high_liquidity_low_momentum_does_not_dominate_stronger_theme():
+    groups = {
+        "대형주저탄력": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("A", "대형1"),
+                _member("B", "대형2"),
+                _member("C", "대형3"),
+            ],
+        },
+        "중형주강세": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("D", "강세1"),
+                _member("E", "강세2"),
+                _member("F", "강세3"),
+            ],
+        },
+    }
+    svc, _ = _service(groups)
+    rankings = {
+        "all_stocks": [
+            _stock("A", "대형1", 1.5, 10_000_000_000_000),
+            _stock("B", "대형2", 1.0, 10_000_000_000_000),
+            _stock("C", "대형3", 0.5, 10_000_000_000_000),
+            _stock("D", "강세1", 8.0, 10_000_000_000),
+            _stock("E", "강세2", 7.0, 10_000_000_000),
+            _stock("F", "강세3", 6.0, 10_000_000_000),
+        ],
+        "program_all_stocks": [],
+    }
+
+    resp = await svc.build_daily_theme_report(rankings, "20260630")
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [item["normalized_name"] for item in resp.data] == ["중형주강세", "대형주저탄력"]
+    strong, mega = resp.data
+    assert strong["leader_avg_change_rate"] > mega["leader_avg_change_rate"]
+    assert strong["theme_score"] > mega["theme_score"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -19,6 +19,41 @@ def _payload(date="20260702"):
     }
 
 
+def _quality_payload(
+    *,
+    date="20260702",
+    codes=None,
+    intraday_minutes=None,
+    program_trades=None,
+    quality=None,
+):
+    codes = codes or ["005930", "000660"]
+    intraday_minutes = intraday_minutes or {code: [{}] for code in codes}
+    program_trades = program_trades or {
+        code: {"program_net_buy_qty": 1} for code in codes
+    }
+    return {
+        "metadata": {
+            "trade_date": date,
+            "codes": codes,
+            "program_source": "program_db",
+            "program_fallback_codes": [],
+            "quality": quality or {
+                "empty_minute_codes": [],
+                "stale_minute_rows_dropped": {},
+            },
+            "row_counts": {
+                "intraday_minutes": sum(len(rows) for rows in intraday_minutes.values()),
+                "execution_strength": len(codes),
+                "program_trades": sum(1 for value in program_trades.values() if value is not None),
+            },
+        },
+        "intraday_minutes": intraday_minutes,
+        "execution_strength": {code: 120.0 for code in codes},
+        "program_trades": program_trades,
+    }
+
+
 @pytest.fixture
 def capture_service():
     svc = MagicMock()
@@ -61,6 +96,7 @@ def _make_task(capture_service, tmp_path, **kwargs):
         program_db_path=tmp_path / "program_trading.db",
         execution_strength_db_path=tmp_path / "execution_strength.db",
         logger=MagicMock(),
+        quality_retry_attempts=0,
     )
     defaults.update(kwargs)
     return MicrostructureCaptureTask(**defaults)
@@ -297,7 +333,8 @@ async def test_quality_gate_failure_emits_background_warning_notification(
         NotificationCategory.BACKGROUND,
         NotificationLevel.WARNING,
         "Microstructure 캡처 품질 게이트 실패",
-        "20260702: intraday=50.0%, program=0.0%, program_db=0.0%, empty_minutes=1, stale_dropped=2",
+        "20260702: intraday=50.0%, program=0.0%, program_db=0.0%, "
+        "empty_minutes=1 [000660], stale_dropped=2 [005930:2]",
     )
     assert kwargs["metadata"]["issues"] == [
         "intraday_coverage_below_threshold",
@@ -307,7 +344,46 @@ async def test_quality_gate_failure_emits_background_warning_notification(
     assert kwargs["metadata"]["codes"] == 2
     assert kwargs["metadata"]["empty_minute_codes"] == ["000660"]
     assert kwargs["metadata"]["stale_minute_rows_dropped"] == 2
+    assert kwargs["metadata"]["stale_minute_rows_dropped_by_code"] == {"005930": 2}
     assert kwargs["metadata"]["program_fallback_codes"] == []
+
+
+@pytest.mark.asyncio
+async def test_intraday_quality_failure_retries_once_before_warning(
+    capture_service, universe_service, tmp_path
+):
+    first_payload = _quality_payload(
+        intraday_minutes={"005930": [{}], "000660": []},
+        quality={
+            "empty_minute_codes": ["000660"],
+            "stale_minute_rows_dropped": {},
+        },
+    )
+    retry_payload = _quality_payload()
+    capture_service.capture = AsyncMock(side_effect=[first_payload, retry_payload])
+    notification_service = MagicMock()
+    notification_service.emit = AsyncMock()
+    db_path = tmp_path / "program_trading.db"
+    db_path.write_bytes(b"")
+    task = _make_task(
+        capture_service,
+        tmp_path,
+        universe_service=universe_service,
+        program_db_path=db_path,
+        notification_service=notification_service,
+        quality_retry_attempts=1,
+        quality_retry_delay_sec=0,
+    )
+
+    await task._on_market_closed("20260702")
+
+    assert capture_service.capture.await_count == 2
+    capture_service.write_overlay_files.assert_called_once_with(
+        retry_payload,
+        tmp_path / "out",
+    )
+    notification_service.emit.assert_not_awaited()
+    assert task.get_progress()["last_result"]["quality_gate_passed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -141,6 +141,17 @@ async def test_next_hourly_slot_sends_again():
 
 
 @pytest.mark.asyncio
+async def test_late_restart_inside_hourly_slot_does_not_send_catchup_alert():
+    deps = _make_task(now=datetime(2026, 7, 6, 10, 41, 0))
+
+    await deps.task._tick()
+
+    deps.theme_service.build_daily_theme_report.assert_not_called()
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+    assert deps.task.get_progress()["last_report_slot"] is None
+
+
+@pytest.mark.asyncio
 async def test_before_0910_skips_alert():
     deps = _make_task(now=datetime(2026, 7, 6, 9, 9, 0))
 


### PR DESCRIPTION
## Summary
- combine KOSDAQ/KOSPI market timing updates into one background notification
- refine intraday theme leader alert ranking and suppress stale catch-up alerts after late restarts
- retry Microstructure intraday minute capture once after low coverage before emitting the quality gate warning
- include empty-minute codes and stale dropped rows by code in Microstructure quality alerts

## Tests
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`