### PR TITLE
YTD 랭킹 및 장중 주도 테마 후속 수정

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -503,8 +503,10 @@ class StockOhlcvRepository:
             return []
 
     async def get_ytd_return_ranking(self, limit: int = 100, market: Optional[str] = None) -> List[Dict]:
-        """최신 거래일과 해당 연도 첫 스냅샷의 종가를 비교한 YTD 수익률 랭킹.
+        """최신 거래일(daily_prices)과 연초 첫 종가(ohlcv)를 비교한 YTD 수익률 랭킹.
 
+        daily_prices 스냅샷 수집은 특정 시점부터 시작되어 연초 데이터가 없을 수 있으므로,
+        연초 기준가는 더 오래 축적된 ohlcv 테이블에서 조회한다.
         market: "KOSPI"/"KOSDAQ" 지정 시 해당 시장으로 필터링, None/"ALL"이면 전체.
         """
         try:
@@ -515,10 +517,11 @@ class StockOhlcvRepository:
                 if not latest_date:
                     return []
 
-                year_prefix = f"{latest_date[:4]}%"
+                year = latest_date[:4]
+                date_glob = f"{year}[0-1][0-9][0-3][0-9]"
                 async with conn.execute(
-                    "SELECT MIN(trade_date) FROM daily_prices WHERE trade_date LIKE ?",
-                    (year_prefix,),
+                    "SELECT MIN(date) FROM ohlcv WHERE date GLOB ?",
+                    (date_glob,),
                 ) as cursor:
                     base_row = await cursor.fetchone()
                 base_date = base_row[0] if base_row and base_row[0] else None
@@ -534,15 +537,15 @@ class StockOhlcvRepository:
 
                 async with conn.execute(
                     f"""
-                    SELECT latest.*, base.current_price AS base_price
+                    SELECT latest.*, base.close AS base_price
                     FROM daily_prices AS latest
-                    JOIN daily_prices AS base
-                      ON base.code = latest.code AND base.trade_date = ?
+                    JOIN ohlcv AS base
+                      ON base.code = latest.code AND base.date = ?
                     WHERE latest.trade_date = ?
                       AND latest.current_price > 0
-                      AND base.current_price > 0
+                      AND base.close > 0
                       {market_filter}
-                    ORDER BY ((CAST(latest.current_price AS REAL) / base.current_price) - 1.0) DESC
+                    ORDER BY ((CAST(latest.current_price AS REAL) / base.close) - 1.0) DESC
                     LIMIT ?
                     """,
                     params,

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -1434,6 +1434,7 @@ class StrategyLogReportService:
         target_date: str,
         *,
         buy_count: int,
+        buy_entries: List[dict],
         profitability_gate_section: Optional[str],
         multiple_testing_section: Optional[str],
         overnight_exposure_section: Optional[str],
@@ -1446,6 +1447,22 @@ class StrategyLogReportService:
 
         if buy_count > 0:
             lines.append(f"• 신규 진입 {buy_count}건 — 체결/포지션 관리 확인")
+            for entry in buy_entries:
+                strategy = _esc(entry.get("strategy") or "전략 미상")
+                code = str(entry.get("code") or "").strip()
+                name = _esc(entry.get("name") or code or "종목 미상")
+                instrument = f"{name}({_esc(code)})" if code else name
+                details = [strategy, instrument]
+
+                qty = _to_int(entry.get("qty"), default=0)
+                if qty > 0:
+                    details.append(f"{qty}주")
+                price = _format_krw(entry.get("price"))
+                if price:
+                    details.append(price)
+                if entry.get("time"):
+                    details.append(_esc(entry["time"]))
+                lines.append(f"  - {' · '.join(details)}")
         else:
             lines.append("• 신규 진입 없음 — 주요 후보는 진입 조건 미달/시그널 없음")
 
@@ -1933,6 +1950,7 @@ class StrategyLogReportService:
             self._last_operational_decision_report = self._build_operational_decision_report(
                 target_date,
                 buy_count=0,
+                buy_entries=[],
                 profitability_gate_section=None,
                 multiple_testing_section=None,
                 overnight_exposure_section=None,
@@ -2112,9 +2130,18 @@ class StrategyLogReportService:
 
         confluence_map: Dict[str, dict] = {}
         fallback_buys: List[dict] = []
+        operational_buy_entries: List[dict] = []
         for summary in strategy_summaries:
             for code, info in summary['bought'].items():
                 fallback_buys.append({'code': code, 'name': info['name']})
+                operational_buy_entries.append({
+                    'strategy': summary['name'],
+                    'code': code,
+                    'name': info['name'],
+                    'qty': info.get('qty'),
+                    'price': info.get('price'),
+                    'time': info.get('time'),
+                })
                 entry = confluence_map.setdefault(code, {'name': info['name'], 'count': 0, 'strategies': []})
                 entry['name'] = info['name']
                 entry['count'] += 1
@@ -2223,6 +2250,7 @@ class StrategyLogReportService:
         self._last_operational_decision_report = self._build_operational_decision_report(
             target_date,
             buy_count=len(fallback_buys),
+            buy_entries=operational_buy_entries,
             profitability_gate_section=profitability_gate_section,
             multiple_testing_section=multiple_testing_section,
             overnight_exposure_section=overnight_exposure_section,

--- a/services/theme_daily_leader_service.py
+++ b/services/theme_daily_leader_service.py
@@ -129,9 +129,9 @@ class ThemeDailyLeaderService:
 
         base_resp.data.sort(
             key=lambda item: (
+                item["market_leadership_score"],
                 item["recent_coverage_count"] > 0,
                 item["recent_trading_value_won"],
-                item["market_leadership_score"],
             ),
             reverse=True,
         )

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -453,20 +453,22 @@ class TestGetAllDailySnapshots:
 
 
 class TestGetYtdReturnRanking:
-    """get_ytd_return_ranking: 연초 첫 스냅샷 대비 최신 수익률 랭킹."""
+    """get_ytd_return_ranking: 연초 첫 스냅샷(ohlcv) 대비 최신 수익률(daily_prices) 랭킹.
+
+    daily_prices 스냅샷 수집은 특정 시점(예: 4월)에 시작될 수 있어 연초 데이터가 없을 수
+    있으므로, 연초 기준가는 더 오래 축적된 ohlcv 테이블에서 조회한다.
+    """
 
     @pytest.mark.asyncio
     async def test_returns_latest_year_ranked_by_ytd_return(self, repo):
-        await repo.upsert_daily_snapshot("20260102", [
-            _make_snapshot("A001", name="상승주", price=100),
-            _make_snapshot("A002", name="보합주", price=200),
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260102", close=100),
+            _make_ohlcv("A002", "20260102", close=200),
+            _make_ohlcv("OLD", "20251230", close=1),
         ])
         await repo.upsert_daily_snapshot("20260713", [
             _make_snapshot("A001", name="상승주", price=150),
             _make_snapshot("A002", name="보합주", price=180),
-        ])
-        await repo.upsert_daily_snapshot("20251230", [
-            _make_snapshot("OLD", name="전년도", price=1),
         ])
 
         result = await repo.get_ytd_return_ranking(limit=10)
@@ -482,8 +484,10 @@ class TestGetYtdReturnRanking:
 
     @pytest.mark.asyncio
     async def test_excludes_stock_without_market_first_day_snapshot(self, repo):
-        await repo.upsert_daily_snapshot("20260102", [_make_snapshot("A001", price=100)])
-        await repo.upsert_daily_snapshot("20260303", [_make_snapshot("IPO", price=100)])
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260102", close=100),
+            _make_ohlcv("IPO", "20260303", close=100),
+        ])
         await repo.upsert_daily_snapshot("20260713", [
             _make_snapshot("A001", price=120),
             _make_snapshot("IPO", price=300),
@@ -499,9 +503,9 @@ class TestGetYtdReturnRanking:
 
     @pytest.mark.asyncio
     async def test_filters_by_market(self, repo):
-        await repo.upsert_daily_snapshot("20260102", [
-            _make_snapshot("A001", price=100, market="KOSPI"),
-            _make_snapshot("A002", price=100, market="KOSDAQ"),
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260102", close=100),
+            _make_ohlcv("A002", "20260102", close=100),
         ])
         await repo.upsert_daily_snapshot("20260713", [
             _make_snapshot("A001", price=150, market="KOSPI"),
@@ -511,6 +515,31 @@ class TestGetYtdReturnRanking:
         result = await repo.get_ytd_return_ranking(limit=10, market="KOSDAQ")
 
         assert [row["code"] for row in result] == ["A002"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_malformed_ohlcv_dates_when_finding_base_date(self, repo):
+        """일부 ohlcv 레코드에 잘못된 형식(자릿수 오류) 날짜가 섞여 있어도 정상 8자리 날짜만 기준일로 채택한다."""
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "202600101", close=999),
+            _make_ohlcv("A001", "20260102", close=100),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_ytd_return_ranking(limit=10)
+
+        assert result[0]["base_date"] == "20260102"
+        assert result[0]["base_price"] == 100
+
+    @pytest.mark.asyncio
+    async def test_includes_market_cap_from_latest_snapshot(self, repo):
+        await repo.upsert_ohlcv([_make_ohlcv("A001", "20260102", close=100)])
+        await repo.upsert_daily_snapshot("20260713", [
+            _make_snapshot("A001", price=150, market_cap=999_000_000),
+        ])
+
+        result = await repo.get_ytd_return_ranking(limit=10)
+
+        assert result[0]["market_cap"] == 999_000_000
 
 
 # ── get_price_history ────────────────────────────────────────────────────────

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1653,3 +1653,48 @@ async def test_operational_decision_report_summarizes_generated_diagnostic(tmp_p
     assert "broker_reconciled 보유 8종목" in decision
     assert "KOSDAQ 상승 regime 집중" in decision
     assert "Deflated Sharpe 약함" in decision
+
+
+@pytest.mark.asyncio
+async def test_operational_decision_report_includes_new_entry_details(tmp_path):
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return [
+                {
+                    "strategy": "first_pullback",
+                    "code": "005930",
+                    "name": "삼성전자",
+                    "buy_price": 75000,
+                    "qty": 2,
+                    "buy_date": "2026-07-16 09:10:00",
+                    "status": "HOLD",
+                    "reason": "원장 체결",
+                }
+            ]
+
+        def get_solds(self):
+            return []
+
+        def get_holds(self):
+            return []
+
+    log_dir = tmp_path / "strategies"
+    log_dir.mkdir()
+    _write_log(
+        str(log_dir / "20260716_091000_FirstPullback.log.json"),
+        [{
+            "timestamp": "2026-07-16 09:10:00,000",
+            "level": "INFO",
+            "data": {"event": "scan_with_watchlist", "count": 1},
+        }],
+    )
+
+    svc = StrategyLogReportService(
+        log_dir=str(log_dir),
+        virtual_trade_service=DummyVirtualTradeService(),
+    )
+    await svc.generate_report("20260716")
+
+    decision = svc.get_last_operational_decision_report()
+    assert "신규 진입 1건 — 체결/포지션 관리 확인" in decision
+    assert "FirstPullback · 삼성전자(005930) · 2주 · ₩75,000 · 09:10" in decision

--- a/tests/unit_test/services/test_theme_daily_leader_service.py
+++ b/tests/unit_test/services/test_theme_daily_leader_service.py
@@ -109,6 +109,51 @@ async def test_intraday_report_gracefully_marks_missing_history():
 
 
 @pytest.mark.asyncio
+async def test_intraday_report_prioritizes_leadership_score_over_recent_trading_value():
+    groups = {
+        "advancing_theme": {
+            "sources": ["NAVER"],
+            "members": [_member("U1", "U1"), _member("U2", "U2"), _member("U3", "U3")],
+        },
+        "falling_theme": {
+            "sources": ["NAVER"],
+            "members": [_member("D1", "D1"), _member("D2", "D2"), _member("D3", "D3")],
+        },
+    }
+    snapshot_repo = MagicMock()
+    snapshot_repo.save_snapshot = AsyncMock()
+    snapshot_repo.get_values_at_or_before = AsyncMock(side_effect=[
+        {
+            "U1": 900_000_000, "U2": 900_000_000, "U3": 900_000_000,
+            "D1": 1_000_000_000, "D2": 1_000_000_000, "D3": 1_000_000_000,
+        },
+        {
+            "U1": 800_000_000, "U2": 800_000_000, "U3": 800_000_000,
+            "D1": 900_000_000, "D2": 900_000_000, "D3": 900_000_000,
+        },
+    ])
+    svc, _ = _service(groups, snapshot_repo=snapshot_repo)
+    rankings = {"all_stocks": [
+        _stock("U1", "U1", 3.0, 1_000_000_000),
+        _stock("U2", "U2", 2.5, 1_000_000_000),
+        _stock("U3", "U3", 2.0, 1_000_000_000),
+        _stock("D1", "D1", -4.0, 10_000_000_000),
+        _stock("D2", "D2", -5.0, 10_000_000_000),
+        _stock("D3", "D3", -6.0, 10_000_000_000),
+    ]}
+
+    resp = await svc.build_intraday_theme_report(
+        rankings,
+        report_time="20260715 10:06",
+        window_minutes=3,
+    )
+
+    assert resp.data[0]["normalized_name"] == "advancing_theme"
+    assert resp.data[0]["market_leadership_score"] > resp.data[1]["market_leadership_score"]
+    assert resp.data[0]["recent_trading_value_won"] < resp.data[1]["recent_trading_value_won"]
+
+
+@pytest.mark.asyncio
 async def test_returns_empty_without_theme_groups():
     svc, _ = _service({})
 

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -631,7 +631,7 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 }
 
 /* 서브 탭(랭킹, 전략 필터 등) 공통 스타일 */
-.ranking-tab, .sub-tab-btn, .investor-toggle, .market-filter {
+.ranking-tab, .sub-tab-btn, .investor-toggle, .market-filter, .ytd-market-toggle {
     background-color: var(--bg-primary) !important;
     color: var(--text-secondary) !important;
     border: 1px solid var(--border) !important;
@@ -644,7 +644,7 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     font-size: 0.9rem;
 }
 
-.ranking-tab:hover, .sub-tab-btn:hover, .investor-toggle:hover, .market-filter:hover {
+.ranking-tab:hover, .sub-tab-btn:hover, .investor-toggle:hover, .market-filter:hover, .ytd-market-toggle:hover {
     background-color: var(--bg-card) !important;
     color: var(--text-primary) !important;
 }
@@ -666,6 +666,22 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 }
 
 .investor-toggle.active {
+    background-color: var(--accent-secondary, #3b82f6) !important;
+    color: white !important;
+    border-color: var(--accent-secondary, #3b82f6) !important;
+    font-weight: bold !important;
+    box-shadow: 0 2px 6px rgba(59, 130, 246, 0.4);
+    opacity: 1;
+}
+
+/* YTD 랭킹 - 코스피/코스닥 토글 - 비선택 상태를 더 어둡게 */
+.ytd-market-toggle:not(.active) {
+    opacity: 0.45;
+    background-color: var(--bg-secondary, #2a2a3e) !important;
+    color: var(--text-muted, #666) !important;
+}
+
+.ytd-market-toggle.active {
     background-color: var(--accent-secondary, #3b82f6) !important;
     color: white !important;
     border-color: var(--accent-secondary, #3b82f6) !important;

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -637,7 +637,8 @@ function renderRankingTable() {
             + `<th class="${sortCls('price')}" onclick="sortRanking('price')">현재가</th>`
             + `<th class="${sortCls('ytd_rate')}" onclick="sortRanking('ytd_rate')">YTD 상승률</th>`
             + `<th class="${sortCls('base_price')}" onclick="sortRanking('base_price')">연초 기준가</th>`
-            + `<th class="${sortCls('base_date')}" onclick="sortRanking('base_date')">기준일</th>`;
+            + `<th class="${sortCls('base_date')}" onclick="sortRanking('base_date')">기준일</th>`
+            + `<th class="${sortCls('market_cap')}" onclick="sortRanking('market_cap')">시가총액</th>`;
     } else if (isInvestor || isProgram || isCombined) {
         const pbmnLabel = isCombined
             ? `${investorLabel} ${isSell ? '순매도대금' : '순매수대금'}`
@@ -762,6 +763,7 @@ function renderRankingTable() {
                 <td class="${ytdColor}">${ytdRate.toFixed(2)}%</td>
                 <td>${parseInt(item.base_price || 0).toLocaleString()}</td>
                 <td>${escapeHtml(item.base_date || '-')}</td>
+                <td>${formatMarketCap(item.market_cap)}</td>
             </tr>`;
             return;
         }

--- a/view/web/templates/ranking.html
+++ b/view/web/templates/ranking.html
@@ -59,7 +59,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/ranking.js?v=8"></script>
+<script src="/static/js/ranking.js?v=9"></script>
 <script>
     loadRanking('rise');
 </script>


### PR DESCRIPTION
## Summary

PR #675 머지 후 발견된 YTD 랭킹 문제와 장중 주도 테마 정렬 문제를 수정합니다.

1. 코스피/코스닥 토글 선택 표시: `.ytd-market-toggle`에 active/inactive 스타일을 추가했습니다.
2. 연초 기준가: 수집 기간이 짧은 `daily_prices` 대신 1월 데이터가 있는 `ohlcv`에서 조회하고, 잘못된 자릿수의 날짜는 제외했습니다.
3. 시가총액: YTD 랭킹 테이블에 정렬 가능한 시가총액 컬럼을 추가했습니다.
4. 장중 주도 테마: 최근 3분 거래대금이 급증한 하락 테마가 양수 주도점수 테마보다 앞서던 문제를 수정했습니다. 주도점수를 1차 정렬 기준으로 사용하고 최근 거래대금은 동점 보조 기준으로 유지합니다.

## Impact

급락 거래가 집중된 테마가 상승 주도 테마 1위로 노출되지 않으며, 상승 강도와 확산을 반영한 주도점수가 장중 순위를 결정합니다.

## Test plan

- [x] `pytest tests/unit_test -v` (6870 passed)
- [x] `pytest tests/integration_test -v` (259 passed)
- [ ] 브라우저에서 코스피/코스닥 토글 시각적 확인 (실전 브로커 자격증명 초기화 위험으로 로컬 서버 직접 기동은 하지 않음)