### PR TITLE
after-market perf 타이머 threshold 게이트 우회 — 1초 미만 실행도 항상 기록

### DIFF
--- a/scheduler/worker/worker_pool.py
+++ b/scheduler/worker/worker_pool.py
@@ -116,9 +116,12 @@ class WorkerPool:
         if self._pm.enabled:
             # 발행(publish) → 실행 시작까지의 큐 대기시간. created_at은 UTC epoch 기준이라
             # time.time()과 직접 뺄셈 가능 (log_timer(name, start_time)와 동일한 계산식).
+            # after-market 태스크는 저빈도(하루 십수 건)라 threshold 게이트 없이 항상 기록
+            # — 기록 부재가 '미실행'을 의미하도록 유지한다.
             self._pm.log_timer(
                 f"AfterMarketTask.{ticket.task_name}(queue_wait)",
                 datetime.fromisoformat(ticket.created_at).timestamp(),
+                threshold=0.0,
             )
         t_exec = self._pm.start_timer()
         try:
@@ -140,4 +143,4 @@ class WorkerPool:
                 else:
                     await self._dlq.handle_failed_ticket(ticket, str(e))
         finally:
-            self._pm.log_timer(f"AfterMarketTask.{ticket.task_name}", t_exec)
+            self._pm.log_timer(f"AfterMarketTask.{ticket.task_name}", t_exec, threshold=0.0)

--- a/tests/unit_test/scheduler/test_worker_pool.py
+++ b/tests/unit_test/scheduler/test_worker_pool.py
@@ -206,3 +206,31 @@ async def test_handle_logs_execution_timer_even_on_failure():
     logged = [c.args[0] for c in fake_logger.info.call_args_list]
     exec_logs = [m for m in logged if m.startswith("[Performance] AfterMarketTask.FAIL_TASK:")]
     assert len(exec_logs) == pool.MAX_RETRIES
+
+
+async def test_handle_logs_timers_below_profiler_threshold():
+    """운영 threshold(1.0s)보다 빨리 끝나도 after-market 타이머는 항상 기록된다.
+
+    2026-07-09 실측: post_market_replay_audit가 1ms에 skip 완료되자 실행시간
+    라인이 threshold 게이트에 억제되어 '미실행'과 구분 불가했던 회귀 방지.
+    """
+    from core.performance_profiler import PerformanceProfiler
+
+    fake_logger = MagicMock()
+    pm = PerformanceProfiler(logger=fake_logger, enabled=True, threshold=1.0)
+    broker = MessageBroker()
+    dlq = MagicMock(spec=DlqManager)
+    pool = WorkerPool(broker=broker, dlq_manager=dlq, performance_profiler=pm, num_workers=1)
+
+    async def fast_handler(payload):
+        pass
+
+    pool.register("FAST_TASK", fast_handler)
+    await pool.start()
+    await broker.publish(Ticket(priority=50, task_name="FAST_TASK", payload={}))
+    await broker.join()
+    await pool.shutdown()
+
+    logged = [c.args[0] for c in fake_logger.info.call_args_list]
+    assert any("AfterMarketTask.FAST_TASK(queue_wait):" in m for m in logged)
+    assert any(m.startswith("[Performance] AfterMarketTask.FAST_TASK:") for m in logged)


### PR DESCRIPTION
## 배경 (2026-07-09 전일 성능 실측)

07-06에 추가한 WorkerPool 태스크 타이머의 첫 전일(全日) 데이터를 분석하던 중, `post_market_replay_audit`와 `newhigh_strategy_coverage_backtest`는 `queue_wait` 라인만 있고 실행시간 완료 라인이 없는 것을 발견.

- 두 태스크 모두 실제로는 정상 실행됨 (audit는 paper 모드 skip으로 1ms 완료, backtest ~0ms 완료)
- 원인: `ctx.pm`의 threshold(운영 1.0s) 게이트가 1초 미만 실행 기록을 억제
- 결과: 텔레메트리상 "빠른 완료"와 "미실행/행"을 구분할 수 없음

## 변경

- `scheduler/worker/worker_pool.py` `_handle()`: queue_wait/실행시간 `log_timer` 호출에 `threshold=0.0` 오버라이드 추가. after-market 태스크는 하루 십수 건 저빈도라 로그 폭주 위험 없음 — 기록 부재가 곧 미실행을 의미하도록 유지.
- `tests/unit_test/scheduler/test_worker_pool.py`: 운영 threshold(1.0s) 조건에서 1초 미만 실행도 두 타이머가 기록되는지 검증하는 회귀 테스트 추가 (TDD — 수정 전 실패 확인).

## 테스트

- 단위 6,724 passed (4m23s)
- 통합 246 passed (3m48s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)