### PR TITLE
Add Telegram notification history to web view

### DIFF
--- a/repositories/telegram_notification_repository.py
+++ b/repositories/telegram_notification_repository.py
@@ -1,0 +1,77 @@
+"""Telegram 발송 성공 이력을 SQLite에 저장하고 조회한다."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+from typing import Union
+
+
+class TelegramNotificationRepository:
+    """Web 알림 센터에서 조회할 Telegram 발송 이력 저장소."""
+
+    def __init__(self, db_path: Union[str, Path] = "data/telegram_notifications.db"):
+        self._db_path = str(db_path)
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_notifications (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sent_at TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    level TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telegram_notifications_sent_at "
+                "ON telegram_notifications(sent_at)"
+            )
+
+    def record(
+        self,
+        *,
+        sent_at: str,
+        source: str,
+        title: str,
+        message: str,
+        level: str = "info",
+    ) -> None:
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO telegram_notifications(sent_at, source, title, message, level)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (sent_at, source, title, message, level),
+            )
+
+    def get_by_date(self, target_date: date, count: int = 200) -> list[dict]:
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT id, sent_at, source, title, message, level
+                FROM telegram_notifications
+                WHERE substr(sent_at, 1, 10) = ?
+                ORDER BY sent_at DESC, id DESC
+                LIMIT ?
+                """,
+                (target_date.isoformat(), count),
+            ).fetchall()
+
+        return [
+            {
+                "id": f"telegram-{row['id']}",
+                "timestamp": row["sent_at"],
+                "category": "TELEGRAM",
+                "level": row["level"],
+                "title": row["title"],
+                "message": row["message"],
+                "metadata": {"source": row["source"]},
+            }
+            for row in rows
+        ]

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -1,5 +1,8 @@
 import asyncio
 from functools import wraps
+from datetime import datetime
+import re
+from zoneinfo import ZoneInfo
 
 import aiohttp
 import html
@@ -19,15 +22,24 @@ def _serialized_report_send(func):
     return wrapper
 
 
+def _telegram_html_to_parts(text: str) -> tuple[str, str]:
+    plain = html.unescape(re.sub(r"<[^>]+>", "", text))
+    lines = [line.strip() for line in plain.splitlines() if line.strip()]
+    if not lines:
+        return "Telegram 알림", ""
+    return lines[0], "\n".join(lines[1:])
+
+
 class TelegramNotifier:
     """Telegram 알림을 비동기적으로 전송하는 핸들러 클래스입니다."""
 
-    def __init__(self, strategy_bot_token: str, backlog_bot_token: str, chat_id: str):
+    def __init__(self, strategy_bot_token: str, backlog_bot_token: str, chat_id: str, history_repository=None):
         self.strategy_bot_token = strategy_bot_token
         self.backlog_bot_token = backlog_bot_token
         self.chat_id = chat_id
         self.strategy_api_url = f"https://api.telegram.org/bot{self.strategy_bot_token}/sendMessage"
         self.backlog_api_url = f"https://api.telegram.org/bot{self.backlog_bot_token}/sendMessage"
+        self._history_repository = history_repository
         # 허용할 카테고리 목록 설정 (기본값: STRATEGY, BACKGROUND, SYSTEM)
         self.allowed_categories = [NotificationCategory.STRATEGY, NotificationCategory.BACKGROUND, NotificationCategory.SYSTEM]
 
@@ -96,6 +108,17 @@ class TelegramNotifier:
                     if response.status != 200:
                         response_text = await response.text()
                         logger.error(f"Telegram 알림 전송 실패: {response.status} - {response_text}")
+                    elif self._history_repository is not None:
+                        try:
+                            self._history_repository.record(
+                                sent_at=event.timestamp,
+                                source="strategy" if event.category == NotificationCategory.STRATEGY else "backlog",
+                                title=event.title,
+                                message=event.message,
+                                level=event.level.value,
+                            )
+                        except Exception as e:
+                            logger.error(f"Telegram 알림 이력 저장 실패: {e}")
         except Exception as e:
             logger.error(f"Telegram 알림 전송 중 예외 발생: {e}")
 
@@ -103,11 +126,12 @@ class TelegramNotifier:
 class TelegramReporter:
     """텔레그램으로 정형화된 리포트(랭킹 등)를 전송하는 클래스입니다."""
 
-    def __init__(self, report_bot_token: str, chat_id: str):
+    def __init__(self, report_bot_token: str, chat_id: str, history_repository=None):
         self.report_bot_token = report_bot_token
         self.chat_id = chat_id
         self.api_url = f"https://api.telegram.org/bot{self.report_bot_token}/sendMessage"
         self._report_send_lock = asyncio.Lock()
+        self._history_repository = history_repository
 
     async def _send_message(self, text: str) -> bool:
         """텔레그램으로 메시지를 비동기적으로 전송하는 헬퍼 메서드입니다."""
@@ -128,6 +152,18 @@ class TelegramReporter:
                         response_text = await response.text()
                         logger.error(f"Telegram 리포트 전송 실패: {response.status} - {response_text}")
                         return False
+            if self._history_repository is not None:
+                try:
+                    title, message = _telegram_html_to_parts(text)
+                    self._history_repository.record(
+                        sent_at=datetime.now(ZoneInfo("Asia/Seoul")).isoformat(),
+                        source="report",
+                        title=title,
+                        message=message,
+                        level="info",
+                    )
+                except Exception as e:
+                    logger.error(f"Telegram 리포트 이력 저장 실패: {e}")
             return True
         except Exception as e:
             logger.error(f"Telegram 리포트 전송 중 예외 발생: {e}")

--- a/tests/unit_test/repositories/test_telegram_notification_repository.py
+++ b/tests/unit_test/repositories/test_telegram_notification_repository.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from repositories.telegram_notification_repository import TelegramNotificationRepository
+
+
+def test_records_and_returns_only_requested_day_latest_first(tmp_path):
+    repository = TelegramNotificationRepository(tmp_path / "telegram_notifications.db")
+
+    repository.record(
+        sent_at="2026-07-12T23:59:59+09:00",
+        source="report",
+        title="어제 리포트",
+        message="어제 내용",
+    )
+    repository.record(
+        sent_at="2026-07-13T09:00:00+09:00",
+        source="strategy",
+        title="매수 시그널",
+        message="삼성전자 매수",
+        level="critical",
+    )
+    repository.record(
+        sent_at="2026-07-13T15:40:00+09:00",
+        source="report",
+        title="장 마감 리포트",
+        message="랭킹 결과",
+    )
+
+    items = repository.get_by_date(datetime(2026, 7, 13).date())
+
+    assert [item["title"] for item in items] == ["장 마감 리포트", "매수 시그널"]
+    assert items[1]["category"] == "TELEGRAM"
+    assert items[1]["level"] == "critical"
+    assert items[1]["metadata"] == {"source": "strategy"}
+
+
+def test_get_by_date_applies_count_limit(tmp_path):
+    repository = TelegramNotificationRepository(tmp_path / "telegram_notifications.db")
+    for minute in range(3):
+        repository.record(
+            sent_at=f"2026-07-13T09:0{minute}:00+09:00",
+            source="report",
+            title=f"리포트 {minute}",
+            message="내용",
+        )
+
+    items = repository.get_by_date(datetime(2026, 7, 13).date(), count=2)
+
+    assert [item["title"] for item in items] == ["리포트 2", "리포트 1"]

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -107,6 +107,43 @@ async def test_handle_event_success(telegram_notifier, sample_event):
 
 
 @pytest.mark.asyncio
+async def test_handle_event_records_successful_telegram_delivery(sample_event):
+    history = MagicMock()
+    notifier = TelegramNotifier("strategy", "backlog", "chat", history_repository=history)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        response = AsyncMock()
+        response.status = 200
+        mock_post.return_value.__aenter__.return_value = response
+
+        await notifier.handle_event(sample_event)
+
+    history.record.assert_called_once_with(
+        sent_at=sample_event.timestamp,
+        source="strategy",
+        title=sample_event.title,
+        message=sample_event.message,
+        level=sample_event.level.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_event_does_not_record_failed_delivery(sample_event):
+    history = MagicMock()
+    notifier = TelegramNotifier("strategy", "backlog", "chat", history_repository=history)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        response = AsyncMock()
+        response.status = 500
+        response.text.return_value = "error"
+        mock_post.return_value.__aenter__.return_value = response
+
+        await notifier.handle_event(sample_event)
+
+    history.record.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_handle_event_escapes_dynamic_html_text(telegram_notifier):
     """동적 알림 내용의 '<' 문자가 Telegram HTML 파싱을 깨지 않도록 escape 된다."""
     event = NotificationEvent(
@@ -329,6 +366,26 @@ async def test_reporter_send_message(telegram_reporter):
         payload = mock_post.call_args[1]['json']
         assert payload['chat_id'] == "test_chat_id"
         assert payload['text'] == "테스트 메시지"
+
+
+@pytest.mark.asyncio
+async def test_reporter_records_successful_message_as_plain_text():
+    history = MagicMock()
+    reporter = TelegramReporter("report", "chat", history_repository=history)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        response = AsyncMock()
+        response.status = 200
+        mock_post.return_value.__aenter__.return_value = response
+
+        result = await reporter._send_message("<b>📊 장 마감 리포트</b>\n삼성전자 &amp; SK하이닉스")
+
+    assert result is True
+    record = history.record.call_args.kwargs
+    assert record["source"] == "report"
+    assert record["title"] == "📊 장 마감 리포트"
+    assert record["message"] == "삼성전자 & SK하이닉스"
+    assert record["level"] == "info"
 
 @pytest.mark.asyncio
 async def test_reporter_send_message_empty(telegram_reporter):

--- a/tests/unit_test/view/web/bootstrap/test_config_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_config_bootstrap.py
@@ -19,6 +19,7 @@ def patched_bootstrap_deps():
         ("env_cls", patch("view.web.bootstrap.config_bootstrap.KoreaInvestApiEnv", autospec=True)),
         ("clock_cls", patch("view.web.bootstrap.config_bootstrap.MarketClock", autospec=True)),
         ("notif_cls", patch("view.web.bootstrap.config_bootstrap.NotificationService", autospec=True)),
+        ("telegram_history_cls", patch("view.web.bootstrap.config_bootstrap.TelegramNotificationRepository", autospec=True)),
         ("op_alert_cls", patch("view.web.bootstrap.config_bootstrap.OperatorAlertService", autospec=True)),
         ("kill_cls", patch("view.web.bootstrap.config_bootstrap.KillSwitchService", autospec=True)),
         ("rej_cls", patch("view.web.bootstrap.config_bootstrap.RejectionDistributionService", autospec=True)),
@@ -70,6 +71,7 @@ def test_config_bootstrap_creates_notification_alert_killswitch(patched_bootstra
     ConfigBootstrap(ctx).run()
 
     assert ctx.notification_service is patched_bootstrap_deps["notif_cls"].return_value
+    assert ctx.telegram_notification_repository is patched_bootstrap_deps["telegram_history_cls"].return_value
     assert ctx.operator_alert_service is patched_bootstrap_deps["op_alert_cls"].return_value
     assert ctx.kill_switch_service is patched_bootstrap_deps["kill_cls"].return_value
 
@@ -128,6 +130,9 @@ def test_config_bootstrap_registers_telegram_when_tokens_present(patched_bootstr
 
     patched_bootstrap_deps["tn_cls"].assert_called_once()
     patched_bootstrap_deps["tr_cls"].assert_called_once()
+    history = patched_bootstrap_deps["telegram_history_cls"].return_value
+    assert patched_bootstrap_deps["tn_cls"].call_args.kwargs["history_repository"] is history
+    assert patched_bootstrap_deps["tr_cls"].call_args.kwargs["history_repository"] is history
     notif_instance = patched_bootstrap_deps["notif_cls"].return_value
     notif_instance.register_external_handler.assert_called_once()
 

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -41,6 +41,7 @@ def mock_deps():
         ("logger", patch("view.web.web_app_initializer.Logger", autospec=True)),
         ("tn", patch("view.web.bootstrap.config_bootstrap.TelegramNotifier", autospec=True)),
         ("tr", patch("view.web.bootstrap.config_bootstrap.TelegramReporter", autospec=True)),
+        ("telegram_history", patch("view.web.bootstrap.config_bootstrap.TelegramNotificationRepository", autospec=True)),
         ("strategy_log_report_task", patch("view.web.bootstrap.service_container.StrategyLogReportTask", autospec=True)),
         ("strategy_log_report_service", patch("view.web.bootstrap.service_container.StrategyLogReportService", autospec=True)),
         ("newhigh_coverage_service", patch("view.web.bootstrap.backtest_task_bootstrap.NewHighStrategyCoverageBacktestService", autospec=True)),
@@ -602,9 +603,14 @@ def test_load_config_and_env_with_telegram(mock_deps):
     mock_deps["tn"].assert_called_once_with(
         backlog_bot_token="TEST_BACKLOG_TOKEN",
         strategy_bot_token="TEST_STRATEGY_TOKEN",
-        chat_id="TEST_CHAT_ID"
+        chat_id="TEST_CHAT_ID",
+        history_repository=mock_deps["telegram_history"].return_value,
     )  # Notifier
-    mock_deps["tr"].assert_called_once_with(report_bot_token="TEST_REPORT_TOKEN", chat_id="TEST_CHAT_ID") # Reporter
+    mock_deps["tr"].assert_called_once_with(
+        report_bot_token="TEST_REPORT_TOKEN",
+        chat_id="TEST_CHAT_ID",
+        history_repository=mock_deps["telegram_history"].return_value,
+    )  # Reporter
     assert ctx.telegram_reporter is not None
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_notification.py
+++ b/tests/unit_test/view/web/test_web_notification.py
@@ -3,6 +3,8 @@
 import pytest
 import asyncio
 import json
+from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
@@ -46,6 +48,30 @@ def test_get_recent_notifications(mock_get_ctx, client, mock_ctx):
     response = client.get(f"/notifications/recent?count=10&category={NotificationCategory.SYSTEM.value}")
     assert response.status_code == 200
     mock_ctx.notification_service.get_recent.assert_called_with(count=10, category=NotificationCategory.SYSTEM)
+
+
+@patch("view.web.routes.notification._get_ctx")
+def test_get_today_telegram_notifications(mock_get_ctx, client, mock_ctx):
+    mock_get_ctx.return_value = mock_ctx
+    mock_ctx.market_clock.get_current_kst_time.return_value = datetime(2026, 7, 13, 10, 0)
+    expected = [{"id": "telegram-1", "category": "TELEGRAM", "title": "리포트"}]
+    mock_ctx.telegram_notification_repository.get_by_date.return_value = expected
+
+    response = client.get("/notifications/telegram/today?count=100")
+
+    assert response.status_code == 200
+    assert response.json() == {"notifications": expected}
+    mock_ctx.telegram_notification_repository.get_by_date.assert_called_once_with(
+        datetime(2026, 7, 13).date(), count=100
+    )
+
+
+def test_web_notification_center_exposes_today_telegram_filter():
+    template = Path("view/web/templates/base.html").read_text(encoding="utf-8")
+    script = Path("view/web/static/js/notifications.js").read_text(encoding="utf-8")
+
+    assert "filterNotifications('TELEGRAM')" in template
+    assert "/api/notifications/telegram/today?count=200" in script
 
 @pytest.mark.asyncio
 @patch("view.web.routes.notification._get_ctx")

--- a/view/web/bootstrap/config_bootstrap.py
+++ b/view/web/bootstrap/config_bootstrap.py
@@ -19,6 +19,7 @@ from services.operator_alert_service import OperatorAlertService
 from services.rejection_distribution_service import RejectionDistributionService
 from services.strategy_log_report_service import _REASON_KR
 from services.telegram_notifier import TelegramNotifier, TelegramReporter
+from repositories.telegram_notification_repository import TelegramNotificationRepository
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -54,6 +55,7 @@ class ConfigBootstrap:
         ctx.virtual_repo.tm = ctx.market_clock
         ctx.virtual_trade_service.tm = ctx.market_clock
         ctx.notification_service = NotificationService(ctx.market_clock)
+        ctx.telegram_notification_repository = TelegramNotificationRepository()
         ctx.operator_alert_service = OperatorAlertService(
             notification_service=ctx.notification_service,
             market_clock=ctx.market_clock,
@@ -110,6 +112,7 @@ class ConfigBootstrap:
                 backlog_bot_token=telegram_backlog_bot_token,
                 strategy_bot_token=telegram_strategy_bot_token,
                 chat_id=telegram_chat_id,
+                history_repository=ctx.telegram_notification_repository,
             )
             ctx.notification_service.register_external_handler(
                 ctx.telegram_notifier.handle_event
@@ -117,7 +120,9 @@ class ConfigBootstrap:
             ctx.logger.info("텔레그램 외부 알림 핸들러가 성공적으로 등록되었습니다.")
 
             ctx.telegram_reporter = TelegramReporter(
-                report_bot_token=telegram_report_bot_token, chat_id=telegram_chat_id
+                report_bot_token=telegram_report_bot_token,
+                chat_id=telegram_chat_id,
+                history_repository=ctx.telegram_notification_repository,
             )
             ctx.logger.info("텔레그램 리포터가 초기화되었습니다.")
         else:

--- a/view/web/routes/notification.py
+++ b/view/web/routes/notification.py
@@ -25,6 +25,17 @@ async def get_recent_notifications(
     return {"notifications": items}
 
 
+@router.get("/notifications/telegram/today")
+async def get_today_telegram_notifications(
+    count: int = Query(200, ge=1, le=200),
+):
+    """오늘 Telegram으로 실제 발송된 알림 목록 조회."""
+    ctx = _get_ctx()
+    today = ctx.market_clock.get_current_kst_time().date()
+    items = ctx.telegram_notification_repository.get_by_date(today, count=count)
+    return {"notifications": items}
+
+
 @router.get("/notifications/stream")
 async def stream_notifications(request: Request):
     """SSE 스트리밍: 알림 이벤트를 실시간으로 브라우저에 전달."""

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -601,6 +601,7 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 }
 .notification-filters {
     display: flex;
+    flex-wrap: wrap;
     gap: 6px;
     padding: 8px 16px;
     border-bottom: 1px solid var(--border);
@@ -661,6 +662,9 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 .notif-item.category-API {
     border-left-color: var(--neutral);
 }
+.notif-item.category-TELEGRAM {
+    border-left-color: #229ed9;
+}
 .notif-item-header {
     display: flex;
     justify-content: space-between;
@@ -679,6 +683,7 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 .notif-category.cat-STRATEGY { background: #b7791f; }
 .notif-category.cat-SYSTEM { background: var(--negative); }
 .notif-category.cat-API { background: var(--neutral); }
+.notif-category.cat-TELEGRAM { background: #229ed9; }
 .notif-time {
     font-size: 0.7rem;
     color: var(--text-secondary);

--- a/view/web/static/js/notifications.js
+++ b/view/web/static/js/notifications.js
@@ -5,6 +5,7 @@ let _notifications = [];
 let _notifUnreadCount = 0;
 let _notifCurrentFilter = 'all';
 let _notifPanelOpen = false;
+let _telegramNotifications = [];
 
 document.addEventListener('DOMContentLoaded', () => {
     initNotifications();
@@ -90,6 +91,18 @@ function filterNotifications(category) {
     document.querySelectorAll('.notif-filter').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.category === category);
     });
+    if (category === 'TELEGRAM') {
+        fetch('/api/notifications/telegram/today?count=200')
+            .then(r => r.json())
+            .then(data => {
+                _telegramNotifications = data.notifications || [];
+                renderNotifications();
+            })
+            .catch(() => {
+                renderNotifications();
+            });
+        return;
+    }
     renderNotifications();
 }
 
@@ -97,13 +110,14 @@ function renderNotifications() {
     const list = document.getElementById('notification-list');
     if (!list) return;
 
-    let items = _notifications;
-    if (_notifCurrentFilter !== 'all') {
+    let items = _notifCurrentFilter === 'TELEGRAM' ? _telegramNotifications : _notifications;
+    if (_notifCurrentFilter !== 'all' && _notifCurrentFilter !== 'TELEGRAM') {
         items = items.filter(n => n.category === _notifCurrentFilter);
     }
 
     if (items.length === 0) {
-        list.innerHTML = '<div class="notification-empty">알림이 없습니다.</div>';
+        const message = _notifCurrentFilter === 'TELEGRAM' ? '오늘 발송된 Telegram 알림이 없습니다.' : '알림이 없습니다.';
+        list.innerHTML = `<div class="notification-empty">${message}</div>`;
         return;
     }
 

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -109,6 +109,7 @@
         <button class="notif-filter" data-category="TRADE" onclick="filterNotifications('TRADE')">매매</button>
         <button class="notif-filter" data-category="API" onclick="filterNotifications('API')">API</button>
         <button class="notif-filter" data-category="SYSTEM" onclick="filterNotifications('SYSTEM')">시스템</button>
+        <button class="notif-filter" data-category="TELEGRAM" onclick="filterNotifications('TELEGRAM')">텔레그램</button>
     </div>
     <div id="notification-list" class="notification-list">
         <div class="notification-empty">알림이 없습니다.</div>
@@ -147,7 +148,7 @@
 </div>
 
 <!-- 공통 스크립트 -->
-<script src="/static/js/notifications.js?v=1"></script>
+<script src="/static/js/notifications.js?v=2"></script>
 <script src="/static/js/kill_switch.js?v=4"></script>
 <script src="/static/js/pagination.js?v=1"></script>
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -165,6 +165,7 @@ class WebAppContext:
         self.foreground_scheduler: ForegroundScheduler = None
         self._mcs: MarketCalendarService = None
         self.notification_service: NotificationService = None
+        self.telegram_notification_repository = None
         self.notification_queue_task: NotificationQueueTask = None
         self.initialized = False
         self.pm: PerformanceProfiler = None


### PR DESCRIPTION
## 변경 사항

- Telegram API 발송 성공 이력을 SQLite에 저장합니다.
- 오늘 발송된 Telegram 알림을 조회하는 Web API를 추가합니다.
- Web 알림 센터에 `텔레그램` 필터를 추가하고 발송 메시지를 읽기 쉬운 일반 텍스트로 표시합니다.

## 배경

기존 Web 알림 센터는 프로세스 메모리의 시스템 이벤트만 보여 주어, `TelegramReporter`가 직접 보낸 리포트와 앱 재시작 전 알림을 확인할 수 없었습니다. 실제 Telegram 발송 성공 건을 별도 영속화해 당일 기록을 Web View에서도 확인할 수 있도록 했습니다.

## 검증

- `pytest tests/unit_test -q` — 6,767 passed
- `pytest tests/integration_test -q` — 247 passed
- 관련 저장소, Telegram 발송기, Web API/UI 테스트 — 131 passed
