### PR TITLE
1차: 관심종목 중요 공시 AI 요약 (Gemini/OpenAI 호환)

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -164,6 +164,23 @@ dart_disclosure:
   daily_digest_time: "19:40"
   max_pages_per_poll: 5
 
+# AI 분석 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트 공통)
+#   1차: 관심종목 중요 공시를 걸러 요약해 텔레그램 알림에 덧붙임
+#   provider 전환은 base_url/api_key/model 만 바꾸면 됨(코드 변경 불필요)
+#   - Gemini : base_url https://generativelanguage.googleapis.com/v1beta/openai , api_key 필수
+#   - Groq   : base_url https://api.groq.com/openai/v1 , api_key 필수
+#   - Ollama : base_url http://localhost:11434/v1 , api_key 불필요(빈 값)
+#   AI 호출 실패/타임아웃 시 기존 규칙 판정으로 자동 폴백(알림은 계속 발송)
+ai_analysis:
+  enabled: false
+  provider: "gemini"
+  base_url: "https://generativelanguage.googleapis.com/v1beta/openai"
+  api_key: ""
+  model: "gemini-2.5-flash"
+  timeout_sec: 15
+  max_tokens: 256
+  disclosure_summary_enabled: true
+
 # 시총갭 리포트 발송 세션 on/off (기본 둘 다 on)
 #   kr: 한국장 마감(15:50 KST) 후 발송 — 미국 시총은 전일 종가 기준(프리뷰)
 #   us: 미국장 마감(16:30 ET ≈ 익일 06:30 KST) 후 발송 — 양쪽 시총 최신(확정값)

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -178,7 +178,8 @@ ai_analysis:
   api_key: ""
   model: "gemini-2.5-flash"
   timeout_sec: 15
-  max_tokens: 256
+  # Gemini 2.5 계열은 thinking 토큰이 max_tokens를 소비하므로 넉넉히 (짧으면 요약이 잘림)
+  max_tokens: 2048
   disclosure_summary_enabled: true
 
 # 시총갭 리포트 발송 세션 on/off (기본 둘 다 on)

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -263,7 +263,9 @@ class AiAnalysisConfig(BaseModel):
     api_key: str = ""
     model: str = "gemini-2.5-flash"
     timeout_sec: float = Field(15.0, gt=0)
-    max_tokens: int = Field(256, ge=1, le=4096)
+    # Gemini 2.5 계열은 thinking 토큰이 max_tokens 예산을 소비하므로, 짧게 잡으면
+    # 실제 요약이 잘린다. 사고 후에도 2~3문장이 완성되도록 넉넉히 둔다.
+    max_tokens: int = Field(2048, ge=1, le=8192)
     disclosure_summary_enabled: bool = True
 
     model_config = {"extra": "allow"}

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -251,6 +251,24 @@ class DartDisclosureConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class AiAnalysisConfig(BaseModel):
+    """AI 분석 공통 설정 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트).
+
+    provider 차이는 base_url/api_key/model 로 흡수한다. api_key 는 클라우드
+    (Gemini/Groq)엔 필수, 로컬 Ollama 엔 불필요(빈 값 허용).
+    """
+    enabled: bool = False
+    provider: str = "gemini"
+    base_url: str = "https://generativelanguage.googleapis.com/v1beta/openai"
+    api_key: str = ""
+    model: str = "gemini-2.5-flash"
+    timeout_sec: float = Field(15.0, gt=0)
+    max_tokens: int = Field(256, ge=1, le=4096)
+    disclosure_summary_enabled: bool = True
+
+    model_config = {"extra": "allow"}
+
+
 class ExecutionQualityReportConfig(BaseModel):
     enabled: bool = True
     min_sample_count: int = 3
@@ -418,6 +436,7 @@ class AppConfig(BaseModel):
     data_quality: DataQualityConfig = Field(default_factory=DataQualityConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     dart_disclosure: DartDisclosureConfig = Field(default_factory=DartDisclosureConfig)
+    ai_analysis: AiAnalysisConfig = Field(default_factory=AiAnalysisConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)
     strategy_performance_degradation: StrategyPerformanceDegradationConfig = Field(

--- a/scripts/check_ai_key.py
+++ b/scripts/check_ai_key.py
@@ -1,0 +1,74 @@
+"""AI 키·엔드포인트 연결을 단독 검증하는 진단 스크립트.
+
+config/config.yaml 의 ai_analysis 설정(base_url/api_key/model)을 읽어 실제
+chat completion 을 한 번 호출한다. 키를 명령행에 넣지 않으므로 셸 히스토리에
+남지 않는다. Gemini/Groq/Ollama 공통(AiClient 가 provider 무관).
+
+사용:
+    python scripts/check_ai_key.py
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from services.ai_client import AiClient  # noqa: E402
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+_DEFAULT_MODEL = "gemini-2.5-flash"
+
+
+def _load_ai_config() -> dict:
+    config_path = _ROOT / "config" / "config.yaml"
+    if not config_path.exists():
+        print(f"[오류] {config_path} 가 없습니다.")
+        print("→ config/config.yaml.example 을 복사해 config.yaml 로 만들고 키를 넣으세요.")
+        sys.exit(1)
+    with open(config_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("ai_analysis") or {}
+
+
+def _mask(api_key: str) -> str:
+    if len(api_key) > 12:
+        return f"{api_key[:6]}...{api_key[-4:]}"
+    return "***"
+
+
+async def _main() -> None:
+    cfg = _load_ai_config()
+    api_key = str(cfg.get("api_key") or "")
+    base_url = str(cfg.get("base_url") or _DEFAULT_BASE_URL)
+    model = str(cfg.get("model") or _DEFAULT_MODEL)
+
+    if not api_key:
+        print("[오류] ai_analysis.api_key 가 비어 있습니다. config.yaml 에 키를 넣으세요.")
+        sys.exit(1)
+    if not api_key.startswith("AIza") and "googleapis" in base_url:
+        print(f"[경고] Gemini 키는 보통 'AIza' 로 시작합니다. 현재 키: {_mask(api_key)}")
+        print("→ Google AI Studio > Create API key 로 발급한 값인지 확인하세요.")
+
+    print(f"모델={model}  base_url={base_url}  키={_mask(api_key)}")
+    print("AI 호출 중...")
+
+    client = AiClient(base_url=base_url, api_key=api_key, model=model, timeout_sec=20)
+    try:
+        result = await client.complete(
+            system="너는 한국 주식 애널리스트다.",
+            user="삼성전자 유상증자 공시를 투자자 관점에서 한 문장으로 요약해줘.",
+        )
+    except Exception as exc:
+        print(f"[실패] {type(exc).__name__}: {exc}")
+        print("→ 키 형식(AIza)·모델명·네트워크/프록시를 확인하세요.")
+        sys.exit(1)
+
+    print("[성공] 응답:")
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/check_ai_key.py
+++ b/scripts/check_ai_key.py
@@ -15,6 +15,12 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+# Windows 콘솔(cp949)이 처리 못 하는 문자에서 출력이 잘리지 않도록 UTF-8 고정.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 from services.ai_client import AiClient  # noqa: E402
 
 _ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/check_ai_key.py
+++ b/scripts/check_ai_key.py
@@ -48,8 +48,13 @@ async def _main() -> None:
     if not api_key:
         print("[오류] ai_analysis.api_key 가 비어 있습니다. config.yaml 에 키를 넣으세요.")
         sys.exit(1)
-    if not api_key.startswith("AIza") and "googleapis" in base_url:
-        print(f"[경고] Gemini 키는 보통 'AIza' 로 시작합니다. 현재 키: {_mask(api_key)}")
+    # Gemini API 키는 'AIza'(구형) 또는 'AQ.'(신형) 로 시작한다. 둘 다 유효.
+    if (
+        "googleapis" in base_url
+        and not api_key.startswith("AIza")
+        and not api_key.startswith("AQ.")
+    ):
+        print(f"[경고] Gemini 키는 보통 'AIza' 또는 'AQ.' 로 시작합니다. 현재 키: {_mask(api_key)}")
         print("→ Google AI Studio > Create API key 로 발급한 값인지 확인하세요.")
 
     print(f"모델={model}  base_url={base_url}  키={_mask(api_key)}")

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -142,6 +142,10 @@ async def _main() -> None:
         if analyzer and importance.score >= threshold:
             summary = await analyzer.summarize(disclosure, importance)
             print(f"   🤖 AI: {summary or '(요약 실패 — 규칙 판정으로 폴백)'}")
+            if args.debug and summary is not None:
+                # ascii()는 한글을 \uXXXX로 바꿔 어떤 콘솔에서도 안 잘림 →
+                # 데이터가 온전한지(길이) vs 콘솔 표시만 잘리는지 확정
+                print(f"   [DEBUG len={len(summary)}] {ascii(summary)}")
             if summary is None and args.debug:
                 await _debug_ai_call(ai_client, disclosure, importance)
         print()

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -20,6 +20,12 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+# Windows 콘솔(cp949)이 처리 못 하는 문자에서 출력이 잘리지 않도록 UTF-8 고정.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 from repositories.favorite_repository import FavoriteRepository  # noqa: E402
 from services.ai_client import AiClient  # noqa: E402
 from services.ai_disclosure_analyzer import AiDisclosureAnalyzer  # noqa: E402

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -142,11 +142,9 @@ async def _main() -> None:
         if analyzer and importance.score >= threshold:
             summary = await analyzer.summarize(disclosure, importance)
             print(f"   🤖 AI: {summary or '(요약 실패 — 규칙 판정으로 폴백)'}")
-            if args.debug and summary is not None:
-                # ascii()는 한글을 \uXXXX로 바꿔 어떤 콘솔에서도 안 잘림 →
-                # 데이터가 온전한지(길이) vs 콘솔 표시만 잘리는지 확정
-                print(f"   [DEBUG len={len(summary)}] {ascii(summary)}")
-            if summary is None and args.debug:
+            if args.debug:
+                if summary is not None:
+                    print(f"   [DEBUG summary len={len(summary)}] {ascii(summary)}")
                 await _debug_ai_call(ai_client, disclosure, importance)
         print()
 
@@ -158,10 +156,14 @@ async def _debug_ai_call(ai_client, disclosure, importance) -> None:
     from services.ai_disclosure_analyzer import _SYSTEM_PROMPT, AiDisclosureAnalyzer
 
     prompt = AiDisclosureAnalyzer._build_prompt(disclosure, importance)
-    print("   --- DEBUG: 직접 호출 traceback ---")
+    print("   --- DEBUG: 원본 응답(finish_reason/usage) ---")
     try:
-        result = await ai_client.complete(system=_SYSTEM_PROMPT, user=prompt, max_tokens=2048)
-        print(f"   DEBUG 성공: {result!r}")
+        data = await ai_client.chat_json(system=_SYSTEM_PROMPT, user=prompt, max_tokens=2048)
+        choice = (data.get("choices") or [{}])[0]
+        print(f"   finish_reason = {choice.get('finish_reason')}")
+        print(f"   usage = {data.get('usage')}")
+        content = (choice.get("message") or {}).get("content")
+        print(f"   content len = {len(content or '')}")
     except Exception:
         traceback.print_exc()
     print("   --- DEBUG 끝 ---")

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -67,7 +67,7 @@ def _build_ai(ai_cfg: dict):
         model=str(ai_cfg.get("model") or _DEFAULT_MODEL),
         timeout_sec=float(ai_cfg.get("timeout_sec", 15)),
     )
-    analyzer = AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 256)))
+    analyzer = AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 2048)))
     return ai_client, analyzer
 
 
@@ -160,7 +160,7 @@ async def _debug_ai_call(ai_client, disclosure, importance) -> None:
     prompt = AiDisclosureAnalyzer._build_prompt(disclosure, importance)
     print("   --- DEBUG: 직접 호출 traceback ---")
     try:
-        result = await ai_client.complete(system=_SYSTEM_PROMPT, user=prompt, max_tokens=256)
+        result = await ai_client.complete(system=_SYSTEM_PROMPT, user=prompt, max_tokens=2048)
         print(f"   DEBUG 성공: {result!r}")
     except Exception:
         traceback.print_exc()

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -50,17 +50,19 @@ async def _fetch(client, date, max_pages):
     return collected
 
 
-def _build_analyzer(ai_cfg: dict):
+def _build_ai(ai_cfg: dict):
+    """(AiClient, AiDisclosureAnalyzer) 또는 (None, None) 반환."""
     ai_key = str(ai_cfg.get("api_key") or "")
     if not (ai_cfg.get("enabled") and ai_key):
-        return None
+        return None, None
     ai_client = AiClient(
         base_url=str(ai_cfg.get("base_url") or _DEFAULT_BASE_URL),
         api_key=ai_key,
         model=str(ai_cfg.get("model") or _DEFAULT_MODEL),
         timeout_sec=float(ai_cfg.get("timeout_sec", 15)),
     )
-    return AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 256)))
+    analyzer = AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 256)))
+    return ai_client, analyzer
 
 
 async def _resolve_targets(args):
@@ -77,6 +79,7 @@ async def _main() -> None:
     parser.add_argument("--codes", default=None, help="쉼표구분 종목코드 (관심종목 대신)")
     parser.add_argument("--all", action="store_true", help="관심종목 필터 없이 전체")
     parser.add_argument("--limit", type=int, default=20, help="표시 건수 상한")
+    parser.add_argument("--debug", action="store_true", help="AI 실패 시 전체 traceback 출력")
     args = parser.parse_args()
 
     config = _load_config()
@@ -96,7 +99,7 @@ async def _main() -> None:
         dart_key, timeout_sec=float(dart_cfg.get("request_timeout_sec", 5))
     )
     rules = DartDisclosureRuleService()
-    analyzer = _build_analyzer(ai_cfg)
+    ai_client, analyzer = _build_ai(ai_cfg)
 
     targets = await _resolve_targets(args)
     if targets is not None and not targets:
@@ -133,7 +136,25 @@ async def _main() -> None:
         if analyzer and importance.score >= threshold:
             summary = await analyzer.summarize(disclosure, importance)
             print(f"   🤖 AI: {summary or '(요약 실패 — 규칙 판정으로 폴백)'}")
+            if summary is None and args.debug:
+                await _debug_ai_call(ai_client, disclosure, importance)
         print()
+
+
+async def _debug_ai_call(ai_client, disclosure, importance) -> None:
+    """AI 실패 원인을 정확히 보기 위해 swallow 없이 직접 호출 후 traceback 출력."""
+    import traceback
+
+    from services.ai_disclosure_analyzer import _SYSTEM_PROMPT, AiDisclosureAnalyzer
+
+    prompt = AiDisclosureAnalyzer._build_prompt(disclosure, importance)
+    print("   --- DEBUG: 직접 호출 traceback ---")
+    try:
+        result = await ai_client.complete(system=_SYSTEM_PROMPT, user=prompt, max_tokens=256)
+        print(f"   DEBUG 성공: {result!r}")
+    except Exception:
+        traceback.print_exc()
+    print("   --- DEBUG 끝 ---")
 
 
 if __name__ == "__main__":

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -1,0 +1,138 @@
+"""공시 → 규칙 점수 → AI 요약 1차 파이프라인 dry-run 진단.
+
+config.yaml 의 dart_disclosure/ai_analysis 설정으로 실제 OpenDART 공시를 받아
+규칙 점수와 AI 요약까지 한 번에 확인한다. 텔레그램·실시간 대기 없이 검증 가능.
+
+사용:
+    python scripts/check_disclosure_ai.py                  # 오늘, 관심종목
+    python scripts/check_disclosure_ai.py --date 20260715  # 특정일
+    python scripts/check_disclosure_ai.py --codes 000660   # 특정 종목
+    python scripts/check_disclosure_ai.py --all --limit 10 # 관심종목 무시, 전체 일부
+"""
+import argparse
+import asyncio
+import sys
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from repositories.favorite_repository import FavoriteRepository  # noqa: E402
+from services.ai_client import AiClient  # noqa: E402
+from services.ai_disclosure_analyzer import AiDisclosureAnalyzer  # noqa: E402
+from services.dart_disclosure_client import DartDisclosureClient  # noqa: E402
+from services.dart_disclosure_rule_service import DartDisclosureRuleService  # noqa: E402
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_config() -> dict:
+    config_path = _ROOT / "config" / "config.yaml"
+    if not config_path.exists():
+        print(f"[오류] {config_path} 가 없습니다.")
+        sys.exit(1)
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+async def _fetch(client, date, max_pages):
+    collected = []
+    for page_no in range(1, max_pages + 1):
+        page = await client.fetch_disclosures(date, page_no=page_no)
+        collected.extend(page.items)
+        if page_no >= page.total_page:
+            break
+    return collected
+
+
+def _build_analyzer(ai_cfg: dict):
+    ai_key = str(ai_cfg.get("api_key") or "")
+    if not (ai_cfg.get("enabled") and ai_key):
+        return None
+    ai_client = AiClient(
+        base_url=str(ai_cfg.get("base_url") or ""),
+        api_key=ai_key,
+        model=str(ai_cfg.get("model") or ""),
+        timeout_sec=float(ai_cfg.get("timeout_sec", 15)),
+    )
+    return AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 256)))
+
+
+async def _resolve_targets(args):
+    if args.codes:
+        return {c.strip() for c in args.codes.split(",") if c.strip()}
+    if args.all:
+        return None  # 필터 없음
+    return {str(c) for c in await FavoriteRepository().get_all()}
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", default=None, help="YYYYMMDD (기본: 오늘 KST)")
+    parser.add_argument("--codes", default=None, help="쉼표구분 종목코드 (관심종목 대신)")
+    parser.add_argument("--all", action="store_true", help="관심종목 필터 없이 전체")
+    parser.add_argument("--limit", type=int, default=20, help="표시 건수 상한")
+    args = parser.parse_args()
+
+    config = _load_config()
+    dart_cfg = config.get("dart_disclosure") or {}
+    ai_cfg = config.get("ai_analysis") or {}
+
+    dart_key = str(dart_cfg.get("api_key") or "")
+    if not dart_key:
+        print("[오류] dart_disclosure.api_key 가 비어 있습니다.")
+        sys.exit(1)
+
+    date = args.date or datetime.now(ZoneInfo("Asia/Seoul")).strftime("%Y%m%d")
+    threshold = int(dart_cfg.get("immediate_alert_score", 70))
+    max_pages = int(dart_cfg.get("max_pages_per_poll", 5))
+
+    client = DartDisclosureClient(
+        dart_key, timeout_sec=float(dart_cfg.get("request_timeout_sec", 5))
+    )
+    rules = DartDisclosureRuleService()
+    analyzer = _build_analyzer(ai_cfg)
+
+    targets = await _resolve_targets(args)
+    if targets is not None and not targets:
+        print("[안내] 관심종목이 비어 있습니다. --codes 또는 --all 로 실행하세요.")
+        return
+
+    label = "전체" if targets is None else (", ".join(sorted(targets)) or "없음")
+    print(f"조회일={date}  대상={label}  즉시알림 임계={threshold}점")
+    print(f"AI 요약={'ON' if analyzer else 'OFF'}")
+    print("OpenDART 조회 중...")
+
+    try:
+        disclosures = await _fetch(client, date, max_pages)
+    except Exception as exc:
+        print(f"[실패] 공시 조회 오류: {type(exc).__name__}: {exc}")
+        print("→ dart_disclosure.api_key·네트워크를 확인하세요.")
+        sys.exit(1)
+
+    if targets is not None:
+        disclosures = [d for d in disclosures if d.stock_code in targets]
+
+    if not disclosures:
+        print("해당 조건의 공시가 없습니다.")
+        return
+
+    print(f"\n총 {len(disclosures)}건 (상위 {min(args.limit, len(disclosures))}건 표시)\n")
+    for disclosure in disclosures[: args.limit]:
+        importance = rules.evaluate(disclosure)
+        print(
+            f"[{importance.level} {importance.score}점] "
+            f"{disclosure.corp_name}({disclosure.stock_code}) — {disclosure.report_name}"
+        )
+        print(f"   근거: {', '.join(importance.reasons)}")
+        if analyzer and importance.score >= threshold:
+            summary = await analyzer.summarize(disclosure, importance)
+            print(f"   🤖 AI: {summary or '(요약 실패 — 규칙 판정으로 폴백)'}")
+        print()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -27,6 +27,8 @@ from services.dart_disclosure_client import DartDisclosureClient  # noqa: E402
 from services.dart_disclosure_rule_service import DartDisclosureRuleService  # noqa: E402
 
 _ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+_DEFAULT_MODEL = "gemini-2.5-flash"
 
 
 def _load_config() -> dict:
@@ -53,9 +55,9 @@ def _build_analyzer(ai_cfg: dict):
     if not (ai_cfg.get("enabled") and ai_key):
         return None
     ai_client = AiClient(
-        base_url=str(ai_cfg.get("base_url") or ""),
+        base_url=str(ai_cfg.get("base_url") or _DEFAULT_BASE_URL),
         api_key=ai_key,
-        model=str(ai_cfg.get("model") or ""),
+        model=str(ai_cfg.get("model") or _DEFAULT_MODEL),
         timeout_sec=float(ai_cfg.get("timeout_sec", 15)),
     )
     return AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 256)))

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -40,7 +40,7 @@ class AiClient:
         *,
         system: str,
         user: str,
-        max_tokens: int = 512,
+        max_tokens: int = 2048,
         temperature: float = 0.2,
     ) -> str:
         url = f"{self._base_url}/chat/completions"

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -43,11 +43,23 @@ class AiClient:
         max_tokens: int = 2048,
         temperature: float = 0.2,
     ) -> str:
+        data = await self.chat_json(
+            system=system, user=user, max_tokens=max_tokens, temperature=temperature
+        )
+        return self._parse(data)
+
+    async def chat_json(
+        self,
+        *,
+        system: str,
+        user: str,
+        max_tokens: int = 2048,
+        temperature: float = 0.2,
+    ) -> dict:
+        """파싱 전 원본 응답 JSON을 반환한다 (진단용: finish_reason/usage 확인)."""
         url = f"{self._base_url}/chat/completions"
         headers = {}
         if self._api_key:
-            # HTTP 헤더는 ASCII만 허용. 키에 한글 등 비ASCII가 섞이면 httpx가
-            # 크립틱한 UnicodeEncodeError를 던지므로, 미리 명확한 안내로 바꾼다.
             if not self._api_key.isascii():
                 raise AiClientError(
                     "KEY_ENCODING",
@@ -65,11 +77,9 @@ class AiClient:
             "temperature": float(temperature),
         }
         if self._http_client is not None:
-            data = await self._request(self._http_client, url, headers, payload)
-        else:
-            async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
-                data = await self._request(client, url, headers, payload)
-        return self._parse(data)
+            return await self._request(self._http_client, url, headers, payload)
+        async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+            return await self._request(client, url, headers, payload)
 
     async def _request(self, client, url, headers, payload):
         response = await client.post(

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -29,7 +29,8 @@ class AiClient:
         timeout_sec: float = 15.0,
     ) -> None:
         self._base_url = str(base_url or "").rstrip("/")
-        self._api_key = str(api_key or "")
+        # 복사 과정에서 붙는 앞뒤 공백·개행 제거 (흔한 오염 원인)
+        self._api_key = str(api_key or "").strip()
         self._model = str(model or "")
         self._http_client = http_client
         self._timeout_sec = float(timeout_sec)
@@ -45,6 +46,14 @@ class AiClient:
         url = f"{self._base_url}/chat/completions"
         headers = {}
         if self._api_key:
+            # HTTP 헤더는 ASCII만 허용. 키에 한글 등 비ASCII가 섞이면 httpx가
+            # 크립틱한 UnicodeEncodeError를 던지므로, 미리 명확한 안내로 바꾼다.
+            if not self._api_key.isascii():
+                raise AiClientError(
+                    "KEY_ENCODING",
+                    "API 키에 ASCII 외 문자가 섞여 있습니다 — config.yaml의 키를 "
+                    "지우고 공백·한글 없이 다시 붙여넣으세요.",
+                )
             headers["Authorization"] = f"Bearer {self._api_key}"
         payload = {
             "model": self._model,

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -1,0 +1,81 @@
+"""OpenAI 호환 chat completions 최소 비동기 클라이언트.
+
+Gemini(생성형 AI OpenAI 호환 엔드포인트)·Groq·로컬 Ollama 를 동일 인터페이스로
+호출한다. provider 차이는 base_url/api_key/model 설정으로 흡수하므로 코드는
+provider 에 비의존한다.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+
+class AiClientError(RuntimeError):
+    def __init__(self, status: str, message: str):
+        self.status = str(status or "")
+        self.message = str(message or "AI API 오류")
+        super().__init__(f"AI API 오류 ({self.status}): {self.message}")
+
+
+class AiClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        model: str,
+        http_client: Optional[httpx.AsyncClient] = None,
+        timeout_sec: float = 15.0,
+    ) -> None:
+        self._base_url = str(base_url or "").rstrip("/")
+        self._api_key = str(api_key or "")
+        self._model = str(model or "")
+        self._http_client = http_client
+        self._timeout_sec = float(timeout_sec)
+
+    async def complete(
+        self,
+        *,
+        system: str,
+        user: str,
+        max_tokens: int = 512,
+        temperature: float = 0.2,
+    ) -> str:
+        url = f"{self._base_url}/chat/completions"
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": int(max_tokens),
+            "temperature": float(temperature),
+        }
+        if self._http_client is not None:
+            data = await self._request(self._http_client, url, headers, payload)
+        else:
+            async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+                data = await self._request(client, url, headers, payload)
+        return self._parse(data)
+
+    async def _request(self, client, url, headers, payload):
+        response = await client.post(
+            url, headers=headers, json=payload, timeout=self._timeout_sec
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _parse(payload: dict) -> str:
+        choices = payload.get("choices") or []
+        if not choices:
+            raise AiClientError("EMPTY", "응답에 choices가 없습니다")
+        message = choices[0].get("message") or {}
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            raise AiClientError("EMPTY", "응답 content가 비어 있습니다")
+        return content.strip()

--- a/services/ai_disclosure_analyzer.py
+++ b/services/ai_disclosure_analyzer.py
@@ -1,0 +1,59 @@
+"""공시 제목/메타 기반 AI 요약 — 실패 시 None 반환(규칙 판정으로 폴백).
+
+OpenDART list API 가 제공하는 제목·기업명·중요도만으로 투자자 관점 핵심을
+요약한다. 원문 다운로드는 하지 않는다(경량 1차). AI 호출이 실패/타임아웃/빈
+응답이면 None 을 돌려 호출측이 기존 규칙 판정을 그대로 쓰도록 한다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DisclosureImportance
+
+
+_SYSTEM_PROMPT = (
+    "너는 한국 주식 투자자를 돕는 애널리스트다. "
+    "기업 공시의 제목과 메타데이터를 보고, 투자 판단에 중요한 핵심을 한국어로 "
+    "2~3문장으로 간결하게 요약한다. 제목에 근거한 사실만 전달하고 과장·추측은 피한다."
+)
+
+
+class AiDisclosureAnalyzer:
+    def __init__(self, ai_client, *, logger=None, max_tokens: int = 256):
+        self._client = ai_client
+        self._logger = logger or logging.getLogger(__name__)
+        self._max_tokens = int(max_tokens)
+
+    async def summarize(
+        self, disclosure: DartDisclosure, importance: DisclosureImportance
+    ) -> Optional[str]:
+        try:
+            summary = await self._client.complete(
+                system=_SYSTEM_PROMPT,
+                user=self._build_prompt(disclosure, importance),
+                max_tokens=self._max_tokens,
+            )
+        except Exception as exc:
+            self._logger.warning(
+                f"AI 공시 요약 실패 — 규칙 판정으로 폴백: {type(exc).__name__}: {exc}"
+            )
+            return None
+        summary = str(summary or "").strip()
+        return summary or None
+
+    @staticmethod
+    def _build_prompt(
+        disclosure: DartDisclosure, importance: DisclosureImportance
+    ) -> str:
+        reasons = ", ".join(importance.reasons) if importance.reasons else "-"
+        return (
+            f"기업명: {disclosure.corp_name} ({disclosure.stock_code})\n"
+            f"공시 제목: {disclosure.report_name}\n"
+            f"제출인: {disclosure.filer_name}\n"
+            f"접수일: {disclosure.receipt_date}\n"
+            f"비고: {disclosure.remarks or '-'}\n"
+            f"규칙 판정: {importance.level} ({importance.score}점) — {reasons}\n\n"
+            "위 공시의 핵심을 투자자 관점에서 2~3문장으로 요약해줘."
+        )

--- a/services/ai_disclosure_analyzer.py
+++ b/services/ai_disclosure_analyzer.py
@@ -21,7 +21,7 @@ _SYSTEM_PROMPT = (
 
 
 class AiDisclosureAnalyzer:
-    def __init__(self, ai_client, *, logger=None, max_tokens: int = 256):
+    def __init__(self, ai_client, *, logger=None, max_tokens: int = 2048):
         self._client = ai_client
         self._logger = logger or logging.getLogger(__name__)
         self._max_tokens = int(max_tokens)

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -556,20 +556,28 @@ class TelegramReporter:
             await self._send_message(current)
 
     @_serialized_report_send
-    async def send_disclosure_alert(self, disclosure, importance) -> bool:
-        """관심종목 중요 공시 한 건을 즉시 전송한다."""
+    async def send_disclosure_alert(self, disclosure, importance, ai_summary: Optional[str] = None) -> bool:
+        """관심종목 중요 공시 한 건을 즉시 전송한다.
+
+        ai_summary 가 주어지면 규칙 판정 위에 AI 요약 블록을 덧붙인다. None 이면
+        (AI 비활성/호출 실패) 기존 규칙 기반 알림과 동일하게 발송한다.
+        """
         company = html.escape(str(disclosure.corp_name or disclosure.stock_code), quote=False)
         stock_code = html.escape(str(disclosure.stock_code), quote=False)
         report_name = html.escape(str(disclosure.report_name), quote=False)
         reasons = "\n".join(
             f"• {html.escape(str(reason), quote=False)}" for reason in importance.reasons
         )
+        ai_block = ""
+        if ai_summary:
+            ai_block = f"🤖 <b>AI 요약</b>\n{html.escape(str(ai_summary), quote=False)}\n\n"
         message = (
             "🚨 <b>관심종목 중요 공시</b>\n\n"
             f"<b>{company} ({stock_code})</b>\n"
             f"공시: {report_name}\n"
             f"중요도: {html.escape(str(importance.level), quote=False)} "
             f"({int(importance.score)}점)\n\n"
+            f"{ai_block}"
             f"<b>판정 근거</b>\n{reasons}\n\n"
             f"접수일: {html.escape(str(disclosure.receipt_date), quote=False)}\n"
             f'<a href="{disclosure.viewer_url}">DART 원문 보기</a>'

--- a/task/background/always_on/dart_disclosure_monitor_task.py
+++ b/task/background/always_on/dart_disclosure_monitor_task.py
@@ -22,6 +22,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
         config,
         market_clock,
         logger=None,
+        ai_analyzer=None,
     ) -> None:
         self._client = client
         self._repository = repository
@@ -31,6 +32,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
         self._config = config
         self._market_clock = market_clock
         self._logger = logger or logging.getLogger(__name__)
+        self._ai_analyzer = ai_analyzer
         self._state = TaskState.IDLE
         self._tasks: List[asyncio.Task] = []
         self._tick_lock: Optional[asyncio.Lock] = None
@@ -173,8 +175,13 @@ class DartDisclosureMonitorTask(SchedulableTask):
         threshold = int(getattr(self._config, "immediate_alert_score", 70))
         pending = await self._repository.get_pending_immediate(threshold)
         for item in pending:
+            ai_summary = None
+            if self._ai_analyzer is not None:
+                ai_summary = await self._ai_analyzer.summarize(
+                    item.disclosure, item.importance
+                )
             sent = await self._reporter.send_disclosure_alert(
-                item.disclosure, item.importance
+                item.disclosure, item.importance, ai_summary=ai_summary
             )
             if sent:
                 await self._repository.mark_immediate_sent(

--- a/tests/unit_test/config/test_ai_analysis_config.py
+++ b/tests/unit_test/config/test_ai_analysis_config.py
@@ -10,6 +10,8 @@ def test_defaults_are_disabled_and_gemini_flash():
     assert cfg.model
     assert cfg.timeout_sec > 0
     assert cfg.disclosure_summary_enabled is True
+    # Gemini 2.5 thinking 토큰이 출력 예산을 갉아먹으므로 요약이 잘리지 않게 넉넉히
+    assert cfg.max_tokens >= 1024
 
 
 def test_accepts_ollama_local_overrides():

--- a/tests/unit_test/config/test_ai_analysis_config.py
+++ b/tests/unit_test/config/test_ai_analysis_config.py
@@ -1,0 +1,35 @@
+from config.config_loader import AiAnalysisConfig
+
+
+def test_defaults_are_disabled_and_gemini_flash():
+    cfg = AiAnalysisConfig()
+
+    assert cfg.enabled is False
+    assert cfg.api_key == ""
+    assert "chat/completions" not in cfg.base_url
+    assert cfg.model
+    assert cfg.timeout_sec > 0
+    assert cfg.disclosure_summary_enabled is True
+
+
+def test_accepts_ollama_local_overrides():
+    cfg = AiAnalysisConfig.model_validate(
+        {
+            "enabled": True,
+            "provider": "ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+            "timeout_sec": 30,
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.base_url == "http://localhost:11434/v1"
+    assert cfg.model == "qwen2.5"
+
+
+def test_unknown_keys_are_tolerated():
+    cfg = AiAnalysisConfig.model_validate({"future_flag": "x", "enabled": False})
+
+    assert cfg.enabled is False

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -1,0 +1,99 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.ai_client import AiClient, AiClientError
+
+
+def _response(payload):
+    response = MagicMock()
+    response.raise_for_status = lambda: None
+    response.json.return_value = payload
+    return response
+
+
+def _completion(content):
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+async def test_complete_posts_openai_compatible_chat_request():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("요약입니다."))
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="test-model",
+        http_client=http_client,
+        timeout_sec=15,
+    )
+
+    result = await client.complete(system="너는 애널리스트다", user="이 공시를 요약해줘")
+
+    assert result == "요약입니다."
+    url = http_client.post.await_args.args[0]
+    assert url == "https://example.com/v1/chat/completions"
+    kwargs = http_client.post.await_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer secret"
+    payload = kwargs["json"]
+    assert payload["model"] == "test-model"
+    assert payload["messages"][0] == {"role": "system", "content": "너는 애널리스트다"}
+    assert payload["messages"][1] == {"role": "user", "content": "이 공시를 요약해줘"}
+
+
+async def test_trailing_slash_base_url_is_normalized():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("ok"))
+    client = AiClient(
+        base_url="http://localhost:11434/v1/",
+        api_key="",
+        model="qwen2.5",
+        http_client=http_client,
+    )
+
+    await client.complete(system="s", user="u")
+
+    url = http_client.post.await_args.args[0]
+    assert url == "http://localhost:11434/v1/chat/completions"
+
+
+async def test_empty_api_key_omits_authorization_header():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("ok"))
+    client = AiClient(
+        base_url="http://localhost:11434/v1",
+        api_key="",
+        model="qwen2.5",
+        http_client=http_client,
+    )
+
+    await client.complete(system="s", user="u")
+
+    assert "Authorization" not in http_client.post.await_args.kwargs["headers"]
+
+
+async def test_missing_choices_raises_ai_client_error():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response({"choices": []})
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+    )
+
+    with pytest.raises(AiClientError):
+        await client.complete(system="s", user="u")
+
+
+async def test_blank_content_raises_ai_client_error():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("   "))
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+    )
+
+    with pytest.raises(AiClientError):
+        await client.complete(system="s", user="u")

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -71,6 +71,38 @@ async def test_empty_api_key_omits_authorization_header():
     assert "Authorization" not in http_client.post.await_args.kwargs["headers"]
 
 
+async def test_api_key_surrounding_whitespace_is_stripped():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("ok"))
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="  AQ.Ab8valid \n",
+        model="m",
+        http_client=http_client,
+    )
+
+    await client.complete(system="s", user="u")
+
+    assert http_client.post.await_args.kwargs["headers"]["Authorization"] == "Bearer AQ.Ab8valid"
+
+
+async def test_non_ascii_api_key_raises_clear_error_not_raw_unicodeerror():
+    http_client = AsyncMock()  # 네트워크 도달 전에 막혀야 한다
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="AQ.Ab8한글오염key",
+        model="m",
+        http_client=http_client,
+    )
+
+    with pytest.raises(AiClientError) as exc_info:
+        await client.complete(system="s", user="u")
+
+    message = str(exc_info.value)
+    assert "ASCII" in message.upper() or "키" in message
+    http_client.post.assert_not_awaited()
+
+
 async def test_missing_choices_raises_ai_client_error():
     http_client = AsyncMock()
     http_client.post.return_value = _response({"choices": []})

--- a/tests/unit_test/services/test_ai_disclosure_analyzer.py
+++ b/tests/unit_test/services/test_ai_disclosure_analyzer.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from services.ai_client import AiClientError
+from services.ai_disclosure_analyzer import AiDisclosureAnalyzer
+from services.dart_disclosure_client import DartDisclosure
+from services.dart_disclosure_rule_service import DisclosureImportance
+
+
+def _disclosure():
+    return DartDisclosure(
+        corp_class="Y",
+        corp_name="삼성전자",
+        corp_code="00126380",
+        stock_code="005930",
+        report_name="전환사채권발행결정",
+        receipt_no="20260714000001",
+        filer_name="삼성전자",
+        receipt_date="20260714",
+        remarks="유",
+    )
+
+
+def _importance():
+    return DisclosureImportance(85, "HIGH", ["자금조달·주식 희석 관련 공시"])
+
+
+async def test_summarize_returns_ai_text_and_passes_context():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(return_value="  전환사채 발행으로 주식 희석 우려가 있습니다.  ")
+    analyzer = AiDisclosureAnalyzer(ai_client, logger=MagicMock())
+
+    result = await analyzer.summarize(_disclosure(), _importance())
+
+    assert result == "전환사채 발행으로 주식 희석 우려가 있습니다."
+    user_prompt = ai_client.complete.await_args.kwargs["user"]
+    assert "삼성전자" in user_prompt
+    assert "전환사채권발행결정" in user_prompt
+    assert "005930" in user_prompt
+
+
+async def test_summarize_returns_none_when_ai_fails():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(side_effect=AiClientError("NETWORK", "timeout"))
+    logger = MagicMock()
+    analyzer = AiDisclosureAnalyzer(ai_client, logger=logger)
+
+    result = await analyzer.summarize(_disclosure(), _importance())
+
+    assert result is None
+    logger.warning.assert_called_once()
+
+
+async def test_summarize_returns_none_when_ai_returns_blank():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(return_value="   ")
+    analyzer = AiDisclosureAnalyzer(ai_client, logger=MagicMock())
+
+    result = await analyzer.summarize(_disclosure(), _importance())
+
+    assert result is None

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -36,6 +36,32 @@ async def test_send_disclosure_alert_escapes_html_and_includes_reason_and_link()
     assert "rcpNo=20260714001234" in message
 
 
+async def test_send_disclosure_alert_includes_ai_summary_block_when_provided():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    stored = _stored("전환사채권발행결정", 85)
+
+    sent = await reporter.send_disclosure_alert(
+        stored.disclosure, stored.importance, ai_summary="전환사채 발행 <주의>"
+    )
+
+    assert sent is True
+    message = reporter._send_message.await_args.args[0]
+    assert "AI 요약" in message
+    assert "전환사채 발행 &lt;주의&gt;" in message
+
+
+async def test_send_disclosure_alert_omits_ai_block_when_absent():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    stored = _stored("전환사채권발행결정", 85)
+
+    await reporter.send_disclosure_alert(stored.disclosure, stored.importance)
+
+    message = reporter._send_message.await_args.args[0]
+    assert "AI 요약" not in message
+
+
 async def test_send_disclosure_digest_formats_multiple_rows():
     reporter = TelegramReporter("token", "chat")
     reporter._send_message = AsyncMock(return_value=True)

--- a/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
@@ -30,7 +30,7 @@ def _disclosure(code="005930", receipt_no="20260714000001", report_name="전환�
     )
 
 
-def _make_task(items, *, initialized=True, now=None):
+def _make_task(items, *, initialized=True, now=None, ai_analyzer=None):
     client = MagicMock()
     client.fetch_disclosures = AsyncMock(
         return_value=DartDisclosurePage(items, 1, 100, len(items), 1)
@@ -74,6 +74,7 @@ def _make_task(items, *, initialized=True, now=None):
         config=config,
         market_clock=_Clock(now or datetime(2026, 7, 14, 10, 0, 0)),
         logger=MagicMock(),
+        ai_analyzer=ai_analyzer,
     )
     return SimpleNamespace(
         task=task,
@@ -82,6 +83,7 @@ def _make_task(items, *, initialized=True, now=None):
         favorites=favorites,
         rules=rule_service,
         reporter=reporter,
+        ai_analyzer=ai_analyzer,
     )
 
 
@@ -107,9 +109,43 @@ async def test_new_favorite_disclosure_is_saved_and_immediately_reported():
     await deps.task._tick()
 
     deps.repo.save_detected.assert_awaited_once()
-    deps.reporter.send_disclosure_alert.assert_awaited_once_with(disclosure, importance)
+    deps.reporter.send_disclosure_alert.assert_awaited_once_with(
+        disclosure, importance, ai_summary=None
+    )
     deps.repo.mark_immediate_sent.assert_awaited_once()
     assert deps.task.get_progress()["sent_count"] == 1
+
+
+async def test_ai_summary_is_attached_to_immediate_alert_when_analyzer_present():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["자금조달·주식 희석 관련 공시"])
+    analyzer = MagicMock()
+    analyzer.summarize = AsyncMock(return_value="전환사채 발행 요약")
+    deps = _make_task([disclosure], initialized=True, ai_analyzer=analyzer)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+
+    await deps.task._tick()
+
+    analyzer.summarize.assert_awaited_once_with(disclosure, importance)
+    deps.reporter.send_disclosure_alert.assert_awaited_once_with(
+        disclosure, importance, ai_summary="전환사채 발행 요약"
+    )
+
+
+async def test_ai_analyzer_failure_falls_back_to_rule_only_alert():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["중요"])
+    analyzer = MagicMock()
+    analyzer.summarize = AsyncMock(return_value=None)  # 폴백 신호
+    deps = _make_task([disclosure], initialized=True, ai_analyzer=analyzer)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+
+    await deps.task._tick()
+
+    deps.reporter.send_disclosure_alert.assert_awaited_once_with(
+        disclosure, importance, ai_summary=None
+    )
+    deps.repo.mark_immediate_sent.assert_awaited_once()
 
 
 async def test_non_favorite_disclosure_is_ignored():

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-17 (1-5 QC 2주차 판정·캡처 후보 소스 구분 metadata 기록)
+최종 업데이트: 2026-07-19 (AI 공시 요약 브랜치 코드리뷰 후속 3건 추가)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -54,6 +54,14 @@
   - 실데이터 검증(20260715 공시)에서 버그 4건 발견·수정: base_url 폴백 누락 / 비ASCII 키 처리 / 콘솔 출력 잘림(UTF-8) / **max_tokens 256→2048**(Gemini 2.5 thinking 토큰이 출력 예산 소비 — 짧으면 요약 잘림).
   - ⚠️ 실전 발동 전제: `dart_disclosure.enabled`(X-1) + 텔레그램 리포터 + 관심종목 1개+ + `ai_analysis.enabled`.
 - [ ] **2차 (종목 자체 AI 분석)**: 검증된 `ctx.ai_client` 재사용. 종목 하나에 [최근 공시 + 재무/시세 + Minervini Stage/RS + 수급]을 컨텍스트로 묶어 AI 종합 분석. 데이터 수집 계층(`StockQueryService`·`MinerviniStageService`·`rs_rating`)은 기존 것 활용, 프롬프트·수집 배선만 추가.
+
+### X-3. AI 공시 요약 코드리뷰 후속 [P2 — 2026-07-19]
+
+- [ ] **Telegram 메시지 길이 제한 적용** — AI 요약은 `max_tokens=2048`까지 반환될 수 있으나 `send_disclosure_alert()`는 단건 메시지를 길이 검증 없이 전송한다. Telegram 한도 초과 시 전송 실패 → `immediate_sent_at` 미기록 → 동일 공시 영구 재시도 가능. 메시지 조립 전 AI 요약을 안전한 길이로 제한하거나 메시지를 분할하고, 초과 응답 회귀 테스트를 추가한다.
+- [ ] **Telegram 재시도 시 AI 중복 호출 제거** — 전송 실패 건은 pending으로 남지만 생성한 AI 요약을 보관하지 않아 매 poll마다 같은 공시를 다시 요약한다. `receipt_no` 기준으로 요약 결과(실패 폴백 포함)를 저장·캐시해 Telegram 전송만 재시도하고, 일시적 전송 실패에서 AI 호출이 1회로 유지되는 테스트를 추가한다.
+- [ ] **빈 API 키 Ollama 진단 지원** — 프로덕션 `AiClient`와 설정은 로컬 Ollama의 빈 키를 허용하지만 `scripts/check_ai_key.py`는 즉시 종료하고 `scripts/check_disclosure_ai.py`는 analyzer를 비활성화한다. `provider` 또는 `base_url` 기준으로 클라우드 제공자에만 키를 요구하고 두 진단 스크립트의 Ollama 경로를 테스트한다.
+
+주요 파일: `services/telegram_notifier.py`, `task/background/always_on/dart_disclosure_monitor_task.py`, `scripts/check_ai_key.py`, `scripts/check_disclosure_ai.py`, `tests/unit_test/services/test_dart_disclosure_telegram.py`, `tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py`
 
 ---
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -45,11 +45,15 @@
 - [ ] 웹 앱을 재시작한 뒤 `data/dart_disclosures.db` 생성과 `dart_disclosure_monitor` 태스크 실행을 확인한다.
 - [ ] 최초 동기화에서 2026-07-15 SK하이닉스 유상증자 공시가 관심종목 요약으로 수신되는지 검증한다.
 
-### X-2. AI 공시 분석용 API 키 발급
+### X-2. AI 공시 분석 (1차 공시 요약 — 완료 / 2차 종목 분석 — 대기)
 
-- [ ] 사용할 AI API 제공자와 모델을 확정한다.
-- [ ] 분석용 API 키를 발급받아 git 비추적 설정 또는 환경변수로 보관한다.
-- [ ] AI 분석 기능 구현 전 호출비용·요청 한도·타임아웃·실패 시 규칙 기반 알림 유지 정책을 확정한다.
+- [x] 제공자·모델 확정: **Gemini 2.5 Flash** (무료 티어). provider 차이는 OpenAI 호환 엔드포인트로 흡수 — `ai_analysis` config(`base_url`/`api_key`/`model`)만 바꾸면 Groq·Ollama 전환 가능(코드 불변).
+- [x] 키 발급·보관: `config/config.yaml`의 `ai_analysis.api_key`(git 비추적). 키 형식은 `AIza`(구형)/`AQ.`(신형) 모두 유효.
+- [x] 정책 확정: AI 실패·타임아웃·빈 응답 시 `None` 반환 → 기존 `DartDisclosureRuleService` 규칙 판정으로 자동 폴백(알림은 계속). `enabled=false`면 현행과 완전 동일.
+- [x] **1차 구현·검증 완료**: 관심종목 중요 공시(규칙 ≥`immediate_alert_score`)에 제목/메타 기반 AI 요약을 텔레그램 알림에 덧붙임. `services/ai_client.py`(OpenAI 호환)·`services/ai_disclosure_analyzer.py` 신규, `dart_disclosure_monitor_task`/`telegram_notifier`/`service_container` 연동. 진단: `scripts/check_ai_key.py`·`scripts/check_disclosure_ai.py`.
+  - 실데이터 검증(20260715 공시)에서 버그 4건 발견·수정: base_url 폴백 누락 / 비ASCII 키 처리 / 콘솔 출력 잘림(UTF-8) / **max_tokens 256→2048**(Gemini 2.5 thinking 토큰이 출력 예산 소비 — 짧으면 요약 잘림).
+  - ⚠️ 실전 발동 전제: `dart_disclosure.enabled`(X-1) + 텔레그램 리포터 + 관심종목 1개+ + `ai_analysis.enabled`.
+- [ ] **2차 (종목 자체 AI 분석)**: 검증된 `ctx.ai_client` 재사용. 종목 하나에 [최근 공시 + 재무/시세 + Minervini Stage/RS + 수급]을 컨텍스트로 묶어 AI 종합 분석. 데이터 수집 계층(`StockQueryService`·`MinerviniStageService`·`rs_rating`)은 기존 것 활용, 프롬프트·수집 배선만 추가.
 
 ---
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -195,7 +195,7 @@
 
 - [x] `docs/backtest.md`(본문은 #619 슬리피지/스프레드 CLI까지 이미 반영, 날짜만 동기화)·`CODEBASE_SUMMARY.md`(bootstrap 분해 진전·EventShadowManager 분리·해외/테마 계층·브로커 계층 계측 4곳 반영) 갱신 완료 (2026-07-05).
 - [x] **`service_container.py` 비대화 경고 해소 — bootstrap 분해 + 의존성 경계 테스트 추가 (2026-07-12)**: #659(서비스↔전략 의존성 경계 강제, `oneil_common_types.py`를 `strategies/`→`common/`으로 이관, `test_architecture_dependencies.py` 신규) · #660(`backtest_task_bootstrap.py` 추출) · #661(`repository_bootstrap.py` 추출) · #662(`market_data_bootstrap.py` 추출) · #663(`query_bootstrap.py` 추출) · #664(`realtime_bootstrap.py` 추출) 6개 PR로 `service_container.py`가 962→**710줄**로 감소, 07-05까지의 증가 추세 반전.
-- 감시(조치 아님): `scheduler/strategy_scheduler.py` 2,153→**2,379줄**(+226) / `services/strategy_log_report_service.py` 2,144→**2,298줄**(+154, 07-08 "정체" 판정 이후 증가 재개) — 분해는 3-4 재승격과 함께 진행.
+- 감시(조치 아님, 2026-07-18 실측): `scheduler/strategy_scheduler.py` 2,153→**2,426줄**(+273) / `services/strategy_log_report_service.py` 2,144→**2,298줄**(+154, 07-08 "정체" 판정 이후 증가 재개) / `view/web/bootstrap/service_container.py` #659~664 분해로 710줄까지 감소 후 **746줄**로 재증가(+36) — 분해는 3-4 재승격과 함께 진행.
 
 ### M-3. 시가총액/미국주식 UI 하드닝 후속 [#653 코드리뷰 xhigh, 2026-07-11]
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from common.types import ErrorCode, Exchange
 from config.config_loader import (
+    AiAnalysisConfig,
     DartDisclosureConfig,
     OrderPolicyConfig,
     PositionSizingConfig,
@@ -25,6 +26,8 @@ from services.backtest_microstructure_capture import BacktestMicrostructureCaptu
 from services.execution_flow_service import ExecutionFlowService
 from services.event_shadow_journal_service import EventShadowJournalService
 from services.deferred_order_queue import DeferredOrderQueue
+from services.ai_client import AiClient
+from services.ai_disclosure_analyzer import AiDisclosureAnalyzer
 from services.dart_disclosure_client import DartDisclosureClient
 from services.dart_disclosure_rule_service import DartDisclosureRuleService
 from services.minervini_stage_service import MinerviniStageService
@@ -194,6 +197,24 @@ class ServiceContainer:
             needs_batch=needs_batch,
         )
 
+        # AI 분석 클라이언트 (Gemini/Groq/Ollama OpenAI 호환) — 1차: 공시 요약,
+        # 2차(종목 분석)에서 ctx.ai_client 재사용. provider 차이는 config 로 흡수.
+        ctx.ai_client = None
+        ctx.ai_disclosure_analyzer = None
+        raw_ai_config = config_dict.get("ai_analysis") or {}
+        ai_config = AiAnalysisConfig.model_validate(raw_ai_config)
+        if ai_config.enabled and ai_config.base_url and ai_config.model:
+            ctx.ai_client = AiClient(
+                base_url=ai_config.base_url,
+                api_key=ai_config.api_key,
+                model=ai_config.model,
+                timeout_sec=float(ai_config.timeout_sec),
+            )
+            if ai_config.disclosure_summary_enabled:
+                ctx.ai_disclosure_analyzer = AiDisclosureAnalyzer(
+                    ctx.ai_client, logger=ctx.logger, max_tokens=int(ai_config.max_tokens)
+                )
+
         ctx.dart_disclosure_client = None
         ctx.dart_disclosure_repository = None
         ctx.dart_disclosure_rule_service = None
@@ -223,6 +244,7 @@ class ServiceContainer:
                     config=dart_config,
                     market_clock=ctx.market_clock,
                     logger=ctx.logger,
+                    ai_analyzer=ctx.ai_disclosure_analyzer,
                 )
 
         try:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -174,6 +174,8 @@ class WebAppContext:
         self.dart_disclosure_repository = None
         self.dart_disclosure_rule_service = None
         self.dart_disclosure_monitor_task = None
+        self.ai_client = None
+        self.ai_disclosure_analyzer = None
         self.initialized = False
         self.pm: PerformanceProfiler = None
 


### PR DESCRIPTION
## 개요

OpenDART 공시 감시 위에 **AI 요약 레이어**를 얹는 1차 기능. 관심종목의 중요 공시(규칙 점수 ≥ `immediate_alert_score`)에 Gemini 기반 한국어 요약을 생성해 텔레그램 즉시 알림에 덧붙인다. `ai_analysis.enabled=false`(기본)이면 현행 동작과 완전히 동일하다.

## 설계

- **provider 무관**: `AiClient`는 OpenAI 호환 `chat/completions` 최소 클라이언트로, Gemini·Groq·Ollama를 동일 인터페이스로 호출한다. provider 전환은 `ai_analysis` config(`base_url`/`api_key`/`model`) 3줄 변경으로 끝나며 코드는 불변.
- **폴백 안전(fail-safe)**: `AiDisclosureAnalyzer.summarize()`는 AI 실패·타임아웃·빈 응답 시 `None`을 반환하고, 호출측(`DartDisclosureMonitorTask`)은 기존 `DartDisclosureRuleService` 규칙 판정을 그대로 사용한다. AI가 꺼져 있거나 죽어도 알림은 계속 발송된다.
- **외과적 연동**: 기존 즉시 알림 경로에만 `ai_summary` 옵션 블록을 추가(하위 호환). 규칙 서비스·저장소·태스크 흐름은 불변.

## 흐름

```
공시 감지 → 규칙 점수(≥임계 필터) → [AI on] AiDisclosureAnalyzer(제목/메타 요약)
  → 텔레그램 알림에 "🤖 AI 요약" 블록 추가
  (AI 실패 시 → 규칙 알림만 그대로)
```

## 변경 사항

**신규**
- `services/ai_client.py` — OpenAI 호환 비동기 chat 클라이언트 (`chat_json`/`complete`)
- `services/ai_disclosure_analyzer.py` — 공시 제목/메타 기반 요약, 실패 시 폴백
- `scripts/check_ai_key.py` — AI 키·엔드포인트 연결 단독 검증
- `scripts/check_disclosure_ai.py` — 공시→규칙→AI 요약 1차 파이프라인 dry-run 진단

**수정**
- `config/config_loader.py` — `AiAnalysisConfig` + `AppConfig.ai_analysis`
- `config/config.yaml.example` — `ai_analysis` 섹션(provider별 주석 포함)
- `services/telegram_notifier.py` — `send_disclosure_alert(..., ai_summary=None)` 옵션 블록
- `task/background/always_on/dart_disclosure_monitor_task.py` — `ai_analyzer` 주입
- `view/web/bootstrap/service_container.py` — AI 클라이언트/analyzer 조립·주입
- `view/web/web_app_initializer.py` — ctx 속성 기본값

## 실데이터 검증

20260715 실제 공시로 end-to-end 검증(케이프 회사합병 HIGH 80점 → AI 요약 완결). 검증 중 발견·수정한 버그 4건:

1. `ai_analysis.base_url` 누락 시 Gemini 기본값 폴백
2. 비ASCII API 키 → 크립틱한 UnicodeEncodeError 대신 명확한 안내
3. Windows 콘솔 출력 잘림 → 진단 스크립트 stdout UTF-8 고정
4. **max_tokens 256→2048** — Gemini 2.5 Flash의 thinking 토큰이 출력 예산을 소비해 요약이 잘리던 문제

## 테스트

- 단위 테스트 6884 passed (신규 AI 관련 테스트 포함, 회귀 0)
- 통합 테스트: DART 파이프라인 통과, 신규 회귀 없음

## 실전 발동 전제

`dart_disclosure.enabled`(X-1) + 텔레그램 리포터 + 관심종목 1개+ + `ai_analysis.enabled` 가 모두 갖춰지면 실제 알림에 요약이 붙는다.

## 후속 (별도 PR)

2차 — 종목 자체 AI 분석(검증된 `ai_client` 재사용, 공시+재무+Stage/RS+수급 종합).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiJGRGLeoyDECmsWX8txb7)_