### PR TITLE
표준 journal 전략명 별칭 통합 — 구 표시명을 현 ID로 read-time 정규화

### DIFF
--- a/common/trade_journal_schema.py
+++ b/common/trade_journal_schema.py
@@ -77,6 +77,22 @@ def _resolve_volatility(
     return None
 
 
+# 2026-05-26경 기록 전략명이 표시명→ID로 전환되며 과거 행이 두 표기로 갈라졌다.
+# gate 표본 카운트·journal 진행률이 전략명 단위이므로 read-time에 구 표시명을
+# 현 ID로 정규화한다. 원본 표기는 metadata(원본 row 복사본)에 보존된다.
+_LEGACY_STRATEGY_NAME_ALIASES = {
+    "래리윌리엄스VBO": "larry_williams_vbo",
+    "LarryWilliamsCB": "larry_williams_cb",
+    "RSI2눌림목": "rsi2_pullback",
+    "첫눌림목": "first_pullback",
+}
+
+
+def _canonical_strategy_name(name: Any) -> str:
+    raw = str(name or "")
+    return _LEGACY_STRATEGY_NAME_ALIASES.get(raw, raw)
+
+
 def normalize_virtual_trade(
     trade: Mapping[str, Any],
     *,
@@ -115,7 +131,7 @@ def normalize_virtual_trade(
 
     return _ordered_record(
         source=source,
-        strategy=str(trade.get("strategy") or ""),
+        strategy=_canonical_strategy_name(trade.get("strategy")),
         code=str(trade.get("code") or ""),
         signal_time=str(trade.get("buy_date") or ""),
         decision_reason="" if is_failed else reason,

--- a/repositories/program_trading_repo.py
+++ b/repositories/program_trading_repo.py
@@ -112,9 +112,21 @@ class ProgramTradingRepo:
 
                 conn.execute("""
                     CREATE TABLE IF NOT EXISTS pt_subscriptions (
-                        code TEXT PRIMARY KEY
+                        code TEXT PRIMARY KEY,
+                        source TEXT NOT NULL DEFAULT 'manual',
+                        updated_at REAL
                     )
                 """)
+                columns = {
+                    row[1]
+                    for row in conn.execute("PRAGMA table_info(pt_subscriptions)").fetchall()
+                }
+                if "source" not in columns:
+                    conn.execute(
+                        "ALTER TABLE pt_subscriptions ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'"
+                    )
+                if "updated_at" not in columns:
+                    conn.execute("ALTER TABLE pt_subscriptions ADD COLUMN updated_at REAL")
             self._logger.info("ProgramTradingRepo: SQLite DB 초기화 완료")
         except Exception as e:
             self._logger.error(f"SQLite DB 초기화 실패: {e}")

--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 import sqlite3
 import threading
+import time
 from enum import Enum
 from typing import Dict, Iterable, Optional, Set
 
@@ -42,6 +43,9 @@ class StreamingStockRepo:
     워치독은 get_pending()으로 "desired - active" 종목을 파악하여 재구독 처리한다.
     """
 
+    SOURCE_MANUAL = "manual"
+    SOURCE_PROGRAM = "program"
+
     def __init__(self, logger=None):
         self._logger = logger or logging.getLogger(__name__)
         self._desired: Dict[StreamingType, Set[str]] = {t: set() for t in StreamingType}
@@ -54,16 +58,37 @@ class StreamingStockRepo:
         self._db_path: Optional[str] = None
 
         # 배치 flush용 pending queue — 즉시 commit 대신 flush_pt_desired_sync()에서 일괄 처리
-        self._pending_desired_ops: list = []  # list of (code: str, add: bool)
+        self._pending_desired_ops: list = []  # list of (code: str, add: bool, source: str)
         self._pending_lock = threading.Lock()
+        self._pt_sources: Dict[str, str] = {}
 
     # ── 초기화 / 영속성 ──────────────────────────────────────────────
 
     def _ensure_pt_subscription_table_locked(self) -> None:
         """pt_subscriptions 테이블을 보장한다. 호출자는 _db_lock을 보유해야 한다."""
-        self._db_conn.execute(
-            "CREATE TABLE IF NOT EXISTS pt_subscriptions (code TEXT PRIMARY KEY)"
-        )
+        self._db_conn.execute("""
+            CREATE TABLE IF NOT EXISTS pt_subscriptions (
+                code TEXT PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'manual',
+                updated_at REAL
+            )
+        """)
+        columns = {
+            row[1]
+            for row in self._db_conn.execute("PRAGMA table_info(pt_subscriptions)").fetchall()
+        }
+        if "source" not in columns:
+            self._db_conn.execute(
+                "ALTER TABLE pt_subscriptions ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'"
+            )
+        if "updated_at" not in columns:
+            self._db_conn.execute(
+                "ALTER TABLE pt_subscriptions ADD COLUMN updated_at REAL"
+            )
+
+    @classmethod
+    def _normalize_source(cls, source: Optional[str]) -> str:
+        return cls.SOURCE_PROGRAM if source == cls.SOURCE_PROGRAM else cls.SOURCE_MANUAL
 
     @staticmethod
     def _normalize_codes(codes: Optional[Iterable[str]]) -> Set[str]:
@@ -93,29 +118,39 @@ class StreamingStockRepo:
             self._db_conn = sqlite3.connect(db_path, check_same_thread=False)
             with self._db_lock:
                 self._ensure_pt_subscription_table_locked()
-                cursor = self._db_conn.execute("SELECT code FROM pt_subscriptions")
-                codes = {row[0] for row in cursor.fetchall()}
+                cursor = self._db_conn.execute("SELECT code, source FROM pt_subscriptions")
+                source_rows = {
+                    row[0]: self._normalize_source(row[1])
+                    for row in cursor.fetchall()
+                }
+                codes = set(source_rows)
                 if not codes:
                     codes = self._normalize_codes(fallback_codes)
                     if codes:
+                        now = time.time()
                         self._db_conn.executemany(
-                            "INSERT OR IGNORE INTO pt_subscriptions (code) VALUES (?)",
-                            [(code,) for code in sorted(codes)],
+                            """
+                            INSERT OR IGNORE INTO pt_subscriptions (code, source, updated_at)
+                            VALUES (?, ?, ?)
+                            """,
+                            [(code, self.SOURCE_MANUAL, now) for code in sorted(codes)],
                         )
+                        source_rows = {code: self.SOURCE_MANUAL for code in codes}
                 self._db_conn.commit()
             # desired 초기화 (lock 불필요 — 앱 시작 단계, 단일 스레드)
             self._desired[StreamingType.PROGRAM_TRADING] = codes
+            self._pt_sources = source_rows
             if codes:
                 self._logger.info(f"StreamingStockRepo: PT desired 복원 {sorted(codes)}")
         except Exception as e:
             self._logger.warning(f"StreamingStockRepo: PT desired DB 복원 실패 (무시): {e}")
 
-    def _persist_pt_desired(self, code: str, add: bool) -> None:
+    def _persist_pt_desired(self, code: str, add: bool, source: str = "manual") -> None:
         """PT desired 변경을 pending queue에 적재. flush_pt_desired_sync()에서 일괄 커밋."""
         if self._db_conn is None:
             return
         with self._pending_lock:
-            self._pending_desired_ops.append((code, add))
+            self._pending_desired_ops.append((code, add, self._normalize_source(source)))
 
     def flush_pt_desired_sync(self) -> None:
         """pending queue의 PT desired 변경을 1회 트랜잭션으로 일괄 커밋."""
@@ -129,10 +164,23 @@ class StreamingStockRepo:
         try:
             with self._db_lock:
                 self._ensure_pt_subscription_table_locked()
-                for code, add in ops:
+                now = time.time()
+                for code, add, source in ops:
                     if add:
                         self._db_conn.execute(
-                            "INSERT OR IGNORE INTO pt_subscriptions (code) VALUES (?)", (code,)
+                            """
+                            INSERT OR IGNORE INTO pt_subscriptions (code, source, updated_at)
+                            VALUES (?, ?, ?)
+                            """,
+                            (code, source, now),
+                        )
+                        self._db_conn.execute(
+                            """
+                            UPDATE pt_subscriptions
+                            SET source = ?, updated_at = ?
+                            WHERE code = ?
+                            """,
+                            (source, now, code),
                         )
                     else:
                         self._db_conn.execute(
@@ -148,17 +196,27 @@ class StreamingStockRepo:
 
     # ── 상태 변경 (asyncio.Lock 보호) ────────────────────────────────
 
-    async def mark_desired(self, code: str, stream_type: StreamingType) -> None:
+    async def mark_desired(
+        self,
+        code: str,
+        stream_type: StreamingType,
+        source: str = "manual",
+    ) -> None:
         """종목을 구독 대상으로 등록한다."""
+        normalized_source = self._normalize_source(source)
         async with self._lock:
             self._desired[stream_type].add(code)
+            if stream_type == StreamingType.PROGRAM_TRADING:
+                self._pt_sources[code] = normalized_source
         if stream_type == StreamingType.PROGRAM_TRADING:
-            self._persist_pt_desired(code, add=True)
+            self._persist_pt_desired(code, add=True, source=normalized_source)
 
     async def unmark_desired(self, code: str, stream_type: StreamingType) -> None:
         """종목을 구독 대상에서 제거한다."""
         async with self._lock:
             self._desired[stream_type].discard(code)
+            if stream_type == StreamingType.PROGRAM_TRADING:
+                self._pt_sources.pop(code, None)
         if stream_type == StreamingType.PROGRAM_TRADING:
             self._persist_pt_desired(code, add=False)
 
@@ -190,6 +248,10 @@ class StreamingStockRepo:
     def get_desired(self, stream_type: StreamingType) -> Set[str]:
         """desired 집합의 복사본을 반환한다 (lock-free 안전 읽기)."""
         return set(self._desired[stream_type])
+
+    def get_pt_subscription_sources(self) -> Dict[str, str]:
+        """PROGRAM_TRADING desired 종목별 등록 출처를 반환한다."""
+        return dict(self._pt_sources)
 
     def get_active(self, stream_type: StreamingType) -> Set[str]:
         """active 집합의 복사본을 반환한다 (lock-free 안전 읽기)."""

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -297,6 +297,56 @@ class ProgramTradingStreamService:
             self.logger.warning(f"프로그램매매 종목명 조회 실패: code={code}, error={e}")
             return code
 
+    @staticmethod
+    def _normalize_subscription_source(source) -> str:
+        return "program" if source == "program" else "manual"
+
+    def _get_pt_subscription_sources(self) -> dict[str, str]:
+        if not self._streaming_stock_repo:
+            return {}
+        getter = getattr(self._streaming_stock_repo, "get_pt_subscription_sources", None)
+        if not callable(getter):
+            return {}
+        try:
+            sources = getter()
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 구독 출처 조회 실패: {e}")
+            return {}
+        if not isinstance(sources, dict):
+            return {}
+        return {
+            str(code): self._normalize_subscription_source(source)
+            for code, source in sources.items()
+        }
+
+    def _sort_codes_by_subscription_source(
+        self,
+        codes: list[str],
+        sources: dict[str, str],
+    ) -> list[str]:
+        return [
+            code
+            for _, code in sorted(
+                enumerate(codes),
+                key=lambda item: (
+                    0 if sources.get(item[1]) == "manual" else 1,
+                    item[0],
+                ),
+            )
+        ]
+
+    def _format_tick_alert_line(
+        self,
+        code: str,
+        label: str,
+        body: str,
+        sources: dict[str, str],
+    ) -> str:
+        source = sources.get(code)
+        if source == "manual":
+            return f"<b>[수동] {html.escape(label)}: {body}</b>"
+        return f"[프로그램] {html.escape(label)}: {body}"
+
     def _extract_latest_program_snapshot(self, data: dict) -> dict | None:
         if not isinstance(data, dict):
             return None
@@ -338,17 +388,19 @@ class ProgramTradingStreamService:
             return None
 
     async def _format_last_tick_report_async(self, codes: list[str]) -> str:
+        sources = self._get_pt_subscription_sources()
+        ordered_codes = self._sort_codes_by_subscription_source(codes, sources)
         lines = [
             "<b>프로그램매매 구독 Tick 상태</b>",
             f"생성: {html.escape(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))}",
             f"구독 종목: {len(codes)}개",
             "",
         ]
-        for code in codes:
+        for code in ordered_codes:
             label = self._format_stock_label(code)
             history = self._pt_history.get(code) or []
             if not history:
-                lines.append(f"{html.escape(label)}: 수신 없음")
+                lines.append(self._format_tick_alert_line(code, label, "수신 없음", sources))
                 continue
 
             tick = dict(history[-1])
@@ -367,25 +419,28 @@ class ProgramTradingStreamService:
             rate = self._format_rate(tick.get("rate", 0.0))
             net_amt = self._format_eok(tick.get("순매수거래대금", 0))
             source = " REST보정" if refreshed else ""
-            lines.append(
-                f"{html.escape(label)}: {price}원 ({rate}) "
+            body = (
+                f"{price}원 ({rate}) "
                 f"체결:{html.escape(trade_time)} 수신:{received_at}{source} 누적 순매수대금:{net_amt}"
             )
+            lines.append(self._format_tick_alert_line(code, label, body, sources))
         return "\n".join(lines)
 
     def _format_last_tick_report(self, codes: list[str]) -> str:
         """하위 호환용 동기 포맷터. 운영 전송은 REST 보정 가능한 async 경로를 사용한다."""
+        sources = self._get_pt_subscription_sources()
+        ordered_codes = self._sort_codes_by_subscription_source(codes, sources)
         lines = [
             "<b>프로그램매매 구독 Tick 상태</b>",
             f"생성: {html.escape(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))}",
             f"구독 종목: {len(codes)}개",
             "",
         ]
-        for code in codes:
+        for code in ordered_codes:
             label = self._format_stock_label(code)
             history = self._pt_history.get(code) or []
             if not history:
-                lines.append(f"{html.escape(label)}: 수신 없음")
+                lines.append(self._format_tick_alert_line(code, label, "수신 없음", sources))
                 continue
 
             tick = history[-1]
@@ -398,10 +453,11 @@ class ProgramTradingStreamService:
             price = self._format_int(tick.get("price", 0))
             rate = self._format_rate(tick.get("rate", 0.0))
             net_amt = self._format_eok(tick.get("순매수거래대금", 0))
-            lines.append(
-                f"{html.escape(label)}: {price}원 ({rate}) "
+            body = (
+                f"{price}원 ({rate}) "
                 f"체결:{html.escape(trade_time)} 수신:{received_at} 누적 순매수대금:{net_amt}"
             )
+            lines.append(self._format_tick_alert_line(code, label, body, sources))
         return "\n".join(lines)
 
     async def _send_telegram_message(self, message: str) -> bool:

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -491,6 +491,7 @@ class StrategyLogReportService:
         self._profitability_gate_config = profitability_gate_config
         self._last_execution_quality_candidates: List[dict] = []
         self._last_strategy_degradation_candidates: List[dict] = []
+        self._last_operational_decision_report: str = ""
 
     def get_last_execution_quality_candidates(self) -> List[dict]:
         """최근 generate_report 실행에서 산출된 체결 품질 비활성화 후보 목록."""
@@ -499,6 +500,28 @@ class StrategyLogReportService:
     def get_last_strategy_degradation_candidates(self) -> List[dict]:
         """최근 generate_report 실행에서 산출된 전략 성과 저하 후보 목록."""
         return list(self._last_strategy_degradation_candidates)
+
+    def get_last_operational_decision_report(self) -> str:
+        """최근 generate_report 실행에서 산출된 운영 의사결정 요약."""
+        return self._last_operational_decision_report
+
+    def save_diagnostic_report(
+        self,
+        report_date: str,
+        report_html: str,
+        report_dir: Optional[str] = None,
+    ) -> str:
+        """기존 상세 전략 리포트를 운영품질진단 산출물로 파일에 축적한다."""
+        if report_dir is None:
+            base_dir = os.path.dirname(os.path.normpath(self._log_dir)) or "."
+            report_dir = os.path.join(base_dir, "reports", "strategy_diagnostics")
+        os.makedirs(report_dir, exist_ok=True)
+        safe_date = re.sub(r"[^0-9]", "", str(report_date)) or datetime.now().strftime("%Y%m%d")
+        stamp = datetime.now().strftime("%H%M%S_%f")
+        path = os.path.join(report_dir, f"{safe_date}_{stamp}_strategy_diagnostic_report.html")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(report_html)
+        return path
 
     # ── 파일 탐색 ────────────────────────────────────────────────
 
@@ -1355,6 +1378,116 @@ class StrategyLogReportService:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _extract_gate_pass_strategies(profitability_gate_section: Optional[str]) -> List[str]:
+        if not profitability_gate_section:
+            return []
+        names: List[str] = []
+        for line in profitability_gate_section.splitlines():
+            match = re.match(r"•\s+(.+?):\s+통과\b", re.sub(r"<[^>]+>", "", line).strip())
+            if match:
+                names.append(match.group(1).strip())
+        return names
+
+    @staticmethod
+    def _multiple_testing_is_weak(multiple_testing_section: Optional[str]) -> bool:
+        if not multiple_testing_section:
+            return False
+        text = re.sub(r"<[^>]+>", "", multiple_testing_section)
+        if "편향 경고" in text or "adjusted Sharpe(proxy) -" in text:
+            return True
+        match = re.search(r"Deflated Sharpe\(확률\)\s+([0-9.]+)", text)
+        if match:
+            try:
+                return float(match.group(1)) < 0.55
+            except ValueError:
+                return False
+        return False
+
+    @staticmethod
+    def _extract_broker_reconciled_count(overnight_exposure_section: Optional[str]) -> Optional[int]:
+        if not overnight_exposure_section or "broker_reconciled" not in overnight_exposure_section:
+            return None
+        match = re.search(r"broker_reconciled:\s+(\d+)종목", overnight_exposure_section)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    @staticmethod
+    def _extract_open_hold_count(overnight_exposure_section: Optional[str]) -> Optional[int]:
+        if not overnight_exposure_section:
+            return None
+        match = re.search(r"현재 보유\(익일 갭 노출\):\s+(\d+)종목", overnight_exposure_section)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    @staticmethod
+    def _extract_regime_concentration_label(regime_decomposition_section: Optional[str]) -> Optional[str]:
+        if not regime_decomposition_section or "단일 regime 집중" not in regime_decomposition_section:
+            return None
+        match = re.search(r"'([^']+)'", regime_decomposition_section)
+        return match.group(1) if match else "단일"
+
+    def _build_operational_decision_report(
+        self,
+        target_date: str,
+        *,
+        buy_count: int,
+        profitability_gate_section: Optional[str],
+        multiple_testing_section: Optional[str],
+        overnight_exposure_section: Optional[str],
+        regime_decomposition_section: Optional[str],
+        degradation_section: Optional[str],
+        execution_quality_section: Optional[str],
+        warnings_section: Optional[str],
+    ) -> str:
+        lines = [f"<b>🧭 [{_fmt_date(target_date)}] 운영 의사결정 요약</b>"]
+
+        if buy_count > 0:
+            lines.append(f"• 신규 진입 {buy_count}건 — 체결/포지션 관리 확인")
+        else:
+            lines.append("• 신규 진입 없음 — 주요 후보는 진입 조건 미달/시그널 없음")
+
+        pass_strategies = self._extract_gate_pass_strategies(profitability_gate_section)
+        multiple_weak = self._multiple_testing_is_weak(multiple_testing_section)
+        if pass_strategies:
+            shown = ", ".join(_esc(name) for name in pass_strategies[:3])
+            extra = f" 외 {len(pass_strategies) - 3}개" if len(pass_strategies) > 3 else ""
+            caveat = " (단 Deflated Sharpe 약함)" if multiple_weak else ""
+            lines.append(f"• 전략 확대 후보: {shown}{extra}{caveat}")
+        else:
+            lines.append("• 전략 확대 후보: 없음 — 표본/수익성 게이트 기준 미충족")
+            if multiple_weak:
+                lines.append("• 검증 리스크: Deflated Sharpe 약함")
+
+        broker_count = self._extract_broker_reconciled_count(overnight_exposure_section)
+        if broker_count is not None:
+            lines.append(
+                f"• 즉시 점검: broker_reconciled 보유 {broker_count}종목의 전략 귀속/청산 책임"
+            )
+        else:
+            open_hold_count = self._extract_open_hold_count(overnight_exposure_section)
+            if open_hold_count:
+                lines.append(f"• 보유 리스크: 익일 갭 노출 {open_hold_count}종목")
+
+        regime_label = self._extract_regime_concentration_label(regime_decomposition_section)
+        if regime_label:
+            lines.append(f"• 리스크: {_esc(regime_label)} regime 집중")
+
+        if degradation_section:
+            lines.append("• 성과 저하 후보: 별도 경고 확인")
+        if execution_quality_section:
+            lines.append("• 체결 품질 후보: 별도 경고 확인")
+        if warnings_section:
+            lines.append("• 시스템 경고: 데이터 수신/파싱 상태 확인")
+
+        if pass_strategies and not (broker_count or regime_label or multiple_weak):
+            lines.append("• 다음 행동: 통과 전략만 소액 확대 검토")
+        else:
+            lines.append("• 다음 행동: 신규매수 기준 유지, 점검 항목 해결 전 전략 확대 보류")
+        return "\n".join(lines)
+
     def _build_replay_audit_lines(self, backtest_records: List[dict]) -> List[str]:
         counts = Counter()
         examples: List[dict] = []
@@ -1797,6 +1930,17 @@ class StrategyLogReportService:
         strategy_files = self._find_strategy_files()
 
         if not strategy_files:
+            self._last_operational_decision_report = self._build_operational_decision_report(
+                target_date,
+                buy_count=0,
+                profitability_gate_section=None,
+                multiple_testing_section=None,
+                overnight_exposure_section=None,
+                regime_decomposition_section=None,
+                degradation_section=None,
+                execution_quality_section=None,
+                warnings_section=None,
+            )
             return (
                 f"<b>📊 [{_fmt_date(target_date)}] 전략 실행 요약</b>\n\n"
                 "당일 전략 로그가 없습니다."
@@ -2076,6 +2220,17 @@ class StrategyLogReportService:
         strategy_correlation_section = self._build_strategy_correlation_section(target_date)
         overnight_exposure_section = self._build_overnight_exposure_section(target_date)
         regime_decomposition_section = self._build_regime_decomposition_section(target_date)
+        self._last_operational_decision_report = self._build_operational_decision_report(
+            target_date,
+            buy_count=len(fallback_buys),
+            profitability_gate_section=profitability_gate_section,
+            multiple_testing_section=multiple_testing_section,
+            overnight_exposure_section=overnight_exposure_section,
+            regime_decomposition_section=regime_decomposition_section,
+            degradation_section=degradation_section,
+            execution_quality_section=execution_quality_section,
+            warnings_section=warnings_section,
+        )
 
         if not active_sections:
             portfolio_summary = self._build_portfolio_summary(target_date, fallback_buys)

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -225,7 +225,11 @@ class SubscriptionPolicy:
                 if code not in self._refs:
                     await self._streaming_stock_repo.unmark_desired(code, stream_type)
             for code in added_codes:
-                await self._streaming_stock_repo.mark_desired(code, stream_type)
+                await self._streaming_stock_repo.mark_desired(
+                    code,
+                    stream_type,
+                    source="program",
+                )
 
         await self._rebalance()
 

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -303,7 +303,13 @@ class TelegramReporter:
         return f"{rate:+.{digits}f}%"
 
     @_serialized_report_send
-    async def send_daily_theme_report(self, themes: List[Dict], report_date: str, limit: int = 10):
+    async def send_daily_theme_report(
+        self,
+        themes: List[Dict],
+        report_date: str,
+        limit: int = 10,
+        show_flow_ratio: bool = True,
+    ):
         """당일 주도 테마 리포트를 텔레그램에 전송한다."""
         title = f"🔥 <b>오늘의 주도 테마 ({report_date})</b>\n"
         await self._send_message(title)
@@ -326,9 +332,13 @@ class TelegramReporter:
                     score_text = f" | 종합점수 {float(theme_score):.2f}"
                 except (TypeError, ValueError):
                     score_text = ""
+            summary_parts = [f"상승비율 {advancing_ratio}"]
+            if show_flow_ratio:
+                summary_parts.append(f"수급비중 {flow_ratio}")
+            summary_line = " | ".join(summary_parts) + score_text
             lines = [
                 f"<b>{rank}. {theme_name}</b>  {avg_rate}  {trading_value}",
-                f"상승비율 {advancing_ratio} | 수급비중 {flow_ratio}{score_text}",
+                summary_line,
                 "<pre>",
             ]
             for leader in (theme.get("leaders") or [])[:3]:

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -635,8 +635,13 @@ class TelegramReporter:
                 except (TypeError, ValueError):
                     ratio_val = None
                     ratio_text = "-"
-                gap_text = self._format_krw_cap(row.get("gap_krw"))
-                flag = " ✅" if (ratio_val is not None and ratio_val < 1) else ""
+                gap_krw = row.get("gap_krw")
+                gap_text = self._format_krw_cap(gap_krw)
+                try:
+                    is_korea_advantage = int(gap_krw) < 0
+                except (TypeError, ValueError):
+                    is_korea_advantage = False
+                flag = " ✅" if is_korea_advantage else ""
                 block.append(f"   {kr_label} <b>{ratio_text}</b> ({gap_text}){flag}")
             blocks.append("\n".join(block))
 

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -448,6 +448,20 @@ class TelegramReporter:
             await self._send_message(current)
 
     @_serialized_report_send
+    async def send_operational_decision_report(self, report_html: str, report_date: str):
+        """운영자가 바로 볼 짧은 의사결정 요약을 텔레그램으로 전송합니다."""
+        current = ""
+        for line in report_html.split('\n'):
+            chunk = line + '\n'
+            if len((current + chunk).encode('utf-8')) > 4000:
+                await self._send_message(current)
+                current = chunk
+            else:
+                current += chunk
+        if current:
+            await self._send_message(current)
+
+    @_serialized_report_send
     async def send_premium_watchlist_report(self, kospi: List[Dict], kosdaq: List[Dict], report_date: str, limit: int = 30):
         """전일 기준 우량주 풀 리포트를 텔레그램으로 전송합니다."""
         title = (

--- a/task/background/after_market/strategy_log_report_task.py
+++ b/task/background/after_market/strategy_log_report_task.py
@@ -66,6 +66,13 @@ class StrategyLogReportTask(AfterMarketTask):
             self._logger.error(f"전략 로그 리포트 생성 실패: {e}", exc_info=True)
             return
 
+        save_diagnostic_report = getattr(self._report_service, "save_diagnostic_report", None)
+        if callable(save_diagnostic_report):
+            try:
+                save_diagnostic_report(latest_trading_date, report_html)
+            except Exception as e:
+                self._logger.warning(f"전략 운영품질진단 리포트 저장 실패: {e}")
+
         await self._emit_execution_quality_candidate_alert(latest_trading_date)
         await self._emit_strategy_degradation_candidate_alert(latest_trading_date)
 
@@ -76,6 +83,23 @@ class StrategyLogReportTask(AfterMarketTask):
                 self._logger.warning(f"거절 사유 분포 파일 저장 실패: {e}")
 
         if self._telegram_reporter:
+            try:
+                get_decision_report = getattr(
+                    self._report_service,
+                    "get_last_operational_decision_report",
+                    None,
+                )
+                send_decision_report = getattr(
+                    self._telegram_reporter,
+                    "send_operational_decision_report",
+                    None,
+                )
+                if callable(get_decision_report) and callable(send_decision_report):
+                    decision_report = get_decision_report()
+                    if decision_report:
+                        await send_decision_report(decision_report, latest_trading_date)
+            except Exception as e:
+                self._logger.warning(f"Telegram 운영 의사결정 리포트 전송 실패: {e}")
             try:
                 await self._telegram_reporter.send_strategy_log_report(report_html, latest_trading_date)
             except Exception as e:

--- a/task/background/intraday/theme_intraday_leader_alert_task.py
+++ b/task/background/intraday/theme_intraday_leader_alert_task.py
@@ -178,6 +178,7 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
             await self._telegram_reporter.send_daily_theme_report(
                 theme_data,
                 report_date=slot_label,
+                show_flow_ratio=False,
             )
         self._progress["last_report_slot"] = slot_label
         self._progress["sent_count"] = len(theme_data)

--- a/tests/unit_test/common/test_trade_journal_schema.py
+++ b/tests/unit_test/common/test_trade_journal_schema.py
@@ -53,6 +53,44 @@ def test_normalize_virtual_trade_outputs_standard_schema_with_net_values():
     assert normalized["mae"] == -1.2
 
 
+def test_normalize_virtual_trade_maps_legacy_strategy_display_names():
+    # 2026-05-26경 기록 전략명이 표시명→ID로 전환되며 과거 행이 두 표기로 갈라짐 —
+    # gate 표본 카운트 희석 방지를 위해 read-time에 구 표시명을 현 ID로 정규화한다.
+    for legacy, canonical in [
+        ("래리윌리엄스VBO", "larry_williams_vbo"),
+        ("LarryWilliamsCB", "larry_williams_cb"),
+        ("RSI2눌림목", "rsi2_pullback"),
+        ("첫눌림목", "first_pullback"),
+    ]:
+        trade = {
+            "strategy": legacy,
+            "code": "005930",
+            "buy_date": "2026-05-15 09:10:00",
+            "buy_price": 10000,
+            "qty": 1,
+            "status": "HOLD",
+            "reason": "",
+        }
+        normalized = normalize_virtual_trade(trade)
+        assert normalized["strategy"] == canonical
+        # 원본 표기는 metadata(원본 row 복사본)에 보존된다.
+        assert normalized["metadata"]["strategy"] == legacy
+
+
+def test_normalize_virtual_trade_keeps_non_legacy_strategy_names():
+    for name in ["오닐PP/BGU", "larry_williams_vbo", "수동매매"]:
+        trade = {
+            "strategy": name,
+            "code": "005930",
+            "buy_date": "2026-07-01 09:10:00",
+            "buy_price": 10000,
+            "qty": 1,
+            "status": "HOLD",
+            "reason": "",
+        }
+        assert normalize_virtual_trade(trade)["strategy"] == name
+
+
 def test_normalize_failed_virtual_trade_uses_rejected_reason():
     trade = {
         "strategy": "S1",

--- a/tests/unit_test/repositories/test_streaming_stock_repo.py
+++ b/tests/unit_test/repositories/test_streaming_stock_repo.py
@@ -131,6 +131,47 @@ async def test_pt_persistence_flow(tmp_path, mock_logger):
     assert "000660" in desired3
 
 
+@pytest.mark.asyncio
+async def test_pt_persistence_tracks_subscription_source(tmp_path, mock_logger):
+    """PROGRAM_TRADING desired는 수동/프로그램 출처를 함께 저장한다."""
+    db_path = str(tmp_path / "test_pt.db")
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path)
+
+    await repo.mark_desired("005930", StreamingType.PROGRAM_TRADING, source="manual")
+    await repo.mark_desired("000660", StreamingType.PROGRAM_TRADING, source="program")
+    repo.flush_pt_desired_sync()
+
+    assert repo.get_pt_subscription_sources() == {
+        "005930": "manual",
+        "000660": "program",
+    }
+
+    conn = sqlite3.connect(db_path)
+    rows = dict(conn.execute("SELECT code, source FROM pt_subscriptions").fetchall())
+    conn.close()
+    assert rows == {
+        "005930": "manual",
+        "000660": "program",
+    }
+
+
+def test_load_legacy_pt_subscription_table_migrates_source_to_manual(tmp_path, mock_logger):
+    """기존 code-only pt_subscriptions 테이블은 manual 기본값으로 이관한다."""
+    db_path = str(tmp_path / "test_pt.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE pt_subscriptions (code TEXT PRIMARY KEY)")
+    conn.execute("INSERT INTO pt_subscriptions (code) VALUES ('005930')")
+    conn.commit()
+    conn.close()
+
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path)
+
+    assert repo.get_desired(StreamingType.PROGRAM_TRADING) == {"005930"}
+    assert repo.get_pt_subscription_sources() == {"005930": "manual"}
+
+
 def test_load_pt_desired_from_db_uses_snapshot_fallback_when_db_empty(tmp_path, mock_logger):
     """기존 스냅샷 구독 종목을 빈 pt_subscriptions 테이블로 1회 이관한다."""
     db_path = str(tmp_path / "test_pt.db")

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -576,6 +576,47 @@ async def test_send_subscribed_last_tick_alert_refreshes_net_amount_from_rest(ma
     assert "REST보정" in message
 
 
+@pytest.mark.asyncio
+async def test_format_last_tick_report_places_manual_sources_first_and_bolds(manager):
+    """수동 등록 PT 구독은 알림 상단에 굵게 표시하고 프로그램 판단 구독과 구분한다."""
+    mock_ssr = MagicMock()
+    mock_ssr.get_pt_subscription_sources.return_value = {
+        "005930": "manual",
+        "000660": "program",
+    }
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.side_effect = lambda code: {
+        "005930": "삼성전자",
+        "000660": "SK하이닉스",
+    }.get(code, code)
+
+    manager.wire_streaming_stock_repo(mock_ssr)
+    manager.wire_alert_dependencies(stock_code_repository=mock_stock_repo)
+    manager.on_data_received({
+        "유가증권단축종목코드": "000660",
+        "주식체결시간": "101530",
+        "price": "200000",
+        "rate": "2.50",
+        "순매수거래대금": "10000000000",
+    })
+    manager.on_data_received({
+        "유가증권단축종목코드": "005930",
+        "주식체결시간": "101531",
+        "price": "72000",
+        "rate": "1.25",
+        "순매수거래대금": "12345600000",
+    })
+
+    message = await manager._format_last_tick_report_async(["000660", "005930"])
+
+    manual_idx = message.index("<b>[수동] 삼성전자:")
+    program_idx = message.index("[프로그램] SK하이닉스:")
+    assert manual_idx < program_idx
+    assert "<b>[수동] 삼성전자: 72,000원" in message
+    assert "[프로그램] SK하이닉스: 200,000원" in message
+    assert mock_ssr.get_pt_subscription_sources.call_count == 1
+
+
 def test_build_db_minute_persistence_status_reports_missing_minutes(manager):
     """장중 1분 단위 저장 여부를 종목별로 계산한다."""
     clock = MarketClock(market_open_time="09:00", market_close_time="09:02")

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1593,3 +1593,63 @@ async def test_near_miss_ma_proximity_filters_far_distance_and_sorts_closest(log
     assert "덜가까운종목" in near_miss_section
     assert "먼종목" not in near_miss_section
     assert near_miss_section.index("가까운종목") < near_miss_section.index("덜가까운종목")
+
+
+def test_save_diagnostic_report_writes_accumulated_file(tmp_path):
+    svc = StrategyLogReportService(log_dir=str(tmp_path / "strategies"))
+
+    path = svc.save_diagnostic_report(
+        "20260709",
+        "<b>diagnostic</b>",
+        report_dir=str(tmp_path / "reports"),
+    )
+
+    assert os.path.exists(path)
+    assert "20260709" in os.path.basename(path)
+    with open(path, "r", encoding="utf-8") as f:
+        assert f.read() == "<b>diagnostic</b>"
+
+
+@pytest.mark.asyncio
+async def test_operational_decision_report_summarizes_generated_diagnostic(tmp_path):
+    log_dir = tmp_path / "strategies"
+    log_dir.mkdir()
+    log_path = log_dir / "20260709_160000_LarryWilliamsVBO.log.json"
+    _write_log(str(log_path), [
+        {
+            "timestamp": "2026-07-09T15:30:00",
+            "data": {"event": "scan_with_watchlist", "count": 3},
+        },
+    ])
+
+    svc = StrategyLogReportService(log_dir=str(log_dir))
+    svc._build_profitability_gate_section = lambda _date: (
+        "<b>💹 전략별 수익성 게이트</b>\n"
+        "• 래리윌리엄스VBO: 통과 — 거래 34/30, 승률 55.9%, PF 1.82, payoff 1.38, 순손익 640,948원\n"
+        "• RSI2눌림목: 표본 부족 — 거래 14/30, 승률 28.6%, PF 0.33, payoff 0.69, 순손익 -639,140원"
+    )
+    svc._build_multiple_testing_section = lambda _date: (
+        "<b>🧪 다중검정 / Deflated Sharpe</b>\n"
+        "• Deflated Sharpe(확률) 0.475 — best SR 0.45, 기대최대 0.51, best 전략 거래 표본 2건\n"
+        "• adjusted Sharpe(proxy) -0.24 (haircut 0.68)\n"
+        "  - ⚠️ 편향 경고: best_positive_median_non_positive"
+    )
+    svc._build_overnight_exposure_section = lambda _date: (
+        "<b>🌙 오버나이트 노출 (익일 갭 리스크)</b>\n"
+        "• 현재 보유(익일 갭 노출): 8종목\n"
+        "  • broker_reconciled: 8종목 (최장 56일, 평균 33.5일)"
+    )
+    svc._build_regime_decomposition_section = lambda _date: (
+        "<b>🧭 전략별 시장국면(regime) 분해</b>\n"
+        "• 집중도: 3/3 전략 주력 국면이 'KOSDAQ 상승' (100%) ⚠️ 단일 regime 집중"
+    )
+
+    await svc.generate_report("20260709")
+    decision = svc.get_last_operational_decision_report()
+
+    assert "운영 의사결정 요약" in decision
+    assert "신규 진입 없음" in decision
+    assert "래리윌리엄스VBO" in decision
+    assert "broker_reconciled 보유 8종목" in decision
+    assert "KOSDAQ 상승 regime 집중" in decision
+    assert "Deflated Sharpe 약함" in decision

--- a/tests/unit_test/services/test_subscription_policy.py
+++ b/tests/unit_test/services/test_subscription_policy.py
@@ -159,6 +159,23 @@ async def test_sync_subscriptions(policy, mock_streaming_stock_repo):
     assert "C" in policy._refs
     assert policy._refs["C"]["cat1"]["priority"] == SubscriptionPriority.HIGH
 
+
+@pytest.mark.asyncio
+async def test_sync_program_trading_subscriptions_marks_program_source(policy, mock_streaming_stock_repo):
+    """정책 동기화로 추가된 PT 구독은 프로그램 판단 출처로 저장한다."""
+    await policy.sync_subscriptions(
+        ["005930"],
+        "microstructure_capture",
+        SubscriptionPriority.LOW,
+        StreamingType.PROGRAM_TRADING,
+    )
+
+    mock_streaming_stock_repo.mark_desired.assert_awaited_once_with(
+        "005930",
+        StreamingType.PROGRAM_TRADING,
+        source="program",
+    )
+
 def test_is_streaming_and_get_status(policy):
     """스트리밍 여부 판별 및 구독 현황 조회 로직 검증"""
     policy._active_codes_price = {"005930"}

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -859,6 +859,34 @@ async def test_send_daily_theme_report_formats_stockeasy_like_cards(telegram_rep
 
 
 @pytest.mark.asyncio
+async def test_send_daily_theme_report_can_hide_flow_ratio(telegram_reporter):
+    """장중 주도 테마 리포트는 수급 데이터가 없으므로 수급비중을 숨길 수 있다."""
+    themes = [
+        {
+            "normalized_name": "반도체/소부장",
+            "leader_avg_change_rate": 12.33,
+            "trading_value_sum_won": 380_100_000_000,
+            "advancing_ratio": 75.0,
+            "flow_ratio": 0.0,
+            "theme_score": 12.17,
+            "leaders": [],
+        }
+    ]
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+
+    await telegram_reporter.send_daily_theme_report(
+        themes,
+        "20260706 10:10",
+        show_flow_ratio=False,
+    )
+
+    full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
+    assert "상승비율 75.0% | 종합점수 12.17" in full
+    assert "수급비중" not in full
+    assert "+0.00%" not in full
+
+
+@pytest.mark.asyncio
 async def test_send_daily_theme_report_empty(telegram_reporter):
     telegram_reporter._send_message = AsyncMock(return_value=True)
 

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -1012,3 +1012,35 @@ async def test_send_market_cap_gap_report_formats_korean_us_gap(telegram_reporte
     # 배율 < 1 (한국 우위) 행에는 ✅ 표시
     assert "<b>0.42x</b>" in full
     assert "✅" in full
+
+
+@pytest.mark.asyncio
+async def test_send_market_cap_gap_report_marks_korea_advantage_by_negative_gap(telegram_reporter):
+    """반올림된 ratio가 1.00이어도 gap이 음수면 한국우위로 표시한다."""
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+    report = {
+        "report_date": "20260709",
+        "trigger": "kr_close",
+        "fx_rate": 1507.48,
+        "korean": [
+            {"symbol": "005930", "name": "삼성전자", "market_cap_krw": 1_622_000_000_000_000},
+        ],
+        "us": [
+            {"symbol": "MU", "name": "Micron", "market_cap_usd": 0, "market_cap_krw": 1_615_000_000_000_000},
+        ],
+        "comparisons": [
+            {
+                "korean_symbol": "005930",
+                "korean_name": "삼성전자",
+                "us_symbol": "MU",
+                "us_name": "Micron",
+                "gap_krw": -7_000_000_000_000,
+                "ratio": 1.00,
+            },
+        ],
+    }
+
+    await telegram_reporter.send_market_cap_gap_report(report, "20260709", "한국장 마감")
+
+    full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
+    assert "삼성전자 <b>1.00x</b> (-7조) ✅" in full

--- a/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
@@ -14,6 +14,8 @@ from interfaces.schedulable_task import TaskPriority, TaskState
 def mock_report_service():
     svc = MagicMock()
     svc.generate_report = AsyncMock(return_value="<html>report</html>")
+    svc.save_diagnostic_report = MagicMock(return_value="logs/reports/diagnostic.html")
+    svc.get_last_operational_decision_report.return_value = "<b>운영 의사결정</b>"
     svc.get_last_execution_quality_candidates.return_value = []
     svc.get_last_strategy_degradation_candidates.return_value = []
     return svc
@@ -37,6 +39,7 @@ def mock_operator_alert_service():
 def mock_telegram():
     tg = MagicMock()
     tg.send_strategy_log_report = AsyncMock()
+    tg.send_operational_decision_report = AsyncMock()
     return tg
 
 
@@ -95,6 +98,18 @@ class TestOnMarketClosed:
         await task._on_market_closed("20260419")
         mock_telegram.send_strategy_log_report.assert_awaited_once_with(
             "<html>report</html>", "20260419"
+        )
+
+    async def test_diagnostic_report_is_saved(self, task, mock_report_service):
+        await task._on_market_closed("20260419")
+        mock_report_service.save_diagnostic_report.assert_called_once_with(
+            "20260419", "<html>report</html>"
+        )
+
+    async def test_operational_decision_report_is_sent(self, task, mock_telegram):
+        await task._on_market_closed("20260419")
+        mock_telegram.send_operational_decision_report.assert_awaited_once_with(
+            "<b>운영 의사결정</b>", "20260419"
         )
 
     async def test_execution_quality_candidates_emit_strategy_warning(

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -111,6 +111,7 @@ async def test_open_tick_sends_intraday_theme_report_for_current_hourly_slot():
     deps.telegram_reporter.send_daily_theme_report.assert_awaited_once_with(
         [{"normalized_name": "반도체", "leaders": []}],
         report_date="20260706 10:10",
+        show_flow_ratio=False,
     )
     progress = deps.task.get_progress()
     assert progress["last_report_slot"] == "20260706 10:10"

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -7,6 +7,50 @@ from common.types import ResCommonResponse
 
 
 @pytest.mark.asyncio
+async def test_post_ranking_ai_analysis_success(web_client, mock_web_ctx):
+    """POST /api/ranking/ai-analysis 는 후보 목록을 AI 분석 서비스로 전달한다."""
+    mock_web_ctx.ai_analysis_service = AsyncMock()
+    mock_web_ctx.ai_analysis_service.analyze_leading_stocks.return_value = ResCommonResponse(
+        rt_cd="0",
+        msg1="AI 분석 성공",
+        data={"analysis": "강한 후보입니다.", "provider": "gemini", "model": "gemini-test"},
+    )
+
+    response = web_client.post(
+        "/api/ranking/ai-analysis",
+        json={
+            "candidates": [{"code": "005930", "name": "삼성전자", "prdy_ctrt": "3.1"}],
+            "market_context": {"category": "rise"},
+            "max_candidates": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["analysis"] == "강한 후보입니다."
+    mock_web_ctx.ai_analysis_service.analyze_leading_stocks.assert_awaited_once_with(
+        [{"code": "005930", "name": "삼성전자", "prdy_ctrt": "3.1"}],
+        market_context={"category": "rise"},
+        max_candidates=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_ranking_ai_analysis_empty_candidates(web_client, mock_web_ctx):
+    """후보가 없으면 AI provider 생성/호출 없이 EMPTY_VALUES 응답을 반환한다."""
+    mock_web_ctx.ai_analysis_service = AsyncMock()
+
+    response = web_client.post("/api/ranking/ai-analysis", json={"candidates": []})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] != "0"
+    assert "후보" in body["msg1"]
+    mock_web_ctx.ai_analysis_service.analyze_leading_stocks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_theme_leaders_success(web_client, mock_web_ctx):
     """GET /api/ranking/theme_leaders 정상 응답 + 기본 category_types=theme."""
     mock_web_ctx.theme_leader_service = AsyncMock()

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -245,7 +245,11 @@ async def test_program_trading_subscription(mock_deps):
     ctx.streaming_service.connect_websocket.assert_awaited_once()
     ctx.streaming_service.subscribe_program_trading.assert_awaited_with("005930")
     ctx.streaming_service.subscribe_unified_price.assert_awaited_with("005930")
-    ctx.streaming_stock_repo.mark_desired.assert_called_with("005930", StreamingType.PROGRAM_TRADING)
+    ctx.streaming_stock_repo.mark_desired.assert_called_with(
+        "005930",
+        StreamingType.PROGRAM_TRADING,
+        source="manual",
+    )
     ctx.streaming_stock_repo.mark_active.assert_any_call("005930", StreamingType.PROGRAM_TRADING)
     ctx.streaming_stock_repo.mark_active.assert_any_call("005930", StreamingType.UNIFIED_PRICE)
 

--- a/tests/unit_test/view/web/test_web_app_program_trading.py
+++ b/tests/unit_test/view/web/test_web_app_program_trading.py
@@ -59,7 +59,11 @@ async def test_start_program_trading_success(mock_ctx):
     assert result is True
     mock_ctx.streaming_service.subscribe_program_trading.assert_called_once_with(code)
     mock_ctx.streaming_service.subscribe_unified_price.assert_called_once_with(code)
-    mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(code, StreamingType.PROGRAM_TRADING)
+    mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(
+        code,
+        StreamingType.PROGRAM_TRADING,
+        source="manual",
+    )
     mock_ctx.streaming_stock_repo.mark_active.assert_any_call(code, StreamingType.PROGRAM_TRADING)
     mock_ctx.streaming_stock_repo.mark_active.assert_any_call(code, StreamingType.UNIFIED_PRICE)
 
@@ -141,4 +145,8 @@ async def test_start_program_trading_dead_reconnect_fail_retry_success(mock_ctx)
     assert result is True
     # 재연결 후 신규 구독 로직 실행 확인
     mock_ctx.streaming_service.connect_websocket.assert_called_once()
-    mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(code, StreamingType.PROGRAM_TRADING)
+    mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(
+        code,
+        StreamingType.PROGRAM_TRADING,
+        source="manual",
+    )

--- a/todo_list.md
+++ b/todo_list.md
@@ -67,6 +67,7 @@
 
 - [ ] shadow / paper / 소액 canary journal을 표준 포맷으로 누적하고, 전략별 profitability gate 통과 근거를 리포트한다. (journal은 `virtual_trade_service.get_standard_journal_records` ← polling scan + REST 가격 경로로 채워져 WS 틱 비의존 — 무틱 블로커와 독립적으로 축적 가능. shadow 하위 요소만 2-4와 동일 의존. 라이브 런타임 시간만 필요.)
   - 표준 journal 축적 현황 리포트 추가 (2026-07-04): 일일 전략 리포트에 source별 레코드 수, SOLD/진행중 status, 전략별 SOLD 표본 진행률(`min_trades` 대비)을 노출해 paper/canary 데이터가 gate 해제 기준까지 얼마나 쌓였는지 확인 가능.
+  - 전략명 별칭 통합 (2026-07-09): 2026-05-26경 기록 전략명이 표시명→ID로 전환되며 표본이 두 표기로 갈라져 있던 것을 `normalize_virtual_trade` read-time 별칭 매핑으로 통합(래리윌리엄스VBO→larry_williams_vbo 등 4쌍, DB 불변). 통합 후 실측 진행률: VBO SOLD 34/100, RSI2 14, CB 4 — 7월은 마켓타이밍 차단으로 +3건뿐(설계된 정체). regime 태그는 62건 중 53건 null(태깅 도입 전)이라 regime별 최소 30은 사실상 신규 축적 필요.
   - 최소 유지 기준: 실전 override `min_trades=100`, `profit_factor>=1.3`, `payoff_ratio>=1.2`, `win_rate>=40%`, `max_drawdown<=12%`, regime별 최소 거래 30. parameter stability·Monte Carlo·regime balance·multiple testing 보정을 운영 편의로 낮추지 않는다.
 
 주요 파일: `services/strategy_live_expansion_gate_service.py`, `services/strategy_profitability_gate_service.py`, `scheduler/strategy_scheduler.py`, `services/strategy_log_report_service.py`

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -1,11 +1,23 @@
 """
 랭킹/시가총액 관련 API 엔드포인트 (ranking.html, marketcap.html).
 """
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
 from common.types import ErrorCode
 from view.web.api_common import _get_ctx, _serialize_response, _serialize_list_items
 
 router = APIRouter()
+
+
+class RankingAIAnalysisRequest(BaseModel):
+    candidates: list[dict[str, Any]] = []
+    market_context: dict[str, Any] | None = None
+    max_candidates: int = 20
+    provider_name: str | None = None
+    model: str | None = None
 
 
 @router.get("/ranking/progress")
@@ -69,6 +81,45 @@ async def get_theme_leaders(include_industry: bool = False):
     cats = ("theme", "industry") if include_industry else ("theme",)
     resp = await svc.get_theme_leaders(category_types=cats)
     return {"rt_cd": resp.rt_cd, "msg1": resp.msg1, "data": resp.data}
+
+
+@router.post("/ranking/ai-analysis")
+async def analyze_ranking_candidates(payload: RankingAIAnalysisRequest):
+    """현재 랭킹 후보를 AI provider로 해설한다. 주문/전략 판단에는 사용하지 않는다."""
+    ctx = _get_ctx()
+    candidates = payload.candidates or []
+    if not candidates:
+        return {
+            "rt_cd": ErrorCode.EMPTY_VALUES.value,
+            "msg1": "AI 분석 대상 후보가 없습니다.",
+            "data": None,
+        }
+
+    ai_service = getattr(ctx, "ai_analysis_service", None)
+    if ai_service is None or payload.provider_name or payload.model:
+        try:
+            from services.ai_analysis_service import AIAnalysisService
+
+            ai_service = AIAnalysisService(
+                provider_name=payload.provider_name,
+                model=payload.model,
+                logger=getattr(ctx, "logger", None),
+            )
+            if not payload.provider_name and not payload.model:
+                ctx.ai_analysis_service = ai_service
+        except Exception as e:
+            return {
+                "rt_cd": ErrorCode.API_ERROR.value,
+                "msg1": str(e),
+                "data": None,
+            }
+
+    resp = await ai_service.analyze_leading_stocks(
+        candidates,
+        market_context=payload.market_context or {},
+        max_candidates=payload.max_candidates,
+    )
+    return _serialize_response(resp)
 
 
 @router.get("/ranking/{category}")

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -6,6 +6,7 @@ let _rankingData = [];
 let _rankingSortState = { key: null, dir: 'asc' };
 let _rankingDirection = null;
 let _rankingSelectedInvestors = new Set(['foreign']);
+let _rankingAIAnalysisState = { loading: false, result: null, error: null };
 
 const _investorTypeFields = {
     'foreign': { pbmn: 'frgn_ntby_tr_pbmn', qty: 'frgn_ntby_qty', isMil: true, label: '외인' },
@@ -18,10 +19,15 @@ let _rankingMarketFilter = 'ALL';
 
 function setMarketFilter(market, btn) {
     _rankingMarketFilter = market;
+    _resetRankingAIAnalysis();
     document.querySelectorAll('.market-filter').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     if (_rankingDirection) loadInvestorRanking();
     else if (_rankingCurrentCategory) loadRanking(_rankingCurrentCategory);
+}
+
+function _resetRankingAIAnalysis() {
+    _rankingAIAnalysisState = { loading: false, result: null, error: null };
 }
 
 function _showRankingSkeleton() {
@@ -51,6 +57,7 @@ async function loadRanking(category) {
     if (window.Paginator) window.Paginator.reset('ranking');
     _rankingCurrentCategory = category;
     _rankingDirection = null;
+    _resetRankingAIAnalysis();
 
     document.querySelectorAll('.ranking-tab').forEach(b => {
         b.classList.remove('active');
@@ -118,6 +125,7 @@ function setRankingDirection(dir) {
         _rankingPollTimer = null;
     }
     _rankingDirection = dir;
+    _resetRankingAIAnalysis();
 
     document.querySelectorAll('.ranking-tab').forEach(b => {
         b.classList.remove('active');
@@ -147,6 +155,7 @@ function toggleRankingInvestor(type) {
         b.classList.toggle('active', _rankingSelectedInvestors.has(b.dataset.inv));
     });
 
+    _resetRankingAIAnalysis();
     loadInvestorRanking();
 }
 
@@ -260,6 +269,7 @@ async function loadThemeLeaders() {
     if (window.Paginator) window.Paginator.reset('ranking');
     _rankingCurrentCategory = 'theme_leaders';
     _rankingDirection = null;
+    _resetRankingAIAnalysis();
 
     document.querySelectorAll('.ranking-tab').forEach(b => {
         b.classList.remove('active');
@@ -327,6 +337,95 @@ function renderThemeLeaders(groups) {
         </div>`;
     }).join('');
     div.innerHTML = cards;
+}
+
+function _buildAIAnalysisCandidate(item) {
+    const candidate = {
+        code: item.stck_shrn_iscd || item.iscd || item.mksc_shrn_iscd || item.code || '',
+        name: item.hts_kor_isnm || item.name || '',
+        rank: item.data_rank || item.rank || '',
+        current_price: item.stck_prpr || item.current_price || '',
+        change_rate: item.prdy_ctrt || item.change_rate || '',
+        volume: item.acml_vol || '',
+        trading_value_won: item.acml_tr_pbmn || item.trading_value || '',
+        market_cap: item.market_cap || '',
+        rs_rating: item.rs_rating || item.rs || '',
+        stage: item.stage || item.minervini_stage || '',
+    };
+    if (item._combined_pbmn !== undefined) candidate.combined_net_amount_won = item._combined_pbmn;
+    if (item._combined_qty !== undefined) candidate.combined_net_qty = item._combined_qty;
+    for (const key of [
+        'frgn_ntby_tr_pbmn', 'frgn_ntby_qty',
+        'orgn_ntby_tr_pbmn', 'orgn_ntby_qty',
+        'prsn_ntby_tr_pbmn', 'prsn_ntby_qty',
+        'whol_smtn_ntby_tr_pbmn', 'whol_smtn_ntby_qty',
+    ]) {
+        if (item[key] !== undefined) candidate[key] = item[key];
+    }
+    return candidate;
+}
+
+function _renderRankingAIAnalysisPanel(totalCount) {
+    if (!totalCount || _rankingCurrentCategory === 'theme_leaders') return '';
+
+    const disabled = _rankingAIAnalysisState.loading ? 'disabled' : '';
+    const buttonText = _rankingAIAnalysisState.loading ? '분석 중...' : 'AI 분석';
+    let body = '';
+    if (_rankingAIAnalysisState.error) {
+        body = `<div style="margin-top:10px; color:var(--text-red); white-space:pre-wrap;">${escapeHtml(_rankingAIAnalysisState.error)}</div>`;
+    } else if (_rankingAIAnalysisState.result) {
+        const result = _rankingAIAnalysisState.result;
+        const meta = [result.provider, result.model].filter(Boolean).join(' · ');
+        body = `<div style="margin-top:10px; white-space:pre-wrap; line-height:1.55;">${escapeHtml(result.analysis || '')}</div>`
+            + (meta ? `<div style="margin-top:8px; color:#888; font-size:0.9em;">${escapeHtml(meta)}</div>` : '');
+    }
+
+    return `<div class="card" style="margin-bottom:12px;">
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
+            <div style="font-weight:600;">랭킹 후보 AI 분석</div>
+            <button class="btn" onclick="runRankingAIAnalysis()" ${disabled}>${buttonText}</button>
+        </div>
+        ${body}
+    </div>`;
+}
+
+async function runRankingAIAnalysis() {
+    if (_rankingAIAnalysisState.loading || !_rankingData.length) return;
+
+    _rankingAIAnalysisState = { loading: true, result: null, error: null };
+    renderRankingTable();
+
+    try {
+        const candidates = _rankingData.slice(0, 20).map(_buildAIAnalysisCandidate);
+        const res = await fetchWithTimeout('/api/ranking/ai-analysis', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                candidates,
+                max_candidates: 20,
+                market_context: {
+                    category: _rankingCurrentCategory,
+                    direction: _rankingDirection,
+                    investors: Array.from(_rankingSelectedInvestors),
+                    market_filter: _rankingMarketFilter,
+                },
+            }),
+        }, 60000);
+        const json = await res.json();
+        if (json.rt_cd !== "0") {
+            _rankingAIAnalysisState = { loading: false, result: null, error: json.msg1 || 'AI 분석 실패' };
+            renderRankingTable();
+            return;
+        }
+        _rankingAIAnalysisState = { loading: false, result: json.data, error: null };
+        renderRankingTable();
+    } catch (e) {
+        const message = e.name === 'AbortError'
+            ? 'AI 분석 요청 시간이 초과되었습니다.'
+            : `AI 분석 오류: ${e}`;
+        _rankingAIAnalysisState = { loading: false, result: null, error: message };
+        renderRankingTable();
+    }
 }
 
 function _formatElapsed(sec) {
@@ -524,7 +623,7 @@ function renderRankingTable() {
         </tr>`;
     });
 
-    div.innerHTML = `<div class="card"><table class="data-table">
+    div.innerHTML = `${_renderRankingAIAnalysisPanel(data.length)}<div class="card"><table class="data-table">
         <thead><tr>${headerRow}</tr></thead>
         <tbody>${rows}</tbody></table></div>`;
 }

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=3"></script>
+<script src="/static/js/ranking.js?v=4"></script>
 <script>
     loadRanking('rise');
 </script>

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -111,6 +111,7 @@ class WebAppContext:
         self.rejection_distribution_service: RejectionDistributionService = None
         self.data_quality_service: DataQualityService = None
         self.indicator_service: IndicatorService = None
+        self.ai_analysis_service = None
         self.virtual_repo = VirtualTradeRepository()
         self.backtest_journal_repository = BacktestJournalRepository()
         self.virtual_trade_service = VirtualTradeService(repository=self.virtual_repo, market_clock=self.market_clock)

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -595,7 +595,11 @@ class WebAppContext:
 
             if sub_pt_success and sub_price_success:
                 if self.streaming_stock_repo:
-                    await self.streaming_stock_repo.mark_desired(code, StreamingType.PROGRAM_TRADING)
+                    await self.streaming_stock_repo.mark_desired(
+                        code,
+                        StreamingType.PROGRAM_TRADING,
+                        source="manual",
+                    )
                     await self.streaming_stock_repo.mark_active(code, StreamingType.PROGRAM_TRADING)
                     await self.streaming_stock_repo.mark_active(code, StreamingType.UNIFIED_PRICE)
                 self.logger.info(f"프로그램매매 신규 구독 성공: {code}")


### PR DESCRIPTION
## 배경
1-6 journal 축적 진행률을 실측하던 중, 2026-05-26경 기록 전략명이 표시명→ID로 전환되며 같은 전략의 표본이 두 표기로 갈라져 있는 것을 발견했다:

| 전략 | 구 표기 (5/14~5/22) | 현 표기 (5/27~) | 합치면 |
|---|---|---|---|
| VBO | 래리윌리엄스VBO 7 | larry_williams_vbo 27 | **34** |
| RSI2 눌림목 | RSI2눌림목 8 | rsi2_pullback 6 | **14** |
| CB | LarryWilliamsCB 3 | larry_williams_cb 1 | **4** |

profitability gate 표본 카운트(`min_trades=100`)와 일일 축적 진행률 리포트가 전략명 단위라 희석된 수치를 보고 있었다. 이중 기록은 진행형이 아닌 과거 전환 흔적이므로 read-time 별칭 매핑으로 충분하다 (DB 마이그레이션 불필요 — 사용자 결정).

추가로 프로그램매매 구독 Tick 알림에서 수동 등록 종목과 프로그램 판단 종목을 구분할 수 없었다. 수동 등록 종목은 알림에서 더 눈에 띄어야 하므로 출처를 저장하고 수동 항목을 상단/볼드로 표시한다.

## 변경
- `normalize_virtual_trade`에 `_LEGACY_STRATEGY_NAME_ALIASES` 4쌍(첫눌림목 포함) read-time 매핑 추가
- DB 불변, 원본 표기는 `metadata`(원본 row 복사본)에 그대로 보존
- 오닐 계열 한글 표시명(오닐PP/BGU 등)은 현역 단일 표기라 매핑 대상 아님 (passthrough 테스트로 고정)
- todo 1-6에 통합 기록 + regime 태그 공백(SOLD 62건 중 53건 null) 실측 명시
- `pt_subscriptions`에 `source`, `updated_at` 컬럼 보장 및 code-only 기존 테이블은 `manual` 기본값으로 이관
- 웹 수동 구독은 `manual`, 정책 동기화 기반 PT 구독은 `program` 출처로 저장
- 프로그램매매 Tick 알림은 `[수동]`/`[프로그램]` 표식을 붙이고, 수동 종목을 상단에 `<b>...</b>`로 표시
- 장중 테마 알림에서는 `수급비중` 라인을 숨김

## 테스트
- 신규/수정 테스트: 전략명 별칭, PT 구독 출처 저장/마이그레이션, 정책 기반 program 출처, 수동 알림 상단 볼드 표시, 장중 테마 수급비중 숨김
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v` 통과
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v` 통과 (246 passed)