### PR TITLE
feat: 종목 AI 분석 UI 추가

### DIFF
--- a/repositories/dart_disclosure_repository.py
+++ b/repositories/dart_disclosure_repository.py
@@ -130,6 +130,19 @@ class DartDisclosureRepository:
             (int(threshold),),
         )
 
+    async def get_recent_by_stock_code(
+        self, stock_code: str, *, limit: int = 5
+    ) -> list[StoredDisclosure]:
+        return await self._query_stored(
+            """
+            SELECT * FROM disclosures
+            WHERE stock_code = ?
+            ORDER BY receipt_date DESC, rcept_no DESC
+            LIMIT ?
+            """,
+            (str(stock_code), max(1, int(limit))),
+        )
+
     async def mark_immediate_sent(self, receipt_no: str, sent_at: datetime) -> None:
         await self._update_timestamp("immediate_sent_at", [receipt_no], sent_at)
 

--- a/services/ai_stock_analyzer.py
+++ b/services/ai_stock_analyzer.py
@@ -1,0 +1,37 @@
+"""현재가·재무·추세·수급·공시 컨텍스트를 이용한 종목 AI 분석."""
+from __future__ import annotations
+
+import json
+
+
+_SYSTEM_PROMPT = (
+    "너는 한국 주식 데이터를 해석하는 보조 애널리스트다. "
+    "제공된 데이터에 근거한 사실과 해석을 구분하고, 데이터가 없으면 없다고 명시한다. "
+    "매수·매도 같은 투자 권유나 확정적 예측은 하지 않는다. "
+    "한국어로 '한줄 요약', '긍정 요인', '위험 요인', '기술·수급', "
+    "'추가 확인사항' 순서의 짧은 섹션으로 답한다."
+)
+
+
+class AiStockAnalyzer:
+    def __init__(self, ai_client, *, max_tokens: int = 2048) -> None:
+        self._client = ai_client
+        self._max_tokens = int(max_tokens)
+
+    async def analyze(self, context: dict) -> str:
+        normalized = {
+            key: value if value not in (None, [], {}) else "데이터 없음"
+            for key, value in context.items()
+        }
+        prompt = (
+            "다음 종목 데이터를 분석해줘. 숫자의 단위와 기준일을 임의로 추정하지 말고, "
+            "서로 충돌하는 데이터가 있으면 그 사실을 밝혀줘.\n\n"
+            f"{json.dumps(normalized, ensure_ascii=False, default=str, indent=2)}"
+        )
+        result = await self._client.complete(
+            system=_SYSTEM_PROMPT,
+            user=prompt,
+            max_tokens=self._max_tokens,
+            temperature=0.2,
+        )
+        return str(result or "").strip()

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -92,6 +92,53 @@ test("현재가 조회 결과에 KOSPI/KOSDAQ 시장 배지를 표시한다", as
   const badge = window.document.querySelector(".stock-market-badge");
   assert(badge, "시장 구분 배지가 없음");
   assert(badge.textContent === "KOSDAQ", "시장 구분 배지 값이 KOSDAQ이 아님");
+  assert(window.document.getElementById("ai-stock-analysis-btn"), "AI 분석 버튼이 없음");
+  assert(window.document.getElementById("ai-stock-analysis-output"), "AI 분석 결과 영역이 없음");
+});
+
+test("AI 종목 분석은 POST로 요청하고 결과를 텍스트로 안전하게 표시한다", async () => {
+  const window = makeWindow();
+  window.document.getElementById("stock-result").innerHTML = `
+    <button id="ai-stock-analysis-btn"></button>
+    <span id="ai-stock-analysis-status"></span>
+    <div id="ai-stock-analysis-sources"></div>
+    <div id="ai-stock-analysis-output"></div>
+  `;
+  let requested = null;
+  window.fetchWithTimeout = async (url, options, timeout) => {
+    requested = { url, options, timeout };
+    return {
+      ok: true,
+      json: async () => ({
+        rt_cd: "0",
+        data: {
+          analysis: "<img src=x onerror=alert(1)>상승 추세",
+          generated_at: "2026-07-19T12:00:00+09:00",
+          sources: {
+            current: true,
+            financial: true,
+            stage: true,
+            rs_rating: true,
+            investor_flow: false,
+            disclosures: false,
+          },
+        },
+      }),
+    };
+  };
+
+  await window.requestAiStockAnalysis("005930");
+
+  assert(requested.url === "/api/stock/005930/ai-analysis", "AI 분석 URL이 잘못됨");
+  assert(requested.options.method === "POST", "AI 분석이 POST 요청이 아님");
+  assert(requested.timeout === 45000, "AI 분석 타임아웃이 45초가 아님");
+  const output = window.document.getElementById("ai-stock-analysis-output");
+  assert(output.textContent.includes("<img src=x"), "AI 결과가 텍스트로 보존되지 않음");
+  assert(!output.querySelector("img"), "AI 결과가 HTML로 실행됨");
+  assert(
+    window.document.getElementById("ai-stock-analysis-sources").textContent.includes("현재가"),
+    "사용 데이터 출처가 표시되지 않음",
+  );
 });
 
 await run();

--- a/tests/unit_test/repositories/test_dart_disclosure_repository.py
+++ b/tests/unit_test/repositories/test_dart_disclosure_repository.py
@@ -80,3 +80,31 @@ async def test_digest_rows_are_marked_after_send(tmp_path, disclosure, importanc
 
     await repo.mark_digest_sent([disclosure.receipt_no], datetime(2026, 7, 14, 19, 40, 0))
     assert await repo.get_pending_digest("20260714", immediate_threshold=70) == []
+
+
+async def test_get_recent_by_stock_code_filters_and_orders(tmp_path, disclosure, importance):
+    repo = DartDisclosureRepository(tmp_path / "dart.db")
+    older = disclosure.__class__(
+        **{
+            **disclosure.__dict__,
+            "receipt_no": "20260713000001",
+            "receipt_date": "20260713",
+            "report_name": "사업보고서",
+        }
+    )
+    other_stock = disclosure.__class__(
+        **{
+            **disclosure.__dict__,
+            "receipt_no": "20260715000001",
+            "receipt_date": "20260715",
+            "stock_code": "000660",
+        }
+    )
+    await repo.save_detected(older, importance)
+    await repo.save_detected(disclosure, importance)
+    await repo.save_detected(other_stock, importance)
+
+    rows = await repo.get_recent_by_stock_code("005930", limit=1)
+
+    assert len(rows) == 1
+    assert rows[0].disclosure.receipt_no == disclosure.receipt_no

--- a/tests/unit_test/services/test_ai_stock_analyzer.py
+++ b/tests/unit_test/services/test_ai_stock_analyzer.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from services.ai_stock_analyzer import AiStockAnalyzer
+
+
+async def test_analyze_passes_all_stock_context_to_ai_client():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(return_value="  상승 추세지만 밸류에이션 확인이 필요합니다.  ")
+    analyzer = AiStockAnalyzer(ai_client, max_tokens=1536)
+    context = {
+        "code": "005930",
+        "name": "삼성전자",
+        "current": {"price": "70000", "per": "15.2"},
+        "financial": [{"stac_yymm": "202512", "roe_val": "9.5"}],
+        "stage": {"stage": 2, "reason": "상승 추세"},
+        "rs_rating": {"rs_rating": 87},
+        "investor_flow": [{"frgn_ntby_tr_pbmn": "12000"}],
+        "disclosures": [{"report_name": "분기보고서", "receipt_date": "20260715"}],
+    }
+
+    result = await analyzer.analyze(context)
+
+    assert result == "상승 추세지만 밸류에이션 확인이 필요합니다."
+    call = ai_client.complete.await_args.kwargs
+    assert call["max_tokens"] == 1536
+    assert "투자 권유" in call["system"]
+    for expected in (
+        "005930",
+        "삼성전자",
+        "70000",
+        "202512",
+        "상승 추세",
+        "87",
+        "12000",
+        "분기보고서",
+    ):
+        assert expected in call["user"]
+
+
+async def test_analyze_accepts_missing_optional_sources():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(return_value="데이터가 제한적입니다.")
+    analyzer = AiStockAnalyzer(ai_client)
+
+    result = await analyzer.analyze(
+        {
+            "code": "005930",
+            "name": "삼성전자",
+            "current": None,
+            "financial": None,
+            "stage": None,
+            "rs_rating": None,
+            "investor_flow": None,
+            "disclosures": [],
+        }
+    )
+
+    assert result == "데이터가 제한적입니다."
+    assert "데이터 없음" in ai_client.complete.await_args.kwargs["user"]

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -32,6 +32,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "StrategyLogReportService", "NotificationQueueTask",
     "AfterMarketReconcileTask", "OpeningPositionReconcileTask",
     "OpeningPositionReconcileService",
+    "AiClient", "AiStockAnalyzer",
     "DartDisclosureClient", "DartDisclosureRepository",
     "DartDisclosureRuleService", "DartDisclosureMonitorTask",
 ]
@@ -172,6 +173,40 @@ def test_service_container_skips_dart_pipeline_without_key(patched_service_conta
 
     assert ctx.dart_disclosure_monitor_task is None
     patched_service_container_deps["DartDisclosureClient"].assert_not_called()
+
+
+def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {
+        "ai_analysis": {
+            "enabled": True,
+            "base_url": "https://ai.example/v1",
+            "api_key": "test-key",
+            "model": "test-model",
+            "timeout_sec": 8,
+            "max_tokens": 1536,
+            "disclosure_summary_enabled": False,
+        }
+    }
+
+    ServiceContainer(ctx).run()
+
+    ai_client_cls = patched_service_container_deps["AiClient"]
+    ai_client_cls.assert_called_once_with(
+        base_url="https://ai.example/v1",
+        api_key="test-key",
+        model="test-model",
+        timeout_sec=8.0,
+    )
+    patched_service_container_deps["AiStockAnalyzer"].assert_called_once_with(
+        ai_client_cls.return_value,
+        max_tokens=1536,
+    )
+    assert ctx.ai_stock_analyzer is patched_service_container_deps[
+        "AiStockAnalyzer"
+    ].return_value
 
 
 def test_service_container_creates_query_and_order_services(patched_service_container_deps):

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -94,6 +94,145 @@ async def test_get_stock_detail_timeout(web_client, mock_web_ctx):
     assert "초과" in json_resp["msg1"]
 
 
+def test_ai_stock_analysis_requires_enabled_ai(web_client, mock_web_ctx):
+    mock_web_ctx.ai_stock_analyzer = None
+
+    response = web_client.post("/api/stock/005930/ai-analysis")
+
+    assert response.status_code == 503
+    assert "AI 분석" in response.json()["detail"]
+
+
+def test_ai_stock_analysis_rejects_invalid_code(web_client, mock_web_ctx):
+    mock_web_ctx.ai_stock_analyzer = MagicMock()
+
+    response = web_client.post("/api/stock/ABC/ai-analysis")
+
+    assert response.status_code == 400
+
+
+def test_ai_stock_analysis_collects_context_and_returns_source_status(
+    web_client, mock_web_ctx
+):
+    from repositories.dart_disclosure_repository import StoredDisclosure
+    from services.dart_disclosure_client import DartDisclosure
+    from services.dart_disclosure_rule_service import DisclosureImportance
+
+    mock_web_ctx.ai_stock_analyzer = MagicMock()
+    mock_web_ctx.ai_stock_analyzer.analyze = AsyncMock(return_value="AI 종합 분석 결과")
+    mock_web_ctx.stock_code_repository.get_name_by_code.return_value = "삼성전자"
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = (
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="성공",
+            data={"price": "70000", "per": "15.2", "pbr": "1.4"},
+        )
+    )
+    mock_web_ctx.stock_query_service.get_financial_ratio.return_value = (
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="성공",
+            data=[{"stac_yymm": "202512", "roe_val": "9.5"}],
+        )
+    )
+    mock_web_ctx.stock_query_service.get_investor_trade_daily_multi.return_value = (
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="성공",
+            data=[{"frgn_ntby_tr_pbmn": "12000"}],
+        )
+    )
+    mock_web_ctx.minervini_stage_service = MagicMock()
+    mock_web_ctx.minervini_stage_service.get_stage_for_code = AsyncMock(
+        return_value=(2, "상승 추세")
+    )
+    mock_web_ctx.rs_rating_service = MagicMock()
+    mock_web_ctx.rs_rating_service.get_rating = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd="0", msg1="성공", data={"rs_rating": 87}
+        )
+    )
+    disclosure = DartDisclosure(
+        corp_class="Y",
+        corp_name="삼성전자",
+        corp_code="00126380",
+        stock_code="005930",
+        report_name="분기보고서",
+        receipt_no="20260715000001",
+        filer_name="삼성전자",
+        receipt_date="20260715",
+    )
+    mock_web_ctx.dart_disclosure_repository = MagicMock()
+    mock_web_ctx.dart_disclosure_repository.get_recent_by_stock_code = AsyncMock(
+        return_value=[
+            StoredDisclosure(
+                disclosure,
+                DisclosureImportance(30, "NORMAL", ["정기보고서"]),
+            )
+        ]
+    )
+
+    response = web_client.post("/api/stock/005930/ai-analysis")
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["analysis"] == "AI 종합 분석 결과"
+    assert payload["code"] == "005930"
+    assert all(payload["sources"].values())
+    context = mock_web_ctx.ai_stock_analyzer.analyze.await_args.args[0]
+    assert context["name"] == "삼성전자"
+    assert context["current"]["price"] == "70000"
+    assert context["financial"][0]["roe_val"] == "9.5"
+    assert context["stage"]["stage"] == 2
+    assert context["rs_rating"]["rs_rating"] == 87
+    assert context["investor_flow"][0]["frgn_ntby_tr_pbmn"] == "12000"
+    assert context["disclosures"][0]["report_name"] == "분기보고서"
+
+
+def test_ai_stock_analysis_continues_with_partial_source_failures(
+    web_client, mock_web_ctx
+):
+    mock_web_ctx.ai_stock_analyzer = MagicMock()
+    mock_web_ctx.ai_stock_analyzer.analyze = AsyncMock(
+        return_value="사용 가능한 데이터 기반 분석"
+    )
+    mock_web_ctx.stock_code_repository.get_name_by_code.return_value = "삼성전자"
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = (
+        ResCommonResponse(
+            rt_cd="0",
+            msg1="성공",
+            data={"price": "70000"},
+        )
+    )
+    mock_web_ctx.stock_query_service.get_financial_ratio.side_effect = RuntimeError(
+        "재무 API 실패"
+    )
+    mock_web_ctx.stock_query_service.get_investor_trade_daily_multi.return_value = (
+        ResCommonResponse(rt_cd="1", msg1="수급 조회 실패", data=None)
+    )
+    mock_web_ctx.minervini_stage_service = None
+    mock_web_ctx.rs_rating_service = None
+    mock_web_ctx.dart_disclosure_repository = None
+
+    response = web_client.post("/api/stock/005930/ai-analysis")
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["analysis"] == "사용 가능한 데이터 기반 분석"
+    assert payload["sources"] == {
+        "current": True,
+        "financial": False,
+        "stage": False,
+        "rs_rating": False,
+        "investor_flow": False,
+        "disclosures": False,
+    }
+    context = mock_web_ctx.ai_stock_analyzer.analyze.await_args.args[0]
+    assert context["current"]["price"] == "70000"
+    assert context["financial"] is None
+    assert context["investor_flow"] is None
+
+
 @pytest.mark.asyncio
 async def test_get_stock_chart(web_client, mock_web_ctx):
     """GET /api/chart/{code} 엔드포인트 테스트"""

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,6 +1,6 @@
 # Investment Trading App - 남은 To-Do
 
-최종 업데이트: 2026-07-19 (AI 공시 요약 코드리뷰 후속 3건 적용 완료)
+최종 업데이트: 2026-07-19 (2차 종목 AI 종합 분석 및 상세 UI 적용 완료)
 
 이 문서는 **현재 남은 실행 항목**만 추린 목록이다. 완료된 구현 상세·완료 체크·과거 세션 요약은 git/PR과 리포트 파일로 추적하고 본 문서에서 제거한다.
 
@@ -45,7 +45,7 @@
 - [ ] 웹 앱을 재시작한 뒤 `data/dart_disclosures.db` 생성과 `dart_disclosure_monitor` 태스크 실행을 확인한다.
 - [ ] 최초 동기화에서 2026-07-15 SK하이닉스 유상증자 공시가 관심종목 요약으로 수신되는지 검증한다.
 
-### X-2. AI 공시 분석 (1차 공시 요약 — 완료 / 2차 종목 분석 — 대기)
+### X-2. AI 분석 (1차 공시 요약 / 2차 종목 분석 — 완료)
 
 - [x] 제공자·모델 확정: **Gemini 2.5 Flash** (무료 티어). provider 차이는 OpenAI 호환 엔드포인트로 흡수 — `ai_analysis` config(`base_url`/`api_key`/`model`)만 바꾸면 Groq·Ollama 전환 가능(코드 불변).
 - [x] 키 발급·보관: `config/config.yaml`의 `ai_analysis.api_key`(git 비추적). 키 형식은 `AIza`(구형)/`AQ.`(신형) 모두 유효.
@@ -53,7 +53,7 @@
 - [x] **1차 구현·검증 완료**: 관심종목 중요 공시(규칙 ≥`immediate_alert_score`)에 제목/메타 기반 AI 요약을 텔레그램 알림에 덧붙임. `services/ai_client.py`(OpenAI 호환)·`services/ai_disclosure_analyzer.py` 신규, `dart_disclosure_monitor_task`/`telegram_notifier`/`service_container` 연동. 진단: `scripts/check_ai_key.py`·`scripts/check_disclosure_ai.py`.
   - 실데이터 검증(20260715 공시)에서 버그 4건 발견·수정: base_url 폴백 누락 / 비ASCII 키 처리 / 콘솔 출력 잘림(UTF-8) / **max_tokens 256→2048**(Gemini 2.5 thinking 토큰이 출력 예산 소비 — 짧으면 요약 잘림).
   - ⚠️ 실전 발동 전제: `dart_disclosure.enabled`(X-1) + 텔레그램 리포터 + 관심종목 1개+ + `ai_analysis.enabled`.
-- [ ] **2차 (종목 자체 AI 분석)**: 검증된 `ctx.ai_client` 재사용. 종목 하나에 [최근 공시 + 재무/시세 + Minervini Stage/RS + 수급]을 컨텍스트로 묶어 AI 종합 분석. 데이터 수집 계층(`StockQueryService`·`MinerviniStageService`·`rs_rating`)은 기존 것 활용, 프롬프트·수집 배선만 추가.
+- [x] **2차 (종목 자체 AI 분석)**: 검증된 `ctx.ai_client`를 재사용해 현재가·재무비율·Minervini Stage·RS Rating·최근 5일 수급·로컬 OpenDART 공시를 병렬 수집하고 AI 종합 분석을 생성한다. 일부 소스 실패 시 남은 데이터로 계속 분석하며 사용 소스를 응답에 노출한다. 종목 상세 UI에서 명시적 버튼을 눌렀을 때만 호출하고, 45초 타임아웃·중복 클릭 방지·안전한 텍스트 렌더링·투자 권유 아님 안내를 적용했다. (`POST /api/stock/{code}/ai-analysis`)
 
 ### X-3. AI 공시 요약 코드리뷰 후속 [완료 — 2026-07-19]
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -28,6 +28,7 @@ from services.event_shadow_journal_service import EventShadowJournalService
 from services.deferred_order_queue import DeferredOrderQueue
 from services.ai_client import AiClient
 from services.ai_disclosure_analyzer import AiDisclosureAnalyzer
+from services.ai_stock_analyzer import AiStockAnalyzer
 from services.dart_disclosure_client import DartDisclosureClient
 from services.dart_disclosure_rule_service import DartDisclosureRuleService
 from services.minervini_stage_service import MinerviniStageService
@@ -201,6 +202,7 @@ class ServiceContainer:
         # 2차(종목 분석)에서 ctx.ai_client 재사용. provider 차이는 config 로 흡수.
         ctx.ai_client = None
         ctx.ai_disclosure_analyzer = None
+        ctx.ai_stock_analyzer = None
         raw_ai_config = config_dict.get("ai_analysis") or {}
         ai_config = AiAnalysisConfig.model_validate(raw_ai_config)
         if ai_config.enabled and ai_config.base_url and ai_config.model:
@@ -209,6 +211,9 @@ class ServiceContainer:
                 api_key=ai_config.api_key,
                 model=ai_config.model,
                 timeout_sec=float(ai_config.timeout_sec),
+            )
+            ctx.ai_stock_analyzer = AiStockAnalyzer(
+                ctx.ai_client, max_tokens=int(ai_config.max_tokens)
             )
             if ai_config.disclosure_summary_enabled:
                 ctx.ai_disclosure_analyzer = AiDisclosureAnalyzer(

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -4,6 +4,7 @@
 """
 import asyncio
 import time
+from datetime import datetime
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from common.overseas_types import OverseasExchange
@@ -182,6 +183,127 @@ async def get_stock_detail(code: str, exchange: str = Query("KRX")):
         ctx.logger.warning(f"[stock] 상세 정보 조회 타임아웃 ({code}, 12s 초과)")
         return {"rt_cd": "1", "msg1": "API 응답 시간이 초과되었습니다.", "data": None}
     return _serialize_response(resp)
+
+
+@router.post("/stock/{code}/ai-analysis")
+async def get_ai_stock_analysis(code: str):
+    """현재가·재무·추세·수급·공시를 모아 요청 시점에 종목 AI 분석을 생성한다."""
+    ctx = _get_ctx()
+    if not code.isdigit() or len(code) != 6:
+        raise HTTPException(status_code=400, detail="국내 종목코드 6자리를 입력하세요.")
+    analyzer = getattr(ctx, "ai_stock_analyzer", None)
+    if analyzer is None:
+        raise HTTPException(
+            status_code=503,
+            detail="AI 분석이 비활성화되어 있습니다. ai_analysis 설정을 확인하세요.",
+        )
+
+    async def _load_stage():
+        service = getattr(ctx, "minervini_stage_service", None)
+        if service is None:
+            return None
+        stage, reason = await service.get_stage_for_code(code)
+        return {"stage": stage, "reason": reason}
+
+    async def _load_rs_rating():
+        service = getattr(ctx, "rs_rating_service", None)
+        if service is None:
+            return None
+        return await service.get_rating(code)
+
+    async def _load_disclosures():
+        repository = getattr(ctx, "dart_disclosure_repository", None)
+        if repository is None:
+            return []
+        rows = await repository.get_recent_by_stock_code(code, limit=5)
+        return [
+            {
+                "report_name": row.disclosure.report_name,
+                "receipt_date": row.disclosure.receipt_date,
+                "importance_level": row.importance.level,
+                "importance_score": row.importance.score,
+                "reasons": row.importance.reasons,
+                "viewer_url": row.disclosure.viewer_url,
+            }
+            for row in rows
+        ]
+
+    results = await asyncio.gather(
+        ctx.stock_query_service.handle_get_current_stock_price(
+            code,
+            caller="stock.py - get_ai_stock_analysis",
+            exchange=Exchange.KRX,
+            force_fresh=True,
+        ),
+        ctx.stock_query_service.get_financial_ratio(code),
+        _load_stage(),
+        _load_rs_rating(),
+        ctx.stock_query_service.get_investor_trade_daily_multi(code, days=5),
+        _load_disclosures(),
+        return_exceptions=True,
+    )
+
+    def _data_or_none(value):
+        if isinstance(value, Exception):
+            ctx.logger.warning(
+                f"[stock-ai] {code} 컨텍스트 일부 조회 실패: "
+                f"{type(value).__name__}: {value}"
+            )
+            return None
+        if isinstance(value, (dict, list)) or value is None:
+            return value
+        serialized = _serialize_response(value)
+        if serialized.get("rt_cd") != "0":
+            return None
+        return serialized.get("data")
+
+    current, financial, stage, rs_rating, investor_flow, disclosures = (
+        _data_or_none(value) for value in results
+    )
+    context = {
+        "code": code,
+        "name": ctx.stock_code_repository.get_name_by_code(code) or code,
+        "current": current,
+        "financial": financial,
+        "stage": stage,
+        "rs_rating": rs_rating,
+        "investor_flow": investor_flow,
+        "disclosures": disclosures,
+    }
+    try:
+        analysis = await analyzer.analyze(context)
+    except Exception as exc:
+        ctx.logger.warning(
+            f"[stock-ai] {code} 분석 실패: {type(exc).__name__}: {exc}"
+        )
+        raise HTTPException(
+            status_code=502, detail="AI 분석 요청에 실패했습니다. 잠시 후 다시 시도하세요."
+        ) from exc
+    if not analysis:
+        raise HTTPException(status_code=502, detail="AI 분석 결과가 비어 있습니다.")
+
+    sources = {
+        key: bool(context[key])
+        for key in (
+            "current",
+            "financial",
+            "stage",
+            "rs_rating",
+            "investor_flow",
+            "disclosures",
+        )
+    }
+    return {
+        "rt_cd": "0",
+        "msg1": "성공",
+        "data": {
+            "code": code,
+            "name": context["name"],
+            "analysis": analysis,
+            "sources": sources,
+            "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        },
+    }
 
 
 @router.get("/stock/{code}")

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -304,11 +304,32 @@ async function searchStock(codeOverride, exchangeOverride) {
                      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
                      font-size: 0.9rem;
                  }
-                 .rs-rating-box .val {
-                     color: var(--text-primary, #333);
-                     margin-left: 6px;
-                     font-size: 1.2rem;
-                 }
+                  .rs-rating-box .val {
+                      color: var(--text-primary, #333);
+                      margin-left: 6px;
+                      font-size: 1.2rem;
+                  }
+                  .ai-stock-analysis-panel {
+                      grid-column: 1 / -1;
+                      border: 1px solid color-mix(in srgb, var(--accent, #4a90e2) 45%, transparent);
+                      border-radius: 10px;
+                      padding: 1rem;
+                      background: color-mix(in srgb, var(--accent, #4a90e2) 7%, var(--background-light, #fff));
+                  }
+                  .ai-stock-analysis-head {
+                      display: flex; align-items: center; justify-content: space-between;
+                      gap: 0.75rem; flex-wrap: wrap;
+                  }
+                  .ai-stock-analysis-head h4 { margin: 0; border: 0; padding: 0; }
+                  .ai-stock-analysis-note, .ai-stock-analysis-meta {
+                      color: var(--text-secondary, #777); font-size: 0.82rem; margin: 0.5rem 0 0;
+                  }
+                  .ai-stock-analysis-output {
+                      display: none; white-space: pre-wrap; line-height: 1.65;
+                      margin-top: 0.85rem; padding-top: 0.85rem;
+                      border-top: 1px solid var(--border-color, #ddd);
+                  }
+                  .ai-stock-analysis-output.error { color: #dc3545; }
             </style>
         `;
 
@@ -389,6 +410,16 @@ async function searchStock(codeOverride, exchangeOverride) {
                         <p><strong>단기 과열:</strong> <span id="detail-short">${data.short_over_yn || loading}</span></p>
                         <p><strong>정리 매매:</strong> <span id="detail-sltr">${data.sltr_yn || loading}</span></p>
                     </div>
+                    <div class="ai-stock-analysis-panel">
+                        <div class="ai-stock-analysis-head">
+                            <h4>🤖 AI 종합 분석</h4>
+                            <button id="ai-stock-analysis-btn" class="btn" onclick="requestAiStockAnalysis('${data.code}')">분석 요청</button>
+                        </div>
+                        <p class="ai-stock-analysis-note">버튼을 누를 때만 AI를 호출합니다. 결과는 투자 판단의 참고 자료이며 투자 권유가 아닙니다.</p>
+                        <p id="ai-stock-analysis-status" class="ai-stock-analysis-meta" aria-live="polite"></p>
+                        <p id="ai-stock-analysis-sources" class="ai-stock-analysis-meta"></p>
+                        <div id="ai-stock-analysis-output" class="ai-stock-analysis-output"></div>
+                    </div>
                 </div>
             </div>
         `;
@@ -425,6 +456,70 @@ async function searchStock(codeOverride, exchangeOverride) {
             resultDiv.innerHTML = `<p class="error">오류 발생: ${e.message}</p>`;
         }
         if(chartCard) chartCard.style.display = 'none';
+    }
+}
+
+async function requestAiStockAnalysis(code) {
+    const targetCode = String(code || _currentStockCode || '').trim();
+    const button = document.getElementById('ai-stock-analysis-btn');
+    const status = document.getElementById('ai-stock-analysis-status');
+    const sources = document.getElementById('ai-stock-analysis-sources');
+    const output = document.getElementById('ai-stock-analysis-output');
+    if (!targetCode || !button || !status || !sources || !output || button.disabled) return;
+
+    button.disabled = true;
+    button.textContent = '분석 중...';
+    status.textContent = '현재가·재무·추세·수급·공시 데이터를 모아 분석하고 있습니다.';
+    sources.textContent = '';
+    output.textContent = '';
+    output.classList.remove('error');
+    output.style.display = 'none';
+
+    try {
+        const response = await fetchWithTimeout(
+            `/api/stock/${encodeURIComponent(targetCode)}/ai-analysis`,
+            { method: 'POST' },
+            45000,
+        );
+        let json = {};
+        try {
+            json = await response.json();
+        } catch (parseError) {
+            console.error('[stock-ai] 응답 파싱 실패:', parseError);
+        }
+        if (!response.ok || json.rt_cd !== '0' || !json.data?.analysis) {
+            throw new Error(json.detail || json.msg1 || `AI 분석 요청 실패 (HTTP ${response.status})`);
+        }
+        if (_currentStockCode && _currentStockCode !== targetCode) return;
+
+        const labels = {
+            current: '현재가·밸류',
+            financial: '재무비율',
+            stage: 'Minervini Stage',
+            rs_rating: 'RS Rating',
+            investor_flow: '투자자 수급',
+            disclosures: '최근 공시',
+        };
+        const usedSources = Object.entries(json.data.sources || {})
+            .filter(([, available]) => available)
+            .map(([key]) => labels[key] || key);
+        status.textContent = json.data.generated_at
+            ? `생성 시각: ${json.data.generated_at}`
+            : '분석 완료';
+        sources.textContent = usedSources.length
+            ? `사용 데이터: ${usedSources.join(' · ')}`
+            : '사용 가능한 데이터가 제한적입니다.';
+        output.textContent = String(json.data.analysis);
+        output.style.display = 'block';
+    } catch (error) {
+        console.error('[stock-ai] 분석 실패:', error);
+        status.textContent = '';
+        output.textContent = error.message || 'AI 분석 요청에 실패했습니다.';
+        output.classList.add('error');
+        output.style.display = 'block';
+    } finally {
+        button.disabled = false;
+        button.textContent = '다시 분석';
     }
 }
 

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -55,7 +55,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/stock.js?v=15"></script>
+<script src="/static/js/stock.js?v=16"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -176,6 +176,7 @@ class WebAppContext:
         self.dart_disclosure_monitor_task = None
         self.ai_client = None
         self.ai_disclosure_analyzer = None
+        self.ai_stock_analyzer = None
         self.initialized = False
         self.pm: PerformanceProfiler = None
 


### PR DESCRIPTION
## 변경 내용

- 기존 `ctx.ai_client`를 재사용하는 종목 AI 분석 서비스를 추가했습니다.
- 현재가·재무비율·Minervini Stage·RS Rating·최근 5일 투자자 수급·최근 OpenDART 공시를 병렬 수집하는 `POST /api/stock/{code}/ai-analysis`를 추가했습니다.
- 일부 데이터 소스 조회가 실패해도 남은 데이터로 분석을 계속하고, 응답에 사용 가능 소스를 함께 반환합니다.
- 종목 상세 화면에 수동 실행형 AI 종합 분석 패널을 추가했습니다. 45초 타임아웃, 중복 요청 방지, 출처 표시, 투자 권유 아님 안내, `textContent` 기반 안전한 결과 표시를 적용했습니다.
- `todo_list.md`의 2차 종목 AI 분석 항목을 완료 처리했습니다.

## 사용자 영향

종목 상세 조회 후 사용자가 명시적으로 버튼을 눌렀을 때만 AI 분석이 실행됩니다. AI 설정이 비활성화된 경우 503 안내를 반환하며 기존 종목 조회 동작에는 영향이 없습니다.

## 검증

- `pytest tests/unit_test -v` — 6,914 passed
- `pytest tests/integration_test -v` — 261 passed
- `node tests/frontend/run_stock_dom_tests.mjs` — 4/4 passed
- `python -m compileall` (변경 Python 모듈)
- `git diff --check`
