### PR TITLE
feat: 서버 제어에 '프로세스 재수행'(재시작) 버튼 추가

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -330,6 +330,73 @@ def test_terminate_process_falls_back_to_os_exit(monkeypatch):
     assert exit_called.get("code") == 0
 
 
+# ── POST /api/system/restart ────────────────────────────────────────────────
+
+
+def test_restart_server_schedules_restart(web_client, mock_web_ctx, monkeypatch):
+    """재수행 엔드포인트는 200으로 응답하고 프로세스 재시작을 예약한다(실제 재시작은 훅으로 분리)."""
+    from view.web.routes import system
+
+    called = {}
+    monkeypatch.setattr(system, "_schedule_restart", lambda *a, **k: called.setdefault("hit", True))
+
+    response = web_client.post("/api/system/restart")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert called.get("hit") is True
+
+
+def test_restart_process_spawns_new_then_terminates(monkeypatch):
+    """_restart_process 는 새 프로세스를 먼저 띄운 뒤 현재 프로세스를 종료한다(순서 보장)."""
+    from view.web.routes import system
+
+    order = []
+    monkeypatch.setattr(system, "_spawn_restarted_process", lambda: order.append("spawn"))
+    monkeypatch.setattr(system, "_terminate_process", lambda: order.append("terminate"))
+
+    system._restart_process()
+
+    assert order == ["spawn", "terminate"]
+
+
+def test_restart_process_keeps_running_when_spawn_fails(monkeypatch):
+    """새 프로세스 기동이 실패하면 현재 프로세스를 종료하지 않는다(유일 서버 보존)."""
+    from view.web.routes import system
+
+    def _boom():
+        raise OSError("spawn failed")
+
+    terminated = {}
+    monkeypatch.setattr(system, "_spawn_restarted_process", _boom)
+    monkeypatch.setattr(system, "_terminate_process", lambda: terminated.setdefault("hit", True))
+
+    system._restart_process()
+
+    assert "hit" not in terminated
+
+
+def test_spawn_restarted_process_launches_same_command(monkeypatch):
+    """_spawn_restarted_process 는 현재 인터프리터/인자로 새 프로세스를 띄운다."""
+    from view.web.routes import system
+
+    captured = {}
+
+    def _fake_popen(args, **kwargs):
+        captured["args"] = list(args)
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    monkeypatch.setattr(system.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(system.sys, "executable", "/usr/bin/python")
+    monkeypatch.setattr(system.sys, "argv", ["main.py"])
+
+    system._spawn_restarted_process()
+
+    assert captured["args"] == ["/usr/bin/python", "main.py"]
+
+
 # ── GET /api/background/status ──────────────────────────────────────────────
 
 

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -4,6 +4,8 @@
 import asyncio
 import os
 import signal
+import subprocess
+import sys
 import threading
 import time
 from fastapi import APIRouter, HTTPException, Query
@@ -412,6 +414,53 @@ async def shutdown_server():
     """웹 서버 프로세스를 종료한다. 종료 후에는 터미널에서 다시 실행해야 한다."""
     _schedule_shutdown()
     return {"success": True, "message": "서버를 종료합니다. 잠시 후 연결이 끊어집니다."}
+
+
+# ── 서버 프로세스 재수행 (UI 재시작 버튼) ────────────────────────────────
+
+def _spawn_restarted_process() -> None:
+    """현재와 동일한 명령으로 새 웹 서버 프로세스를 띄운다.
+
+    main.py 는 대화형 메뉴 없이 run_web() 을 바로 실행하므로 현재 인터프리터/인자를
+    그대로 재실행하면 웹 모드로 다시 진입한다. 부모(현재) 프로세스 종료와 독립적으로
+    살아남도록 Windows 는 새 콘솔(CREATE_NEW_CONSOLE)에서, POSIX 는 새 세션에서 띄운다.
+    무거운 서비스 조립으로 새 프로세스의 포트 bind 는 수 초 뒤에 일어나므로, 그 사이
+    현재 프로세스가 종료되며 포트를 반납한다.
+    """
+    args = [sys.executable, *sys.argv]
+    kwargs = {"cwd": os.getcwd(), "close_fds": True}
+    if os.name == "nt":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(args, **kwargs)
+
+
+def _restart_process() -> None:
+    """새 프로세스를 띄운 뒤 현재 프로세스를 종료한다.
+
+    새 프로세스 기동이 실패하면 현재 프로세스를 종료하지 않는다 — 교체 프로세스 없이
+    유일한 서버까지 내려가는 것을 막고 수동 재시작을 유도하기 위함이다.
+    """
+    try:
+        _spawn_restarted_process()
+    except Exception:
+        return
+    _terminate_process()
+
+
+def _schedule_restart(delay_sec: float = _SHUTDOWN_DELAY_SEC) -> None:
+    """HTTP 응답이 먼저 전송되도록 약간의 지연 후 재시작하도록 예약한다."""
+    timer = threading.Timer(delay_sec, _restart_process)
+    timer.daemon = True
+    timer.start()
+
+
+@router.post("/system/restart")
+async def restart_server():
+    """웹 서버 프로세스를 재수행(재시작)한다. 새 프로세스가 뜬 뒤 현재 프로세스는 종료된다."""
+    _schedule_restart()
+    return {"success": True, "message": "서버를 재시작합니다. 잠시 후 새 프로세스로 다시 연결됩니다."}
 
 
 # 1. 동기(def) 함수를 비동기(async def) 함수로 변경하여 이벤트 루프 데드락 방지

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -860,6 +860,30 @@ async function savePositionSizingLimits() {
     }
 }
 
+// ── 서버 프로세스 재수행(재시작) ─────────────────────────────
+async function restartServer(btn) {
+    if (!confirm('웹 서버 프로세스를 재시작합니다.\n새 프로세스가 뜬 뒤 현재 프로세스는 종료되며, 잠시 후 다시 연결됩니다.\n\n계속하시겠습니까?')) return;
+    const msgEl = document.getElementById('shutdown-msg');
+    if (btn) btn.disabled = true;
+    if (msgEl) { msgEl.textContent = '재시작 요청 중...'; msgEl.style.color = 'var(--text-secondary, #888)'; }
+    try {
+        const res = await fetch('/api/system/restart', { method: 'POST' });
+        const data = await res.json().catch(() => ({}));
+        if (res.ok && data.success) {
+            if (msgEl) { msgEl.textContent = '서버를 재시작합니다. 잠시 후 새 프로세스로 다시 연결됩니다.'; msgEl.style.color = 'var(--primary-color, #1976d2)'; }
+            if (typeof showToast === 'function') showToast('서버 재시작 요청을 전송했습니다.', 'success');
+        } else {
+            if (btn) btn.disabled = false;
+            if (msgEl) { msgEl.textContent = '재시작 실패: ' + (data.detail || JSON.stringify(data)); msgEl.style.color = 'var(--danger-color, #f44336)'; }
+        }
+    } catch (e) {
+        // 현재 프로세스가 종료되면 fetch 가 네트워크 에러로 끝날 수 있다 — 재시작 진행 중으로 간주.
+        console.error('[system] 재시작 요청 오류', e);
+        if (msgEl) { msgEl.textContent = '현재 프로세스가 종료되었습니다. 잠시 후 새 프로세스로 새로고침하세요.'; msgEl.style.color = 'var(--primary-color, #1976d2)'; }
+        if (typeof showToast === 'function') showToast('서버 재시작을 요청했습니다.', 'success');
+    }
+}
+
 // ── 서버 프로세스 종료 ───────────────────────────────────────
 async function shutdownServer(btn) {
     if (!confirm('웹 서버 프로세스를 종료합니다.\n종료 후에는 터미널에서 다시 실행해야 합니다.\n\n계속하시겠습니까?')) return;

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -156,8 +156,13 @@
         <div class="card" style="padding: 20px 12px;">
             <h3 style="margin-top: 0; margin-bottom: 12px;">🖥️ 서버 제어</h3>
             <p style="font-size: 0.9rem; color: var(--text-secondary, #888); margin: 0 0 12px;">
-                웹 서버 프로세스를 종료합니다. 종료 후에는 터미널에서 <code>python main.py --web</code> 으로 다시 실행해야 합니다.
+                <strong>재수행</strong>은 새 프로세스를 띄운 뒤 현재 프로세스를 종료합니다(웹 모드로 자동 복귀).
+                <strong>종료</strong>는 프로세스를 내리며, 이후 터미널에서 <code>python main.py --web</code> 으로 다시 실행해야 합니다.
             </p>
+            <button id="btn-restart-server" class="btn" onclick="restartServer(this)"
+                    style="background: var(--primary-color, #1976d2); color: #fff; height: 36px; margin-right: 8px;">
+                프로세스 재수행
+            </button>
             <button id="btn-shutdown-server" class="btn" onclick="shutdownServer(this)"
                     style="background: var(--danger-color, #f44336); color: #fff; height: 36px;">
                 프로세스 종료
@@ -169,5 +174,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/system.js?v=22"></script>
+<script src="/static/js/system.js?v=23"></script>
 {% endblock %}


### PR DESCRIPTION
## 요약

시스템 설정 > **서버 제어**에서 기존 '프로세스 종료' 버튼 옆에 **'프로세스 재수행'(재시작)** 버튼을 추가합니다. 터미널로 가지 않고 UI에서 서버를 재시작할 수 있습니다.

## 동작

`POST /api/system/restart` — 기존 shutdown 패턴을 미러:

1. 새 프로세스를 `[sys.executable, *sys.argv]` 로 기동 — `main.py` 가 대화형 메뉴 없이 `run_web()` 을 바로 실행하므로 **웹 모드로 자동 복귀**. Windows는 `CREATE_NEW_CONSOLE`(새 콘솔에 로그 표시), POSIX는 `start_new_session`.
2. HTTP 응답이 나간 뒤 `threading.Timer` 로 현재 프로세스를 종료(기존 `_terminate_process` 재사용).
3. **새 프로세스 기동 실패 시 현재 프로세스를 종료하지 않음** — 교체 없이 유일 서버가 내려가는 것을 방지.

새 프로세스는 무거운 서비스 조립을 거친 뒤에야 포트를 bind 하므로, 그 사이 현재 프로세스가 종료되며 포트를 반납해 bind 충돌을 피합니다.

## 변경 파일

- `view/web/routes/system.py` — `_spawn_restarted_process` / `_restart_process` / `_schedule_restart` + `POST /system/restart`
- `view/web/templates/system.html` — 재수행 버튼 + 안내 문구
- `view/web/static/js/system.js` — `restartServer()` (confirm → POST → 안내), `?v=22→23`

## 테스트 (TDD)

- 단위 4건 추가: 엔드포인트 재시작 예약 / spawn 명령 인자 / spawn→terminate 순서 / 기동 실패 시 서버 보존. red 확인 후 구현.
- 시스템 라우트 93 + 통합 247 통과. 실제 프로세스 spawn·종료는 서버 제어 액션이라 자동 구동하지 않고 subprocess mock 으로 계약을 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)