### PR TITLE
YTD 상승률 탭 분리 및 코스피/코스닥 필터 추가

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -502,8 +502,11 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository daily_prices 전종목 조회 실패: {e}")
             return []
 
-    async def get_ytd_return_ranking(self, limit: int = 100) -> List[Dict]:
-        """최신 거래일과 해당 연도 첫 스냅샷의 종가를 비교한 YTD 수익률 랭킹."""
+    async def get_ytd_return_ranking(self, limit: int = 100, market: Optional[str] = None) -> List[Dict]:
+        """최신 거래일과 해당 연도 첫 스냅샷의 종가를 비교한 YTD 수익률 랭킹.
+
+        market: "KOSPI"/"KOSDAQ" 지정 시 해당 시장으로 필터링, None/"ALL"이면 전체.
+        """
         try:
             async with self._get_read_connection() as conn:
                 async with conn.execute("SELECT MAX(trade_date) FROM daily_prices") as cursor:
@@ -522,8 +525,15 @@ class StockOhlcvRepository:
                 if not base_date:
                     return []
 
+                market_filter = ""
+                params = [base_date, latest_date]
+                if market and market != "ALL":
+                    market_filter = "AND latest.market = ?"
+                    params.append(market)
+                params.append(limit)
+
                 async with conn.execute(
-                    """
+                    f"""
                     SELECT latest.*, base.current_price AS base_price
                     FROM daily_prices AS latest
                     JOIN daily_prices AS base
@@ -531,10 +541,11 @@ class StockOhlcvRepository:
                     WHERE latest.trade_date = ?
                       AND latest.current_price > 0
                       AND base.current_price > 0
+                      {market_filter}
                     ORDER BY ((CAST(latest.current_price AS REAL) / base.current_price) - 1.0) DESC
                     LIMIT ?
                     """,
-                    (base_date, latest_date, limit),
+                    params,
                 ) as cursor:
                     rows = await cursor.fetchall()
 

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -102,9 +102,9 @@ class StockRepository:
         """특정 거래일의 전체 종목 스냅샷을 시가총액 내림차순으로 조회."""
         return await self._ohlcv_repo.get_all_daily_snapshots(trade_date)
 
-    async def get_ytd_return_ranking(self, limit: int = 100) -> List[Dict]:
+    async def get_ytd_return_ranking(self, limit: int = 100, market: Optional[str] = None) -> List[Dict]:
         """최신 거래일 기준 YTD 수익률 랭킹 조회."""
-        return await self._ohlcv_repo.get_ytd_return_ranking(limit=limit)
+        return await self._ohlcv_repo.get_ytd_return_ranking(limit=limit, market=market)
 
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
         """is_newhigh 및 is_historical_newhigh 컬럼 업데이트."""

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -29,6 +29,7 @@ def _make_snapshot(
     mang_issu_cls_code=None,
     mrkt_warn_cls_code=None,
     invt_caful_yn=None,
+    market="KOSPI",
 ):
     return {
         "code": code,
@@ -49,7 +50,7 @@ def _make_snapshot(
         "eps": None,
         "w52_high": None,
         "w52_low": None,
-        "market": "KOSPI",
+        "market": market,
         "iscd_stat_cls_code": iscd_stat_cls_code,
         "mang_issu_cls_code": mang_issu_cls_code,
         "mrkt_warn_cls_code": mrkt_warn_cls_code,
@@ -495,6 +496,21 @@ class TestGetYtdReturnRanking:
     @pytest.mark.asyncio
     async def test_returns_empty_without_snapshots(self, repo):
         assert await repo.get_ytd_return_ranking() == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_market(self, repo):
+        await repo.upsert_daily_snapshot("20260102", [
+            _make_snapshot("A001", price=100, market="KOSPI"),
+            _make_snapshot("A002", price=100, market="KOSDAQ"),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [
+            _make_snapshot("A001", price=150, market="KOSPI"),
+            _make_snapshot("A002", price=200, market="KOSDAQ"),
+        ])
+
+        result = await repo.get_ytd_return_ranking(limit=10, market="KOSDAQ")
+
+        assert [row["code"] for row in result] == ["A002"]
 
 
 # ── get_price_history ────────────────────────────────────────────────────────

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -165,7 +165,18 @@ async def test_get_ytd_ranking(web_client, mock_web_ctx):
     body = response.json()
     assert body["rt_cd"] == "0"
     assert body["data"][0]["ytd_return_rate"] == 50.0
-    mock_web_ctx.stock_repository.get_ytd_return_ranking.assert_awaited_once_with(limit=30)
+    mock_web_ctx.stock_repository.get_ytd_return_ranking.assert_awaited_once_with(limit=30, market=None)
+
+
+@pytest.mark.asyncio
+async def test_get_ytd_ranking_with_market_filter(web_client, mock_web_ctx):
+    """GET /api/ranking/ytd?market=KOSPI 는 market 필터를 그대로 저장소에 전달한다."""
+    mock_web_ctx.stock_repository.get_ytd_return_ranking = AsyncMock(return_value=[])
+
+    response = web_client.get("/api/ranking/ytd?limit=30&market=KOSPI")
+
+    assert response.status_code == 200
+    mock_web_ctx.stock_repository.get_ytd_return_ranking.assert_awaited_once_with(limit=30, market="KOSPI")
 
 
 @pytest.mark.asyncio

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -1,7 +1,7 @@
 """
 랭킹/시가총액 관련 API 엔드포인트 (ranking.html, marketcap.html).
 """
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -177,14 +177,14 @@ async def get_period_investor_program_ranking(
 
 
 @router.get("/ranking/ytd")
-async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500)):
+async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500), market: Optional[str] = Query(None)):
     """저장된 일별 스냅샷으로 연초 대비 수익률 랭킹을 반환한다."""
     ctx = _get_ctx()
     repository = getattr(ctx, "stock_repository", None)
     if not repository:
         return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "StockRepository 미설정", "data": []}
 
-    data = await repository.get_ytd_return_ranking(limit=limit)
+    data = await repository.get_ytd_return_ranking(limit=limit, market=market)
     return {
         "rt_cd": ErrorCode.SUCCESS.value,
         "msg1": "YTD 상승률 랭킹 조회 성공" if data else "YTD 비교 데이터가 없습니다.",

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -18,6 +18,7 @@ const _investorTypeFields = {
 };
 
 let _rankingMarketFilter = 'ALL';
+let _rankingYtdMarket = 'ALL';
 
 function setMarketFilter(market, btn) {
     _rankingMarketFilter = market;
@@ -27,6 +28,14 @@ function setMarketFilter(market, btn) {
     if (_rankingCurrentCategory === 'investor_period') loadPeriodInvestorRanking();
     else if (_rankingDirection) loadInvestorRanking();
     else if (_rankingCurrentCategory) loadRanking(_rankingCurrentCategory);
+}
+
+function setYtdMarketFilter(market) {
+    _rankingYtdMarket = market;
+    document.querySelectorAll('.ytd-market-toggle').forEach(b => {
+        b.classList.toggle('active', b.dataset.ytdMarket === market);
+    });
+    loadRanking('ytd');
 }
 
 function _resetRankingAIAnalysis() {
@@ -71,6 +80,8 @@ async function loadRanking(category) {
     if (invRow) invRow.style.display = 'none';
     const periodRow = document.getElementById('period-investor-row');
     if (periodRow) periodRow.style.display = 'none';
+    const ytdMarketRow = document.getElementById('ytd-market-row');
+    if (ytdMarketRow) ytdMarketRow.style.display = category === 'ytd' ? '' : 'none';
 
     const div = document.getElementById('ranking-result');
     _showRankingSkeleton();
@@ -81,6 +92,8 @@ async function loadRanking(category) {
             res = await fetchWithTimeout(`/api/ranking/minervini_stage2`);
         } else if (category === 'newhigh') {
             res = await fetchWithTimeout(`/api/ranking/newhigh`);
+        } else if (category === 'ytd') {
+            res = await fetchWithTimeout(`/api/ranking/ytd?market=${_rankingYtdMarket}`);
         } else {
             res = await fetchWithTimeout(`/api/ranking/${category}`);
         }

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -13,7 +13,6 @@
             </div>
             <div class="form-row">
                 <button class="btn ranking-tab active" data-cat="rise" onclick="loadRanking('rise')">상승률</button>
-                <button class="btn ranking-tab" data-cat="ytd" onclick="loadRanking('ytd')">YTD 상승률</button>
                 <button class="btn ranking-tab" data-cat="fall" onclick="loadRanking('fall')">하락률</button>
                 <button class="btn ranking-tab" data-cat="volume" onclick="loadRanking('volume')">거래량</button>
                 <button class="btn ranking-tab" data-cat="trading_value" onclick="loadRanking('trading_value')">거래대금</button>
@@ -21,6 +20,14 @@
                 <button class="btn ranking-tab" data-cat="newhigh" onclick="loadRanking('newhigh')">신고가</button>
                 <button class="btn ranking-tab" data-cat="theme_leaders" onclick="loadThemeLeaders()">지금 테마</button>
                 <button class="btn ranking-tab" data-cat="investor_period" onclick="loadPeriodInvestorRanking()">기간수급</button>
+            </div>
+            <div class="form-row" style="margin-top: 6px;">
+                <button class="btn ranking-tab" data-cat="ytd" onclick="loadRanking('ytd')">YTD 상승률</button>
+                <div id="ytd-market-row" style="display: none; margin-left: 8px; padding-left: 12px; border-left: 2px solid var(--accent-secondary, #3b82f6);">
+                    <button class="btn ytd-market-toggle active" data-ytd-market="ALL" onclick="setYtdMarketFilter('ALL')">전체</button>
+                    <button class="btn ytd-market-toggle" data-ytd-market="KOSPI" onclick="setYtdMarketFilter('KOSPI')">코스피</button>
+                    <button class="btn ytd-market-toggle" data-ytd-market="KOSDAQ" onclick="setYtdMarketFilter('KOSDAQ')">코스닥</button>
+                </div>
             </div>
             <div class="ranking-investor-group" style="margin-top: 6px;">
                 <div class="form-row" style="margin-bottom: 0;">
@@ -52,7 +59,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=7"></script>
+<script src="/static/js/ranking.js?v=8"></script>
 <script>
     loadRanking('rise');
 </script>


### PR DESCRIPTION
## Summary
- 랭킹 화면의 "YTD 상승률" 탭을 첫 번째 행에서 별도의 두 번째 행으로 이동
- YTD 상승률 조회에 전체/코스피/코스닥 필터 토글 추가 (`daily_prices.market` 컬럼 기준)
- `/api/ranking/ytd`에 `market` 쿼리 파라미터 추가, 저장소 계층까지 전달

## Test plan
- [x] `pytest tests/unit_test -v` (6866 passed)
- [x] `pytest tests/integration_test -v` (259 passed)
- [ ] 실제 브라우저에서 KOSPI/KOSDAQ 토글 동작 육안 확인 (실전 브로커 자격증명 초기화 위험으로 이번 세션에서는 로컬 서버를 직접 띄우지 않음 — 배포 전 확인 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)