### PR TITLE
Extract repository bootstrap

### DIFF
--- a/tests/unit_test/view/web/bootstrap/test_repository_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_repository_bootstrap.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
+
+
+def test_repository_bootstrap_builds_profiler_cache_and_stock_repository():
+    ctx = SimpleNamespace(logger=MagicMock(), pm=None, stock_repository=None)
+    config = {"performance_logging": True, "performance_threshold": 0.25}
+
+    with patch("view.web.bootstrap.repository_bootstrap.PerformanceProfiler") as profiler, \
+         patch("view.web.bootstrap.repository_bootstrap.CacheStore") as cache_store, \
+         patch("view.web.bootstrap.repository_bootstrap.StockRepository") as stock_repository:
+        result = RepositoryBootstrap(ctx).run(config)
+
+    profiler.assert_called_once_with(enabled=True, threshold=0.25)
+    cache_store.assert_called_once_with(config)
+    cache_store.return_value.set_logger.assert_called_once_with(ctx.logger)
+    stock_repository.assert_called_once_with(logger=ctx.logger)
+    assert ctx.pm is profiler.return_value
+    assert ctx.stock_repository is stock_repository.return_value
+    assert result is cache_store.return_value

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -17,7 +17,7 @@ from view.web.bootstrap.runtime_mode import RuntimeMode
 
 
 SERVICE_CONTAINER_PATCH_NAMES = [
-    "CacheStore", "StockRepository", "RSRatingRepository", "RSRatingService",
+    "RSRatingRepository", "RSRatingService",
     "MarketDataService", "IndicatorService", "MessageBroker", "DlqManager",
     "WorkerPool", "TimeDispatcher", "DataQualityService", "RankingTask",
     "StockQueryService", "MinerviniStageService", "MinerviniUpdateTask",
@@ -37,7 +37,11 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
     "StrategyLogReportService", "NotificationQueueTask",
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
-    "OpeningPositionReconcileService", "PerformanceProfiler",
+    "OpeningPositionReconcileService",
+]
+
+REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
+    "CacheStore", "StockRepository", "PerformanceProfiler",
 ]
 
 BACKTEST_BOOTSTRAP_PATCH_NAMES = [
@@ -56,6 +60,10 @@ def patched_service_container_deps():
     targets.extend(
         (name, patch(f"view.web.bootstrap.backtest_task_bootstrap.{name}", autospec=True))
         for name in BACKTEST_BOOTSTRAP_PATCH_NAMES
+    )
+    targets.extend(
+        (name, patch(f"view.web.bootstrap.repository_bootstrap.{name}", autospec=True))
+        for name in REPOSITORY_BOOTSTRAP_PATCH_NAMES
     )
     with contextlib.ExitStack() as stack:
         mocks = {name: stack.enter_context(p) for name, p in targets}

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -37,7 +37,7 @@ def mock_deps():
         ("osb", patch("view.web.bootstrap.strategy_factory.OneilSqueezeBreakoutStrategy", autospec=True)),
         ("pp", patch("view.web.bootstrap.strategy_factory.OneilPocketPivotStrategy", autospec=True)),
         ("htf", patch("view.web.bootstrap.strategy_factory.HighTightFlagStrategy", autospec=True)),
-        ("cm", patch("view.web.bootstrap.service_container.CacheStore", autospec=True)),
+        ("cm", patch("view.web.bootstrap.repository_bootstrap.CacheStore", autospec=True)),
         ("logger", patch("view.web.web_app_initializer.Logger", autospec=True)),
         ("tn", patch("view.web.bootstrap.config_bootstrap.TelegramNotifier", autospec=True)),
         ("tr", patch("view.web.bootstrap.config_bootstrap.TelegramReporter", autospec=True)),

--- a/view/web/bootstrap/repository_bootstrap.py
+++ b/view/web/bootstrap/repository_bootstrap.py
@@ -1,0 +1,35 @@
+"""공통 저장소와 성능 프로파일러 초기화 조립."""
+
+from typing import Any, TYPE_CHECKING
+
+from core.cache.cache_store import CacheStore
+from core.performance_profiler import PerformanceProfiler
+from repositories.stock_repository import StockRepository
+
+if TYPE_CHECKING:  # pragma: no cover
+    from view.web.web_app_initializer import WebAppContext
+
+
+class RepositoryBootstrap:
+    """서비스 조립에 앞서 공통 인프라 저장소를 컨텍스트에 구성한다."""
+
+    def __init__(self, context: "WebAppContext") -> None:
+        self._ctx = context
+
+    def run(self, config: dict[str, Any]) -> CacheStore:
+        ctx = self._ctx
+        perf_log = config.get("performance_logging", False)
+        perf_threshold = config.get("performance_threshold", 0.1)
+        ctx.pm = PerformanceProfiler(enabled=perf_log, threshold=perf_threshold)
+
+        try:
+            cache_store = CacheStore(config)
+            cache_store.set_logger(ctx.logger)
+            ctx.stock_repository = StockRepository(logger=ctx.logger)
+            return cache_store
+        except Exception as exc:
+            ctx.logger.critical(
+                f"[ServiceBootstrap:Repository] 초기화 실패: {exc}",
+                exc_info=True,
+            )
+            raise

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -19,13 +19,10 @@ from config.config_loader import (
     RiskGateConfig,
 )
 from core.account_snapshot import AccountSnapshotCache
-from core.cache.cache_store import CacheStore
 from core.market_clock import MarketClock
-from core.performance_profiler import PerformanceProfiler
 from repositories.execution_strength_repo import ExecutionStrengthRepository
 from repositories.rs_rating_repository import RSRatingRepository
 from repositories.stock_classification_repository import StockClassificationRepository
-from repositories.stock_repository import StockRepository
 from repositories.streaming_stock_repo import StreamingStockRepo
 from scheduler.dispatcher.time_dispatcher import TimeDispatcher
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
@@ -86,6 +83,7 @@ from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntra
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
+from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
 from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -197,17 +195,7 @@ class ServiceContainer:
         elif hasattr(config_dict, "dict"):
             config_dict = config_dict.dict()
 
-        perf_log = config_dict.get("performance_logging", False)
-        perf_threshold = config_dict.get("performance_threshold", 0.1)
-        ctx.pm = PerformanceProfiler(enabled=perf_log, threshold=perf_threshold)
-
-        try:
-            cache_store = CacheStore(config_dict)
-            cache_store.set_logger(ctx.logger)
-            ctx.stock_repository = StockRepository(logger=ctx.logger)
-        except Exception as e:
-            ctx.logger.critical(f"[ServiceBootstrap:Repository] 초기화 실패: {e}", exc_info=True)
-            raise
+        cache_store = RepositoryBootstrap(ctx).run(config_dict)
 
         try:
             ctx.rs_rating_repository = RSRatingRepository(logger=ctx.logger)


### PR DESCRIPTION
## 변경 사항

- 성능 프로파일러, 캐시 저장소, 주식 저장소 초기화를 `RepositoryBootstrap`으로 추출했습니다.
- `ServiceContainer`는 생성된 캐시 저장소를 반환받아 후속 `MarketDataService` 조립에 전달합니다.
- 새 bootstrap 단위 테스트를 추가하고 기존 fixture patch 경로를 실제 소유 모듈로 갱신했습니다.

## 배경 및 영향

`ServiceContainer`가 저장소 인프라 생성과 서비스 조립을 함께 담당하고 있었습니다. 저장소 초기화와 실패 로깅을 독립된 기능 경계로 옮겨 후속 조립 분할의 기반을 마련했습니다. 기존 캐시 저장소 수명과 예외 전파 동작은 유지됩니다.

## 검증

- `pytest tests/unit_test -q`: 6752 passed
- `pytest tests/integration_test -q`: 247 passed
- Repository/ServiceContainer 집중 테스트: 22 passed
- WebAppContext 집중 테스트: 55 passed
