### PR TITLE
기간수급 예열 및 YTD 랭킹·주간 리포트 추가

### DIFF
--- a/config/task_config.yaml
+++ b/config/task_config.yaml
@@ -16,6 +16,7 @@ after_market_tasks:
     strategy_log_report: 40         # strategy_log_report — replay audit 이후 리포트 생성
     ranking_refresh: 5          # RankingTask — 장 마감 5분 후
     daily_theme_leader_report: 15  # ThemeDailyLeaderReportTask — 랭킹 갱신 후 당일 주도 테마 리포트 발송
+    ytd_ranking_report: 15      # YtdRankingReportTask — 주 마지막 거래일, 가격 수집 후 주간 YTD 리포트
     daily_price_collector: 10      # DailyPriceCollectorTask — 장 마감 10분 후
     ohlcv_update: 20             # OhlcvUpdateTask — 장 마감 20분 후
     post_market_replay_audit: 30  # PostMarketReplayAuditTask — live 후보군 missed-signal 감사

--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -502,6 +502,58 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository daily_prices 전종목 조회 실패: {e}")
             return []
 
+    async def get_ytd_return_ranking(self, limit: int = 100) -> List[Dict]:
+        """최신 거래일과 해당 연도 첫 스냅샷의 종가를 비교한 YTD 수익률 랭킹."""
+        try:
+            async with self._get_read_connection() as conn:
+                async with conn.execute("SELECT MAX(trade_date) FROM daily_prices") as cursor:
+                    latest_row = await cursor.fetchone()
+                latest_date = latest_row[0] if latest_row and latest_row[0] else None
+                if not latest_date:
+                    return []
+
+                year_prefix = f"{latest_date[:4]}%"
+                async with conn.execute(
+                    "SELECT MIN(trade_date) FROM daily_prices WHERE trade_date LIKE ?",
+                    (year_prefix,),
+                ) as cursor:
+                    base_row = await cursor.fetchone()
+                base_date = base_row[0] if base_row and base_row[0] else None
+                if not base_date:
+                    return []
+
+                async with conn.execute(
+                    """
+                    SELECT latest.*, base.current_price AS base_price
+                    FROM daily_prices AS latest
+                    JOIN daily_prices AS base
+                      ON base.code = latest.code AND base.trade_date = ?
+                    WHERE latest.trade_date = ?
+                      AND latest.current_price > 0
+                      AND base.current_price > 0
+                    ORDER BY ((CAST(latest.current_price AS REAL) / base.current_price) - 1.0) DESC
+                    LIMIT ?
+                    """,
+                    (base_date, latest_date, limit),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+
+            results = []
+            for rank, row in enumerate(rows, 1):
+                item = dict(row)
+                item["base_date"] = base_date
+                item["latest_date"] = latest_date
+                item["ytd_return_rate"] = round(
+                    (item["current_price"] / item["base_price"] - 1.0) * 100,
+                    2,
+                )
+                item["data_rank"] = str(rank)
+                results.append(item)
+            return results
+        except Exception as e:
+            self._logger.error(f"StockOhlcvRepository YTD 수익률 랭킹 조회 실패: {e}")
+            return []
+
     async def get_newhigh_stocks(self, trade_date: str) -> List[Dict]:
         """특정 거래일의 신고가(is_newhigh=1) 종목을 시가총액 내림차순으로 조회."""
         try:

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -102,6 +102,10 @@ class StockRepository:
         """특정 거래일의 전체 종목 스냅샷을 시가총액 내림차순으로 조회."""
         return await self._ohlcv_repo.get_all_daily_snapshots(trade_date)
 
+    async def get_ytd_return_ranking(self, limit: int = 100) -> List[Dict]:
+        """최신 거래일 기준 YTD 수익률 랭킹 조회."""
+        return await self._ohlcv_repo.get_ytd_return_ranking(limit=limit)
+
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
         """is_newhigh 및 is_historical_newhigh 컬럼 업데이트."""
         await self._ohlcv_repo.update_newhigh_fields(trade_date, records)

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -314,6 +314,39 @@ class TelegramReporter:
         if current_message:
             await self._send_message(current_message)
 
+    @_serialized_report_send
+    async def send_ytd_ranking_report(
+        self,
+        ranking_data: List[Dict],
+        report_date: str,
+        limit: int = 20,
+    ) -> bool:
+        """주 마지막 거래일 기준 YTD 상승률 상위 종목을 전송한다."""
+        if not ranking_data:
+            return False
+
+        first = ranking_data[0]
+        base_date = html.escape(str(first.get("base_date") or "-"), quote=False)
+        latest_date = html.escape(str(first.get("latest_date") or report_date), quote=False)
+        lines = [
+            f"📈 <b>주간 YTD 상승률 랭킹 ({report_date})</b>",
+            f"기준: {base_date} → {latest_date}",
+            "<pre>",
+            "순 종목         현재가       YTD",
+            "-" * 34,
+        ]
+        for rank, item in enumerate(ranking_data[:limit], 1):
+            name = html.escape(str(item.get("name") or item.get("code") or "-"), quote=False)
+            name = name[:8]
+            try:
+                price = f"{int(item.get('current_price') or 0):,}"
+            except (TypeError, ValueError):
+                price = "-"
+            rate = self._format_signed_pct(item.get("ytd_return_rate"), digits=2)
+            lines.append(f"{rank:<2} {name:<8} {price:>10} {rate:>9}")
+        lines.append("</pre>")
+        return await self._send_message("\n".join(lines))
+
     @staticmethod
     def _format_won_100m(value) -> str:
         try:

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -44,6 +44,7 @@ class RankingTask(AfterMarketTask):
     API_CHUNK_SIZE = 8
     PERIOD_RANKING_ALLOWED_DAYS = {1, 3, 5, 10, 20}
     PERIOD_RANKING_ALLOWED_METRICS = {"amount", "qty"}
+    DEFAULT_PERIOD_RANKING_DAYS = 5
 
     def __init__(
         self,
@@ -144,8 +145,9 @@ class RankingTask(AfterMarketTask):
         date: str = payload.get("date", "")
         needs_basic = not self._basic_last_collected_date or self._basic_last_collected_date != date
         needs_investor = not self._last_collected_date or self._last_collected_date != date
+        needs_period = (date, self.DEFAULT_PERIOD_RANKING_DAYS) not in self._period_ranking_cache
 
-        if not needs_basic and not needs_investor:
+        if not needs_basic and not needs_investor and not needs_period:
             self._logger.info(f"RankingTask execute: {date} 이미 완료 — 스킵")
             return
 
@@ -157,6 +159,8 @@ class RankingTask(AfterMarketTask):
             if needs_investor:
                 await self.refresh_investor_ranking()
                 self._last_collected_date = date
+            if needs_period:
+                await self.prewarm_period_ranking(date)
 
     # ── 장마감 후 자동 갱신 스케줄러 ────────────────────────────
 
@@ -174,6 +178,10 @@ class RankingTask(AfterMarketTask):
             not self._last_collected_date
             or self._last_collected_date != latest_trading_date
         )
+        needs_period = (
+            latest_trading_date,
+            self.DEFAULT_PERIOD_RANKING_DAYS,
+        ) not in self._period_ranking_cache
 
         if needs_basic:
             await self.refresh_basic_ranking()
@@ -181,6 +189,8 @@ class RankingTask(AfterMarketTask):
         if needs_investor:
             await self.refresh_investor_ranking()
             self._last_collected_date = latest_trading_date
+        if needs_period:
+            await self.prewarm_period_ranking(latest_trading_date)
 
     # ── 기본 랭킹 캐시 (상승/하락/거래량/거래대금) ───────────────
 
@@ -588,22 +598,7 @@ class RankingTask(AfterMarketTask):
             target_date = datetime.now().strftime("%Y%m%d")
 
         cache_key = (str(target_date), days)
-        results = self._period_ranking_cache.get(cache_key)
-        if results is None:
-            task = self._period_ranking_tasks.get(cache_key)
-            if task is None:
-                task = asyncio.create_task(
-                    self._collect_period_investor_program_ranking(str(target_date), days)
-                )
-                self._period_ranking_tasks[cache_key] = task
-            try:
-                results, is_complete = await task
-            finally:
-                if task.done() and self._period_ranking_tasks.get(cache_key) is task:
-                    self._period_ranking_tasks.pop(cache_key, None)
-
-            if is_complete:
-                self._period_ranking_cache[cache_key] = results
+        results = await self._get_or_collect_period_ranking(cache_key)
 
         sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
         ranked_results = [
@@ -621,6 +616,47 @@ class RankingTask(AfterMarketTask):
             msg1=f"최근 {days}거래일 외국인+기관+프로그램 기간 순매수 랭킹 조회 성공",
             data=top,
         )
+
+    async def prewarm_period_ranking(
+        self,
+        target_date: str,
+        days: int = DEFAULT_PERIOD_RANKING_DAYS,
+    ) -> None:
+        """장 마감 배치의 유휴 구간에서 기본 기간수급 캐시를 미리 생성한다."""
+        cache_key = (str(target_date), days)
+        if cache_key in self._period_ranking_cache:
+            return
+        self._logger.info(f"기간수급 랭킹 캐시 예열 시작: {target_date}, {days}일")
+        await self._get_or_collect_period_ranking(cache_key)
+        if cache_key in self._period_ranking_cache:
+            self._logger.info(f"기간수급 랭킹 캐시 예열 완료: {target_date}, {days}일")
+        else:
+            self._logger.warning(f"기간수급 랭킹 캐시 예열 미완료: {target_date}, {days}일")
+
+    async def _get_or_collect_period_ranking(
+        self,
+        cache_key: tuple[str, int],
+    ) -> List[Dict]:
+        results = self._period_ranking_cache.get(cache_key)
+        if results is not None:
+            return results
+
+        task = self._period_ranking_tasks.get(cache_key)
+        if task is None:
+            target_date, days = cache_key
+            task = asyncio.create_task(
+                self._collect_period_investor_program_ranking(target_date, days)
+            )
+            self._period_ranking_tasks[cache_key] = task
+        try:
+            results, is_complete = await task
+        finally:
+            if task.done() and self._period_ranking_tasks.get(cache_key) is task:
+                self._period_ranking_tasks.pop(cache_key, None)
+
+        if is_complete:
+            self._period_ranking_cache[cache_key] = results
+        return results
 
     async def _collect_period_investor_program_ranking(
         self,

--- a/task/background/after_market/ytd_ranking_report_task.py
+++ b/task/background/after_market/ytd_ranking_report_task.py
@@ -1,0 +1,127 @@
+"""주 마지막 거래일 장 마감 후 YTD 상승률 랭킹을 전송한다."""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from task.background.after_market.after_market_task_base import AfterMarketTask
+
+
+class YtdRankingReportTask(AfterMarketTask):
+    """다음 개장일이 다음 주인 거래일에만 YTD 주간 리포트를 전송한다."""
+
+    _STATE_KEY = "ytd_ranking_report_last_sent"
+    REPORT_LIMIT = 20
+
+    def __init__(
+        self,
+        stock_repository,
+        telegram_reporter=None,
+        market_calendar_service=None,
+        market_clock=None,
+        scheduler_store=None,
+        worker_pool=None,
+        logger=None,
+    ):
+        super().__init__(
+            mcs=market_calendar_service,
+            market_clock=market_clock,
+            logger=logger or logging.getLogger(__name__),
+            worker_pool=worker_pool,
+        )
+        self._stock_repository = stock_repository
+        self._telegram_reporter = telegram_reporter
+        self._scheduler_store = scheduler_store
+        self._last_reported_date: Optional[str] = self._load_last_reported_date()
+        self._progress = {
+            "running": False,
+            "last_reported_date": self._last_reported_date,
+            "last_result_count": 0,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "ytd_ranking_report"
+
+    @property
+    def _scheduler_label(self) -> str:
+        return "YtdRankingReportTask"
+
+    def get_progress(self) -> dict:
+        return dict(self._progress)
+
+    def _load_last_reported_date(self) -> Optional[str]:
+        if self._scheduler_store is None:
+            return None
+        try:
+            return self._scheduler_store.load_keyed(self._STATE_KEY)
+        except Exception as exc:
+            self._logger.warning(f"YTD 주간 리포트 마지막 전송일 로드 실패: {exc}")
+            return None
+
+    def _save_last_reported_date(self, date_str: str) -> None:
+        if self._scheduler_store is None:
+            return
+        try:
+            self._scheduler_store.save_keyed(self._STATE_KEY, date_str)
+        except Exception as exc:
+            self._logger.warning(f"YTD 주간 리포트 마지막 전송일 저장 실패: {exc}")
+
+    @staticmethod
+    def _week_key(date_str: str) -> tuple[int, int]:
+        iso = datetime.strptime(date_str, "%Y%m%d").isocalendar()
+        return iso.year, iso.week
+
+    def _already_reported_this_week(self, date_str: str) -> bool:
+        if not self._last_reported_date:
+            return False
+        try:
+            return self._week_key(self._last_reported_date) == self._week_key(date_str)
+        except ValueError:
+            return False
+
+    async def _is_last_trading_day_of_week(self, date_str: str) -> bool:
+        current = datetime.strptime(date_str, "%Y%m%d")
+        if self._mcs is None:
+            return current.weekday() == 4
+
+        next_open = await self._mcs.get_next_open_day(date_str)
+        if not next_open or next_open == date_str:
+            self._logger.warning(f"YTD 주간 리포트 다음 개장일 확인 실패: {date_str}")
+            return False
+        return self._week_key(next_open) != self._week_key(date_str)
+
+    async def _on_market_closed(self, latest_trading_date: str) -> None:
+        if self._already_reported_this_week(latest_trading_date):
+            self._logger.info(f"YTD 주간 리포트: {latest_trading_date} 주차 이미 전송 완료 — 스킵")
+            return
+        if not await self._is_last_trading_day_of_week(latest_trading_date):
+            self._logger.info(f"YTD 주간 리포트: {latest_trading_date} 주 마지막 거래일 아님 — 스킵")
+            return
+        if self._telegram_reporter is None:
+            self._logger.warning("YTD 주간 리포트: TelegramReporter 미설정 — 스킵")
+            return
+
+        self._progress["running"] = True
+        try:
+            rows = await self._stock_repository.get_ytd_return_ranking(limit=self.REPORT_LIMIT)
+            if not rows:
+                self._logger.warning("YTD 주간 리포트: 비교 데이터 없음 — 전송 보류")
+                return
+
+            sent = await self._telegram_reporter.send_ytd_ranking_report(
+                rows,
+                latest_trading_date,
+            )
+            if not sent:
+                self._logger.warning("YTD 주간 리포트: Telegram 전송 실패 — 완료 처리하지 않음")
+                return
+
+            self._last_reported_date = latest_trading_date
+            self._save_last_reported_date(latest_trading_date)
+            self._progress["last_reported_date"] = latest_trading_date
+            self._progress["last_result_count"] = len(rows)
+        except Exception as exc:
+            self._logger.error(f"YTD 주간 리포트 전송 실패: {exc}", exc_info=True)
+        finally:
+            self._progress["running"] = False

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -451,6 +451,52 @@ class TestGetAllDailySnapshots:
         assert await repo.get_all_daily_snapshots("20260414") == []
 
 
+class TestGetYtdReturnRanking:
+    """get_ytd_return_ranking: 연초 첫 스냅샷 대비 최신 수익률 랭킹."""
+
+    @pytest.mark.asyncio
+    async def test_returns_latest_year_ranked_by_ytd_return(self, repo):
+        await repo.upsert_daily_snapshot("20260102", [
+            _make_snapshot("A001", name="상승주", price=100),
+            _make_snapshot("A002", name="보합주", price=200),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [
+            _make_snapshot("A001", name="상승주", price=150),
+            _make_snapshot("A002", name="보합주", price=180),
+        ])
+        await repo.upsert_daily_snapshot("20251230", [
+            _make_snapshot("OLD", name="전년도", price=1),
+        ])
+
+        result = await repo.get_ytd_return_ranking(limit=10)
+
+        assert [row["code"] for row in result] == ["A001", "A002"]
+        assert result[0]["ytd_return_rate"] == pytest.approx(50.0)
+        assert result[1]["ytd_return_rate"] == pytest.approx(-10.0)
+        assert result[0]["base_date"] == "20260102"
+        assert result[0]["latest_date"] == "20260713"
+        assert result[0]["base_price"] == 100
+        assert result[0]["current_price"] == 150
+        assert result[0]["data_rank"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_excludes_stock_without_market_first_day_snapshot(self, repo):
+        await repo.upsert_daily_snapshot("20260102", [_make_snapshot("A001", price=100)])
+        await repo.upsert_daily_snapshot("20260303", [_make_snapshot("IPO", price=100)])
+        await repo.upsert_daily_snapshot("20260713", [
+            _make_snapshot("A001", price=120),
+            _make_snapshot("IPO", price=300),
+        ])
+
+        result = await repo.get_ytd_return_ranking(limit=10)
+
+        assert [row["code"] for row in result] == ["A001"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_snapshots(self, repo):
+        assert await repo.get_ytd_return_ranking() == []
+
+
 # ── get_price_history ────────────────────────────────────────────────────────
 
 class TestGetPriceHistory:

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -22,14 +22,17 @@ async def test_execute_skips_when_already_done():
     task = _make_task()
     task._basic_last_collected_date = "20250417"
     task._last_collected_date = "20250417"
+    task._period_ranking_cache[("20250417", task.DEFAULT_PERIOD_RANKING_DAYS)] = []
 
     task.refresh_basic_ranking = AsyncMock()
     task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
 
     await task.execute({"date": "20250417"})
 
     task.refresh_basic_ranking.assert_not_called()
     task.refresh_investor_ranking.assert_not_called()
+    task.prewarm_period_ranking.assert_not_called()
 
 
 async def test_execute_runs_both_when_not_done():
@@ -39,11 +42,13 @@ async def test_execute_runs_both_when_not_done():
 
     task.refresh_basic_ranking = AsyncMock()
     task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
 
     await task.execute({"date": "20250417"})
 
     task.refresh_basic_ranking.assert_called_once()
     task.refresh_investor_ranking.assert_called_once()
+    task.prewarm_period_ranking.assert_awaited_once_with("20250417")
     assert task._basic_last_collected_date == "20250417"
     assert task._last_collected_date == "20250417"
 
@@ -55,11 +60,29 @@ async def test_execute_runs_only_investor_if_basic_done():
 
     task.refresh_basic_ranking = AsyncMock()
     task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
 
     await task.execute({"date": "20250417"})
 
     task.refresh_basic_ranking.assert_not_called()
     task.refresh_investor_ranking.assert_called_once()
+    task.prewarm_period_ranking.assert_awaited_once_with("20250417")
+
+
+async def test_execute_prewarms_default_period_when_daily_rankings_are_done():
+    task = _make_task()
+    task._basic_last_collected_date = "20250417"
+    task._last_collected_date = "20250417"
+
+    task.refresh_basic_ranking = AsyncMock()
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task.execute({"date": "20250417"})
+
+    task.refresh_basic_ranking.assert_not_called()
+    task.refresh_investor_ranking.assert_not_called()
+    task.prewarm_period_ranking.assert_awaited_once_with("20250417")
 
 
 async def test_execute_sets_state_running_then_idle():
@@ -73,6 +96,7 @@ async def test_execute_sets_state_running_then_idle():
 
     task.refresh_basic_ranking = capture_state
     task.refresh_investor_ranking = capture_state
+    task.prewarm_period_ranking = capture_state
 
     await task.execute({"date": "20250417"})
 

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -483,18 +483,40 @@ async def test_send_ranking_report_combined_ranking(telegram_reporter):
     
     telegram_reporter._send_message = AsyncMock(return_value=True)
     await telegram_reporter.send_ranking_report(rankings, "20250101")
-    
+
     calls = telegram_reporter._send_message.call_args_list
     full_message = "".join([call[0][0] for call in calls])
-    
+
     # 1. 외인+기관 = 100억 + 50억 = 150억. divisor=100이므로 150으로 표시
     assert "외인+기관 순매수" in full_message
     assert "150" in full_message
-    
+
     # 2. 외인+기관+프로그램 = 100억(백만) + 50억(백만) + 200억(원 단위 -> 20000 백만)
     # 총 35000 (백만 단위, 350억). divisor=100이므로 350으로 표시
     assert "외인+기관+프로그램 순매수" in full_message
     assert "350" in full_message
+
+
+@pytest.mark.asyncio
+async def test_send_ytd_ranking_report(telegram_reporter):
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+    rows = [{
+        "name": "삼성전자",
+        "current_price": 75000,
+        "base_price": 50000,
+        "base_date": "20260102",
+        "latest_date": "20260717",
+        "ytd_return_rate": 50.0,
+    }]
+
+    sent = await telegram_reporter.send_ytd_ranking_report(rows, "20260717")
+
+    assert sent is True
+    message = telegram_reporter._send_message.await_args.args[0]
+    assert "주간 YTD 상승률 랭킹" in message
+    assert "삼성전자" in message
+    assert "+50.00%" in message
+    assert "20260102" in message
 
 @pytest.mark.asyncio
 async def test_send_ranking_report_splits_message(telegram_reporter):

--- a/tests/unit_test/task/background/after_market/test_ytd_ranking_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_ytd_ranking_report_task.py
@@ -1,0 +1,106 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from task.background.after_market.ytd_ranking_report_task import YtdRankingReportTask
+
+
+class _FakeStore:
+    def __init__(self):
+        self.data = {}
+
+    def load_keyed(self, key):
+        return self.data.get(key)
+
+    def save_keyed(self, key, value):
+        self.data[key] = value
+
+
+def _make_task(*, next_open="20260720", rows=None, store=None):
+    repository = MagicMock()
+    repository.get_ytd_return_ranking = AsyncMock(return_value=[{
+        "code": "005930",
+        "name": "삼성전자",
+        "current_price": 75000,
+        "base_price": 50000,
+        "base_date": "20260102",
+        "latest_date": "20260717",
+        "ytd_return_rate": 50.0,
+    }] if rows is None else rows)
+    reporter = MagicMock()
+    reporter.send_ytd_ranking_report = AsyncMock(return_value=True)
+    mcs = MagicMock()
+    mcs.get_next_open_day = AsyncMock(return_value=next_open)
+    task = YtdRankingReportTask(
+        stock_repository=repository,
+        telegram_reporter=reporter,
+        market_calendar_service=mcs,
+        scheduler_store=store,
+        logger=MagicMock(),
+    )
+    return task, repository, reporter
+
+
+@pytest.mark.asyncio
+async def test_friday_close_sends_weekly_report_once():
+    task, repository, reporter = _make_task(next_open="20260720")
+
+    await task._on_market_closed("20260717")
+    await task._on_market_closed("20260717")
+
+    repository.get_ytd_return_ranking.assert_awaited_once_with(limit=20)
+    reporter.send_ytd_ranking_report.assert_awaited_once()
+    assert task.get_progress()["last_reported_date"] == "20260717"
+
+
+@pytest.mark.asyncio
+async def test_thursday_sends_when_friday_is_closed():
+    task, _, reporter = _make_task(next_open="20260720")
+
+    await task._on_market_closed("20260716")
+
+    reporter.send_ytd_ranking_report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_thursday_skips_when_friday_is_open():
+    task, repository, reporter = _make_task(next_open="20260717")
+
+    await task._on_market_closed("20260716")
+
+    repository.get_ytd_return_ranking.assert_not_awaited()
+    reporter.send_ytd_ranking_report.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persisted_week_prevents_resend_after_restart():
+    store = _FakeStore()
+    task1, _, reporter1 = _make_task(store=store)
+    await task1._on_market_closed("20260717")
+    reporter1.send_ytd_ranking_report.assert_awaited_once()
+
+    task2, repository2, reporter2 = _make_task(store=store)
+    await task2._on_market_closed("20260717")
+
+    repository2.get_ytd_return_ranking.assert_not_awaited()
+    reporter2.send_ytd_ranking_report.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_send_is_not_marked_complete():
+    task, _, reporter = _make_task()
+    reporter.send_ytd_ranking_report.return_value = False
+
+    await task._on_market_closed("20260717")
+
+    assert task.get_progress()["last_reported_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_ranking_is_not_sent_or_marked_complete():
+    task, _, reporter = _make_task(rows=[])
+
+    await task._on_market_closed("20260717")
+
+    reporter.send_ytd_ranking_report.assert_not_awaited()
+    assert task.get_progress()["last_reported_date"] is None

--- a/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
@@ -17,6 +17,7 @@ def test_query_bootstrap_builds_domestic_ranking_and_query_service():
         _mcs=MagicMock(),
         market_data_service=MagicMock(),
         worker_pool=MagicMock(),
+        stock_repository=MagicMock(),
         theme_classification_repository=MagicMock(),
         indicator_service=MagicMock(),
         streaming_event_logger=MagicMock(),
@@ -33,3 +34,30 @@ def test_query_bootstrap_builds_domestic_ranking_and_query_service():
     assert ctx.ranking_task is ranking.return_value
     assert ctx.stock_query_service is query.return_value
     assert ctx.market_cap_gap_service is None
+    assert ctx.ytd_ranking_report_task is None
+
+
+def test_query_bootstrap_builds_ytd_weekly_report_for_batch_mode():
+    ctx = SimpleNamespace(
+        broker=MagicMock(), stock_code_repository=MagicMock(), stock_repository=MagicMock(),
+        env=MagicMock(), logger=MagicMock(), market_clock=MagicMock(), pm=MagicMock(),
+        notification_service=MagicMock(), telegram_reporter=MagicMock(), _mcs=MagicMock(),
+        market_data_service=MagicMock(), worker_pool=MagicMock(),
+        theme_classification_repository=MagicMock(), indicator_service=MagicMock(),
+        streaming_event_logger=MagicMock(),
+    )
+
+    with patch("view.web.bootstrap.query_bootstrap.RankingTask"), \
+         patch("view.web.bootstrap.query_bootstrap.StockQueryService"), \
+         patch("view.web.bootstrap.query_bootstrap.MarketCapGapService"), \
+         patch("view.web.bootstrap.query_bootstrap.MarketCapGapReportTask"), \
+         patch("view.web.bootstrap.query_bootstrap.YtdRankingReportTask") as ytd_task, \
+         patch("view.web.bootstrap.query_bootstrap.StrategySchedulerStore"):
+        QueryBootstrap(ctx, us_market_calendar_factory=MagicMock()).run(
+            config={}, is_overseas_us=False, needs_batch=True,
+        )
+
+    assert ctx.ytd_ranking_report_task is ytd_task.return_value
+    _, kwargs = ytd_task.call_args
+    assert kwargs["stock_repository"] is ctx.stock_repository
+    assert kwargs["worker_pool"] is ctx.worker_pool

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -53,6 +53,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
         "microstructure_capture_task", "program_capture_subscription_task",
         "theme_intraday_leader_alert_task",
+        "ytd_ranking_report_task",
     ]:
         task = MagicMock()
         task.task_name = name
@@ -91,17 +92,17 @@ def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
 
 # ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
 
-def test_all_mode_registers_23_tasks_to_background(patched_scheduler_deps):
+def test_all_mode_registers_24_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 23
+    assert bg.register.call_count == 24
 
 
-def test_all_mode_registers_14_tasks_to_time_dispatcher(patched_scheduler_deps):
+def test_all_mode_registers_15_tasks_to_time_dispatcher(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
-    assert ctx.time_dispatcher.register_task.call_count == 14
+    assert ctx.time_dispatcher.register_task.call_count == 15
 
 
 # ---------- mode 별 task 등록 ----------
@@ -188,6 +189,7 @@ def test_batch_only_registers_after_market_tasks_no_watchdog(patched_scheduler_d
         "theme_classification_task", "theme_daily_leader_report_task",
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
         "microstructure_capture_task", "program_capture_subscription_task",
+        "ytd_ranking_report_task",
     }
     assert names == expected
     assert "websocket_watchdog_task" not in names
@@ -236,6 +238,6 @@ def test_skips_none_tasks(patched_scheduler_deps):
     _run(ctx)
     # opening_position_reconcile_task 는 TRADING 그룹 + TimeDispatcher 등록 대상이었으므로
     # 둘 다 -1 감소한다.
-    assert ctx.time_dispatcher.register_task.call_count == 13
+    assert ctx.time_dispatcher.register_task.call_count == 14
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 22
+    assert bg.register.call_count == 23

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -121,6 +121,29 @@ async def test_get_ranking_failure(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_get_ytd_ranking(web_client, mock_web_ctx):
+    """GET /api/ranking/ytd 는 저장된 연초 대비 수익률 랭킹을 반환한다."""
+    mock_web_ctx.stock_repository.get_ytd_return_ranking = AsyncMock(return_value=[{
+        "code": "005930",
+        "name": "삼성전자",
+        "current_price": 75000,
+        "base_price": 50000,
+        "base_date": "20260102",
+        "latest_date": "20260713",
+        "ytd_return_rate": 50.0,
+        "data_rank": "1",
+    }])
+
+    response = web_client.get("/api/ranking/ytd?limit=30")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"][0]["ytd_return_rate"] == 50.0
+    mock_web_ctx.stock_repository.get_ytd_return_ranking.assert_awaited_once_with(limit=30)
+
+
+@pytest.mark.asyncio
 async def test_get_period_investor_program_ranking(web_client, mock_web_ctx):
     """GET /api/ranking/investor-period 는 기간 수급 랭킹을 반환한다."""
     mock_web_ctx.ranking_task.get_period_investor_program_net_buy_ranking = AsyncMock(return_value=ResCommonResponse(

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -29,6 +29,7 @@ def mock_deps():
 
         ("ous", patch("view.web.bootstrap.service_container.OneilUniverseService", autospec=True)),
         ("ranking_task", patch("view.web.bootstrap.query_bootstrap.RankingTask", autospec=True)),
+        ("ytd_ranking_report_task", patch("view.web.bootstrap.query_bootstrap.YtdRankingReportTask", autospec=True)),
         ("watchdog_task", patch("view.web.bootstrap.realtime_bootstrap.WebSocketWatchdogTask", autospec=True)),
         ("watchdog_task_in_main", patch("view.web.web_app_initializer.WebSocketWatchdogTask", autospec=True)),
         ("premium_watchlist_task", patch("view.web.bootstrap.service_container.PremiumWatchlistGeneratorTask", autospec=True)),

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -57,6 +57,8 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert "/static/js/overseas.js" in response.text
         elif path == "/ranking":
             assert "상위 종목 랭킹" in response.text
+            assert 'data-cat="ytd"' in response.text
+            assert "YTD 상승률" in response.text
         elif path == "/marketcap":
             assert "시가총액 상위 종목" in response.text
         elif path == "/virtual":

--- a/view/web/bootstrap/query_bootstrap.py
+++ b/view/web/bootstrap/query_bootstrap.py
@@ -8,6 +8,7 @@ from services.market_cap_gap_service import MarketCapGapService
 from services.stock_query_service import StockQueryService
 from task.background.after_market.market_cap_gap_report_task import MarketCapGapReportTask
 from task.background.after_market.ranking_task import RankingTask
+from task.background.after_market.ytd_ranking_report_task import YtdRankingReportTask
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -34,6 +35,7 @@ class QueryBootstrap:
                 ctx.market_cap_gap_service = None
                 ctx.market_cap_gap_report_kr_task = None
                 ctx.market_cap_gap_report_us_task = None
+                ctx.ytd_ranking_report_task = None
             else:
                 ctx.ranking_task = RankingTask(
                     broker_api_wrapper=ctx.broker,
@@ -79,6 +81,7 @@ class QueryBootstrap:
             ctx.market_cap_gap_service = None
             ctx.market_cap_gap_report_kr_task = None
             ctx.market_cap_gap_report_us_task = None
+            ctx.ytd_ranking_report_task = None
             return
 
         ctx.market_cap_gap_service = MarketCapGapService.build_default(
@@ -88,6 +91,16 @@ class QueryBootstrap:
         kr_gap_enabled = config.get("market_cap_gap_report_kr_enabled", True)
         us_gap_enabled = config.get("market_cap_gap_report_us_enabled", True)
         gap_report_store = StrategySchedulerStore(logger=ctx.logger)
+        ytd_report_enabled = config.get("ytd_ranking_report_enabled", True)
+        ctx.ytd_ranking_report_task = YtdRankingReportTask(
+            stock_repository=ctx.stock_repository,
+            telegram_reporter=getattr(ctx, "telegram_reporter", None),
+            market_calendar_service=ctx._mcs,
+            market_clock=ctx.market_clock,
+            scheduler_store=gap_report_store,
+            worker_pool=ctx.worker_pool,
+            logger=ctx.logger,
+        ) if ytd_report_enabled else None
         ctx.market_cap_gap_report_kr_task = MarketCapGapReportTask(
             market_cap_gap_service=ctx.market_cap_gap_service,
             telegram_reporter=getattr(ctx, "telegram_reporter", None),

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -116,6 +116,7 @@ class SchedulerBootstrap:
     def _register_batch_tasks(self) -> None:
         ctx = self._ctx
         self._register(ctx.ranking_task, TaskPriority.LOW)
+        self._register(self._optional_task("ytd_ranking_report_task"), TaskPriority.LOW)
         # 자체 AfterMarketLoop 사용: 한국장/미국장 각각의 cron timezone이 필요해
         # KST TimeDispatcher에는 등록하지 않는다.
         self._register(self._optional_task("market_cap_gap_report_kr_task"))

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -155,6 +155,22 @@ async def get_period_investor_program_ranking(
     return _serialize_response(resp)
 
 
+@router.get("/ranking/ytd")
+async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500)):
+    """저장된 일별 스냅샷으로 연초 대비 수익률 랭킹을 반환한다."""
+    ctx = _get_ctx()
+    repository = getattr(ctx, "stock_repository", None)
+    if not repository:
+        return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "StockRepository 미설정", "data": []}
+
+    data = await repository.get_ytd_return_ranking(limit=limit)
+    return {
+        "rt_cd": ErrorCode.SUCCESS.value,
+        "msg1": "YTD 상승률 랭킹 조회 성공" if data else "YTD 비교 데이터가 없습니다.",
+        "data": _serialize_list_items(data),
+    }
+
+
 @router.get("/ranking/{category}")
 async def get_ranking(category: str):
     """랭킹 조회 (rise/fall/volume/trading_value/foreign_buy/foreign_sell/inst_buy/inst_sell/prsn_buy/prsn_sell)."""

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -93,7 +93,7 @@ async function loadRanking(category) {
 
         if (!json.data || json.data.length === 0) {
             const isPaperBlock = json.msg1 && json.msg1.includes('실전투자 전용');
-            if (isPaperBlock) {
+            if (isPaperBlock || category === 'ytd') {
                 div.innerHTML = `<div class="card" style="text-align:center; padding:40px;">
                     <p style="font-size:1.2em;">${json.msg1}</p>
                 </div>`;
@@ -564,6 +564,7 @@ function renderRankingTable() {
     const isCombined = cat === 'investor_buy' || cat === 'investor_sell';
     const isPeriodInvestor = cat === 'investor_period';
     const isTradingValue = cat === 'trading_value';
+    const isYtd = cat === 'ytd';
     const isSell = cat.endsWith('_sell') || cat === 'investor_sell';
 
     const sortCls = (key) => {
@@ -586,6 +587,13 @@ function renderRankingTable() {
             + `<th class="${sortCls('period_inst')}" onclick="sortRanking('period_inst')">기관 ${unitLabel}</th>`
             + `<th class="${sortCls('period_program')}" onclick="sortRanking('period_program')">프로그램 ${unitLabel}</th>`
             + `<th class="${sortCls('period_combined')}" onclick="sortRanking('period_combined')">${totalLabel}</th>`;
+    } else if (isYtd) {
+        headerRow = `<th class="${sortCls('rank')}" onclick="sortRanking('rank')">순위</th>`
+            + `<th class="${sortCls('name')}" onclick="sortRanking('name')">종목명</th>`
+            + `<th class="${sortCls('price')}" onclick="sortRanking('price')">현재가</th>`
+            + `<th class="${sortCls('ytd_rate')}" onclick="sortRanking('ytd_rate')">YTD 상승률</th>`
+            + `<th class="${sortCls('base_price')}" onclick="sortRanking('base_price')">연초 기준가</th>`
+            + `<th class="${sortCls('base_date')}" onclick="sortRanking('base_date')">기준일</th>`;
     } else if (isInvestor || isProgram || isCombined) {
         const pbmnLabel = isCombined
             ? `${investorLabel} ${isSell ? '순매도대금' : '순매수대금'}`
@@ -700,6 +708,19 @@ function renderRankingTable() {
             </tr>`;
             return;
         }
+        if (isYtd) {
+            const ytdRate = parseFloat(item.ytd_return_rate || 0);
+            const ytdColor = ytdRate > 0 ? 'text-red' : (ytdRate < 0 ? 'text-blue' : '');
+            rows += `<tr>
+                <td>${item.data_rank || item.rank || '-'}</td>
+                <td><a href="/stock?code=${code}" target="_blank" class="stock-link">${escapeHtml(item.name || code)}</a></td>
+                <td>${parseInt(item.current_price || 0).toLocaleString()}</td>
+                <td class="${ytdColor}">${ytdRate.toFixed(2)}%</td>
+                <td>${parseInt(item.base_price || 0).toLocaleString()}</td>
+                <td>${escapeHtml(item.base_date || '-')}</td>
+            </tr>`;
+            return;
+        }
         let extraCols;
         if (isMinervini) {
             extraCols = `<td>S${item.stage}</td><td>${item.rs_rating || '-'}</td><td>${formatMarketCap(item.market_cap || 0)}</td>`;
@@ -780,8 +801,8 @@ function rankingSortCompare(data, key, dir) {
             vb = (b.industry || '').toLowerCase();
             return d * va.localeCompare(vb);
         } else if (key === 'price') {
-            va = parseInt(a.stck_prpr || 0);
-            vb = parseInt(b.stck_prpr || 0);
+            va = parseInt(a.stck_prpr || a.current_price || 0);
+            vb = parseInt(b.stck_prpr || b.current_price || 0);
         } else if (key === 'rate') {
             va = parseFloat(a.prdy_ctrt || 0);
             vb = parseFloat(b.prdy_ctrt || 0);
@@ -835,6 +856,15 @@ function rankingSortCompare(data, key, dir) {
         } else if (key === 'period_combined' && isPeriodInvestor) {
             va = parseInt(_rankingPeriodMetric === 'amount' ? a.combined_period_ntby_tr_pbmn_won || 0 : a.combined_period_ntby_qty || 0);
             vb = parseInt(_rankingPeriodMetric === 'amount' ? b.combined_period_ntby_tr_pbmn_won || 0 : b.combined_period_ntby_qty || 0);
+        } else if (key === 'ytd_rate') {
+            va = parseFloat(a.ytd_return_rate || 0);
+            vb = parseFloat(b.ytd_return_rate || 0);
+        } else if (key === 'base_price') {
+            va = parseInt(a.base_price || 0);
+            vb = parseInt(b.base_price || 0);
+        } else if (key === 'base_date') {
+            va = parseInt(a.base_date || 0);
+            vb = parseInt(b.base_date || 0);
         } else if (key === 'market_cap') {
             va = parseInt(a.market_cap || 0);
             vb = parseInt(b.market_cap || 0);

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -13,6 +13,7 @@
             </div>
             <div class="form-row">
                 <button class="btn ranking-tab active" data-cat="rise" onclick="loadRanking('rise')">상승률</button>
+                <button class="btn ranking-tab" data-cat="ytd" onclick="loadRanking('ytd')">YTD 상승률</button>
                 <button class="btn ranking-tab" data-cat="fall" onclick="loadRanking('fall')">하락률</button>
                 <button class="btn ranking-tab" data-cat="volume" onclick="loadRanking('volume')">거래량</button>
                 <button class="btn ranking-tab" data-cat="trading_value" onclick="loadRanking('trading_value')">거래대금</button>
@@ -51,7 +52,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=5"></script>
+<script src="/static/js/ranking.js?v=6"></script>
 <script>
     loadRanking('rise');
 </script>

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -140,6 +140,7 @@ class WebAppContext:
         self.scheduler: StrategyScheduler = None
         self.oneil_universe_service: OneilUniverseService = None
         self.ranking_task: RankingTask = None
+        self.ytd_ranking_report_task = None
         self.minervini_update_task: MinerviniUpdateTask = None
         self.websocket_watchdog_task: WebSocketWatchdogTask = None
         self.pre_market_health_check_task: PreMarketHealthCheckTask = None


### PR DESCRIPTION
## 변경 사항
- 장 마감 저우선순위 랭킹 배치가 기본 5일 기간수급 캐시를 미리 예열하도록 변경했습니다.
- 동일 기준일/기간의 백그라운드 예열과 웹 요청이 하나의 수집 작업을 공유합니다.
- 최신 거래일과 해당 연도 첫 시장 스냅샷을 비교하는 YTD 상승률 저장소 조회 및 API를 추가했습니다.
- 랭킹 화면에 YTD 상승률 탭과 현재가, YTD 상승률, 연초 기준가, 실제 기준일 표를 추가했습니다.
- YTD 상승률 Top 20을 한 주의 마지막 거래일 장 마감 15분 후 Telegram으로 리포트합니다.
- 금요일 휴장 시 그 주의 직전 거래일을 판별하며, 전송일을 저장해 재시작 후에도 주 1회만 발송합니다.

## 배경
기간수급 랭킹은 최초 웹 요청에서 전 종목 데이터를 수집해 응답이 오래 걸렸습니다. 또한 연초 이후 성과를 한 화면에서 비교하고 주간 단위로 확인할 수 있는 랭킹 뷰와 리포트가 없었습니다.

## 사용자 영향
- 기본 5일 기간수급 화면은 장 마감 배치가 완료된 뒤 즉시 캐시 결과를 사용합니다.
- YTD 탭에서 연초 공통 기준일 데이터가 있는 종목을 수익률 순으로 조회하고 정렬할 수 있습니다.
- 매주 마지막 거래일에만 YTD Top 20 리포트를 받으며, Telegram 전송 실패 시에는 완료 처리하지 않아 다음 실행에서 재시도할 수 있습니다.
- 연초 공통 기준일 스냅샷이 없는 신규 상장 종목은 1차 버전에서 제외됩니다.

## 검증
- `node --check view/web/static/js/ranking.js`
- `pytest tests/unit_test -v` — 6,780 passed
- `pytest tests/integration_test -v` — 247 passed