### PR TITLE
feat: 랭킹·현재가 표시와 텔레그램 리포트 보관함 개선

### DIFF
--- a/repositories/stock_code_repository.py
+++ b/repositories/stock_code_repository.py
@@ -130,6 +130,15 @@ class StockCodeRepository:
             self.logger.warning(f"❗ 종목코드 없음: {name}")
         return code
 
+    def get_market_by_code(self, code: str) -> str:
+        """종목코드의 시장 구분(KOSPI/KOSDAQ 등)을 반환한다."""
+        if "시장구분" not in self.df.columns:
+            return ""
+        row = self.df[self.df["종목코드"] == code]
+        if row.empty:
+            return ""
+        return str(row.iloc[0]["시장구분"] or "")
+
     def search_by_name(self, keyword: str, limit: int = 20) -> list:
         """종목명 부분 일치 검색. [{"code": "005930", "name": "삼성전자"}, ...] 형태로 반환."""
         keyword_lower = keyword.lower()

--- a/repositories/telegram_notification_repository.py
+++ b/repositories/telegram_notification_repository.py
@@ -75,3 +75,49 @@ class TelegramNotificationRepository:
             }
             for row in rows
         ]
+
+    def list_reports(self, limit: int = 200) -> list[dict]:
+        """상세 리포트 보관함에 표시할 Telegram 발송 이력을 반환한다."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT id, sent_at, source, title
+                FROM telegram_notifications
+                ORDER BY sent_at DESC, id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [self._report_metadata(row) for row in rows]
+
+    def get_report(self, report_id: str) -> dict | None:
+        """보관함용 Telegram 발송 이력 한 건을 반환한다."""
+        prefix = "telegram-"
+        value = str(report_id)
+        if not value.startswith(prefix) or not value[len(prefix):].isdigit():
+            return None
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT id, sent_at, source, title, message
+                FROM telegram_notifications
+                WHERE id = ?
+                """,
+                (int(value[len(prefix):]),),
+            ).fetchone()
+        if row is None:
+            return None
+        return {**self._report_metadata(row), "content": row["message"]}
+
+    @staticmethod
+    def _report_metadata(row: sqlite3.Row) -> dict:
+        return {
+            "id": f"telegram-{row['id']}",
+            "report_date": row["sent_at"][:10].replace("-", ""),
+            "created_at": row["sent_at"],
+            "kind": "telegram",
+            "title": row["title"],
+            "source": row["source"],
+        }

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -770,6 +770,7 @@ class RankingTask(AfterMarketTask):
         industry_map = await self._load_industry_map()
         results: List[Dict] = []
         is_complete = True
+        observed_trading_dates = {str(target_date)}
 
         for chunk in _chunked(all_stocks, self.API_CHUNK_SIZE):
             await self._suspend_event.wait()
@@ -802,6 +803,12 @@ class RankingTask(AfterMarketTask):
 
                 investor_rows = investor_resp.data if investor_resp and isinstance(investor_resp.data, list) else []
                 program_rows = program_resp.data if program_resp and isinstance(program_resp.data, list) else []
+                for row in [*investor_rows, *program_rows]:
+                    if not isinstance(row, dict):
+                        continue
+                    trading_date = str(row.get("stck_bsop_date") or "")
+                    if len(trading_date) == 8 and trading_date.isdigit():
+                        observed_trading_dates.add(trading_date)
 
                 frgn_qty = self._sum_rows(investor_rows, "frgn_ntby_qty")
                 orgn_qty = self._sum_rows(investor_rows, "orgn_ntby_qty")
@@ -846,6 +853,10 @@ class RankingTask(AfterMarketTask):
                     "program_period_ntby_tr_pbmn_won": str(program_pbmn_won),
                     "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
                 })
+
+        earliest_trading_date = min(observed_trading_dates)
+        for result in results:
+            result["earliest_trading_date"] = earliest_trading_date
 
         return results, is_complete
 

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -68,4 +68,30 @@ test("국내 조회에 필요한 입력과 차트 DOM이 존재한다", async ()
   assert(window.document.getElementById("stockChart"), "차트 캔버스 누락");
 });
 
+test("현재가 조회 결과에 KOSPI/KOSDAQ 시장 배지를 표시한다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.startsWith("/api/stock/123456?")) {
+      return {
+        ok: true,
+        json: async () => ({
+          rt_cd: "0",
+          data: {
+            code: "123456", name: "테스트종목", market: "KOSDAQ",
+            price: "10000", change: "0", rate: "0", sign: "",
+            open: "10000", high: "10100", low: "9900", prev_close: "10000",
+          },
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ rt_cd: "1", data: null }) };
+  };
+
+  await window.searchStock("123456");
+
+  const badge = window.document.querySelector(".stock-market-badge");
+  assert(badge, "시장 구분 배지가 없음");
+  assert(badge.textContent === "KOSDAQ", "시장 구분 배지 값이 KOSDAQ이 아님");
+});
+
 await run();

--- a/tests/unit_test/repositories/test_stock_code_repository.py
+++ b/tests/unit_test/repositories/test_stock_code_repository.py
@@ -256,6 +256,10 @@ def test_kosdaq_methods(test_db_with_market, mock_logger):
     assert mapper.is_kosdaq('005930') is False
     assert mapper.is_kosdaq('999999') is False
 
+    assert mapper.get_market_by_code('005930') == 'KOSPI'
+    assert mapper.get_market_by_code('123456') == 'KOSDAQ'
+    assert mapper.get_market_by_code('999999') == ''
+
 
 def test_kosdaq_methods_missing_column(test_db, mock_logger):
     """시장구분 컬럼이 없을 때 KOSDAQ 관련 메서드가 안전하게 동작하는지 테스트합니다."""
@@ -263,6 +267,7 @@ def test_kosdaq_methods_missing_column(test_db, mock_logger):
 
     assert mapper.get_kosdaq_codes() == []
     assert mapper.is_kosdaq('005930') is False
+    assert mapper.get_market_by_code('005930') == ''
 
 
 def test_get_name_by_code_without_logger(test_db):

--- a/tests/unit_test/repositories/test_telegram_notification_repository.py
+++ b/tests/unit_test/repositories/test_telegram_notification_repository.py
@@ -47,3 +47,29 @@ def test_get_by_date_applies_count_limit(tmp_path):
     items = repository.get_by_date(datetime(2026, 7, 13).date(), count=2)
 
     assert [item["title"] for item in items] == ["리포트 2", "리포트 1"]
+
+
+def test_list_reports_and_get_report_for_archive(tmp_path):
+    repository = TelegramNotificationRepository(tmp_path / "telegram_notifications.db")
+    repository.record(
+        sent_at="2026-07-16T16:34:39+09:00",
+        source="report",
+        title="장 마감 랭킹",
+        message="상승률 및 수급 랭킹 내용",
+    )
+
+    reports = repository.list_reports(limit=20)
+
+    assert reports == [{
+        "id": "telegram-1",
+        "report_date": "20260716",
+        "created_at": "2026-07-16T16:34:39+09:00",
+        "kind": "telegram",
+        "title": "장 마감 랭킹",
+        "source": "report",
+    }]
+    assert repository.get_report("telegram-1") == {
+        **reports[0],
+        "content": "상승률 및 수급 랭킹 내용",
+    }
+    assert repository.get_report("telegram-invalid") is None

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -294,8 +294,8 @@ async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_se
 
     broker.get_investor_trade_by_stock_daily_multi = AsyncMock(side_effect=lambda code, date=None, days=5: {
         "005930": _make_investor_multi_response([
-            {"frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
-            {"frgn_ntby_qty": "5", "orgn_ntby_qty": "5", "frgn_ntby_tr_pbmn": "50", "orgn_ntby_tr_pbmn": "50"},
+            {"stck_bsop_date": "20250101", "frgn_ntby_qty": "10", "orgn_ntby_qty": "20", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "200"},
+            {"stck_bsop_date": "20241224", "frgn_ntby_qty": "5", "orgn_ntby_qty": "5", "frgn_ntby_tr_pbmn": "50", "orgn_ntby_tr_pbmn": "50"},
         ]),
         "000660": _make_investor_multi_response([
             {"frgn_ntby_qty": "50", "orgn_ntby_qty": "10", "frgn_ntby_tr_pbmn": "10", "orgn_ntby_tr_pbmn": "10"},
@@ -332,6 +332,7 @@ async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_se
     assert resp.data[0]["industry"] == "IT"
     assert resp.data[1]["industry"] == "반도체"
     assert all(item["latest_trading_date"] == "20250101" for item in resp.data)
+    assert resp.data[1]["earliest_trading_date"] == "20241224"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -29,6 +29,7 @@ async def test_get_stock_price(web_client, mock_web_ctx):
     mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = ResCommonResponse(
         rt_cd="0", msg1="Success", data={"code": "005930", "price": 70000}
     )
+    mock_web_ctx.stock_code_repository.get_market_by_code.return_value = "KOSPI"
 
     response = web_client.get("/api/stock/005930")
 
@@ -36,6 +37,8 @@ async def test_get_stock_price(web_client, mock_web_ctx):
     json_resp = response.json()
     assert json_resp["rt_cd"] == "0"
     assert json_resp["data"]["price"] == 70000
+    assert json_resp["data"]["market"] == "KOSPI"
+    mock_web_ctx.stock_code_repository.get_market_by_code.assert_called_once_with("005930")
     from common.types import Exchange
     mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX)
 

--- a/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_strategy_report.py
@@ -134,14 +134,26 @@ def test_diagnostic_report_archive_list(web_client, mock_web_ctx):
             "created_at": "2026-07-14T16:21:51",
         }
     ]
+    mock_web_ctx.telegram_notification_repository.list_reports.return_value = [
+        {
+            "id": "telegram-7",
+            "report_date": "20260715",
+            "created_at": "2026-07-15T17:00:00+09:00",
+            "kind": "telegram",
+            "title": "신고가 리포트",
+            "source": "report",
+        }
+    ]
 
     response = web_client.get("/api/strategies/diagnostic-reports?limit=20")
 
     assert response.status_code == 200
-    assert response.json()["reports"][0]["report_date"] == "20260714"
+    assert response.json()["reports"][0]["title"] == "신고가 리포트"
+    assert response.json()["reports"][1]["report_date"] == "20260714"
     mock_web_ctx.strategy_diagnostic_report_repository.list_reports.assert_called_once_with(
         limit=20
     )
+    mock_web_ctx.telegram_notification_repository.list_reports.assert_called_once_with(limit=20)
 
 
 def test_diagnostic_report_archive_detail(web_client, mock_web_ctx):
@@ -165,3 +177,21 @@ def test_diagnostic_report_archive_detail_not_found(web_client, mock_web_ctx):
     response = web_client.get("/api/strategies/diagnostic-reports/missing.html")
 
     assert response.status_code == 404
+
+
+def test_telegram_report_archive_detail(web_client, mock_web_ctx):
+    mock_web_ctx.telegram_notification_repository.get_report.return_value = {
+        "id": "telegram-7",
+        "report_date": "20260715",
+        "created_at": "2026-07-15T17:00:00+09:00",
+        "kind": "telegram",
+        "title": "신고가 리포트",
+        "source": "report",
+        "content": "신고가 종목 10개",
+    }
+
+    response = web_client.get("/api/strategies/diagnostic-reports/telegram-7")
+
+    assert response.status_code == 200
+    assert response.json()["content"] == "신고가 종목 10개"
+    mock_web_ctx.telegram_notification_repository.get_report.assert_called_once_with("telegram-7")

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -208,6 +208,8 @@ async def get_stock_price(code: str, exchange: str = Query("KRX")):
         ctx.logger.warning(f"[stock] 현재가 조회 타임아웃 ({code}, 12s 초과)")
         return {"rt_cd": "1", "msg1": "API 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.", "data": None}
     result = _serialize_response(resp)
+    if result.get("rt_cd") == "0" and isinstance(result.get("data"), dict):
+        result["data"]["market"] = ctx.stock_code_repository.get_market_by_code(code)
 
     ctx.pm.log_timer(f"get_stock_price({code})", t_start)
 

--- a/view/web/routes/strategy_report.py
+++ b/view/web/routes/strategy_report.py
@@ -22,16 +22,39 @@ _DEFAULT_LOG_DIR = os.path.join("logs", "strategies", "rejections")
 
 @router.get("/strategies/diagnostic-reports")
 async def get_diagnostic_reports(limit: int = Query(100, ge=1, le=500)):
-    """저장된 전략 상세 진단 리포트 목록을 최신순으로 반환한다."""
-    repository = _get_ctx().strategy_diagnostic_report_repository
-    return {"reports": repository.list_reports(limit=limit)}
+    """전략 상세 진단과 Telegram 발송 이력을 최신순으로 반환한다."""
+    ctx = _get_ctx()
+    diagnostics = [
+        {
+            **report,
+            "kind": "strategy_diagnostic",
+            "title": "전략 상세 진단",
+        }
+        for report in ctx.strategy_diagnostic_report_repository.list_reports(limit=limit)
+    ]
+    telegram = ctx.telegram_notification_repository.list_reports(limit=limit)
+    reports = sorted(
+        [*diagnostics, *telegram],
+        key=lambda report: report.get("created_at", ""),
+        reverse=True,
+    )
+    return {"reports": reports[:limit]}
 
 
 @router.get("/strategies/diagnostic-reports/{report_id}")
 async def get_diagnostic_report(report_id: str):
-    """전략 상세 진단 리포트 한 건을 반환한다."""
-    repository = _get_ctx().strategy_diagnostic_report_repository
-    report = repository.get_report(report_id)
+    """전략 상세 진단 또는 Telegram 발송 이력 한 건을 반환한다."""
+    ctx = _get_ctx()
+    if report_id.startswith("telegram-"):
+        report = ctx.telegram_notification_repository.get_report(report_id)
+    else:
+        report = ctx.strategy_diagnostic_report_repository.get_report(report_id)
+        if report is not None:
+            report = {
+                **report,
+                "kind": "strategy_diagnostic",
+                "title": "전략 상세 진단",
+            }
     if report is None:
         raise HTTPException(status_code=404, detail="상세 리포트를 찾을 수 없습니다.")
     return report

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -820,10 +820,14 @@ function renderRankingTable() {
 }
 
 function _renderPeriodRankingLabel(data) {
-    const raw = data[0] && data[0].latest_trading_date;
-    const dateLabel = raw && raw.length === 8
-        ? ` (~ ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)})`
+    const latest = data[0] && data[0].latest_trading_date;
+    const earliest = data[0] && data[0].earliest_trading_date;
+    const formatDate = raw => raw && raw.length === 8
+        ? `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`
         : '';
+    const start = formatDate(earliest);
+    const end = formatDate(latest);
+    const dateLabel = start && end ? ` (${start} ~ ${end})` : end ? ` (~ ${end})` : '';
     return `<p style="color:#888; margin: 4px 0 12px;">최근 ${_rankingPeriodDays}거래일 기준${dateLabel}</p>`;
 }
 

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -637,7 +637,6 @@ function renderRankingTable() {
             + `<th class="${sortCls('price')}" onclick="sortRanking('price')">현재가</th>`
             + `<th class="${sortCls('ytd_rate')}" onclick="sortRanking('ytd_rate')">YTD 상승률</th>`
             + `<th class="${sortCls('base_price')}" onclick="sortRanking('base_price')">연초 기준가</th>`
-            + `<th class="${sortCls('base_date')}" onclick="sortRanking('base_date')">기준일</th>`
             + `<th class="${sortCls('market_cap')}" onclick="sortRanking('market_cap')">시가총액</th>`;
     } else if (isInvestor || isProgram || isCombined) {
         const pbmnLabel = isCombined
@@ -762,7 +761,6 @@ function renderRankingTable() {
                 <td>${parseInt(item.current_price || 0).toLocaleString()}</td>
                 <td class="${ytdColor}">${ytdRate.toFixed(2)}%</td>
                 <td>${parseInt(item.base_price || 0).toLocaleString()}</td>
-                <td>${escapeHtml(item.base_date || '-')}</td>
                 <td>${formatMarketCap(item.market_cap)}</td>
             </tr>`;
             return;
@@ -811,8 +809,9 @@ function renderRankingTable() {
     });
 
     const periodLabel = isPeriodInvestor ? _renderPeriodRankingLabel(data) : '';
+    const ytdLabel = isYtd ? _renderYtdRankingLabel(data) : '';
 
-    div.innerHTML = `${periodLabel}${_renderRankingAIAnalysisPanel(data.length)}<div class="card"><table class="data-table">
+    div.innerHTML = `${periodLabel}${ytdLabel}${_renderRankingAIAnalysisPanel(data.length)}<div class="card"><table class="data-table">
         <thead><tr>${headerRow}</tr></thead>
         <tbody>${rows}</tbody></table></div>`;
 }
@@ -823,6 +822,14 @@ function _renderPeriodRankingLabel(data) {
         ? ` (~ ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)})`
         : '';
     return `<p style="color:#888; margin: 4px 0 12px;">최근 ${_rankingPeriodDays}거래일 기준${dateLabel}</p>`;
+}
+
+function _renderYtdRankingLabel(data) {
+    const raw = data[0] && data[0].base_date;
+    const dateLabel = raw && raw.length === 8
+        ? `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`
+        : '-';
+    return `<p style="color:#888; margin: 4px 0 12px;">연초 기준일: ${dateLabel}</p>`;
 }
 
 function sortRanking(key) {
@@ -918,9 +925,6 @@ function rankingSortCompare(data, key, dir) {
         } else if (key === 'base_price') {
             va = parseInt(a.base_price || 0);
             vb = parseInt(b.base_price || 0);
-        } else if (key === 'base_date') {
-            va = parseInt(a.base_date || 0);
-            vb = parseInt(b.base_date || 0);
         } else if (key === 'market_cap') {
             va = parseInt(a.market_cap || 0);
             vb = parseInt(b.market_cap || 0);

--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -723,6 +723,8 @@ function renderRankingTable() {
         return isNaN(n) ? '-' : n.toLocaleString();
     };
 
+    const ytdMarketCapRank = isYtd ? _buildMarketCapRankMap(_rankingData) : null;
+
     let rows = '';
     pageData.forEach(item => {
         const rate = parseFloat(item.prdy_ctrt || 0);
@@ -755,13 +757,14 @@ function renderRankingTable() {
         if (isYtd) {
             const ytdRate = parseFloat(item.ytd_return_rate || 0);
             const ytdColor = ytdRate > 0 ? 'text-red' : (ytdRate < 0 ? 'text-blue' : '');
+            const mcapRank = ytdMarketCapRank ? ytdMarketCapRank.get(code) : null;
             rows += `<tr>
                 <td>${item.data_rank || item.rank || '-'}</td>
                 <td><a href="/stock?code=${code}" target="_blank" class="stock-link">${escapeHtml(item.name || code)}</a></td>
                 <td>${parseInt(item.current_price || 0).toLocaleString()}</td>
                 <td class="${ytdColor}">${ytdRate.toFixed(2)}%</td>
                 <td>${parseInt(item.base_price || 0).toLocaleString()}</td>
-                <td>${formatMarketCap(item.market_cap)}</td>
+                <td>${formatMarketCap(item.market_cap)}${mcapRank ? ` (${mcapRank}위)` : ''}</td>
             </tr>`;
             return;
         }
@@ -822,6 +825,16 @@ function _renderPeriodRankingLabel(data) {
         ? ` (~ ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)})`
         : '';
     return `<p style="color:#888; margin: 4px 0 12px;">최근 ${_rankingPeriodDays}거래일 기준${dateLabel}</p>`;
+}
+
+function _buildMarketCapRankMap(list) {
+    const map = new Map();
+    const sorted = list.slice().sort((a, b) => parseInt(b.market_cap || 0) - parseInt(a.market_cap || 0));
+    sorted.forEach((item, idx) => {
+        const code = item.stck_shrn_iscd || item.iscd || item.mksc_shrn_iscd || item.code || '';
+        if (code) map.set(code, idx + 1);
+    });
+    return map;
 }
 
 function _renderYtdRankingLabel(data) {

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -207,6 +207,8 @@ async function searchStock(codeOverride, exchangeOverride) {
         const sign = data.sign || '';
         const newHighBadge = (data.is_new_high) ? '<span class="badge new-high">🔥 신고가</span>' : '';
         const newLowBadge = (data.is_new_low) ? '<span class="badge new-low">💧 신저가</span>' : '';
+        const market = ['KOSPI', 'KOSDAQ'].includes(data.market) ? data.market : '';
+        const marketBadge = market ? `<span class="stock-market-badge ${market.toLowerCase()}">${market}</span>` : '';
 
         const styles = `
             <style>
@@ -215,6 +217,12 @@ async function searchStock(codeOverride, exchangeOverride) {
                 .exchange-btn.active { background: var(--accent, #4a90e2); color: white; border-color: var(--accent, #4a90e2); font-weight: bold; }
                 .exchange-btn:hover { background: var(--bg-card, #e8e8e8); }
                 .stock-title { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+                .stock-market-badge {
+                    color: #fff; font-size: 0.75rem; line-height: 1;
+                    padding: 0.35rem 0.55rem; border-radius: 999px; font-weight: 700;
+                }
+                .stock-market-badge.kospi { background: #2980b9; }
+                .stock-market-badge.kosdaq { background: #8e44ad; }
                 .badge.new-high {
                     background-color: #ff6b35; color: white; font-size: 0.8em;
                     padding: 0.2em 0.6em; border-radius: 10px; font-weight: bold; white-space: nowrap;
@@ -326,7 +334,7 @@ async function searchStock(codeOverride, exchangeOverride) {
                 <button id="fav-toggle-btn" class="fav-star-btn" onclick="toggleFavorite('${data.code}')" title="관심종목">☆</button>
                 ${exchangeButtons}
                 <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
-                    <h3 class="stock-title" style="margin:0;" id="stock-title-area">${data.name} (${data.code}) ${newHighBadge}${newLowBadge}</h3>
+                    <h3 class="stock-title" style="margin:0;" id="stock-title-area">${data.name} (${data.code}) ${marketBadge}${newHighBadge}${newLowBadge}</h3>
                 </div>
                 <p id="rt-price" class="price ${changeClass}">${fnum(data.price, '원')}</p>
                 <p id="rt-change-rate" class="change-rate">전일대비: ${sign}${fnum(data.change_absolute || Math.abs(data.change))} (${frate(data.rate)})</p>

--- a/view/web/static/js/strategy_reports.js
+++ b/view/web/static/js/strategy_reports.js
@@ -35,7 +35,8 @@ function renderStrategyReportList() {
         <button type="button" class="strategy-report-item ${report.id === _selectedStrategyReportId ? 'active' : ''}"
                 data-report-id="${escapeHtml(report.id)}"
                 onclick="selectStrategyReport(this.dataset.reportId)">
-            <strong>${formatReportDate(report.report_date)}</strong>
+            <strong>${escapeHtml(report.title || '전략 상세 진단')}</strong>
+            <span>${report.kind === 'telegram' ? '텔레그램' : '전략 상세'} · ${formatReportDate(report.report_date)}</span>
             <span>${formatCreatedAt(report.created_at)}</span>
         </button>
     `).join('');
@@ -52,7 +53,8 @@ async function selectStrategyReport(reportId) {
         const response = await fetch(`/api/strategies/diagnostic-reports/${encodeURIComponent(reportId)}`);
         if (!response.ok) throw new Error('상세 조회 실패');
         const report = await response.json();
-        meta.textContent = `${formatReportDate(report.report_date)} · ${formatCreatedAt(report.created_at)}`;
+        const kind = report.kind === 'telegram' ? '텔레그램' : '전략 상세';
+        meta.textContent = `${kind} · ${report.title || '전략 상세 진단'} · ${formatReportDate(report.report_date)} · ${formatCreatedAt(report.created_at)}`;
         content.replaceChildren(sanitizeStrategyReport(report.content || ''));
     } catch (_) {
         clearStrategyReportViewer('상세 리포트를 불러오지 못했습니다.');

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -55,7 +55,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/stock.js?v=14"></script>
+<script src="/static/js/stock.js?v=15"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/view/web/templates/strategy_reports.html
+++ b/view/web/templates/strategy_reports.html
@@ -5,7 +5,7 @@
     <div class="strategy-report-header">
         <div>
             <h2>상세 리포트 보관함</h2>
-            <p>텔레그램에는 운영 요약만 전송되고, 전략별 상세 진단은 이곳에 보관됩니다.</p>
+            <p>전략별 상세 진단과 발송된 모든 텔레그램 메시지를 이곳에서 확인할 수 있습니다.</p>
         </div>
         <button type="button" class="btn" onclick="loadStrategyReports()">새로고침</button>
     </div>
@@ -23,5 +23,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/strategy_reports.js?v=1"></script>
+<script src="/static/js/strategy_reports.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## 변경 사항
- YTD 랭킹 기준일을 표 위 라벨로 이동하고 시가총액에 현재 목록 내 순위를 표시
- 기간수급 라벨에 증권사 응답 기준 실제 시작 거래일과 종료 거래일을 함께 표시
- 상세 리포트 보관함에서 전략 상세 진단과 성공적으로 발송된 모든 텔레그램 메시지를 최신순으로 통합 조회
- 텔레그램 항목의 유형, 제목, 발송 시각, 본문을 구분해 표시
- 현재가 조회 결과의 종목명 옆에 KOSPI/KOSDAQ 시장 배지를 표시

## 배경
기간수급 화면은 종료일만 보여 실제 집계 구간을 알기 어려웠고, 텔레그램 발송 이력은 SQLite에 저장되고 있었지만 상세 리포트 화면과 연결되지 않아 조회할 수 없었습니다. 현재가 화면도 종목의 소속 시장을 바로 확인할 수 없었습니다.

## 영향
휴장일을 포함한 달력 계산 대신 실제 API 거래일을 사용해 기간수급 범위를 정확히 표시합니다. 기존 전략 상세 리포트는 그대로 유지하면서 텔레그램 발송 이력도 같은 보관함에서 확인할 수 있습니다. 현재가 조회에서는 로컬 종목코드 저장소의 시장 정보를 사용하며 KOSPI/KOSDAQ 종목만 명확한 배지로 표시합니다.

## 검증
- `pytest tests/unit_test -v` — 6,874 passed
- `pytest tests/integration_test -v` — 259 passed
- `node tests/frontend/run_stock_dom_tests.mjs` — 3 passed
- `git diff --check`