### PR TITLE
기간수급 UI 개선 — 선택 상태 표시 + 기준일 라벨

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -617,7 +617,7 @@ class RankingTask(AfterMarketTask):
 
         sort_field = "combined_period_ntby_tr_pbmn_won" if metric == "amount" else "combined_period_ntby_qty"
         ranked_results = [
-            dict(item, period_metric=metric)
+            dict(item, period_metric=metric, latest_trading_date=str(target_date))
             for item in results
             if self._to_int(item.get(sort_field)) > 0
         ]

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -331,6 +331,7 @@ async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_se
     assert all(item["hts_kor_isnm"] != "NAVER" for item in resp.data)
     assert resp.data[0]["industry"] == "IT"
     assert resp.data[1]["industry"] == "반도체"
+    assert all(item["latest_trading_date"] == "20250101" for item in resp.data)
 
 
 @pytest.mark.asyncio

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -674,6 +674,13 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     opacity: 1;
 }
 
+/* 기간수급 기간(일수)/지표 선택 - 비선택 상태를 더 어둡게 */
+.period-days:not(.active), .period-metric:not(.active) {
+    opacity: 0.45;
+    background: var(--bg-secondary, #2a2a3e) !important;
+    color: var(--text-muted, #666) !important;
+}
+
 /* 시장 필터 */
 .market-filter {
     padding: 5px 12px !important;

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -795,9 +795,19 @@ function renderRankingTable() {
         </tr>`;
     });
 
-    div.innerHTML = `${_renderRankingAIAnalysisPanel(data.length)}<div class="card"><table class="data-table">
+    const periodLabel = isPeriodInvestor ? _renderPeriodRankingLabel(data) : '';
+
+    div.innerHTML = `${periodLabel}${_renderRankingAIAnalysisPanel(data.length)}<div class="card"><table class="data-table">
         <thead><tr>${headerRow}</tr></thead>
         <tbody>${rows}</tbody></table></div>`;
+}
+
+function _renderPeriodRankingLabel(data) {
+    const raw = data[0] && data[0].latest_trading_date;
+    const dateLabel = raw && raw.length === 8
+        ? ` (~ ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)})`
+        : '';
+    return `<p style="color:#888; margin: 4px 0 12px;">최근 ${_rankingPeriodDays}거래일 기준${dateLabel}</p>`;
 }
 
 function sortRanking(key) {


### PR DESCRIPTION
## 문제

기간수급 랭킹 화면에서 두 가지 UX 이슈:
1. 5D/1D/3D/10D/20D, 금액/수량 버튼이 전부 같은 색으로 보여 현재 선택 상태를 구분할 수 없음
2. 표에 표시된 데이터가 어느 기준일 기준 N거래일인지 알 수 없음

(스크린샷 확인)

## 변경

### 1차: 선택 버튼 활성 상태 표시
`.ranking-tab`, `.investor-toggle`, `.market-filter`는 비활성 상태를 흐리게 처리하는 CSS 규칙이 있는데, `.period-days`/`.period-metric`은 이 그룹에 빠져 있어 `button.btn` 기본 스타일(항상 진한 강조색)만 적용되던 문제. JS의 `.active` 토글은 정상 동작 중이라 CSS만 보완 (`.investor-toggle:not(.active)`와 동일 패턴).

### 2차: 조회 기준일 라벨 추가
버튼 상태만으로는 정확한 기준일을 알 수 없어, 표 상단에 "최근 N거래일 기준 (~ YYYY-MM-DD)" 라벨 추가.
- `RankingTask.get_period_investor_program_net_buy_ranking`: 각 결과 항목에 `latest_trading_date` 필드 추가
- `ranking.js`: `investor_period` 카테고리 렌더링 시 라벨 삽입

## 검증

- 백엔드 필드 추가는 TDD로 진행 (실패 테스트 확인 후 구현)
- 전체 단위 테스트 6,864개 통과
- 통합 테스트 259개 통과
- CSS/JS 시각 변경은 자동 회귀 테스트 인프라 없음(ranking.js/style.css 대상 테스트 부재) — 수동 확인 대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)