### PR TITLE
일별 차트 조회 시 output1을 캔들로 오파싱하는 버그 수정

### DIFF
--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -435,8 +435,8 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
 
         raw = response_data.data
         if isinstance(raw, dict):
-            # KIS 관례: output1 = 요약/메타, output2 = 캔들 리스트
-            output_list = raw.get("output2") or raw.get("output") or raw.get("output1") or []
+            # KIS 관례: output1 = 요약/메타(캔들 아님, 폴백 대상 아님), output2 = 캔들 리스트
+            output_list = raw.get("output2") or raw.get("output") or []
         else:
             output_list = raw or []
 

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -740,6 +740,30 @@ async def test_inquire_daily_itemchartprice_parses_output2(mocker, mock_quotatio
 
 
 @pytest.mark.asyncio
+async def test_inquire_daily_itemchartprice_output2_empty_does_not_use_output1(mocker, mock_quotations):
+    """output2가 빈 리스트일 때 output1(현재가 요약)을 캔들 데이터로 오인해 파싱하면 안 된다."""
+    payload = {
+        "msg1": "정상처리 되었습니다.",
+        "msg_cd": "MCA00000",
+        "rt_cd": "0",
+        "output1": {"stck_shrn_iscd": "005930", "stck_prpr": "70000", "per": "12.34"},
+        "output2": [],
+    }
+    mocker.patch.object(
+        mock_quotations, "call_api",
+        return_value=ResCommonResponse(rt_cd="0", msg1="ok", data=payload)
+    )
+
+    res = await mock_quotations.inquire_daily_itemchartprice(
+        "005930", start_date="20250814", end_date="20250814", fid_period_div_code="D"
+    )
+
+    assert res.rt_cd == ErrorCode.SUCCESS.value
+    assert res.data == []
+    mock_quotations._logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_current_price_success(mock_quotations):
     """
     get_current_price가 정상적인 응답을 반환하는 경우를 테스트합니다.


### PR DESCRIPTION
## Summary
- `inquire_daily_itemchartprice`가 `output2`(캔들 리스트)가 빈 리스트일 때 `output1`(현재가 요약 dict)을 캔들 1건으로 오인해 파싱을 시도하던 버그를 수정. `output1`은 애초에 캔들 스키마(`stck_bsop_date`, `stck_oprc` 등)를 갖지 않아 매 호출마다 pydantic validation 경고가 발생하고 있었음(오늘 하루 로그 기준 955건).
- `output1` 폴백을 제거하고 `output2` 또는 `output` 키만 사용하도록 수정. `output2`가 정말 비어있으면 (정상적으로) 빈 리스트를 반환.
- 같은 파일의 `inquire_time_itemchartprice`는 `output1` 폴백이 의도된 동작(기존 테스트로 커버)이라 건드리지 않음.

## Test plan
- [x] TDD: 버그를 재현하는 실패 테스트(`test_inquire_daily_itemchartprice_output2_empty_does_not_use_output1`) 작성 후 수정으로 통과 확인
- [x] `pytest tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py` (99 passed)
- [x] `pytest tests/unit_test` 전체 (6702 passed)
- [x] `pytest tests/integration_test` 전체 (246 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)