### PR TITLE
Separate domestic and US market views

### DIFF
--- a/tests/frontend/run_autocomplete_dom_tests.mjs
+++ b/tests/frontend/run_autocomplete_dom_tests.mjs
@@ -1,10 +1,10 @@
 /*
- * jsdom 기반 종목 자동완성(autocomplete.js + stock.js) 회귀 테스트.
+ * jsdom 기반 국내/미국장 종목 자동완성 회귀 테스트.
  *
  * 목적:
  *  1) autocomplete.js 일반화(valueKey/searchImpl/formatItem/item 전달)가 기존
  *     국내 자동완성 동작을 깨지 않는지 행위로 검증.
- *  2) 해외 심볼 자동완성: 심볼 prefix / 영문명 부분일치 매칭, 선택 시 거래소
+ *  2) 미국장 심볼 자동완성: 심볼 prefix / 영문명 부분일치 매칭, 선택 시 거래소
  *     드롭다운 자동설정 + 조회 트리거를 검증.
  *
  * 실행: node run_autocomplete_dom_tests.mjs  (exit 0 = 전부 통과)
@@ -16,19 +16,21 @@ import { test, assert, run } from "./harness.mjs";
 
 const AUTOCOMPLETE_JS = resolve(import.meta.dirname, "../../view/web/static/js/autocomplete.js");
 const STOCK_JS = resolve(import.meta.dirname, "../../view/web/static/js/stock.js");
+const OVERSEAS_AUTOCOMPLETE_JS = resolve(
+  import.meta.dirname,
+  "../../view/web/static/js/overseas_autocomplete.js",
+);
 
 const SCAFFOLD = `
 <div id="section-stock" class="section">
   <div class="card">
-    <button id="stock-mode-domestic" class="exchange-btn active">국내</button>
-    <button id="stock-mode-overseas" class="exchange-btn">해외</button>
     <div id="domestic-stock-row" style="position:relative;">
       <input id="stock-code-input" type="text">
       <ul id="stock-autocomplete-list"></ul>
     </div>
-    <div id="overseas-stock-row" style="display:none; position:relative;">
-      <input id="overseas-stock-symbol" type="text">
-      <select id="overseas-stock-exchange">
+    <div id="overseas-stock-row" style="position:relative;">
+      <input id="overseas-symbol" type="text">
+      <select id="overseas-exchange">
         <option value="NASD">NASDAQ</option>
         <option value="NYSE">NYSE</option>
         <option value="AMEX">AMEX</option>
@@ -55,7 +57,7 @@ async function makeWindow() {
   window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
   window.fetch = async () => ({ json: async () => ({ stocks: [] }) });
   window.loadAndRenderStockChart = () => {};
-  window.loadAndRenderOverseasStockChart = () => {};
+  window.loadOverseasQuote = () => {};
   window.formatTradingValue = () => "";
   window.alert = () => {};
   window.ALL_STOCKS = [];
@@ -67,6 +69,10 @@ async function makeWindow() {
   const s = window.document.createElement("script");
   s.textContent = readFileSync(STOCK_JS, "utf8");
   window.document.body.appendChild(s);
+
+  const o = window.document.createElement("script");
+  o.textContent = readFileSync(OVERSEAS_AUTOCOMPLETE_JS, "utf8");
+  window.document.body.appendChild(o);
 
   // JSDOM 은 DOMContentLoaded 를 비동기로 발사하므로, 자동완성 init(_initDom)이
   // 실행될 때까지 한 틱 대기한다.
@@ -118,7 +124,7 @@ test("해외 자동완성: 심볼 prefix 입력 시 드롭다운 렌더", async 
       { s: "LLY", n: "Eli Lilly and Co", e: "NYSE" },
     ],
   }));
-  typeInto(window, "overseas-stock-symbol", "AAP");
+  typeInto(window, "overseas-symbol", "AAP");
   const list = window.document.getElementById("overseas-autocomplete-list");
   assert(list.style.display === "block", "해외 드롭다운이 표시되지 않음");
   assert(list.querySelectorAll("li").length === 1, "해외 심볼 prefix 결과 수 불일치");
@@ -133,34 +139,34 @@ test("해외 자동완성: 영문명 부분일치(대소문자 무시) 매칭", 
       { s: "LLY", n: "Eli Lilly and Co", e: "NYSE" },
     ],
   }));
-  typeInto(window, "overseas-stock-symbol", "lilly");
+  typeInto(window, "overseas-symbol", "lilly");
   const list = window.document.getElementById("overseas-autocomplete-list");
   assert(list.querySelectorAll("li").length === 1, "영문명 부분일치 결과 수 불일치");
   assert(list.querySelector("li").textContent.startsWith("LLY"), "영문명 매칭 실패");
 });
 
-test("해외 자동완성: 선택 시 거래소 드롭다운 자동설정 + searchOverseasStock 호출", async () => {
+test("해외 자동완성: 선택 시 거래소 드롭다운 자동설정 + loadOverseasQuote 호출", async () => {
   const window = await makeWindow();
   window.document.dispatchEvent(new window.CustomEvent("all-overseas-stocks-ready", {
     detail: [{ s: "LLY", n: "Eli Lilly and Co", e: "NYSE" }],
   }));
   let searched = false;
-  window.searchOverseasStock = () => { searched = true; };
+  window.loadOverseasQuote = () => { searched = true; };
 
-  typeInto(window, "overseas-stock-symbol", "LLY");
+  typeInto(window, "overseas-symbol", "LLY");
   window.document.getElementById("overseas-autocomplete-list").querySelector("li").click();
 
-  assert(window.document.getElementById("overseas-stock-symbol").value === "LLY", "심볼 input 미설정");
-  assert(window.document.getElementById("overseas-stock-exchange").value === "NYSE",
+  assert(window.document.getElementById("overseas-symbol").value === "LLY", "심볼 input 미설정");
+  assert(window.document.getElementById("overseas-exchange").value === "NYSE",
     "회귀: 선택한 심볼의 거래소로 드롭다운이 자동설정되지 않음");
-  assert(searched === true, "선택 후 searchOverseasStock 미호출");
+  assert(searched === true, "선택 후 loadOverseasQuote 미호출");
 });
 
-test("해외 자동완성: 미선택 Enter 시 onConfirm(searchOverseasStock) 호출", async () => {
+test("해외 자동완성: 미선택 Enter 시 onConfirm(loadOverseasQuote) 호출", async () => {
   const window = await makeWindow();
   let searched = false;
-  window.searchOverseasStock = () => { searched = true; };
-  const input = window.document.getElementById("overseas-stock-symbol");
+  window.loadOverseasQuote = () => { searched = true; };
+  const input = window.document.getElementById("overseas-symbol");
   input.value = "TSLA";
   input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter" }));
   assert(searched === true, "미선택 Enter 시 직접 입력 조회가 트리거되지 않음");

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -1,12 +1,8 @@
 /*
  * jsdom 기반 /stock 화면 회귀 테스트.
  *
- * 목적: 해외(overseas) 기능이 기존 국내 경로를 깨는 런타임 DOM 회귀를
- * "함수 이름 문자열 존재" 수준이 아니라 실제 DOM 행위로 잡는다.
- *
- * 대표 회귀: 국내 조회 후 차트 카드(#stock-chart-card)는 #stock-result 안으로
- * 이동된다. 모드 토글/해외 조회가 #stock-result 를 비울 때 차트 카드를 먼저
- * 대피시키지 않으면 카드가 영구 파괴되어 이후 국내 차트가 깨진다.
+ * 목적: /stock 화면이 국내 전용 조회 경로를 유지하고 차트 렌더링이
+ * 정상 동작하는지 실제 DOM 행위로 검증한다.
  *
  * 실행: node run_stock_dom_tests.mjs  (exit 0 = 전부 통과)
  */
@@ -24,15 +20,9 @@ const STOCK_JS = process.env.STOCK_JS_PATH
 const SCAFFOLD = `
 <div id="section-stock" class="section">
   <div class="card">
-    <button id="stock-mode-domestic" class="exchange-btn active">국내</button>
-    <button id="stock-mode-overseas" class="exchange-btn">해외</button>
     <div id="domestic-stock-row">
       <input id="stock-code-input" type="text">
       <ul id="stock-autocomplete-list"></ul>
-    </div>
-    <div id="overseas-stock-row" style="display:none;">
-      <input id="overseas-stock-symbol" type="text">
-      <select id="overseas-stock-exchange"><option value="NASD">NASDAQ</option></select>
     </div>
   </div>
   <div id="stock-result"></div>
@@ -51,12 +41,10 @@ function makeWindow() {
   const { window } = dom;
   // stock.js 가 로드 시점에 호출/참조하는 전역 스텁
   window.StockAutocomplete = () => {};
-  window._overseasStockSearch = () => [];
   window.showLoading = (el, msg) => { if (el) el.innerHTML = `<p class="loading">${msg}</p>`; };
   window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
   window.fetch = async () => ({ json: async () => ({ stocks: [] }) });
   window.loadAndRenderStockChart = () => {};
-  window.loadAndRenderOverseasStockChart = () => {};
   window.formatTradingValue = () => "";
   window.ALL_STOCKS = [];
   window._matchMixed = () => false;
@@ -67,94 +55,17 @@ function makeWindow() {
   return window;
 }
 
-/* 국내 조회 직후 상태 재현: 차트 카드를 #stock-result 안(#chart-placeholder)으로 이동 */
-function simulateDomesticSearchRendered(window) {
-  const result = window.document.getElementById("stock-result");
-  result.innerHTML = '<div class="card stock-info-box"><div id="chart-placeholder"></div></div>';
-  const placeholder = window.document.getElementById("chart-placeholder");
-  placeholder.appendChild(window.document.getElementById("stock-chart-card"));
-}
-
-
-test("setStockMarketMode('overseas') 가 stock-result 안의 차트 카드를 파괴하지 않는다", async () => {
+test("stock.js는 해외 조회 진입점을 노출하지 않는다", async () => {
   const window = makeWindow();
-  simulateDomesticSearchRendered(window);
-  assert(window.document.getElementById("stock-chart-card"), "사전조건: 차트 카드 존재");
-
-  window.setStockMarketMode("overseas");
-
-  assert(window.document.getElementById("stock-chart-card"),
-    "회귀: 국내→해외 전환 시 차트 카드가 DOM에서 사라짐");
-  const card = window.document.getElementById("stock-chart-card");
-  assert(card.parentElement.id === "section-stock", "차트 카드는 section-stock 으로 대피되어야 함");
-  assert(window.document.getElementById("stock-result").innerHTML === "", "결과 영역은 비워져야 함");
-  assert(window.document.getElementById("overseas-stock-row").style.display !== "none", "해외 입력행이 보여야 함");
-  assert(window.document.getElementById("domestic-stock-row").style.display === "none", "국내 입력행은 숨겨져야 함");
+  assert(typeof window.setStockMarketMode === "undefined", "국내/해외 모드 토글이 남아 있음");
+  assert(typeof window.searchOverseasStock === "undefined", "해외 조회 함수가 남아 있음");
 });
 
-test("국내→해외→국내 왕복 후에도 차트 카드와 캔버스가 보존된다", async () => {
+test("국내 조회에 필요한 입력과 차트 DOM이 존재한다", async () => {
   const window = makeWindow();
-  simulateDomesticSearchRendered(window);
-  window.setStockMarketMode("overseas");
-  window.setStockMarketMode("domestic");
-  assert(window.document.getElementById("stock-chart-card"), "왕복 후 차트 카드 소실");
-  assert(window.document.getElementById("stockChart"), "왕복 후 차트 캔버스 소실");
-});
-
-test("searchOverseasStock 가 차트 카드를 보존하고 최소 view model 을 렌더한다", async () => {
-  const window = makeWindow();
-  simulateDomesticSearchRendered(window);
-  let chartCalledWith = null;
-  window.loadAndRenderOverseasStockChart = (symbol, exchange) => {
-    chartCalledWith = { symbol, exchange };
-  };
-  window.fetchWithTimeout = async (url) => {
-    if (url.includes("/api/market-mode")) {
-      return { ok: true, json: async () => ({ enabled_market_modes: ["domestic", "overseas_us"] }) };
-    }
-    if (url.includes("/api/overseas/stock/")) {
-      return { ok: true, json: async () => ({
-        rt_cd: "0",
-        data: { symbol: "AAPL", exchange: "NASD", currency: "USD", price: 190.5, change_rate: 1.23, volume: 1000, timestamp: "20260614" },
-      }) };
-    }
-    return { ok: false, json: async () => ({}) };
-  };
-  window.document.getElementById("overseas-stock-symbol").value = "aapl";
-
-  await window.searchOverseasStock();
-
-  assert(window.document.getElementById("stock-chart-card"), "회귀: 해외 조회가 차트 카드를 파괴함");
-  const html = window.document.getElementById("stock-result").innerHTML;
-  assert(html.includes("AAPL"), "심볼 표시 누락");
-  assert(html.includes("NASDAQ"), "거래소 표시명 누락");
-  assert(html.includes("$190.50"), "가격(USD) 표시 누락");
-  assert(chartCalledWith && chartCalledWith.symbol === "AAPL" && chartCalledWith.exchange === "NASD",
-    "해외 조회 성공 후 해외 차트 로더가 호출되어야 함");
-  // 해외 렌더는 국내 전용 SSE 타깃 id 를 만들면 안 된다(틱 핸들러 오작동 방지)
-  assert(!html.includes('id="rt-price"'), "해외 렌더가 국내 전용 rt-price id 를 생성함");
-});
-
-test("overseas_us 미enabled 시 searchOverseasStock 가 fail-close 하고 시세 API 를 호출하지 않는다", async () => {
-  const window = makeWindow();
-  let priceCalled = false;
-  window.fetchWithTimeout = async (url) => {
-    if (url.includes("/api/market-mode")) {
-      return { ok: true, json: async () => ({ enabled_market_modes: ["domestic"] }) };
-    }
-    if (url.includes("/api/overseas/stock/")) {
-      priceCalled = true;
-      return { ok: true, json: async () => ({ rt_cd: "0", data: {} }) };
-    }
-    return { ok: false, json: async () => ({}) };
-  };
-  window.document.getElementById("overseas-stock-symbol").value = "AAPL";
-
-  await window.searchOverseasStock();
-
-  assert(priceCalled === false, "fail-close 인데 해외 시세 API 가 호출됨");
-  const html = window.document.getElementById("stock-result").innerHTML;
-  assert(html.includes("overseas_us"), "fail-close 메시지 누락");
+  assert(window.document.getElementById("stock-code-input"), "국내 종목 입력 누락");
+  assert(window.document.getElementById("stock-chart-card"), "차트 카드 누락");
+  assert(window.document.getElementById("stockChart"), "차트 캔버스 누락");
 });
 
 await run();

--- a/tests/integration_test/view/web/static/js/test_it_js_static_files.py
+++ b/tests/integration_test/view/web/static/js/test_it_js_static_files.py
@@ -18,3 +18,12 @@ def test_real_web_app_serves_all_static_js_files():
         assert response.status_code == 200
         assert response.text.strip()
         assert "javascript" in response.headers["content-type"]
+
+
+def test_pjax_updates_market_navigation_and_view_context():
+    source = (JS_ROOT / "common.js").read_text(encoding="utf-8")
+
+    assert "nav.market-nav a" in source
+    assert "data-view-market" in source
+    assert "newMarketNav" in source
+    assert "newFeatureNav" in source

--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -85,3 +85,56 @@ def test_rendered_pages_reference_served_static_assets(web_client_with_fake_ctx)
 
             assert asset.status_code == 200, f"{page_path} references missing asset: {static_path}"
             assert asset.content
+
+
+@pytest.mark.parametrize(
+    ("page_path", "expected_market"),
+    [
+        ("/stock", "domestic"),
+        ("/favorite", "domestic"),
+        ("/balance", "domestic"),
+        ("/order", "domestic"),
+        ("/overseas", "overseas_us"),
+        ("/virtual", "common"),
+        ("/system", "common"),
+    ],
+)
+def test_rendered_pages_expose_view_market_context(
+    web_client_with_fake_ctx,
+    page_path,
+    expected_market,
+):
+    page = web_client_with_fake_ctx.get(page_path)
+
+    assert page.status_code == 200
+    assert f'data-view-market="{expected_market}"' in page.text
+
+
+def test_navigation_separates_domestic_overseas_and_common_areas(web_client_with_fake_ctx):
+    page = web_client_with_fake_ctx.get("/stock")
+
+    assert page.status_code == 200
+    assert 'data-nav-market="domestic"' in page.text
+    assert 'data-nav-market="overseas_us"' in page.text
+    assert 'data-nav-market="common"' in page.text
+    assert '>한국장<' in page.text
+    assert '>미국장<' in page.text
+
+
+def test_stock_page_is_domestic_only(web_client_with_fake_ctx):
+    page = web_client_with_fake_ctx.get("/stock")
+
+    assert page.status_code == 200
+    assert 'id="stock-market-label"' in page.text
+    assert 'id="stock-mode-overseas"' not in page.text
+    assert 'id="overseas-stock-row"' not in page.text
+    assert "searchOverseasStock" not in page.text
+
+
+def test_home_groups_market_and_common_entry_points(web_client_with_fake_ctx):
+    page = web_client_with_fake_ctx.get("/")
+
+    assert page.status_code == 200
+    assert 'data-home-market="domestic"' in page.text
+    assert 'data-home-market="overseas_us"' in page.text
+    assert 'data-home-market="common"' in page.text

--- a/tests/unit_test/view/web/test_stock_js_contracts.py
+++ b/tests/unit_test/view/web/test_stock_js_contracts.py
@@ -1,61 +1,30 @@
-"""stock.js 소스 계약(회귀 잠금) — 해외 기능이 국내 차트 경로를 깨지 않도록 강제.
+"""한국장과 미국장 화면의 프런트엔드 소유 경계를 잠그는 정적 계약 테스트."""
 
-런타임 DOM 행위는 tests/integration_test/.../test_it_stock_js_dom_regression.py(jsdom)가
-검증한다. 본 모듈은 node toolchain 없이도 항상 도는 in-gate 정적 계약으로,
-"차트 카드 대피가 stock-result 비우기보다 먼저 온다"는 핵심 순서를 잠근다.
-"""
 from pathlib import Path
 
-import pytest
 
-_STOCK_JS = Path("view/web/static/js/stock.js")
+def test_stock_js_is_domestic_only():
+    stock_js = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
 
-
-@pytest.fixture(scope="module")
-def stock_js() -> str:
-    return _STOCK_JS.read_text(encoding="utf-8")
-
-
-def _function_body(src: str, name: str) -> str:
-    """`function name(` 부터 다음 top-level `\\nfunction ` 직전까지를 반환(근사)."""
-    start = src.index(f"function {name}(")
-    rest = src[start + 1:]
-    nxt = rest.find("\nfunction ")
-    return rest if nxt == -1 else rest[:nxt]
+    assert "setStockMarketMode" not in stock_js
+    assert "searchOverseasStock" not in stock_js
+    assert "/api/overseas/" not in stock_js
 
 
-def test_detach_helper_defined(stock_js):
-    assert "function _detachStockChartCard(" in stock_js
+def test_overseas_autocomplete_owns_symbol_lookup():
+    autocomplete_js = Path(
+        "view/web/static/js/overseas_autocomplete.js"
+    ).read_text(encoding="utf-8")
+
+    assert "/api/overseas/stocks/list" in autocomplete_js
+    assert "overseas-symbol" in autocomplete_js
+    assert "overseas-exchange" in autocomplete_js
+    assert "loadOverseasQuote" in autocomplete_js
 
 
-def test_set_market_mode_detaches_chart_before_clearing_result(stock_js):
-    """회귀 잠금: setStockMarketMode 는 stock-result 를 비우기 전에 차트 카드를 대피해야 한다.
+def test_overseas_template_loads_dedicated_autocomplete():
+    template = Path("view/web/templates/overseas.html").read_text(encoding="utf-8")
 
-    순서가 뒤바뀌면 stock-result 안으로 이동돼 있던 차트 카드가 innerHTML 초기화로 파괴된다.
-    """
-    body = _function_body(stock_js, "setStockMarketMode")
-    detach_at = body.find("_detachStockChartCard()")
-    clear_at = body.find("innerHTML = ''")
-    assert detach_at != -1, "setStockMarketMode 가 _detachStockChartCard 를 호출하지 않음"
-    assert clear_at != -1, "setStockMarketMode 가 stock-result 를 비우지 않음"
-    assert detach_at < clear_at, "차트 카드 대피가 stock-result 비우기보다 먼저 와야 함"
-
-
-def test_search_overseas_detaches_chart_before_overwriting_result(stock_js):
-    """회귀 잠금: searchOverseasStock 도 결과를 덮어쓰기(showLoading) 전에 차트 카드를 대피."""
-    body = _function_body(stock_js, "searchOverseasStock")
-    detach_at = body.find("_detachStockChartCard()")
-    loading_at = body.find("showLoading(")
-    assert detach_at != -1, "searchOverseasStock 가 _detachStockChartCard 를 호출하지 않음"
-    assert loading_at != -1, "searchOverseasStock 가 showLoading 으로 결과를 덮어쓰지 않음"
-    assert detach_at < loading_at, "차트 카드 대피가 결과 덮어쓰기보다 먼저 와야 함"
-
-
-def test_overseas_render_does_not_reuse_domestic_sse_ids(stock_js):
-    """해외 렌더는 국내 전용 SSE 타깃 id(rt-price/rt-change-rate/rt-high/rt-low)를 만들면 안 된다.
-
-    재사용 시 stock-price-tick 핸들러가 해외 결과 DOM 을 국내 틱으로 덮어쓸 수 있다.
-    """
-    body = _function_body(stock_js, "searchOverseasStock")
-    for forbidden in ('id="rt-price"', 'id="rt-change-rate"', 'id="rt-high"', 'id="rt-low"'):
-        assert forbidden not in body, f"해외 렌더가 국내 전용 {forbidden} 를 생성함"
+    assert 'id="overseas-autocomplete-list"' in template
+    assert "/static/js/autocomplete.js" in template
+    assert "/static/js/overseas_autocomplete.js" in template

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -37,12 +37,10 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert "Investment" in response.text
         elif path == "/stock":
             assert "종목 현재가 조회" in response.text
-            # V2.1: 국내/해외 조회 모드 토글 + 해외 ticker 입력
-            assert 'id="stock-mode-domestic"' in response.text
-            assert 'id="stock-mode-overseas"' in response.text
-            assert 'id="overseas-stock-symbol"' in response.text
-            assert 'id="overseas-stock-exchange"' in response.text
-            assert 'value="NASD"' in response.text
+            assert 'id="stock-market-label"' in response.text
+            assert 'id="stock-code-input"' in response.text
+            assert 'id="stock-mode-overseas"' not in response.text
+            assert 'id="overseas-stock-row"' not in response.text
         elif path == "/balance":
             assert "계좌 잔고" in response.text
         elif path == "/order":
@@ -95,14 +93,13 @@ def test_virtual_static_js_exposes_divergence_workflow():
     assert "slippage_pct" in script
 
 
-def test_stock_static_js_exposes_overseas_mode():
-    """stock.js가 /stock 화면에서 해외 모드 조회를 fail-close와 함께 지원해야 한다."""
+def test_stock_static_js_does_not_expose_overseas_mode():
+    """stock.js는 한국장 전용이며 미국장 조회는 overseas.js가 소유한다."""
     script = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
 
-    assert "setStockMarketMode" in script
-    assert "searchOverseasStock" in script
-    assert "/api/overseas/stock/" in script
-    assert "/api/market-mode" in script
+    assert "setStockMarketMode" not in script
+    assert "searchOverseasStock" not in script
+    assert "/api/overseas/" not in script
 
 
 def test_overseas_static_js_exposes_manual_workflow():

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -151,12 +151,83 @@ body {
 .badge.ks-tripped { background: #f38ba8; color: #1e1e2e; cursor: pointer; animation: ks-pulse 1.2s ease-in-out infinite; }
 @keyframes ks-pulse { 0%,100% { opacity:1; } 50% { opacity:0.55; } }
 
-/* Navigation */
+/* Market navigation */
+.market-nav {
+    display: flex;
+    gap: 6px;
+    padding: 8px 24px 0;
+    background: var(--bg-secondary);
+    overflow-x: auto;
+}
+
+.market-nav a {
+    color: var(--text-secondary);
+    padding: 8px 18px;
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    text-decoration: none;
+    white-space: nowrap;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.market-nav a:hover { color: var(--text-primary); }
+.market-nav a.active {
+    color: var(--accent);
+    background: var(--bg-primary);
+    border-color: var(--accent);
+}
+
+/* Feature navigation */
 .nav {
     display: flex;
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
+}
+
+.page-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+}
+
+.market-context-badge {
+    padding: 5px 10px;
+    border-radius: 12px;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.market-context-badge.domestic {
+    color: #fff;
+    background: #2980b9;
+}
+
+@media (max-width: 640px) {
+    .header {
+        align-items: flex-start;
+        gap: 10px;
+        padding: 10px 14px;
+    }
+
+    .status-bar {
+        gap: 6px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+
+    .market-nav {
+        padding-left: 14px;
+        padding-right: 14px;
+    }
+
+    .nav button, .nav a {
+        padding: 10px 14px;
+    }
 }
 
 .nav button, .nav a {

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -201,10 +201,20 @@ async function navigatePjax(href) {
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, 'text/html');
         const newMain = doc.querySelector('#page-main');
-        if (!newMain) throw new Error('page-main not found');
+        const newMarketNav = doc.querySelector('nav.market-nav');
+        const newFeatureNav = doc.querySelector('nav.nav');
+        if (!newMain || !newMarketNav || !newFeatureNav) {
+            throw new Error('page layout not found');
+        }
 
         const pageMain = document.querySelector('#page-main');
         pageMain.innerHTML = newMain.innerHTML;
+        document.querySelector('nav.market-nav').replaceWith(newMarketNav.cloneNode(true));
+        document.querySelector('nav.nav').replaceWith(newFeatureNav.cloneNode(true));
+        document.body.setAttribute(
+            'data-view-market',
+            doc.body.getAttribute('data-view-market') || 'common',
+        );
 
         await loadHeadScripts(doc);
         await executePageScripts(pageMain);
@@ -231,7 +241,7 @@ async function navigatePjax(href) {
 
 // 네비게이션 클릭 가로채기
 document.addEventListener('click', (e) => {
-    const link = e.target.closest('nav.nav a');
+    const link = e.target.closest('nav.nav a, nav.market-nav a');
     if (!link) return;
     const href = link.getAttribute('href');
     if (!href || href === '#') return;

--- a/view/web/static/js/overseas_autocomplete.js
+++ b/view/web/static/js/overseas_autocomplete.js
@@ -1,0 +1,64 @@
+/* view/web/static/js/overseas_autocomplete.js — 미국장 심볼 자동완성 */
+
+window.ALL_OVERSEAS_STOCKS = (function () {
+    try {
+        const cached = localStorage.getItem('all_overseas_stocks_v1');
+        if (cached) return JSON.parse(cached);
+    } catch (_) {}
+    return null;
+})();
+
+let _overseasStocksLoading = false;
+
+function _ensureOverseasStocksLoaded() {
+    if (window.ALL_OVERSEAS_STOCKS || _overseasStocksLoading) return;
+    _overseasStocksLoading = true;
+    fetch('/api/overseas/stocks/list')
+        .then(response => response.json())
+        .then(json => {
+            window.ALL_OVERSEAS_STOCKS = json.stocks || [];
+            try {
+                localStorage.setItem(
+                    'all_overseas_stocks_v1',
+                    JSON.stringify(window.ALL_OVERSEAS_STOCKS),
+                );
+            } catch (_) {}
+            document.dispatchEvent(new CustomEvent(
+                'all-overseas-stocks-ready',
+                { detail: window.ALL_OVERSEAS_STOCKS },
+            ));
+        })
+        .catch(() => { window.ALL_OVERSEAS_STOCKS = []; })
+        .finally(() => { _overseasStocksLoading = false; });
+}
+
+function initOverseasAutocomplete() {
+    if (typeof StockAutocomplete !== 'function') return;
+
+    StockAutocomplete({
+        inputId: 'overseas-symbol',
+        listId: 'overseas-autocomplete-list',
+        valueKey: 's',
+        readyEvent: 'all-overseas-stocks-ready',
+        getInitial: () => window.ALL_OVERSEAS_STOCKS || null,
+        searchImpl: _overseasStockSearch,
+        formatItem: stock => `${stock.s} — ${stock.n} (${stock.e})`,
+        onSelect: (symbol, _name, stock) => {
+            const input = document.getElementById('overseas-symbol');
+            const exchange = document.getElementById('overseas-exchange');
+            if (input) input.value = symbol;
+            if (exchange && stock && stock.e) exchange.value = stock.e;
+            if (typeof loadOverseasQuote === 'function') loadOverseasQuote();
+        },
+        onConfirm: () => {
+            if (typeof loadOverseasQuote === 'function') loadOverseasQuote();
+        },
+    });
+    _ensureOverseasStocksLoaded();
+}
+
+initOverseasAutocomplete();
+
+document.addEventListener('pjax:ready', event => {
+    if (event.detail?.path === '/overseas') initOverseasAutocomplete();
+});

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -3,31 +3,6 @@
 let _currentExchange = 'KRX';
 let _currentStockCode = null;
 
-/* 해외 심볼 리스트: localStorage 즉시 복원, 없으면 해외 모드 진입 시 지연 로드.
- * 국내(ALL_STOCKS)와 달리 대부분의 방문자가 국내만 쓰므로 ~7천 심볼을
- * 매 방문마다 받지 않도록 lazy 로드한다. */
-window.ALL_OVERSEAS_STOCKS = (function () {
-    try {
-        var cached = localStorage.getItem('all_overseas_stocks_v1');
-        if (cached) return JSON.parse(cached);
-    } catch (e) {}
-    return null;
-})();
-let _overseasStocksLoading = false;
-function _ensureOverseasStocksLoaded() {
-    if (window.ALL_OVERSEAS_STOCKS || _overseasStocksLoading) return;
-    _overseasStocksLoading = true;
-    fetch('/api/overseas/stocks/list')
-        .then(function (r) { return r.json(); })
-        .then(function (json) {
-            window.ALL_OVERSEAS_STOCKS = json.stocks || [];
-            try { localStorage.setItem('all_overseas_stocks_v1', JSON.stringify(window.ALL_OVERSEAS_STOCKS)); } catch (e) {}
-            document.dispatchEvent(new CustomEvent('all-overseas-stocks-ready', { detail: window.ALL_OVERSEAS_STOCKS }));
-        })
-        .catch(function () { window.ALL_OVERSEAS_STOCKS = []; })
-        .finally(function () { _overseasStocksLoading = false; });
-}
-
 // SSE 실시간 틱 수신 → 가격·전일대비·당일시세(고가·저가) UI 업데이트
 document.addEventListener('stock-price-tick', function (e) {
     const tick = e.detail;
@@ -56,160 +31,6 @@ document.addEventListener('stock-price-tick', function (e) {
     if (lowEl  && tick.low  > 0) lowEl.textContent  = fmt(tick.low);
 });
 
-/* ── 국내/해외 조회 모드 토글 (V2.1) ── */
-
-/* 차트 카드를 stock-result 밖(section-stock)으로 대피시키고 숨긴다.
- * searchStock가 차트 카드를 stock-result 안으로 옮기므로, stock-result를
- * 비우기 전에 먼저 대피시키지 않으면 innerHTML 초기화 시 카드가 파괴된다. */
-function _detachStockChartCard() {
-    const chartCard = document.getElementById('stock-chart-card');
-    const sectionStock = document.getElementById('section-stock');
-    if (chartCard && sectionStock && chartCard.parentElement !== sectionStock) {
-        sectionStock.appendChild(chartCard);
-    }
-    if (chartCard) chartCard.style.display = 'none';
-}
-
-function setStockMarketMode(mode) {
-    const domesticRow = document.getElementById('domestic-stock-row');
-    const overseasRow = document.getElementById('overseas-stock-row');
-    const domesticBtn = document.getElementById('stock-mode-domestic');
-    const overseasBtn = document.getElementById('stock-mode-overseas');
-    const isOverseas = mode === 'overseas';
-
-    if (domesticRow) domesticRow.style.display = isOverseas ? 'none' : '';
-    if (overseasRow) overseasRow.style.display = isOverseas ? '' : 'none';
-    if (domesticBtn) domesticBtn.classList.toggle('active', !isOverseas);
-    if (overseasBtn) overseasBtn.classList.toggle('active', isOverseas);
-
-    // 해외 모드 진입 시 자동완성용 심볼 리스트를 지연 로드한다.
-    if (isOverseas) _ensureOverseasStocksLoaded();
-
-    // 모드 전환 시 결과/차트 영역 초기화 (국내↔해외 잔여 UI 방지)
-    // 차트 카드를 먼저 대피시킨 뒤 결과를 비운다.
-    _detachStockChartCard();
-    const resultDiv = document.getElementById('stock-result');
-    if (resultDiv) resultDiv.innerHTML = '';
-}
-
-/* overseas_us가 enabled된 run에서만 해외 조회 허용 (fail-close) */
-async function _ensureOverseasEnabledForStock() {
-    try {
-        const res = await fetchWithTimeout('/api/market-mode', {}, 5000);
-        if (!res.ok) return false;
-        const json = await res.json();
-        return Array.isArray(json.enabled_market_modes) && json.enabled_market_modes.includes('overseas_us');
-    } catch (_) {
-        return false;
-    }
-}
-
-function _overseasExchangeLabel(exchange) {
-    return ({ NASD: 'NASDAQ', NYSE: 'NYSE', AMEX: 'AMEX' })[exchange] || exchange || '-';
-}
-
-function _formatOverseasTimestamp(value) {
-    const text = String(value || '').trim();
-    if (/^\d{8}$/.test(text)) {
-        return `${text.substring(0, 4)}-${text.substring(4, 6)}-${text.substring(6, 8)}`;
-    }
-    return text || '-';
-}
-
-async function searchOverseasStock() {
-    const symbolInput = document.getElementById('overseas-stock-symbol');
-    const exchangeSel = document.getElementById('overseas-stock-exchange');
-    const symbol = symbolInput ? symbolInput.value.trim().toUpperCase() : '';
-    const exchange = exchangeSel ? exchangeSel.value : 'NASD';
-    const resultDiv = document.getElementById('stock-result');
-    if (!symbol) {
-        alert('심볼을 입력하세요.');
-        return;
-    }
-    if (symbolInput) symbolInput.value = symbol;
-    if (!resultDiv) return;
-
-    // 해외 모드는 국내 실시간 구독을 끊고 차트 카드를 대피시킨 뒤 다시 배치한다.
-    if (typeof unsubscribeRealtimePrice === 'function') {
-        unsubscribeRealtimePrice();
-    }
-    _detachStockChartCard();
-
-    showLoading(resultDiv, '해외 종목 조회 중...');
-    try {
-        const enabled = await _ensureOverseasEnabledForStock();
-        if (!enabled) {
-            resultDiv.innerHTML = '<p class="error">해외주식 조회는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.</p>';
-            return;
-        }
-        const res = await fetchWithTimeout(`/api/overseas/stock/${encodeURIComponent(symbol)}?exchange=${exchange}`, {}, 20000);
-        const json = await res.json();
-        if (!res.ok || json.rt_cd !== '0') {
-            resultDiv.innerHTML = `<p class="error">조회 실패: ${json.msg1 || res.status}</p>`;
-            return;
-        }
-        const data = json.data || {};
-        const rate = Number(data.change_rate || 0);
-        const rateClass = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
-        const exchangeLabel = _overseasExchangeLabel(data.exchange || exchange);
-        const usd = (v) => {
-            const n = Number(v);
-            return Number.isFinite(n) ? '$' + n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
-        };
-        const num = (v) => {
-            const n = Number(String(v ?? '').replace(/,/g, ''));
-            return Number.isFinite(n) ? n.toLocaleString() : '-';
-        };
-        resultDiv.innerHTML = `
-            <div class="card stock-info-box" style="position: relative;">
-                <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
-                    <h3 class="stock-title" style="margin:0;">
-                        ${data.symbol || symbol}
-                        <span style="color:#aaa;font-size:0.85rem;">${exchangeLabel} ${data.currency || 'USD'}</span>
-                    </h3>
-                    <span class="badge" style="background:var(--bg-primary,#f5f5f5); border:1px solid var(--border,#ccc); border-radius:8px; padding:8px 10px; font-weight:bold;">
-                        해외
-                    </span>
-                </div>
-                <p class="price ${rateClass}">${usd(data.price)}</p>
-                <p class="change-rate">등락률: <span class="${rateClass}">${Number.isFinite(rate) ? (rate > 0 ? '+' : '') + rate.toFixed(2) + '%' : '-'}</span></p>
-                <div id="chart-placeholder" style="margin: 16px 0;"></div>
-                <div class="stock-details">
-                    <div class="detail-group">
-                        <h4>기본 정보</h4>
-                        <p><strong>거래소:</strong> <span>${exchangeLabel}</span></p>
-                        <p><strong>통화:</strong> <span>${data.currency || 'USD'}</span></p>
-                    </div>
-                    <div class="detail-group">
-                        <h4>시세</h4>
-                        <p><strong>현재가:</strong> <span>${usd(data.price)}</span></p>
-                        <p><strong>등락률:</strong> <span class="${rateClass}">${Number.isFinite(rate) ? (rate > 0 ? '+' : '') + rate.toFixed(2) + '%' : '-'}</span></p>
-                    </div>
-                    <div class="detail-group">
-                        <h4>거래</h4>
-                        <p><strong>거래량:</strong> <span>${num(data.volume)}</span></p>
-                        <p><strong>시각:</strong> <span>${_formatOverseasTimestamp(data.timestamp)}</span></p>
-                    </div>
-                </div>
-            </div>
-        `;
-        const chartCard = document.getElementById('stock-chart-card');
-        const placeholder = document.getElementById('chart-placeholder');
-        if (chartCard && placeholder) {
-            placeholder.appendChild(chartCard);
-        }
-        if (typeof loadAndRenderOverseasStockChart === 'function') {
-            loadAndRenderOverseasStockChart(data.symbol || symbol, data.exchange || exchange);
-        }
-    } catch (e) {
-        if (e.name === 'AbortError') {
-            resultDiv.innerHTML = `<p class="error">해외주식 조회 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.</p>`;
-        } else {
-            resultDiv.innerHTML = `<p class="error">통신 오류: ${e.message || e}</p>`;
-        }
-    }
-}
-
 function changeExchange(exchange, btn) {
     if (_currentExchange === exchange) return;
     _currentExchange = exchange;
@@ -235,28 +56,6 @@ StockAutocomplete({
     onConfirm: function() { searchStock(); }
 });
 
-/* ── 해외 심볼 자동완성 (심볼 prefix + 영문명 매칭, 선택 시 거래소 자동설정) ── */
-function _initOverseasAutocomplete() {
-    StockAutocomplete({
-        inputId: 'overseas-stock-symbol',
-        listId: 'overseas-autocomplete-list',
-        valueKey: 's',
-        readyEvent: 'all-overseas-stocks-ready',
-        getInitial: function () { return window.ALL_OVERSEAS_STOCKS || null; },
-        searchImpl: _overseasStockSearch,
-        formatItem: function (s) { return s.s + ' — ' + s.n + ' (' + s.e + ')'; },
-        onSelect: function (symbol, name, item) {
-            const input = document.getElementById('overseas-stock-symbol');
-            if (input) input.value = symbol;
-            const sel = document.getElementById('overseas-stock-exchange');
-            if (sel && item && item.e) sel.value = item.e;
-            searchOverseasStock();
-        },
-        onConfirm: function () { searchOverseasStock(); }
-    });
-}
-_initOverseasAutocomplete();
-
 /* ── Pjax 재방문 시 자동완성 재초기화 ── */
 document.addEventListener('pjax:ready', (e) => {
     if (e.detail?.path !== '/stock') return;
@@ -270,13 +69,11 @@ document.addEventListener('pjax:ready', (e) => {
         },
         onConfirm: function() { searchStock(); }
     });
-    _initOverseasAutocomplete();
-
-        const urlParams = new URLSearchParams(window.location.search);
-        const code = urlParams.get('code');
-        if (code) {
-            searchStock(code);
-        }
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+    if (code) {
+        searchStock(code);
+    }
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=10">
+    <link rel="stylesheet" href="/static/css/style.css?v=11">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }
@@ -48,9 +48,9 @@
     {% block head_scripts %}
     <!-- 차트 라이브러리는 필요한 페이지에서만 로드 -->
     {% endblock %}
-    <script src="/static/js/common.js?v=9"></script>
+    <script src="/static/js/common.js?v=10"></script>
 </head>
-<body>
+<body data-view-market="{{ view_market|default('common') }}">
 
 <header class="header">
     <h1>Investment</h1>
@@ -73,21 +73,30 @@
     </div>
 </header>
 
-<nav class="nav">
-    <!-- Flask에서 active_page 변수를 넘겨주어 활성화 클래스 적용 -->
-    <a href="/" class="{% if active_page == 'home' %}active{% endif %}">홈</a>
-    <a href="/stock" class="{% if active_page == 'stock' %}active{% endif %}">현재가 조회</a>
-    <a href="/favorite" class="{% if active_page == 'favorite' %}active{% endif %}">즐겨찾기</a>
-    <a href="/balance" class="{% if active_page == 'balance' %}active{% endif %}">계좌 잔고</a>
-    <a href="/order" class="{% if active_page == 'order' %}active{% endif %}">매수/매도</a>
-    <a href="/overseas" class="{% if active_page == 'overseas' %}active{% endif %}">미국주식</a>
-    <a href="/ranking" class="{% if active_page == 'ranking' %}active{% endif %}">랭킹</a>
-    <a href="/marketcap" class="{% if active_page == 'marketcap' %}active{% endif %}">시가총액</a>
-    <a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>
-    <a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>
-    <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>
-    <a href="/program" class="{% if active_page == 'program' %}active{% endif %}">프로그램매매</a>
-    <a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>
+<nav class="market-nav" aria-label="시장 선택">
+    <a href="/stock" data-nav-market="domestic" class="{% if view_market == 'domestic' %}active{% endif %}">한국장</a>
+    <a href="/overseas" data-nav-market="overseas_us" class="{% if view_market == 'overseas_us' %}active{% endif %}">미국장</a>
+    <a href="/" data-nav-market="common" class="{% if view_market == 'common' %}active{% endif %}">공통</a>
+</nav>
+
+<nav class="nav" aria-label="기능 메뉴">
+    {% if view_market == 'domestic' %}
+        <a href="/stock" class="{% if active_page == 'stock' %}active{% endif %}">현재가</a>
+        <a href="/favorite" class="{% if active_page == 'favorite' %}active{% endif %}">즐겨찾기</a>
+        <a href="/balance" class="{% if active_page == 'balance' %}active{% endif %}">계좌 잔고</a>
+        <a href="/order" class="{% if active_page == 'order' %}active{% endif %}">매수/매도</a>
+        <a href="/ranking" class="{% if active_page == 'ranking' %}active{% endif %}">랭킹</a>
+        <a href="/marketcap" class="{% if active_page == 'marketcap' %}active{% endif %}">시가총액</a>
+        <a href="/program" class="{% if active_page == 'program' %}active{% endif %}">프로그램매매</a>
+    {% elif view_market == 'overseas_us' %}
+        <a href="/overseas" class="{% if active_page == 'overseas' %}active{% endif %}">미국장 개요·거래</a>
+    {% else %}
+        <a href="/" class="{% if active_page == 'home' %}active{% endif %}">홈</a>
+        <a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>
+        <a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>
+        <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>
+        <a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>
+    {% endif %}
 </nav>
 
 <main class="main" id="page-main">

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -10,12 +10,18 @@
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
             border-color: var(--accent, #4a90e2);
         }
+        .home-menu-group { margin-top: 28px; text-align: left; }
+        .home-menu-group h3 { margin-bottom: 12px; }
+        .home-menu-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
     </style>
     <div class="section">
         <div class="card" style="text-align: center; padding: 48px 24px;">
             <h2 style="margin-bottom: 12px;">Investment</h2>
             <p style="color: var(--text-secondary); margin-bottom: 32px;">한국투자증권 Open API 기반 주식 자동매매 시스템</p>
-            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; max-width: 800px; margin: 0 auto;">
+            <div style="max-width: 900px; margin: 0 auto;">
+            <section class="home-menu-group" data-home-market="domestic">
+                <h3>한국장</h3>
+                <div class="home-menu-grid">
                 <a href="/stock" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">📈</div>
                     <div style="font-weight: 600;">현재가 조회</div>
@@ -36,6 +42,30 @@
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">🏆</div>
                     <div style="font-weight: 600;">랭킹</div>
                 </a>
+                <a href="/marketcap" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
+                    <div style="font-size: 1.5rem; margin-bottom: 8px;">🏢</div>
+                    <div style="font-weight: 600;">시가총액</div>
+                </a>
+                <a href="/program" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
+                    <div style="font-size: 1.5rem; margin-bottom: 8px;">🖥️</div>
+                    <div style="font-weight: 600;">프로그램매매</div>
+                </a>
+                </div>
+            </section>
+
+            <section class="home-menu-group" data-home-market="overseas_us">
+                <h3>미국장</h3>
+                <div class="home-menu-grid">
+                <a href="/overseas" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
+                    <div style="font-size: 1.5rem; margin-bottom: 8px;">🇺🇸</div>
+                    <div style="font-weight: 600;">시세·보유·주문</div>
+                </a>
+                </div>
+            </section>
+
+            <section class="home-menu-group" data-home-market="common">
+                <h3>공통</h3>
+                <div class="home-menu-grid">
                 <a href="/virtual" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">📊</div>
                     <div style="font-weight: 600;">모의투자 기록</div>
@@ -44,14 +74,16 @@
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">⏰</div>
                     <div style="font-weight: 600;">전략 스케줄러</div>
                 </a>
-                <a href="/program" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
-                    <div style="font-size: 1.5rem; margin-bottom: 8px;">🖥️</div>
-                    <div style="font-weight: 600;">프로그램매매</div>
+                <a href="/strategy-reports" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
+                    <div style="font-size: 1.5rem; margin-bottom: 8px;">📝</div>
+                    <div style="font-weight: 600;">상세 리포트</div>
                 </a>
                 <a href="/system" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">⚙️</div>
                     <div style="font-weight: 600;">시스템 상태</div>
                 </a>
+                </div>
+            </section>
             </div>
         </div>
     </div>

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -15,7 +15,7 @@
 
     <div class="card overseas-header">
         <div>
-            <h2>미국주식</h2>
+            <h2>미국장</h2>
             <p class="overseas-status">NASDAQ · NYSE · AMEX / USD 지정가 주문 지원</p>
             <p id="overseas-status" class="overseas-status">해외주식 기능 상태를 확인 중입니다.</p>
         </div>
@@ -29,9 +29,10 @@
     <section id="overseas-panel-overview" class="overseas-panel">
         <div class="card">
             <h2>시세 조회</h2>
-            <div class="form-row">
+            <div class="form-row" style="position:relative;">
                 <label>심볼</label>
                 <input type="text" id="overseas-symbol" placeholder="AAPL" maxlength="12" autocomplete="off">
+                <ul id="overseas-autocomplete-list" class="autocomplete-list"></ul>
             </div>
             <div class="form-row">
                 <label>거래소</label>
@@ -111,5 +112,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="/static/js/autocomplete.js?v=2"></script>
+<script src="/static/js/overseas_autocomplete.js?v=1"></script>
 <script src="/static/js/overseas.js?v=5"></script>
 {% endblock %}

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -8,33 +8,17 @@
 {% endblock %}
 
 {% block content %}
-    <style>
-        .stock-mode-toggle .exchange-btn { padding: 4px 14px; font-size: 13px; background: var(--bg-primary, #f5f5f5); border: 1px solid var(--border, #ccc); color: var(--text-secondary, #555); border-radius: 4px; cursor: pointer; }
-        .stock-mode-toggle .exchange-btn.active { background: var(--accent, #4a90e2); color: #fff; border-color: var(--accent, #4a90e2); font-weight: bold; }
-    </style>
     <div id="section-stock" class="section">
         <div class="card">
-            <h2>종목 현재가 조회</h2>
-            <div class="stock-mode-toggle" style="display:flex; gap:4px; margin-bottom:10px;">
-                <button type="button" id="stock-mode-domestic" class="exchange-btn active" onclick="setStockMarketMode('domestic')">국내</button>
-                <button type="button" id="stock-mode-overseas" class="exchange-btn" onclick="setStockMarketMode('overseas')">해외</button>
+            <div class="page-title-row">
+                <h2>종목 현재가 조회</h2>
+                <span id="stock-market-label" class="market-context-badge domestic">한국장</span>
             </div>
             <div id="domestic-stock-row" class="form-row" style="position: relative;">
                 <label>종목코드/종목명</label>
                 <input type="text" id="stock-code-input" placeholder="예: 005930 / 삼성전자 / ㅅㅅㅈㅈ / 삼성ㅈㅈ" autocomplete="off">
                 <button class="btn" onclick="searchStock()">조회</button>
                 <ul id="stock-autocomplete-list" class="autocomplete-list"></ul>
-            </div>
-            <div id="overseas-stock-row" class="form-row" style="display:none; position: relative;">
-                <label>심볼/종목명</label>
-                <input type="text" id="overseas-stock-symbol" placeholder="예: AAPL / Apple" maxlength="40" autocomplete="off">
-                <select id="overseas-stock-exchange">
-                    <option value="NASD">NASDAQ</option>
-                    <option value="NYSE">NYSE</option>
-                    <option value="AMEX">AMEX</option>
-                </select>
-                <button class="btn" onclick="searchOverseasStock()">조회</button>
-                <ul id="overseas-autocomplete-list" class="autocomplete-list"></ul>
             </div>
         </div>
         <div id="stock-result"></div>
@@ -71,7 +55,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/stock.js?v=13"></script>
+<script src="/static/js/stock.js?v=14"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -263,7 +263,13 @@ app.include_router(operator_dashboard_router, prefix="/api")
 page_router = APIRouter()
 
 # 공통 페이지 렌더링 함수 (로그인 체크 포함)
-async def render_page(request: Request, template_name: str, active_page: str, extra_context: dict = None):
+async def render_page(
+    request: Request,
+    template_name: str,
+    active_page: str,
+    extra_context: dict = None,
+    view_market: str = "common",
+):
     try:
         ctx = web_api._get_ctx()
     except Exception:
@@ -278,7 +284,7 @@ async def render_page(request: Request, template_name: str, active_page: str, ex
         if not token or token != expected_token:
             return templates.TemplateResponse(request, "login.html")
 
-    context = {"active_page": active_page}
+    context = {"active_page": active_page, "view_market": view_market}
     if extra_context:
         context.update(extra_context)
     return templates.TemplateResponse(request, template_name, context)
@@ -291,7 +297,7 @@ async def index(request: Request):
 @page_router.get("/stock")
 async def stock(request: Request):
     # 종목 리스트는 클라이언트에서 /api/stocks/list + localStorage로 관리
-    return await render_page(request, "stock.html", "stock")
+    return await render_page(request, "stock.html", "stock", view_market="domestic")
 
 @page_router.get("/balance")
 async def balance(request: Request):
@@ -317,23 +323,29 @@ async def balance(request: Request):
     except Exception:
         pass
     extra = {"initial_data": initial_data} if initial_data else None
-    return await render_page(request, "balance.html", "balance", extra_context=extra)
+    return await render_page(
+        request,
+        "balance.html",
+        "balance",
+        extra_context=extra,
+        view_market="domestic",
+    )
 
 @page_router.get("/order")
 async def order(request: Request):
-    return await render_page(request, "order.html", "order")
+    return await render_page(request, "order.html", "order", view_market="domestic")
 
 @page_router.get("/overseas")
 async def overseas(request: Request):
-    return await render_page(request, "overseas.html", "overseas")
+    return await render_page(request, "overseas.html", "overseas", view_market="overseas_us")
 
 @page_router.get("/ranking")
 async def ranking(request: Request):
-    return await render_page(request, "ranking.html", "ranking")
+    return await render_page(request, "ranking.html", "ranking", view_market="domestic")
 
 @page_router.get("/marketcap")
 async def marketcap(request: Request):
-    return await render_page(request, "marketcap.html", "marketcap")
+    return await render_page(request, "marketcap.html", "marketcap", view_market="domestic")
 
 @page_router.get("/virtual")
 async def virtual(request: Request):
@@ -345,7 +357,7 @@ async def scheduler(request: Request):
 
 @page_router.get("/program")
 async def program(request: Request):
-    return await render_page(request, "program.html", "program")
+    return await render_page(request, "program.html", "program", view_market="domestic")
 
 @page_router.get("/system")
 async def system(request: Request):
@@ -353,7 +365,7 @@ async def system(request: Request):
 
 @page_router.get("/favorite")
 async def favorite(request: Request):
-    return await render_page(request, "favorite.html", "favorite")
+    return await render_page(request, "favorite.html", "favorite", view_market="domestic")
 
 @page_router.get("/operator")
 async def operator_dashboard(request: Request):


### PR DESCRIPTION
## 변경 내용

- 상단 내비게이션을 한국장, 미국장, 공통 영역으로 분리했습니다.
- 각 페이지에 `view_market` 컨텍스트를 부여하고 PJAX 이동에서도 시장 메뉴와 컨텍스트가 함께 갱신되도록 했습니다.
- `/stock`을 한국장 전용 화면으로 단순화하고 중복된 미국 종목 조회 코드를 제거했습니다.
- 미국 종목 자동완성을 `/overseas` 허브로 이전했습니다.
- 홈 진입점을 한국장, 미국장, 공통 기능별로 그룹화했습니다.

## 배경 및 영향

기존 화면에서는 국내 기능과 미국 기능이 동일한 내비게이션에 섞여 있었고, 미국 현재가 조회가 `/stock`과 `/overseas`에 중복되어 현재 시장 컨텍스트를 파악하기 어려웠습니다. 이번 변경으로 조회와 거래 기능의 시장 소유 경계가 명확해지고, 기존 미국장 API 및 주문 흐름은 그대로 유지됩니다.

## 검증

- `npm --prefix tests/frontend test`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -q` — 6,854 passed
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -q` — 259 passed
- 관련 화면 계약 및 정적 자산 테스트 — 23 passed
- `git diff --check`
