### PR TITLE
[codex] Add period investor program ranking

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -210,6 +210,10 @@ class BrokerAPIWrapper:
     async def get_program_trade_by_stock_daily(self, stock_code: str, date: str = None) -> ResCommonResponse:
         """종목별 프로그램매매추이(일별) 조회 (실전 전용)"""
         return await self._client.get_program_trade_by_stock_daily(stock_code, date)
+
+    async def get_program_trade_by_stock_daily_multi(self, stock_code: str, date: str = None, days: int = 3) -> ResCommonResponse:
+        """종목별 프로그램매매추이(일별) 다중일 조회 (실전 전용)"""
+        return await self._client.get_program_trade_by_stock_daily_multi(stock_code, date, days)
     #
     # async def get_stock_news(self, stock_code: str) -> ResCommonResponse:
     #     """

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -256,6 +256,10 @@ class KoreaInvestApiClient:
     async def get_program_trade_by_stock_daily(self, stock_code: str, date: str = None) -> ResCommonResponse:
         """종목별 프로그램 매매동향(일별) 조회 (실전 전용)"""
         return await self._quotations.get_program_trade_by_stock_daily(stock_code, date)
+
+    async def get_program_trade_by_stock_daily_multi(self, stock_code: str, date: str = None, days: int = 3) -> ResCommonResponse:
+        """종목별 프로그램 매매동향(일별) 다중일 조회 (실전 전용) — output[:days] 리스트 반환"""
+        return await self._quotations.get_program_trade_by_stock_daily_multi(stock_code, date, days)
     
     # async def get_stock_news(self, stock_code: str) -> ResCommonResponse:
     #     """

--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -850,6 +850,57 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
                 data=None
             )
 
+    async def get_program_trade_by_stock_daily_multi(self, stock_code: str, date: str = None, days: int = 3) -> ResCommonResponse:
+        """
+        종목별 프로그램매매추이(일별) 다중일 조회
+        실전 전용 (모의투자 미지원)
+        output[:days] 를 리스트로 반환한다.
+        """
+        if date is None:
+            date = datetime.now().strftime("%Y%m%d")
+
+        full_config = self._env.active_config
+        tr_id = self._trid_provider.quotations(TrIdLeaf.PROGRAM_TRADE_BY_STOCK_DAILY)
+
+        self._headers.set_tr_id(tr_id)
+        self._headers.set_custtype(full_config["custtype"])
+
+        params = Params.program_trade_by_stock_daily(stock_code=stock_code, date=date)
+
+        response: ResCommonResponse = await self.call_api(
+            "GET", EndpointKey.PROGRAM_TRADE_BY_STOCK_DAILY, params=params, retry_count=1
+        )
+
+        if response.rt_cd != ErrorCode.SUCCESS.value:
+            return response
+
+        try:
+            if not isinstance(response.data, dict):
+                raise TypeError(f"Expected dict, got {type(response.data)}")
+
+            output = response.data.get("output", [])
+
+            if not isinstance(output, list) or not output:
+                return ResCommonResponse(
+                    rt_cd=ErrorCode.SUCCESS.value,
+                    msg1="데이터 없음",
+                    data=[]
+                )
+
+            return ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="프로그램매매추이 다중일 조회 성공",
+                data=output[:days]
+            )
+        except (TypeError, AttributeError) as e:
+            error_msg = f"프로그램매매추이 다중일 응답 형식 오류: {e}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(
+                rt_cd=ErrorCode.PARSING_ERROR.value,
+                msg1=error_msg,
+                data=None
+            )
+
     # async def get_stock_news(self, stock_code: str) -> ResCommonResponse:
     #     """
     #     종목 뉴스 조회

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -42,6 +42,8 @@ class RankingTask(AfterMarketTask):
 
     # 청크 크기 (API 호출 페이싱은 ApiBudgetLimiter가 중앙에서 담당)
     API_CHUNK_SIZE = 8
+    PERIOD_RANKING_ALLOWED_DAYS = {1, 3, 5, 10, 20}
+    PERIOD_RANKING_ALLOWED_METRICS = {"amount", "qty"}
 
     def __init__(
         self,
@@ -56,6 +58,7 @@ class RankingTask(AfterMarketTask):
         telegram_reporter: Optional[TelegramReporter] = None,
         market_calendar_service: Optional[MarketCalendarService] = None,
         worker_pool: Optional[WorkerPool] = None,
+        stock_classification_repository=None,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -70,6 +73,7 @@ class RankingTask(AfterMarketTask):
         self.pm = performance_profiler if performance_profiler else PerformanceProfiler(enabled=False)
         self._notification_service = notification_service
         self._telegram_reporter = telegram_reporter
+        self._stock_classification_repository = stock_classification_repository
         self._suspend_event: asyncio.Event = asyncio.Event()
         self._suspend_event.set()  # 초기에는 실행 가능 상태
 
@@ -514,6 +518,165 @@ class RankingTask(AfterMarketTask):
         for i, item in enumerate(top, 1):
             item["data_rank"] = str(i)
         return top
+
+    @staticmethod
+    def _to_int(value, default: int = 0) -> int:
+        try:
+            if value in (None, ""):
+                return default
+            return int(str(value).replace(",", ""))
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _sum_rows(rows: List[Dict], field: str) -> int:
+        return sum(RankingTask._to_int(row.get(field, 0)) for row in rows if isinstance(row, dict))
+
+    async def _load_industry_map(self) -> Dict[str, str]:
+        """분류 저장소에서 종목코드 -> 대표 업종명을 만든다. 데이터가 없으면 빈 dict."""
+        repo = self._stock_classification_repository
+        if repo is None:
+            return {}
+
+        try:
+            groups = await repo.get_groups(category_types=("industry",))
+        except Exception as e:
+            self._logger.warning(f"업종 분류 조회 실패: {e}")
+            return {}
+
+        industry_map: Dict[str, str] = {}
+        for industry, group in sorted((groups or {}).items(), key=lambda item: item[0]):
+            members = group.get("members", []) if isinstance(group, dict) else []
+            for member in members:
+                if not isinstance(member, dict):
+                    continue
+                code = str(member.get("code") or "").strip()
+                if code and code not in industry_map:
+                    industry_map[code] = industry
+        return industry_map
+
+    async def get_period_investor_program_net_buy_ranking(
+        self,
+        days: int = 5,
+        metric: str = "amount",
+        limit: int = 30,
+    ) -> ResCommonResponse:
+        """최근 N거래일 외국인+기관+프로그램 순매수 기간 랭킹을 생성한다.
+
+        amount 정렬은 외국인/기관 백만원 단위와 프로그램 원 단위를 원 단위로 통일한다.
+        qty 정렬은 세 주체의 순매수량 합산 기준이다.
+        """
+        if days not in self.PERIOD_RANKING_ALLOWED_DAYS:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1=f"days는 {sorted(self.PERIOD_RANKING_ALLOWED_DAYS)} 중 하나여야 합니다.",
+                data=[],
+            )
+        if metric not in self.PERIOD_RANKING_ALLOWED_METRICS:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.INVALID_INPUT.value,
+                msg1="metric은 amount 또는 qty 여야 합니다.",
+                data=[],
+            )
+
+        target_date = None
+        if self._mcs:
+            target_date = await self._mcs.get_latest_trading_date()
+        if not target_date:
+            target_date = datetime.now().strftime("%Y%m%d")
+
+        all_stocks = self._load_all_stocks()
+        if not all_stocks:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="대상 종목 없음",
+                data=[],
+            )
+
+        industry_map = await self._load_industry_map()
+        results: List[Dict] = []
+
+        for chunk in _chunked(all_stocks, self.API_CHUNK_SIZE):
+            await self._suspend_event.wait()
+
+            investor_tasks = [
+                self._fetch_with_retry(self._broker.get_investor_trade_by_stock_daily_multi, code, target_date, days)
+                for code, _, _ in chunk
+            ]
+            program_tasks = [
+                self._fetch_with_retry(self._broker.get_program_trade_by_stock_daily_multi, code, target_date, days)
+                for code, _, _ in chunk
+            ]
+            all_responses = await asyncio.gather(
+                *investor_tasks, *program_tasks, return_exceptions=True
+            )
+            investor_responses = all_responses[:len(chunk)]
+            program_responses = all_responses[len(chunk):]
+
+            for (code, name, _market), investor_resp, program_resp in zip(chunk, investor_responses, program_responses):
+                if isinstance(investor_resp, Exception) or isinstance(program_resp, Exception):
+                    continue
+
+                investor_rows = investor_resp.data if investor_resp and isinstance(investor_resp.data, list) else []
+                program_rows = program_resp.data if program_resp and isinstance(program_resp.data, list) else []
+
+                frgn_qty = self._sum_rows(investor_rows, "frgn_ntby_qty")
+                orgn_qty = self._sum_rows(investor_rows, "orgn_ntby_qty")
+                frgn_pbmn_mil = self._sum_rows(investor_rows, "frgn_ntby_tr_pbmn")
+                orgn_pbmn_mil = self._sum_rows(investor_rows, "orgn_ntby_tr_pbmn")
+                program_qty = self._sum_rows(program_rows, "whol_smtn_ntby_qty")
+                program_pbmn_won = self._sum_rows(program_rows, "whol_smtn_ntby_tr_pbmn")
+
+                frgn_pbmn_won = frgn_pbmn_mil * 1_000_000
+                orgn_pbmn_won = orgn_pbmn_mil * 1_000_000
+                combined_pbmn_won = frgn_pbmn_won + orgn_pbmn_won + program_pbmn_won
+                combined_qty = frgn_qty + orgn_qty + program_qty
+
+                rank_value = combined_pbmn_won if metric == "amount" else combined_qty
+                if rank_value <= 0:
+                    continue
+
+                first_investor = investor_rows[0] if investor_rows and isinstance(investor_rows[0], dict) else {}
+                first_program = program_rows[0] if program_rows and isinstance(program_rows[0], dict) else {}
+                stck_prpr = first_investor.get("stck_prpr") or first_program.get("stck_clpr") or "0"
+                acml_tr_pbmn = first_investor.get("acml_tr_pbmn") or first_program.get("acml_tr_pbmn") or "0"
+
+                results.append({
+                    "stck_shrn_iscd": code,
+                    "hts_kor_isnm": name,
+                    "industry": industry_map.get(code, "-"),
+                    "period_days": str(days),
+                    "period_metric": metric,
+                    "stck_prpr": str(stck_prpr or "0"),
+                    "prdy_ctrt": str(first_investor.get("prdy_ctrt") or first_program.get("prdy_ctrt") or "0"),
+                    "prdy_vrss": str(first_investor.get("prdy_vrss") or first_program.get("prdy_vrss") or "0"),
+                    "prdy_vrss_sign": str(first_investor.get("prdy_vrss_sign") or first_program.get("prdy_vrss_sign") or ""),
+                    "acml_tr_pbmn": str(acml_tr_pbmn or "0"),
+                    "frgn_period_ntby_qty": str(frgn_qty),
+                    "orgn_period_ntby_qty": str(orgn_qty),
+                    "program_period_ntby_qty": str(program_qty),
+                    "combined_period_ntby_qty": str(combined_qty),
+                    "frgn_period_ntby_tr_pbmn": str(frgn_pbmn_mil),
+                    "orgn_period_ntby_tr_pbmn": str(orgn_pbmn_mil),
+                    "program_period_ntby_tr_pbmn": str(program_pbmn_won // 1_000_000),
+                    "combined_period_ntby_tr_pbmn": str(combined_pbmn_won // 1_000_000),
+                    "frgn_period_ntby_tr_pbmn_won": str(frgn_pbmn_won),
+                    "orgn_period_ntby_tr_pbmn_won": str(orgn_pbmn_won),
+                    "program_period_ntby_tr_pbmn_won": str(program_pbmn_won),
+                    "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
+                })
+
+        sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
+        results.sort(key=lambda item: self._to_int(item.get(sort_field)), reverse=True)
+        top = [dict(item) for item in results[:limit]]
+        for i, item in enumerate(top, 1):
+            item["data_rank"] = str(i)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1=f"최근 {days}거래일 외국인+기관+프로그램 기간 순매수 랭킹 조회 성공",
+            data=top,
+        )
 
     async def get_trading_value_ranking(self, limit: int = 30) -> ResCommonResponse:
         """투자자 데이터 기반 거래대금 랭킹 반환 (캐시에서 즉시)."""

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -1988,6 +1988,46 @@ async def test_get_program_trade_by_stock_daily_parsing_error(mock_quotations):
 
 
 @pytest.mark.asyncio
+async def test_get_program_trade_by_stock_daily_multi_success(mock_quotations):
+    """프로그램매매추이 다중일 조회는 output[:days] 리스트를 반환한다."""
+    api = mock_quotations
+    api.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data={
+            "output": [
+                {"stck_bsop_date": "20260305", "whol_smtn_ntby_qty": "1000"},
+                {"stck_bsop_date": "20260304", "whol_smtn_ntby_qty": "-500"},
+                {"stck_bsop_date": "20260303", "whol_smtn_ntby_qty": "300"},
+            ]
+        },
+    ))
+
+    result = await api.get_program_trade_by_stock_daily_multi("005930", date="20260305", days=2)
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert len(result.data) == 2
+    assert result.data[0]["stck_bsop_date"] == "20260305"
+    assert result.data[1]["stck_bsop_date"] == "20260304"
+    api.call_api.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_program_trade_by_stock_daily_multi_empty(mock_quotations):
+    """프로그램매매추이 다중일 output 이 비어 있으면 빈 리스트를 반환한다."""
+    api = mock_quotations
+    api.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": []}
+    ))
+
+    result = await api.get_program_trade_by_stock_daily_multi("005930")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data == []
+    assert "데이터 없음" in result.msg1
+
+
+@pytest.mark.asyncio
 async def test_read_only_ranking_apis_pass_through_in_paper_mode(mock_quotations):
     """paper 모드에서도 조회성 랭킹 API는 KIS 조회 엔드포인트로 전달한다."""
     mock_quotations._env.is_paper_trading = True

--- a/tests/unit_test/brokers/test_broker_api_wrapper.py
+++ b/tests/unit_test/brokers/test_broker_api_wrapper.py
@@ -677,6 +677,11 @@ async def test_investor_and_program_trade_delegations(broker_wrapper_instance):
     mock_client.get_program_trade_by_stock_daily.assert_called_once_with("005930", "20250101")
     assert result == {"program": "trade"}
 
+    mock_client.get_program_trade_by_stock_daily_multi.return_value = [{"program": "multi"}]
+    result = await wrapper.get_program_trade_by_stock_daily_multi("005930", "20250101", days=5)
+    mock_client.get_program_trade_by_stock_daily_multi.assert_called_once_with("005930", "20250101", 5)
+    assert result == [{"program": "multi"}]
+
 
 @pytest.mark.asyncio
 async def test_check_holiday_delegation(broker_wrapper_instance):

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -33,6 +33,15 @@ def _make_program_response(ntby_tr_pbmn=0, ntby_qty=0, stck_clpr="10000", prdy_c
     )
 
 
+def _make_program_multi_response(rows):
+    """프로그램매매추이 다중일 응답 생성 헬퍼."""
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data=rows,
+    )
+
+
 @pytest.fixture
 def mock_deps():
     broker = MagicMock()
@@ -103,6 +112,15 @@ def _make_investor_response(
             "orgn_ntby_tr_pbmn": str(orgn_pbmn),
             "prsn_ntby_tr_pbmn": str(prsn_pbmn),
         }
+    )
+
+
+def _make_investor_multi_response(rows):
+    """투자자 매매동향 다중일 응답 생성 헬퍼."""
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data=rows,
     )
 
 # ==============================================================================
@@ -262,6 +280,90 @@ async def test_refresh_investor_ranking_basic(bg_service, mock_deps):
     # 개인 순매도 상위: 삼성(-300)
     prsn_sell = await bg_service.get_prsn_net_sell_ranking()
     assert prsn_sell.data[0]["hts_kor_isnm"] == "삼성전자"
+
+
+@pytest.mark.asyncio
+async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_service, mock_deps):
+    """기간 수급 랭킹은 외국인+기관(백만원)과 프로그램(원)을 원 단위로 합산해 정렬한다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([
+        ("005930", "삼성전자", "KOSPI"),
+        ("000660", "SK하이닉스", "KOSPI"),
+        ("035420", "NAVER", "KOSDAQ"),
+    ])
+
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(side_effect=lambda code, date=None, days=5: {
+        "005930": _make_investor_multi_response([
+            {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
+            {"frgn_ntby_qty": "5", "orgn_ntby_qty": "5", "frgn_ntby_tr_pbmn": "50", "orgn_ntby_tr_pbmn": "50"},
+        ]),
+        "000660": _make_investor_multi_response([
+            {"frgn_ntby_qty": "50", "orgn_ntby_qty": "10", "frgn_ntby_tr_pbmn": "10", "orgn_ntby_tr_pbmn": "10"},
+        ]),
+        "035420": _make_investor_multi_response([
+            {"frgn_ntby_qty": "-10", "orgn_ntby_qty": "-10", "frgn_ntby_tr_pbmn": "-100", "orgn_ntby_tr_pbmn": "-100"},
+        ]),
+    }[code])
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(side_effect=lambda code, date=None, days=5: {
+        "005930": _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "7", "whol_smtn_ntby_tr_pbmn": "70000000"},
+        ]),
+        "000660": _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "200", "whol_smtn_ntby_tr_pbmn": "900000000"},
+        ]),
+        "035420": _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "1", "whol_smtn_ntby_tr_pbmn": "1000000"},
+        ]),
+    }[code])
+    bg_service._stock_classification_repository = AsyncMock()
+    bg_service._stock_classification_repository.get_groups.return_value = {
+        "반도체": {"members": [{"code": "005930", "name": "삼성전자"}]},
+        "IT": {"members": [{"code": "000660", "name": "SK하이닉스"}]},
+    }
+
+    resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5)
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [item["hts_kor_isnm"] for item in resp.data] == ["SK하이닉스", "삼성전자"]
+    assert resp.data[0]["combined_period_ntby_tr_pbmn_won"] == "920000000"
+    assert resp.data[1]["combined_period_ntby_tr_pbmn_won"] == "470000000"
+    assert all(item["hts_kor_isnm"] != "NAVER" for item in resp.data)
+    assert resp.data[0]["industry"] == "IT"
+    assert resp.data[1]["industry"] == "반도체"
+
+
+@pytest.mark.asyncio
+async def test_period_investor_program_ranking_can_sort_by_qty(bg_service, mock_deps):
+    """metric=qty 는 외국인+기관+프로그램 기간 순매수량 합산 기준으로 정렬한다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([
+        ("005930", "삼성전자", "KOSPI"),
+        ("000660", "SK하이닉스", "KOSPI"),
+    ])
+
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(side_effect=lambda code, date=None, days=5: {
+        "005930": _make_investor_multi_response([
+            {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "500", "orgn_ntby_tr_pbmn": "500"},
+        ]),
+        "000660": _make_investor_multi_response([
+            {"frgn_ntby_qty": "100", "orgn_ntby_qty": "100", "frgn_ntby_tr_pbmn": "10", "orgn_ntby_tr_pbmn": "10"},
+        ]),
+    }[code])
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(side_effect=lambda code, date=None, days=5: {
+        "005930": _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "1", "whol_smtn_ntby_tr_pbmn": "1"},
+        ]),
+        "000660": _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "100", "whol_smtn_ntby_tr_pbmn": "1"},
+        ]),
+    }[code])
+
+    resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty")
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert [item["hts_kor_isnm"] for item in resp.data] == ["SK하이닉스", "삼성전자"]
+    assert resp.data[0]["combined_period_ntby_qty"] == "300"
+    assert resp.data[1]["combined_period_ntby_qty"] == "31"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -121,6 +121,47 @@ async def test_get_ranking_failure(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_period_investor_program_ranking(web_client, mock_web_ctx):
+    """GET /api/ranking/investor-period 는 기간 수급 랭킹을 반환한다."""
+    mock_web_ctx.ranking_task.get_period_investor_program_net_buy_ranking = AsyncMock(return_value=ResCommonResponse(
+        rt_cd="0",
+        msg1="Success",
+        data=[{
+            "data_rank": "1",
+            "industry": "반도체",
+            "hts_kor_isnm": "삼성전자",
+            "combined_period_ntby_tr_pbmn_won": "300000000",
+        }],
+    ))
+
+    response = web_client.get("/api/ranking/investor-period?days=5&metric=amount&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"][0]["industry"] == "반도체"
+    mock_web_ctx.ranking_task.get_period_investor_program_net_buy_ranking.assert_awaited_once_with(
+        days=5,
+        metric="amount",
+        limit=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_period_investor_program_ranking_validates_query(web_client, mock_web_ctx):
+    """기간 수급 랭킹은 허용된 days/metric 만 받는다."""
+    mock_web_ctx.ranking_task.get_period_investor_program_net_buy_ranking = AsyncMock()
+
+    response = web_client.get("/api/ranking/investor-period?days=7&metric=amount")
+    assert response.status_code == 400
+
+    response = web_client.get("/api/ranking/investor-period?days=5&metric=bad")
+    assert response.status_code == 400
+
+    mock_web_ctx.ranking_task.get_period_investor_program_net_buy_ranking.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_top_market_cap(web_client, mock_web_ctx):
     """GET /api/top-market-cap 엔드포인트 테스트"""
     mock_web_ctx.broker.get_top_market_cap_stocks_code.return_value = ResCommonResponse(

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -316,6 +316,7 @@ class ServiceContainer:
                     market_calendar_service=ctx._mcs,
                     market_data_service=ctx.market_data_service,
                     worker_pool=ctx.worker_pool,
+                    stock_classification_repository=getattr(ctx, "theme_classification_repository", None),
                 )
                 if needs_batch:
                     ctx.market_cap_gap_service = MarketCapGapService(

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -3,7 +3,7 @@
 """
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from common.types import ErrorCode
@@ -119,6 +119,39 @@ async def analyze_ranking_candidates(payload: RankingAIAnalysisRequest):
         market_context=payload.market_context or {},
         max_candidates=payload.max_candidates,
     )
+    return _serialize_response(resp)
+
+
+@router.get("/ranking/investor-period")
+async def get_period_investor_program_ranking(
+    days: int = Query(5),
+    metric: str = Query("amount"),
+    limit: int = Query(30, ge=1, le=100),
+):
+    """최근 N거래일 외국인+기관+프로그램 기간 순매수 랭킹 조회."""
+    valid_days = (1, 3, 5, 10, 20)
+    valid_metrics = ("amount", "qty")
+    if days not in valid_days:
+        raise HTTPException(status_code=400, detail=f"days는 {', '.join(map(str, valid_days))} 중 하나여야 합니다.")
+    if metric not in valid_metrics:
+        raise HTTPException(status_code=400, detail="metric은 amount 또는 qty 여야 합니다.")
+
+    ctx = _get_ctx()
+    ranking_task = getattr(ctx, "ranking_task", None)
+    if not ranking_task:
+        return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "RankingTask 미설정", "data": []}
+
+    resp = await ranking_task.get_period_investor_program_net_buy_ranking(
+        days=days,
+        metric=metric,
+        limit=limit,
+    )
+    if resp and resp.rt_cd == ErrorCode.SUCCESS.value:
+        return {
+            "rt_cd": resp.rt_cd,
+            "msg1": resp.msg1,
+            "data": _serialize_list_items(resp.data),
+        }
     return _serialize_response(resp)
 
 

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -7,6 +7,8 @@ let _rankingSortState = { key: null, dir: 'asc' };
 let _rankingDirection = null;
 let _rankingSelectedInvestors = new Set(['foreign']);
 let _rankingAIAnalysisState = { loading: false, result: null, error: null };
+let _rankingPeriodDays = 5;
+let _rankingPeriodMetric = 'amount';
 
 const _investorTypeFields = {
     'foreign': { pbmn: 'frgn_ntby_tr_pbmn', qty: 'frgn_ntby_qty', isMil: true, label: '외인' },
@@ -22,7 +24,8 @@ function setMarketFilter(market, btn) {
     _resetRankingAIAnalysis();
     document.querySelectorAll('.market-filter').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
-    if (_rankingDirection) loadInvestorRanking();
+    if (_rankingCurrentCategory === 'investor_period') loadPeriodInvestorRanking();
+    else if (_rankingDirection) loadInvestorRanking();
     else if (_rankingCurrentCategory) loadRanking(_rankingCurrentCategory);
 }
 
@@ -66,6 +69,8 @@ async function loadRanking(category) {
 
     const invRow = document.getElementById('investor-type-row');
     if (invRow) invRow.style.display = 'none';
+    const periodRow = document.getElementById('period-investor-row');
+    if (periodRow) periodRow.style.display = 'none';
 
     const div = document.getElementById('ranking-result');
     _showRankingSkeleton();
@@ -134,6 +139,8 @@ function setRankingDirection(dir) {
 
     const invRow = document.getElementById('investor-type-row');
     if (invRow) invRow.style.display = '';
+    const periodRow = document.getElementById('period-investor-row');
+    if (periodRow) periodRow.style.display = 'none';
 
     document.querySelectorAll('.investor-toggle').forEach(b => {
         b.classList.toggle('active', _rankingSelectedInvestors.has(b.dataset.inv));
@@ -157,6 +164,74 @@ function toggleRankingInvestor(type) {
 
     _resetRankingAIAnalysis();
     loadInvestorRanking();
+}
+
+function setPeriodInvestorDays(days, btn) {
+    _rankingPeriodDays = days;
+    document.querySelectorAll('.period-days').forEach(b => {
+        b.classList.toggle('active', parseInt(b.dataset.days || 0) === days);
+    });
+    loadPeriodInvestorRanking();
+}
+
+function setPeriodInvestorMetric(metric, btn) {
+    _rankingPeriodMetric = metric;
+    document.querySelectorAll('.period-metric').forEach(b => {
+        b.classList.toggle('active', b.dataset.metric === metric);
+    });
+    loadPeriodInvestorRanking();
+}
+
+async function loadPeriodInvestorRanking() {
+    if (_rankingPollTimer) {
+        clearTimeout(_rankingPollTimer);
+        _rankingPollTimer = null;
+    }
+    if (window.Paginator) window.Paginator.reset('ranking');
+    _rankingCurrentCategory = 'investor_period';
+    _rankingDirection = null;
+    _rankingSortState = { key: null, dir: 'asc' };
+    _resetRankingAIAnalysis();
+
+    document.querySelectorAll('.ranking-tab').forEach(b => {
+        b.classList.remove('active');
+        if (b.dataset.cat === 'investor_period') b.classList.add('active');
+    });
+
+    const invRow = document.getElementById('investor-type-row');
+    if (invRow) invRow.style.display = 'none';
+    const periodRow = document.getElementById('period-investor-row');
+    if (periodRow) periodRow.style.display = '';
+
+    document.querySelectorAll('.period-days').forEach(b => {
+        b.classList.toggle('active', parseInt(b.dataset.days || 0) === _rankingPeriodDays);
+    });
+    document.querySelectorAll('.period-metric').forEach(b => {
+        b.classList.toggle('active', b.dataset.metric === _rankingPeriodMetric);
+    });
+
+    const div = document.getElementById('ranking-result');
+    _showRankingSkeleton();
+
+    try {
+        const url = `/api/ranking/investor-period?days=${_rankingPeriodDays}&metric=${_rankingPeriodMetric}&limit=30`;
+        const res = await fetchWithTimeout(url, {}, 300000);
+        const json = await res.json();
+
+        if (json.rt_cd !== "0") {
+            div.innerHTML = `<p class="error">실패: ${json.msg1}</p>`;
+            return;
+        }
+
+        _rankingData = json.data || [];
+        renderRankingTable();
+    } catch (e) {
+        if (e.name === 'AbortError') {
+            div.innerHTML = '<p class="error">요청 시간이 초과되었습니다. 기간수급 수집은 전체 종목을 순회하므로 잠시 후 다시 시도해주세요.</p>';
+        } else {
+            div.innerHTML = "오류: " + e;
+        }
+    }
 }
 
 async function loadInvestorRanking() {
@@ -277,6 +352,8 @@ async function loadThemeLeaders() {
     });
     const invRow = document.getElementById('investor-type-row');
     if (invRow) invRow.style.display = 'none';
+    const periodRow = document.getElementById('period-investor-row');
+    if (periodRow) periodRow.style.display = 'none';
 
     const div = document.getElementById('ranking-result');
     _showRankingSkeleton();
@@ -485,6 +562,7 @@ function renderRankingTable() {
     const isInvestor = ['foreign_buy', 'foreign_sell', 'inst_buy', 'inst_sell', 'prsn_buy', 'prsn_sell'].includes(cat);
     const isProgram = ['program_buy', 'program_sell'].includes(cat);
     const isCombined = cat === 'investor_buy' || cat === 'investor_sell';
+    const isPeriodInvestor = cat === 'investor_period';
     const isTradingValue = cat === 'trading_value';
     const isSell = cat.endsWith('_sell') || cat === 'investor_sell';
 
@@ -498,7 +576,17 @@ function renderRankingTable() {
         : '';
 
     let headerRow;
-    if (isInvestor || isProgram || isCombined) {
+    if (isPeriodInvestor) {
+        const unitLabel = _rankingPeriodMetric === 'amount' ? '순매수대금' : '순매수량';
+        const totalLabel = _rankingPeriodMetric === 'amount' ? '매수금액(백만)' : '합산순매수량';
+        headerRow = `<th class="${sortCls('rank')}" onclick="sortRanking('rank')">순위</th>`
+            + `<th class="${sortCls('industry')}" onclick="sortRanking('industry')">업종</th>`
+            + `<th class="${sortCls('name')}" onclick="sortRanking('name')">종목명</th>`
+            + `<th class="${sortCls('period_foreign')}" onclick="sortRanking('period_foreign')">외국인 ${unitLabel}</th>`
+            + `<th class="${sortCls('period_inst')}" onclick="sortRanking('period_inst')">기관 ${unitLabel}</th>`
+            + `<th class="${sortCls('period_program')}" onclick="sortRanking('period_program')">프로그램 ${unitLabel}</th>`
+            + `<th class="${sortCls('period_combined')}" onclick="sortRanking('period_combined')">${totalLabel}</th>`;
+    } else if (isInvestor || isProgram || isCombined) {
         const pbmnLabel = isCombined
             ? `${investorLabel} ${isSell ? '순매도대금' : '순매수대금'}`
             : (isSell ? '순매도대금' : '순매수대금');
@@ -574,12 +662,44 @@ function renderRankingTable() {
         }
         return v.toLocaleString() + "억";
     };
+    const formatPeriodAmountMillion = (val) => {
+        const n = parseInt(val || 0);
+        return isNaN(n) ? '-' : n.toLocaleString();
+    };
+    const formatPeriodQty = (val) => {
+        const n = parseInt(val || 0);
+        return isNaN(n) ? '-' : n.toLocaleString();
+    };
 
     let rows = '';
     pageData.forEach(item => {
         const rate = parseFloat(item.prdy_ctrt || 0);
         const color = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
         const code = item.stck_shrn_iscd || item.iscd || item.mksc_shrn_iscd || item.code || '';
+        if (isPeriodInvestor) {
+            const foreignVal = _rankingPeriodMetric === 'amount'
+                ? formatPeriodAmountMillion(item.frgn_period_ntby_tr_pbmn)
+                : formatPeriodQty(item.frgn_period_ntby_qty);
+            const instVal = _rankingPeriodMetric === 'amount'
+                ? formatPeriodAmountMillion(item.orgn_period_ntby_tr_pbmn)
+                : formatPeriodQty(item.orgn_period_ntby_qty);
+            const programVal = _rankingPeriodMetric === 'amount'
+                ? formatPeriodAmountMillion(item.program_period_ntby_tr_pbmn)
+                : formatPeriodQty(item.program_period_ntby_qty);
+            const combinedVal = _rankingPeriodMetric === 'amount'
+                ? formatPeriodAmountMillion(item.combined_period_ntby_tr_pbmn)
+                : formatPeriodQty(item.combined_period_ntby_qty);
+            rows += `<tr>
+                <td>${item.data_rank || item.rank || '-'}</td>
+                <td>${escapeHtml(item.industry || '-')}</td>
+                <td><a href="/stock?code=${code}" target="_blank" class="stock-link">${escapeHtml(item.hts_kor_isnm || item.name || code)}</a></td>
+                <td>${foreignVal}</td>
+                <td>${instVal}</td>
+                <td>${programVal}</td>
+                <td>${combinedVal}</td>
+            </tr>`;
+            return;
+        }
         let extraCols;
         if (isMinervini) {
             extraCols = `<td>S${item.stage}</td><td>${item.rs_rating || '-'}</td><td>${formatMarketCap(item.market_cap || 0)}</td>`;
@@ -642,6 +762,7 @@ function sortRanking(key) {
 function rankingSortCompare(data, key, dir) {
     const cat = _rankingCurrentCategory;
     const isCombined = cat === 'investor_buy' || cat === 'investor_sell';
+    const isPeriodInvestor = cat === 'investor_period';
     const isInvestor = ['foreign_buy', 'foreign_sell', 'inst_buy', 'inst_sell', 'prsn_buy', 'prsn_sell'].includes(cat);
     const sorted = data.slice();
     const d = dir === 'asc' ? 1 : -1;
@@ -653,6 +774,10 @@ function rankingSortCompare(data, key, dir) {
         } else if (key === 'name') {
             va = (a.hts_kor_isnm || a.name || '').toLowerCase();
             vb = (b.hts_kor_isnm || b.name || '').toLowerCase();
+            return d * va.localeCompare(vb);
+        } else if (key === 'industry') {
+            va = (a.industry || '').toLowerCase();
+            vb = (b.industry || '').toLowerCase();
             return d * va.localeCompare(vb);
         } else if (key === 'price') {
             va = parseInt(a.stck_prpr || 0);
@@ -698,6 +823,18 @@ function rankingSortCompare(data, key, dir) {
                 va = acmlA ? (rawA / acmlA) : 0;
                 vb = acmlB ? (rawB / acmlB) : 0;
             }
+        } else if (key === 'period_foreign' && isPeriodInvestor) {
+            va = parseInt(_rankingPeriodMetric === 'amount' ? a.frgn_period_ntby_tr_pbmn_won || 0 : a.frgn_period_ntby_qty || 0);
+            vb = parseInt(_rankingPeriodMetric === 'amount' ? b.frgn_period_ntby_tr_pbmn_won || 0 : b.frgn_period_ntby_qty || 0);
+        } else if (key === 'period_inst' && isPeriodInvestor) {
+            va = parseInt(_rankingPeriodMetric === 'amount' ? a.orgn_period_ntby_tr_pbmn_won || 0 : a.orgn_period_ntby_qty || 0);
+            vb = parseInt(_rankingPeriodMetric === 'amount' ? b.orgn_period_ntby_tr_pbmn_won || 0 : b.orgn_period_ntby_qty || 0);
+        } else if (key === 'period_program' && isPeriodInvestor) {
+            va = parseInt(_rankingPeriodMetric === 'amount' ? a.program_period_ntby_tr_pbmn_won || 0 : a.program_period_ntby_qty || 0);
+            vb = parseInt(_rankingPeriodMetric === 'amount' ? b.program_period_ntby_tr_pbmn_won || 0 : b.program_period_ntby_qty || 0);
+        } else if (key === 'period_combined' && isPeriodInvestor) {
+            va = parseInt(_rankingPeriodMetric === 'amount' ? a.combined_period_ntby_tr_pbmn_won || 0 : a.combined_period_ntby_qty || 0);
+            vb = parseInt(_rankingPeriodMetric === 'amount' ? b.combined_period_ntby_tr_pbmn_won || 0 : b.combined_period_ntby_qty || 0);
         } else if (key === 'market_cap') {
             va = parseInt(a.market_cap || 0);
             vb = parseInt(b.market_cap || 0);

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -19,6 +19,7 @@
                 <button class="btn ranking-tab" data-cat="minervini_stage2" onclick="loadRanking('minervini_stage2')">Minervini S2</button>
                 <button class="btn ranking-tab" data-cat="newhigh" onclick="loadRanking('newhigh')">신고가</button>
                 <button class="btn ranking-tab" data-cat="theme_leaders" onclick="loadThemeLeaders()">테마주도</button>
+                <button class="btn ranking-tab" data-cat="investor_period" onclick="loadPeriodInvestorRanking()">기간수급</button>
             </div>
             <div class="ranking-investor-group" style="margin-top: 6px;">
                 <div class="form-row" style="margin-bottom: 0;">
@@ -31,6 +32,17 @@
                         <button class="btn investor-toggle" data-inv="program" onclick="toggleRankingInvestor('program')">프로그램</button>
                     </div>
                 </div>
+                <div id="period-investor-row" class="form-row" style="display: none; margin-top: 6px; margin-bottom: 0;">
+                    <button class="btn period-days active" data-days="5" onclick="setPeriodInvestorDays(5, this)">5D</button>
+                    <button class="btn period-days" data-days="1" onclick="setPeriodInvestorDays(1, this)">1D</button>
+                    <button class="btn period-days" data-days="3" onclick="setPeriodInvestorDays(3, this)">3D</button>
+                    <button class="btn period-days" data-days="10" onclick="setPeriodInvestorDays(10, this)">10D</button>
+                    <button class="btn period-days" data-days="20" onclick="setPeriodInvestorDays(20, this)">20D</button>
+                    <div style="margin-left: 8px; padding-left: 12px; border-left: 2px solid var(--accent-secondary, #3b82f6);">
+                        <button class="btn period-metric active" data-metric="amount" onclick="setPeriodInvestorMetric('amount', this)">금액</button>
+                        <button class="btn period-metric" data-metric="qty" onclick="setPeriodInvestorMetric('qty', this)">수량</button>
+                    </div>
+                </div>
             </div>
         </div>
         <div id="ranking-result"></div>
@@ -39,7 +51,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=4"></script>
+<script src="/static/js/ranking.js?v=5"></script>
 <script>
     loadRanking('rise');
 </script>


### PR DESCRIPTION
﻿## What changed
- Added a multi-day KIS program trading wrapper and delegated it through the broker layers.
- Added a period investor/program ranking endpoint for recent 1/3/5/10/20 trading-day presets.
- Added a ranking UI tab for 기간수급 with amount/quantity toggles and industry enrichment.
- Covered program multi-day parsing, period amount/quantity aggregation, industry enrichment, and route validation with tests.

## Why
The existing ranking report only covered same-day investor/program flows. This adds the requested selected-period ranking view with the default sort based on foreign + institution + program net buying amount.

## Validation
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v`
