### PR TITLE
기간수급 랭킹 DB 영속화 및 재시작 self-heal 추가

### DIFF
--- a/repositories/period_ranking_repository.py
+++ b/repositories/period_ranking_repository.py
@@ -1,0 +1,56 @@
+"""기간수급(외국인+기관+프로그램 순매수) 랭킹 원천 데이터를 SQLite에 영속화한다.
+
+RankingTask의 in-memory 기간수급 캐시는 재시작 시 소실되고, TimeDispatcher는
+거래일당 1회만 티켓을 발행하므로 재시작 후 당일 데이터를 복원하는 용도로 쓴다.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+
+class PeriodRankingRepository:
+    """기간수급 랭킹 결과를 (거래일, 조회일수) 키로 저장/조회한다."""
+
+    def __init__(self, db_path: Union[str, Path] = "data/period_ranking.db"):
+        self._db_path = str(db_path)
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS period_ranking (
+                    trade_date TEXT NOT NULL,
+                    days INTEGER NOT NULL,
+                    results TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
+                    PRIMARY KEY (trade_date, days)
+                )
+                """
+            )
+
+    def save(self, trade_date: str, days: int, results: List[Dict]) -> None:
+        """결과를 저장하고 이전 거래일 행은 정리한다 (조회는 항상 최신 거래일 기준)."""
+        payload = json.dumps(results, ensure_ascii=False)
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO period_ranking (trade_date, days, results, updated_at) "
+                "VALUES (?, ?, ?, datetime('now', 'localtime'))",
+                (str(trade_date), int(days), payload),
+            )
+            conn.execute(
+                "DELETE FROM period_ranking WHERE trade_date < ?",
+                (str(trade_date),),
+            )
+
+    def get(self, trade_date: str, days: int) -> Optional[List[Dict]]:
+        """저장된 결과를 반환한다. 없으면 None."""
+        with sqlite3.connect(self._db_path) as conn:
+            row = conn.execute(
+                "SELECT results FROM period_ranking WHERE trade_date = ? AND days = ?",
+                (str(trade_date), int(days)),
+            ).fetchone()
+        if not row:
+            return None
+        return json.loads(row[0])

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -60,6 +60,7 @@ class RankingTask(AfterMarketTask):
         market_calendar_service: Optional[MarketCalendarService] = None,
         worker_pool: Optional[WorkerPool] = None,
         stock_classification_repository=None,
+        period_ranking_repository=None,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -75,6 +76,7 @@ class RankingTask(AfterMarketTask):
         self._notification_service = notification_service
         self._telegram_reporter = telegram_reporter
         self._stock_classification_repository = stock_classification_repository
+        self._period_ranking_repository = period_ranking_repository
         self._suspend_event: asyncio.Event = asyncio.Event()
         self._suspend_event.set()  # 초기에는 실행 가능 상태
 
@@ -122,6 +124,9 @@ class RankingTask(AfterMarketTask):
 
     async def _on_start_hook(self) -> None:
         self._suspend_event.set()
+        # 재시작 복구: TimeDispatcher는 거래일당 1회만 티켓을 발행하므로
+        # 티켓 발행 후 재시작하면 당일 기간수급 캐시가 비어도 재예열이 없다.
+        self._tasks.append(asyncio.create_task(self._period_ranking_self_heal()))
 
     async def suspend(self) -> None:
         """랭킹 수집을 일시 중지한다 (chunk 사이에서 대기)."""
@@ -633,6 +638,48 @@ class RankingTask(AfterMarketTask):
         else:
             self._logger.warning(f"기간수급 랭킹 캐시 예열 미완료: {target_date}, {days}일")
 
+    async def _period_ranking_self_heal(self) -> None:
+        """시작 시 당일 기간수급 캐시가 없으면 DB 복원 또는 예열한다 (장중 제외)."""
+        try:
+            if self._mcs is None:
+                return
+            if await self._mcs.is_market_open_now():
+                return
+            target_date = await self._mcs.get_latest_trading_date()
+            if not target_date:
+                return
+            cache_key = (str(target_date), self.DEFAULT_PERIOD_RANKING_DAYS)
+            if cache_key in self._period_ranking_cache:
+                return
+            async with self._running_state():
+                await self.prewarm_period_ranking(str(target_date))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self._logger.warning(f"기간수급 self-heal 실패: {e}")
+
+    def _load_period_ranking_from_db(self, cache_key: tuple[str, int]) -> Optional[List[Dict]]:
+        if not self._period_ranking_repository:
+            return None
+        target_date, days = cache_key
+        try:
+            return self._period_ranking_repository.get(target_date, days)
+        except Exception as e:
+            self._logger.warning(f"기간수급 DB 조회 실패: {e}")
+            return None
+
+    async def _save_period_ranking_to_db(self, cache_key: tuple[str, int], results: List[Dict]) -> None:
+        if not self._period_ranking_repository:
+            return
+        # 장중 수집분은 당일 부분 데이터일 수 있어 영속화하지 않는다
+        if self._mcs and await self._mcs.is_market_open_now():
+            return
+        target_date, days = cache_key
+        try:
+            self._period_ranking_repository.save(target_date, days, results)
+        except Exception as e:
+            self._logger.warning(f"기간수급 DB 저장 실패: {e}")
+
     async def _get_or_collect_period_ranking(
         self,
         cache_key: tuple[str, int],
@@ -640,6 +687,12 @@ class RankingTask(AfterMarketTask):
         results = self._period_ranking_cache.get(cache_key)
         if results is not None:
             return results
+
+        stored = self._load_period_ranking_from_db(cache_key)
+        if stored:
+            self._logger.info(f"기간수급 랭킹 DB 복원: {cache_key[0]}, {cache_key[1]}일")
+            self._period_ranking_cache[cache_key] = stored
+            return stored
 
         task = self._period_ranking_tasks.get(cache_key)
         if task is None:
@@ -656,6 +709,7 @@ class RankingTask(AfterMarketTask):
 
         if is_complete:
             self._period_ranking_cache[cache_key] = results
+            await self._save_period_ranking_to_db(cache_key, results)
         return results
 
     async def _collect_period_investor_program_ranking(

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -603,7 +603,14 @@ class RankingTask(AfterMarketTask):
             target_date = datetime.now().strftime("%Y%m%d")
 
         cache_key = (str(target_date), days)
-        results = await self._get_or_collect_period_ranking(cache_key)
+        results = self._peek_period_ranking(cache_key)
+        if results is None:
+            self._trigger_period_ranking_collection(cache_key)
+            return ResCommonResponse(
+                rt_cd=ErrorCode.SUCCESS.value,
+                msg1=f"최근 {days}거래일 기간수급 수집 중입니다. 완료되면 자동 갱신됩니다.",
+                data=[],
+            )
 
         sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
         ranked_results = [
@@ -658,6 +665,39 @@ class RankingTask(AfterMarketTask):
         except Exception as e:
             self._logger.warning(f"기간수급 self-heal 실패: {e}")
 
+    def _peek_period_ranking(self, cache_key: tuple[str, int]) -> Optional[List[Dict]]:
+        """메모리 → DB 순으로 즉시 반환 가능한 기간수급 결과를 찾는다."""
+        results = self._period_ranking_cache.get(cache_key)
+        if results is not None:
+            return results
+        stored = self._load_period_ranking_from_db(cache_key)
+        if stored:
+            self._logger.info(f"기간수급 랭킹 DB 복원: {cache_key[0]}, {cache_key[1]}일")
+            self._period_ranking_cache[cache_key] = stored
+            return stored
+        return None
+
+    def _trigger_period_ranking_collection(self, cache_key: tuple[str, int]) -> None:
+        """기간수급 수집을 백그라운드로 시작한다 (이미 진행 중이면 no-op)."""
+        if cache_key in self._period_ranking_tasks:
+            return
+        self._logger.info(
+            f"기간수급 캐시 없음 → 온디맨드 백그라운드 수집 트리거: {cache_key[0]}, {cache_key[1]}일"
+        )
+        self._tasks = [t for t in self._tasks if not t.done()]
+        self._tasks.append(
+            asyncio.create_task(self._collect_period_ranking_in_background(cache_key))
+        )
+
+    async def _collect_period_ranking_in_background(self, cache_key: tuple[str, int]) -> None:
+        try:
+            async with self._running_state():
+                await self._get_or_collect_period_ranking(cache_key)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self._logger.warning(f"기간수급 백그라운드 수집 실패: {e}")
+
     def _load_period_ranking_from_db(self, cache_key: tuple[str, int]) -> Optional[List[Dict]]:
         if not self._period_ranking_repository:
             return None
@@ -684,15 +724,9 @@ class RankingTask(AfterMarketTask):
         self,
         cache_key: tuple[str, int],
     ) -> List[Dict]:
-        results = self._period_ranking_cache.get(cache_key)
+        results = self._peek_period_ranking(cache_key)
         if results is not None:
             return results
-
-        stored = self._load_period_ranking_from_db(cache_key)
-        if stored:
-            self._logger.info(f"기간수급 랭킹 DB 복원: {cache_key[0]}, {cache_key[1]}일")
-            self._period_ranking_cache[cache_key] = stored
-            return stored
 
         task = self._period_ranking_tasks.get(cache_key)
         if task is None:

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -97,6 +97,7 @@ class RankingTask(AfterMarketTask):
         self._last_collected_date: Optional[str] = None
         self._period_ranking_cache: Dict[tuple[str, int], List[Dict]] = {}
         self._period_ranking_tasks: Dict[tuple[str, int], asyncio.Task] = {}
+        self._period_ranking_intraday_keys: set[tuple[str, int]] = set()
 
         # 기본 랭킹 캐시 (상승/하락/거래량/거래대금) — 장마감 후 1회
         self._basic_ranking_cache: Dict[str, ResCommonResponse] = {}
@@ -148,6 +149,7 @@ class RankingTask(AfterMarketTask):
         멱등성 보장: 동일 날짜에 기본·투자자 랭킹이 모두 수집되어 있으면 즉시 반환.
         """
         date: str = payload.get("date", "")
+        self._invalidate_intraday_period_cache()
         needs_basic = not self._basic_last_collected_date or self._basic_last_collected_date != date
         needs_investor = not self._last_collected_date or self._last_collected_date != date
         needs_period = (date, self.DEFAULT_PERIOD_RANKING_DAYS) not in self._period_ranking_cache
@@ -175,6 +177,7 @@ class RankingTask(AfterMarketTask):
 
     async def _on_market_closed(self, latest_trading_date: str) -> None:
         """장 마감 후 콜백: 해당 거래일의 랭킹 갱신이 필요하면 실행."""
+        self._invalidate_intraday_period_cache()
         needs_basic = (
             not self._basic_last_collected_date
             or self._basic_last_collected_date != latest_trading_date
@@ -708,11 +711,15 @@ class RankingTask(AfterMarketTask):
             self._logger.warning(f"기간수급 DB 조회 실패: {e}")
             return None
 
+    def _invalidate_intraday_period_cache(self) -> None:
+        """장중에 수집된 기간수급 캐시를 무효화한다 (마감 후 완전본 재수집 유도)."""
+        for key in self._period_ranking_intraday_keys:
+            self._period_ranking_cache.pop(key, None)
+            self._logger.info(f"장중 수집 기간수급 캐시 무효화: {key[0]}, {key[1]}일")
+        self._period_ranking_intraday_keys.clear()
+
     async def _save_period_ranking_to_db(self, cache_key: tuple[str, int], results: List[Dict]) -> None:
         if not self._period_ranking_repository:
-            return
-        # 장중 수집분은 당일 부분 데이터일 수 있어 영속화하지 않는다
-        if self._mcs and await self._mcs.is_market_open_now():
             return
         target_date, days = cache_key
         try:
@@ -743,7 +750,11 @@ class RankingTask(AfterMarketTask):
 
         if is_complete:
             self._period_ranking_cache[cache_key] = results
-            await self._save_period_ranking_to_db(cache_key, results)
+            if self._mcs and await self._mcs.is_market_open_now():
+                # 장중 수집분은 당일 부분 데이터 — 장 마감 시 무효화·재수집 대상으로 표시
+                self._period_ranking_intraday_keys.add(cache_key)
+            else:
+                await self._save_period_ranking_to_db(cache_key, results)
         return results
 
     async def _collect_period_investor_program_ranking(

--- a/tests/unit_test/repositories/test_period_ranking_repository.py
+++ b/tests/unit_test/repositories/test_period_ranking_repository.py
@@ -1,0 +1,42 @@
+"""PeriodRankingRepository — 기간수급 랭킹 SQLite 영속화 테스트."""
+import pytest
+
+from repositories.period_ranking_repository import PeriodRankingRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return PeriodRankingRepository(db_path=tmp_path / "period_ranking.db")
+
+
+def test_get_returns_none_when_empty(repo):
+    assert repo.get("20260714", 5) is None
+
+
+def test_save_and_get_roundtrip(repo):
+    results = [
+        {"stck_shrn_iscd": "005930", "combined_period_ntby_tr_pbmn_won": "123"},
+        {"stck_shrn_iscd": "000660", "combined_period_ntby_tr_pbmn_won": "45"},
+    ]
+    repo.save("20260714", 5, results)
+    assert repo.get("20260714", 5) == results
+
+
+def test_save_replaces_same_key(repo):
+    repo.save("20260714", 5, [{"a": "1"}])
+    repo.save("20260714", 5, [{"a": "2"}])
+    assert repo.get("20260714", 5) == [{"a": "2"}]
+
+
+def test_days_variants_kept_for_same_date(repo):
+    repo.save("20260714", 5, [{"a": "d5"}])
+    repo.save("20260714", 10, [{"a": "d10"}])
+    assert repo.get("20260714", 5) == [{"a": "d5"}]
+    assert repo.get("20260714", 10) == [{"a": "d10"}]
+
+
+def test_save_prunes_older_trade_dates(repo):
+    repo.save("20260713", 5, [{"a": "old"}])
+    repo.save("20260714", 5, [{"a": "new"}])
+    assert repo.get("20260713", 5) is None
+    assert repo.get("20260714", 5) == [{"a": "new"}]

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -321,6 +321,7 @@ async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_se
         "IT": {"members": [{"code": "000660", "name": "SK하이닉스"}]},
     }
 
+    await bg_service.prewarm_period_ranking("20250101")
     resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5)
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
@@ -358,6 +359,7 @@ async def test_period_investor_program_ranking_can_sort_by_qty(bg_service, mock_
         ]),
     }[code])
 
+    await bg_service.prewarm_period_ranking("20250101")
     resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty")
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
@@ -376,10 +378,12 @@ async def test_period_investor_program_ranking_excludes_partial_api_results(bg_s
     ]))
     broker.get_program_trade_by_stock_daily_multi = AsyncMock(return_value=None)
 
+    await bg_service.prewarm_period_ranking("20250101")
     resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5)
 
     assert resp.rt_cd == ErrorCode.SUCCESS.value
     assert resp.data == []
+    await asyncio.gather(*bg_service._tasks)  # 온디맨드 재수집 태스크 정리
 
 
 @pytest.mark.asyncio
@@ -394,6 +398,7 @@ async def test_period_investor_program_ranking_reuses_collection_for_other_metri
         {"whol_smtn_ntby_qty": "30", "whol_smtn_ntby_tr_pbmn": "300000000"},
     ]))
 
+    await bg_service.prewarm_period_ranking("20250101")
     amount_resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount")
     qty_resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty")
 
@@ -405,7 +410,7 @@ async def test_period_investor_program_ranking_reuses_collection_for_other_metri
 
 @pytest.mark.asyncio
 async def test_period_investor_program_ranking_shares_in_progress_collection(bg_service, mock_deps):
-    """동일 기준일·기간의 동시 요청은 한 번의 원천 수집 Task를 공유한다."""
+    """수집 진행 중 재요청은 새 수집을 트리거하지 않고 '수집 중' 응답을 즉시 반환한다."""
     broker, mapper, _, _, _, _ = mock_deps
     mapper.df = _make_stock_df([("005930", "삼성전자", "KOSPI")])
     gate = asyncio.Event()
@@ -433,17 +438,21 @@ async def test_period_investor_program_ranking_shares_in_progress_collection(bg_
     broker.get_investor_trade_by_stock_daily_multi = AsyncMock(side_effect=fetch_investor)
     broker.get_program_trade_by_stock_daily_multi = AsyncMock(side_effect=fetch_program)
 
-    first = asyncio.create_task(bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount"))
+    first = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount")
+    assert first.data == []
+    assert "수집 중" in first.msg1
     await asyncio.wait_for(started.wait(), timeout=1)
-    second = asyncio.create_task(bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty"))
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(asyncio.shield(second), timeout=0.05)
 
+    second = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="qty")
+    assert second.data == []
     assert calls == {"investor": 1, "program": 1}
+
     gate.set()
-    first_resp, second_resp = await asyncio.gather(first, second)
-    assert first_resp.rt_cd == ErrorCode.SUCCESS.value
-    assert second_resp.rt_cd == ErrorCode.SUCCESS.value
+    await asyncio.gather(*bg_service._tasks)
+
+    resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5, metric="amount")
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data[0]["hts_kor_isnm"] == "삼성전자"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
@@ -1,0 +1,160 @@
+"""RankingTask 기간수급 DB 영속화 + 재시작 self-heal 테스트.
+
+배경: TimeDispatcher는 거래일당 1회만 ranking_refresh 티켓을 발행하므로,
+티켓 발행 이후 앱을 재시작하면 in-memory 기간수급 캐시가 비어도 당일
+재예열이 없었다. DB 폴백과 시작 시 self-heal로 이를 복구한다.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from task.background.after_market.ranking_task import RankingTask
+
+
+def _make_task(period_repo=None, mcs=None, worker_pool=None) -> RankingTask:
+    broker = MagicMock()
+    stock_repo = MagicMock()
+    stock_repo.df = MagicMock()
+    stock_repo.df.iterrows.return_value = iter([])
+    return RankingTask(
+        broker_api_wrapper=broker,
+        stock_code_repository=stock_repo,
+        logger=MagicMock(),
+        market_calendar_service=mcs,
+        worker_pool=worker_pool,
+        period_ranking_repository=period_repo,
+    )
+
+
+def _make_mcs(market_open=False, latest_date="20260714") -> MagicMock:
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=market_open)
+    mcs.get_latest_trading_date = AsyncMock(return_value=latest_date)
+    return mcs
+
+
+# ── _get_or_collect_period_ranking: DB 폴백/저장 ──────────────────
+
+
+async def test_get_or_collect_loads_from_db_without_collecting():
+    repo = MagicMock()
+    repo.get.return_value = [{"a": "1"}]
+    task = _make_task(period_repo=repo)
+    task._collect_period_investor_program_ranking = AsyncMock()
+
+    results = await task._get_or_collect_period_ranking(("20260714", 5))
+
+    assert results == [{"a": "1"}]
+    assert task._period_ranking_cache[("20260714", 5)] == [{"a": "1"}]
+    task._collect_period_investor_program_ranking.assert_not_called()
+    repo.get.assert_called_once_with("20260714", 5)
+
+
+async def test_get_or_collect_saves_complete_results_to_db():
+    repo = MagicMock()
+    repo.get.return_value = None
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], True)
+    )
+
+    results = await task._get_or_collect_period_ranking(("20260714", 5))
+
+    assert results == [{"a": "1"}]
+    repo.save.assert_called_once_with("20260714", 5, [{"a": "1"}])
+
+
+async def test_get_or_collect_skips_db_save_during_market_open():
+    repo = MagicMock()
+    repo.get.return_value = None
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=True))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], True)
+    )
+
+    await task._get_or_collect_period_ranking(("20260714", 5))
+
+    repo.save.assert_not_called()
+    # 기존 동작 유지: 메모리 캐시는 장중에도 채운다
+    assert task._period_ranking_cache[("20260714", 5)] == [{"a": "1"}]
+
+
+async def test_get_or_collect_does_not_save_incomplete_results():
+    repo = MagicMock()
+    repo.get.return_value = None
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], False)
+    )
+
+    await task._get_or_collect_period_ranking(("20260714", 5))
+
+    repo.save.assert_not_called()
+    assert ("20260714", 5) not in task._period_ranking_cache
+
+
+async def test_get_or_collect_db_error_falls_back_to_collect():
+    repo = MagicMock()
+    repo.get.side_effect = RuntimeError("db broken")
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], True)
+    )
+
+    results = await task._get_or_collect_period_ranking(("20260714", 5))
+
+    assert results == [{"a": "1"}]
+    task._collect_period_investor_program_ranking.assert_called_once()
+
+
+# ── _period_ranking_self_heal: 재시작 복구 ─────────────────────────
+
+
+async def test_self_heal_prewarms_when_cache_missing():
+    task = _make_task(mcs=_make_mcs(market_open=False, latest_date="20260714"))
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.prewarm_period_ranking.assert_awaited_once_with("20260714")
+
+
+async def test_self_heal_skips_when_market_open():
+    task = _make_task(mcs=_make_mcs(market_open=True))
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.prewarm_period_ranking.assert_not_called()
+
+
+async def test_self_heal_skips_when_memory_cache_exists():
+    task = _make_task(mcs=_make_mcs(market_open=False, latest_date="20260714"))
+    task._period_ranking_cache[("20260714", task.DEFAULT_PERIOD_RANKING_DAYS)] = []
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.prewarm_period_ranking.assert_not_called()
+
+
+async def test_self_heal_noop_without_mcs():
+    task = _make_task(mcs=None)
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.prewarm_period_ranking.assert_not_called()
+
+
+async def test_start_spawns_self_heal_task():
+    worker_pool = MagicMock()
+    task = _make_task(mcs=_make_mcs(market_open=False), worker_pool=worker_pool)
+    task._period_ranking_self_heal = AsyncMock()
+    try:
+        await task.start()
+        assert task._tasks, "start()가 self-heal 태스크를 스폰해야 한다"
+        # conftest가 asyncio.sleep을 패치하므로 스폰된 태스크를 직접 await 한다
+        await asyncio.gather(*task._tasks)
+        task._period_ranking_self_heal.assert_awaited_once()
+    finally:
+        await task.stop()

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
@@ -106,6 +106,68 @@ async def test_get_or_collect_db_error_falls_back_to_collect():
     task._collect_period_investor_program_ranking.assert_called_once()
 
 
+# ── 장중 수집 캐시 무효화 ──────────────────────────────────────────
+
+
+async def test_intraday_collection_marked_for_invalidation():
+    repo = MagicMock()
+    repo.get.return_value = None
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=True))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], True)
+    )
+
+    await task._get_or_collect_period_ranking(("20260714", 5))
+
+    assert ("20260714", 5) in task._period_ranking_intraday_keys
+    repo.save.assert_not_called()
+
+
+async def test_after_close_collection_not_marked_intraday():
+    task = _make_task(mcs=_make_mcs(market_open=False))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=([{"a": "1"}], True)
+    )
+
+    await task._get_or_collect_period_ranking(("20260714", 5))
+
+    assert ("20260714", 5) not in task._period_ranking_intraday_keys
+    assert task._period_ranking_cache[("20260714", 5)] == [{"a": "1"}]
+
+
+async def test_execute_invalidates_intraday_cache_and_reprewarms():
+    task = _make_task(mcs=_make_mcs(market_open=False))
+    task._period_ranking_cache[("20260714", 5)] = [{"a": "partial"}]
+    task._period_ranking_intraday_keys.add(("20260714", 5))
+    task._basic_last_collected_date = "20260714"
+    task._last_collected_date = "20260714"
+    task.refresh_basic_ranking = AsyncMock()
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task.execute({"date": "20260714"})
+
+    assert ("20260714", 5) not in task._period_ranking_cache
+    assert not task._period_ranking_intraday_keys
+    task.prewarm_period_ranking.assert_awaited_once_with("20260714")
+
+
+async def test_on_market_closed_invalidates_intraday_cache():
+    task = _make_task(mcs=_make_mcs(market_open=False))
+    task._period_ranking_cache[("20260714", 5)] = [{"a": "partial"}]
+    task._period_ranking_intraday_keys.add(("20260714", 5))
+    task._basic_last_collected_date = "20260714"
+    task._last_collected_date = "20260714"
+    task.refresh_basic_ranking = AsyncMock()
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._on_market_closed("20260714")
+
+    assert ("20260714", 5) not in task._period_ranking_cache
+    task.prewarm_period_ranking.assert_awaited_once_with("20260714")
+
+
 # ── get_period...: 비차단 온디맨드 수집 ────────────────────────────
 
 

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
@@ -106,6 +106,58 @@ async def test_get_or_collect_db_error_falls_back_to_collect():
     task._collect_period_investor_program_ranking.assert_called_once()
 
 
+# ── get_period...: 비차단 온디맨드 수집 ────────────────────────────
+
+
+async def test_get_period_returns_collecting_immediately_on_cache_miss():
+    task = _make_task(mcs=_make_mcs(market_open=False, latest_date="20260714"))
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=(
+            [{"hts_kor_isnm": "삼성전자", "combined_period_ntby_tr_pbmn_won": "100"}],
+            True,
+        )
+    )
+
+    resp = await task.get_period_investor_program_net_buy_ranking(days=5)
+
+    assert resp.rt_cd == "0"
+    assert resp.data == []
+    assert "수집 중" in resp.msg1
+    assert task._tasks, "백그라운드 수집 태스크가 스폰되어야 한다"
+
+    await asyncio.gather(*task._tasks)
+
+    resp2 = await task.get_period_investor_program_net_buy_ranking(days=5)
+    assert resp2.data[0]["hts_kor_isnm"] == "삼성전자"
+    task._collect_period_investor_program_ranking.assert_called_once()
+
+
+async def test_get_period_returns_db_data_without_collecting():
+    repo = MagicMock()
+    repo.get.return_value = [
+        {"hts_kor_isnm": "SK하이닉스", "combined_period_ntby_tr_pbmn_won": "920000000"}
+    ]
+    task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False, latest_date="20260714"))
+    task._collect_period_investor_program_ranking = AsyncMock()
+
+    resp = await task.get_period_investor_program_net_buy_ranking(days=5)
+
+    assert resp.rt_cd == "0"
+    assert resp.data[0]["hts_kor_isnm"] == "SK하이닉스"
+    task._collect_period_investor_program_ranking.assert_not_called()
+    assert not task._tasks
+
+
+async def test_trigger_period_collection_dedups_in_progress():
+    task = _make_task(mcs=_make_mcs())
+    key = ("20260714", 5)
+    task._period_ranking_tasks[key] = MagicMock()  # 수집 진행 중 시뮬레이션
+
+    task._trigger_period_ranking_collection(key)
+
+    assert not task._tasks, "진행 중이면 새 수집 태스크를 만들지 않는다"
+
+
 # ── _period_ranking_self_heal: 재시작 복구 ─────────────────────────
 
 

--- a/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_query_bootstrap.py
@@ -24,7 +24,8 @@ def test_query_bootstrap_builds_domestic_ranking_and_query_service():
     )
 
     with patch("view.web.bootstrap.query_bootstrap.RankingTask") as ranking, \
-         patch("view.web.bootstrap.query_bootstrap.StockQueryService") as query:
+         patch("view.web.bootstrap.query_bootstrap.StockQueryService") as query, \
+         patch("view.web.bootstrap.query_bootstrap.PeriodRankingRepository") as period_repo:
         QueryBootstrap(ctx, us_market_calendar_factory=MagicMock()).run(
             config={},
             is_overseas_us=False,
@@ -35,6 +36,8 @@ def test_query_bootstrap_builds_domestic_ranking_and_query_service():
     assert ctx.stock_query_service is query.return_value
     assert ctx.market_cap_gap_service is None
     assert ctx.ytd_ranking_report_task is None
+    _, kwargs = ranking.call_args
+    assert kwargs["period_ranking_repository"] is period_repo.return_value
 
 
 def test_query_bootstrap_builds_ytd_weekly_report_for_batch_mode():
@@ -49,6 +52,7 @@ def test_query_bootstrap_builds_ytd_weekly_report_for_batch_mode():
 
     with patch("view.web.bootstrap.query_bootstrap.RankingTask"), \
          patch("view.web.bootstrap.query_bootstrap.StockQueryService"), \
+         patch("view.web.bootstrap.query_bootstrap.PeriodRankingRepository"), \
          patch("view.web.bootstrap.query_bootstrap.MarketCapGapService"), \
          patch("view.web.bootstrap.query_bootstrap.MarketCapGapReportTask"), \
          patch("view.web.bootstrap.query_bootstrap.YtdRankingReportTask") as ytd_task, \

--- a/view/web/bootstrap/query_bootstrap.py
+++ b/view/web/bootstrap/query_bootstrap.py
@@ -3,6 +3,7 @@
 from typing import Any, TYPE_CHECKING
 
 from core.market_clock import MarketClock
+from repositories.period_ranking_repository import PeriodRankingRepository
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
 from services.market_cap_gap_service import MarketCapGapService
 from services.stock_query_service import StockQueryService
@@ -54,6 +55,7 @@ class QueryBootstrap:
                         "theme_classification_repository",
                         None,
                     ),
+                    period_ranking_repository=PeriodRankingRepository(),
                 )
                 self._build_market_cap_gap_tasks(config, needs_batch)
 

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -224,6 +224,16 @@ async function loadPeriodInvestorRanking() {
         }
 
         _rankingData = json.data || [];
+        if (_rankingData.length === 0 && (json.msg1 || '').includes('수집 중')) {
+            div.innerHTML = `<div class="card" style="text-align:center; padding:40px;">
+                <div class="loading-indicator" style="margin-bottom: 12px;"><span class="spinner"></span><span class="loading-text" style="font-size:1.2em;">기간수급 수집 중...</span></div>
+                <p style="color:#888; margin-top:8px;">전체 종목을 순회하여 기간 순매수를 집계하고 있습니다. 완료되면 자동 표시됩니다.</p>
+            </div>`;
+            _rankingPollTimer = setTimeout(() => {
+                if (_rankingCurrentCategory === 'investor_period') loadPeriodInvestorRanking();
+            }, 10000);
+            return;
+        }
         renderRankingTable();
     } catch (e) {
         if (e.name === 'AbortError') {


### PR DESCRIPTION
## 문제

랭킹 페이지의 기간수급이 background idle time에 갱신되지 않고, 탭을 선택해야 그때서야 수집이 시작되는 문제.

**원인 (2026-07-14 실로그로 확인)**
1. 기간수급 캐시(`_period_ranking_cache`)는 in-memory 전용 — 앱 재시작 시 소실
2. 예열 트리거는 TimeDispatcher `ranking_refresh` 티켓 1일 1회뿐인데, 발행일이 SQLite에 영속화되어 재시작 후 같은 거래일엔 재발행되지 않음 (`time_dispatcher.py` dedup)
3. 캐시가 빈 상태에서 기간수급 탭 선택 시 전 종목 수집(약 12분)이 HTTP 요청 안에서 동기 실행 → 프런트 타임아웃

실제 타임라인: 15:45 티켓 발행 → 16:10 예열 완료 → **21:31 재시작** → "마지막 발행 거래일 복원: 20260714"로 재발행 차단 → 캐시 공백.

## 변경

### 1차: DB 영속화 + 재시작 self-heal
- **`repositories/period_ranking_repository.py` 신규**: 기간수급 결과를 (거래일, days) 키로 SQLite(`data/period_ranking.db`)에 JSON 영속화. 조회는 항상 최신 거래일이므로 저장 시 이전 거래일 행 정리
- **`RankingTask._get_or_collect_period_ranking`**: 메모리 미스 → DB 복원 폴백 추가. 수집 완료 시 DB 저장 (장중 수집분은 당일 부분 데이터일 수 있어 저장 제외)
- **`RankingTask` 시작 시 self-heal**: 장 마감 후 & 당일 기본(5일) 캐시 없음 → 백그라운드 예열 재트리거 (DB에 있으면 예열 경로에서 즉시 복원)
- **`query_bootstrap`**: repository 주입

### 2차: 조회 비차단화
- **`get_period_investor_program_net_buy_ranking`**: 캐시·DB 미스 시 수집을 백그라운드 태스크로 트리거하고 "수집 중" 응답을 즉시 반환 (투자자 랭킹의 온디맨드 트리거 패턴과 통일). 진행 중 재요청은 새 수집을 만들지 않음
- **`ranking.js`**: "수집 중" 응답 시 스피너 안내 표시 + 10초 간격 자동 재조회 (탭 이탈 시 중단)

### 3차: 장중 수집 캐시 무효화
- 장중에 수집된 기간수급 캐시는 당일 부분 데이터인데, 마감 후 티켓의 `needs_period` 체크가 이를 완전본으로 오인해 예열을 건너뛰고 저녁 내내 부분 데이터가 표시되던 기존 문제 수정
- 장중 수집 완료분을 `_period_ranking_intraday_keys`로 표시하고, 장 마감 콜백(`execute`/`_on_market_closed`) 진입 시 무효화해 완전본 재수집 트리거

투자자 랭킹의 기존 "DB 조회 → 캐시 → 백그라운드 갱신 트리거" 패턴(NewHigh/Minervini)과 동일한 구조.

## 검증

- 신규 단위 테스트 22개 (repository round-trip / DB 폴백·저장·장중 제외 / self-heal 4분기 / start 스폰 / 비차단 계약 3종 / 장중 무효화 4종) + 기존 기간수급 테스트 5개를 비차단 계약으로 적응
- 전체 단위 테스트 6,854개 통과
- 통합 테스트 248개 통과
- ranking.js는 자동화 테스트 인프라 부재로 수동 검증 대상 (기존 jsdom 하네스는 /stock 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)