### PR TITLE
fix: YTD 랭킹 연초 기준일이 휴장일로 잡히는 문제 수정

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -519,9 +519,17 @@ class StockOhlcvRepository:
 
                 year = latest_date[:4]
                 date_glob = f"{year}[0-1][0-9][0-3][0-9]"
+                # 휴장일(채권 등 현재 추적 종목과 무관한 코드만 존재)이 연초 최초 날짜로
+                # 잡히지 않도록, 최신 스냅샷 종목과 실제로 겹치는 코드가 있는 날짜만 후보로 삼는다.
                 async with conn.execute(
-                    "SELECT MIN(date) FROM ohlcv WHERE date GLOB ?",
-                    (date_glob,),
+                    """
+                    SELECT MIN(base.date)
+                    FROM ohlcv AS base
+                    JOIN daily_prices AS latest
+                      ON latest.code = base.code AND latest.trade_date = ?
+                    WHERE base.date GLOB ?
+                    """,
+                    (latest_date, date_glob),
                 ) as cursor:
                     base_row = await cursor.fetchone()
                 base_date = base_row[0] if base_row and base_row[0] else None

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -531,6 +531,22 @@ class TestGetYtdReturnRanking:
         assert result[0]["base_price"] == 100
 
     @pytest.mark.asyncio
+    async def test_skips_holiday_only_date_with_no_overlapping_codes(self, repo):
+        """연초 첫 ohlcv 날짜가 휴장일(채권 등 다른 코드만 존재)이라 현재 종목과 전혀
+        겹치지 않으면, 실제로 겹치는 코드가 있는 다음 날짜를 기준일로 채택한다."""
+        await repo.upsert_ohlcv([
+            _make_ohlcv("BOND1", "20260101", close=999),
+            _make_ohlcv("A001", "20260102", close=100),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_ytd_return_ranking(limit=10)
+
+        assert [row["code"] for row in result] == ["A001"]
+        assert result[0]["base_date"] == "20260102"
+        assert result[0]["base_price"] == 100
+
+    @pytest.mark.asyncio
     async def test_includes_market_cap_from_latest_snapshot(self, repo):
         await repo.upsert_ohlcv([_make_ohlcv("A001", "20260102", close=100)])
         await repo.upsert_daily_snapshot("20260713", [


### PR DESCRIPTION
## Summary
- `/ranking/ytd`가 항상 "YTD 비교 데이터가 없습니다"를 반환하던 문제 수정
- 원인: `get_ytd_return_ranking`이 연초 기준가를 `ohlcv` 테이블의 `MIN(date)`로 찾는데, 신정(2026-01-01) 같은 휴장일에 채권 등 다른 코드만 존재하는 경우 그 날짜가 기준일로 채택되어 현재 `daily_prices`가 추적하는 종목과 전혀 겹치지 않음 → 결과가 항상 빈 배열
- 수정: 최신 스냅샷(`daily_prices`) 종목과 실제로 겹치는 코드가 있는 날짜만 연초 기준일 후보로 삼도록 JOIN 조건 추가

## Test plan
- [x] 버그를 재현하는 신규 유닛 테스트 작성(`test_skips_holiday_only_date_with_no_overlapping_codes`) → 수정 전 실패 확인
- [x] `pytest tests/unit_test -v` — 6868 passed (기존에도 실패하던 4건은 로거/재시도큐/스케줄러/시세캐싱 영역으로 본 변경과 무관)
- [x] `pytest tests/integration_test -v` — 259 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)