### PR TITLE
Extract backtest task bootstrap

### DIFF
--- a/tests/unit_test/view/web/bootstrap/test_backtest_task_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_backtest_task_bootstrap.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
+
+
+def test_backtest_task_bootstrap_builds_both_batch_tasks():
+    ctx = SimpleNamespace(
+        stock_repository=MagicMock(),
+        stock_query_service=MagicMock(),
+        oneil_universe_service=MagicMock(),
+        indicator_service=MagicMock(),
+        market_clock=MagicMock(),
+        backtest_journal_repository=MagicMock(),
+        virtual_trade_service=MagicMock(),
+        broker=MagicMock(),
+        env=MagicMock(),
+        logger=MagicMock(log_dir="logs"),
+        _mcs=MagicMock(),
+        worker_pool=MagicMock(),
+    )
+
+    with patch("view.web.bootstrap.backtest_task_bootstrap.PostMarketReplayAuditTask") as audit_task, \
+         patch("view.web.bootstrap.backtest_task_bootstrap.NewHighStrategyCoverageBacktestTask") as coverage_task:
+        BacktestTaskBootstrap(ctx).run()
+
+    assert ctx.post_market_replay_audit_task is audit_task.return_value
+    assert ctx.newhigh_strategy_coverage_backtest_task is coverage_task.return_value

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -38,6 +38,9 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "StrategyLogReportService", "NotificationQueueTask",
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
     "OpeningPositionReconcileService", "PerformanceProfiler",
+]
+
+BACKTEST_BOOTSTRAP_PATCH_NAMES = [
     "PostMarketReplayAuditService", "PostMarketReplayAuditTask",
     "NewHighStrategyCoverageBacktestService", "NewHighStrategyCoverageBacktestTask",
 ]
@@ -50,6 +53,10 @@ def patched_service_container_deps():
         (name, patch(f"view.web.bootstrap.service_container.{name}", autospec=True))
         for name in SERVICE_CONTAINER_PATCH_NAMES
     ]
+    targets.extend(
+        (name, patch(f"view.web.bootstrap.backtest_task_bootstrap.{name}", autospec=True))
+        for name in BACKTEST_BOOTSTRAP_PATCH_NAMES
+    )
     with contextlib.ExitStack() as stack:
         mocks = {name: stack.enter_context(p) for name, p in targets}
         yield mocks

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -43,8 +43,8 @@ def mock_deps():
         ("tr", patch("view.web.bootstrap.config_bootstrap.TelegramReporter", autospec=True)),
         ("strategy_log_report_task", patch("view.web.bootstrap.service_container.StrategyLogReportTask", autospec=True)),
         ("strategy_log_report_service", patch("view.web.bootstrap.service_container.StrategyLogReportService", autospec=True)),
-        ("newhigh_coverage_service", patch("view.web.bootstrap.service_container.NewHighStrategyCoverageBacktestService", autospec=True)),
-        ("newhigh_coverage_task", patch("view.web.bootstrap.service_container.NewHighStrategyCoverageBacktestTask", autospec=True)),
+        ("newhigh_coverage_service", patch("view.web.bootstrap.backtest_task_bootstrap.NewHighStrategyCoverageBacktestService", autospec=True)),
+        ("newhigh_coverage_task", patch("view.web.bootstrap.backtest_task_bootstrap.NewHighStrategyCoverageBacktestTask", autospec=True)),
     ]
 
     with contextlib.ExitStack() as stack:

--- a/view/web/bootstrap/backtest_task_bootstrap.py
+++ b/view/web/bootstrap/backtest_task_bootstrap.py
@@ -1,0 +1,70 @@
+"""장마감 replay/coverage 백테스트 태스크 조립."""
+
+import os
+from typing import TYPE_CHECKING
+
+from scheduler.strategy_scheduler_store import StrategySchedulerStore
+from services.newhigh_strategy_coverage_backtest_service import (
+    NewHighStrategyCoverageBacktestService,
+)
+from services.post_market_replay_audit_service import PostMarketReplayAuditService
+from strategies.debug.strategy_debug_runner import StrategyDebugRunner
+from task.background.after_market.newhigh_strategy_coverage_backtest_task import (
+    NewHighStrategyCoverageBacktestTask,
+)
+from task.background.after_market.post_market_replay_audit_task import (
+    PostMarketReplayAuditTask,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from view.web.web_app_initializer import WebAppContext
+
+
+class BacktestTaskBootstrap:
+    """백테스트 감사 및 신고가 커버리지 태스크를 컨텍스트에 조립한다."""
+
+    def __init__(self, context: "WebAppContext") -> None:
+        self._ctx = context
+
+    def run(self) -> None:
+        ctx = self._ctx
+        program_provider = getattr(ctx.broker, "_client", ctx.broker)
+
+        ctx.post_market_replay_audit_task = PostMarketReplayAuditTask(
+            audit_service=PostMarketReplayAuditService(
+                stock_query_service=ctx.stock_query_service,
+                universe_service=ctx.oneil_universe_service,
+                indicator_service=ctx.indicator_service,
+                market_clock=ctx.market_clock,
+                backtest_journal_repository=ctx.backtest_journal_repository,
+                scheduler_store=StrategySchedulerStore(logger=ctx.logger),
+                debug_runner_factory=StrategyDebugRunner,
+                virtual_trade_service=ctx.virtual_trade_service,
+                log_dir=os.path.join(ctx.logger.log_dir, "strategies"),
+                program_provider=program_provider,
+                env=ctx.env,
+                logger=ctx.logger,
+            ),
+            mcs=ctx._mcs,
+            market_clock=ctx.market_clock,
+            logger=ctx.logger,
+            worker_pool=ctx.worker_pool,
+        )
+        ctx.newhigh_strategy_coverage_backtest_task = NewHighStrategyCoverageBacktestTask(
+            coverage_service=NewHighStrategyCoverageBacktestService(
+                stock_repository=ctx.stock_repository,
+                stock_query_service=ctx.stock_query_service,
+                universe_service=ctx.oneil_universe_service,
+                indicator_service=ctx.indicator_service,
+                market_clock=ctx.market_clock,
+                backtest_journal_repository=ctx.backtest_journal_repository,
+                debug_runner_factory=StrategyDebugRunner,
+                program_provider=program_provider,
+                env=ctx.env,
+                logger=ctx.logger,
+            ),
+            mcs=ctx._mcs,
+            market_clock=ctx.market_clock,
+            logger=ctx.logger,
+            worker_pool=ctx.worker_pool,
+        )

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -29,7 +29,6 @@ from repositories.stock_repository import StockRepository
 from repositories.streaming_stock_repo import StreamingStockRepo
 from scheduler.dispatcher.time_dispatcher import TimeDispatcher
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
-from strategies.debug.strategy_debug_runner import StrategyDebugRunner
 from scheduler.ticket_queue.dlq_manager import DlqManager
 from scheduler.ticket_queue.message_broker import MessageBroker
 from scheduler.worker.worker_pool import WorkerPool
@@ -44,7 +43,6 @@ from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
 from services.oneil_universe_service import OneilUniverseService
-from services.newhigh_strategy_coverage_backtest_service import NewHighStrategyCoverageBacktestService
 from services.theme_classification_collector_service import ThemeClassificationCollectorService
 from services.us_market_calendar_service import USMarketCalendarService
 from services.theme_daily_leader_service import ThemeDailyLeaderService
@@ -65,7 +63,6 @@ from services.event_shadow_journal_service import EventShadowJournalService
 from services.overseas_candidate_service import OverseasCandidateService
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
-from services.post_market_replay_audit_service import PostMarketReplayAuditService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
@@ -80,8 +77,6 @@ from task.background.after_market.premium_watchlist_generator_task import Premiu
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
-from task.background.after_market.post_market_replay_audit_task import PostMarketReplayAuditTask
-from task.background.after_market.newhigh_strategy_coverage_backtest_task import NewHighStrategyCoverageBacktestTask
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
@@ -90,6 +85,7 @@ from task.background.intraday.program_capture_subscription_task import ProgramCa
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
+from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -780,44 +776,7 @@ class ServiceContainer:
                     worker_pool=ctx.worker_pool,
                     rejection_distribution_service=ctx.rejection_distribution_service,
                 )
-                ctx.post_market_replay_audit_task = PostMarketReplayAuditTask(
-                    audit_service=PostMarketReplayAuditService(
-                        stock_query_service=ctx.stock_query_service,
-                        universe_service=ctx.oneil_universe_service,
-                        indicator_service=ctx.indicator_service,
-                        market_clock=ctx.market_clock,
-                        backtest_journal_repository=ctx.backtest_journal_repository,
-                        scheduler_store=StrategySchedulerStore(logger=ctx.logger),
-                        debug_runner_factory=StrategyDebugRunner,
-                        virtual_trade_service=ctx.virtual_trade_service,
-                        log_dir=os.path.join(ctx.logger.log_dir, "strategies"),
-                        program_provider=getattr(ctx.broker, "_client", ctx.broker),
-                        env=ctx.env,
-                        logger=ctx.logger,
-                    ),
-                    mcs=ctx._mcs,
-                    market_clock=ctx.market_clock,
-                    logger=ctx.logger,
-                    worker_pool=ctx.worker_pool,
-                )
-                ctx.newhigh_strategy_coverage_backtest_task = NewHighStrategyCoverageBacktestTask(
-                    coverage_service=NewHighStrategyCoverageBacktestService(
-                        stock_repository=ctx.stock_repository,
-                        stock_query_service=ctx.stock_query_service,
-                        universe_service=ctx.oneil_universe_service,
-                        indicator_service=ctx.indicator_service,
-                        market_clock=ctx.market_clock,
-                        backtest_journal_repository=ctx.backtest_journal_repository,
-                        debug_runner_factory=StrategyDebugRunner,
-                        program_provider=getattr(ctx.broker, "_client", ctx.broker),
-                        env=ctx.env,
-                        logger=ctx.logger,
-                    ),
-                    mcs=ctx._mcs,
-                    market_clock=ctx.market_clock,
-                    logger=ctx.logger,
-                    worker_pool=ctx.worker_pool,
-                )
+                BacktestTaskBootstrap(ctx).run()
                 ctx.after_market_reconcile_task = AfterMarketReconcileTask(
                     order_execution_service=ctx.order_execution_service,
                     notification_service=ctx.notification_service,


### PR DESCRIPTION
## 변경 사항

- 장마감 replay audit와 신고가 전략 coverage 태스크 조립을 `BacktestTaskBootstrap`으로 추출했습니다.
- `ServiceContainer`는 해당 기능 조립을 새 bootstrap에 위임합니다.
- 추출 모듈 단위 테스트를 추가하고 기존 fixture patch 경로를 새 소유 모듈로 갱신했습니다.

## 배경 및 영향

1,000줄 규모의 `ServiceContainer`가 모든 서비스와 태스크 생성 책임을 보유해 변경 영향과 테스트 결합이 컸습니다. 기능 단위 분할의 첫 단계로 서로 밀접한 두 백테스트 태스크를 독립된 조립 모듈로 이동했습니다. 런타임 모드 조건과 생성 순서는 유지됩니다.

이 PR은 #659 위에 쌓인 스택 PR입니다. #659 병합 후 base를 `main`으로 변경할 예정입니다.

## 검증

- `pytest tests/unit_test -q`: 6751 passed
- `pytest tests/integration_test -q`: 247 passed
- bootstrap 집중 테스트: 22 passed
- WebAppContext 집중 테스트: 55 passed
