### PR TITLE
AI 공시 알림 재시도 하드닝

### DIFF
--- a/scripts/check_ai_key.py
+++ b/scripts/check_ai_key.py
@@ -50,8 +50,9 @@ async def _main() -> None:
     api_key = str(cfg.get("api_key") or "")
     base_url = str(cfg.get("base_url") or _DEFAULT_BASE_URL)
     model = str(cfg.get("model") or _DEFAULT_MODEL)
+    provider = str(cfg.get("provider") or "gemini").strip().lower()
 
-    if not api_key:
+    if not api_key and provider != "ollama":
         print("[오류] ai_analysis.api_key 가 비어 있습니다. config.yaml 에 키를 넣으세요.")
         sys.exit(1)
     # Gemini API 키는 'AIza'(구형) 또는 'AQ.'(신형) 로 시작한다. 둘 다 유효.

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -59,7 +59,7 @@ async def _fetch(client, date, max_pages):
 def _build_ai(ai_cfg: dict):
     """(AiClient, AiDisclosureAnalyzer) 또는 (None, None) 반환."""
     ai_key = str(ai_cfg.get("api_key") or "")
-    if not (ai_cfg.get("enabled") and ai_key):
+    if not ai_cfg.get("enabled"):
         return None, None
     ai_client = AiClient(
         base_url=str(ai_cfg.get("base_url") or _DEFAULT_BASE_URL),

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -13,6 +13,8 @@ import unicodedata
 
 logger = logging.getLogger(__name__)
 
+_DISCLOSURE_AI_SUMMARY_MAX_CHARS = 1000
+
 
 def _serialized_report_send(func):
     @wraps(func)
@@ -570,7 +572,12 @@ class TelegramReporter:
         )
         ai_block = ""
         if ai_summary:
-            ai_block = f"🤖 <b>AI 요약</b>\n{html.escape(str(ai_summary), quote=False)}\n\n"
+            summary_text = str(ai_summary).strip()
+            if len(summary_text) > _DISCLOSURE_AI_SUMMARY_MAX_CHARS:
+                summary_text = (
+                    summary_text[: _DISCLOSURE_AI_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
+                )
+            ai_block = f"🤖 <b>AI 요약</b>\n{html.escape(summary_text, quote=False)}\n\n"
         message = (
             "🚨 <b>관심종목 중요 공시</b>\n\n"
             f"<b>{company} ({stock_code})</b>\n"

--- a/task/background/always_on/dart_disclosure_monitor_task.py
+++ b/task/background/always_on/dart_disclosure_monitor_task.py
@@ -33,6 +33,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
         self._market_clock = market_clock
         self._logger = logger or logging.getLogger(__name__)
         self._ai_analyzer = ai_analyzer
+        self._ai_summary_cache: Dict[str, Optional[str]] = {}
         self._state = TaskState.IDLE
         self._tasks: List[asyncio.Task] = []
         self._tick_lock: Optional[asyncio.Lock] = None
@@ -175,23 +176,27 @@ class DartDisclosureMonitorTask(SchedulableTask):
         threshold = int(getattr(self._config, "immediate_alert_score", 70))
         pending = await self._repository.get_pending_immediate(threshold)
         for item in pending:
-            ai_summary = None
-            if self._ai_analyzer is not None:
-                ai_summary = await self._ai_analyzer.summarize(
-                    item.disclosure, item.importance
-                )
+            receipt_no = item.disclosure.receipt_no
+            if receipt_no in self._ai_summary_cache:
+                ai_summary = self._ai_summary_cache[receipt_no]
+            else:
+                ai_summary = None
+                if self._ai_analyzer is not None:
+                    ai_summary = await self._ai_analyzer.summarize(
+                        item.disclosure, item.importance
+                    )
+                    self._ai_summary_cache[receipt_no] = ai_summary
             sent = await self._reporter.send_disclosure_alert(
                 item.disclosure, item.importance, ai_summary=ai_summary
             )
             if sent:
                 await self._repository.mark_immediate_sent(
-                    item.disclosure.receipt_no, now
+                    receipt_no, now
                 )
+                self._ai_summary_cache.pop(receipt_no, None)
                 self._progress["sent_count"] += 1
             else:
-                await self._repository.increment_send_retry(
-                    item.disclosure.receipt_no
-                )
+                await self._repository.increment_send_retry(receipt_no)
 
     async def _send_digest_if_due(self, now: datetime, date: str) -> None:
         if not bool(getattr(self._config, "daily_digest_enabled", True)):

--- a/tests/unit_test/scripts/test_check_ai_scripts.py
+++ b/tests/unit_test/scripts/test_check_ai_scripts.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from scripts import check_ai_key, check_disclosure_ai
+
+
+async def test_check_ai_key_allows_empty_api_key_for_ollama(monkeypatch):
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(return_value="연결 성공")
+    ai_client_factory = MagicMock(return_value=ai_client)
+    monkeypatch.setattr(
+        check_ai_key,
+        "_load_ai_config",
+        lambda: {
+            "provider": "ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+        },
+    )
+    monkeypatch.setattr(check_ai_key, "AiClient", ai_client_factory)
+
+    await check_ai_key._main()
+
+    ai_client_factory.assert_called_once_with(
+        base_url="http://localhost:11434/v1",
+        api_key="",
+        model="qwen2.5",
+        timeout_sec=20,
+    )
+    ai_client.complete.assert_awaited_once()
+
+
+def test_disclosure_dry_run_builds_ollama_analyzer_without_api_key():
+    ai_client, analyzer = check_disclosure_ai._build_ai(
+        {
+            "enabled": True,
+            "provider": "ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+        }
+    )
+
+    assert ai_client is not None
+    assert analyzer is not None

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -51,6 +51,21 @@ async def test_send_disclosure_alert_includes_ai_summary_block_when_provided():
     assert "전환사채 발행 &lt;주의&gt;" in message
 
 
+async def test_send_disclosure_alert_truncates_oversized_ai_summary():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    stored = _stored("전환사채권발행결정", 85)
+
+    await reporter.send_disclosure_alert(
+        stored.disclosure, stored.importance, ai_summary="가" * 5000
+    )
+
+    message = reporter._send_message.await_args.args[0]
+    assert len(message) <= 4000
+    assert "가" * 5000 not in message
+    assert "…" in message
+
+
 async def test_send_disclosure_alert_omits_ai_block_when_absent():
     reporter = TelegramReporter("token", "chat")
     reporter._send_message = AsyncMock(return_value=True)

--- a/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
@@ -148,6 +148,42 @@ async def test_ai_analyzer_failure_falls_back_to_rule_only_alert():
     deps.repo.mark_immediate_sent.assert_awaited_once()
 
 
+async def test_telegram_retry_reuses_ai_summary_without_second_ai_call():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["중요"])
+    analyzer = MagicMock()
+    analyzer.summarize = AsyncMock(return_value="재사용할 요약")
+    deps = _make_task([disclosure], initialized=True, ai_analyzer=analyzer)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+    deps.reporter.send_disclosure_alert.side_effect = [False, True]
+
+    await deps.task._send_pending_immediate(deps.task._market_clock.now)
+    await deps.task._send_pending_immediate(deps.task._market_clock.now)
+
+    analyzer.summarize.assert_awaited_once_with(disclosure, importance)
+    assert deps.reporter.send_disclosure_alert.await_count == 2
+    for call in deps.reporter.send_disclosure_alert.await_args_list:
+        assert call.kwargs["ai_summary"] == "재사용할 요약"
+
+
+async def test_telegram_retry_reuses_rule_fallback_without_second_ai_call():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["중요"])
+    analyzer = MagicMock()
+    analyzer.summarize = AsyncMock(return_value=None)
+    deps = _make_task([disclosure], initialized=True, ai_analyzer=analyzer)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+    deps.reporter.send_disclosure_alert.side_effect = [False, True]
+
+    await deps.task._send_pending_immediate(deps.task._market_clock.now)
+    await deps.task._send_pending_immediate(deps.task._market_clock.now)
+
+    analyzer.summarize.assert_awaited_once_with(disclosure, importance)
+    assert deps.reporter.send_disclosure_alert.await_count == 2
+    for call in deps.reporter.send_disclosure_alert.await_args_list:
+        assert call.kwargs["ai_summary"] is None
+
+
 async def test_non_favorite_disclosure_is_ignored():
     deps = _make_task([_disclosure(code="000660")])
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-19 (AI 공시 요약 브랜치 코드리뷰 후속 3건 추가)
+최종 업데이트: 2026-07-19 (AI 공시 요약 코드리뷰 후속 3건 적용 완료)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -55,11 +55,11 @@
   - ⚠️ 실전 발동 전제: `dart_disclosure.enabled`(X-1) + 텔레그램 리포터 + 관심종목 1개+ + `ai_analysis.enabled`.
 - [ ] **2차 (종목 자체 AI 분석)**: 검증된 `ctx.ai_client` 재사용. 종목 하나에 [최근 공시 + 재무/시세 + Minervini Stage/RS + 수급]을 컨텍스트로 묶어 AI 종합 분석. 데이터 수집 계층(`StockQueryService`·`MinerviniStageService`·`rs_rating`)은 기존 것 활용, 프롬프트·수집 배선만 추가.
 
-### X-3. AI 공시 요약 코드리뷰 후속 [P2 — 2026-07-19]
+### X-3. AI 공시 요약 코드리뷰 후속 [완료 — 2026-07-19]
 
-- [ ] **Telegram 메시지 길이 제한 적용** — AI 요약은 `max_tokens=2048`까지 반환될 수 있으나 `send_disclosure_alert()`는 단건 메시지를 길이 검증 없이 전송한다. Telegram 한도 초과 시 전송 실패 → `immediate_sent_at` 미기록 → 동일 공시 영구 재시도 가능. 메시지 조립 전 AI 요약을 안전한 길이로 제한하거나 메시지를 분할하고, 초과 응답 회귀 테스트를 추가한다.
-- [ ] **Telegram 재시도 시 AI 중복 호출 제거** — 전송 실패 건은 pending으로 남지만 생성한 AI 요약을 보관하지 않아 매 poll마다 같은 공시를 다시 요약한다. `receipt_no` 기준으로 요약 결과(실패 폴백 포함)를 저장·캐시해 Telegram 전송만 재시도하고, 일시적 전송 실패에서 AI 호출이 1회로 유지되는 테스트를 추가한다.
-- [ ] **빈 API 키 Ollama 진단 지원** — 프로덕션 `AiClient`와 설정은 로컬 Ollama의 빈 키를 허용하지만 `scripts/check_ai_key.py`는 즉시 종료하고 `scripts/check_disclosure_ai.py`는 analyzer를 비활성화한다. `provider` 또는 `base_url` 기준으로 클라우드 제공자에만 키를 요구하고 두 진단 스크립트의 Ollama 경로를 테스트한다.
+- [x] **Telegram 메시지 길이 제한 적용** — AI 요약을 최대 1,000자로 제한하고 초과 시 말줄임표를 붙인다. 장문 응답 회귀 테스트로 단건 메시지가 4,000자 이내인지 검증한다.
+- [x] **Telegram 재시도 시 AI 중복 호출 제거** — `DartDisclosureMonitorTask`가 `receipt_no`별 AI 요약과 `None` 폴백을 프로세스 수명 내 캐시하고, Telegram 전송 성공 시 제거한다. 전송 실패 후 재시도에서 AI 호출이 1회로 유지되는 두 경로를 테스트한다.
+- [x] **빈 API 키 Ollama 진단 지원** — `check_ai_key.py`는 Ollama에 한해 빈 키를 허용하고, `check_disclosure_ai.py`는 `enabled` 기준으로 analyzer를 생성한다. 두 진단 스크립트의 Ollama 빈 키 경로 테스트를 추가했다.
 
 주요 파일: `services/telegram_notifier.py`, `task/background/always_on/dart_disclosure_monitor_task.py`, `scripts/check_ai_key.py`, `scripts/check_disclosure_ai.py`, `tests/unit_test/services/test_dart_disclosure_telegram.py`, `tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py`
 


### PR DESCRIPTION
## 변경 내용

- AI 공시 요약을 최대 1,000자로 제한해 Telegram 단건 메시지 초과를 방지합니다.
- `receipt_no`별 AI 요약과 규칙 폴백 결과를 캐시해 Telegram 재시도 시 AI API 중복 호출을 막습니다.
- Ollama 진단 경로에서 빈 API 키를 허용하고 프로덕션 동작과 일치시킵니다.
- `todo_list.md`의 X-3 후속 3건을 완료로 갱신했습니다.

## 원인 및 영향

장문 AI 응답은 Telegram 전송 실패를 만들 수 있었고, 실패 건이 pending으로 남으면서 매 poll마다 같은 AI 요약을 다시 호출할 수 있었습니다. 또한 진단 스크립트가 키 없는 로컬 Ollama 구성을 차단했습니다.

## 검증

- 관련 단위 테스트: 19 passed
- 전체 단위 테스트: 6,906 passed
- 전체 통합 테스트: 261 passed