### PR TITLE
Improve theme leader quality and subscription sources

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -289,7 +289,11 @@ class BrokerAPIWrapper:
                                 exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
         """범용 주식 주문을 실행합니다 (KoreaInvestApiTrading 위임)."""
         if self._cb_is_open():
-            remaining = (self._cb_open_until - datetime.now()).seconds // 60
+            remaining_seconds = max(
+                1,
+                int((self._cb_open_until - datetime.now()).total_seconds()) + 1,
+            )
+            remaining = (remaining_seconds + 59) // 60
             if self._logger:
                 self._logger.warning(
                     f"[CircuitBreaker] 주문 차단됨 ({remaining}분 남음): {stock_code}"
@@ -297,6 +301,7 @@ class BrokerAPIWrapper:
             return ResCommonResponse(
                 rt_cd=ErrorCode.API_ERROR.value,
                 msg1=f"서킷 브레이커 개방 — {remaining}분 후 재시도",
+                data={"retry_after_seconds": remaining_seconds},
             )
         resp = await self._client.place_stock_order(stock_code, order_price, order_qty, is_buy, exchange=exchange)
         rt_cd = getattr(resp, 'rt_cd', None) if resp else None

--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -45,6 +45,7 @@ class StreamingStockRepo:
 
     SOURCE_MANUAL = "manual"
     SOURCE_PROGRAM = "program"
+    SOURCE_LEGACY = "legacy"
 
     def __init__(self, logger=None):
         self._logger = logger or logging.getLogger(__name__)
@@ -69,7 +70,7 @@ class StreamingStockRepo:
         self._db_conn.execute("""
             CREATE TABLE IF NOT EXISTS pt_subscriptions (
                 code TEXT PRIMARY KEY,
-                source TEXT NOT NULL DEFAULT 'manual',
+                source TEXT NOT NULL DEFAULT 'legacy',
                 updated_at REAL
             )
         """)
@@ -79,7 +80,7 @@ class StreamingStockRepo:
         }
         if "source" not in columns:
             self._db_conn.execute(
-                "ALTER TABLE pt_subscriptions ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'"
+                "ALTER TABLE pt_subscriptions ADD COLUMN source TEXT NOT NULL DEFAULT 'legacy'"
             )
         if "updated_at" not in columns:
             self._db_conn.execute(
@@ -88,7 +89,11 @@ class StreamingStockRepo:
 
     @classmethod
     def _normalize_source(cls, source: Optional[str]) -> str:
-        return cls.SOURCE_PROGRAM if source == cls.SOURCE_PROGRAM else cls.SOURCE_MANUAL
+        if source == cls.SOURCE_PROGRAM:
+            return cls.SOURCE_PROGRAM
+        if source == cls.SOURCE_MANUAL:
+            return cls.SOURCE_MANUAL
+        return cls.SOURCE_LEGACY
 
     @staticmethod
     def _normalize_codes(codes: Optional[Iterable[str]]) -> Set[str]:
@@ -118,11 +123,17 @@ class StreamingStockRepo:
             self._db_conn = sqlite3.connect(db_path, check_same_thread=False)
             with self._db_lock:
                 self._ensure_pt_subscription_table_locked()
-                cursor = self._db_conn.execute("SELECT code, source FROM pt_subscriptions")
-                source_rows = {
-                    row[0]: self._normalize_source(row[1])
-                    for row in cursor.fetchall()
-                }
+                cursor = self._db_conn.execute("SELECT code, source, updated_at FROM pt_subscriptions")
+                source_rows = {}
+                for code, source, updated_at in cursor.fetchall():
+                    normalized_source = self._normalize_source(source)
+                    if normalized_source == self.SOURCE_MANUAL and updated_at is None:
+                        normalized_source = self.SOURCE_LEGACY
+                        self._db_conn.execute(
+                            "UPDATE pt_subscriptions SET source = ? WHERE code = ?",
+                            (normalized_source, code),
+                        )
+                    source_rows[code] = normalized_source
                 codes = set(source_rows)
                 if not codes:
                     codes = self._normalize_codes(fallback_codes)
@@ -133,9 +144,9 @@ class StreamingStockRepo:
                             INSERT OR IGNORE INTO pt_subscriptions (code, source, updated_at)
                             VALUES (?, ?, ?)
                             """,
-                            [(code, self.SOURCE_MANUAL, now) for code in sorted(codes)],
+                            [(code, self.SOURCE_LEGACY, now) for code in sorted(codes)],
                         )
-                        source_rows = {code: self.SOURCE_MANUAL for code in codes}
+                        source_rows = {code: self.SOURCE_LEGACY for code in codes}
                 self._db_conn.commit()
             # desired 초기화 (lock 불필요 — 앱 시작 단계, 단일 스레드)
             self._desired[StreamingType.PROGRAM_TRADING] = codes

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -180,6 +180,194 @@ class StrategyScheduler:
         self._signal_history: List[SignalRecord] = self._load_signal_history()
         self._subscriber_queues: List[asyncio.Queue] = []
         self._strategy_failure_alert_keys: set[tuple[str, str, str, str, str, str]] = set()
+        self._force_exit_retry_tasks: Dict[str, asyncio.Task] = {}
+
+    @staticmethod
+    def _is_force_exit_circuit_breaker_response(signal: TradeSignal, resp) -> bool:
+        """강제청산 주문이 로컬 서킷브레이커에만 차단됐는지 판별한다."""
+        return bool(
+            signal.action == "SELL"
+            and str(signal.reason or "").startswith("전략 종료 강제 청산")
+            and resp is not None
+            and "서킷 브레이커 개방" in str(getattr(resp, "msg1", "") or "")
+        )
+
+    @staticmethod
+    def _force_exit_retry_delay_sec(resp) -> int:
+        data = getattr(resp, "data", None)
+        if isinstance(data, dict):
+            try:
+                return max(1, int(data.get("retry_after_seconds") or 0))
+            except (TypeError, ValueError):
+                pass
+        # 구버전 응답에는 분 단위 문구만 있어 정확한 해제 시각을 알 수 없다.
+        # 기본 5분 대기 후 사전 검증을 수행한다.
+        return 5 * 60
+
+    def _force_exit_retry_key(self, signal: TradeSignal) -> str:
+        return f"{signal.strategy_name}:{signal.code}"
+
+    def _schedule_force_exit_circuit_breaker_retry(self, signal: TradeSignal, resp) -> bool:
+        """서킷브레이커 해제 후 강제청산을 안전하게 한 번 재시도한다.
+
+        재시도 전에는 반드시 미체결 매도와 실제 잔고를 조회한다. 따라서 이전 요청이
+        응답 유실 상태에서 이미 접수됐어도 중복 매도를 제출하지 않는다.
+        """
+        delay_sec = self._force_exit_retry_delay_sec(resp)
+        now = self._tm.get_current_kst_time()
+        cutoff = self._get_order_cutoff_time(self._tm.get_market_close_time())
+        if now + timedelta(seconds=delay_sec) >= cutoff:
+            self._logger.error(
+                f"[Scheduler] 강제 청산 재시도 예약 불가(주문 컷오프 초과): "
+                f"code={signal.code}, retry_after={delay_sec}s"
+            )
+            return False
+
+        key = self._force_exit_retry_key(signal)
+        existing = self._force_exit_retry_tasks.get(key)
+        if existing is not None and not existing.done():
+            self._logger.info(
+                f"[Scheduler] 강제 청산 재시도 이미 예약됨: {key}"
+            )
+            return True
+
+        retry_signal = TradeSignal(
+            strategy_name=signal.strategy_name,
+            code=signal.code,
+            name=signal.name,
+            action="SELL",
+            price=signal.price,
+            qty=signal.qty,
+            reason=signal.reason,
+            exchange=signal.exchange,
+        )
+        task = asyncio.create_task(
+            self._retry_force_exit_after_circuit_breaker(key, retry_signal, delay_sec)
+        )
+        self._force_exit_retry_tasks[key] = task
+        def _clear_completed_task(done, retry_key=key):
+            if self._force_exit_retry_tasks.get(retry_key) is done:
+                self._force_exit_retry_tasks.pop(retry_key, None)
+        task.add_done_callback(_clear_completed_task)
+        self._logger.warning(
+            f"[Scheduler] 강제 청산 재시도 예약: code={signal.code}, "
+            f"서킷브레이커 해제 후 {delay_sec}초 뒤 잔고/미체결 확인"
+        )
+        return True
+
+    async def _retry_force_exit_after_circuit_breaker(
+        self,
+        key: str,
+        signal: TradeSignal,
+        delay_sec: int,
+    ) -> None:
+        try:
+            if self._tm is not None and hasattr(self._tm, "async_sleep"):
+                await self._tm.async_sleep(delay_sec)
+            else:
+                await asyncio.sleep(delay_sec)
+
+            if not self._running:
+                self._logger.info(
+                    f"[Scheduler] 강제 청산 재시도 취소(스케줄러 정지): code={signal.code}"
+                )
+                return
+
+            now = self._tm.get_current_kst_time()
+            if now >= self._get_order_cutoff_time(self._tm.get_market_close_time()):
+                self._logger.error(
+                    f"[Scheduler] 강제 청산 재시도 취소(주문 컷오프): code={signal.code}"
+                )
+                return
+
+            broker = getattr(self._oes, "broker_api_wrapper", None)
+            if broker is None:
+                self._logger.error(
+                    f"[Scheduler] 강제 청산 재시도 취소(브로커 없음): code={signal.code}"
+                )
+                return
+
+            unfilled_resp = await broker.inquire_unfilled_orders()
+            if not unfilled_resp or unfilled_resp.rt_cd != ErrorCode.SUCCESS.value:
+                self._logger.error(
+                    f"[Scheduler] 강제 청산 재시도 취소(미체결 확인 실패): code={signal.code}"
+                )
+                return
+            if self._has_broker_unfilled_sell(unfilled_resp.data, signal.code):
+                self._logger.warning(
+                    f"[Scheduler] 강제 청산 재시도 생략(기존 미체결 매도 확인): code={signal.code}"
+                )
+                return
+
+            positions = await self._get_broker_position_map_for_force_exit()
+            broker_qty = positions.get(str(signal.code), 0)
+            if broker_qty <= 0:
+                self._logger.warning(
+                    f"[Scheduler] 강제 청산 재시도 생략(보유 수량 없음): code={signal.code}"
+                )
+                return
+
+            retry_price = 0
+            retry_reason = "전략 종료 강제 청산 재시도 (서킷 브레이커 해제 후 시장가)"
+            try:
+                quote = await broker.get_asking_price(signal.code)
+                if quote and quote.rt_cd == ErrorCode.SUCCESS.value:
+                    best_bid = self._extract_best_bid(quote.data)
+                    if best_bid > 0:
+                        retry_price = best_bid
+                        retry_reason = (
+                            "전략 종료 강제 청산 재시도 "
+                            f"(서킷 브레이커 해제 후 지정가 {best_bid:,}원)"
+                        )
+            except Exception as exc:
+                self._logger.warning(
+                    f"[Scheduler] 강제 청산 재시도 호가 조회 실패, 시장가 사용: "
+                    f"code={signal.code}, error={exc}"
+                )
+
+            retry_signal = TradeSignal(
+                strategy_name=signal.strategy_name,
+                code=signal.code,
+                name=signal.name,
+                action="SELL",
+                price=retry_price,
+                qty=min(int(signal.qty or 0), broker_qty),
+                reason=retry_reason,
+                exchange=signal.exchange,
+            )
+            if retry_signal.qty <= 0:
+                return
+            self._logger.warning(
+                f"[Scheduler] 강제 청산 재시도 실행: code={signal.code}, qty={retry_signal.qty}"
+            )
+            # 재시도 주문이 다시 서킷브레이커에 막힐 경우 새 예약을 허용한다.
+            self._force_exit_retry_tasks.pop(key, None)
+            await self._execute_signal(retry_signal)
+        except asyncio.CancelledError:
+            self._logger.info(f"[Scheduler] 강제 청산 재시도 취소됨: {key}")
+            raise
+        except Exception as exc:
+            self._logger.exception(
+                f"[Scheduler] 강제 청산 재시도 예외: code={signal.code}, error={exc}"
+            )
+
+    @staticmethod
+    def _has_broker_unfilled_sell(data, stock_code: str) -> bool:
+        """증권사 미체결 목록에 동일 종목 매도 주문이 있는지 확인한다."""
+        if not isinstance(data, dict):
+            return False
+        rows = data.get("output") or data.get("output1") or []
+        if isinstance(rows, dict):
+            rows = [rows]
+        target = str(stock_code).strip()
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            code = str(row.get("pdno") or row.get("PDNO") or "").strip()
+            side = str(row.get("sll_buy_dvsn_cd") or row.get("SLL_BUY_DVSN_CD") or "").strip()
+            if code == target and side == "01":
+                return True
+        return False
 
     # ── 전략 등록 ──
 
@@ -233,6 +421,13 @@ class StrategyScheduler:
         perform_exit = not save_state
         for cfg in self._strategies:
             await self.stop_strategy(cfg.strategy.name, perform_force_exit=perform_exit)
+
+        retry_tasks = list(self._force_exit_retry_tasks.values())
+        for task in retry_tasks:
+            task.cancel()
+        if retry_tasks:
+            await asyncio.gather(*retry_tasks, return_exceptions=True)
+        self._force_exit_retry_tasks.clear()
 
         await StrategyStateIO.flush_pending()
         self.close()
@@ -1055,10 +1250,42 @@ class StrategyScheduler:
                     api_success = False
                     msg = resp.msg1 if resp else "응답 없음"
                     order_error_msg = msg
-                    self._logger.warning(
-                        f"[Scheduler] API 주문 실패: {signal.action} {signal.code} - {msg} "
-                        f"(CSV는 기록됨)"
-                    )
+                    if self._is_force_exit_circuit_breaker_response(signal, resp) and \
+                            self._schedule_force_exit_circuit_breaker_retry(signal, resp):
+                        # 서킷브레이커 자체는 주문 API에 요청을 보내지 않은 로컬 차단이다.
+                        # 예약 작업이 해제 후 잔고/미체결을 확인하고 안전하게 재시도한다.
+                        order_deferred = True
+                        self._logger.warning(
+                            f"[Scheduler] 강제 청산 주문 보류(서킷브레이커 재시도 예정): "
+                            f"{signal.code} - {msg}"
+                        )
+                        if self._notification_service:
+                            await self._notification_service.emit(
+                                NotificationCategory.STRATEGY,
+                                NotificationLevel.WARNING,
+                                f"[{signal.strategy_name}] {signal.name} 강제 청산 재시도 예약",
+                                (
+                                    f"종목: {signal.name}({signal.code})\n"
+                                    f"주문: {log_price:,}원 × {signal.qty}주\n"
+                                    "상태: 서킷브레이커 해제 후 잔고·미체결을 확인한 뒤 재시도"
+                                ),
+                                metadata={
+                                    "strategy_name": signal.strategy_name,
+                                    "code": signal.code,
+                                    "action": signal.action,
+                                    "price": log_price,
+                                    "qty": signal.qty,
+                                    "reason": signal.reason,
+                                    "order_error": msg,
+                                    "retry_scheduled": True,
+                                    "trace_id": tid,
+                                },
+                            )
+                    else:
+                        self._logger.warning(
+                            f"[Scheduler] API 주문 실패: {signal.action} {signal.code} - {msg} "
+                            f"(CSV는 기록됨)"
+                        )
             except Exception as e:
                 api_success = False
                 order_error_msg = str(e)

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -299,7 +299,11 @@ class ProgramTradingStreamService:
 
     @staticmethod
     def _normalize_subscription_source(source) -> str:
-        return "program" if source == "program" else "manual"
+        if source == "program":
+            return "program"
+        if source == "manual":
+            return "manual"
+        return "legacy"
 
     def _get_pt_subscription_sources(self) -> dict[str, str]:
         if not self._streaming_stock_repo:
@@ -329,7 +333,7 @@ class ProgramTradingStreamService:
             for _, code in sorted(
                 enumerate(codes),
                 key=lambda item: (
-                    0 if sources.get(item[1]) == "manual" else 1,
+                    {"manual": 0, "program": 1, "legacy": 2}.get(sources.get(item[1]), 2),
                     item[0],
                 ),
             )
@@ -345,7 +349,9 @@ class ProgramTradingStreamService:
         source = sources.get(code)
         if source == "manual":
             return f"<b>[수동] {html.escape(label)}: {body}</b>"
-        return f"[프로그램] {html.escape(label)}: {body}"
+        if source == "program":
+            return f"[프로그램] {html.escape(label)}: {body}"
+        return f"[기존] {html.escape(label)}: {body}"
 
     def _extract_latest_program_snapshot(self, data: dict) -> dict | None:
         if not isinstance(data, dict):

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -325,14 +325,26 @@ class TelegramReporter:
             trading_value = self._format_won_100m(theme.get("trading_value_sum_won"))
             advancing_ratio = self._format_signed_pct(theme.get("advancing_ratio"), digits=1).replace("+", "")
             flow_ratio = self._format_signed_pct(theme.get("flow_ratio"), digits=2)
-            theme_score = theme.get("theme_score")
+            theme_score = theme.get("market_leadership_score", theme.get("theme_score"))
             score_text = ""
             if theme_score is not None:
                 try:
-                    score_text = f" | 종합점수 {float(theme_score):.2f}"
+                    score_label = "주도점수" if "market_leadership_score" in theme else "종합점수"
+                    score_text = f" | {score_label} {float(theme_score):.2f}"
                 except (TypeError, ValueError):
                     score_text = ""
-            summary_parts = [f"상승비율 {advancing_ratio}"]
+            member_count = theme.get("scored_member_count")
+            advance_count = theme.get("advance_count")
+            if member_count is not None and advance_count is not None:
+                summary_parts = [f"상승 {advance_count}/{member_count} ({advancing_ratio})"]
+            else:
+                summary_parts = [f"상승비율 {advancing_ratio}"]
+            liquidity_bonus = theme.get("liquidity_bonus")
+            if liquidity_bonus is not None:
+                try:
+                    summary_parts.append(f"유동성 +{float(liquidity_bonus):.2f}")
+                except (TypeError, ValueError):
+                    pass
             if show_flow_ratio:
                 summary_parts.append(f"수급비중 {flow_ratio}")
             summary_line = " | ".join(summary_parts) + score_text

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -346,6 +346,19 @@ class TelegramReporter:
                 rate = self._format_signed_pct(leader.get("change_rate"), digits=1)
                 tv = self._format_won_100m(leader.get("trading_value_won"))
                 lines.append(f"{name} {rate} {tv}")
+            momentum_leaders = theme.get("momentum_leaders") or []
+            liquid_codes = {leader.get("code") for leader in (theme.get("leaders") or [])}
+            thin_momentum_leaders = [
+                leader for leader in momentum_leaders
+                if leader.get("code") not in liquid_codes
+            ]
+            if thin_momentum_leaders:
+                lines.append("상승률 상위(저유동성 포함)")
+                for leader in thin_momentum_leaders[:3]:
+                    name = html.escape(str(leader.get("name") or leader.get("code") or ""), quote=False)
+                    rate = self._format_signed_pct(leader.get("change_rate"), digits=1)
+                    tv = self._format_won_100m(leader.get("trading_value_won"))
+                    lines.append(f"{name} {rate} {tv}")
             lines.append("</pre>")
             parts.append("\n".join(lines))
 

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -131,6 +131,11 @@ class ThemeDailyLeaderService:
                     flow_ratio=flow_ratio,
                     trading_value_concentration_ratio=trading_value_concentration_ratio,
                 )
+                liquidity_bonus = self._build_liquidity_bonus(
+                    trading_value_sum,
+                    leader_avg_change_rate,
+                )
+                market_leadership_score = round(score_info["theme_score"] + liquidity_bonus, 2)
 
                 themes.append({
                     "normalized_name": normalized_name,
@@ -154,6 +159,9 @@ class ThemeDailyLeaderService:
                     "zero_trading_value_ratio": score_info["zero_trading_value_ratio"],
                     "negative_trading_value_ratio": score_info["negative_trading_value_ratio"],
                     "theme_score": score_info["theme_score"],
+                    "momentum_score": score_info["theme_score"],
+                    "liquidity_bonus": liquidity_bonus,
+                    "market_leadership_score": market_leadership_score,
                     "leaders": leaders,
                     "momentum_leaders": momentum_leaders[:leader_count],
                 })
@@ -161,7 +169,7 @@ class ThemeDailyLeaderService:
             themes.sort(
                 key=lambda item: (
                     item["is_liquid_theme"],
-                    item["theme_score"],
+                    item["market_leadership_score"],
                     item["leader_avg_change_rate"],
                     item["advancing_ratio"],
                     item["trading_value_sum_won"],
@@ -265,6 +273,19 @@ class ThemeDailyLeaderService:
             "negative_trading_value_ratio": round(negative_trading_value_ratio, 2),
             "theme_score": round(theme_score, 2),
         }
+
+    @classmethod
+    def _build_liquidity_bonus(
+        cls,
+        trading_value_sum_won: int,
+        leader_avg_change_rate: float,
+    ) -> float:
+        """시장 주도성 정렬용 거래대금 보너스. 저탄력 대형주는 보너스를 제한한다."""
+        if trading_value_sum_won < cls.MIN_LIQUID_THEME_TRADING_VALUE_WON:
+            return 0.0
+        ratio = trading_value_sum_won / cls.MIN_LIQUID_THEME_TRADING_VALUE_WON
+        cap = 1.5 if leader_avg_change_rate < 5.0 else 9.0
+        return round(min(math.log10(ratio) * 2.0, cap), 2)
 
     @staticmethod
     def _build_member_score(member: Dict[str, Any], stock: Any, program_net_won: int) -> Dict[str, Any]:

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -37,6 +37,10 @@ def _get(item: Any, key: str, default: Any = None) -> Any:
 class ThemeDailyLeaderService:
     """장마감 랭킹 캐시를 테마별로 묶어 당일 주도 테마를 산출한다."""
 
+    MIN_LIQUID_LEADER_TRADING_VALUE_WON = 1_000_000_000  # 10억
+    MIN_LIQUID_THEME_TRADING_VALUE_WON = 10_000_000_000  # 100억
+    MIN_LIQUID_MEMBER_COUNT = 2
+
     def __init__(
         self,
         classification_repository: "StockClassificationRepository",
@@ -94,12 +98,21 @@ class ThemeDailyLeaderService:
                 if len(scored) < min_members:
                     continue
 
-                scored.sort(
+                momentum_leaders = sorted(
+                    scored,
                     key=lambda item: (item["change_rate"], item["trading_value_won"]),
                     reverse=True,
                 )
-                leaders = scored[:leader_count]
+                liquid_members = [
+                    item for item in momentum_leaders
+                    if item["trading_value_won"] >= self.MIN_LIQUID_LEADER_TRADING_VALUE_WON
+                ]
+                leaders = liquid_members[:leader_count]
                 trading_value_sum = sum(item["trading_value_won"] for item in scored)
+                trading_value_concentration_ratio = (
+                    max(item["trading_value_won"] for item in scored) / trading_value_sum * 100
+                    if trading_value_sum else 0.0
+                )
                 fi_net_sum = sum(item["fi_net_buy_won"] for item in scored)
                 program_net_sum = sum(item["program_net_buy_won"] for item in scored)
                 advance_count = sum(1 for item in scored if item["change_rate"] > 0)
@@ -109,13 +122,14 @@ class ThemeDailyLeaderService:
                 )
                 leader_avg_change_rate = round(
                     sum(item["change_rate"] for item in leaders) / len(leaders), 2
-                )
+                ) if leaders else 0.0
                 score_info = self._build_theme_score(
                     scored=scored,
                     leader_avg_change_rate=leader_avg_change_rate,
                     advancing_ratio=round(advance_count / len(scored) * 100, 1),
                     trading_value_sum_won=trading_value_sum,
                     flow_ratio=flow_ratio,
+                    trading_value_concentration_ratio=trading_value_concentration_ratio,
                 )
 
                 themes.append({
@@ -123,10 +137,16 @@ class ThemeDailyLeaderService:
                     "sources": group.get("sources", []),
                     "report_date": report_date,
                     "scored_member_count": len(scored),
+                    "liquid_member_count": len(liquid_members),
+                    "is_liquid_theme": (
+                        trading_value_sum >= self.MIN_LIQUID_THEME_TRADING_VALUE_WON
+                        and len(liquid_members) >= self.MIN_LIQUID_MEMBER_COUNT
+                    ),
                     "leader_avg_change_rate": leader_avg_change_rate,
                     "advance_count": advance_count,
                     "advancing_ratio": score_info["advancing_ratio"],
                     "trading_value_sum_won": trading_value_sum,
+                    "trading_value_concentration_ratio": round(trading_value_concentration_ratio, 2),
                     "fi_net_buy_won": fi_net_sum,
                     "program_net_buy_won": program_net_sum,
                     "flow_ratio": flow_ratio,
@@ -135,10 +155,12 @@ class ThemeDailyLeaderService:
                     "negative_trading_value_ratio": score_info["negative_trading_value_ratio"],
                     "theme_score": score_info["theme_score"],
                     "leaders": leaders,
+                    "momentum_leaders": momentum_leaders[:leader_count],
                 })
 
             themes.sort(
                 key=lambda item: (
+                    item["is_liquid_theme"],
                     item["theme_score"],
                     item["leader_avg_change_rate"],
                     item["advancing_ratio"],
@@ -200,6 +222,7 @@ class ThemeDailyLeaderService:
         advancing_ratio: float,
         trading_value_sum_won: int,
         flow_ratio: float,
+        trading_value_concentration_ratio: float,
     ) -> Dict[str, float]:
         total_count = len(scored)
         zero_trading_value_count = sum(1 for item in scored if item["trading_value_won"] <= 0)
@@ -224,6 +247,7 @@ class ThemeDailyLeaderService:
             zero_trading_value_count / total_count * 100 if total_count else 0.0
         )
         clipped_flow_ratio = max(min(flow_ratio, 20.0), -20.0)
+        concentration_penalty = max(trading_value_concentration_ratio - 70.0, 0.0) * 0.05
         theme_score = (
             leader_avg_change_rate * 0.45
             + value_weighted_change_rate * 0.20
@@ -232,6 +256,7 @@ class ThemeDailyLeaderService:
             + clipped_flow_ratio * 0.10
             - zero_trading_value_ratio * 0.05
             - negative_trading_value_ratio * 0.04
+            - concentration_penalty
         )
         return {
             "advancing_ratio": advancing_ratio,

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -92,6 +92,8 @@ class RankingTask(AfterMarketTask):
         self._investor_ranking_updated_at: Optional[datetime] = None
         self._is_refreshing: bool = False
         self._last_collected_date: Optional[str] = None
+        self._period_ranking_cache: Dict[tuple[str, int], List[Dict]] = {}
+        self._period_ranking_tasks: Dict[tuple[str, int], asyncio.Task] = {}
 
         # 기본 랭킹 캐시 (상승/하락/거래량/거래대금) — 장마감 후 1회
         self._basic_ranking_cache: Dict[str, ResCommonResponse] = {}
@@ -585,16 +587,54 @@ class RankingTask(AfterMarketTask):
         if not target_date:
             target_date = datetime.now().strftime("%Y%m%d")
 
+        cache_key = (str(target_date), days)
+        results = self._period_ranking_cache.get(cache_key)
+        if results is None:
+            task = self._period_ranking_tasks.get(cache_key)
+            if task is None:
+                task = asyncio.create_task(
+                    self._collect_period_investor_program_ranking(str(target_date), days)
+                )
+                self._period_ranking_tasks[cache_key] = task
+            try:
+                results, is_complete = await task
+            finally:
+                if task.done() and self._period_ranking_tasks.get(cache_key) is task:
+                    self._period_ranking_tasks.pop(cache_key, None)
+
+            if is_complete:
+                self._period_ranking_cache[cache_key] = results
+
+        sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
+        ranked_results = [
+            dict(item, period_metric=metric)
+            for item in results
+            if self._to_int(item.get(sort_field)) > 0
+        ]
+        ranked_results.sort(key=lambda item: self._to_int(item.get(sort_field)), reverse=True)
+        top = [dict(item) for item in ranked_results[:limit]]
+        for i, item in enumerate(top, 1):
+            item["data_rank"] = str(i)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1=f"최근 {days}거래일 외국인+기관+프로그램 기간 순매수 랭킹 조회 성공",
+            data=top,
+        )
+
+    async def _collect_period_investor_program_ranking(
+        self,
+        target_date: str,
+        days: int,
+    ) -> tuple[List[Dict], bool]:
+        """기간 수급 원천 데이터를 수집한다. 불완전한 결과는 캐시하지 않는다."""
         all_stocks = self._load_all_stocks()
         if not all_stocks:
-            return ResCommonResponse(
-                rt_cd=ErrorCode.SUCCESS.value,
-                msg1="대상 종목 없음",
-                data=[],
-            )
+            return [], True
 
         industry_map = await self._load_industry_map()
         results: List[Dict] = []
+        is_complete = True
 
         for chunk in _chunked(all_stocks, self.API_CHUNK_SIZE):
             await self._suspend_event.wait()
@@ -614,7 +654,15 @@ class RankingTask(AfterMarketTask):
             program_responses = all_responses[len(chunk):]
 
             for (code, name, _market), investor_resp, program_resp in zip(chunk, investor_responses, program_responses):
-                if isinstance(investor_resp, Exception) or isinstance(program_resp, Exception):
+                if (
+                    isinstance(investor_resp, Exception)
+                    or isinstance(program_resp, Exception)
+                    or not investor_resp
+                    or not program_resp
+                    or investor_resp.rt_cd != ErrorCode.SUCCESS.value
+                    or program_resp.rt_cd != ErrorCode.SUCCESS.value
+                ):
+                    is_complete = False
                     continue
 
                 investor_rows = investor_resp.data if investor_resp and isinstance(investor_resp.data, list) else []
@@ -632,8 +680,7 @@ class RankingTask(AfterMarketTask):
                 combined_pbmn_won = frgn_pbmn_won + orgn_pbmn_won + program_pbmn_won
                 combined_qty = frgn_qty + orgn_qty + program_qty
 
-                rank_value = combined_pbmn_won if metric == "amount" else combined_qty
-                if rank_value <= 0:
+                if combined_pbmn_won <= 0 and combined_qty <= 0:
                     continue
 
                 first_investor = investor_rows[0] if investor_rows and isinstance(investor_rows[0], dict) else {}
@@ -646,7 +693,6 @@ class RankingTask(AfterMarketTask):
                     "hts_kor_isnm": name,
                     "industry": industry_map.get(code, "-"),
                     "period_days": str(days),
-                    "period_metric": metric,
                     "stck_prpr": str(stck_prpr or "0"),
                     "prdy_ctrt": str(first_investor.get("prdy_ctrt") or first_program.get("prdy_ctrt") or "0"),
                     "prdy_vrss": str(first_investor.get("prdy_vrss") or first_program.get("prdy_vrss") or "0"),
@@ -666,17 +712,7 @@ class RankingTask(AfterMarketTask):
                     "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
                 })
 
-        sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
-        results.sort(key=lambda item: self._to_int(item.get(sort_field)), reverse=True)
-        top = [dict(item) for item in results[:limit]]
-        for i, item in enumerate(top, 1):
-            item["data_rank"] = str(i)
-
-        return ResCommonResponse(
-            rt_cd=ErrorCode.SUCCESS.value,
-            msg1=f"최근 {days}거래일 외국인+기관+프로그램 기간 순매수 랭킹 조회 성공",
-            data=top,
-        )
+        return results, is_complete
 
     async def get_trading_value_ranking(self, limit: int = 30) -> ResCommonResponse:
         """투자자 데이터 기반 거래대금 랭킹 반환 (캐시에서 즉시)."""

--- a/tests/unit_test/repositories/test_streaming_stock_repo.py
+++ b/tests/unit_test/repositories/test_streaming_stock_repo.py
@@ -156,8 +156,8 @@ async def test_pt_persistence_tracks_subscription_source(tmp_path, mock_logger):
     }
 
 
-def test_load_legacy_pt_subscription_table_migrates_source_to_manual(tmp_path, mock_logger):
-    """기존 code-only pt_subscriptions 테이블은 manual 기본값으로 이관한다."""
+def test_load_legacy_pt_subscription_table_migrates_source_to_legacy(tmp_path, mock_logger):
+    """기존 code-only pt_subscriptions 테이블은 출처 미확인(legacy)으로 이관한다."""
     db_path = str(tmp_path / "test_pt.db")
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE pt_subscriptions (code TEXT PRIMARY KEY)")
@@ -169,7 +169,7 @@ def test_load_legacy_pt_subscription_table_migrates_source_to_manual(tmp_path, m
     repo.load_pt_desired_from_db(db_path)
 
     assert repo.get_desired(StreamingType.PROGRAM_TRADING) == {"005930"}
-    assert repo.get_pt_subscription_sources() == {"005930": "manual"}
+    assert repo.get_pt_subscription_sources() == {"005930": "legacy"}
 
 
 def test_load_pt_desired_from_db_uses_snapshot_fallback_when_db_empty(tmp_path, mock_logger):
@@ -186,6 +186,32 @@ def test_load_pt_desired_from_db_uses_snapshot_fallback_when_db_empty(tmp_path, 
     rows = {row[0] for row in conn.execute("SELECT code FROM pt_subscriptions").fetchall()}
     conn.close()
     assert rows == {"005930", "000660"}
+    assert repo.get_pt_subscription_sources() == {
+        "005930": "legacy",
+        "000660": "legacy",
+    }
+
+
+def test_load_pt_desired_from_db_reclassifies_old_manual_rows_without_timestamp(tmp_path, mock_logger):
+    """출처 추적 전 manual 행(updated_at NULL)은 legacy로 재분류한다."""
+    db_path = str(tmp_path / "test_pt.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE pt_subscriptions (code TEXT PRIMARY KEY, source TEXT, updated_at REAL)"
+    )
+    conn.execute(
+        "INSERT INTO pt_subscriptions (code, source, updated_at) VALUES ('005930', 'manual', NULL)"
+    )
+    conn.commit()
+    conn.close()
+
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path)
+
+    assert repo.get_pt_subscription_sources() == {"005930": "legacy"}
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT source FROM pt_subscriptions WHERE code = '005930'").fetchone()[0] == "legacy"
+    conn.close()
 
 
 def test_load_pt_desired_from_db_prefers_existing_db_over_snapshot_fallback(tmp_path, mock_logger):

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -3365,6 +3365,55 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             "strategy_force_exit:래리윌리엄스VBO",
         )
 
+    async def test_force_exit_circuit_breaker_retries_after_safe_preflight(self):
+        """강제청산이 서킷브레이커에 막히면 해제 후 잔고/미체결 확인 뒤 재시도한다."""
+        from datetime import datetime
+
+        scheduler, _, oes, tm, _ = self._make_scheduler(dry_run=False)
+        scheduler._running = True
+        now = datetime(2026, 7, 10, 15, 12, 0)
+        tm.get_current_kst_time.return_value = now
+        tm.get_market_close_time.return_value = datetime(2026, 7, 10, 15, 40, 0)
+        tm.async_sleep = AsyncMock()
+
+        broker = MagicMock()
+        broker.inquire_unfilled_orders = AsyncMock(
+            return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": []})
+        )
+        broker.get_account_balance = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1="OK",
+                data={"output1": [{"pdno": "105560", "hldg_qty": "5"}]},
+            )
+        )
+        broker.get_asking_price = AsyncMock(
+            return_value=ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"bidp1": "185100"}
+            )
+        )
+        oes.broker_api_wrapper = broker
+        oes.handle_place_sell_order.side_effect = [
+            ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1="서킷 브레이커 개방 — 4분 후 재시도",
+                data={"retry_after_seconds": 1},
+            ),
+            ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK"),
+        ]
+
+        signal = TradeSignal(
+            code="105560", name="KB금융", action="SELL", price=185000, qty=5,
+            reason="전략 종료 강제 청산 (지정가 185,000원)", strategy_name="래리윌리엄스VBO",
+        )
+        await scheduler._execute_signal(signal)
+        await asyncio.sleep(0)
+
+        self.assertEqual(oes.handle_place_sell_order.await_count, 2)
+        retry_call = oes.handle_place_sell_order.await_args_list[1]
+        self.assertEqual(retry_call.args[:3], ("105560", 185100, 5))
+        self.assertIn("서킷 브레이커 해제", retry_call.kwargs["strategy_notification"]["reason"])
+
     async def test_execute_strategy_sell_reprices_to_best_bid_when_above_book(self):
         scheduler, _, oes, _, _ = self._make_scheduler(dry_run=False)
         oes.broker_api_wrapper = MagicMock()

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -617,6 +617,29 @@ async def test_format_last_tick_report_places_manual_sources_first_and_bolds(man
     assert mock_ssr.get_pt_subscription_sources.call_count == 1
 
 
+@pytest.mark.asyncio
+async def test_format_last_tick_report_marks_legacy_source_separately(manager):
+    """출처 미확인 구독은 수동이 아닌 기존 구독으로 표시한다."""
+    mock_ssr = MagicMock()
+    mock_ssr.get_pt_subscription_sources.return_value = {
+        "005930": "manual",
+        "000660": "program",
+        "080220": "legacy",
+    }
+    mock_stock_repo = MagicMock()
+    mock_stock_repo.get_name_by_code.side_effect = lambda code: {
+        "005930": "삼성전자", "000660": "SK하이닉스", "080220": "제주반도체",
+    }.get(code, code)
+
+    manager.wire_streaming_stock_repo(mock_ssr)
+    manager.wire_alert_dependencies(stock_code_repository=mock_stock_repo)
+
+    message = await manager._format_last_tick_report_async(["080220", "000660", "005930"])
+
+    assert message.index("[수동] 삼성전자") < message.index("[프로그램] SK하이닉스")
+    assert message.index("[프로그램] SK하이닉스") < message.index("[기존] 제주반도체")
+
+
 def test_build_db_minute_persistence_status_reports_missing_minutes(manager):
     """장중 1분 단위 저장 여부를 종목별로 계산한다."""
     clock = MarketClock(market_open_time="09:00", market_close_time="09:02")

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -98,7 +98,7 @@ async def test_builds_theme_report_from_ranking_data():
     resp = await svc.build_daily_theme_report(rankings, "20260630")
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
-    assert [item["normalized_name"] for item in resp.data] == ["우주항공", "반도체/소부장"]
+    assert [item["normalized_name"] for item in resp.data] == ["반도체/소부장", "우주항공"]
 
     semi = next(item for item in resp.data if item["normalized_name"] == "반도체/소부장")
     assert semi["scored_member_count"] == 4
@@ -266,3 +266,29 @@ async def test_penalizes_theme_trading_value_concentrated_in_one_stock():
 
     assert [theme["normalized_name"] for theme in resp.data] == ["대금분산", "단일종목쏠림"]
     assert resp.data[1]["trading_value_concentration_ratio"] == 90.0
+
+
+@pytest.mark.asyncio
+async def test_ranks_high_liquidity_theme_above_thin_higher_momentum_theme():
+    """시장 주도 순위는 소수 급등 테마보다 대금이 크게 붙은 테마를 우선한다."""
+    svc, _ = _service({
+        "통신장비": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "기가레인"), _member("B", "빛과전자"), _member("C", "주성코퍼레이션")],
+        },
+        "반도체장비": {
+            "sources": ["NAVER"],
+            "members": [_member("D", "저스템"), _member("E", "피에스케이"), _member("F", "유진테크")],
+        },
+    })
+    rankings = {"all_stocks": [
+        _stock("A", "기가레인", 29.9, 2_100_000_000), _stock("B", "빛과전자", 29.9, 16_200_000_000), _stock("C", "주성코퍼레이션", 19.1, 17_900_000_000),
+        _stock("D", "저스템", 24.1, 20_500_000_000), _stock("E", "피에스케이", 23.3, 177_700_000_000), _stock("F", "유진테크", 20.0, 1_240_500_000_000),
+    ]}
+
+    resp = await svc.build_daily_theme_report(rankings, "20260710")
+
+    assert [theme["normalized_name"] for theme in resp.data] == ["반도체장비", "통신장비"]
+    semi, telecom = resp.data
+    assert semi["market_leadership_score"] > telecom["market_leadership_score"]
+    assert telecom["leader_avg_change_rate"] > semi["leader_avg_change_rate"]

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -154,7 +154,8 @@ async def test_ranks_liquid_theme_above_thin_high_change_theme():
     assert resp.rt_cd == ErrorCode.SUCCESS.value
     assert [item["normalized_name"] for item in resp.data] == ["대금동반상승", "저유동성급등"]
     liquid, thin = resp.data
-    assert liquid["leader_avg_change_rate"] < thin["leader_avg_change_rate"]
+    assert liquid["leader_avg_change_rate"] > thin["leader_avg_change_rate"]
+    assert thin["momentum_leaders"][0]["change_rate"] > liquid["leaders"][0]["change_rate"]
     assert liquid["theme_score"] > thin["theme_score"]
     assert thin["zero_trading_value_ratio"] == 66.67
 
@@ -214,3 +215,54 @@ async def test_skips_theme_with_less_than_min_members():
     resp = await svc.build_daily_theme_report(rankings, "20260630")
 
     assert resp.data == []
+
+
+@pytest.mark.asyncio
+async def test_separates_thin_momentum_stock_from_liquid_theme_leaders():
+    """10억 미만 급등주는 상승률 상위로만 보이고 유동성 주도주에서는 제외한다."""
+    svc, _ = _service({
+        "OLED": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "베셀"), _member("B", "티에스이"), _member("C", "예스티")],
+        }
+    })
+    rankings = {
+        "all_stocks": [
+            _stock("A", "베셀", 23.2, 900_000_000),
+            _stock("B", "티에스이", 20.0, 32_300_000_000),
+            _stock("C", "예스티", 18.8, 17_200_000_000),
+        ],
+        "program_all_stocks": [],
+    }
+
+    resp = await svc.build_daily_theme_report(rankings, "20260710")
+
+    theme = resp.data[0]
+    assert [item["code"] for item in theme["leaders"]] == ["B", "C"]
+    assert [item["code"] for item in theme["momentum_leaders"]] == ["A", "B", "C"]
+    assert theme["liquid_member_count"] == 2
+    assert theme["is_liquid_theme"] is True
+
+
+@pytest.mark.asyncio
+async def test_penalizes_theme_trading_value_concentrated_in_one_stock():
+    """동일한 상승률·총대금이라도 한 종목 쏠림 테마는 분산 테마보다 뒤로 보낸다."""
+    svc, _ = _service({
+        "단일종목쏠림": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "쏠림1"), _member("B", "쏠림2"), _member("C", "쏠림3")],
+        },
+        "대금분산": {
+            "sources": ["NAVER"],
+            "members": [_member("D", "분산1"), _member("E", "분산2"), _member("F", "분산3")],
+        },
+    })
+    rankings = {"all_stocks": [
+        _stock("A", "쏠림1", 10, 90_000_000_000), _stock("B", "쏠림2", 10, 5_000_000_000), _stock("C", "쏠림3", 10, 5_000_000_000),
+        _stock("D", "분산1", 10, 34_000_000_000), _stock("E", "분산2", 10, 33_000_000_000), _stock("F", "분산3", 10, 33_000_000_000),
+    ]}
+
+    resp = await svc.build_daily_theme_report(rankings, "20260710")
+
+    assert [theme["normalized_name"] for theme in resp.data] == ["대금분산", "단일종목쏠림"]
+    assert resp.data[1]["trading_value_concentration_ratio"] == 90.0

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -367,6 +367,86 @@ async def test_period_investor_program_ranking_can_sort_by_qty(bg_service, mock_
 
 
 @pytest.mark.asyncio
+async def test_period_investor_program_ranking_excludes_partial_api_results(bg_service, mock_deps):
+    """세 주체 합산 랭킹은 투자자·프로그램 응답이 모두 성공한 종목만 포함한다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([("005930", "삼성전자", "KOSPI")])
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(return_value=_make_investor_multi_response([
+        {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
+    ]))
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(return_value=None)
+
+    resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5)
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data == []
+
+
+@pytest.mark.asyncio
+async def test_period_investor_program_ranking_reuses_collection_for_other_metric(bg_service, mock_deps):
+    """같은 기준일·기간에서 지표만 바꾸면 원천 API를 다시 호출하지 않는다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([("005930", "삼성전자", "KOSPI")])
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(return_value=_make_investor_multi_response([
+        {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
+    ]))
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(return_value=_make_program_multi_response([
+        {"whol_smtn_ntby_qty": "30", "whol_smtn_ntby_tr_pbmn": "300000000"},
+    ]))
+
+    amount_resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount")
+    qty_resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty")
+
+    assert amount_resp.rt_cd == ErrorCode.SUCCESS.value
+    assert qty_resp.rt_cd == ErrorCode.SUCCESS.value
+    assert broker.get_investor_trade_by_stock_daily_multi.await_count == 1
+    assert broker.get_program_trade_by_stock_daily_multi.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_period_investor_program_ranking_shares_in_progress_collection(bg_service, mock_deps):
+    """동일 기준일·기간의 동시 요청은 한 번의 원천 수집 Task를 공유한다."""
+    broker, mapper, _, _, _, _ = mock_deps
+    mapper.df = _make_stock_df([("005930", "삼성전자", "KOSPI")])
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    calls = {"investor": 0, "program": 0}
+
+    async def fetch_investor(*_args):
+        calls["investor"] += 1
+        if sum(calls.values()) == 2:
+            started.set()
+        await gate.wait()
+        return _make_investor_multi_response([
+            {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
+        ])
+
+    async def fetch_program(*_args):
+        calls["program"] += 1
+        if sum(calls.values()) == 2:
+            started.set()
+        await gate.wait()
+        return _make_program_multi_response([
+            {"whol_smtn_ntby_qty": "30", "whol_smtn_ntby_tr_pbmn": "300000000"},
+        ])
+
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(side_effect=fetch_investor)
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(side_effect=fetch_program)
+
+    first = asyncio.create_task(bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    second = asyncio.create_task(bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty"))
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(second), timeout=0.05)
+
+    assert calls == {"investor": 1, "program": 1}
+    gate.set()
+    first_resp, second_resp = await asyncio.gather(first, second)
+    assert first_resp.rt_cd == ErrorCode.SUCCESS.value
+    assert second_resp.rt_cd == ErrorCode.SUCCESS.value
+
+
+@pytest.mark.asyncio
 async def test_refresh_investor_ranking_etf_excluded(bg_service, mock_deps):
     """ETF/ETN 종목은 제외되어야 한다."""
     broker, mapper, _, _, _, _ = mock_deps

--- a/tests/unit_test/view/web/test_web_app_program_trading.py
+++ b/tests/unit_test/view/web/test_web_app_program_trading.py
@@ -104,7 +104,7 @@ async def test_stop_program_trading_keeps_independent_price_subscription(mock_ct
 
 @pytest.mark.asyncio
 async def test_start_program_trading_already_subscribed_alive(mock_ctx):
-    """이미 desired에 있고 연결 살아있으면 스킵"""
+    """기존 desired를 UI에서 다시 선택하면 수동 출처로 승격한다."""
     code = "005930"
     mock_ctx.streaming_stock_repo.get_desired.return_value = {code}  # 이미 구독 중
     mock_ctx.broker.is_websocket_receive_alive.return_value = True
@@ -113,6 +113,11 @@ async def test_start_program_trading_already_subscribed_alive(mock_ctx):
 
     assert result is True
     mock_ctx.streaming_service.connect_websocket.assert_not_called()
+    mock_ctx.streaming_stock_repo.mark_desired.assert_awaited_once_with(
+        code,
+        StreamingType.PROGRAM_TRADING,
+        source="manual",
+    )
 
 
 @pytest.mark.asyncio

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -3,6 +3,7 @@
 TradingApp의 초기화 로직을 참고하여 서비스 레이어만 초기화한다.
 """
 import asyncio
+import inspect
 import time
 from config.config_loader import load_configs, KillSwitchConfig, RiskGateConfig, DataQualityConfig
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
@@ -573,9 +574,25 @@ class WebAppContext:
 
                 # 재연결 후에도 desired에 있으면 성공으로 간주
                 if self.streaming_stock_repo and code in self.streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING):
+                    mark_result = self.streaming_stock_repo.mark_desired(
+                        code,
+                        StreamingType.PROGRAM_TRADING,
+                        source="manual",
+                    )
+                    if inspect.isawaitable(mark_result):
+                        await mark_result
                     return True
                 self.logger.info(f"[프로그램매매] {code} 재연결 실패로 구독 해제됨. 신규 구독 재시도.")
             else:
+                # 구버전/이관 구독을 사용자가 UI에서 다시 선택하면 수동 등록으로 확정한다.
+                if self.streaming_stock_repo:
+                    mark_result = self.streaming_stock_repo.mark_desired(
+                        code,
+                        StreamingType.PROGRAM_TRADING,
+                        source="manual",
+                    )
+                    if inspect.isawaitable(mark_result):
+                        await mark_result
                 return True
 
         try:


### PR DESCRIPTION
## Summary
- Share period-ranking collection by trading date and day window
- Separate manual, automated, and legacy program-trading subscriptions
- Promote the four confirmed manual subscriptions without restarting the live process
- Separate liquid leaders from thin momentum stocks and penalize concentrated theme turnover
- Rank themes by market-leadership score, combining momentum with a capped turnover bonus

## Tests
- python -m pytest tests/unit_test -q (6,739 passed)
- python -m pytest tests/integration_test -q (245 passed; one xdist worker crash, failed test passed with -n0)