### PR TITLE
CI Hang 자동 종료 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,15 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+concurrency:
+  group: python-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     
     # 🔐 README 수정 및 Pages 배포를 위해 모든 쓰기 권한을 활성화합니다.
     permissions:


### PR DESCRIPTION
## 변경 내용

- 동일 PR/브랜치에서 새 CI가 시작되면 이전 실행을 자동 취소합니다.
- `build-and-test` job에 20분 timeout을 적용합니다.

## 원인

이전 PR 커밋의 `Run tests with coverage` 단계가 종료되지 않았고, workflow에 timeout과 concurrency 제어가 없어 후속 커밋의 성공 여부와 무관하게 실행 상태로 남았습니다.

## 영향

오래된 CI 실행이 runner를 점유하거나 PR 화면에 계속 진행 중으로 표시되는 문제를 방지합니다. 정상 CI는 약 4분이므로 20분 timeout은 충분한 여유를 유지합니다.

## 검증

- PyYAML `BaseLoader`로 workflow 구문 로드 성공
- `concurrency.cancel-in-progress == true` 확인
- `jobs.build-and-test.timeout-minutes == 20` 확인
- `git diff --check` 통과

애플리케이션 코드는 변경하지 않아 전체 pytest는 생략했습니다. 이 PR의 GitHub Actions 실행으로 workflow 동작을 최종 검증합니다.
