### PR TITLE
fix: DART 인코딩 보완 및 관련 공시 묶음 요약

### DIFF
--- a/repositories/dart_disclosure_repository.py
+++ b/repositories/dart_disclosure_repository.py
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS disclosures (
     importance_score INTEGER NOT NULL,
     importance_level TEXT NOT NULL,
     importance_reasons TEXT NOT NULL,
+    event_key TEXT NOT NULL DEFAULT '',
     detected_at TEXT NOT NULL,
     alert_suppressed INTEGER NOT NULL DEFAULT 0,
     immediate_sent_at TEXT,
@@ -46,6 +47,7 @@ CREATE TABLE IF NOT EXISTS monitor_state (
 class StoredDisclosure:
     disclosure: DartDisclosure
     importance: DisclosureImportance
+    event_key: str = ""
 
 
 class DartDisclosureRepository:
@@ -58,6 +60,12 @@ class DartDisclosureRepository:
     async def _setup(self, conn: aiosqlite.Connection) -> None:
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute(_DDL_DISCLOSURES)
+        async with conn.execute("PRAGMA table_info(disclosures)") as cur:
+            columns = {str(row[1]) for row in await cur.fetchall()}
+        if "event_key" not in columns:
+            await conn.execute(
+                "ALTER TABLE disclosures ADD COLUMN event_key TEXT NOT NULL DEFAULT ''"
+            )
         await conn.execute(_DDL_STATE)
         await conn.commit()
 
@@ -67,6 +75,7 @@ class DartDisclosureRepository:
         importance: DisclosureImportance,
         *,
         suppress_immediate: bool = False,
+        event_key: str = "",
     ) -> bool:
         detected_at = datetime.now().isoformat()
         async with aiosqlite.connect(self._db_path) as conn:
@@ -76,8 +85,9 @@ class DartDisclosureRepository:
                 INSERT OR IGNORE INTO disclosures(
                     rcept_no, corp_code, stock_code, corp_name, report_name,
                     filer_name, receipt_date, remarks, importance_score,
-                    importance_level, importance_reasons, detected_at, alert_suppressed
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    importance_level, importance_reasons, event_key, detected_at,
+                    alert_suppressed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     disclosure.receipt_no,
@@ -91,6 +101,7 @@ class DartDisclosureRepository:
                     importance.score,
                     importance.level,
                     json.dumps(importance.reasons, ensure_ascii=False),
+                    str(event_key or "")[:300],
                     detected_at,
                     int(suppress_immediate),
                 ),
@@ -228,4 +239,5 @@ class DartDisclosureRepository:
                 level=row["importance_level"],
                 reasons=json.loads(row["importance_reasons"]),
             ),
+            event_key=str(row["event_key"] or ""),
         )

--- a/services/ai_disclosure_analyzer.py
+++ b/services/ai_disclosure_analyzer.py
@@ -17,7 +17,9 @@ _SYSTEM_PROMPT = (
     "투자 중요도를 0~100점으로 평가하고 2~3문장으로 요약한다. "
     "90점 이상은 존속·거래·감사 등 치명적 사건, 80점대는 대규모 희석·구조개편, "
     "70점대는 구체적인 실적·수주·신제품·공장·시장진출 계획, 50점대는 중간 영향, "
-    "30점 이하는 정기·안내성 정보다. 반드시 JSON 객체만 반환한다."
+    "30점 이하는 정기·안내성 정보다. 동일한 경제적 사건의 여러 문서를 묶을 수 있게 "
+    "상품종류·회차·금액 등 본문 식별자를 정규화한 event_key를 만든다. 확실한 식별자가 "
+    "없으면 event_key는 빈 문자열로 둔다. 반드시 JSON 객체만 반환한다."
 )
 
 
@@ -25,6 +27,7 @@ _SYSTEM_PROMPT = (
 class AiDisclosureAnalysis:
     summary: str
     importance: DisclosureImportance
+    event_key: str = ""
 
 
 class AiDisclosureAnalyzer:
@@ -78,7 +81,10 @@ class AiDisclosureAnalyzer:
             f"{str(document_text or '')[:16_000]}\n"
             "[공시 원문 끝]\n\n"
             '다음 형식으로 반환: {"summary":"...", "score":75, '
-            '"reasons":["구체적 근거 1","구체적 근거 2"]}'
+            '"reasons":["구체적 근거 1","구체적 근거 2"], '
+            '"event_key":"사건종류|회차·계약상대 등 식별자|금액·기준일"}\n'
+            "event_key는 같은 기업의 동일 경제적 사건 문서에서 완전히 같은 값이어야 "
+            "하며, 문서 제목·접수번호는 넣지 않는다. 동일성을 확신할 수 없으면 \"\"."
         )
 
     @classmethod
@@ -103,7 +109,12 @@ class AiDisclosureAnalyzer:
             level=cls._level(score),
             reasons=reasons,
         )
-        return AiDisclosureAnalysis(summary=summary, importance=importance)
+        event_key = str(payload.get("event_key") or "").strip()[:300]
+        return AiDisclosureAnalysis(
+            summary=summary,
+            importance=importance,
+            event_key=event_key,
+        )
 
     @staticmethod
     def _level(score: int) -> str:

--- a/services/dart_disclosure_client.py
+++ b/services/dart_disclosure_client.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional
 
 import httpx
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 
 
 @dataclass(frozen=True)
@@ -101,26 +102,44 @@ class DartDisclosureClient:
                 timeout=self._timeout_sec,
             )
             main_response.raise_for_status()
-            dcm_no = self._extract_dcm_no(main_response.text, receipt_no)
-            if not dcm_no:
+            main_html = self._decode_response_text(main_response)
+            sections = self._extract_viewer_sections(main_html, receipt_no)
+            if not sections:
+                dcm_no = self._extract_dcm_no(main_html, receipt_no)
+                if dcm_no:
+                    sections = [(dcm_no, "0", "0", "0", "HTML")]
+            if not sections:
                 return ""
 
-            viewer_response = await client.get(
-                self.VIEWER_URL,
-                params={
-                    "rcpNo": receipt_no,
-                    "dcmNo": dcm_no,
-                    "eleId": "0",
-                    "offset": "0",
-                    "length": "0",
-                    "dtd": "HTML",
-                },
-                timeout=self._timeout_sec,
-            )
-            viewer_response.raise_for_status()
-            text = BeautifulSoup(viewer_response.text, "html.parser").get_text(
-                "\n", strip=True
-            )
+            extracted_parts = []
+            extracted_length = 0
+            for dcm_no, ele_id, offset, length, dtd in sections:
+                viewer_response = await client.get(
+                    self.VIEWER_URL,
+                    params={
+                        "rcpNo": receipt_no,
+                        "dcmNo": dcm_no,
+                        "eleId": ele_id,
+                        "offset": offset,
+                        "length": length,
+                        "dtd": dtd,
+                    },
+                    timeout=self._timeout_sec,
+                )
+                viewer_response.raise_for_status()
+                viewer_html = self._decode_response_text(viewer_response)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", XMLParsedAsHTMLWarning)
+                    part = BeautifulSoup(viewer_html, "html.parser").get_text(
+                        "\n", strip=True
+                    )
+                if part:
+                    extracted_parts.append(part)
+                    extracted_length += len(part)
+                if extracted_length >= max(1, int(max_chars)):
+                    break
+
+            text = "\n".join(extracted_parts)
             text = re.sub(r"[ \t]+", " ", text)
             text = re.sub(r"\n{2,}", "\n", text).strip()
             return text[: max(1, int(max_chars))]
@@ -154,6 +173,68 @@ class DartDisclosureClient:
         )
         match = re.search(pattern, str(html or ""))
         return match.group(1) if match else ""
+
+    @staticmethod
+    def _extract_viewer_sections(
+        html: str, receipt_no: str
+    ) -> list[tuple[str, str, str, str, str]]:
+        text = str(html or "")
+        escaped_receipt = re.escape(receipt_no)
+        node_pattern = re.compile(
+            r"""node\d+\[['"]rcpNo['"]\]\s*=\s*["']"""
+            + escaped_receipt
+            + r"""["']\s*;.*?"""
+            r"""node\d+\[['"]dcmNo['"]\]\s*=\s*["'](\d+)["']\s*;.*?"""
+            r"""node\d+\[['"]eleId['"]\]\s*=\s*["'](\d+)["']\s*;.*?"""
+            r"""node\d+\[['"]offset['"]\]\s*=\s*["'](\d+)["']\s*;.*?"""
+            r"""node\d+\[['"]length['"]\]\s*=\s*["'](\d+)["']\s*;.*?"""
+            r"""node\d+\[['"]dtd['"]\]\s*=\s*["']([^"']+)["']\s*;""",
+            re.DOTALL,
+        )
+        sections = node_pattern.findall(text)
+        if not sections:
+            call_pattern = re.compile(
+                r"""viewDoc\(\s*["']"""
+                + escaped_receipt
+                + r"""["']\s*,\s*["'](\d+)["']\s*,\s*["'](\d+)["']"""
+                r"""\s*,\s*["'](\d+)["']\s*,\s*["'](\d+)["']"""
+                r"""\s*,\s*["']([^"']+)["']""",
+            )
+            sections = call_pattern.findall(text)
+        return list(dict.fromkeys(sections))
+
+    @staticmethod
+    def _decode_response_text(response) -> str:
+        """DART 구형 문서의 EUC-KR 표기를 Windows CP949로 호환 디코딩한다."""
+        content = getattr(response, "content", None)
+        if not isinstance(content, bytes):
+            return str(getattr(response, "text", "") or "")
+        head = content[:4096].lower()
+        charset_match = re.search(
+            br"""(?:charset|encoding)\s*=\s*["']?\s*([a-z0-9._-]+)""", head
+        )
+        charset = (
+            charset_match.group(1).decode("ascii", errors="ignore")
+            if charset_match
+            else ""
+        )
+        if charset in {"euc-kr", "euckr", "ks_c_5601-1987", "cp949", "uhc"}:
+            return content.decode("cp949", errors="replace")
+        if charset in {"utf-8", "utf8"}:
+            return content.decode("utf-8", errors="replace")
+
+        encoding = str(getattr(response, "encoding", "") or "").lower()
+        if encoding in {"euc-kr", "euckr", "ks_c_5601-1987", "cp949", "uhc"}:
+            encoding = "cp949"
+        if encoding:
+            try:
+                return content.decode(encoding)
+            except (LookupError, UnicodeDecodeError):
+                pass
+        try:
+            return content.decode("utf-8")
+        except UnicodeDecodeError:
+            return content.decode("cp949", errors="replace")
 
     @staticmethod
     def _parse_response(payload: dict) -> DartDisclosurePage:

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -597,17 +597,52 @@ class TelegramReporter:
         if not stored_items:
             return True
         header = f"📋 <b>관심종목 공시 요약 — {html.escape(str(report_date), quote=False)}</b>\n"
-        parts = []
-        for item in stored_items:
+        grouped = []
+        group_indexes = {}
+        for index, item in enumerate(stored_items):
             disclosure = item.disclosure
-            importance = item.importance
+            event_key = str(getattr(item, "event_key", "") or "").strip()
+            key = (
+                (str(disclosure.stock_code), str(disclosure.receipt_date), event_key)
+                if event_key
+                else ("receipt", str(disclosure.receipt_no), str(index))
+            )
+            if key not in group_indexes:
+                group_indexes[key] = len(grouped)
+                grouped.append([])
+            grouped[group_indexes[key]].append(item)
+
+        parts = []
+        for group in grouped:
+            disclosure = group[0].disclosure
             company = html.escape(str(disclosure.corp_name or disclosure.stock_code), quote=False)
-            report_name = html.escape(str(disclosure.report_name), quote=False)
+            stock_code = html.escape(str(disclosure.stock_code), quote=False)
+            if len(group) == 1:
+                importance = group[0].importance
+                report_name = html.escape(str(disclosure.report_name), quote=False)
+                parts.append(
+                    f"\n<b>{company} ({stock_code})</b>\n"
+                    f"• {report_name}\n"
+                    f"• 중요도: {html.escape(str(importance.level), quote=False)} ({int(importance.score)}점)\n"
+                    f'<a href="{disclosure.viewer_url}">원문</a>\n'
+                )
+                continue
+
+            importance = max(group, key=lambda row: int(row.importance.score)).importance
+            titles = "\n".join(
+                f"  - {html.escape(str(row.disclosure.report_name), quote=False)}"
+                for row in group
+            )
+            links = " · ".join(
+                f'<a href="{row.disclosure.viewer_url}">원문 {number}</a>'
+                for number, row in enumerate(group, 1)
+            )
             parts.append(
-                f"\n<b>{company} ({html.escape(str(disclosure.stock_code), quote=False)})</b>\n"
-                f"• {report_name}\n"
-                f"• 중요도: {html.escape(str(importance.level), quote=False)} ({int(importance.score)}점)\n"
-                f'<a href="{disclosure.viewer_url}">원문</a>\n'
+                f"\n<b>{company} ({stock_code})</b>\n"
+                f"• 관련 공시 {len(group)}건\n{titles}\n"
+                f"• 중요도: {html.escape(str(importance.level), quote=False)} "
+                f"({int(importance.score)}점)\n"
+                f"{links}\n"
             )
 
         messages = []

--- a/task/background/always_on/dart_disclosure_monitor_task.py
+++ b/task/background/always_on/dart_disclosure_monitor_task.py
@@ -140,6 +140,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
                     continue
                 preliminary = self._rules.evaluate(disclosure)
                 importance = preliminary
+                event_key = ""
                 if initialized:
                     analysis = await self._analyze_actual_content(
                         disclosure, preliminary
@@ -148,6 +149,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
                         importance = self._merge_importance(
                             preliminary, analysis.importance
                         )
+                        event_key = analysis.event_key
                     self._ai_summary_cache[disclosure.receipt_no] = (
                         analysis.summary if analysis is not None else None
                     )
@@ -155,6 +157,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
                     disclosure,
                     importance,
                     suppress_immediate=not initialized,
+                    event_key=event_key,
                 )
                 if not initialized and inserted:
                     baseline_items.append(StoredDisclosure(disclosure, importance))

--- a/tests/unit_test/repositories/test_dart_disclosure_repository.py
+++ b/tests/unit_test/repositories/test_dart_disclosure_repository.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import sqlite3
 
 import pytest
 
@@ -108,3 +109,35 @@ async def test_get_recent_by_stock_code_filters_and_orders(tmp_path, disclosure,
 
     assert len(rows) == 1
     assert rows[0].disclosure.receipt_no == disclosure.receipt_no
+
+
+async def test_event_key_round_trips_and_legacy_schema_is_migrated(
+    tmp_path, disclosure, importance
+):
+    path = tmp_path / "legacy.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE disclosures (
+                rcept_no TEXT PRIMARY KEY, corp_code TEXT NOT NULL,
+                stock_code TEXT NOT NULL, corp_name TEXT NOT NULL,
+                report_name TEXT NOT NULL, filer_name TEXT NOT NULL,
+                receipt_date TEXT NOT NULL, remarks TEXT NOT NULL,
+                importance_score INTEGER NOT NULL, importance_level TEXT NOT NULL,
+                importance_reasons TEXT NOT NULL, detected_at TEXT NOT NULL,
+                alert_suppressed INTEGER NOT NULL DEFAULT 0,
+                immediate_sent_at TEXT, digest_sent_at TEXT,
+                send_retry_count INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+
+    repo = DartDisclosureRepository(path)
+    await repo.save_detected(
+        disclosure,
+        importance,
+        event_key="ELS|37980,37981|20000000000",
+    )
+
+    rows = await repo.get_recent_by_stock_code(disclosure.stock_code)
+    assert rows[0].event_key == "ELS|37980,37981|20000000000"

--- a/tests/unit_test/services/test_ai_disclosure_analyzer.py
+++ b/tests/unit_test/services/test_ai_disclosure_analyzer.py
@@ -29,7 +29,8 @@ async def test_analyze_returns_structured_result_and_passes_document_text():
     ai_client.complete = AsyncMock(
         return_value=(
             '```json\n{"summary":"하이브리드 본더 공장과 미국 법인을 추진합니다.",'
-            '"score":75,"reasons":["신제품 및 생산능력 확대"]}\n```'
+            '"score":75,"reasons":["신제품 및 생산능력 확대"],'
+            '"event_key":"공장투자|하이브리드본더|2027상반기"}\n```'
         )
     )
     analyzer = AiDisclosureAnalyzer(ai_client, logger=MagicMock())
@@ -44,12 +45,14 @@ async def test_analyze_returns_structured_result_and_passes_document_text():
     assert result.importance.score == 75
     assert result.importance.level == "HIGH"
     assert result.importance.reasons == ["신제품 및 생산능력 확대"]
+    assert result.event_key == "공장투자|하이브리드본더|2027상반기"
     user_prompt = ai_client.complete.await_args.kwargs["user"]
     assert "삼성전자" in user_prompt
     assert "전환사채권발행결정" in user_prompt
     assert "005930" in user_prompt
     assert "하이브리드 본더 전용 공장" in user_prompt
     assert ai_client.complete.await_args.kwargs["usage_type"] == "disclosure"
+    assert '"event_key"' in user_prompt
 
 
 async def test_analyze_returns_none_when_ai_fails():

--- a/tests/unit_test/services/test_dart_disclosure_client.py
+++ b/tests/unit_test/services/test_dart_disclosure_client.py
@@ -19,6 +19,7 @@ def _text_response(text):
     response = MagicMock()
     response.raise_for_status = lambda: None
     response.text = text
+    response.content = text.encode("utf-8")
     return response
 
 
@@ -127,3 +128,54 @@ async def test_fetch_disclosure_text_returns_empty_when_viewer_id_is_missing():
     client = DartDisclosureClient("secret", http_client=http_client)
 
     assert await client.fetch_disclosure_text("20260720800314") == ""
+
+
+async def test_fetch_disclosure_text_decodes_euc_kr_document_as_cp949():
+    http_client = AsyncMock()
+    main = _text_response(
+        'viewDoc("20260720000120", "11480001", "0", "0", "0", "HTML", "");'
+    )
+    viewer = MagicMock()
+    viewer.raise_for_status = lambda: None
+    viewer.content = (
+        '<html><head><meta charset="euc-kr"></head>'
+        "<body>미래에셋증권 주가연계증권 발행</body></html>"
+    ).encode("cp949")
+    viewer.text = viewer.content.decode("latin-1")
+    http_client.get.side_effect = [main, viewer]
+    client = DartDisclosureClient("secret", http_client=http_client)
+
+    text = await client.fetch_disclosure_text("20260720000120")
+
+    assert "미래에셋증권 주가연계증권 발행" in text
+    assert "�" not in text
+
+
+async def test_fetch_disclosure_text_uses_real_viewer_section_parameters():
+    http_client = AsyncMock()
+    main = _text_response(
+        """
+        node1['rcpNo'] = "20260720000120";
+        node1['dcmNo'] = "11482504";
+        node1['eleId'] = "1";
+        node1['offset'] = "787";
+        node1['length'] = "6248";
+        node1['dtd'] = "dart4.xsd";
+        """
+    )
+    viewer = _text_response("<html><body>정상 한글 본문</body></html>")
+    http_client.get.side_effect = [main, viewer]
+    client = DartDisclosureClient("secret", http_client=http_client)
+
+    text = await client.fetch_disclosure_text("20260720000120")
+
+    assert text == "정상 한글 본문"
+    params = http_client.get.await_args_list[1].kwargs["params"]
+    assert params == {
+        "rcpNo": "20260720000120",
+        "dcmNo": "11482504",
+        "eleId": "1",
+        "offset": "787",
+        "length": "6248",
+        "dtd": "dart4.xsd",
+    }

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -6,20 +6,26 @@ from services.dart_disclosure_rule_service import DisclosureImportance
 from services.telegram_notifier import TelegramReporter
 
 
-def _stored(report_name="분기보고서 (2026.03)", score=30):
+def _stored(
+    report_name="분기보고서 (2026.03)",
+    score=30,
+    *,
+    receipt_no="20260714001234",
+    event_key="",
+):
     disclosure = DartDisclosure(
         corp_class="Y",
         corp_name="A&B <전자>",
         corp_code="00126380",
         stock_code="005930",
         report_name=report_name,
-        receipt_no="20260714001234",
+        receipt_no=receipt_no,
         filer_name="A&B",
         receipt_date="20260714",
         remarks="유",
     )
     importance = DisclosureImportance(score, "NORMAL", ["정기보고서"])
-    return StoredDisclosure(disclosure, importance)
+    return StoredDisclosure(disclosure, importance, event_key)
 
 
 async def test_send_disclosure_alert_escapes_html_and_includes_reason_and_link():
@@ -89,3 +95,37 @@ async def test_send_disclosure_digest_formats_multiple_rows():
     assert "관심종목 공시 요약" in full
     assert "분기보고서" in full
     assert "기업설명회" in full
+
+
+async def test_send_disclosure_digest_groups_only_same_non_empty_event_key():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    rows = [
+        _stored(
+            "일괄신고추가서류(파생결합증권-주가연계증권)",
+            10,
+            receipt_no="20260720000120",
+            event_key="ELS|37980,37981|20000000000",
+        ),
+        _stored(
+            "투자설명서(일괄신고)",
+            10,
+            receipt_no="20260720000134",
+            event_key="ELS|37980,37981|20000000000",
+        ),
+        _stored(
+            "증권신고서(채무증권)",
+            10,
+            receipt_no="20260720000190",
+            event_key="CP|2-1,2-2,2-3|1191161446589",
+        ),
+    ]
+
+    await reporter.send_disclosure_digest(rows, "20260720")
+
+    full = "".join(call.args[0] for call in reporter._send_message.await_args_list)
+    assert "관련 공시 2건" in full
+    assert full.count("<b>A&amp;B &lt;전자&gt; (005930)</b>") == 2
+    assert "원문 1" in full
+    assert "원문 2" in full
+    assert "증권신고서(채무증권)" in full

--- a/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
@@ -258,6 +258,7 @@ async def test_actual_content_analysis_can_promote_low_title_to_immediate_alert(
         return_value=AiDisclosureAnalysis(
             "하이브리드 본더 공장과 미국 법인 설립을 추진합니다.",
             promoted,
+            "기업가치제고|하이브리드본더|2027상반기",
         )
     )
     deps = _make_task([disclosure], initialized=True, ai_analyzer=analyzer)
@@ -273,6 +274,10 @@ async def test_actual_content_analysis_can_promote_low_title_to_immediate_alert(
         disclosure, preliminary, "공시 실제 본문"
     )
     assert deps.repo.save_detected.await_args.args[1] == promoted
+    assert (
+        deps.repo.save_detected.await_args.kwargs["event_key"]
+        == "기업가치제고|하이브리드본더|2027상반기"
+    )
     deps.reporter.send_disclosure_alert.assert_awaited_once_with(
         disclosure,
         promoted,


### PR DESCRIPTION
## 원인

- DART 메인 문서의 실제 목차 파라미터를 사용하지 않고 전체 뷰어를 기본값으로 요청해, `MS949` 응답 헤더와 UTF-8 XML 선언이 충돌하는 문서에서 한글이 깨졌습니다.
- 일일 공시 요약은 저장된 공시를 접수번호별로 그대로 출력해, 같은 ELS 발행 건의 일괄신고추가서류와 투자설명서도 중복 항목으로 표시했습니다.

## 변경

- 메인 페이지에서 `dcmNo`, `eleId`, `offset`, `length`, `dtd`를 추출해 실제 목차 본문을 읽습니다.
- UTF-8 및 EUC-KR/CP949 문서를 명시적으로 디코딩합니다.
- AI 본문 분석 결과에 동일 경제적 사건을 식별하는 `event_key`를 추가합니다.
- `event_key`를 SQLite에 저장하고 기존 DB에는 컬럼을 자동 추가합니다.
- 같은 종목·접수일·비어 있지 않은 `event_key`인 문서만 일일 요약에서 묶습니다.
- 식별이 불확실하거나 사건이 다른 공시는 기존처럼 개별 항목으로 유지합니다.

## 실제 공시 확인

- `20260720000120` 일괄신고추가서류와 `20260720000134` 투자설명서는 같은 ELS 제37980·37981회, 200억원 발행 건으로 묶을 수 있습니다.
- `20260720000190` 증권신고서(채무증권)는 별도 채무증권 발행 건이므로 분리됩니다.
- 세 문서 모두 한글 본문이 깨지지 않고 복원되는 것을 확인했습니다.

## 테스트

- `pytest tests/unit_test -v`: 6,961 passed
- `pytest tests/integration_test -v`: 263 passed
