### PR TITLE
fix: AI 클라이언트 일시적 업스트림 오류 재시도

### DIFF
--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -6,9 +6,13 @@ provider 에 비의존한다.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Optional
 
 import httpx
+
+# 업스트림 과부하/속도제한 등 재시도로 회복 가능한 상태 코드
+_RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 
 
 class AiClientError(RuntimeError):
@@ -28,6 +32,8 @@ class AiClient:
         http_client: Optional[httpx.AsyncClient] = None,
         timeout_sec: float = 15.0,
         usage_limiter=None,
+        max_retries: int = 2,
+        retry_backoff_sec: float = 0.5,
     ) -> None:
         self._base_url = str(base_url or "").rstrip("/")
         # 복사 과정에서 붙는 앞뒤 공백·개행 제거 (흔한 오염 원인)
@@ -36,6 +42,8 @@ class AiClient:
         self._http_client = http_client
         self._timeout_sec = float(timeout_sec)
         self._usage_limiter = usage_limiter
+        self._max_retries = max(0, int(max_retries))
+        self._retry_backoff_sec = float(retry_backoff_sec)
 
     async def complete(
         self,
@@ -92,11 +100,27 @@ class AiClient:
             return await self._request(client, url, headers, payload)
 
     async def _request(self, client, url, headers, payload):
-        response = await client.post(
-            url, headers=headers, json=payload, timeout=self._timeout_sec
-        )
-        response.raise_for_status()
-        return response.json()
+        """일시적 업스트림 오류(503 과부하 등)는 지수 백오프로 재시도한다.
+
+        사용량 예약은 호출 전 1회만 하므로 재시도가 일일 할당량을 추가로 쓰지 않는다.
+        """
+        last_exc = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = await client.post(
+                    url, headers=headers, json=payload, timeout=self._timeout_sec
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code not in _RETRYABLE_STATUS:
+                    raise
+                last_exc = exc
+            except httpx.TransportError as exc:
+                last_exc = exc
+            if attempt < self._max_retries:
+                await asyncio.sleep(self._retry_backoff_sec * (2**attempt))
+        raise last_exc
 
     @staticmethod
     def _parse(payload: dict) -> str:

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from services.ai_client import AiClient, AiClientError
@@ -175,3 +176,130 @@ async def test_usage_limit_block_prevents_http_request():
         await client.complete(system="s", user="u", usage_type="ranking")
 
     http_client.post.assert_not_awaited()
+
+
+def _status_response(status_code):
+    """실제 httpx.Response 로 raise_for_status 동작을 그대로 재현한다."""
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    return httpx.Response(status_code, request=request, json={"error": "upstream"})
+
+
+async def test_transient_503_is_retried_then_succeeds():
+    http_client = AsyncMock()
+    http_client.post.side_effect = [
+        _status_response(503),
+        _response(_completion("복구된 응답")),
+    ]
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+        retry_backoff_sec=0,
+    )
+
+    result = await client.complete(system="s", user="u")
+
+    assert result == "복구된 응답"
+    assert http_client.post.await_count == 2
+
+
+async def test_transient_network_error_is_retried_then_succeeds():
+    http_client = AsyncMock()
+    http_client.post.side_effect = [
+        httpx.ConnectError("connection reset"),
+        _response(_completion("ok")),
+    ]
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+        retry_backoff_sec=0,
+    )
+
+    assert await client.complete(system="s", user="u") == "ok"
+    assert http_client.post.await_count == 2
+
+
+async def test_client_error_4xx_is_not_retried():
+    http_client = AsyncMock()
+    http_client.post.return_value = _status_response(401)
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="bad",
+        model="m",
+        http_client=http_client,
+        retry_backoff_sec=0,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.complete(system="s", user="u")
+
+    http_client.post.assert_awaited_once()
+
+
+async def test_retry_exhaustion_raises_last_error():
+    http_client = AsyncMock()
+    http_client.post.return_value = _status_response(503)
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+        max_retries=2,
+        retry_backoff_sec=0,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.complete(system="s", user="u")
+
+    assert http_client.post.await_count == 3  # 최초 1회 + 재시도 2회
+
+
+async def test_retry_does_not_consume_extra_usage_quota():
+    http_client = AsyncMock()
+    http_client.post.side_effect = [
+        _status_response(503),
+        _status_response(503),
+        _response(_completion("ok")),
+    ]
+    usage_limiter = MagicMock()
+    usage_limiter.reserve = AsyncMock()
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+        usage_limiter=usage_limiter,
+        retry_backoff_sec=0,
+    )
+
+    await client.complete(system="s", user="u", usage_type="stock")
+
+    usage_limiter.reserve.assert_awaited_once_with("stock")
+    assert http_client.post.await_count == 3
+
+
+async def test_backoff_grows_exponentially_between_attempts(monkeypatch):
+    slept = []
+
+    async def _fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", _fake_sleep)
+    http_client = AsyncMock()
+    http_client.post.return_value = _status_response(503)
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="m",
+        http_client=http_client,
+        max_retries=2,
+        retry_backoff_sec=0.5,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.complete(system="s", user="u")
+
+    assert slept == [0.5, 1.0]


### PR DESCRIPTION
## 배경

웹 종목 화면의 **🤖 AI 종합 분석**이 `AI 분석 요청에 실패했습니다`로 실패하는 현상을 조사했다.
로그에 원인이 그대로 남아 있었다:

```
2026-07-20 20:52:06 - WARNING - [stock-ai] 080220 분석 실패:
HTTPStatusError: Server error '503 Service Unavailable' for url
'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
```

Gemini 업스트림의 일시적 과부하(503)다. 코드 결함은 아니지만,
`AiClient._request`가 `raise_for_status()` 한 번으로 끝나 **재시도가 전혀 없어**
일시적 503 한 번이 곧바로 사용자 화면 실패로 노출됐다.
(2026-07-19 23시 2건, 07-20 20시 4건 — 산발적)

## 변경

- `services/ai_client.py`: 408/429/5xx 및 `httpx.TransportError`를 지수 백오프로 재시도
  - 기본 `max_retries=2`, `retry_backoff_sec=0.5` → 0.5s, 1.0s
  - 4xx 클라이언트 오류(401/404 등)는 재시도하지 않고 즉시 전파
- 재시도 루프를 `usage_limiter.reserve()` **이후**에 두어 일일 AI 할당량을 추가 소모하지 않음

## 테스트 (TDD)

실패 테스트 6개를 먼저 작성해 Red 확인 후 구현했다:

- 503 → 재시도 후 성공
- 네트워크 오류(`ConnectError`) → 재시도 후 성공
- 4xx는 재시도하지 않음 (1회 호출)
- 재시도 소진 시 마지막 예외 전파 (총 3회 호출)
- 재시도해도 `reserve()`는 1회만
- 백오프가 지수적으로 증가 (`[0.5, 1.0]`)

```
tests/unit_test        6967 passed
tests/integration_test  263 passed
```

## 남은 이슈 (이번 PR 범위 밖)

`AiUsageLimiter`에 `release`/`refund`가 없어, **실패한 호출도 일일 할당량을 차감한 채 복구되지 않는다.**
이번 변경으로 재시도가 quota를 늘리진 않지만, 최종 실패 건의 차감은 그대로 남는다. 별도 이슈로 다루는 게 맞다고 본다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)