### PR TITLE
Separate Telegram summaries from detailed report archive

### DIFF
--- a/repositories/strategy_diagnostic_report_repository.py
+++ b/repositories/strategy_diagnostic_report_repository.py
@@ -1,0 +1,76 @@
+"""전략 상세 진단 리포트 파일을 저장하고 조회한다."""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Union
+
+
+_REPORT_ID_PATTERN = re.compile(
+    r"^(?P<date>\d{8})_(?P<time>\d{6})_(?P<microsecond>\d{6})_"
+    r"strategy_diagnostic_report\.html$"
+)
+
+
+class StrategyDiagnosticReportRepository:
+    """웹 상세 리포트 보관함의 파일 저장소."""
+
+    def __init__(
+        self,
+        report_dir: Union[str, Path] = "logs/reports/strategy_diagnostics",
+    ) -> None:
+        self._report_dir = Path(report_dir)
+        self._report_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _current_stamp() -> str:
+        return datetime.now().strftime("%H%M%S_%f")
+
+    def save(self, report_date: str, content: str) -> dict:
+        safe_date = re.sub(r"[^0-9]", "", str(report_date))
+        if len(safe_date) != 8:
+            safe_date = datetime.now().strftime("%Y%m%d")
+        report_id = (
+            f"{safe_date}_{self._current_stamp()}_strategy_diagnostic_report.html"
+        )
+        path = self._report_dir / report_id
+        path.write_text(content, encoding="utf-8")
+        return self._metadata(report_id)
+
+    def list_reports(self, limit: int = 100) -> list[dict]:
+        report_ids = sorted(
+            (
+                path.name
+                for path in self._report_dir.glob("*_strategy_diagnostic_report.html")
+                if _REPORT_ID_PATTERN.fullmatch(path.name)
+            ),
+            reverse=True,
+        )
+        return [self._metadata(report_id) for report_id in report_ids[:limit]]
+
+    def get_report(self, report_id: str) -> dict | None:
+        if not _REPORT_ID_PATTERN.fullmatch(str(report_id)):
+            return None
+        path = self._report_dir / report_id
+        if not path.is_file():
+            return None
+        return {
+            **self._metadata(report_id),
+            "content": path.read_text(encoding="utf-8"),
+        }
+
+    @staticmethod
+    def _metadata(report_id: str) -> dict:
+        match = _REPORT_ID_PATTERN.fullmatch(report_id)
+        if match is None:  # pragma: no cover - 내부 검증 후에만 호출
+            raise ValueError(f"잘못된 전략 진단 리포트 ID: {report_id}")
+        created_at = datetime.strptime(
+            f"{match.group('date')}{match.group('time')}{match.group('microsecond')}",
+            "%Y%m%d%H%M%S%f",
+        )
+        return {
+            "id": report_id,
+            "report_date": match.group("date"),
+            "created_at": created_at.isoformat(),
+        }

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -515,13 +515,13 @@ class StrategyLogReportService:
         if report_dir is None:
             base_dir = os.path.dirname(os.path.normpath(self._log_dir)) or "."
             report_dir = os.path.join(base_dir, "reports", "strategy_diagnostics")
-        os.makedirs(report_dir, exist_ok=True)
-        safe_date = re.sub(r"[^0-9]", "", str(report_date)) or datetime.now().strftime("%Y%m%d")
-        stamp = datetime.now().strftime("%H%M%S_%f")
-        path = os.path.join(report_dir, f"{safe_date}_{stamp}_strategy_diagnostic_report.html")
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(report_html)
-        return path
+        from repositories.strategy_diagnostic_report_repository import (
+            StrategyDiagnosticReportRepository,
+        )
+
+        repository = StrategyDiagnosticReportRepository(report_dir)
+        saved = repository.save(report_date, report_html)
+        return os.path.join(report_dir, saved["id"])
 
     # ── 파일 탐색 ────────────────────────────────────────────────
 

--- a/task/background/after_market/strategy_log_report_task.py
+++ b/task/background/after_market/strategy_log_report_task.py
@@ -100,12 +100,8 @@ class StrategyLogReportTask(AfterMarketTask):
                         await send_decision_report(decision_report, latest_trading_date)
             except Exception as e:
                 self._logger.warning(f"Telegram 운영 의사결정 리포트 전송 실패: {e}")
-            try:
-                await self._telegram_reporter.send_strategy_log_report(report_html, latest_trading_date)
-            except Exception as e:
-                self._logger.warning(f"Telegram 리포트 전송 실패: {e}")
 
-        self._logger.info("전략 로그 리포트 발송 완료")
+        self._logger.info("전략 상세 리포트 저장 및 운영 요약 발송 완료")
 
     async def _emit_execution_quality_candidate_alert(self, report_date: str) -> None:
         if not self._notification_service:

--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -23,6 +23,7 @@ PAGE_PATHS = [
     "/marketcap",
     "/virtual",
     "/scheduler",
+    "/strategy-reports",
     "/program",
     "/system",
 ]

--- a/tests/unit_test/repositories/test_strategy_diagnostic_report_repository.py
+++ b/tests/unit_test/repositories/test_strategy_diagnostic_report_repository.py
@@ -1,0 +1,38 @@
+from repositories.strategy_diagnostic_report_repository import (
+    StrategyDiagnosticReportRepository,
+)
+
+
+def test_save_list_and_get_report(tmp_path):
+    repository = StrategyDiagnosticReportRepository(tmp_path)
+
+    saved = repository.save("2026-07-14", "<b>상세 리포트</b>")
+    reports = repository.list_reports()
+
+    assert saved["report_date"] == "20260714"
+    assert reports[0]["id"] == saved["id"]
+    assert repository.get_report(saved["id"]) == {
+        **saved,
+        "content": "<b>상세 리포트</b>",
+    }
+
+
+def test_list_reports_is_latest_first_and_limited(tmp_path, monkeypatch):
+    repository = StrategyDiagnosticReportRepository(tmp_path)
+    stamps = iter(["090000_000001", "160000_000002"])
+    monkeypatch.setattr(repository, "_current_stamp", lambda: next(stamps))
+
+    first = repository.save("20260713", "first")
+    second = repository.save("20260714", "second")
+
+    reports = repository.list_reports(limit=1)
+
+    assert [item["id"] for item in reports] == [second["id"]]
+    assert first["id"] != second["id"]
+
+
+def test_get_report_rejects_path_traversal_and_unknown_file(tmp_path):
+    repository = StrategyDiagnosticReportRepository(tmp_path)
+
+    assert repository.get_report("../config.yaml") is None
+    assert repository.get_report("missing.html") is None

--- a/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_strategy_log_report_task.py
@@ -94,11 +94,9 @@ class TestOnMarketClosed:
         await task._on_market_closed("20260419")
         mock_report_service.generate_report.assert_awaited_once_with("20260419")
 
-    async def test_telegram_reporter_receives_report_html(self, task, mock_telegram):
+    async def test_detailed_report_is_not_sent_to_telegram(self, task, mock_telegram):
         await task._on_market_closed("20260419")
-        mock_telegram.send_strategy_log_report.assert_awaited_once_with(
-            "<html>report</html>", "20260419"
-        )
+        mock_telegram.send_strategy_log_report.assert_not_awaited()
 
     async def test_diagnostic_report_is_saved(self, task, mock_report_service):
         await task._on_market_closed("20260419")
@@ -340,11 +338,12 @@ class TestOnMarketClosed:
         assert args[2] == "전략 성과 저하 후보"
         assert kwargs["metadata"]["alert_type"] == "strategy_degradation_candidate"
 
-    async def test_telegram_send_called(self, task, mock_telegram):
+    async def test_only_operational_summary_is_sent_to_telegram(self, task, mock_telegram):
         await task._on_market_closed("20260419")
-        mock_telegram.send_strategy_log_report.assert_awaited_once_with(
-            "<html>report</html>", "20260419"
+        mock_telegram.send_operational_decision_report.assert_awaited_once_with(
+            "<b>운영 의사결정</b>", "20260419"
         )
+        mock_telegram.send_strategy_log_report.assert_not_awaited()
 
     async def test_report_generation_failure_skips_notification_and_telegram(
         self, task, mock_report_service, mock_notification_service, mock_telegram
@@ -359,7 +358,8 @@ class TestOnMarketClosed:
     ):
         task_minimal._telegram_reporter = mock_telegram
         await task_minimal._on_market_closed("20260419")
-        mock_telegram.send_strategy_log_report.assert_awaited_once()
+        mock_telegram.send_operational_decision_report.assert_awaited_once()
+        mock_telegram.send_strategy_log_report.assert_not_awaited()
 
     async def test_notification_service_without_candidate_getter_returns(
         self, mock_notification_service

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -129,6 +129,19 @@ def test_render_page_success(mock_web_app_context_cls):
             assert "Investment Login" not in response.text
             assert "Investment - Web View" in response.text
 
+
+def test_strategy_report_archive_page(mock_web_app_context_cls):
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": False}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
+        with TestClient(app) as client:
+            response = client.get("/strategy-reports")
+
+    assert response.status_code == 200
+    assert "상세 리포트 보관함" in response.text
+    assert "/static/js/strategy_reports.js" in response.text
+
 def test_debug_handler_do_get_404():
     """진단 서버 404 경로 처리 테스트"""
     handler = _DebugHandler.__new__(_DebugHandler)
@@ -264,7 +277,7 @@ def test_all_page_routers(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
         with TestClient(app) as client:
             client.cookies.set("access_token", "correct_token")
-            pages = ["/stock", "/balance", "/order", "/ranking", "/marketcap", "/virtual", "/scheduler", "/program", "/system", "/favorite"]
+            pages = ["/stock", "/balance", "/order", "/ranking", "/marketcap", "/virtual", "/scheduler", "/strategy-reports", "/program", "/system", "/favorite"]
             for page in pages:
                 response = client.get(page)
                 assert response.status_code == 200

--- a/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
@@ -124,3 +124,44 @@ async def test_rejected_reasons_field_names(web_client, mock_web_ctx):
     assert "count" in row
     assert "label_kr" in row
     assert "strategy" in row
+
+
+def test_diagnostic_report_archive_list(web_client, mock_web_ctx):
+    mock_web_ctx.strategy_diagnostic_report_repository.list_reports.return_value = [
+        {
+            "id": "20260714_162151_000001_strategy_diagnostic_report.html",
+            "report_date": "20260714",
+            "created_at": "2026-07-14T16:21:51",
+        }
+    ]
+
+    response = web_client.get("/api/strategies/diagnostic-reports?limit=20")
+
+    assert response.status_code == 200
+    assert response.json()["reports"][0]["report_date"] == "20260714"
+    mock_web_ctx.strategy_diagnostic_report_repository.list_reports.assert_called_once_with(
+        limit=20
+    )
+
+
+def test_diagnostic_report_archive_detail(web_client, mock_web_ctx):
+    report_id = "20260714_162151_000001_strategy_diagnostic_report.html"
+    mock_web_ctx.strategy_diagnostic_report_repository.get_report.return_value = {
+        "id": report_id,
+        "report_date": "20260714",
+        "created_at": "2026-07-14T16:21:51",
+        "content": "<b>상세 리포트</b>",
+    }
+
+    response = web_client.get(f"/api/strategies/diagnostic-reports/{report_id}")
+
+    assert response.status_code == 200
+    assert response.json()["content"] == "<b>상세 리포트</b>"
+
+
+def test_diagnostic_report_archive_detail_not_found(web_client, mock_web_ctx):
+    mock_web_ctx.strategy_diagnostic_report_repository.get_report.return_value = None
+
+    response = web_client.get("/api/strategies/diagnostic-reports/missing.html")
+
+    assert response.status_code == 404

--- a/view/web/bootstrap/config_bootstrap.py
+++ b/view/web/bootstrap/config_bootstrap.py
@@ -7,6 +7,7 @@
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from config.config_loader import KillSwitchConfig, load_configs
@@ -20,6 +21,9 @@ from services.rejection_distribution_service import RejectionDistributionService
 from services.strategy_log_report_service import _REASON_KR
 from services.telegram_notifier import TelegramNotifier, TelegramReporter
 from repositories.telegram_notification_repository import TelegramNotificationRepository
+from repositories.strategy_diagnostic_report_repository import (
+    StrategyDiagnosticReportRepository,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -56,6 +60,12 @@ class ConfigBootstrap:
         ctx.virtual_trade_service.tm = ctx.market_clock
         ctx.notification_service = NotificationService(ctx.market_clock)
         ctx.telegram_notification_repository = TelegramNotificationRepository()
+        logger_log_dir = getattr(ctx.logger, "log_dir", "logs")
+        if not isinstance(logger_log_dir, (str, Path)):
+            logger_log_dir = "logs"
+        ctx.strategy_diagnostic_report_repository = StrategyDiagnosticReportRepository(
+            Path(logger_log_dir) / "reports" / "strategy_diagnostics"
+        )
         ctx.operator_alert_service = OperatorAlertService(
             notification_service=ctx.notification_service,
             market_clock=ctx.market_clock,

--- a/view/web/routes/strategy_report.py
+++ b/view/web/routes/strategy_report.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from typing import List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
 
 from common.trade_journal_schema import normalize_virtual_trade
 from services.regime_performance_service import (
@@ -18,6 +18,23 @@ from view.web.api_common import _get_ctx
 router = APIRouter()
 
 _DEFAULT_LOG_DIR = os.path.join("logs", "strategies", "rejections")
+
+
+@router.get("/strategies/diagnostic-reports")
+async def get_diagnostic_reports(limit: int = Query(100, ge=1, le=500)):
+    """저장된 전략 상세 진단 리포트 목록을 최신순으로 반환한다."""
+    repository = _get_ctx().strategy_diagnostic_report_repository
+    return {"reports": repository.list_reports(limit=limit)}
+
+
+@router.get("/strategies/diagnostic-reports/{report_id}")
+async def get_diagnostic_report(report_id: str):
+    """전략 상세 진단 리포트 한 건을 반환한다."""
+    repository = _get_ctx().strategy_diagnostic_report_repository
+    report = repository.get_report(report_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="상세 리포트를 찾을 수 없습니다.")
+    return report
 
 
 def _read_file_rows(date: str, log_dir: str) -> List[dict]:

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -12,6 +12,97 @@
     --border: #dcdde1;
 }
 
+/* 전략 상세 리포트 보관함 */
+.strategy-report-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.strategy-report-header h2,
+.strategy-report-header p {
+    margin: 0;
+}
+
+.strategy-report-header p {
+    margin-top: 6px;
+    color: var(--text-secondary);
+}
+
+.strategy-report-layout {
+    display: grid;
+    grid-template-columns: minmax(210px, 280px) minmax(0, 1fr);
+    gap: 16px;
+    min-height: 560px;
+}
+
+.strategy-report-list,
+.strategy-report-viewer {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.strategy-report-list {
+    overflow-y: auto;
+    max-height: 70vh;
+}
+
+.strategy-report-item {
+    display: flex;
+    width: 100%;
+    padding: 13px 14px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    color: var(--text-primary);
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    text-align: left;
+}
+
+.strategy-report-item:hover,
+.strategy-report-item.active {
+    background: rgba(233, 69, 96, 0.14);
+}
+
+.strategy-report-item span,
+.strategy-report-meta,
+.strategy-report-empty {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.strategy-report-empty,
+.strategy-report-meta {
+    padding: 14px;
+}
+
+.strategy-report-meta {
+    border-bottom: 1px solid var(--border);
+}
+
+.strategy-report-content {
+    padding: 18px;
+    white-space: pre-wrap;
+    line-height: 1.65;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+    .strategy-report-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .strategy-report-list {
+        max-height: 220px;
+    }
+}
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {

--- a/view/web/static/js/strategy_reports.js
+++ b/view/web/static/js/strategy_reports.js
@@ -1,0 +1,95 @@
+let _strategyReports = [];
+let _selectedStrategyReportId = null;
+
+document.addEventListener('DOMContentLoaded', loadStrategyReports);
+
+async function loadStrategyReports() {
+    const list = document.getElementById('strategy-report-list');
+    try {
+        const response = await fetch('/api/strategies/diagnostic-reports?limit=200');
+        if (!response.ok) throw new Error('목록 조회 실패');
+        const data = await response.json();
+        _strategyReports = data.reports || [];
+        renderStrategyReportList();
+        if (_strategyReports.length > 0) {
+            const selected = _strategyReports.some(item => item.id === _selectedStrategyReportId)
+                ? _selectedStrategyReportId
+                : _strategyReports[0].id;
+            await selectStrategyReport(selected);
+        } else {
+            clearStrategyReportViewer('저장된 상세 리포트가 없습니다.');
+        }
+    } catch (_) {
+        list.innerHTML = '<div class="strategy-report-empty">상세 리포트 목록을 불러오지 못했습니다.</div>';
+        clearStrategyReportViewer('조회 상태를 확인해 주세요.');
+    }
+}
+
+function renderStrategyReportList() {
+    const list = document.getElementById('strategy-report-list');
+    if (_strategyReports.length === 0) {
+        list.innerHTML = '<div class="strategy-report-empty">저장된 상세 리포트가 없습니다.</div>';
+        return;
+    }
+    list.innerHTML = _strategyReports.map(report => `
+        <button type="button" class="strategy-report-item ${report.id === _selectedStrategyReportId ? 'active' : ''}"
+                data-report-id="${escapeHtml(report.id)}"
+                onclick="selectStrategyReport(this.dataset.reportId)">
+            <strong>${formatReportDate(report.report_date)}</strong>
+            <span>${formatCreatedAt(report.created_at)}</span>
+        </button>
+    `).join('');
+}
+
+async function selectStrategyReport(reportId) {
+    _selectedStrategyReportId = reportId;
+    renderStrategyReportList();
+    const meta = document.getElementById('strategy-report-meta');
+    const content = document.getElementById('strategy-report-content');
+    meta.textContent = '리포트를 불러오는 중입니다.';
+    content.replaceChildren();
+    try {
+        const response = await fetch(`/api/strategies/diagnostic-reports/${encodeURIComponent(reportId)}`);
+        if (!response.ok) throw new Error('상세 조회 실패');
+        const report = await response.json();
+        meta.textContent = `${formatReportDate(report.report_date)} · ${formatCreatedAt(report.created_at)}`;
+        content.replaceChildren(sanitizeStrategyReport(report.content || ''));
+    } catch (_) {
+        clearStrategyReportViewer('상세 리포트를 불러오지 못했습니다.');
+    }
+}
+
+function sanitizeStrategyReport(source) {
+    const template = document.createElement('template');
+    template.innerHTML = source;
+    const fragment = document.createDocumentFragment();
+
+    function appendSafe(parent, node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            parent.appendChild(document.createTextNode(node.textContent));
+            return;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        const target = node.tagName === 'B' ? document.createElement('strong') : parent;
+        if (target !== parent) parent.appendChild(target);
+        node.childNodes.forEach(child => appendSafe(target, child));
+    }
+
+    template.content.childNodes.forEach(node => appendSafe(fragment, node));
+    return fragment;
+}
+
+function clearStrategyReportViewer(message) {
+    document.getElementById('strategy-report-meta').textContent = message;
+    document.getElementById('strategy-report-content').replaceChildren();
+}
+
+function formatReportDate(value) {
+    const text = String(value || '');
+    return text.length === 8 ? `${text.slice(0, 4)}-${text.slice(4, 6)}-${text.slice(6, 8)}` : text;
+}
+
+function formatCreatedAt(value) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value || '') : date.toLocaleString('ko-KR');
+}

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=9">
+    <link rel="stylesheet" href="/static/css/style.css?v=10">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }
@@ -85,6 +85,7 @@
     <a href="/marketcap" class="{% if active_page == 'marketcap' %}active{% endif %}">시가총액</a>
     <a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>
     <a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>
+    <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>
     <a href="/program" class="{% if active_page == 'program' %}active{% endif %}">프로그램매매</a>
     <a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>
 </nav>

--- a/view/web/templates/strategy_reports.html
+++ b/view/web/templates/strategy_reports.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section strategy-report-archive">
+    <div class="strategy-report-header">
+        <div>
+            <h2>상세 리포트 보관함</h2>
+            <p>텔레그램에는 운영 요약만 전송되고, 전략별 상세 진단은 이곳에 보관됩니다.</p>
+        </div>
+        <button type="button" class="btn" onclick="loadStrategyReports()">새로고침</button>
+    </div>
+
+    <div class="strategy-report-layout">
+        <aside id="strategy-report-list" class="strategy-report-list">
+            <div class="strategy-report-empty">저장된 상세 리포트를 불러오는 중입니다.</div>
+        </aside>
+        <article class="strategy-report-viewer">
+            <div id="strategy-report-meta" class="strategy-report-meta">리포트를 선택하세요.</div>
+            <div id="strategy-report-content" class="strategy-report-content"></div>
+        </article>
+    </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/strategy_reports.js?v=1"></script>
+{% endblock %}

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -167,6 +167,7 @@ class WebAppContext:
         self._mcs: MarketCalendarService = None
         self.notification_service: NotificationService = None
         self.telegram_notification_repository = None
+        self.strategy_diagnostic_report_repository = None
         self.notification_queue_task: NotificationQueueTask = None
         self.dart_disclosure_client = None
         self.dart_disclosure_repository = None

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -359,6 +359,10 @@ async def favorite(request: Request):
 async def operator_dashboard(request: Request):
     return await render_page(request, "operator_dashboard.html", "operator")
 
+@page_router.get("/strategy-reports")
+async def strategy_reports(request: Request):
+    return await render_page(request, "strategy_reports.html", "strategy_reports")
+
 # 5. 로그아웃
 @page_router.get("/logout")
 async def logout():


### PR DESCRIPTION
## What changed

- send only the short operational decision summary to Telegram after the market closes
- keep generating and saving the full strategy diagnostic report
- add a dedicated file-backed strategy diagnostic report repository
- expose report list and detail APIs under `/api/strategies/diagnostic-reports`
- add a responsive `상세 리포트` web page with date-based navigation
- render stored report content with a strict client-side tag allowlist

## Why

The web notification center represented messages that were actually sent to Telegram. As a result, keeping a detailed report in that view required sending the full report to mobile as well. This change separates mobile notification history from the durable detailed-report archive.

## Impact

- mobile Telegram receives the concise operational decision summary only
- detailed strategy diagnostics remain available in the web view at `/strategy-reports`
- previously saved diagnostic files using the existing filename format are visible in the new archive
- Telegram delivery history continues to represent actual Telegram messages

## Validation

- `python -m pytest tests/unit_test -v` — 6,832 passed
- `python -m pytest tests/integration_test -v` — 248 passed