### PR TITLE
1-5 캡처 후보 소스 구분 metadata 기록 + QC 2주차 판정 동기화

### DIFF
--- a/services/backtest_microstructure_capture.py
+++ b/services/backtest_microstructure_capture.py
@@ -37,6 +37,7 @@ class BacktestMicrostructureCaptureService:
         include_execution_strength: bool = True,
         program_source: str = "daily_rest",
         execution_strength_source: str = "rest_scalar",
+        candidate_sources: dict[str, list[str]] | None = None,
     ) -> dict[str, Any]:
         selected_codes = [code.strip() for code in codes if code.strip()]
         intraday, stale_minute_rows_dropped = await self._capture_intraday(
@@ -70,8 +71,7 @@ class BacktestMicrostructureCaptureService:
             if include_intraday else []
         )
 
-        return {
-            "metadata": {
+        metadata: dict[str, Any] = {
                 "schema_version": 1,
                 "capture_type": "backtest_microstructure_overlay",
                 "trade_date": date_ymd,
@@ -101,7 +101,11 @@ class BacktestMicrostructureCaptureService:
                         if value is not None
                     ),
                 },
-            },
+        }
+        if candidate_sources is not None:
+            metadata["candidate_sources"] = candidate_sources
+        return {
+            "metadata": metadata,
             "intraday_minutes": intraday,
             "execution_strength": execution_strength,
             "execution_strength_intraday": execution_strength_intraday,

--- a/task/background/after_market/microstructure_capture_task.py
+++ b/task/background/after_market/microstructure_capture_task.py
@@ -11,7 +11,7 @@ from services.backtest_microstructure_quality import (
 )
 from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.after_market_task_base import AfterMarketTask
-from task.background.capture_candidates import resolve_capture_codes
+from task.background.capture_candidates import resolve_capture_codes_with_sources
 
 
 class MicrostructureCaptureTask(AfterMarketTask):
@@ -105,9 +105,9 @@ class MicrostructureCaptureTask(AfterMarketTask):
         except Exception as exc:
             self._logger.warning(f"{self.task_name}: 마지막 캡처 날짜 저장 실패 — {exc}")
 
-    async def _resolve_codes(self) -> list[str]:
-        """캡처 대상 종목: 보유 종목 우선 + Pool B 워치리스트, 중복 제거 후 cap."""
-        return await resolve_capture_codes(
+    async def _resolve_codes(self) -> tuple[list[str], dict[str, list[str]]]:
+        """캡처 대상 종목: 보유 종목 우선 + Pool B 워치리스트, 중복 제거 후 cap + 소스 구분."""
+        return await resolve_capture_codes_with_sources(
             virtual_trade_service=self._virtual_trade_service,
             universe_service=self._universe_service,
             stock_query_service=self._stock_query_service,
@@ -124,7 +124,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 f"{self.task_name}: {latest_trading_date} 이미 캡처됨 — skip"
             )
             return
-        codes = await self._resolve_codes()
+        codes, candidate_sources = await self._resolve_codes()
         if not codes:
             # 날짜를 저장하지 않아 이후 재실행(예: force) 시 재시도 여지를 남긴다.
             self._logger.warning(f"{self.task_name}: 캡처 대상 종목 없음 — skip")
@@ -142,6 +142,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 latest_trading_date=latest_trading_date,
                 program_source=program_source,
                 execution_strength_source=execution_strength_source,
+                candidate_sources=candidate_sources,
             )
             self._service.write_overlay_files(payload, self._output_dir)
             self._last_captured_date = latest_trading_date
@@ -155,6 +156,10 @@ class MicrostructureCaptureTask(AfterMarketTask):
             )
             self._progress["last_result"] = {
                 "codes": len(codes),
+                "candidate_source_counts": {
+                    source: len(source_codes)
+                    for source, source_codes in candidate_sources.items()
+                },
                 "program_source": program_source,
                 "row_counts": metadata.get("row_counts"),
                 "program_fallback_codes": program_fallback_codes,
@@ -199,12 +204,14 @@ class MicrostructureCaptureTask(AfterMarketTask):
         latest_trading_date: str,
         program_source: str,
         execution_strength_source: str,
+        candidate_sources: dict[str, list[str]] | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         payload = await self._capture_once(
             codes=codes,
             latest_trading_date=latest_trading_date,
             program_source=program_source,
             execution_strength_source=execution_strength_source,
+            candidate_sources=candidate_sources,
         )
         quality_summary = summarize_capture_quality(payload, fallback_codes=codes)
 
@@ -223,6 +230,7 @@ class MicrostructureCaptureTask(AfterMarketTask):
                 latest_trading_date=latest_trading_date,
                 program_source=program_source,
                 execution_strength_source=execution_strength_source,
+                candidate_sources=candidate_sources,
             )
             quality_summary = summarize_capture_quality(payload, fallback_codes=codes)
 
@@ -235,12 +243,14 @@ class MicrostructureCaptureTask(AfterMarketTask):
         latest_trading_date: str,
         program_source: str,
         execution_strength_source: str,
+        candidate_sources: dict[str, list[str]] | None = None,
     ) -> dict[str, Any]:
         return await self._service.capture(
             codes=codes,
             date_ymd=latest_trading_date,
             program_source=program_source,
             execution_strength_source=execution_strength_source,
+            candidate_sources=candidate_sources,
         )
 
     async def _emit_quality_gate_warning(

--- a/task/background/capture_candidates.py
+++ b/task/background/capture_candidates.py
@@ -52,7 +52,7 @@ async def _fetch_ranking_codes(
     return codes
 
 
-async def resolve_capture_codes(
+async def resolve_capture_codes_with_sources(
     *,
     virtual_trade_service=None,
     universe_service=None,
@@ -61,8 +61,14 @@ async def resolve_capture_codes(
     max_codes: Optional[int] = None,
     logger=None,
     task_name: str = "capture_candidates",
-) -> list[str]:
-    """캡처 대상 종목: 보유 우선 + Pool B 워치리스트 + 거래대금 랭킹 보충, 중복 제거 후 cap."""
+) -> tuple[list[str], dict[str, list[str]]]:
+    """`resolve_capture_codes` + 최종 목록의 소스 구분.
+
+    랭킹 보충 코드는 필터 통과 '후보'가 아니므로 replay metadata에서 PIT 후보군으로
+    해석할 때 소스를 구분할 수 있어야 한다. (todo 1-8) 반환되는 소스 구분은
+    dedup·cap 적용 후 최종 목록 기준이며, base(보유+워치리스트)와 중복인 랭킹
+    코드는 base로 귀속된다.
+    """
     codes: list[str] = []
     if virtual_trade_service is not None:
         try:
@@ -78,17 +84,45 @@ async def resolve_capture_codes(
         except Exception as exc:
             if logger:
                 logger.warning(f"{task_name}: 워치리스트 조회 실패 — {exc}")
+    base_codes = list(dict.fromkeys(code for code in codes if code))
     if stock_query_service is not None:
-        base_count = len(dict.fromkeys(code for code in codes if code))
         ranking_codes = await _fetch_ranking_codes(
             stock_query_service, ranking_limit, logger, task_name
         )
         codes.extend(ranking_codes)
         if ranking_codes and logger:
             logger.info(
-                f"{task_name}: 캡처 후보 랭킹 보충 — 기본 {base_count}종목 + 랭킹 {len(ranking_codes)}종목"
+                f"{task_name}: 캡처 후보 랭킹 보충 — 기본 {len(base_codes)}종목 + 랭킹 {len(ranking_codes)}종목"
             )
     deduped = list(dict.fromkeys(code for code in codes if code))
     if max_codes is not None:
-        return deduped[:max_codes]
-    return deduped
+        deduped = deduped[:max_codes]
+    base_set = set(base_codes)
+    sources = {
+        "base": [code for code in deduped if code in base_set],
+        "ranking_supplement": [code for code in deduped if code not in base_set],
+    }
+    return deduped, sources
+
+
+async def resolve_capture_codes(
+    *,
+    virtual_trade_service=None,
+    universe_service=None,
+    stock_query_service=None,
+    ranking_limit: int = 20,
+    max_codes: Optional[int] = None,
+    logger=None,
+    task_name: str = "capture_candidates",
+) -> list[str]:
+    """캡처 대상 종목: 보유 우선 + Pool B 워치리스트 + 거래대금 랭킹 보충, 중복 제거 후 cap."""
+    codes, _ = await resolve_capture_codes_with_sources(
+        virtual_trade_service=virtual_trade_service,
+        universe_service=universe_service,
+        stock_query_service=stock_query_service,
+        ranking_limit=ranking_limit,
+        max_codes=max_codes,
+        logger=logger,
+        task_name=task_name,
+    )
+    return codes

--- a/tests/unit_test/services/test_backtest_microstructure_capture.py
+++ b/tests/unit_test/services/test_backtest_microstructure_capture.py
@@ -522,3 +522,32 @@ def test_write_overlay_files_includes_execution_strength_intraday(tmp_path):
         paths["execution_strength_intraday"].read_text(encoding="utf-8")
     ) == {"000001": [{"time": "090001", "strength": 100.0}]}
 
+
+@pytest.mark.asyncio
+async def test_capture_records_candidate_sources_in_metadata():
+    sqs = AsyncMock()
+    sqs.get_day_intraday_minutes_list.return_value = []
+    sqs.get_stock_conclusion.return_value = _response({"output": [{"tday_rltv": "100.0"}]})
+    program_provider = AsyncMock()
+    program_provider.get_program_trade_by_stock_daily.return_value = _response(
+        {"whol_smtn_ntby_qty": "0"}
+    )
+    service = BacktestMicrostructureCaptureService(
+        stock_query_service=sqs,
+        program_provider=program_provider,
+    )
+
+    payload = await service.capture(
+        codes=["000001", "100001"],
+        date_ymd="20260512",
+        candidate_sources={"base": ["000001"], "ranking_supplement": ["100001"]},
+    )
+
+    assert payload["metadata"]["candidate_sources"] == {
+        "base": ["000001"],
+        "ranking_supplement": ["100001"],
+    }
+
+    plain = await service.capture(codes=["000001"], date_ymd="20260512")
+    assert "candidate_sources" not in plain["metadata"]
+

--- a/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
+++ b/tests/unit_test/task/background/after_market/test_microstructure_capture_task.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from common.types import ErrorCode, ResCommonResponse
 from services.notification_service import NotificationCategory, NotificationLevel
 from task.background.after_market.microstructure_capture_task import MicrostructureCaptureTask
 
@@ -534,3 +535,32 @@ async def test_execution_strength_metrics_exposed_in_last_result(
     last_result = task.get_progress()["last_result"]
     assert last_result["execution_strength_fallback_codes"] == ["000660"]
     assert last_result["execution_strength_db_coverage_pct"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_candidate_sources_passed_to_capture_and_counts_exposed(
+    capture_service, universe_service, tmp_path
+):
+    sqs = MagicMock()
+    sqs.get_top_trading_value_stocks = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="ok",
+            data=[{"mksc_shrn_iscd": "100001", "hts_kor_isnm": "랭킹A"}],
+        )
+    )
+    task = _make_task(
+        capture_service, tmp_path,
+        universe_service=universe_service,
+        stock_query_service=sqs,
+    )
+
+    await task._on_market_closed("20260702")
+
+    kwargs = capture_service.capture.await_args.kwargs
+    assert kwargs["candidate_sources"] == {
+        "base": ["005930", "000660"],
+        "ranking_supplement": ["100001"],
+    }
+    last_result = task.get_progress()["last_result"]
+    assert last_result["candidate_source_counts"] == {"base": 2, "ranking_supplement": 1}

--- a/tests/unit_test/task/background/test_capture_candidates.py
+++ b/tests/unit_test/task/background/test_capture_candidates.py
@@ -2,7 +2,10 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from common.types import ErrorCode, ResCommonResponse
-from task.background.capture_candidates import resolve_capture_codes
+from task.background.capture_candidates import (
+    resolve_capture_codes,
+    resolve_capture_codes_with_sources,
+)
 
 
 def _make_virtual_trade_service(codes):
@@ -109,3 +112,49 @@ async def test_without_stock_query_service_behavior_unchanged():
         universe_service=_make_universe_service(["000002"]),
     )
     assert codes == ["000001", "000002"]
+
+
+async def test_with_sources_splits_base_and_ranking_supplement():
+    sqs = _make_stock_query_service([
+        _ranking_item("100001", "랭킹A"),
+        _ranking_item("100002", "랭킹B"),
+    ])
+    codes, sources = await resolve_capture_codes_with_sources(
+        virtual_trade_service=_make_virtual_trade_service(["000001"]),
+        universe_service=_make_universe_service(["000002"]),
+        stock_query_service=sqs,
+    )
+    assert codes == ["000001", "000002", "100001", "100002"]
+    assert sources == {
+        "base": ["000001", "000002"],
+        "ranking_supplement": ["100001", "100002"],
+    }
+
+
+async def test_with_sources_ranking_overlap_counted_as_base():
+    sqs = _make_stock_query_service([
+        _ranking_item("000001", "보유중복"),
+        _ranking_item("100001", "랭킹A"),
+    ])
+    codes, sources = await resolve_capture_codes_with_sources(
+        virtual_trade_service=_make_virtual_trade_service(["000001"]),
+        universe_service=_make_universe_service([]),
+        stock_query_service=sqs,
+    )
+    assert codes == ["000001", "100001"]
+    assert sources == {"base": ["000001"], "ranking_supplement": ["100001"]}
+
+
+async def test_with_sources_max_codes_cap_reflected_in_split():
+    sqs = _make_stock_query_service([
+        _ranking_item("100001", "랭킹A"),
+        _ranking_item("100002", "랭킹B"),
+    ])
+    codes, sources = await resolve_capture_codes_with_sources(
+        virtual_trade_service=_make_virtual_trade_service(["000001"]),
+        universe_service=_make_universe_service(["000002"]),
+        stock_query_service=sqs,
+        max_codes=3,
+    )
+    assert codes == ["000001", "000002", "100001"]
+    assert sources == {"base": ["000001", "000002"], "ranking_supplement": ["100001"]}

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-15 (OpenDART·AI 분석용 외부 API 키 준비 항목 추가)
+최종 업데이트: 2026-07-17 (1-5 QC 2주차 판정·캡처 후보 소스 구분 metadata 기록)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -65,7 +65,10 @@
   - 체결강도 장중 시계열 캡처 배선 완료 (2026-07-04): WS 체결 틱(H0STCNT0)에 포함된 `체결강도`를 `PriceStreamService.on_price_tick`에서 종목당 60초 샘플링해 `es_history` SQLite(`data/execution_strength/`, `ExecutionStrengthRepository`)에 축적 — **신규 WS 구독 없음**(기존 PRICE 틱 무임승차, 슬롯 비간섭). 장마감 캡처가 `execution_strength_source=es_db`로 소비하고 DB 미스 종목은 기존 REST 스칼라 유지 + `metadata.execution_strength_fallback_codes` 기록. QC에 `execution_strength_db_coverage_pct`(임계 30% — 배선 전손 감지용) 노출, overlay 파일 `replay_execution_strength_intraday_*.json` 추가. `execution_strength_capture_enabled`(기본 on).
   - QC 1주차 판정 (2026-07-08, 4거래일 07-03/06/07/08 실측): ① program fallback 2종목(07-06)→0→0 수렴 — PT 구독 배선 의도대로 작동, program_db 완전 커버 도달. ② ES fallback(일 4~6종목)은 3일 모두 `empty_minute_codes`(무거래/정지 종목)와 정확히 일치 — 거래가 있었던 후보는 ES 시계열 전량 커버, "무틱 ~55% 제한" 우려는 캡처 후보군에선 실측상 미발현(표본 9~12종목/일 단서). ③ stale row 필터 작동(033160 매일 57행 드랍). 이후 관찰은 이 기준선 대비 악화 여부로 판단.
   - 캡처 전용 후보 확장 (2026-07-08): 워치리스트 기근(Pool B 항목 참조)으로 코퍼스 폭이 9~12종목/일에 갇혀, `resolve_capture_codes`에 거래대금 상위 랭킹 보충(기본 20종목, ETF 프리픽스 제외, 조회 실패 시 무보충) 추가 — 장마감 캡처·장중 PT 구독 공통 적용, 트레이딩 후보/주문 경로 불변. 랭킹 API는 실전 전용이라 모의 환경에선 자동으로 기존 동작.
-  - ※ 남은 한계: 체결강도 시계열 커버리지가 "PRICE 구독 중 + 유틱" 종목으로 제한(무틱 ~55% — 2-4 해소 시 개선, 미커버는 EOD 스칼라 폴백; 랭킹 보충분도 PRICE 미구독이면 EOD 스칼라). 남은 것: quality 플래그·PT/ES 커버리지(`program_fallback_codes`·`execution_strength_fallback_codes` 감소 여부) 일일 관찰.
+  - QC 2주차 판정 (2026-07-17, 07-09~16 6거래일 실측): 코퍼스 폭 34종목/일 안착(랭킹 보충 효과). ① program fallback 10→8→5→4 — 1주차 "0 수렴" 기준선과 다르나 후보 34 vs PT 구독 cap 10의 구조적 결과이며 program_db coverage는 48→88%로 상승 추세(pt_history 누적·구독 로테이션). 005935(삼성전자우) 상시 폴백은 #672 우선주 PT 구독 제외의 예상된 결과. ② ES fallback(일 14~19종목)이 empty_minute(9~11) 초과 — 초과분 전수 확인 결과 전부 랭킹 보충 대형주(현대차·삼성SDI·NAVER 등, PRICE 미구독 → 설계된 EOD 스칼라 폴백). **회귀 아님 판정.** 신기준선: base(보유+워치리스트) 종목의 fallback 발생만 회귀 신호로 본다. ③ stale 필터 정상(033160 57행/일, 07-16부터 019210 89행 추가).
+  - **QC 게이트 상시 실패 발견 (2026-07-17)**: 07-09~16 6일 전부 `quality_gate_passed=false`, 주원인 `intraday_coverage_below_threshold`(실측 45~74% < 임계 80%) — 분모에 무거래/정지 base 종목(~10종목)이 포함되는 구조라 현행 정의로는 통과 불가능. → candidate_sources 데이터 축적 후 coverage 분모 재정의(무거래 제외 또는 base-only) 혹은 임계 조정 필요. 그 전까지 게이트 WARNING 알림은 참고용으로만 해석.
+  - 캡처 후보 소스 구분 metadata 기록 (2026-07-17): `resolve_capture_codes_with_sources`로 base(보유+워치리스트) vs ranking_supplement를 구분해 `metadata.candidate_sources`에 기록, 태스크 `last_result.candidate_source_counts` 노출. 기존엔 info 로그에 개수만 남아 replay 파일 단독으로 PIT 후보(base) 식별이 불가능했던 갭 해소 — 1-8 해제 조건 (a)의 전제.
+  - ※ 남은 한계: 체결강도 시계열 커버리지가 "PRICE 구독 중 + 유틱" 종목으로 제한(무틱 ~55% — 2-4 해소 시 개선, 미커버는 EOD 스칼라 폴백; 랭킹 보충분도 PRICE 미구독이면 EOD 스칼라). 남은 것: base 종목 기준 fallback 발생 여부 일일 관찰(신기준선), QC 게이트 coverage 정의 재조정.
 - [blocked — 캡처 코퍼스 축적 후] 실제 replay fixture를 통과 케이스까지 확장 → replay overlay.
 - [ ] 한국장 실전 microstructure fixture(bid/ask book·잔량·체결강도·프로그램매매 overlay)로 체결 모델 보정 + 시장가/최유리/지정가별 fill quality가 live journal과 얼마나 벌어지는지 리포트.
 
@@ -77,7 +80,7 @@
 - [blocked] 활성 전략 전체 walk-forward + Monte Carlo 재실행 + 민감도 표 — **2026-07-03 파일럿(VBO 6/15-30, PP 6/1-12) 결과 전 구간 0거래**로 현시점 무의미.
   - 원인 ①: 백테스트 유니버스가 **현재 시점** `data/premium_stocks.json`(PIT 아님) — 2026-07-03 재생성 기준 KOSPI 0종목/KOSDAQ 0종목이라 어떤 과거 구간을 돌려도 후보가 없다.
   - 원인 ②: 6월 하순 양시장 MA 하락 → 마켓 타이밍 게이트가 스캔 차단(`market_timing_off_both`) — 롱온리 전략의 정상 휴식.
-  - 해제 조건: (a) 1-5 캡처 코퍼스 축적(`replay_microstructure_*.json`의 `metadata.codes`가 당일 후보 스냅샷 = PIT 후보군 역할) 또는 (b) 시장 회복으로 Pool B 복원. ※ 2026-07-08 랭킹 보충으로 codes 폭 확대 — 단, 보충분은 필터 통과 '후보'가 아닌 유동성 상위 종목이므로 PIT 후보군으로 해석할 때 소스 구분에 유의(보충 발생 시 capture_candidates info 로그에 소스별 개수 기록).
+  - 해제 조건: (a) 1-5 캡처 코퍼스 축적(`replay_microstructure_*.json`의 `metadata.codes`가 당일 후보 스냅샷 = PIT 후보군 역할) 또는 (b) 시장 회복으로 Pool B 복원. ※ 2026-07-08 랭킹 보충으로 codes 폭 확대 — 단, 보충분은 필터 통과 '후보'가 아닌 유동성 상위 종목이므로 PIT 후보군으로 해석할 때 소스 구분에 유의. 2026-07-17부터 `metadata.candidate_sources`(base/ranking_supplement)가 파일에 기록되므로 PIT 후보군은 base만 사용(그 이전 파일은 로그 교차 참조 필요).
   - 실행 메모: 첫 런이 REST 지배적(12거래일 ≈ 18~23분), **캐시 워밍 후 변형 런 ≈ 1분** — 후보만 갖춰지면 민감도 그리드는 저렴.
 
 주요 파일: `scripts/run_backtest.py`, `services/backtest_walk_forward.py`, `docs/backtest.md`, `data/backtest_*.json`


### PR DESCRIPTION
## 배경

todo 1-8(백테스트 재실행)의 해제 조건 (a)는 캡처 코퍼스의 `metadata.codes`를 PIT 후보군으로 쓰는 것인데, 2026-07-08 거래대금 랭킹 보충(#647) 이후 codes에 필터 통과 후보(base)와 유동성 상위 보충분이 섞여 있고 소스 구분은 info 로그의 **개수**로만 남아 replay 파일 단독으로는 base 식별이 불가능했다.

## 변경 내용

- `resolve_capture_codes_with_sources` 신규 (`task/background/capture_candidates.py`): 최종(dedup+cap) 목록 기준 `base`(보유+워치리스트) vs `ranking_supplement` 구분 반환. 랭킹 코드가 base와 중복이면 base 귀속. `resolve_capture_codes`는 thin wrapper로 유지 — 기존 호출부·테스트 7건 불변.
- `BacktestMicrostructureCaptureService.capture()`에 `candidate_sources` 옵션 추가: 전달 시에만 `metadata.candidate_sources` 기록 (미전달 시 기존 스키마 그대로 — QC 스크립트 등 소비자 무영향).
- `MicrostructureCaptureTask`가 소스 구분을 capture로 스레딩하고 `last_result.candidate_source_counts` 노출.
- todo 1-5/1-8 동기화: **QC 2주차 판정** (07-09~16 6거래일 실측) 기록.

## QC 2주차 판정 요약

- 코퍼스 폭 34종목/일 안착. program fallback 10→4·ES fallback의 empty_minute 초과분(4~8종목/일)은 전수 확인 결과 전부 랭킹 보충 대형주(PT cap 10 미커버 / PRICE 미구독 EOD 스칼라) — **회귀 아님**. 신기준선: base 종목 fallback 발생만 회귀 신호.
- **신규 발견**: QC 게이트가 6일 전부 실패 중(`intraday_coverage` 67~74% < 임계 80%) — 분모에 무거래/정지 base 종목 포함 탓으로 구조적 통과 불가. coverage 분모 재정의(candidate_sources 축적 후 base-only 검토)는 후속 과제로 todo에 기록.

## 테스트

- 신규 5건 (TDD): 소스 분리/중복 귀속/cap 반영 3건 + metadata 기록·키 부재 1건 + 태스크 스레딩·counts 노출 1건
- 단위 전체 6,879 passed / 통합 전체 259 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)