### PR TITLE
feat: add SK hynix ADR price gap report

### DIFF
--- a/services/market_cap_gap_service.py
+++ b/services/market_cap_gap_service.py
@@ -260,6 +260,11 @@ class StaticUsMarketCapProvider:
 
 
 class MarketCapGapService:
+    ADR_KOREAN_SYMBOL = "000660"
+    ADR_KOREAN_NAME = "SK하이닉스"
+    ADR_SYMBOLS = ("SKHY", "SKHYV")
+    ADS_PER_COMMON_SHARE = 10
+
     DEFAULT_KOREAN_TARGETS = (
         ("005930", "삼성전자"),
         ("000660", "SK하이닉스"),
@@ -368,6 +373,69 @@ class MarketCapGapService:
         }
 
     @staticmethod
+    def _read_price(data, *names: str) -> float:
+        for name in names:
+            value = data.get(name) if isinstance(data, dict) else getattr(data, name, None)
+            try:
+                price = float(value or 0)
+            except (TypeError, ValueError):
+                continue
+            if price > 0:
+                return price
+        return 0.0
+
+    async def _build_adr_gap(self, fx_rate: Optional[float]) -> Optional[dict]:
+        if not fx_rate:
+            return None
+        try:
+            domestic_resp = await self._broker.get_current_price(self.ADR_KOREAN_SYMBOL)
+        except Exception as exc:
+            self._logger.warning(f"ADR 국내 본주 가격 조회 실패: {exc}")
+            return None
+        if getattr(domestic_resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return None
+        korean_price = self._read_price(
+            getattr(domestic_resp, "data", None), "stck_prpr", "current_price", "price"
+        )
+        if korean_price <= 0:
+            return None
+
+        adr_symbol = None
+        adr_price = 0.0
+        for symbol in self.ADR_SYMBOLS:
+            try:
+                overseas_resp = await self._broker.get_overseas_price(symbol)
+            except Exception as exc:
+                self._logger.warning(f"ADR 가격 조회 실패: {symbol} {exc}")
+                continue
+            if getattr(overseas_resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+                continue
+            adr_price = self._read_price(
+                getattr(overseas_resp, "data", None), "price", "last", "last_price"
+            )
+            if adr_price > 0:
+                adr_symbol = symbol
+                break
+        if not adr_symbol:
+            return None
+
+        implied_price = int(round(adr_price * float(fx_rate) * self.ADS_PER_COMMON_SHARE))
+        korean_price_int = int(round(korean_price))
+        gap_krw = implied_price - korean_price_int
+        return {
+            "korean_symbol": self.ADR_KOREAN_SYMBOL,
+            "korean_name": self.ADR_KOREAN_NAME,
+            "korean_price_krw": korean_price_int,
+            "adr_symbol": adr_symbol,
+            "adr_price_usd": adr_price,
+            "ads_per_common_share": self.ADS_PER_COMMON_SHARE,
+            "fx_rate": float(fx_rate),
+            "implied_korean_price_krw": implied_price,
+            "gap_krw": gap_krw,
+            "gap_percent": round(gap_krw / korean_price_int * 100, 2),
+        }
+
+    @staticmethod
     def _build_comparisons(korean: list[dict], us: list[dict]) -> list[dict]:
         comparisons: list[dict] = []
         for kr in korean:
@@ -403,4 +471,5 @@ class MarketCapGapService:
             "korean": korean,
             "us": us,
             "comparisons": self._build_comparisons(korean, us) if fx_rate else [],
+            "adr_gap": await self._build_adr_gap(fx_rate),
         }

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -643,9 +643,25 @@ class TelegramReporter:
             )
             lines += ["", f"🇰🇷 {kr_summary}"]
 
+        adr_gap = report.get("adr_gap")
+        if adr_gap:
+            gap_percent = float(adr_gap.get("gap_percent") or 0)
+            gap_label = "ADR 프리미엄" if gap_percent > 0 else "ADR 디스카운트" if gap_percent < 0 else "동일"
+            lines += [
+                "",
+                "🔄 <b>SK하이닉스 ADR 가격갭</b>",
+                f"본주 {html.escape(str(adr_gap.get('korean_symbol') or ''), quote=False)} "
+                f"{int(adr_gap.get('korean_price_krw') or 0):,}원",
+                f"ADR {html.escape(str(adr_gap.get('adr_symbol') or ''), quote=False)} "
+                f"${float(adr_gap.get('adr_price_usd') or 0):,.2f}",
+                f"환산 {int(adr_gap.get('implied_korean_price_krw') or 0):,}원 · "
+                f"{gap_percent:+.2f}% ({gap_label})",
+                "1 ADS = 본주 0.1주 · 환율·거래비용 미반영",
+            ]
+
         comparisons = report.get("comparisons") or []
         if not comparisons:
-            lines += ["", "시총갭 계산 불가: 환율 또는 시총 데이터 부족"]
+            lines += ["", "미국 비교군 시총갭 계산 불가: 환율 또는 시총 데이터 부족"]
             await self._send_message("\n".join(lines))
             return
 

--- a/tests/unit_test/services/test_market_cap_gap_service.py
+++ b/tests/unit_test/services/test_market_cap_gap_service.py
@@ -5,6 +5,7 @@ import sqlite3
 import pytest
 
 from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange, OverseasPriceSummary
 from services.market_cap_gap_service import (
     MarketCapGapService,
     MarketCapQuote,
@@ -48,6 +49,70 @@ async def test_build_report_compares_korean_caps_to_us_caps_in_krw():
     )
     assert samsung_nvda["gap_krw"] == 3_700_000_000_000_000
     assert samsung_nvda["ratio"] == 8.4
+
+
+@pytest.mark.asyncio
+async def test_build_report_includes_skhynix_adr_price_gap_with_symbol_fallback():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        _domestic_response(500_000_000_000_000),
+        _domestic_response(200_000_000_000_000),
+    ])
+    broker.get_current_price = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="OK",
+        data=SimpleNamespace(stck_prpr="2076000"),
+    ))
+    broker.get_overseas_price = AsyncMock(side_effect=[
+        ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="not found", data=None),
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data=OverseasPriceSummary(
+                symbol="SKHYV",
+                exchange=OverseasExchange.NASD,
+                price=176.0,
+            ),
+        ),
+    ])
+    provider = StaticUsMarketCapProvider(quotes=[], usdkrw=1380.0)
+    service = MarketCapGapService(broker=broker, us_provider=provider, korean_provider=None)
+
+    report = await service.build_report(report_date="20260710", trigger="us_close")
+
+    assert report["adr_gap"] == {
+        "korean_symbol": "000660",
+        "korean_name": "SK하이닉스",
+        "korean_price_krw": 2_076_000,
+        "adr_symbol": "SKHYV",
+        "adr_price_usd": 176.0,
+        "ads_per_common_share": 10,
+        "fx_rate": 1380.0,
+        "implied_korean_price_krw": 2_428_800,
+        "gap_krw": 352_800,
+        "gap_percent": 16.99,
+    }
+    assert [call.args[0] for call in broker.get_overseas_price.await_args_list] == ["SKHY", "SKHYV"]
+
+
+@pytest.mark.asyncio
+async def test_build_report_omits_adr_gap_when_price_data_is_missing():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        _domestic_response(500_000_000_000_000),
+        _domestic_response(200_000_000_000_000),
+    ])
+    broker.get_current_price = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="failed", data=None,
+    ))
+    broker.get_overseas_price = AsyncMock()
+    provider = StaticUsMarketCapProvider(quotes=[], usdkrw=1380.0)
+    service = MarketCapGapService(broker=broker, us_provider=provider, korean_provider=None)
+
+    report = await service.build_report(report_date="20260710", trigger="kr_close")
+
+    assert report["adr_gap"] is None
+    broker.get_overseas_price.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -1044,3 +1044,35 @@ async def test_send_market_cap_gap_report_marks_korea_advantage_by_negative_gap(
 
     full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
     assert "삼성전자 <b>1.00x</b> (-7조) ✅" in full
+
+
+@pytest.mark.asyncio
+async def test_send_market_cap_gap_report_formats_skhynix_adr_gap(telegram_reporter):
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+    report = {
+        "fx_rate": 1380.0,
+        "korean": [],
+        "us": [],
+        "comparisons": [],
+        "adr_gap": {
+            "korean_symbol": "000660",
+            "korean_name": "SK하이닉스",
+            "korean_price_krw": 2_076_000,
+            "adr_symbol": "SKHYV",
+            "adr_price_usd": 176.0,
+            "ads_per_common_share": 10,
+            "implied_korean_price_krw": 2_428_800,
+            "gap_krw": 352_800,
+            "gap_percent": 16.99,
+        },
+    }
+
+    await telegram_reporter.send_market_cap_gap_report(report, "20260710", "미국장 마감")
+
+    full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
+    assert "SK하이닉스 ADR 가격갭" in full
+    assert "000660 2,076,000원" in full
+    assert "SKHYV $176.00" in full
+    assert "환산 2,428,800원" in full
+    assert "+16.99% (ADR 프리미엄)" in full
+    assert "1 ADS = 본주 0.1주" in full


### PR DESCRIPTION
## Summary
- calculate SK hynix ADR implied Korean share price using the 1 ADS = 0.1 common share ratio
- use SKHY with SKHYV fallback during the when-issued ticker transition
- include the ADR premium or discount in the existing Korean and US market-close Telegram reports

## Tests
- pytest tests/unit_test -v (6745 passed)
- pytest tests/integration_test -v (247 passed)