### PR TITLE
통합 테스트 상태와 저장소 수명주기 격리

### DIFF
--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -27,6 +27,26 @@ def fast_sleep(mocker):
     mocker.patch("asyncio.sleep", new_callable=AsyncMock)
     mocker.patch("core.retry_queue.api_request_queue.asyncio.sleep", new_callable=AsyncMock)
 
+
+@pytest.fixture(autouse=True)
+def isolate_program_trading_db(mocker, tmp_path):
+    """통합 테스트가 운영 프로그램매매 DB를 읽거나 누적하지 않도록 격리한다."""
+    base_dir = tmp_path / "program_subscribe"
+    mocker.patch(
+        "services.program_trading_stream_service.ProgramTradingStreamService._get_base_dir",
+        return_value=str(base_dir),
+    )
+
+
+@pytest.fixture(autouse=True)
+async def flush_strategy_state_io_tasks():
+    """테스트 이벤트 루프가 닫히기 전에 전략 상태 저장 태스크를 완료한다."""
+    from utils.strategy_state_io import StrategyStateIO
+
+    yield
+
+    await StrategyStateIO.flush_pending(timeout=5.0)
+
 @pytest.fixture(scope="session")
 def test_cache_config():
     test_base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".cache"))
@@ -628,10 +648,13 @@ async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
 
         # TestClient에 연결
         api_common.set_ctx(web_ctx)
-        with TestClient(web_app) as client:
-            web_ctx._test_client = client
-            yield web_ctx
-        api_common.set_ctx(None)
+        try:
+            with TestClient(web_app) as client:
+                web_ctx._test_client = client
+                yield web_ctx
+        finally:
+            api_common.set_ctx(None)
+            await web_ctx.shutdown()
 
 
 def _unwrap_client_from_ctx(web_ctx):

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -13,6 +13,9 @@ from typing import Any, Dict, Iterable, Optional
 from tests.integration_test import ctx  # ← 방금 만든 모듈
 
 
+_test_log_cleanup_done = False
+
+
 @pytest.fixture(autouse=True)
 def patch_cache_wrap_client_for_tests(mocker):
     # 캐시를 바이패스하여 NoneType 에러 원천 차단
@@ -40,11 +43,21 @@ def isolate_program_trading_db(mocker, tmp_path):
 
 @pytest.fixture(autouse=True)
 async def flush_strategy_state_io_tasks():
-    """테스트 이벤트 루프가 닫히기 전에 전략 상태 저장 태스크를 완료한다."""
+    """테스트 이벤트 루프가 닫히기 전에 전략 상태 I/O 태스크를 완료한다."""
+    import asyncio
     from utils.strategy_state_io import StrategyStateIO
 
     yield
 
+    state_load_tasks = [
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task()
+        and not task.done()
+        and getattr(task.get_coro(), "__name__", "") == "_load_state_async"
+    ]
+    if state_load_tasks:
+        await asyncio.gather(*state_load_tasks, return_exceptions=True)
     await StrategyStateIO.flush_pending(timeout=5.0)
 
 @pytest.fixture(scope="session")
@@ -94,11 +107,18 @@ def clear_cache_files(test_cache_config):
         shutil.rmtree(base_dir, onerror=on_rm_error)
 
 @pytest.fixture(scope="function")
-def test_logger(request):
+def test_logger(request, mocker):
+    global _test_log_cleanup_done
+
     # 📌 현재 conftest.py 기준 ./log 경로 생성
     log_dir = os.path.join(os.path.dirname(__file__), "log")
     os.makedirs(log_dir, exist_ok=True)
+    if _test_log_cleanup_done:
+        # 보존기간 정리는 worker 최초 Logger 생성에서 한 번만 수행한다.
+        # 매 테스트마다 전체 로그 트리를 다시 stat하면 fixture setup 병목이 된다.
+        mocker.patch.object(Logger, "_cleanup_old_logs", return_value=None)
     logger = Logger(log_dir=log_dir)
+    _test_log_cleanup_done = True
 
     # 실행되는 테스트 케이스 이름 로깅
     tc_name = request.node.name

--- a/tests/integration_test/strategies/test_it_api_larry_williams_channel_breakout_strategy.py
+++ b/tests/integration_test/strategies/test_it_api_larry_williams_channel_breakout_strategy.py
@@ -406,13 +406,14 @@ async def test_check_exits_no_position_state_no_exit(strategy, mock_sqs):
 # ─── state persistence ────────────────────────────────────────────────────────
 
 @pytest.fixture(autouse=True)
-def _reset_strategy_state_io():
+async def _reset_strategy_state_io():
     """StrategyStateIO class-level lock/pending 상태는 event loop 사이 leak 발생.
     각 테스트 전후 reset 으로 분리.
     """
     from utils.strategy_state_io import StrategyStateIO
     StrategyStateIO._reset_for_test()
     yield
+    await StrategyStateIO.flush_pending(timeout=5.0)
     StrategyStateIO._reset_for_test()
 
 

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -957,6 +957,23 @@ async def test_shutdown_cancels_pending_refresh_tasks_and_stops_broker(mock_deps
 
 
 @pytest.mark.asyncio
+async def test_shutdown_closes_program_trading_service_and_stock_repository(mock_deps):
+    """shutdown은 컨텍스트가 소유한 DB 저장소와 스트림 서비스를 닫는다."""
+    ctx = WebAppContext(None)
+    ctx.background_scheduler = None
+    ctx.broker = None
+    ctx.program_trading_stream_service = MagicMock()
+    ctx.program_trading_stream_service.shutdown = AsyncMock()
+    ctx.stock_repository = MagicMock()
+    ctx.stock_repository.close = AsyncMock()
+
+    await ctx.shutdown()
+
+    ctx.program_trading_stream_service.shutdown.assert_awaited_once()
+    ctx.stock_repository.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_shutdown_cancels_price_subscription_init_task(mock_deps):
     """shutdown은 초기 가격 구독 task도 취소해 pending task를 남기지 않는다."""
     ctx = WebAppContext(None)

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -432,8 +432,12 @@ class WebAppContext:
         self._price_subscription_init_task = None
         if self.background_scheduler:
             await self.background_scheduler.shutdown()
+        if self.program_trading_stream_service:
+            await self.program_trading_stream_service.shutdown()
         if self.broker:
             await self.broker.stop()
+        if self.stock_repository:
+            await self.stock_repository.close()
         self.logger.info("웹 앱: 서비스 종료 완료")
 
     # --- 프로그램매매 실시간 스트리밍 ---


### PR DESCRIPTION
## 변경 내용

- 통합 테스트의 프로그램매매 SQLite DB를 테스트별 임시 디렉터리로 격리했습니다.
- 테스트 이벤트 루프 종료 전에 전략 state load/save 태스크를 완료합니다.
- `deep_paper_ctx` teardown에서 `WebAppContext.shutdown()`을 보장합니다.
- 웹 컨텍스트 종료 시 `ProgramTradingStreamService`와 `StockRepository`를 명시적으로 닫습니다.
- 통합 테스트 로그 보존기간 정리를 worker 최초 한 번만 수행합니다.

## 원인

통합 테스트가 운영 `data/program_subscribe` DB를 공유해 금일 히스토리 50,348건을 반복 로드했고, 일부 비동기 state I/O 태스크와 SQLite 연결이 teardown 이후까지 남았습니다. 또한 각 테스트의 `Logger` 생성 때마다 전체 로그 트리에서 약 30,000회의 파일 `stat`을 반복해 fixture setup 병목이 발생했습니다.

## 영향

운영 데이터와 통합 테스트가 분리되고, 웹 애플리케이션 및 테스트 종료 시 소유 자원이 정리됩니다. 대표 반복 fixture setup은 평균 약 5.00초에서 1.97초로 60.6% 감소했습니다. 전체 통합 스위트는 실행 편차를 포함해 기존 164.37초에서 119.96~133.72초로 18.6~27.0% 단축됐습니다.

## 검증

- `pytest tests/unit_test -v` — 6,867개 수집, 종료 코드 0
- `pytest tests/integration_test -v` — 259 passed in 119.96s
- `pytest tests/integration_test -q` — 259 passed in 133.72s
- 최신 로그: 50,348건 운영 DB 복구 0건
- 최신 로그: pending task 0건
- 최신 로그: StockRepository/StockOhlcvRepository 미종료 경고 0건
