### PR TITLE
CacheStore 순수 미스를 '잘못된 캐시 구조' 경고로 오탐하던 스팸 제거

### DIFF
--- a/core/cache/cache_store.py
+++ b/core/cache/cache_store.py
@@ -71,6 +71,10 @@ class CacheStore:
                 if self._logger:
                     self._logger.debug(f"🚫 File Cache MISS: {key}")
 
+        if raw is None:
+            # 순수 캐시 MISS — 구조 오류가 아니므로 경고 없이 종료 (MISS debug 로그는 위에서 남김)
+            return None
+
         if not isinstance(raw, dict) or "timestamp" not in raw or "data" not in raw:
             if self._logger:
                 self._logger.warning(f"[CacheStore] ❌ 잘못된 캐시 구조 감지: {key} / 내용: {raw}")

--- a/tests/unit_test/core/cache/test_cache_store.py
+++ b/tests/unit_test/core/cache/test_cache_store.py
@@ -397,6 +397,11 @@ def test_cache_store_get_raw_rejects_invalid_timestamp(cache_store):
 
 
 def test_cache_store_get_raw_logs_memory_and_file_miss(cache_store):
+    """순수 캐시 MISS는 debug 로그만 남기고 '잘못된 캐시 구조' 경고를 찍지 않는다.
+
+    2026-07-09 실측: 장마감 배치의 콜드 미스 1만여 건이 전부 구조 오류 WARNING으로
+    오탐 기록되던 회귀 방지.
+    """
     logger = MagicMock()
     cache_store.set_logger(logger)
 
@@ -404,7 +409,19 @@ def test_cache_store_get_raw_logs_memory_and_file_miss(cache_store):
     debug_messages = [call.args[0] for call in logger.debug.call_args_list]
     assert any("Memory Cache MISS: missing_key" in message for message in debug_messages)
     assert any("File Cache MISS: missing_key" in message for message in debug_messages)
-    logger.warning.assert_called_once()
+    logger.warning.assert_not_called()
+
+
+def test_cache_store_get_raw_warns_on_malformed_entry(cache_store):
+    """내용이 존재하지만 wrapper 구조(timestamp/data)가 아니면 경고 후 None을 반환한다."""
+    key = "malformed_entry"
+    cache_store.set(key, {"unexpected": "shape"})
+    logger = MagicMock()
+    cache_store.set_logger(logger)
+
+    assert cache_store.get_raw(key) is None
+    warning_messages = [call.args[0] for call in logger.warning.call_args_list]
+    assert any("잘못된 캐시 구조 감지" in message for message in warning_messages)
 
 
 def test_cache_store_get_raw_logs_file_hit_after_memory_clear(cache_store):


### PR DESCRIPTION
## 배경 (2026-07-09 전일 성능 분석 후속 ②)

전일 로그에서 `[CacheStore] ❌ 잘못된 캐시 구조 감지: PAPER_get_investor_trade_by_stock_daily_... / 내용: None` WARNING이 하루 1만여 건(메서드별 5,124건씩) 발견됨.

**조사 결과 당초 추정("실패 응답 None이 캐시에 저장됨")은 오진이었음:**
- 실패 응답 캐시 차단 게이트(`cache_wrapper.py` — `rt_cd==SUCCESS`만 저장)는 이미 정상 동작 중
- 실제 원인: `CacheStore.get_raw()`가 메모리/파일 캐시 **모두 MISS인 경우(raw=None)에도 구조 검사에 진입**해 오탐 WARNING을 기록
- 장마감 랭킹 배치가 종목별 날짜 키(당일 최초 조회 = 전부 콜드 미스)로 조회하면서 미스 건수만큼 경고가 쏟아진 것

## 변경

- `core/cache/cache_store.py` `get_raw()`: 순수 MISS는 경고 없이 조기 반환 (MISS debug 로그는 기존 유지). '잘못된 캐시 구조' 경고는 내용이 존재하지만 wrapper 형식(timestamp/data)이 깨진 경우에만 유지.
- `tests/unit_test/core/cache/test_cache_store.py`:
  - 기존 미스 테스트가 오탐 동작(`warning 1회`)을 고정하고 있어 `assert_not_called()`로 수정 (TDD — 수정 전 실패 확인)
  - 형식이 깨진 엔트리는 여전히 경고하는 회귀 테스트 추가

## 테스트

- 캐시 단위 120 passed
- 전체 단위 6,724 passed (6m04s) / 통합 246 passed (4m04s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)