### PR TITLE
Extract market data bootstrap

### DIFF
--- a/tests/unit_test/view/web/bootstrap/test_market_data_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_market_data_bootstrap.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from view.web.bootstrap.market_data_bootstrap import MarketDataBootstrap
+
+
+def test_market_data_bootstrap_builds_core_market_data_services():
+    ctx = SimpleNamespace(
+        logger=MagicMock(),
+        broker=MagicMock(),
+        env=SimpleNamespace(is_paper_trading=True),
+        market_clock=MagicMock(),
+        _mcs=MagicMock(),
+        pm=MagicMock(),
+        stock_repository=MagicMock(),
+        stock_code_repository=MagicMock(),
+        operator_alert_service=MagicMock(),
+        full_config={},
+        enabled_market_modes=["domestic"],
+    )
+    cache_store = MagicMock()
+
+    with patch("view.web.bootstrap.market_data_bootstrap.MarketDataService") as market_data, \
+         patch("view.web.bootstrap.market_data_bootstrap.IndicatorService") as indicator, \
+         patch("view.web.bootstrap.market_data_bootstrap.DataQualityService") as quality:
+        MarketDataBootstrap(
+            ctx,
+            us_market_calendar_factory=MagicMock(),
+        ).run(cache_store)
+
+    assert ctx.market_data_service is market_data.return_value
+    assert ctx.indicator_service is indicator.return_value
+    assert ctx.data_quality_service is quality.return_value
+    quality.return_value.apply_trading_mode.assert_called_once_with(True)

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -17,9 +17,7 @@ from view.web.bootstrap.runtime_mode import RuntimeMode
 
 
 SERVICE_CONTAINER_PATCH_NAMES = [
-    "RSRatingRepository", "RSRatingService",
-    "MarketDataService", "IndicatorService", "MessageBroker", "DlqManager",
-    "WorkerPool", "TimeDispatcher", "DataQualityService", "RankingTask",
+    "RankingTask",
     "StockQueryService", "MinerviniStageService", "MinerviniUpdateTask",
     "StreamingService", "PriceStreamService", "StreamingStockRepo",
     "ExecutionStrengthRepository",
@@ -28,7 +26,6 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "PositionSizingService", "RiskGateService", "ExecutionFlowService",
     "OrderPolicyService", "DeferredOrderQueue", "OrderExecutionService",
     "OneilUniverseService", "NaverFinanceScraperService",
-    "StockClassificationRepository", "ThemeLeaderService", "ThemeDailyLeaderService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "ThemeIntradayLeaderAlertTask",
     "MarketCapGapService", "MarketCapGapReportTask", "USMarketCalendarService",
@@ -42,6 +39,13 @@ SERVICE_CONTAINER_PATCH_NAMES = [
 
 REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
     "CacheStore", "StockRepository", "PerformanceProfiler",
+]
+
+MARKET_DATA_BOOTSTRAP_PATCH_NAMES = [
+    "RSRatingRepository", "RSRatingService", "StockClassificationRepository",
+    "ThemeLeaderService", "ThemeDailyLeaderService", "MarketDataService",
+    "IndicatorService", "MessageBroker", "DlqManager", "WorkerPool",
+    "TimeDispatcher", "DataQualityService",
 ]
 
 BACKTEST_BOOTSTRAP_PATCH_NAMES = [
@@ -64,6 +68,10 @@ def patched_service_container_deps():
     targets.extend(
         (name, patch(f"view.web.bootstrap.repository_bootstrap.{name}", autospec=True))
         for name in REPOSITORY_BOOTSTRAP_PATCH_NAMES
+    )
+    targets.extend(
+        (name, patch(f"view.web.bootstrap.market_data_bootstrap.{name}", autospec=True))
+        for name in MARKET_DATA_BOOTSTRAP_PATCH_NAMES
     )
     with contextlib.ExitStack() as stack:
         mocks = {name: stack.enter_context(p) for name, p in targets}

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -14,7 +14,7 @@ def mock_deps():
         ("env", patch("view.web.bootstrap.config_bootstrap.KoreaInvestApiEnv", autospec=True)),
         ("tm", patch("view.web.bootstrap.config_bootstrap.MarketClock", autospec=True)),
         ("broker", patch("view.web.bootstrap.broker_bootstrap.BrokerAPIWrapper", autospec=True)),
-        ("mds", patch("view.web.bootstrap.service_container.MarketDataService", autospec=True)),
+        ("mds", patch("view.web.bootstrap.market_data_bootstrap.MarketDataService", autospec=True)),
         ("sqs", patch("view.web.bootstrap.service_container.StockQueryService", autospec=True)),
         ("oes", patch("view.web.bootstrap.service_container.OrderExecutionService", autospec=True)),
         ("risk_gate", patch("view.web.bootstrap.service_container.RiskGateService", autospec=True)),
@@ -25,7 +25,7 @@ def mock_deps():
         ("oscm", patch("view.web.web_app_initializer.OverseasStockCodeRepository", autospec=True)),
         ("sched", patch("view.web.bootstrap.strategy_factory.StrategyScheduler", autospec=True)),
         ("rdm", patch("view.web.web_app_initializer.ProgramTradingStreamService", autospec=True)),
-        ("ind", patch("view.web.bootstrap.service_container.IndicatorService", autospec=True)),
+        ("ind", patch("view.web.bootstrap.market_data_bootstrap.IndicatorService", autospec=True)),
 
         ("ous", patch("view.web.bootstrap.service_container.OneilUniverseService", autospec=True)),
         ("ranking_task", patch("view.web.bootstrap.service_container.RankingTask", autospec=True)),

--- a/view/web/bootstrap/market_data_bootstrap.py
+++ b/view/web/bootstrap/market_data_bootstrap.py
@@ -1,0 +1,125 @@
+"""시장 데이터 핵심 서비스와 공용 작업 인프라 조립."""
+
+from typing import TYPE_CHECKING
+
+from config.config_loader import DataQualityConfig
+from core.market_clock import MarketClock
+from repositories.rs_rating_repository import RSRatingRepository
+from repositories.stock_classification_repository import StockClassificationRepository
+from scheduler.dispatcher.time_dispatcher import TimeDispatcher
+from scheduler.ticket_queue.dlq_manager import DlqManager
+from scheduler.ticket_queue.message_broker import MessageBroker
+from scheduler.worker.worker_pool import WorkerPool
+from services.data_quality_service import DataQualityService
+from services.indicator_service import IndicatorService
+from services.market_data_service import MarketDataService
+from services.rs_rating_service import RSRatingService
+from services.theme_daily_leader_service import ThemeDailyLeaderService
+from services.theme_leader_service import ThemeLeaderService
+from view.web.market_mode_utils import is_market_enabled
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.cache.cache_store import CacheStore
+    from view.web.web_app_initializer import WebAppContext
+
+
+class MarketDataBootstrap:
+    """시장 데이터 핵심 서비스와 공용 dispatcher를 컨텍스트에 구성한다."""
+
+    def __init__(self, context: "WebAppContext", us_market_calendar_factory) -> None:
+        self._ctx = context
+        self._us_market_calendar_factory = us_market_calendar_factory
+
+    def run(self, cache_store: "CacheStore") -> None:
+        ctx = self._ctx
+        try:
+            ctx.rs_rating_repository = RSRatingRepository(logger=ctx.logger)
+            ctx.rs_rating_service = RSRatingService(
+                stock_ohlcv_repository=ctx.stock_repository._ohlcv_repo,
+                rs_rating_repository=ctx.rs_rating_repository,
+                stock_code_repository=ctx.stock_code_repository,
+                logger=ctx.logger,
+                performance_profiler=ctx.pm,
+            )
+        except Exception as exc:
+            ctx.logger.warning(f"[ServiceBootstrap:RSRating] 초기화 실패: {exc}")
+
+        try:
+            ctx.theme_classification_repository = StockClassificationRepository(logger=ctx.logger)
+            ctx.theme_leader_service = ThemeLeaderService(
+                classification_repository=ctx.theme_classification_repository,
+                rs_rating_repository=getattr(ctx, "rs_rating_repository", None),
+                logger=ctx.logger,
+                performance_profiler=ctx.pm,
+            )
+            ctx.theme_daily_leader_service = ThemeDailyLeaderService(
+                classification_repository=ctx.theme_classification_repository,
+                logger=ctx.logger,
+                performance_profiler=ctx.pm,
+            )
+        except Exception as exc:
+            ctx.logger.warning(f"[ServiceBootstrap:ThemeLeader] 초기화 실패: {exc}")
+            ctx.theme_classification_repository = None
+            ctx.theme_leader_service = None
+            ctx.theme_daily_leader_service = None
+
+        try:
+            ctx.market_data_service = MarketDataService(
+                broker_api_wrapper=ctx.broker,
+                env=ctx.env,
+                logger=ctx.logger,
+                market_clock=ctx.market_clock,
+                cache_store=cache_store,
+                market_calendar_service=ctx._mcs,
+                performance_profiler=ctx.pm,
+                stock_repository=ctx.stock_repository,
+                data_quality_service=getattr(ctx, "data_quality_service", None),
+            )
+            ctx.indicator_service = IndicatorService(
+                cache_store=cache_store,
+                performance_profiler=ctx.pm,
+                operator_alert_service=getattr(ctx, "operator_alert_service", None),
+            )
+            ctx.message_broker = MessageBroker()
+            ctx.dlq_manager = DlqManager(logger=ctx.logger)
+            ctx.worker_pool = WorkerPool(
+                broker=ctx.message_broker,
+                dlq_manager=ctx.dlq_manager,
+                logger=ctx.logger,
+                num_workers=1,
+                performance_profiler=ctx.pm,
+            )
+            ctx.time_dispatcher = TimeDispatcher(
+                broker=ctx.message_broker,
+                market_clock=ctx.market_clock,
+                mcs=ctx._mcs,
+                logger=ctx.logger,
+            )
+            ctx.time_dispatcher_us = None
+            if is_market_enabled(ctx, "overseas_us"):
+                us_clock = MarketClock.for_us_equities(logger=ctx.logger)
+                ctx.time_dispatcher_us = TimeDispatcher(
+                    broker=ctx.message_broker,
+                    market_clock=us_clock,
+                    mcs=self._us_market_calendar_factory(
+                        market_clock=us_clock,
+                        logger=ctx.logger,
+                    ),
+                    logger=ctx.logger,
+                    db_path="data/time_dispatcher_state_us.db",
+                )
+            ctx.data_quality_service = DataQualityService(
+                config=getattr(ctx.full_config, "data_quality", None) or DataQualityConfig(),
+                market_clock=ctx.market_clock,
+                logger=ctx.logger,
+                operator_alert_service=ctx.operator_alert_service,
+            )
+            ctx.data_quality_service.apply_trading_mode(
+                bool(getattr(ctx.env, "is_paper_trading", True))
+            )
+        except Exception as exc:
+            ctx.logger.critical(
+                f"[ServiceBootstrap:CoreServices] 초기화 실패: {exc}",
+                exc_info=True,
+            )
+            raise

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -13,7 +13,6 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from common.types import ErrorCode, Exchange
 from config.config_loader import (
-    DataQualityConfig,
     OrderPolicyConfig,
     PositionSizingConfig,
     RiskGateConfig,
@@ -21,20 +20,11 @@ from config.config_loader import (
 from core.account_snapshot import AccountSnapshotCache
 from core.market_clock import MarketClock
 from repositories.execution_strength_repo import ExecutionStrengthRepository
-from repositories.rs_rating_repository import RSRatingRepository
-from repositories.stock_classification_repository import StockClassificationRepository
 from repositories.streaming_stock_repo import StreamingStockRepo
-from scheduler.dispatcher.time_dispatcher import TimeDispatcher
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
-from scheduler.ticket_queue.dlq_manager import DlqManager
-from scheduler.ticket_queue.message_broker import MessageBroker
-from scheduler.worker.worker_pool import WorkerPool
 from services.backtest_microstructure_capture import BacktestMicrostructureCaptureService
-from services.data_quality_service import DataQualityService
 from services.execution_flow_service import ExecutionFlowService
-from services.indicator_service import IndicatorService
 from services.deferred_order_queue import DeferredOrderQueue
-from services.market_data_service import MarketDataService
 from services.market_cap_gap_service import MarketCapGapService
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
@@ -42,8 +32,6 @@ from services.newhigh_service import NewHighService
 from services.oneil_universe_service import OneilUniverseService
 from services.theme_classification_collector_service import ThemeClassificationCollectorService
 from services.us_market_calendar_service import USMarketCalendarService
-from services.theme_daily_leader_service import ThemeDailyLeaderService
-from services.theme_leader_service import ThemeLeaderService
 from task.background.after_market.theme_classification_task import ThemeClassificationTask
 from services.opening_position_reconcile_service import OpeningPositionReconcileService
 from services.order_execution_service import OrderExecutionService
@@ -52,7 +40,6 @@ from services.position_sizing_service import PositionSizingService
 from services.price_stream_service import PriceStreamService
 from services.price_subscription_service import PriceSubscriptionService
 from services.risk_gate_service import RiskGateService
-from services.rs_rating_service import RSRatingService
 from services.stock_query_service import StockQueryService
 from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
@@ -84,6 +71,7 @@ from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTa
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
+from view.web.bootstrap.market_data_bootstrap import MarketDataBootstrap
 from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -196,91 +184,10 @@ class ServiceContainer:
             config_dict = config_dict.dict()
 
         cache_store = RepositoryBootstrap(ctx).run(config_dict)
-
-        try:
-            ctx.rs_rating_repository = RSRatingRepository(logger=ctx.logger)
-            ctx.rs_rating_service = RSRatingService(
-                stock_ohlcv_repository=ctx.stock_repository._ohlcv_repo,
-                rs_rating_repository=ctx.rs_rating_repository,
-                stock_code_repository=ctx.stock_code_repository,
-                logger=ctx.logger,
-                performance_profiler=ctx.pm,
-            )
-        except Exception as e:
-            ctx.logger.warning(f"[ServiceBootstrap:RSRating] 초기화 실패: {e}")
-
-        try:
-            ctx.theme_classification_repository = StockClassificationRepository(logger=ctx.logger)
-            ctx.theme_leader_service = ThemeLeaderService(
-                classification_repository=ctx.theme_classification_repository,
-                rs_rating_repository=getattr(ctx, "rs_rating_repository", None),
-                logger=ctx.logger,
-                performance_profiler=ctx.pm,
-            )
-            ctx.theme_daily_leader_service = ThemeDailyLeaderService(
-                classification_repository=ctx.theme_classification_repository,
-                logger=ctx.logger,
-                performance_profiler=ctx.pm,
-            )
-        except Exception as e:
-            ctx.logger.warning(f"[ServiceBootstrap:ThemeLeader] 초기화 실패: {e}")
-            ctx.theme_classification_repository = None
-            ctx.theme_leader_service = None
-            ctx.theme_daily_leader_service = None
-
-        try:
-            ctx.market_data_service = MarketDataService(
-                broker_api_wrapper=ctx.broker, env=ctx.env, logger=ctx.logger, market_clock=ctx.market_clock, cache_store=cache_store,
-                market_calendar_service=ctx._mcs,
-                performance_profiler=ctx.pm,
-                stock_repository=ctx.stock_repository,
-                data_quality_service=getattr(ctx, "data_quality_service", None),
-            )
-            ctx.indicator_service = IndicatorService(
-                cache_store=cache_store,
-                performance_profiler=ctx.pm,
-                operator_alert_service=getattr(ctx, "operator_alert_service", None),
-            )
-            ctx.message_broker = MessageBroker()
-            ctx.dlq_manager = DlqManager(logger=ctx.logger)
-            ctx.worker_pool = WorkerPool(
-                broker=ctx.message_broker,
-                dlq_manager=ctx.dlq_manager,
-                logger=ctx.logger,
-                num_workers=1,  # after_market 태스크는 API 레이트 리밋 고려해 순차 실행
-                performance_profiler=ctx.pm,
-            )
-            ctx.time_dispatcher = TimeDispatcher(
-                broker=ctx.message_broker,
-                market_clock=ctx.market_clock,
-                mcs=ctx._mcs,
-                logger=ctx.logger,
-            )
-            # 미국장 배치(해외 dry-run 등)를 위한 별도 TimeDispatcher. KST dispatcher와
-            # 동일한 MessageBroker/WorkerPool 을 공유하며, 미국장 클럭으로 NY 마감을 감지한다.
-            # O-1: 규칙 기반 NYSE 캘린더(mcs) 주입 → 휴장일에는 latest_trading_date가
-            # 직전 거래일로 유지되어 중복 발행이 차단된다 (주말 필터만 있던 기존 한계 해소).
-            ctx.time_dispatcher_us = None
-            if is_market_enabled(ctx, "overseas_us"):
-                us_clock = MarketClock.for_us_equities(logger=ctx.logger)
-                ctx.time_dispatcher_us = TimeDispatcher(
-                    broker=ctx.message_broker,
-                    market_clock=us_clock,
-                    mcs=USMarketCalendarService(market_clock=us_clock, logger=ctx.logger),
-                    logger=ctx.logger,
-                    db_path="data/time_dispatcher_state_us.db",
-                )
-            ctx.data_quality_service = DataQualityService(
-                config=getattr(ctx.full_config, "data_quality", None) or DataQualityConfig(),
-                market_clock=ctx.market_clock,
-                logger=ctx.logger,
-                operator_alert_service=ctx.operator_alert_service,
-            )
-            ctx.data_quality_service.apply_trading_mode(bool(getattr(ctx.env, "is_paper_trading", True)))
-            # NOTE: market_data_service._data_quality_service back-injection is performed by WiringPhase.
-        except Exception as e:
-            ctx.logger.critical(f"[ServiceBootstrap:CoreServices] 초기화 실패: {e}", exc_info=True)
-            raise
+        MarketDataBootstrap(
+            ctx,
+            us_market_calendar_factory=USMarketCalendarService,
+        ).run(cache_store)
 
         try:
             if is_overseas_us:


### PR DESCRIPTION
## 변경 사항

- RS Rating, 테마 분류, 시장 데이터, 지표, 데이터 품질 서비스 조립을 `MarketDataBootstrap`으로 추출했습니다.
- MessageBroker, WorkerPool, 한국/미국 TimeDispatcher 생성도 같은 시장 데이터 실행 인프라 경계로 이동했습니다.
- 미국장 캘린더 생성기를 composition root에서 주입해 조립 책임과 테스트 격리를 명확히 했습니다.
- 기존 fixture patch 경로를 실제 소유 모듈로 갱신했습니다.

## 배경 및 영향

`ServiceContainer`가 시장 데이터 서비스와 공용 작업 인프라의 구체 생성까지 담당하고 있었습니다. 관련 객체를 하나의 기능 bootstrap으로 이동해 후속 조회·실시간 bootstrap 분리를 위한 경계를 만들었습니다. 초기화 순서, 실패 처리, 미국장 dispatcher 동작은 유지됩니다.

## 검증

- `pytest tests/unit_test -q`: 6753 passed
- `pytest tests/integration_test -q`: 247 passed
- MarketData/ServiceContainer 집중 테스트: 22 passed
- WebAppContext 집중 테스트: 55 passed
