### PR TITLE
Extract query bootstrap

### DIFF
--- a/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from view.web.bootstrap.query_bootstrap import QueryBootstrap
+
+
+def test_query_bootstrap_builds_domestic_ranking_and_query_service():
+    ctx = SimpleNamespace(
+        broker=MagicMock(),
+        stock_code_repository=MagicMock(),
+        env=MagicMock(),
+        logger=MagicMock(),
+        market_clock=MagicMock(),
+        pm=MagicMock(),
+        notification_service=MagicMock(),
+        telegram_reporter=MagicMock(),
+        _mcs=MagicMock(),
+        market_data_service=MagicMock(),
+        worker_pool=MagicMock(),
+        theme_classification_repository=MagicMock(),
+        indicator_service=MagicMock(),
+        streaming_event_logger=MagicMock(),
+    )
+
+    with patch("view.web.bootstrap.query_bootstrap.RankingTask") as ranking, \
+         patch("view.web.bootstrap.query_bootstrap.StockQueryService") as query:
+        QueryBootstrap(ctx, us_market_calendar_factory=MagicMock()).run(
+            config={},
+            is_overseas_us=False,
+            needs_batch=False,
+        )
+
+    assert ctx.ranking_task is ranking.return_value
+    assert ctx.stock_query_service is query.return_value
+    assert ctx.market_cap_gap_service is None

--- a/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
+
+
+def test_realtime_bootstrap_builds_streaming_chain():
+    ctx = SimpleNamespace(
+        broker=MagicMock(), logger=MagicMock(), market_clock=MagicMock(),
+        market_data_service=MagicMock(), streaming_event_logger=MagicMock(),
+        data_quality_service=MagicMock(), _mcs=MagicMock(),
+        kill_switch_service=MagicMock(), stock_repository=MagicMock(),
+        notification_service=MagicMock(), operator_alert_service=MagicMock(),
+        program_trading_stream_service=MagicMock(), pm=MagicMock(),
+    )
+    ctx.program_trading_stream_service.load_snapshot.return_value = {}
+
+    with patch("view.web.bootstrap.realtime_bootstrap.StreamingService") as streaming, \
+         patch("view.web.bootstrap.realtime_bootstrap.PriceStreamService") as price_stream, \
+         patch("view.web.bootstrap.realtime_bootstrap.PriceSubscriptionService") as subscriptions, \
+         patch("view.web.bootstrap.realtime_bootstrap.WebSocketWatchdogTask") as watchdog:
+        RealtimeBootstrap(ctx).run(config={}, needs_realtime=True)
+
+    assert ctx.streaming_service is streaming.return_value
+    assert ctx.price_stream_service is price_stream.return_value
+    assert ctx.price_subscription_service is subscriptions.return_value
+    assert ctx.websocket_watchdog_task is watchdog.return_value

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -17,8 +17,7 @@ from view.web.bootstrap.runtime_mode import RuntimeMode
 
 
 SERVICE_CONTAINER_PATCH_NAMES = [
-    "RankingTask",
-    "StockQueryService", "MinerviniStageService", "MinerviniUpdateTask",
+    "MinerviniStageService", "MinerviniUpdateTask",
     "StreamingService", "PriceStreamService", "StreamingStockRepo",
     "ExecutionStrengthRepository",
     "PriceSubscriptionService", "WebSocketWatchdogTask", "PreMarketHealthCheckTask",
@@ -28,7 +27,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OneilUniverseService", "NaverFinanceScraperService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "ThemeIntradayLeaderAlertTask",
-    "MarketCapGapService", "MarketCapGapReportTask", "USMarketCalendarService",
+    "USMarketCalendarService",
     "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
     "NewHighTask", "NewHighService", "StrategyLogReportTask",
@@ -46,6 +45,11 @@ MARKET_DATA_BOOTSTRAP_PATCH_NAMES = [
     "ThemeLeaderService", "ThemeDailyLeaderService", "MarketDataService",
     "IndicatorService", "MessageBroker", "DlqManager", "WorkerPool",
     "TimeDispatcher", "DataQualityService",
+]
+
+QUERY_BOOTSTRAP_PATCH_NAMES = [
+    "RankingTask", "MarketCapGapService", "MarketCapGapReportTask",
+    "StockQueryService",
 ]
 
 BACKTEST_BOOTSTRAP_PATCH_NAMES = [
@@ -72,6 +76,10 @@ def patched_service_container_deps():
     targets.extend(
         (name, patch(f"view.web.bootstrap.market_data_bootstrap.{name}", autospec=True))
         for name in MARKET_DATA_BOOTSTRAP_PATCH_NAMES
+    )
+    targets.extend(
+        (name, patch(f"view.web.bootstrap.query_bootstrap.{name}", autospec=True))
+        for name in QUERY_BOOTSTRAP_PATCH_NAMES
     )
     with contextlib.ExitStack() as stack:
         mocks = {name: stack.enter_context(p) for name, p in targets}

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -18,9 +18,7 @@ from view.web.bootstrap.runtime_mode import RuntimeMode
 
 SERVICE_CONTAINER_PATCH_NAMES = [
     "MinerviniStageService", "MinerviniUpdateTask",
-    "StreamingService", "PriceStreamService", "StreamingStockRepo",
-    "ExecutionStrengthRepository",
-    "PriceSubscriptionService", "WebSocketWatchdogTask", "PreMarketHealthCheckTask",
+    "PreMarketHealthCheckTask",
     "DailyPriceCollectorTask", "OhlcvUpdateTask", "AccountSnapshotCache",
     "PositionSizingService", "RiskGateService", "ExecutionFlowService",
     "OrderPolicyService", "DeferredOrderQueue", "OrderExecutionService",
@@ -52,6 +50,12 @@ QUERY_BOOTSTRAP_PATCH_NAMES = [
     "StockQueryService",
 ]
 
+REALTIME_BOOTSTRAP_PATCH_NAMES = [
+    "StreamingService", "EventShadowJournalService", "StrategyEventRouter",
+    "ExecutionStrengthRepository", "PriceStreamService", "StreamingStockRepo",
+    "PriceSubscriptionService", "WebSocketWatchdogTask",
+]
+
 BACKTEST_BOOTSTRAP_PATCH_NAMES = [
     "PostMarketReplayAuditService", "PostMarketReplayAuditTask",
     "NewHighStrategyCoverageBacktestService", "NewHighStrategyCoverageBacktestTask",
@@ -80,6 +84,10 @@ def patched_service_container_deps():
     targets.extend(
         (name, patch(f"view.web.bootstrap.query_bootstrap.{name}", autospec=True))
         for name in QUERY_BOOTSTRAP_PATCH_NAMES
+    )
+    targets.extend(
+        (name, patch(f"view.web.bootstrap.realtime_bootstrap.{name}", autospec=True))
+        for name in REALTIME_BOOTSTRAP_PATCH_NAMES
     )
     with contextlib.ExitStack() as stack:
         mocks = {name: stack.enter_context(p) for name, p in targets}

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -29,7 +29,7 @@ def mock_deps():
 
         ("ous", patch("view.web.bootstrap.service_container.OneilUniverseService", autospec=True)),
         ("ranking_task", patch("view.web.bootstrap.query_bootstrap.RankingTask", autospec=True)),
-        ("watchdog_task", patch("view.web.bootstrap.service_container.WebSocketWatchdogTask", autospec=True)),
+        ("watchdog_task", patch("view.web.bootstrap.realtime_bootstrap.WebSocketWatchdogTask", autospec=True)),
         ("watchdog_task_in_main", patch("view.web.web_app_initializer.WebSocketWatchdogTask", autospec=True)),
         ("premium_watchlist_task", patch("view.web.bootstrap.service_container.PremiumWatchlistGeneratorTask", autospec=True)),
         ("log_cleanup_task", patch("view.web.bootstrap.service_container.LogCleanupTask", autospec=True)),

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -15,7 +15,7 @@ def mock_deps():
         ("tm", patch("view.web.bootstrap.config_bootstrap.MarketClock", autospec=True)),
         ("broker", patch("view.web.bootstrap.broker_bootstrap.BrokerAPIWrapper", autospec=True)),
         ("mds", patch("view.web.bootstrap.market_data_bootstrap.MarketDataService", autospec=True)),
-        ("sqs", patch("view.web.bootstrap.service_container.StockQueryService", autospec=True)),
+        ("sqs", patch("view.web.bootstrap.query_bootstrap.StockQueryService", autospec=True)),
         ("oes", patch("view.web.bootstrap.service_container.OrderExecutionService", autospec=True)),
         ("risk_gate", patch("view.web.bootstrap.service_container.RiskGateService", autospec=True)),
         ("order_policy", patch("view.web.bootstrap.service_container.OrderPolicyService", autospec=True)),
@@ -28,7 +28,7 @@ def mock_deps():
         ("ind", patch("view.web.bootstrap.market_data_bootstrap.IndicatorService", autospec=True)),
 
         ("ous", patch("view.web.bootstrap.service_container.OneilUniverseService", autospec=True)),
-        ("ranking_task", patch("view.web.bootstrap.service_container.RankingTask", autospec=True)),
+        ("ranking_task", patch("view.web.bootstrap.query_bootstrap.RankingTask", autospec=True)),
         ("watchdog_task", patch("view.web.bootstrap.service_container.WebSocketWatchdogTask", autospec=True)),
         ("watchdog_task_in_main", patch("view.web.web_app_initializer.WebSocketWatchdogTask", autospec=True)),
         ("premium_watchlist_task", patch("view.web.bootstrap.service_container.PremiumWatchlistGeneratorTask", autospec=True)),

--- a/view/web/bootstrap/query_bootstrap.py
+++ b/view/web/bootstrap/query_bootstrap.py
@@ -1,0 +1,115 @@
+"""랭킹·시가총액 갭 리포트와 주식 조회 서비스 조립."""
+
+from typing import Any, TYPE_CHECKING
+
+from core.market_clock import MarketClock
+from scheduler.strategy_scheduler_store import StrategySchedulerStore
+from services.market_cap_gap_service import MarketCapGapService
+from services.stock_query_service import StockQueryService
+from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
+from task.background.after_market.ranking_task import RankingTask
+
+if TYPE_CHECKING:  # pragma: no cover
+    from view.web.web_app_initializer import WebAppContext
+
+
+class QueryBootstrap:
+    """조회 서비스와 조회 기반 배치 태스크를 컨텍스트에 구성한다."""
+
+    def __init__(self, context: "WebAppContext", us_market_calendar_factory) -> None:
+        self._ctx = context
+        self._us_market_calendar_factory = us_market_calendar_factory
+
+    def run(
+        self,
+        *,
+        config: dict[str, Any],
+        is_overseas_us: bool,
+        needs_batch: bool,
+    ) -> None:
+        ctx = self._ctx
+        try:
+            if is_overseas_us:
+                ctx.ranking_task = None
+                ctx.market_cap_gap_service = None
+                ctx.market_cap_gap_report_kr_task = None
+                ctx.market_cap_gap_report_us_task = None
+            else:
+                ctx.ranking_task = RankingTask(
+                    broker_api_wrapper=ctx.broker,
+                    stock_code_repository=ctx.stock_code_repository,
+                    env=ctx.env,
+                    logger=ctx.logger,
+                    market_clock=ctx.market_clock,
+                    performance_profiler=ctx.pm,
+                    notification_service=ctx.notification_service,
+                    telegram_reporter=getattr(ctx, "telegram_reporter", None),
+                    market_calendar_service=ctx._mcs,
+                    market_data_service=ctx.market_data_service,
+                    worker_pool=ctx.worker_pool,
+                    stock_classification_repository=getattr(
+                        ctx,
+                        "theme_classification_repository",
+                        None,
+                    ),
+                )
+                self._build_market_cap_gap_tasks(config, needs_batch)
+
+            ctx.stock_query_service = StockQueryService(
+                market_data_service=ctx.market_data_service,
+                logger=ctx.logger,
+                market_clock=ctx.market_clock,
+                indicator_service=ctx.indicator_service,
+                ranking_task=ctx.ranking_task,
+                performance_profiler=ctx.pm,
+                notification_service=ctx.notification_service,
+                broker_api_wrapper=ctx.broker,
+                streaming_logger=ctx.streaming_event_logger,
+            )
+        except Exception as exc:
+            ctx.logger.critical(
+                f"[ServiceBootstrap:QueryServices] 초기화 실패: {exc}",
+                exc_info=True,
+            )
+            raise
+
+    def _build_market_cap_gap_tasks(self, config: dict[str, Any], needs_batch: bool) -> None:
+        ctx = self._ctx
+        if not needs_batch:
+            ctx.market_cap_gap_service = None
+            ctx.market_cap_gap_report_kr_task = None
+            ctx.market_cap_gap_report_us_task = None
+            return
+
+        ctx.market_cap_gap_service = MarketCapGapService.build_default(
+            broker=ctx.broker,
+            logger=ctx.logger,
+        )
+        kr_gap_enabled = config.get("market_cap_gap_report_kr_enabled", True)
+        us_gap_enabled = config.get("market_cap_gap_report_us_enabled", True)
+        gap_report_store = StrategySchedulerStore(logger=ctx.logger)
+        ctx.market_cap_gap_report_kr_task = MarketCapGapReportTask(
+            market_cap_gap_service=ctx.market_cap_gap_service,
+            telegram_reporter=getattr(ctx, "telegram_reporter", None),
+            notification_service=ctx.notification_service,
+            session="kr_close",
+            market_calendar_service=ctx._mcs,
+            market_clock=ctx.market_clock,
+            scheduler_store=gap_report_store,
+            logger=ctx.logger,
+        ) if kr_gap_enabled else None
+
+        us_gap_clock = MarketClock.for_us_equities(logger=ctx.logger)
+        ctx.market_cap_gap_report_us_task = MarketCapGapReportTask(
+            market_cap_gap_service=ctx.market_cap_gap_service,
+            telegram_reporter=getattr(ctx, "telegram_reporter", None),
+            notification_service=ctx.notification_service,
+            session="us_close",
+            market_calendar_service=self._us_market_calendar_factory(
+                market_clock=us_gap_clock,
+                logger=ctx.logger,
+            ),
+            market_clock=us_gap_clock,
+            scheduler_store=gap_report_store,
+            logger=ctx.logger,
+        ) if us_gap_enabled else None

--- a/view/web/bootstrap/realtime_bootstrap.py
+++ b/view/web/bootstrap/realtime_bootstrap.py
@@ -1,0 +1,106 @@
+"""실시간 스트리밍, 가격 구독 및 watchdog 조립."""
+
+from typing import Any, TYPE_CHECKING
+
+from repositories.execution_strength_repo import ExecutionStrengthRepository
+from repositories.streaming_stock_repo import StreamingStockRepo
+from services.event_shadow_journal_service import EventShadowJournalService
+from services.price_stream_service import PriceStreamService
+from services.price_subscription_service import PriceSubscriptionService
+from services.strategy_event_router import StrategyEventRouter
+from services.streaming_service import StreamingService
+from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
+
+if TYPE_CHECKING:  # pragma: no cover
+    from view.web.web_app_initializer import WebAppContext
+
+
+class RealtimeBootstrap:
+    """실시간 서비스 체인을 컨텍스트에 구성하거나 명시적으로 비활성화한다."""
+
+    def __init__(self, context: "WebAppContext") -> None:
+        self._ctx = context
+
+    def run(self, *, config: dict[str, Any], needs_realtime: bool) -> None:
+        ctx = self._ctx
+        if not needs_realtime:
+            self._disable()
+            return
+
+        ctx.streaming_service = StreamingService(
+            broker_api_wrapper=ctx.broker,
+            logger=ctx.logger,
+            market_clock=ctx.market_clock,
+            market_data_service=ctx.market_data_service,
+            streaming_logger=ctx.streaming_event_logger,
+            data_quality_service=ctx.data_quality_service,
+        )
+        ctx.event_shadow_journal_service = EventShadowJournalService(
+            log_root="logs/strategies",
+            logger=ctx.logger,
+        )
+        ctx.strategy_event_router = StrategyEventRouter(
+            market_clock=ctx._mcs,
+            kill_switch_service=ctx.kill_switch_service,
+            logger=ctx.logger,
+            throttle_sec=0.1,
+            signal_debounce_sec=0.5,
+            signal_sink=None,
+        )
+        es_capture_enabled = config.get("execution_strength_capture_enabled", True)
+        ctx.execution_strength_repo = (
+            ExecutionStrengthRepository(logger=ctx.logger)
+            if es_capture_enabled
+            else None
+        )
+        ctx.price_stream_service = PriceStreamService(
+            stock_repo=ctx.stock_repository,
+            logger=ctx.logger,
+            data_quality_service=ctx.data_quality_service,
+            notification_service=ctx.notification_service,
+            event_router=ctx.strategy_event_router,
+            execution_strength_recorder=ctx.execution_strength_repo,
+        )
+        ctx.streaming_stock_repo = StreamingStockRepo(logger=ctx.logger)
+        snapshot = ctx.program_trading_stream_service.load_snapshot()
+        fallback_codes = []
+        if isinstance(snapshot, dict):
+            raw_codes = snapshot.get("subscribedCodes", [])
+            if isinstance(raw_codes, list):
+                fallback_codes = raw_codes
+        ctx.streaming_stock_repo.load_pt_desired_from_db(
+            "data/program_subscribe/program_trading.db",
+            fallback_codes=fallback_codes,
+        )
+        ctx.price_subscription_service = PriceSubscriptionService(
+            streaming_service=ctx.streaming_service,
+            stock_repo=ctx.stock_repository,
+            logger=ctx.logger,
+            streaming_logger=ctx.streaming_event_logger,
+            streaming_stock_repo=ctx.streaming_stock_repo,
+            market_calendar=ctx._mcs,
+        )
+        ctx.websocket_watchdog_task = WebSocketWatchdogTask(
+            streaming_service=ctx.streaming_service,
+            program_trading_stream_service=ctx.program_trading_stream_service,
+            market_calendar_service=ctx._mcs,
+            performance_profiler=ctx.pm,
+            notification_service=ctx.notification_service,
+            operator_alert_service=ctx.operator_alert_service,
+            logger=ctx.logger,
+            streaming_logger=ctx.streaming_event_logger,
+            streaming_stock_repo=ctx.streaming_stock_repo,
+            price_subscription_service=ctx.price_subscription_service,
+            price_stream_service=ctx.price_stream_service,
+        )
+
+    def _disable(self) -> None:
+        ctx = self._ctx
+        ctx.streaming_service = None
+        ctx.event_shadow_journal_service = None
+        ctx.strategy_event_router = None
+        ctx.execution_strength_repo = None
+        ctx.price_stream_service = None
+        ctx.streaming_stock_repo = None
+        ctx.price_subscription_service = None
+        ctx.websocket_watchdog_task = None

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -19,11 +19,10 @@ from config.config_loader import (
 )
 from core.account_snapshot import AccountSnapshotCache
 from core.market_clock import MarketClock
-from repositories.execution_strength_repo import ExecutionStrengthRepository
-from repositories.streaming_stock_repo import StreamingStockRepo
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
 from services.backtest_microstructure_capture import BacktestMicrostructureCaptureService
 from services.execution_flow_service import ExecutionFlowService
+from services.event_shadow_journal_service import EventShadowJournalService
 from services.deferred_order_queue import DeferredOrderQueue
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
@@ -36,12 +35,7 @@ from services.opening_position_reconcile_service import OpeningPositionReconcile
 from services.order_execution_service import OrderExecutionService
 from services.order_policy_service import OrderPolicyService
 from services.position_sizing_service import PositionSizingService
-from services.price_stream_service import PriceStreamService
-from services.price_subscription_service import PriceSubscriptionService
 from services.risk_gate_service import RiskGateService
-from services.streaming_service import StreamingService
-from services.strategy_event_router import StrategyEventRouter
-from services.event_shadow_journal_service import EventShadowJournalService
 from services.overseas_candidate_service import OverseasCandidateService
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
@@ -63,12 +57,12 @@ from task.background.intraday.opening_position_reconcile_task import OpeningPosi
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
-from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
 from view.web.bootstrap.market_data_bootstrap import MarketDataBootstrap
 from view.web.bootstrap.query_bootstrap import QueryBootstrap
+from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
 from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -237,89 +231,10 @@ class ServiceContainer:
         # NOTE: minervini_stage_service ↔ minervini_update_task circular wiring is performed by WiringPhase.
 
         try:
-            if needs_realtime:
-                ctx.streaming_service = StreamingService(
-                    broker_api_wrapper=ctx.broker,
-                    logger=ctx.logger,
-                    market_clock=ctx.market_clock,
-                    market_data_service=ctx.market_data_service,
-                    streaming_logger=ctx.streaming_event_logger,
-                    data_quality_service=ctx.data_quality_service,
-                )
-                # P2 2-4: event-driven shadow 인프라. shadow 활성 전략이 있을 때만 로그가 생성된다.
-                ctx.event_shadow_journal_service = EventShadowJournalService(
-                    log_root="logs/strategies",
-                    logger=ctx.logger,
-                )
-                ctx.strategy_event_router = StrategyEventRouter(
-                    market_clock=ctx._mcs,
-                    kill_switch_service=ctx.kill_switch_service,
-                    logger=ctx.logger,
-                    throttle_sec=0.1,  # Q5: evaluator burst 흡수만, trigger crossing 보장.
-                    signal_debounce_sec=0.5,  # Q5: 같은 (strategy, code) 중복 publish 차단.
-                    signal_sink=None,  # PR-3 본 작업에서 live consumer 주입 예정. shadow 운영은 None 유지.
-                )
-                # todo 1-5: 체결강도 장중 시계열 축적 — 기존 PRICE 틱에 무임승차 (신규 구독 없음).
-                # 장마감 microstructure 캡처가 es_db 소스로 소비한다.
-                es_capture_enabled = config_dict.get(
-                    "execution_strength_capture_enabled", True
-                )
-                ctx.execution_strength_repo = (
-                    ExecutionStrengthRepository(logger=ctx.logger)
-                    if es_capture_enabled else None
-                )
-                ctx.price_stream_service = PriceStreamService(
-                    stock_repo=ctx.stock_repository,
-                    logger=ctx.logger,
-                    data_quality_service=ctx.data_quality_service,
-                    notification_service=ctx.notification_service,
-                    event_router=ctx.strategy_event_router,
-                    execution_strength_recorder=ctx.execution_strength_repo,
-                )
-                # NOTE: data_quality / streaming / stock_query <-> price_stream wiring is performed by WiringPhase.
-                ctx.streaming_stock_repo = StreamingStockRepo(logger=ctx.logger)
-                pt_snapshot = ctx.program_trading_stream_service.load_snapshot()
-                fallback_pt_codes = []
-                if isinstance(pt_snapshot, dict):
-                    raw_codes = pt_snapshot.get("subscribedCodes", [])
-                    if isinstance(raw_codes, list):
-                        fallback_pt_codes = raw_codes
-                ctx.streaming_stock_repo.load_pt_desired_from_db(
-                    "data/program_subscribe/program_trading.db",
-                    fallback_codes=fallback_pt_codes,
-                )
-                ctx.price_subscription_service = PriceSubscriptionService(
-                    streaming_service=ctx.streaming_service,
-                    stock_repo=ctx.stock_repository,
-                    logger=ctx.logger,
-                    streaming_logger=ctx.streaming_event_logger,
-                    streaming_stock_repo=ctx.streaming_stock_repo,
-                    market_calendar=ctx._mcs,
-                )
-                # NOTE: streaming.set_streaming_stock_repo, program_trading.wire_streaming_stock_repo,
-                # and stock_query.price_subscription_service wiring is performed by WiringPhase.
-                ctx.websocket_watchdog_task = WebSocketWatchdogTask(
-                    streaming_service=ctx.streaming_service,
-                    program_trading_stream_service=ctx.program_trading_stream_service,
-                    market_calendar_service=ctx._mcs,
-                    performance_profiler=ctx.pm,
-                    notification_service=ctx.notification_service,
-                    operator_alert_service=ctx.operator_alert_service,
-                    logger=ctx.logger,
-                    streaming_logger=ctx.streaming_event_logger,
-                    streaming_stock_repo=ctx.streaming_stock_repo,
-                    price_subscription_service=ctx.price_subscription_service,
-                    price_stream_service=ctx.price_stream_service,
-                )
-            else:
-                ctx.streaming_service = None
-                ctx.event_shadow_journal_service = None
-                ctx.strategy_event_router = None
-                ctx.execution_strength_repo = None
-                ctx.price_stream_service = None
-                ctx.streaming_stock_repo = None
-                ctx.price_subscription_service = None
-                ctx.websocket_watchdog_task = None
+            RealtimeBootstrap(ctx).run(
+                config=config_dict,
+                needs_realtime=needs_realtime,
+            )
 
             if needs_trading:
                 ctx.pre_market_health_check_task = PreMarketHealthCheckTask(

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -25,7 +25,6 @@ from scheduler.strategy_scheduler_store import StrategySchedulerStore
 from services.backtest_microstructure_capture import BacktestMicrostructureCaptureService
 from services.execution_flow_service import ExecutionFlowService
 from services.deferred_order_queue import DeferredOrderQueue
-from services.market_cap_gap_service import MarketCapGapService
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
@@ -40,7 +39,6 @@ from services.position_sizing_service import PositionSizingService
 from services.price_stream_service import PriceStreamService
 from services.price_subscription_service import PriceSubscriptionService
 from services.risk_gate_service import RiskGateService
-from services.stock_query_service import StockQueryService
 from services.streaming_service import StreamingService
 from services.strategy_event_router import StrategyEventRouter
 from services.event_shadow_journal_service import EventShadowJournalService
@@ -52,13 +50,11 @@ from task.background.after_market.after_market_reconcile_task import AfterMarket
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
 from task.background.after_market.daily_price_collector_task import DailyPriceCollectorTask
 from task.background.after_market.log_cleanup_task import LogCleanupTask
-from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
 from task.background.after_market.microstructure_capture_task import MicrostructureCaptureTask
 from task.background.after_market.minervini_update_task import MinerviniUpdateTask
 from task.background.after_market.newhigh_task import NewHighTask
 from task.background.after_market.ohlcv_update_task import OhlcvUpdateTask
 from task.background.after_market.premium_watchlist_generator_task import PremiumWatchlistGeneratorTask
-from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.strategy_log_report_task import StrategyLogReportTask
 from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
@@ -72,6 +68,7 @@ from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
 from view.web.bootstrap.market_data_bootstrap import MarketDataBootstrap
+from view.web.bootstrap.query_bootstrap import QueryBootstrap
 from view.web.market_mode_utils import is_market_enabled
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -189,78 +186,14 @@ class ServiceContainer:
             us_market_calendar_factory=USMarketCalendarService,
         ).run(cache_store)
 
-        try:
-            if is_overseas_us:
-                ctx.ranking_task = None
-                ctx.market_cap_gap_service = None
-                ctx.market_cap_gap_report_kr_task = None
-                ctx.market_cap_gap_report_us_task = None
-            else:
-                ctx.ranking_task = RankingTask(
-                    broker_api_wrapper=ctx.broker,
-                    stock_code_repository=ctx.stock_code_repository,
-                    env=ctx.env,
-                    logger=ctx.logger,
-                    market_clock=ctx.market_clock,
-                    performance_profiler=ctx.pm,
-                    notification_service=ctx.notification_service,
-                    telegram_reporter=getattr(ctx, 'telegram_reporter', None),
-                    market_calendar_service=ctx._mcs,
-                    market_data_service=ctx.market_data_service,
-                    worker_pool=ctx.worker_pool,
-                    stock_classification_repository=getattr(ctx, "theme_classification_repository", None),
-                )
-                if needs_batch:
-                    ctx.market_cap_gap_service = MarketCapGapService.build_default(
-                        broker=ctx.broker,
-                        logger=ctx.logger,
-                    )
-                    # 한국장/미국장 시총갭 리포트는 config 플래그로 개별 on/off (기본 둘 다 on)
-                    kr_gap_enabled = config_dict.get("market_cap_gap_report_kr_enabled", True)
-                    us_gap_enabled = config_dict.get("market_cap_gap_report_us_enabled", True)
-                    # 재시작 시 catch-up 으로 인한 중복 전송을 막기 위해 "마지막 전송 날짜"를 SQLite 에 영속화.
-                    gap_report_store = StrategySchedulerStore(logger=ctx.logger)
-                    ctx.market_cap_gap_report_kr_task = MarketCapGapReportTask(
-                        market_cap_gap_service=ctx.market_cap_gap_service,
-                        telegram_reporter=getattr(ctx, "telegram_reporter", None),
-                        notification_service=ctx.notification_service,
-                        session="kr_close",
-                        market_calendar_service=ctx._mcs,
-                        market_clock=ctx.market_clock,
-                        scheduler_store=gap_report_store,
-                        logger=ctx.logger,
-                    ) if kr_gap_enabled else None
-                    # O-1: NYSE 캘린더 주입 — 미국 휴장일에 us_close 리포트 스킵.
-                    us_gap_clock = MarketClock.for_us_equities(logger=ctx.logger)
-                    ctx.market_cap_gap_report_us_task = MarketCapGapReportTask(
-                        market_cap_gap_service=ctx.market_cap_gap_service,
-                        telegram_reporter=getattr(ctx, "telegram_reporter", None),
-                        notification_service=ctx.notification_service,
-                        session="us_close",
-                        market_calendar_service=USMarketCalendarService(
-                            market_clock=us_gap_clock, logger=ctx.logger,
-                        ),
-                        market_clock=us_gap_clock,
-                        scheduler_store=gap_report_store,
-                        logger=ctx.logger,
-                    ) if us_gap_enabled else None
-                else:
-                    ctx.market_cap_gap_service = None
-                    ctx.market_cap_gap_report_kr_task = None
-                    ctx.market_cap_gap_report_us_task = None
-            ctx.stock_query_service = StockQueryService(
-                market_data_service=ctx.market_data_service, logger=ctx.logger, market_clock=ctx.market_clock,
-                indicator_service=ctx.indicator_service,
-                ranking_task=ctx.ranking_task,
-                performance_profiler=ctx.pm,
-                notification_service=ctx.notification_service,
-                broker_api_wrapper=ctx.broker,
-                streaming_logger=ctx.streaming_event_logger,
-            )
-            # NOTE: indicator_service / favorite_service collaborator wiring is performed by WiringPhase.
-        except Exception as e:
-            ctx.logger.critical(f"[ServiceBootstrap:QueryServices] 초기화 실패: {e}", exc_info=True)
-            raise
+        QueryBootstrap(
+            ctx,
+            us_market_calendar_factory=USMarketCalendarService,
+        ).run(
+            config=config_dict,
+            is_overseas_us=is_overseas_us,
+            needs_batch=needs_batch,
+        )
 
         try:
             if is_overseas_us:


### PR DESCRIPTION
## 변경 사항

- 랭킹, 시가총액 갭 서비스/리포트 태스크, `StockQueryService` 조립을 `QueryBootstrap`으로 추출했습니다.
- 국내/해외 모드와 배치 활성화 분기를 새 bootstrap이 소유합니다.
- 미국장 캘린더 생성기는 composition root에서 주입합니다.
- 기존 fixture patch 경로를 실제 소유 모듈로 갱신했습니다.

## 배경 및 영향

조회 서비스와 조회 기반 배치 태스크 생성이 `ServiceContainer`에 직접 포함돼 있었습니다. 이를 기능 단위 bootstrap으로 이동해 초기화 조건과 오류 경계를 응집시켰습니다. 기존 국내/해외 분기, 시총갭 설정 플래그, 실패 전파 동작은 유지됩니다.

## 검증

- `pytest tests/unit_test -q`: 6754 passed
- `pytest tests/integration_test -q`: 247 passed
- Query/ServiceContainer 집중 테스트: 22 passed
- WebAppContext 집중 테스트: 55 passed
