### PR TITLE
Add DART disclosure monitoring and improve realtime resilience

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -150,6 +150,20 @@ notifications:
       STRATEGY: ["warning", "error", "critical"]
       API: ["error", "critical"]
 
+# OpenDART 관심종목 공시 알림 (API 키 발급 후 enabled=true)
+dart_disclosure:
+  enabled: false
+  api_key: ""
+  poll_interval_sec: 300
+  off_hours_interval_sec: 1800
+  active_start_time: "07:00"
+  active_end_time: "19:30"
+  request_timeout_sec: 5
+  immediate_alert_score: 70
+  daily_digest_enabled: true
+  daily_digest_time: "19:40"
+  max_pages_per_poll: 5
+
 # 시총갭 리포트 발송 세션 on/off (기본 둘 다 on)
 #   kr: 한국장 마감(15:50 KST) 후 발송 — 미국 시총은 전일 종가 기준(프리뷰)
 #   us: 미국장 마감(16:30 ET ≈ 익일 06:30 KST) 후 발송 — 양쪽 시총 최신(확정값)

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -235,6 +235,22 @@ class NotificationsConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class DartDisclosureConfig(BaseModel):
+    enabled: bool = False
+    api_key: str = ""
+    poll_interval_sec: int = Field(300, ge=60)
+    off_hours_interval_sec: int = Field(1800, ge=60)
+    active_start_time: str = "07:00"
+    active_end_time: str = "19:30"
+    request_timeout_sec: float = Field(5.0, gt=0)
+    immediate_alert_score: int = Field(70, ge=0, le=100)
+    daily_digest_enabled: bool = True
+    daily_digest_time: str = "19:40"
+    max_pages_per_poll: int = Field(5, ge=1, le=100)
+
+    model_config = {"extra": "allow"}
+
+
 class ExecutionQualityReportConfig(BaseModel):
     enabled: bool = True
     min_sample_count: int = 3
@@ -401,6 +417,7 @@ class AppConfig(BaseModel):
     order_execution: OrderExecutionConfig = Field(default_factory=OrderExecutionConfig)
     data_quality: DataQualityConfig = Field(default_factory=DataQualityConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
+    dart_disclosure: DartDisclosureConfig = Field(default_factory=DartDisclosureConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)
     strategy_performance_degradation: StrategyPerformanceDegradationConfig = Field(

--- a/core/loggers/streaming_event_logger.py
+++ b/core/loggers/streaming_event_logger.py
@@ -519,6 +519,15 @@ class StreamingEventLogger:
             return
         self._logger.warning({"action": "pt_restore_failed_pending", "codes": sorted(codes)})
 
+    def log_pt_capacity_pending(self, selected: list, pending: list, max_codes: int) -> None:
+        """WebSocket 슬롯 한도로 이번 복원에서 제외된 PT 종목을 기록한다."""
+        self._logger.warning({
+            "action": "pt_capacity_pending",
+            "selected": selected,
+            "pending": pending,
+            "max_codes": max_codes,
+        })
+
     def log_price_restore_start(self, desired_count: int) -> None:
         """H0UNCNT0(실시간 체결가) 구독 복원 시작.
 

--- a/core/retry_queue/client_with_retry_queue.py
+++ b/core/retry_queue/client_with_retry_queue.py
@@ -27,6 +27,7 @@ _EXCLUDED_METHODS = frozenset({
     "is_websocket_receive_alive",
     # 구독 ACK 대기 — 큐/버짓에 태우면 안 되는 단순 await (budget 카테고리 미등록 → 직접 호출)
     "wait_for_unified_price_ack",
+    "wait_for_program_trading_ack",
 })
 
 _BUDGET_ONLY_METHOD_CATEGORIES = {

--- a/repositories/dart_disclosure_repository.py
+++ b/repositories/dart_disclosure_repository.py
@@ -1,0 +1,218 @@
+"""OpenDART 공시 감지·발송 상태 SQLite 저장소."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Union
+
+import aiosqlite
+
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DisclosureImportance
+
+
+_DDL_DISCLOSURES = """
+CREATE TABLE IF NOT EXISTS disclosures (
+    rcept_no TEXT PRIMARY KEY,
+    corp_code TEXT NOT NULL,
+    stock_code TEXT NOT NULL,
+    corp_name TEXT NOT NULL,
+    report_name TEXT NOT NULL,
+    filer_name TEXT NOT NULL,
+    receipt_date TEXT NOT NULL,
+    remarks TEXT NOT NULL,
+    importance_score INTEGER NOT NULL,
+    importance_level TEXT NOT NULL,
+    importance_reasons TEXT NOT NULL,
+    detected_at TEXT NOT NULL,
+    alert_suppressed INTEGER NOT NULL DEFAULT 0,
+    immediate_sent_at TEXT,
+    digest_sent_at TEXT,
+    send_retry_count INTEGER NOT NULL DEFAULT 0
+)
+"""
+
+_DDL_STATE = """
+CREATE TABLE IF NOT EXISTS monitor_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"""
+
+
+@dataclass(frozen=True)
+class StoredDisclosure:
+    disclosure: DartDisclosure
+    importance: DisclosureImportance
+
+
+class DartDisclosureRepository:
+    DB_PATH = Path("data/dart_disclosures.db")
+
+    def __init__(self, db_path: Union[str, Path, None] = None) -> None:
+        self._db_path = Path(db_path or self.DB_PATH)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _setup(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute(_DDL_DISCLOSURES)
+        await conn.execute(_DDL_STATE)
+        await conn.commit()
+
+    async def save_detected(
+        self,
+        disclosure: DartDisclosure,
+        importance: DisclosureImportance,
+        *,
+        suppress_immediate: bool = False,
+    ) -> bool:
+        detected_at = datetime.now().isoformat()
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            cur = await conn.execute(
+                """
+                INSERT OR IGNORE INTO disclosures(
+                    rcept_no, corp_code, stock_code, corp_name, report_name,
+                    filer_name, receipt_date, remarks, importance_score,
+                    importance_level, importance_reasons, detected_at, alert_suppressed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    disclosure.receipt_no,
+                    disclosure.corp_code,
+                    disclosure.stock_code,
+                    disclosure.corp_name,
+                    disclosure.report_name,
+                    disclosure.filer_name,
+                    disclosure.receipt_date,
+                    disclosure.remarks,
+                    importance.score,
+                    importance.level,
+                    json.dumps(importance.reasons, ensure_ascii=False),
+                    detected_at,
+                    int(suppress_immediate),
+                ),
+            )
+            await conn.commit()
+            return cur.rowcount > 0
+
+    async def has_receipt(self, receipt_no: str) -> bool:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                "SELECT 1 FROM disclosures WHERE rcept_no = ? LIMIT 1", (receipt_no,)
+            ) as cur:
+                return await cur.fetchone() is not None
+
+    async def get_known_receipt_nos(self, receipt_nos: Iterable[str]) -> set[str]:
+        receipt_nos = list(dict.fromkeys(str(value) for value in receipt_nos if value))
+        if not receipt_nos:
+            return set()
+        placeholders = ",".join("?" for _ in receipt_nos)
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                f"SELECT rcept_no FROM disclosures WHERE rcept_no IN ({placeholders})",
+                tuple(receipt_nos),
+            ) as cur:
+                rows = await cur.fetchall()
+        return {str(row[0]) for row in rows}
+
+    async def get_pending_immediate(self, threshold: int) -> list[StoredDisclosure]:
+        return await self._query_stored(
+            """
+            SELECT * FROM disclosures
+            WHERE importance_score >= ? AND immediate_sent_at IS NULL AND alert_suppressed = 0
+            ORDER BY detected_at ASC, rcept_no ASC
+            """,
+            (int(threshold),),
+        )
+
+    async def mark_immediate_sent(self, receipt_no: str, sent_at: datetime) -> None:
+        await self._update_timestamp("immediate_sent_at", [receipt_no], sent_at)
+
+    async def increment_send_retry(self, receipt_no: str) -> None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            await conn.execute(
+                "UPDATE disclosures SET send_retry_count = send_retry_count + 1 WHERE rcept_no = ?",
+                (receipt_no,),
+            )
+            await conn.commit()
+
+    async def get_pending_digest(
+        self, receipt_date: str, *, immediate_threshold: int
+    ) -> list[StoredDisclosure]:
+        return await self._query_stored(
+            """
+            SELECT * FROM disclosures
+            WHERE receipt_date = ? AND importance_score < ? AND digest_sent_at IS NULL
+            ORDER BY importance_score DESC, rcept_no ASC
+            """,
+            (receipt_date, int(immediate_threshold)),
+        )
+
+    async def mark_digest_sent(self, receipt_nos: Iterable[str], sent_at: datetime) -> None:
+        await self._update_timestamp("digest_sent_at", list(receipt_nos), sent_at)
+
+    async def is_initialized(self) -> bool:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                "SELECT value FROM monitor_state WHERE key = 'initialized'"
+            ) as cur:
+                row = await cur.fetchone()
+        return bool(row and row[0] == "1")
+
+    async def mark_initialized(self) -> None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            await conn.execute(
+                "INSERT OR REPLACE INTO monitor_state(key, value) VALUES ('initialized', '1')"
+            )
+            await conn.commit()
+
+    async def _query_stored(self, sql: str, params: tuple) -> list[StoredDisclosure]:
+        async with aiosqlite.connect(self._db_path) as conn:
+            conn.row_factory = aiosqlite.Row
+            await self._setup(conn)
+            async with conn.execute(sql, params) as cur:
+                rows = await cur.fetchall()
+        return [self._from_row(row) for row in rows]
+
+    async def _update_timestamp(
+        self, column: str, receipt_nos: list[str], sent_at: datetime
+    ) -> None:
+        if not receipt_nos:
+            return
+        placeholders = ",".join("?" for _ in receipt_nos)
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            await conn.execute(
+                f"UPDATE disclosures SET {column} = ? WHERE rcept_no IN ({placeholders})",
+                (sent_at.isoformat(), *receipt_nos),
+            )
+            await conn.commit()
+
+    @staticmethod
+    def _from_row(row) -> StoredDisclosure:
+        return StoredDisclosure(
+            disclosure=DartDisclosure(
+                corp_class="",
+                corp_name=row["corp_name"],
+                corp_code=row["corp_code"],
+                stock_code=row["stock_code"],
+                report_name=row["report_name"],
+                receipt_no=row["rcept_no"],
+                filer_name=row["filer_name"],
+                receipt_date=row["receipt_date"],
+                remarks=row["remarks"],
+            ),
+            importance=DisclosureImportance(
+                score=int(row["importance_score"]),
+                level=row["importance_level"],
+                reasons=json.loads(row["importance_reasons"]),
+            ),
+        )

--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -62,6 +62,7 @@ class StreamingStockRepo:
         self._pending_desired_ops: list = []  # list of (code: str, add: bool, source: str)
         self._pending_lock = threading.Lock()
         self._pt_sources: Dict[str, str] = {}
+        self._pt_capacity_pending: Set[str] = set()
 
     # ── 초기화 / 영속성 ──────────────────────────────────────────────
 
@@ -264,6 +265,14 @@ class StreamingStockRepo:
         """PROGRAM_TRADING desired 종목별 등록 출처를 반환한다."""
         return dict(self._pt_sources)
 
+    def set_pt_capacity_pending(self, codes: Iterable[str]) -> None:
+        """WebSocket 슬롯 한도로 활성 복원에서 제외된 PT 종목을 기록한다."""
+        self._pt_capacity_pending = self._normalize_codes(codes)
+
+    def get_pt_capacity_pending(self) -> Set[str]:
+        """WebSocket 슬롯 확보를 기다리는 PT 종목 snapshot을 반환한다."""
+        return set(self._pt_capacity_pending)
+
     def get_active(self, stream_type: StreamingType) -> Set[str]:
         """active 집합의 복사본을 반환한다 (lock-free 안전 읽기)."""
         return set(self._active[stream_type])
@@ -285,6 +294,10 @@ class StreamingStockRepo:
                 "desired": sorted(self._desired[stream_type]),
                 "active": sorted(self._active[stream_type]),
                 "pending": sorted(self.get_pending(stream_type)),
+                **(
+                    {"capacity_pending": sorted(self._pt_capacity_pending)}
+                    if stream_type == StreamingType.PROGRAM_TRADING else {}
+                ),
             }
             for stream_type in StreamingType
         }

--- a/services/dart_disclosure_client.py
+++ b/services/dart_disclosure_client.py
@@ -1,0 +1,124 @@
+"""OpenDART 공시검색 API의 최소 비동기 클라이언트."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import httpx
+
+
+@dataclass(frozen=True)
+class DartDisclosure:
+    corp_class: str
+    corp_name: str
+    corp_code: str
+    stock_code: str
+    report_name: str
+    receipt_no: str
+    filer_name: str
+    receipt_date: str
+    remarks: str = ""
+
+    @property
+    def viewer_url(self) -> str:
+        return f"https://dart.fss.or.kr/dsaf001/main.do?rcpNo={self.receipt_no}"
+
+
+@dataclass(frozen=True)
+class DartDisclosurePage:
+    items: List[DartDisclosure]
+    page_no: int
+    page_count: int
+    total_count: int
+    total_page: int
+
+
+class DartApiError(RuntimeError):
+    def __init__(self, status: str, message: str):
+        self.status = str(status or "")
+        self.message = str(message or "OpenDART API 오류")
+        super().__init__(f"OpenDART API 오류 ({self.status}): {self.message}")
+
+
+class DartDisclosureClient:
+    LIST_URL = "https://opendart.fss.or.kr/api/list.json"
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        http_client: Optional[httpx.AsyncClient] = None,
+        timeout_sec: float = 5.0,
+    ) -> None:
+        self._api_key = api_key
+        self._http_client = http_client
+        self._timeout_sec = float(timeout_sec)
+
+    async def fetch_disclosures(
+        self,
+        date: str,
+        *,
+        page_no: int = 1,
+        page_count: int = 100,
+    ) -> DartDisclosurePage:
+        params = {
+            "crtfc_key": self._api_key,
+            "bgn_de": date,
+            "end_de": date,
+            "last_reprt_at": "N",
+            "sort": "date",
+            "sort_mth": "desc",
+            "page_no": int(page_no),
+            "page_count": int(page_count),
+        }
+        if self._http_client is not None:
+            response = await self._request(self._http_client, params)
+        else:
+            async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+                response = await self._request(client, params)
+        return self._parse_response(response.json())
+
+    async def _request(self, client, params):
+        last_error = None
+        for _attempt in range(2):
+            try:
+                response = await client.get(
+                    self.LIST_URL,
+                    params=params,
+                    timeout=self._timeout_sec,
+                )
+                response.raise_for_status()
+                return response
+            except httpx.RequestError as exc:
+                last_error = exc
+        raise DartApiError("NETWORK", type(last_error).__name__)
+
+    @staticmethod
+    def _parse_response(payload: dict) -> DartDisclosurePage:
+        status = str(payload.get("status") or "")
+        if status == "013":
+            return DartDisclosurePage([], 1, 100, 0, 0)
+        if status != "000":
+            raise DartApiError(status, payload.get("message", ""))
+
+        items = [
+            DartDisclosure(
+                corp_class=str(row.get("corp_cls") or ""),
+                corp_name=str(row.get("corp_name") or ""),
+                corp_code=str(row.get("corp_code") or ""),
+                stock_code=str(row.get("stock_code") or ""),
+                report_name=str(row.get("report_nm") or ""),
+                receipt_no=str(row.get("rcept_no") or ""),
+                filer_name=str(row.get("flr_nm") or ""),
+                receipt_date=str(row.get("rcept_dt") or ""),
+                remarks=str(row.get("rm") or ""),
+            )
+            for row in (payload.get("list") or [])
+        ]
+        return DartDisclosurePage(
+            items=items,
+            page_no=int(payload.get("page_no") or 1),
+            page_count=int(payload.get("page_count") or 100),
+            total_count=int(payload.get("total_count") or len(items)),
+            total_page=int(payload.get("total_page") or (1 if items else 0)),
+        )

--- a/services/dart_disclosure_rule_service.py
+++ b/services/dart_disclosure_rule_service.py
@@ -1,0 +1,75 @@
+"""공시 제목에 기반한 설명 가능한 중요도 규칙."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from services.dart_disclosure_client import DartDisclosure
+
+
+@dataclass(frozen=True)
+class DisclosureImportance:
+    score: int
+    level: str
+    reasons: list[str]
+
+
+class DartDisclosureRuleService:
+    _RULES = (
+        (100, ("상장폐지", "거래정지", "감사의견거절", "부적정의견"), "상장·감사 위험 관련 공시"),
+        (95, ("횡령", "배임", "회생절차", "영업정지"), "중대한 경영 위험 관련 공시"),
+        (85, ("전환사채", "신주인수권부사채", "유상증자", "감자결정"), "자금조달·주식 희석 관련 공시"),
+        (80, ("최대주주변경", "합병결정", "회사분할", "주식교환", "주식이전"), "지배구조·기업구조 변경 공시"),
+        (80, ("공급계약해지", "계약해지", "계약철회"), "계약 해지·철회 관련 공시"),
+        (70, ("단일판매공급계약체결", "공급계약체결"), "공급계약 관련 공시"),
+        (70, ("잠정실적", "영업실적", "매출액또는손익구조"), "실적 관련 공시"),
+        (60, ("자기주식취득", "자기주식소각", "현금현물배당", "배당결정"), "주주환원 관련 공시"),
+        (50, ("신규시설투자", "타법인주식", "대량보유상황", "임원주요주주"), "투자·지분변동 관련 공시"),
+        (30, ("사업보고서", "반기보고서", "분기보고서"), "정기보고서"),
+        (20, ("기업설명회", "IR개최", "주주총회"), "일정·안내성 공시"),
+    )
+
+    def evaluate(self, disclosure: DartDisclosure) -> DisclosureImportance:
+        normalized = self._normalize(disclosure.report_name)
+        score = 10
+        reasons = ["일반 공시"]
+        for rule_score, keywords, reason in self._RULES:
+            if self._contains_any(normalized, keywords):
+                score = rule_score
+                reasons = [reason]
+                break
+
+        if "정정" in disclosure.report_name:
+            reasons.append("기존 공시의 정정 제출")
+        if "철" in disclosure.remarks or "철회" in normalized:
+            score = max(score, 80)
+            reasons.append("철회 표시가 있는 공시")
+
+        return DisclosureImportance(
+            score=score,
+            level=self._level(score),
+            reasons=list(dict.fromkeys(reasons)),
+        )
+
+    @staticmethod
+    def _normalize(value: str) -> str:
+        return "".join(
+            char for char in str(value or "")
+            if char not in " \t\r\nㆍ·-_/[]()"
+        ).upper()
+
+    @classmethod
+    def _contains_any(cls, text: str, keywords: Iterable[str]) -> bool:
+        return any(cls._normalize(keyword) in text for keyword in keywords)
+
+    @staticmethod
+    def _level(score: int) -> str:
+        if score >= 90:
+            return "CRITICAL"
+        if score >= 70:
+            return "HIGH"
+        if score >= 50:
+            return "MEDIUM"
+        if score >= 30:
+            return "NORMAL"
+        return "LOW"

--- a/services/program_trading_stream_service.py
+++ b/services/program_trading_stream_service.py
@@ -43,6 +43,7 @@ class ProgramTradingStreamService:
         self._pt_history: dict = {}
         self._last_tick_ts_by_code: dict[str, float] = {}
         self.last_data_ts = 0.0
+        self._history_date = datetime.now().date().isoformat()
 
         # 클라이언트 스트리밍 큐
         self._pt_queues: list = []
@@ -113,6 +114,21 @@ class ProgramTradingStreamService:
     def _load_pt_history(self):
         self._pt_history = self._repo.load_today_history()
 
+    def _ensure_current_day_history(self) -> None:
+        """자정 이후 전일 메모리 tick이 오늘 데이터로 노출되지 않도록 초기화한다."""
+        current_date = datetime.now().date().isoformat()
+        if self._history_date == current_date:
+            return
+
+        previous_date = self._history_date
+        self._pt_history.clear()
+        self._last_tick_ts_by_code.clear()
+        self.last_data_ts = 0.0
+        self._history_date = current_date
+        self.logger.info(
+            f"프로그램매매 메모리 히스토리 일자 전환: {previous_date} -> {current_date}"
+        )
+
     def _bulk_insert_to_db(self, batch: list):
         self._repo._bulk_insert_to_db(batch)
 
@@ -154,6 +170,7 @@ class ProgramTradingStreamService:
         DB 쓰기는 버퍼에 적재 후 백그라운드에서 일괄 처리하여
         이벤트 루프 블로킹을 방지한다.
         """
+        self._ensure_current_day_history()
         code = data.get('유가증권단축종목코드')
         if not code:
             return
@@ -215,6 +232,7 @@ class ProgramTradingStreamService:
 
     def get_history_data(self):
         """현재 메모리에 있는 히스토리 데이터 반환."""
+        self._ensure_current_day_history()
         return self._pt_history
 
     # ── 스냅샷 저장/로드 (repo 위임) ─────────────────────────────────
@@ -329,6 +347,19 @@ class ProgramTradingStreamService:
             for code, source in sources.items()
         }
 
+    def _get_pt_capacity_pending(self) -> set[str]:
+        if not self._streaming_stock_repo:
+            return set()
+        getter = getattr(self._streaming_stock_repo, "get_pt_capacity_pending", None)
+        if not callable(getter):
+            return set()
+        try:
+            codes = getter()
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 용량 대기 목록 조회 실패: {e}")
+            return set()
+        return {str(code) for code in codes} if isinstance(codes, (set, list, tuple)) else set()
+
     def _sort_codes_by_subscription_source(
         self,
         codes: list[str],
@@ -400,7 +431,9 @@ class ProgramTradingStreamService:
             return None
 
     async def _format_last_tick_report_async(self, codes: list[str]) -> str:
+        self._ensure_current_day_history()
         sources = self._get_pt_subscription_sources()
+        capacity_pending = self._get_pt_capacity_pending()
         ordered_codes = self._sort_codes_by_subscription_source(codes, sources)
         lines = [
             "<b>프로그램매매 구독 Tick 상태</b>",
@@ -412,7 +445,11 @@ class ProgramTradingStreamService:
             label = self._format_stock_label(code)
             history = self._pt_history.get(code) or []
             if not history:
-                lines.append(self._format_tick_alert_line(code, label, "수신 없음", sources))
+                body = (
+                    "구독 대기 (WebSocket 한도)"
+                    if code in capacity_pending else "수신 없음"
+                )
+                lines.append(self._format_tick_alert_line(code, label, body, sources))
                 continue
 
             tick = dict(history[-1])
@@ -440,7 +477,9 @@ class ProgramTradingStreamService:
 
     def _format_last_tick_report(self, codes: list[str]) -> str:
         """하위 호환용 동기 포맷터. 운영 전송은 REST 보정 가능한 async 경로를 사용한다."""
+        self._ensure_current_day_history()
         sources = self._get_pt_subscription_sources()
+        capacity_pending = self._get_pt_capacity_pending()
         ordered_codes = self._sort_codes_by_subscription_source(codes, sources)
         lines = [
             "<b>프로그램매매 구독 Tick 상태</b>",
@@ -452,7 +491,11 @@ class ProgramTradingStreamService:
             label = self._format_stock_label(code)
             history = self._pt_history.get(code) or []
             if not history:
-                lines.append(self._format_tick_alert_line(code, label, "수신 없음", sources))
+                body = (
+                    "구독 대기 (WebSocket 한도)"
+                    if code in capacity_pending else "수신 없음"
+                )
+                lines.append(self._format_tick_alert_line(code, label, body, sources))
                 continue
 
             tick = history[-1]

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -79,6 +79,7 @@ class SubscriptionPolicy:
         # 현재 실제로 WebSocket 구독 중인 종목 집합
         self._active_codes_price: Set[str] = set()
         self._active_codes_pt: Set[str] = set()
+        self._external_reserved_slots = 0
 
         # summary 로그 스로틀 (동시 다발적 rebalance 호출로 인한 중복 발화 방지)
         self._last_summary_time: float = 0.0
@@ -98,6 +99,10 @@ class SubscriptionPolicy:
         self._active_codes_pt.clear()
         self._streaming_logger.log_clear_active_state(f"SubscriptionPolicy: active 상태 초기화 {count_price}개 클리어")
         self._streaming_logger.log_clear_active_state(f"SubscriptionPolicy: active 상태 초기화 {count_pt}개 클리어")
+
+    def set_external_reserved_slots(self, slots: int) -> None:
+        """정책 외부에서 복원한 PT/주문통보 슬롯을 일반 구독 배정에서 제외한다."""
+        self._external_reserved_slots = max(0, min(int(slots), self.MAX_WS_SLOTS))
 
     async def add_subscription(
         self, code: str, priority: SubscriptionPriority, 
@@ -275,7 +280,7 @@ class SubscriptionPolicy:
         desired_price: Set[str] = set()
         desired_pt: Set[str] = set()
 
-        available_slots = self.MAX_WS_SLOTS
+        available_slots = max(0, self.MAX_WS_SLOTS - self._external_reserved_slots)
 
         # 2. 슬롯 할당 (Greedy)
         for code in ranked_codes:
@@ -405,6 +410,8 @@ class SubscriptionPolicy:
                     return
             elif stream_type == StreamingType.PROGRAM_TRADING:
                 success = await self._streaming.subscribe_program_trading(code)
+                if success:
+                    success = await self._streaming.wait_program_trading_ack(code)
             if success:
                 if stream_type == StreamingType.UNIFIED_PRICE:
                     self._active_codes_price.add(code)
@@ -470,6 +477,8 @@ class SubscriptionPolicy:
         """
         missing_companion_price = self._active_codes_pt - self._active_codes_price
         return (
+            self._external_reserved_slots
+            +
             len(self._active_codes_price)
             + len(self._active_codes_pt)
             + len(missing_companion_price)

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -418,7 +418,7 @@ class TelegramReporter:
                 summary_parts.append(f"수급비중 {flow_ratio}")
             summary_line = " | ".join(summary_parts) + score_text
             lines = [
-                f"<b>{rank}. {theme_name}</b>  {avg_rate}  {trading_value}",
+                f"<b>{rank}. {theme_name}</b>  주도주 평균 {avg_rate}  {trading_value}",
                 summary_line,
                 "<pre>",
             ]
@@ -554,6 +554,62 @@ class TelegramReporter:
                 current += chunk
         if current:
             await self._send_message(current)
+
+    @_serialized_report_send
+    async def send_disclosure_alert(self, disclosure, importance) -> bool:
+        """관심종목 중요 공시 한 건을 즉시 전송한다."""
+        company = html.escape(str(disclosure.corp_name or disclosure.stock_code), quote=False)
+        stock_code = html.escape(str(disclosure.stock_code), quote=False)
+        report_name = html.escape(str(disclosure.report_name), quote=False)
+        reasons = "\n".join(
+            f"• {html.escape(str(reason), quote=False)}" for reason in importance.reasons
+        )
+        message = (
+            "🚨 <b>관심종목 중요 공시</b>\n\n"
+            f"<b>{company} ({stock_code})</b>\n"
+            f"공시: {report_name}\n"
+            f"중요도: {html.escape(str(importance.level), quote=False)} "
+            f"({int(importance.score)}점)\n\n"
+            f"<b>판정 근거</b>\n{reasons}\n\n"
+            f"접수일: {html.escape(str(disclosure.receipt_date), quote=False)}\n"
+            f'<a href="{disclosure.viewer_url}">DART 원문 보기</a>'
+        )
+        return await self._send_message(message)
+
+    @_serialized_report_send
+    async def send_disclosure_digest(self, stored_items, report_date: str) -> bool:
+        """즉시 알림 기준 미만 공시를 일일 요약으로 전송한다."""
+        if not stored_items:
+            return True
+        header = f"📋 <b>관심종목 공시 요약 — {html.escape(str(report_date), quote=False)}</b>\n"
+        parts = []
+        for item in stored_items:
+            disclosure = item.disclosure
+            importance = item.importance
+            company = html.escape(str(disclosure.corp_name or disclosure.stock_code), quote=False)
+            report_name = html.escape(str(disclosure.report_name), quote=False)
+            parts.append(
+                f"\n<b>{company} ({html.escape(str(disclosure.stock_code), quote=False)})</b>\n"
+                f"• {report_name}\n"
+                f"• 중요도: {html.escape(str(importance.level), quote=False)} ({int(importance.score)}점)\n"
+                f'<a href="{disclosure.viewer_url}">원문</a>\n'
+            )
+
+        messages = []
+        current = header
+        for part in parts:
+            if len((current + part).encode("utf-8")) > 4000:
+                messages.append(current)
+                current = header + part
+            else:
+                current += part
+        if current:
+            messages.append(current)
+
+        success = True
+        for message in messages:
+            success = await self._send_message(message) and success
+        return success
 
     @_serialized_report_send
     async def send_premium_watchlist_report(self, kospi: List[Dict], kosdaq: List[Dict], report_date: str, limit: int = 30):

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -107,8 +107,14 @@ class ThemeDailyLeaderService:
                     item for item in momentum_leaders
                     if item["trading_value_won"] >= self.MIN_LIQUID_LEADER_TRADING_VALUE_WON
                 ]
+                liquid_advancing_members = [
+                    item for item in liquid_members if item["change_rate"] > 0
+                ]
                 leaders = liquid_members[:leader_count]
                 trading_value_sum = sum(item["trading_value_won"] for item in scored)
+                advancing_trading_value_sum = sum(
+                    item["trading_value_won"] for item in scored if item["change_rate"] > 0
+                )
                 trading_value_concentration_ratio = (
                     max(item["trading_value_won"] for item in scored) / trading_value_sum * 100
                     if trading_value_sum else 0.0
@@ -116,6 +122,12 @@ class ThemeDailyLeaderService:
                 fi_net_sum = sum(item["fi_net_buy_won"] for item in scored)
                 program_net_sum = sum(item["program_net_buy_won"] for item in scored)
                 advance_count = sum(1 for item in scored if item["change_rate"] > 0)
+                advancing_ratio = round(advance_count / len(scored) * 100, 1)
+                is_liquid_theme = (
+                    advancing_trading_value_sum >= self.MIN_LIQUID_THEME_TRADING_VALUE_WON
+                    and len(liquid_advancing_members) >= self.MIN_LIQUID_MEMBER_COUNT
+                    and advancing_ratio >= 50.0
+                )
                 flow_ratio = (
                     round(((fi_net_sum + program_net_sum) / trading_value_sum) * 100, 2)
                     if trading_value_sum else 0.0
@@ -126,14 +138,17 @@ class ThemeDailyLeaderService:
                 score_info = self._build_theme_score(
                     scored=scored,
                     leader_avg_change_rate=leader_avg_change_rate,
-                    advancing_ratio=round(advance_count / len(scored) * 100, 1),
+                    advancing_ratio=advancing_ratio,
                     trading_value_sum_won=trading_value_sum,
                     flow_ratio=flow_ratio,
                     trading_value_concentration_ratio=trading_value_concentration_ratio,
                 )
-                liquidity_bonus = self._build_liquidity_bonus(
-                    trading_value_sum,
-                    leader_avg_change_rate,
+                liquidity_bonus = (
+                    self._build_liquidity_bonus(
+                        advancing_trading_value_sum,
+                        leader_avg_change_rate,
+                    )
+                    if is_liquid_theme else 0.0
                 )
                 market_leadership_score = round(score_info["theme_score"] + liquidity_bonus, 2)
 
@@ -143,14 +158,13 @@ class ThemeDailyLeaderService:
                     "report_date": report_date,
                     "scored_member_count": len(scored),
                     "liquid_member_count": len(liquid_members),
-                    "is_liquid_theme": (
-                        trading_value_sum >= self.MIN_LIQUID_THEME_TRADING_VALUE_WON
-                        and len(liquid_members) >= self.MIN_LIQUID_MEMBER_COUNT
-                    ),
+                    "liquid_advancing_member_count": len(liquid_advancing_members),
+                    "is_liquid_theme": is_liquid_theme,
                     "leader_avg_change_rate": leader_avg_change_rate,
                     "advance_count": advance_count,
                     "advancing_ratio": score_info["advancing_ratio"],
                     "trading_value_sum_won": trading_value_sum,
+                    "advancing_trading_value_sum_won": advancing_trading_value_sum,
                     "trading_value_concentration_ratio": round(trading_value_concentration_ratio, 2),
                     "fi_net_buy_won": fi_net_sum,
                     "program_net_buy_won": program_net_sum,

--- a/task/background/always_on/dart_disclosure_monitor_task.py
+++ b/task/background/always_on/dart_disclosure_monitor_task.py
@@ -1,0 +1,228 @@
+"""관심종목 OpenDART 공시를 주기적으로 감시하는 저우선순위 태스크."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+from repositories.dart_disclosure_repository import StoredDisclosure
+
+
+class DartDisclosureMonitorTask(SchedulableTask):
+    def __init__(
+        self,
+        *,
+        client,
+        repository,
+        favorite_repository,
+        rule_service,
+        telegram_reporter,
+        config,
+        market_clock,
+        logger=None,
+    ) -> None:
+        self._client = client
+        self._repository = repository
+        self._favorites = favorite_repository
+        self._rules = rule_service
+        self._reporter = telegram_reporter
+        self._config = config
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._tick_lock: Optional[asyncio.Lock] = None
+        self._progress: Dict = {
+            "running": False,
+            "last_checked_at": None,
+            "last_success_at": None,
+            "matched_count": 0,
+            "sent_count": 0,
+            "pending_digest_count": 0,
+            "last_error": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "dart_disclosure_monitor"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    def get_progress(self) -> Dict:
+        return dict(self._progress)
+
+    def _get_tick_lock(self) -> asyncio.Lock:
+        if self._tick_lock is None:
+            self._tick_lock = asyncio.Lock()
+        return self._tick_lock
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        self._state = TaskState.RUNNING
+        self._progress["running"] = True
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+        self._progress["running"] = False
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.RUNNING
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                if self._state == TaskState.RUNNING:
+                    try:
+                        await self._tick()
+                    except Exception as exc:
+                        self._progress["last_error"] = f"{type(exc).__name__}: {exc}"
+                        self._logger.error(
+                            f"{self.task_name}: 공시 조회 실패 — {exc}", exc_info=True
+                        )
+                now = self._market_clock.get_current_kst_time()
+                await asyncio.sleep(self._interval_for(now))
+        except asyncio.CancelledError:
+            pass
+
+    async def _tick(self) -> None:
+        lock = self._get_tick_lock()
+        if lock.locked():
+            return
+        async with lock:
+            now = self._market_clock.get_current_kst_time()
+            date = now.strftime("%Y%m%d")
+            self._progress["last_checked_at"] = now.isoformat()
+            self._progress["matched_count"] = 0
+            self._progress["sent_count"] = 0
+            self._progress["last_error"] = None
+
+            await self._send_digest_if_due(now, date)
+
+            favorite_codes = {str(code) for code in await self._favorites.get_all()}
+            if not favorite_codes:
+                self._progress["last_success_at"] = now.isoformat()
+                return
+
+            initialized = await self._repository.is_initialized()
+            disclosures = await self._fetch_recent(date)
+            matching = [item for item in disclosures if item.stock_code in favorite_codes]
+            self._progress["matched_count"] = len(matching)
+
+            baseline_items = []
+            for disclosure in matching:
+                importance = self._rules.evaluate(disclosure)
+                inserted = await self._repository.save_detected(
+                    disclosure,
+                    importance,
+                    suppress_immediate=not initialized,
+                )
+                if not initialized and inserted:
+                    baseline_items.append(StoredDisclosure(disclosure, importance))
+
+            if not initialized:
+                await self._repository.mark_initialized()
+                if baseline_items:
+                    sent = await self._reporter.send_disclosure_digest(
+                        baseline_items, date
+                    )
+                    if sent:
+                        await self._repository.mark_digest_sent(
+                            [item.disclosure.receipt_no for item in baseline_items], now
+                        )
+            else:
+                await self._send_pending_immediate(now)
+
+            self._progress["last_success_at"] = now.isoformat()
+
+    async def _fetch_recent(self, date: str) -> list:
+        collected = []
+        max_pages = int(getattr(self._config, "max_pages_per_poll", 5))
+        for page_no in range(1, max_pages + 1):
+            page = await self._client.fetch_disclosures(date, page_no=page_no)
+            collected.extend(page.items)
+            if page_no >= page.total_page:
+                break
+            receipt_nos = [item.receipt_no for item in page.items]
+            known = await self._repository.get_known_receipt_nos(receipt_nos)
+            if receipt_nos and all(receipt_no in known for receipt_no in receipt_nos):
+                break
+        return collected
+
+    async def _send_pending_immediate(self, now: datetime) -> None:
+        threshold = int(getattr(self._config, "immediate_alert_score", 70))
+        pending = await self._repository.get_pending_immediate(threshold)
+        for item in pending:
+            sent = await self._reporter.send_disclosure_alert(
+                item.disclosure, item.importance
+            )
+            if sent:
+                await self._repository.mark_immediate_sent(
+                    item.disclosure.receipt_no, now
+                )
+                self._progress["sent_count"] += 1
+            else:
+                await self._repository.increment_send_retry(
+                    item.disclosure.receipt_no
+                )
+
+    async def _send_digest_if_due(self, now: datetime, date: str) -> None:
+        if not bool(getattr(self._config, "daily_digest_enabled", True)):
+            return
+        if now.strftime("%H:%M") < str(
+            getattr(self._config, "daily_digest_time", "19:40")
+        ):
+            return
+        threshold = int(getattr(self._config, "immediate_alert_score", 70))
+        pending = await self._repository.get_pending_digest(
+            date, immediate_threshold=threshold
+        )
+        self._progress["pending_digest_count"] = len(pending)
+        if not pending:
+            return
+        sent = await self._reporter.send_disclosure_digest(pending, date)
+        if sent:
+            await self._repository.mark_digest_sent(
+                [item.disclosure.receipt_no for item in pending], now
+            )
+            self._progress["pending_digest_count"] = 0
+
+    def _interval_for(self, now: datetime) -> int:
+        hhmm = now.strftime("%H:%M")
+        start = str(getattr(self._config, "active_start_time", "07:00"))
+        end = str(getattr(self._config, "active_end_time", "19:30"))
+        if start <= hhmm <= end:
+            interval = int(getattr(self._config, "poll_interval_sec", 300))
+        else:
+            interval = int(getattr(self._config, "off_hours_interval_sec", 1800))
+
+        if bool(getattr(self._config, "daily_digest_enabled", True)):
+            digest_hhmm = str(getattr(self._config, "daily_digest_time", "19:40"))
+            try:
+                hour, minute = (int(part) for part in digest_hhmm.split(":", 1))
+                digest_at = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+                if now < digest_at:
+                    interval = min(interval, max(1, int((digest_at - now).total_seconds())))
+            except (TypeError, ValueError):
+                pass
+        return interval

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -5,6 +5,7 @@ WebSocket 수신 태스크 상태를 주기적으로 감시하고,
 데이터 수신이 끊기면 재연결한다.
 """
 import asyncio
+import inspect
 import logging
 import time
 from typing import Dict, List, Optional, TYPE_CHECKING
@@ -40,6 +41,9 @@ class WebSocketWatchdogTask(SchedulableTask):
     RECONNECT_ALERT_CONFIRMATION_COUNT = 2
     REALTIME_HEALTH_CHECK_END_HOUR = 15
     REALTIME_HEALTH_CHECK_END_MINUTE = 20
+    # KIS 40슬롯 중 PT 18종목(H0STPGM0+H0UNCNT0=36)과 주문통보 1슬롯을 예약한다.
+    PT_RESTORE_MAX_CODES = 18
+    ORDER_NOTICE_RESERVED_SLOTS = 1
 
     def __init__(
         self,
@@ -79,6 +83,7 @@ class WebSocketWatchdogTask(SchedulableTask):
         self._last_reconnect_started_ts: float = 0.0
         self._reconnect_trigger_counts: Dict[str, int] = {}
         self._pt_no_initial_data_started_ts: Optional[float] = None
+        self._capacity_pending_pt_codes: set[str] = set()
 
     # ── SchedulableTask 인터페이스 구현 ────────────────────────
 
@@ -175,7 +180,11 @@ class WebSocketWatchdogTask(SchedulableTask):
                     if self._streaming_stock_repo else []
                 raw_price_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.UNIFIED_PRICE)) \
                     if self._streaming_stock_repo else []
-                price_codes = sorted(set(raw_price_codes) | set(pt_codes))
+                monitored_pt_codes = [
+                    code for code in pt_codes
+                    if code not in self._capacity_pending_pt_codes
+                ]
+                price_codes = sorted(set(raw_price_codes) | set(monitored_pt_codes))
                 active_price_codes = set(self._streaming_stock_repo.get_active(StreamingType.UNIFIED_PRICE)) \
                     if self._streaming_stock_repo else set()
                 active_pt_codes = set(self._streaming_stock_repo.get_active(StreamingType.PROGRAM_TRADING)) \
@@ -340,6 +349,7 @@ class WebSocketWatchdogTask(SchedulableTask):
                     pending_pt_codes = [
                         code for code in pt_codes
                         if code not in active_pt_codes
+                        and code not in self._capacity_pending_pt_codes
                     ]
                     if pending_pt_codes:
                         for code in pending_pt_codes:
@@ -475,7 +485,7 @@ class WebSocketWatchdogTask(SchedulableTask):
             "market_open": self._market_open,
         }
 
-    async def _restore_all_subscriptions(self) -> None:
+    async def _restore_all_subscriptions(self, reset_connection: bool = True) -> None:
         """
         앱 시작 또는 재연결 직후 모든 구독(PT + H0UNCNT0)을 복원한다.
 
@@ -500,7 +510,50 @@ class WebSocketWatchdogTask(SchedulableTask):
             await self._streaming_stock_repo.clear_active(StreamingType.UNIFIED_PRICE)
 
         # ── 2. PT + H0STCNT0 복원 ─────────────────────────────────
-        pt_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)) if self._streaming_stock_repo else []
+        all_pt_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)) if self._streaming_stock_repo else []
+        sources = {}
+        if self._streaming_stock_repo:
+            getter = getattr(self._streaming_stock_repo, "get_pt_subscription_sources", None)
+            if callable(getter):
+                sources = getter() or {}
+        source_rank = {"manual": 0, "program": 1, "legacy": 2}
+        ordered_pt_codes = sorted(
+            all_pt_codes,
+            key=lambda code: (source_rank.get(sources.get(code), 2), code),
+        )
+        pt_codes = ordered_pt_codes[:self.PT_RESTORE_MAX_CODES]
+        capacity_pending = ordered_pt_codes[self.PT_RESTORE_MAX_CODES:]
+        self._capacity_pending_pt_codes = set(capacity_pending)
+        if self._streaming_stock_repo:
+            setter = getattr(self._streaming_stock_repo, "set_pt_capacity_pending", None)
+            if callable(setter):
+                setter(capacity_pending)
+
+        if self._streaming_logger and capacity_pending:
+            self._streaming_logger.log_pt_capacity_pending(
+                selected=pt_codes,
+                pending=capacity_pending,
+                max_codes=self.PT_RESTORE_MAX_CODES,
+            )
+
+        if self._price_subscription_service:
+            reserved_slots = (
+                len(pt_codes) * 2
+                + self.ORDER_NOTICE_RESERVED_SLOTS
+            )
+            reserve = getattr(self._price_subscription_service, "set_external_reserved_slots", None)
+            if callable(reserve):
+                reserve(reserved_slots)
+            self._price_subscription_service.clear_active_state()
+
+        # 시작 단계에서 먼저 등록된 가격 구독을 비우고 하나의 슬롯 계획으로 다시 구성한다.
+        if self._streaming_service and reset_connection:
+            try:
+                disconnect_result = self._streaming_service.disconnect_websocket()
+                if inspect.isawaitable(disconnect_result):
+                    await disconnect_result
+            except Exception as e:
+                self._logger.warning(f"구독 복원 전 WebSocket 초기화 실패 (계속 진행): {e}")
 
         import time as _time
         _recovery_start = _time.monotonic()
@@ -510,8 +563,8 @@ class WebSocketWatchdogTask(SchedulableTask):
         if pt_codes:
             if self._streaming_logger:
                 self._streaming_logger.log_subscription_recovery_start(
-                    total=len(pt_codes),
-                    codes=pt_codes,
+                    total=len(all_pt_codes),
+                    codes=all_pt_codes,
                 )
             connected = await self._streaming_service.connect_websocket()
             if not connected:
@@ -554,14 +607,13 @@ class WebSocketWatchdogTask(SchedulableTask):
             if self._streaming_logger:
                 self._streaming_logger.log_subscription_recovery_done(
                     success=pt_success,
-                    total=len(pt_codes),
-                    failed_codes=pt_failed,
+                    total=len(all_pt_codes),
+                    failed_codes=[*pt_failed, *capacity_pending],
                     elapsed_ms=(_time.monotonic() - _recovery_start) * 1000,
                 )
 
         # ── 3. H0UNCNT0 복원 (핵심 버그 수정) ────────────────────
         if self._price_subscription_service:
-            self._price_subscription_service.clear_active_state()
             desired_count = len(self._price_subscription_service._refs)
             if desired_count > 0:
                 # PT 구독이 없어도 WebSocket 연결 보장 (미연결 시 _rebalance() 실패 방지)
@@ -582,7 +634,7 @@ class WebSocketWatchdogTask(SchedulableTask):
             self._streaming_logger.log_restore(
                 codes=pt_codes,
                 success=pt_success,
-                total=len(pt_codes),
+                total=len(all_pt_codes),
             )
 
     async def force_reconnect(self, trigger: str = "manual") -> None:
@@ -627,7 +679,7 @@ class WebSocketWatchdogTask(SchedulableTask):
                 if self._streaming_logger:
                     self._streaming_logger.log_force_reconnect_disconnect_error(str(e))
 
-            await self._restore_all_subscriptions()
+            await self._restore_all_subscriptions(reset_connection=False)
 
             restored_count, desired_count = self._get_reconnect_restore_counts(pt_codes)
             if self._oas and trigger != "market_open":
@@ -661,7 +713,7 @@ class WebSocketWatchdogTask(SchedulableTask):
         """재연결 후 desired 구독 대비 active 복원 개수를 계산한다."""
         from repositories.streaming_stock_repo import StreamingType
 
-        desired_pt_codes = set(pt_codes)
+        desired_pt_codes = set(pt_codes) - self._capacity_pending_pt_codes
         active_pt_codes = set()
         if self._streaming_stock_repo:
             active_pt_codes = set(self._streaming_stock_repo.get_active(StreamingType.PROGRAM_TRADING))

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -600,8 +600,7 @@ async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
         mock_vtm_instance.log_sell_by_strategy_async = AsyncMock()
         mock_vtm_instance.log_order_failure_async = AsyncMock()
 
-        web_ctx = WebAppContext(SimpleContext())
-        web_ctx.logger = test_logger
+        web_ctx = WebAppContext(SimpleContext(), logger=test_logger)
         web_ctx.load_config_and_env()
 
         # 토큰 발급 mock

--- a/tests/integration_test/test_it_dart_disclosure_pipeline.py
+++ b/tests/integration_test/test_it_dart_disclosure_pipeline.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from repositories.dart_disclosure_repository import DartDisclosureRepository
+from repositories.favorite_repository import FavoriteRepository
+from services.dart_disclosure_client import DartDisclosureClient
+from services.dart_disclosure_rule_service import DartDisclosureRuleService
+from services.telegram_notifier import TelegramReporter
+from task.background.always_on.dart_disclosure_monitor_task import DartDisclosureMonitorTask
+
+
+class _Clock:
+    def get_current_kst_time(self):
+        return datetime(2026, 7, 14, 10, 0, 0)
+
+
+async def test_it_new_favorite_disclosure_is_sent_once_and_persisted(tmp_path):
+    def handler(request: httpx.Request):
+        assert request.url.params["bgn_de"] == "20260714"
+        return httpx.Response(
+            200,
+            json={
+                "status": "000",
+                "message": "정상",
+                "page_no": 1,
+                "page_count": 100,
+                "total_count": 1,
+                "total_page": 1,
+                "list": [
+                    {
+                        "corp_cls": "Y",
+                        "corp_name": "삼성전자",
+                        "corp_code": "00126380",
+                        "stock_code": "005930",
+                        "report_nm": "전환사채권발행결정",
+                        "rcept_no": "20260714001234",
+                        "flr_nm": "삼성전자",
+                        "rcept_dt": "20260714",
+                        "rm": "유",
+                    }
+                ],
+            },
+        )
+
+    favorites = FavoriteRepository(tmp_path / "favorites.db")
+    await favorites.add("005930")
+    repository = DartDisclosureRepository(tmp_path / "dart.db")
+    await repository.mark_initialized()
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    config = SimpleNamespace(
+        poll_interval_sec=300,
+        off_hours_interval_sec=1800,
+        active_start_time="07:00",
+        active_end_time="19:30",
+        immediate_alert_score=70,
+        daily_digest_enabled=True,
+        daily_digest_time="19:40",
+        max_pages_per_poll=5,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        task = DartDisclosureMonitorTask(
+            client=DartDisclosureClient("test-key", http_client=http_client),
+            repository=repository,
+            favorite_repository=favorites,
+            rule_service=DartDisclosureRuleService(),
+            telegram_reporter=reporter,
+            config=config,
+            market_clock=_Clock(),
+            logger=MagicMock(),
+        )
+        await task._tick()
+        await task._tick()
+
+    assert reporter._send_message.await_count == 1
+    message = reporter._send_message.await_args.args[0]
+    assert "전환사채권발행결정" in message
+    assert "rcpNo=20260714001234" in message
+    assert await repository.get_pending_immediate(70) == []

--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -550,8 +550,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
 
             # _sync_calendar_if_needed는 실제 KIS HTTP 호출을 유발하므로 mock 처리
@@ -609,8 +608,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
             ctx._mcs._sync_calendar_if_needed = AsyncMock()
 
@@ -641,8 +639,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
             ctx._mcs._sync_calendar_if_needed = AsyncMock()
 
@@ -673,8 +670,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
             ctx._mcs._sync_calendar_if_needed = AsyncMock()
 
@@ -714,8 +710,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
             ctx._mcs._sync_calendar_if_needed = AsyncMock()
 
@@ -753,8 +748,7 @@ class TestWebAppContextInitialization:
              patch("view.web.web_app_initializer.OverseasStockCodeRepository"), \
              patch("view.web.web_app_initializer.StockCodeRepository"):
 
-            ctx = WebAppContext(SimpleContext())
-            ctx.logger = test_logger
+            ctx = WebAppContext(SimpleContext(), logger=test_logger)
             ctx.load_config_and_env()
             ctx._mcs._sync_calendar_if_needed = AsyncMock()
 

--- a/tests/unit_test/config/test_dart_disclosure_config.py
+++ b/tests/unit_test/config/test_dart_disclosure_config.py
@@ -1,0 +1,26 @@
+from config.config_loader import AppConfig, DartDisclosureConfig
+
+
+def test_dart_disclosure_config_defaults_are_safe():
+    config = DartDisclosureConfig()
+
+    assert config.enabled is False
+    assert config.api_key == ""
+    assert config.poll_interval_sec == 300
+    assert config.immediate_alert_score == 70
+
+
+def test_app_config_accepts_dart_disclosure_section():
+    config = AppConfig.model_validate(
+        {
+            "web": {"host": "127.0.0.1", "port": 8000},
+            "dart_disclosure": {
+                "enabled": True,
+                "api_key": "test-key",
+                "poll_interval_sec": 600,
+            },
+        }
+    )
+
+    assert config.dart_disclosure.enabled is True
+    assert config.dart_disclosure.poll_interval_sec == 600

--- a/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
+++ b/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
@@ -85,6 +85,9 @@ class FakeClient:
     async def unsubscribe_program_trading(self, stock_code: str) -> None:
         pass
 
+    async def wait_for_program_trading_ack(self, stock_code: str, timeout=None) -> bool:
+        return True
+
     async def subscribe_unified_price(self, stock_code: str) -> bool:
         return True
 
@@ -469,8 +472,16 @@ class TestExcludedMethodsSet:
             "subscribe_order_notice",
             "unsubscribe_order_notice",
             "is_websocket_receive_alive",
+            "wait_for_program_trading_ack",
         }
         assert expected.issubset(_EXCLUDED_METHODS)
+
+    async def test_program_trading_ack_wait_bypasses_retry_queue(self, fake_client, queue):
+        queue.submit = AsyncMock()
+        wrapped = ClientWithRetryQueue(fake_client, queue)
+
+        assert await wrapped.wait_for_program_trading_ack("005930") is True
+        queue.submit.assert_not_awaited()
 
 
 class TestEmergencyPriorityPropagation:

--- a/tests/unit_test/repositories/test_dart_disclosure_repository.py
+++ b/tests/unit_test/repositories/test_dart_disclosure_repository.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+import pytest
+
+from repositories.dart_disclosure_repository import DartDisclosureRepository
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DisclosureImportance
+
+
+@pytest.fixture
+def disclosure():
+    return DartDisclosure(
+        corp_class="Y",
+        corp_name="삼성전자",
+        corp_code="00126380",
+        stock_code="005930",
+        report_name="전환사채권발행결정",
+        receipt_no="20260714001234",
+        filer_name="삼성전자",
+        receipt_date="20260714",
+        remarks="유",
+    )
+
+
+@pytest.fixture
+def importance():
+    return DisclosureImportance(score=85, level="HIGH", reasons=["전환사채 발행 관련 공시"])
+
+
+async def test_save_detected_is_idempotent(tmp_path, disclosure, importance):
+    repo = DartDisclosureRepository(tmp_path / "dart.db")
+
+    assert await repo.save_detected(disclosure, importance) is True
+    assert await repo.save_detected(disclosure, importance) is False
+    assert await repo.has_receipt(disclosure.receipt_no) is True
+
+
+async def test_get_known_receipt_nos_checks_page_in_one_query(tmp_path, disclosure, importance):
+    repo = DartDisclosureRepository(tmp_path / "dart.db")
+    await repo.save_detected(disclosure, importance)
+
+    known = await repo.get_known_receipt_nos(
+        [disclosure.receipt_no, "20260714009999"]
+    )
+
+    assert known == {disclosure.receipt_no}
+
+
+async def test_pending_immediate_excludes_suppressed_and_sent(tmp_path, disclosure, importance):
+    repo = DartDisclosureRepository(tmp_path / "dart.db")
+    await repo.save_detected(disclosure, importance, suppress_immediate=True)
+    assert await repo.get_pending_immediate(70) == []
+
+    second = disclosure.__class__(**{**disclosure.__dict__, "receipt_no": "20260714001235"})
+    await repo.save_detected(second, importance)
+    pending = await repo.get_pending_immediate(70)
+    assert [item.disclosure.receipt_no for item in pending] == ["20260714001235"]
+
+    await repo.mark_immediate_sent(second.receipt_no, datetime(2026, 7, 14, 12, 0, 0))
+    assert await repo.get_pending_immediate(70) == []
+
+
+async def test_initialization_state_persists(tmp_path):
+    path = tmp_path / "dart.db"
+    repo = DartDisclosureRepository(path)
+    assert await repo.is_initialized() is False
+
+    await repo.mark_initialized()
+
+    assert await DartDisclosureRepository(path).is_initialized() is True
+
+
+async def test_digest_rows_are_marked_after_send(tmp_path, disclosure, importance):
+    repo = DartDisclosureRepository(tmp_path / "dart.db")
+    normal_importance = DisclosureImportance(score=30, level="NORMAL", reasons=["정기보고서"])
+    await repo.save_detected(disclosure, normal_importance)
+
+    pending = await repo.get_pending_digest("20260714", immediate_threshold=70)
+    assert len(pending) == 1
+
+    await repo.mark_digest_sent([disclosure.receipt_no], datetime(2026, 7, 14, 19, 40, 0))
+    assert await repo.get_pending_digest("20260714", immediate_threshold=70) == []

--- a/tests/unit_test/services/test_dart_disclosure_client.py
+++ b/tests/unit_test/services/test_dart_disclosure_client.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.dart_disclosure_client import (
+    DartApiError,
+    DartDisclosureClient,
+)
+
+
+def _response(payload):
+    response = MagicMock()
+    response.raise_for_status = lambda: None
+    response.json.return_value = payload
+    return response
+
+
+async def test_fetch_disclosures_uses_official_list_contract_and_parses_rows():
+    http_client = AsyncMock()
+    http_client.get.return_value = _response(
+        {
+            "status": "000",
+            "message": "정상",
+            "page_no": 1,
+            "page_count": 100,
+            "total_count": 1,
+            "total_page": 1,
+            "list": [
+                {
+                    "corp_cls": "Y",
+                    "corp_name": "삼성전자",
+                    "corp_code": "00126380",
+                    "stock_code": "005930",
+                    "report_nm": "단일판매ㆍ공급계약체결",
+                    "rcept_no": "20260714001234",
+                    "flr_nm": "삼성전자",
+                    "rcept_dt": "20260714",
+                    "rm": "유",
+                }
+            ],
+        }
+    )
+    client = DartDisclosureClient("secret", http_client=http_client, timeout_sec=5)
+
+    page = await client.fetch_disclosures("20260714", page_no=1)
+
+    assert page.total_page == 1
+    assert page.items[0].stock_code == "005930"
+    assert page.items[0].receipt_no == "20260714001234"
+    assert page.items[0].viewer_url.endswith("rcpNo=20260714001234")
+    params = http_client.get.await_args.kwargs["params"]
+    assert params == {
+        "crtfc_key": "secret",
+        "bgn_de": "20260714",
+        "end_de": "20260714",
+        "last_reprt_at": "N",
+        "sort": "date",
+        "sort_mth": "desc",
+        "page_no": 1,
+        "page_count": 100,
+    }
+
+
+async def test_no_data_status_returns_empty_page():
+    http_client = AsyncMock()
+    http_client.get.return_value = _response({"status": "013", "message": "조회된 데이타가 없습니다."})
+    client = DartDisclosureClient("secret", http_client=http_client)
+
+    page = await client.fetch_disclosures("20260714")
+
+    assert page.items == []
+    assert page.total_page == 0
+
+
+async def test_api_error_does_not_expose_key():
+    http_client = AsyncMock()
+    http_client.get.return_value = _response({"status": "020", "message": "요청 제한 초과"})
+    client = DartDisclosureClient("super-secret", http_client=http_client)
+
+    with pytest.raises(DartApiError) as exc_info:
+        await client.fetch_disclosures("20260714")
+
+    assert exc_info.value.status == "020"
+    assert "super-secret" not in str(exc_info.value)

--- a/tests/unit_test/services/test_dart_disclosure_rule_service.py
+++ b/tests/unit_test/services/test_dart_disclosure_rule_service.py
@@ -1,0 +1,57 @@
+import pytest
+
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DartDisclosureRuleService
+
+
+def _disclosure(report_name: str, remarks: str = "") -> DartDisclosure:
+    return DartDisclosure(
+        corp_class="Y",
+        corp_name="테스트",
+        corp_code="00123456",
+        stock_code="123456",
+        report_name=report_name,
+        receipt_no="20260714000001",
+        filer_name="테스트",
+        receipt_date="20260714",
+        remarks=remarks,
+    )
+
+
+@pytest.mark.parametrize(
+    ("report_name", "minimum_score", "expected_level"),
+    [
+        ("상장폐지결정", 100, "CRITICAL"),
+        ("횡령ㆍ배임혐의발생", 95, "CRITICAL"),
+        ("전환사채권발행결정", 85, "HIGH"),
+        ("최대주주변경", 80, "HIGH"),
+        ("단일판매ㆍ공급계약체결", 70, "HIGH"),
+        ("현금ㆍ현물배당결정", 60, "MEDIUM"),
+        ("분기보고서 (2026.03)", 30, "NORMAL"),
+        ("기업설명회(IR)개최", 20, "LOW"),
+    ],
+)
+def test_rule_engine_assigns_deterministic_scores(report_name, minimum_score, expected_level):
+    result = DartDisclosureRuleService().evaluate(_disclosure(report_name))
+
+    assert result.score >= minimum_score
+    assert result.level == expected_level
+    assert result.reasons
+
+
+def test_withdrawal_and_correction_are_explained():
+    result = DartDisclosureRuleService().evaluate(
+        _disclosure("[기재정정] 단일판매ㆍ공급계약체결", remarks="철")
+    )
+
+    assert result.score >= 80
+    assert any("정정" in reason for reason in result.reasons)
+    assert any("철회" in reason for reason in result.reasons)
+
+
+def test_unknown_report_remains_low_and_explainable():
+    result = DartDisclosureRuleService().evaluate(_disclosure("기타경영사항(자율공시)"))
+
+    assert result.score == 10
+    assert result.level == "LOW"
+    assert result.reasons == ["일반 공시"]

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock
+
+from repositories.dart_disclosure_repository import StoredDisclosure
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DisclosureImportance
+from services.telegram_notifier import TelegramReporter
+
+
+def _stored(report_name="분기보고서 (2026.03)", score=30):
+    disclosure = DartDisclosure(
+        corp_class="Y",
+        corp_name="A&B <전자>",
+        corp_code="00126380",
+        stock_code="005930",
+        report_name=report_name,
+        receipt_no="20260714001234",
+        filer_name="A&B",
+        receipt_date="20260714",
+        remarks="유",
+    )
+    importance = DisclosureImportance(score, "NORMAL", ["정기보고서"])
+    return StoredDisclosure(disclosure, importance)
+
+
+async def test_send_disclosure_alert_escapes_html_and_includes_reason_and_link():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    stored = _stored("전환사채권발행결정", 85)
+
+    sent = await reporter.send_disclosure_alert(stored.disclosure, stored.importance)
+
+    assert sent is True
+    message = reporter._send_message.await_args.args[0]
+    assert "A&amp;B &lt;전자&gt;" in message
+    assert "정기보고서" in message
+    assert "rcpNo=20260714001234" in message
+
+
+async def test_send_disclosure_digest_formats_multiple_rows():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    rows = [_stored(), _stored("기업설명회(IR)개최", 20)]
+
+    sent = await reporter.send_disclosure_digest(rows, "20260714")
+
+    assert sent is True
+    full = "".join(call.args[0] for call in reporter._send_message.await_args_list)
+    assert "관심종목 공시 요약" in full
+    assert "분기보고서" in full
+    assert "기업설명회" in full

--- a/tests/unit_test/services/test_program_trading_stream_service.py
+++ b/tests/unit_test/services/test_program_trading_stream_service.py
@@ -640,6 +640,42 @@ async def test_format_last_tick_report_marks_legacy_source_separately(manager):
     assert message.index("[프로그램] SK하이닉스") < message.index("[기존] 제주반도체")
 
 
+@pytest.mark.asyncio
+async def test_format_last_tick_report_discards_previous_day_memory(manager):
+    """자정 이후 상태 알림에 전일 메모리 tick을 재사용하지 않는다."""
+    manager._pt_history["005930"] = [{
+        "유가증권단축종목코드": "005930",
+        "주식체결시간": "153000",
+        "price": "70000",
+        "rate": "1.00",
+        "순매수거래대금": "100000000",
+    }]
+    manager._last_tick_ts_by_code["005930"] = time.time()
+    manager.last_data_ts = time.time()
+    manager._history_date = "2026-07-13"
+
+    message = await manager._format_last_tick_report_async(["005930"])
+
+    assert "[기존] 005930: 수신 없음" in message
+    assert "70,000원" not in message
+    assert manager._last_tick_ts_by_code == {}
+    assert manager.last_data_ts == 0.0
+
+
+@pytest.mark.asyncio
+async def test_format_last_tick_report_marks_capacity_pending(manager):
+    """WebSocket 한도로 제외된 종목은 실제 구독의 무수신과 구분한다."""
+    mock_ssr = MagicMock()
+    mock_ssr.get_pt_subscription_sources.return_value = {"005930": "manual"}
+    mock_ssr.get_pt_capacity_pending.return_value = {"005930"}
+    manager.wire_streaming_stock_repo(mock_ssr)
+
+    message = await manager._format_last_tick_report_async(["005930"])
+
+    assert "구독 대기 (WebSocket 한도)" in message
+    assert "수신 없음" not in message
+
+
 def test_build_db_minute_persistence_status_reports_missing_minutes(manager):
     """장중 1분 단위 저장 여부를 종목별로 계산한다."""
     clock = MarketClock(market_open_time="09:00", market_close_time="09:02")

--- a/tests/unit_test/services/test_subscription_policy.py
+++ b/tests/unit_test/services/test_subscription_policy.py
@@ -14,6 +14,7 @@ def mock_streaming():
     svc.unsubscribe_program_trading = AsyncMock(return_value=True)
     # 구독 ACK 확정 — 기본은 확정(True). 미확정 경로는 개별 테스트에서 override.
     svc.wait_unified_price_ack = AsyncMock(return_value=True)
+    svc.wait_program_trading_ack = AsyncMock(return_value=True)
     return svc
 
 @pytest.fixture
@@ -82,6 +83,26 @@ def test_clear_active_state(policy, mock_streaming_logger):
     assert len(policy._active_codes_pt) == 0
     # 구체화된 로깅 메서드 호출 검증
     assert mock_streaming_logger.log_clear_active_state.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_external_reserved_slots_reduce_rebalance_capacity(policy, mock_streaming):
+    """워치독이 복원한 PT 슬롯을 제외한 범위에서만 일반 구독을 배정한다."""
+    policy.MAX_WS_SLOTS = 4
+    policy.set_external_reserved_slots(2)
+    for code in ("000001", "000002", "000003"):
+        policy._refs[code] = {
+            "portfolio": {
+                "priority": SubscriptionPriority.HIGH,
+                "type": StreamingType.UNIFIED_PRICE,
+            }
+        }
+
+    await policy._rebalance()
+
+    subscribed = {call.args[0] for call in mock_streaming.subscribe_unified_price.await_args_list}
+    assert subscribed == {"000001", "000002"}
+    assert policy._calculate_used_slots() == 4
 
 @pytest.mark.asyncio
 async def test_add_remove_subscription(policy, mock_streaming_stock_repo):

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -931,7 +931,7 @@ async def test_send_daily_theme_report_formats_stockeasy_like_cards(telegram_rep
     full = "".join(call[0][0] for call in telegram_reporter._send_message.call_args_list)
     assert "오늘의 주도 테마" in full
     assert "1. 반도체/소부장" in full
-    assert "+12.33%" in full
+    assert "주도주 평균 +12.33%" in full
     assert "3,801억" in full
     assert "종합점수 12.17" in full
     assert "테스 +14.9% 1,930억" in full

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -292,3 +292,65 @@ async def test_ranks_high_liquidity_theme_above_thin_higher_momentum_theme():
     semi, telecom = resp.data
     assert semi["market_leadership_score"] > telecom["market_leadership_score"]
     assert telecom["leader_avg_change_rate"] > semi["leader_avg_change_rate"]
+
+
+@pytest.mark.asyncio
+async def test_liquidity_bonus_uses_advancing_trading_value_only():
+    """하락 대형주의 거래대금은 테마 유동성 보너스를 만들지 않는다."""
+    svc, _ = _service({
+        "대형주혼합": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "상승1"), _member("B", "상승2"), _member("C", "하락대형주")],
+        }
+    })
+    rankings = {"all_stocks": [
+        _stock("A", "상승1", 10.0, 20_000_000_000),
+        _stock("B", "상승2", 5.0, 20_000_000_000),
+        _stock("C", "하락대형주", -1.0, 1_000_000_000_000),
+    ]}
+
+    resp = await svc.build_daily_theme_report(rankings, "20260714")
+
+    theme = resp.data[0]
+    assert theme["advancing_trading_value_sum_won"] == 40_000_000_000
+    assert theme["liquidity_bonus"] == 1.2
+    assert theme["is_liquid_theme"] is True
+
+
+@pytest.mark.asyncio
+async def test_theme_requires_two_liquid_advancers_and_half_breadth():
+    """거래대금이 커도 상승 확산 조건이 부족하면 주도 테마로 인정하지 않는다."""
+    svc, _ = _service({
+        "단일상승": {
+            "sources": ["NAVER"],
+            "members": [_member("A", "상승1"), _member("B", "하락1"), _member("C", "하락2")],
+        },
+        "낮은확산": {
+            "sources": ["NAVER"],
+            "members": [
+                _member("D", "상승2"), _member("E", "상승3"), _member("F", "하락3"),
+                _member("G", "하락4"), _member("H", "하락5"),
+            ],
+        },
+    })
+    rankings = {"all_stocks": [
+        _stock("A", "상승1", 20.0, 100_000_000_000),
+        _stock("B", "하락1", -1.0, 100_000_000_000),
+        _stock("C", "하락2", -1.0, 100_000_000_000),
+        _stock("D", "상승2", 10.0, 100_000_000_000),
+        _stock("E", "상승3", 9.0, 100_000_000_000),
+        _stock("F", "하락3", -1.0, 100_000_000_000),
+        _stock("G", "하락4", -1.0, 100_000_000_000),
+        _stock("H", "하락5", -1.0, 100_000_000_000),
+    ]}
+
+    resp = await svc.build_daily_theme_report(rankings, "20260714")
+
+    by_name = {theme["normalized_name"]: theme for theme in resp.data}
+    assert by_name["단일상승"]["liquid_advancing_member_count"] == 1
+    assert by_name["단일상승"]["is_liquid_theme"] is False
+    assert by_name["단일상승"]["liquidity_bonus"] == 0.0
+    assert by_name["낮은확산"]["liquid_advancing_member_count"] == 2
+    assert by_name["낮은확산"]["advancing_ratio"] == 40.0
+    assert by_name["낮은확산"]["is_liquid_theme"] is False
+    assert by_name["낮은확산"]["liquidity_bonus"] == 0.0

--- a/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
@@ -1,0 +1,171 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from repositories.dart_disclosure_repository import StoredDisclosure
+from services.dart_disclosure_client import DartDisclosure, DartDisclosurePage
+from services.dart_disclosure_rule_service import DisclosureImportance
+from task.background.always_on.dart_disclosure_monitor_task import DartDisclosureMonitorTask
+
+
+class _Clock:
+    def __init__(self, now: datetime):
+        self.now = now
+
+    def get_current_kst_time(self):
+        return self.now
+
+
+def _disclosure(code="005930", receipt_no="20260714000001", report_name="전환사채권발행결정"):
+    return DartDisclosure(
+        corp_class="Y",
+        corp_name="삼성전자",
+        corp_code="00126380",
+        stock_code=code,
+        report_name=report_name,
+        receipt_no=receipt_no,
+        filer_name="삼성전자",
+        receipt_date="20260714",
+        remarks="유",
+    )
+
+
+def _make_task(items, *, initialized=True, now=None):
+    client = MagicMock()
+    client.fetch_disclosures = AsyncMock(
+        return_value=DartDisclosurePage(items, 1, 100, len(items), 1)
+    )
+    repo = MagicMock()
+    repo.is_initialized = AsyncMock(return_value=initialized)
+    repo.mark_initialized = AsyncMock()
+    repo.has_receipt = AsyncMock(return_value=False)
+    repo.get_known_receipt_nos = AsyncMock(return_value=set())
+    repo.save_detected = AsyncMock(return_value=True)
+    repo.get_pending_immediate = AsyncMock(return_value=[])
+    repo.mark_immediate_sent = AsyncMock()
+    repo.increment_send_retry = AsyncMock()
+    repo.get_pending_digest = AsyncMock(return_value=[])
+    repo.mark_digest_sent = AsyncMock()
+    favorites = MagicMock()
+    favorites.get_all = AsyncMock(return_value=["005930"])
+    rule_service = MagicMock()
+    rule_service.evaluate.return_value = DisclosureImportance(
+        score=85, level="HIGH", reasons=["자금조달·주식 희석 관련 공시"]
+    )
+    reporter = MagicMock()
+    reporter.send_disclosure_alert = AsyncMock(return_value=True)
+    reporter.send_disclosure_digest = AsyncMock(return_value=True)
+    config = SimpleNamespace(
+        poll_interval_sec=300,
+        off_hours_interval_sec=1800,
+        active_start_time="07:00",
+        active_end_time="19:30",
+        immediate_alert_score=70,
+        daily_digest_enabled=True,
+        daily_digest_time="19:40",
+        max_pages_per_poll=5,
+    )
+    task = DartDisclosureMonitorTask(
+        client=client,
+        repository=repo,
+        favorite_repository=favorites,
+        rule_service=rule_service,
+        telegram_reporter=reporter,
+        config=config,
+        market_clock=_Clock(now or datetime(2026, 7, 14, 10, 0, 0)),
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(
+        task=task,
+        client=client,
+        repo=repo,
+        favorites=favorites,
+        rules=rule_service,
+        reporter=reporter,
+    )
+
+
+async def test_first_tick_baselines_matching_disclosures_without_alert_flood():
+    deps = _make_task([_disclosure(), _disclosure(code="000660")], initialized=False)
+
+    await deps.task._tick()
+
+    deps.repo.save_detected.assert_awaited_once()
+    assert deps.repo.save_detected.await_args.kwargs["suppress_immediate"] is True
+    deps.repo.mark_initialized.assert_awaited_once()
+    deps.reporter.send_disclosure_alert.assert_not_awaited()
+    deps.reporter.send_disclosure_digest.assert_awaited_once()
+    deps.repo.mark_digest_sent.assert_awaited_once()
+
+
+async def test_new_favorite_disclosure_is_saved_and_immediately_reported():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["자금조달·주식 희석 관련 공시"])
+    deps = _make_task([disclosure], initialized=True)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+
+    await deps.task._tick()
+
+    deps.repo.save_detected.assert_awaited_once()
+    deps.reporter.send_disclosure_alert.assert_awaited_once_with(disclosure, importance)
+    deps.repo.mark_immediate_sent.assert_awaited_once()
+    assert deps.task.get_progress()["sent_count"] == 1
+
+
+async def test_non_favorite_disclosure_is_ignored():
+    deps = _make_task([_disclosure(code="000660")])
+
+    await deps.task._tick()
+
+    deps.repo.save_detected.assert_not_awaited()
+    deps.rules.evaluate.assert_not_called()
+
+
+async def test_empty_favorites_skip_external_request():
+    deps = _make_task([_disclosure()])
+    deps.favorites.get_all.return_value = []
+
+    await deps.task._tick()
+
+    deps.client.fetch_disclosures.assert_not_awaited()
+
+
+async def test_failed_telegram_send_remains_pending_for_retry():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["중요"])
+    deps = _make_task([disclosure])
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+    deps.reporter.send_disclosure_alert.return_value = False
+
+    await deps.task._tick()
+
+    deps.repo.mark_immediate_sent.assert_not_awaited()
+    deps.repo.increment_send_retry.assert_awaited_once_with(disclosure.receipt_no)
+
+
+async def test_digest_is_sent_once_at_configured_time():
+    disclosure = _disclosure(report_name="분기보고서 (2026.03)")
+    importance = DisclosureImportance(30, "NORMAL", ["정기보고서"])
+    deps = _make_task([], now=datetime(2026, 7, 14, 19, 40, 0))
+    deps.repo.get_pending_digest.return_value = [StoredDisclosure(disclosure, importance)]
+
+    await deps.task._tick()
+
+    deps.reporter.send_disclosure_digest.assert_awaited_once_with(
+        [StoredDisclosure(disclosure, importance)], "20260714"
+    )
+    deps.repo.mark_digest_sent.assert_awaited_once()
+
+
+def test_task_is_low_priority_and_reports_initial_progress():
+    deps = _make_task([])
+
+    assert deps.task.task_name == "dart_disclosure_monitor"
+    assert int(deps.task.priority) == 100
+    assert deps.task.get_progress()["running"] is False
+
+
+def test_sleep_interval_wakes_at_digest_time_during_off_hours():
+    deps = _make_task([], now=datetime(2026, 7, 14, 19, 35, 0))
+
+    assert deps.task._interval_for(deps.task._market_clock.now) == 300

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -172,6 +172,35 @@ async def test_restore_program_trading_success(watchdog_task, mock_deps):
 
 
 @pytest.mark.asyncio
+async def test_restore_caps_pt_codes_and_prioritizes_subscription_source(watchdog_task):
+    """한도 초과 시 수동, 프로그램, 기존 순으로 복원하고 초과 종목은 요청하지 않는다."""
+    svc = watchdog_task
+    svc.mcs.is_market_open_now = AsyncMock(return_value=True)
+    svc.PT_RESTORE_MAX_CODES = 3
+    codes = {"000001", "000002", "000003", "000004", "000005"}
+    svc._streaming_stock_repo.get_desired.return_value = codes
+    svc._streaming_stock_repo.get_pt_subscription_sources.return_value = {
+        "000001": "legacy",
+        "000002": "program",
+        "000003": "manual",
+        "000004": "manual",
+        "000005": "program",
+    }
+
+    with patch("task.background.intraday.websocket_watchdog_task.asyncio.sleep", new_callable=AsyncMock):
+        await svc._restore_all_subscriptions()
+
+    requested = [call.args[0] for call in svc._streaming_service.subscribe_program_trading.await_args_list]
+    assert requested == ["000003", "000004", "000002"]
+    assert svc._capacity_pending_pt_codes == {"000001", "000005"}
+    svc._streaming_logger.log_pt_capacity_pending.assert_called_once_with(
+        selected=["000003", "000004", "000002"],
+        pending=["000005", "000001"],
+        max_codes=3,
+    )
+
+
+@pytest.mark.asyncio
 async def test_restore_program_trading_partial_failure(watchdog_task, mock_deps):
     """_restore_all_subscriptions: 구독 예외 종목은 desired 유지(재시도 대기), 성공 종목은 active 등록."""
     svc = watchdog_task
@@ -571,7 +600,7 @@ async def test_force_reconnect_skips_concurrent_request(watchdog_task):
 
     release = asyncio.Event()
 
-    async def slow_restore():
+    async def slow_restore(**kwargs):
         await release.wait()
 
     svc._restore_all_subscriptions = AsyncMock(side_effect=slow_restore)

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -60,6 +60,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         setattr(ctx, name, task)
     ctx.price_subscription_service = None  # _initialize_price_subscriptions 에서 즉시 종료
     ctx._initialize_price_subscriptions = MagicMock()
+    ctx.dart_disclosure_monitor_task = None
     return ctx
 
 
@@ -117,6 +118,16 @@ def test_web_only_registers_notification_and_watchdog(patched_scheduler_deps):
     _run(ctx)
     names = _registered_bg_task_names(patched_scheduler_deps)
     assert names == {"notification_queue_task", "websocket_watchdog_task"}
+
+
+def test_web_registers_optional_dart_disclosure_monitor(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    ctx.dart_disclosure_monitor_task = MagicMock(task_name="dart_disclosure_monitor")
+
+    _run(ctx)
+
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert "dart_disclosure_monitor" in names
 
 
 def test_overseas_us_registers_dryrun_task(patched_scheduler_deps):

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -32,6 +32,8 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "StrategyLogReportService", "NotificationQueueTask",
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
     "OpeningPositionReconcileService",
+    "DartDisclosureClient", "DartDisclosureRepository",
+    "DartDisclosureRuleService", "DartDisclosureMonitorTask",
 ]
 
 REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
@@ -115,6 +117,7 @@ def _make_fake_context():
     ctx.kill_switch_service = MagicMock()
     ctx.rejection_distribution_service = MagicMock()
     ctx.favorite_service = MagicMock()
+    ctx.favorite_repo = MagicMock()
     ctx.program_trading_stream_service = MagicMock()
     ctx.telegram_reporter = MagicMock()
     ctx.pm = None
@@ -132,6 +135,42 @@ def test_service_container_creates_core_services(patched_service_container_deps)
     assert ctx.market_data_service is patched_service_container_deps["MarketDataService"].return_value
     assert ctx.indicator_service is patched_service_container_deps["IndicatorService"].return_value
     assert ctx.data_quality_service is patched_service_container_deps["DataQualityService"].return_value
+
+
+def test_service_container_builds_enabled_dart_disclosure_pipeline(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {
+        "dart_disclosure": {
+            "enabled": True,
+            "api_key": "dart-test-key",
+            "request_timeout_sec": 4,
+        }
+    }
+
+    ServiceContainer(ctx).run()
+
+    client_cls = patched_service_container_deps["DartDisclosureClient"]
+    client_cls.assert_called_once_with("dart-test-key", timeout_sec=4.0)
+    task_kwargs = patched_service_container_deps["DartDisclosureMonitorTask"].call_args.kwargs
+    assert task_kwargs["favorite_repository"] is ctx.favorite_repo
+    assert task_kwargs["telegram_reporter"] is ctx.telegram_reporter
+    assert ctx.dart_disclosure_monitor_task is patched_service_container_deps[
+        "DartDisclosureMonitorTask"
+    ].return_value
+
+
+def test_service_container_skips_dart_pipeline_without_key(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {"dart_disclosure": {"enabled": True, "api_key": ""}}
+
+    ServiceContainer(ctx).run()
+
+    assert ctx.dart_disclosure_monitor_task is None
+    patched_service_container_deps["DartDisclosureClient"].assert_not_called()
 
 
 def test_service_container_creates_query_and_order_services(patched_service_container_deps):

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -90,6 +90,21 @@ def test_runtime_mode_injection(mock_deps):
     assert ctx2.runtime_mode == (RuntimeMode.WEB | RuntimeMode.TRADING)
 
 
+def test_logger_injection_skips_default_logger_construction(mock_deps):
+    """logger 인자로 주입 시 내부 Logger() 를 생성하지 않고 주입된 인스턴스를 그대로 사용한다.
+
+    WebAppContext.__init__ 이 항상 Logger() 를 생성하면, 테스트에서 나중에
+    ctx.logger 를 재할당해도 이미 실행된 Logger() 부작용(logs/common 파일 생성,
+    'operational_logger'/'debug_logger' 전역 싱글턴 핸들러 교체)을 되돌릴 수 없다.
+    """
+    injected_logger = MagicMock()
+
+    ctx = WebAppContext(None, logger=injected_logger)
+
+    assert ctx.logger is injected_logger
+    mock_deps["logger"].assert_not_called()
+
+
 def test_initialize_scheduler_noop_when_trading_disabled(mock_deps):
     """runtime_mode=WEB 일 때 initialize_scheduler() 가 StrategyScheduler 를 생성하지 않는다."""
     from view.web.bootstrap.runtime_mode import RuntimeMode

--- a/todo_list.md
+++ b/todo_list.md
@@ -169,7 +169,7 @@
 ### M-2. 문서 동기화 + 구조 감시 [저위험 상시]
 
 - [x] `docs/backtest.md`(본문은 #619 슬리피지/스프레드 CLI까지 이미 반영, 날짜만 동기화)·`CODEBASE_SUMMARY.md`(bootstrap 분해 진전·EventShadowManager 분리·해외/테마 계층·브로커 계층 계측 4곳 반영) 갱신 완료 (2026-07-05).
-- [x] **`service_container.py` 비대화 경고 해소 — bootstrap 분해 + 의존성 경계 테스트 추가 (2026-07-12)**: #659(서비스↔전략 의존성 경계 강제, `oneil_common_types.py`를 `strategies/`→`common/`으로 이관, `test_architecture_dependencies.py` 신규) · #660(`backtest_task_bootstrap.py` 추출) · #661(`repository_bootstrap.py` 추출) · #662(`market_data_bootstrap.py` 추출) 4개 PR로 `service_container.py`가 962→**862줄**로 감소, 07-05까지의 증가 추세 반전.
+- [x] **`service_container.py` 비대화 경고 해소 — bootstrap 분해 + 의존성 경계 테스트 추가 (2026-07-12)**: #659(서비스↔전략 의존성 경계 강제, `oneil_common_types.py`를 `strategies/`→`common/`으로 이관, `test_architecture_dependencies.py` 신규) · #660(`backtest_task_bootstrap.py` 추출) · #661(`repository_bootstrap.py` 추출) · #662(`market_data_bootstrap.py` 추출) · #663(`query_bootstrap.py` 추출) · #664(`realtime_bootstrap.py` 추출) 6개 PR로 `service_container.py`가 962→**710줄**로 감소, 07-05까지의 증가 추세 반전.
 - 감시(조치 아님): `scheduler/strategy_scheduler.py` 2,153→**2,379줄**(+226) / `services/strategy_log_report_service.py` 2,144→**2,298줄**(+154, 07-08 "정체" 판정 이후 증가 재개) — 분해는 3-4 재승격과 함께 진행.
 
 ### M-3. 시가총액/미국주식 UI 하드닝 후속 [#653 코드리뷰 xhigh, 2026-07-11]

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -105,6 +105,7 @@ class SchedulerBootstrap:
         ctx = self._ctx
         # NotificationQueueTask 는 TimeDispatcher 등록 대상이 아님 (always-on)
         self._register(ctx.notification_queue_task)
+        self._register(self._optional_task("dart_disclosure_monitor_task"))
 
     def _register_trading_tasks(self) -> None:
         ctx = self._ctx

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from common.types import ErrorCode, Exchange
 from config.config_loader import (
+    DartDisclosureConfig,
     OrderPolicyConfig,
     PositionSizingConfig,
     RiskGateConfig,
@@ -24,6 +25,8 @@ from services.backtest_microstructure_capture import BacktestMicrostructureCaptu
 from services.execution_flow_service import ExecutionFlowService
 from services.event_shadow_journal_service import EventShadowJournalService
 from services.deferred_order_queue import DeferredOrderQueue
+from services.dart_disclosure_client import DartDisclosureClient
+from services.dart_disclosure_rule_service import DartDisclosureRuleService
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
@@ -53,6 +56,7 @@ from task.background.after_market.strategy_log_report_task import StrategyLogRep
 from task.background.after_market.theme_daily_leader_report_task import ThemeDailyLeaderReportTask
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
+from task.background.always_on.dart_disclosure_monitor_task import DartDisclosureMonitorTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
@@ -64,6 +68,7 @@ from view.web.bootstrap.market_data_bootstrap import MarketDataBootstrap
 from view.web.bootstrap.query_bootstrap import QueryBootstrap
 from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
 from view.web.market_mode_utils import is_market_enabled
+from repositories.dart_disclosure_repository import DartDisclosureRepository
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -188,6 +193,37 @@ class ServiceContainer:
             is_overseas_us=is_overseas_us,
             needs_batch=needs_batch,
         )
+
+        ctx.dart_disclosure_client = None
+        ctx.dart_disclosure_repository = None
+        ctx.dart_disclosure_rule_service = None
+        ctx.dart_disclosure_monitor_task = None
+        raw_dart_config = config_dict.get("dart_disclosure") or {}
+        dart_config = DartDisclosureConfig.model_validate(raw_dart_config)
+        if dart_config.enabled:
+            if not needs_web or is_overseas_us:
+                ctx.logger.info("OpenDART 공시 모니터는 국내 WEB 런타임에서만 동작합니다.")
+            elif not dart_config.api_key:
+                ctx.logger.warning("OpenDART 공시 모니터가 활성화됐지만 API 키가 없어 비활성화합니다.")
+            elif getattr(ctx, "telegram_reporter", None) is None:
+                ctx.logger.warning("OpenDART 공시 모니터가 활성화됐지만 텔레그램 리포터가 없어 비활성화합니다.")
+            else:
+                ctx.dart_disclosure_client = DartDisclosureClient(
+                    dart_config.api_key,
+                    timeout_sec=float(dart_config.request_timeout_sec),
+                )
+                ctx.dart_disclosure_repository = DartDisclosureRepository()
+                ctx.dart_disclosure_rule_service = DartDisclosureRuleService()
+                ctx.dart_disclosure_monitor_task = DartDisclosureMonitorTask(
+                    client=ctx.dart_disclosure_client,
+                    repository=ctx.dart_disclosure_repository,
+                    favorite_repository=ctx.favorite_repo,
+                    rule_service=ctx.dart_disclosure_rule_service,
+                    telegram_reporter=ctx.telegram_reporter,
+                    config=dart_config,
+                    market_clock=ctx.market_clock,
+                    logger=ctx.logger,
+                )
 
         try:
             if is_overseas_us:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -95,9 +95,9 @@ class WebAppContext:
 
     REST_PRICE_REFRESH_COOLDOWN_SEC = 10.0
 
-    def __init__(self, app_context, runtime_mode=None):
+    def __init__(self, app_context, runtime_mode=None, logger=None):
         from view.web.bootstrap.runtime_mode import RuntimeMode
-        self.logger = Logger()
+        self.logger = logger if logger is not None else Logger()
         self.runtime_mode: RuntimeMode = runtime_mode if runtime_mode is not None else RuntimeMode.ALL
         self.market_mode: str = "domestic"
         self.enabled_market_modes: list[str] = ["domestic"]
@@ -168,6 +168,10 @@ class WebAppContext:
         self.notification_service: NotificationService = None
         self.telegram_notification_repository = None
         self.notification_queue_task: NotificationQueueTask = None
+        self.dart_disclosure_client = None
+        self.dart_disclosure_repository = None
+        self.dart_disclosure_rule_service = None
+        self.dart_disclosure_monitor_task = None
         self.initialized = False
         self.pm: PerformanceProfiler = None
 


### PR DESCRIPTION
## What changed

- add configurable OpenDART disclosure polling for favorite domestic stocks
- classify disclosures by importance and send immediate Telegram alerts or a daily digest
- persist disclosure processing state to prevent duplicate notifications
- wire the always-on disclosure monitor into the web runtime and scheduler
- improve realtime subscription, program-trading stream, and WebSocket watchdog recovery behavior
- refine theme leader report labeling and related integration fixtures

## Why

Operators need timely disclosure alerts for watched stocks without duplicate messages, while the realtime pipeline needs clearer recovery behavior when subscriptions or WebSocket traffic become stale.

## Impact

- OpenDART monitoring remains disabled by default and requires an API key before activation
- enabled domestic web runtimes can monitor favorite stocks and publish Telegram disclosure alerts
- realtime stream recovery has additional diagnostics and resilience safeguards

## Validation

- `python -m pytest tests/unit_test -v` — 6,821 passed
- `python -m pytest tests/integration_test -v` — 248 passed