### PR TITLE
fix: 강제청산 절반 오버나이트 유출 (broker_reconciled 고아 생성 차단)

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -520,83 +520,124 @@ class VirtualTradeRepository:
             market_regime
         )
 
-    def log_sell(self, code: str, current_price, qty: int = 1, reason: str = ""):
-        """가상 매도 — 해당 종목 가장 최근 HOLD 건."""
+    def _settle_hold_sale(self, trade_id: int, held_qty, sold_qty, current_price,
+                          return_rate: float, sell_date: str, reason: str) -> int:
+        """HOLD row 매도 정산. 실제 매도된 수량을 반환한다.
+
+        sold_qty 가 None 이거나 보유 수량 이상이면 전량 청산(기존 동작).
+        보유 수량보다 적으면 부분 매도로 보고 lot 을 분할한다 — 매도분은 신규 SOLD row 로
+        떼어내고 원본 row 는 잔량만 남긴 채 HOLD 를 유지한다. 잔량이 HOLD 로 남아야
+        전략 귀속이 보존되고 다음 청산(강제청산 최종 tier 등)이 대상을 찾을 수 있다.
+        """
+        held = int(held_qty or 0)
+        filled = held if sold_qty is None else int(sold_qty)
+
+        if filled <= 0 or filled >= held:
+            with self._db:
+                self._db.execute(
+                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD', reason=? WHERE id=?",
+                    (sell_date, current_price, round(return_rate, 2), reason, trade_id)
+                )
+            return held if held > 0 else filled
+
+        columns = [r[1] for r in self._db.execute("PRAGMA table_info(trades)").fetchall() if r[1] != "id"]
+        overrides = {
+            "qty": filled,
+            "sell_date": sell_date,
+            "sell_price": current_price,
+            "return_rate": round(return_rate, 2),
+            "status": "SOLD",
+            "reason": reason,
+        }
+        select_terms, params = [], []
+        for col in columns:
+            if col in overrides:
+                select_terms.append("?")
+                params.append(overrides[col])
+            else:
+                select_terms.append(col)
+        params.append(trade_id)
+
+        with self._db:
+            self._db.execute(
+                f"INSERT INTO trades ({', '.join(columns)}) "
+                f"SELECT {', '.join(select_terms)} FROM trades WHERE id=?",
+                params
+            )
+            self._db.execute("UPDATE trades SET qty=? WHERE id=?", (held - filled, trade_id))
+        logger.info(f"[가상매매] 부분 매도 분할: trade_id={trade_id} 매도 {filled}주 / 잔량 {held - filled}주 HOLD 유지")
+        return filled
+
+    def log_sell(self, code: str, current_price, qty: int | None = None, reason: str = ""):
+        """가상 매도 — 해당 종목 가장 최근 HOLD 건.
+
+        qty 미지정(None)이면 보유 전량 청산. 보유 수량보다 적으면 부분 매도로 처리한다.
+        """
         with self._lock:
             row = self._db.execute(
-                "SELECT id, buy_price FROM trades WHERE code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                "SELECT id, buy_price, qty FROM trades WHERE code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
                 (code,)
             ).fetchone()
             if row is None:
                 logger.warning(f"[가상매매] {code} 매도 실패: 보유 내역 없음")
                 return
-            trade_id, buy_price = row
+            trade_id, buy_price, held_qty = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
             sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            with self._db:
-                self._db.execute(
-                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD', reason=? WHERE id=?",
-                    (sell_date, current_price, round(return_rate, 2), reason, trade_id)
-                )
+            self._settle_hold_sale(trade_id, held_qty, qty, current_price, return_rate, sell_date, reason)
             logger.info(f"[가상매매] {code} 매도 기록 (수익률: {return_rate:.2f}%{', 사유: '+reason if reason else ''})")
 
-    async def log_sell_async(self, code: str, current_price, qty: int = 1, reason: str = ""):
+    async def log_sell_async(self, code: str, current_price, qty: int | None = None, reason: str = ""):
         """log_sell의 비동기 래퍼 (스레드 실행). 반환값 없음 (None)."""
         await asyncio.to_thread(self.log_sell, code, current_price, qty, reason)
 
-    def log_sell_with_result(self, code: str, current_price, qty: int = 1, reason: str = "") -> SellResult:
+    def log_sell_with_result(self, code: str, current_price, qty: int | None = None, reason: str = "") -> SellResult:
         """매도 기록 후 SellResult 반환. KS hook 연결용."""
         with self._lock:
             row = self._db.execute(
-                "SELECT id, buy_price, buy_date FROM trades WHERE code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                "SELECT id, buy_price, buy_date, qty FROM trades WHERE code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
                 (code,)
             ).fetchone()
             if row is None:
                 logger.warning(f"[가상매매] {code} 매도 실패: 보유 내역 없음")
                 return SellResult(return_rate=None, net_pnl_won=None, pnl_filled_qty=0)
-            trade_id, buy_price, buy_date = row
+            trade_id, buy_price, buy_date, held_qty = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
             sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            with self._db:
-                self._db.execute(
-                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD', reason=? WHERE id=?",
-                    (sell_date, current_price, round(return_rate, 2), reason, trade_id)
-                )
+            filled_qty = self._settle_hold_sale(
+                trade_id, held_qty, qty, current_price, return_rate, sell_date, reason
+            )
             logger.info(f"[가상매매] {code} 매도 기록 (수익률: {return_rate:.2f}%{', 사유: '+reason if reason else ''})")
             net_pnl_won: Optional[int] = None
             if buy_price and current_price and reason != _FORCE_CLOSE_REASON:
-                net_pnl_won = TransactionCostUtils.calculate_net_pnl_won(buy_price, current_price, qty)
+                net_pnl_won = TransactionCostUtils.calculate_net_pnl_won(buy_price, current_price, filled_qty)
             is_intraday_trade = _date_key(buy_date) == _date_key(sell_date)
             return SellResult(
                 return_rate=round(return_rate, 2),
                 net_pnl_won=net_pnl_won,
-                pnl_filled_qty=qty,
+                pnl_filled_qty=filled_qty,
                 is_intraday_trade=is_intraday_trade,
             )
 
-    async def log_sell_async_with_result(self, code: str, current_price, qty: int = 1, reason: str = "") -> SellResult:
+    async def log_sell_async_with_result(self, code: str, current_price, qty: int | None = None, reason: str = "") -> SellResult:
         """log_sell_with_result의 비동기 래퍼."""
         return await asyncio.to_thread(self.log_sell_with_result, code, current_price, qty, reason)
 
-    def log_sell_by_strategy(self, strategy_name: str, code: str, current_price, qty: int = 1, reason: str = "") -> float | None:
+    def log_sell_by_strategy(self, strategy_name: str, code: str, current_price, qty: int | None = None, reason: str = "") -> float | None:
         """전략+종목 매칭 매도. 성공 시 수익률 반환, 실패 시 None 반환."""
         with self._lock:
             where, params = self._strategy_filter(strategy_name)
             row = self._db.execute(
-                f"SELECT id, buy_price FROM trades WHERE {where} AND code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                f"SELECT id, buy_price, qty FROM trades WHERE {where} AND code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
                 (*params, code)
             ).fetchone()
             if row is None:
                 logger.warning(f"[가상매매] {strategy_name}/{code} 매도 실패: 보유 내역 없음")
                 return None
-            trade_id, buy_price = row
+            trade_id, buy_price, held_qty = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
             sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            with self._db:
-                self._db.execute(
-                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD', reason=? WHERE id=?",
-                    (sell_date, current_price, round(return_rate, 2), reason, trade_id)
-                )
+            self._settle_hold_sale(trade_id, held_qty, qty, current_price, return_rate, sell_date, reason)
             logger.info(f"[가상매매] {strategy_name}/{code} 매도 기록 (수익률: {round(return_rate, 2):.2f}%{', 사유: '+reason if reason else ''})")
             return round(return_rate, 2)
 
@@ -617,38 +658,36 @@ class VirtualTradeRepository:
                 logger.info(f"[가상매매] {strategy_name}/{code} HOLD 수량 동기화 → {normalized_qty}")
             return int(cursor.rowcount or 0)
 
-    async def log_sell_by_strategy_async(self, strategy_name: str, code: str, current_price, qty: int = 1, reason: str = "") -> float | None:
+    async def log_sell_by_strategy_async(self, strategy_name: str, code: str, current_price, qty: int | None = None, reason: str = "") -> float | None:
         """log_sell_by_strategy의 비동기 래퍼. 성공 시 수익률(%) 반환. contract 유지."""
         return await asyncio.to_thread(self.log_sell_by_strategy, strategy_name, code, current_price, qty, reason)
 
-    def log_sell_by_strategy_with_result(self, strategy_name: str, code: str, current_price, qty: int = 1, reason: str = "") -> SellResult:
+    def log_sell_by_strategy_with_result(self, strategy_name: str, code: str, current_price, qty: int | None = None, reason: str = "") -> SellResult:
         """전략+종목 매칭 매도 후 SellResult 반환. KS hook 연결용."""
         with self._lock:
             where, params = self._strategy_filter(strategy_name)
             row = self._db.execute(
-                f"SELECT id, buy_price, buy_date FROM trades WHERE {where} AND code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
+                f"SELECT id, buy_price, buy_date, qty FROM trades WHERE {where} AND code=? AND status='HOLD' ORDER BY id DESC LIMIT 1",
                 (*params, code)
             ).fetchone()
             if row is None:
                 logger.warning(f"[가상매매] {strategy_name}/{code} 매도 실패: 보유 내역 없음")
                 return SellResult(return_rate=None, net_pnl_won=None, pnl_filled_qty=0)
-            trade_id, buy_price, buy_date = row
+            trade_id, buy_price, buy_date, held_qty = row
             return_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price else 0
             sell_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
-            with self._db:
-                self._db.execute(
-                    "UPDATE trades SET sell_date=?, sell_price=?, return_rate=?, status='SOLD', reason=? WHERE id=?",
-                    (sell_date, current_price, round(return_rate, 2), reason, trade_id)
-                )
+            filled_qty = self._settle_hold_sale(
+                trade_id, held_qty, qty, current_price, return_rate, sell_date, reason
+            )
             logger.info(f"[가상매매] {strategy_name}/{code} 매도 기록 (수익률: {round(return_rate, 2):.2f}%{', 사유: '+reason if reason else ''})")
             net_pnl_won: Optional[int] = None
             if buy_price and current_price and reason != _FORCE_CLOSE_REASON:
-                net_pnl_won = TransactionCostUtils.calculate_net_pnl_won(buy_price, current_price, qty)
+                net_pnl_won = TransactionCostUtils.calculate_net_pnl_won(buy_price, current_price, filled_qty)
             is_intraday_trade = _date_key(buy_date) == _date_key(sell_date)
             return SellResult(
                 return_rate=round(return_rate, 2),
                 net_pnl_won=net_pnl_won,
-                pnl_filled_qty=qty,
+                pnl_filled_qty=filled_qty,
                 is_intraday_trade=is_intraday_trade,
             )
 

--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -97,7 +97,9 @@ class StrategyScheduler:
     FORCE_EXIT_MINUTES_BEFORE = 30  # 장 마감 N분 전 강제 청산 (= 첫 tier 진입 시점)
     # tiered force-exit: (마감 N분 전, 누적 청산 비율). 마지막 tier 는 반드시 1.0(전량) 으로
     # 마감 전 flat 보장. 1주 포지션은 중간 tier 에서 floor 라운딩으로 0주 → 최종 tier 에서 전량.
-    FORCE_EXIT_TIERS = [(30, 0.5), (15, 1.0)]
+    # 최종 tier 는 ORDER_CUTOFF_MINUTES_BEFORE_CLOSE 보다 먼저 발화해야 한다. 컷오프 이후로
+    # 잡히면 영구 미실행되어 잔량이 그대로 오버나이트로 넘어간다.
+    FORCE_EXIT_TIERS = [(30, 0.5), (25, 1.0)]
     # 15:40 설정 기준 15:20(KRX 종가 동시호가 시작) 이후 전략 주문 중단.
     # 의도: 동시호가 구간은 연속체결이 없어 현재가 기반 전략 판단이 무의미하다.
     # check_exits 도 함께 중단된다 — 당일청산 전략은 FORCE_EXIT(마감 30분 전)가

--- a/scripts/repair_partial_sell_ledger.py
+++ b/scripts/repair_partial_sell_ledger.py
@@ -1,0 +1,151 @@
+"""부분 매도가 전량 청산으로 잘못 기록된 원장 행을 분할 복구한다.
+
+배경: `log_sell` 계열이 qty 를 무시하고 lot 전체를 status='SOLD' 로 뒤집던 결함(PR #700)
+때문에, 실제로는 절반만 체결된 주문이 전량 청산으로 기록됐다. 남은 잔량은 로컬 원장에서
+사라져 다음 개장 대사에서 'broker_reconciled' 고아로 재등록되고, 그 시점부터 손절/청산을
+관리하는 전략이 없어진다.
+
+이 스크립트는 해당 행을 수정 후 코드가 애초에 만들었을 상태로 되돌린다:
+  - 원본 행 → 잔량(qty - filled)만 남긴 HOLD 로 복원 (매도 필드 초기화, 전략 귀속 유지)
+  - 신규 행   → 실제 체결분(filled)을 담은 SOLD 로 분리
+
+실제 체결 수량은 로그의 execution_quality 이벤트(`filled_qty`)에서 확인해 넘긴다.
+
+사용:
+    # dry-run (기본) — 변경 없이 전/후만 출력
+    python scripts/repair_partial_sell_ledger.py --trade-id 269 --filled-qty 4
+
+    # 실제 반영 (DB 백업 후 수정)
+    python scripts/repair_partial_sell_ledger.py --trade-id 269 --filled-qty 4 --apply
+
+주의: 반영 전 브로커 잔고의 실제 보유 수량이 잔량과 일치하는지 확인할 것.
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from datetime import datetime
+
+DEFAULT_DB = "data/VirtualTradeRepository/virtual_trade.db"
+# 복원된 HOLD 행이 가져야 할 매도 관련 필드 값. 정상 HOLD 행과 동일한 형태로 맞춘다
+# (return_rate/reason 은 NOT NULL 이라 NULL 이 아닌 기본값을 써야 한다).
+_HOLD_RESET = {"sell_date": None, "sell_price": None, "return_rate": 0.0, "reason": ""}
+
+
+def _fetch_row(conn: sqlite3.Connection, trade_id: int) -> sqlite3.Row:
+    row = conn.execute("SELECT * FROM trades WHERE id=?", (trade_id,)).fetchone()
+    if row is None:
+        sys.exit(f"[중단] trade id={trade_id} 행이 없습니다.")
+    return row
+
+
+def _validate(row: sqlite3.Row, filled_qty: int) -> int:
+    if row["status"] != "SOLD":
+        sys.exit(f"[중단] id={row['id']} status={row['status']} — SOLD 행만 복구 대상입니다.")
+    held = int(row["qty"] or 0)
+    if filled_qty <= 0:
+        sys.exit(f"[중단] filled-qty 는 1 이상이어야 합니다 (입력 {filled_qty}).")
+    if filled_qty >= held:
+        sys.exit(
+            f"[중단] filled-qty({filled_qty}) 가 기록 수량({held}) 이상입니다 — "
+            f"부분 매도가 아니므로 복구할 것이 없습니다."
+        )
+    return held
+
+
+def _print_plan(row: sqlite3.Row, filled_qty: int, held: int) -> None:
+    remaining = held - filled_qty
+    print("=" * 72)
+    print(f"복구 대상: id={row['id']}  {row['strategy']}  {row['code']}")
+    print(f"  매수    {row['buy_date']}  @{row['buy_price']:,.0f}  {held}주")
+    print(f"  매도기록 {row['sell_date']}  @{row['sell_price']:,.0f}  수익률 {row['return_rate']}%")
+    print("-" * 72)
+    print("[현재] 1개 행")
+    print(f"  id={row['id']}  SOLD  qty={held}   ← 실제로는 {filled_qty}주만 체결됨 (과대기록)")
+    print()
+    print("[복구 후] 2개 행")
+    print(f"  id={row['id']}  HOLD  qty={remaining}   전략={row['strategy']} (매도필드 초기화, 잔량 보유 복원)")
+    print(f"  id=신규    SOLD  qty={filled_qty}   @{row['sell_price']:,.0f}  수익률 {row['return_rate']}%")
+    print("=" * 72)
+
+
+def _backup(conn: sqlite3.Connection, db_path: str) -> str:
+    """일관된 전체 스냅샷을 남긴다.
+
+    이 DB 는 WAL 모드라 파일 복사(shutil.copy)는 -wal 에 있는 최신 커밋을 놓쳐
+    조용히 불완전한 백업을 만든다. sqlite3 backup API 를 써야 한다.
+    """
+    backup_path = f"{db_path}.bak-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    dest = sqlite3.connect(backup_path)
+    try:
+        conn.backup(dest)
+    finally:
+        dest.close()
+    return backup_path
+
+
+def _apply(conn: sqlite3.Connection, row: sqlite3.Row, filled_qty: int, held: int) -> int:
+    columns = [r[1] for r in conn.execute("PRAGMA table_info(trades)").fetchall() if r[1] != "id"]
+    overrides = {"qty": filled_qty}
+    select_terms, params = [], []
+    for col in columns:
+        if col in overrides:
+            select_terms.append("?")
+            params.append(overrides[col])
+        else:
+            select_terms.append(col)
+    params.append(row["id"])
+
+    with conn:
+        cursor = conn.execute(
+            f"INSERT INTO trades ({', '.join(columns)}) "
+            f"SELECT {', '.join(select_terms)} FROM trades WHERE id=?",
+            params,
+        )
+        new_id = cursor.lastrowid
+        reset_cols = ", ".join(f"{col}=?" for col in _HOLD_RESET)
+        conn.execute(
+            f"UPDATE trades SET qty=?, status='HOLD', {reset_cols} WHERE id=?",
+            (held - filled_qty, *_HOLD_RESET.values(), row["id"]),
+        )
+    return new_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="부분 매도 오기록 원장 행 분할 복구")
+    parser.add_argument("--trade-id", type=int, required=True, help="복구할 SOLD 행의 id")
+    parser.add_argument("--filled-qty", type=int, required=True,
+                        help="실제 체결 수량 (로그 execution_quality 의 filled_qty)")
+    parser.add_argument("--db", default=DEFAULT_DB, help=f"DB 경로 (기본 {DEFAULT_DB})")
+    parser.add_argument("--apply", action="store_true",
+                        help="실제 반영. 생략 시 dry-run (변경 없음)")
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    conn.row_factory = sqlite3.Row
+
+    row = _fetch_row(conn, args.trade_id)
+    held = _validate(row, args.filled_qty)
+    _print_plan(row, args.filled_qty, held)
+
+    if not args.apply:
+        print("\n[DRY-RUN] 변경하지 않았습니다. 실제 반영하려면 --apply 를 붙이세요.")
+        return
+
+    backup = _backup(conn, args.db)
+    print(f"\n[백업] {backup}")
+
+    new_id = _apply(conn, row, args.filled_qty, held)
+    print(f"[반영] id={args.trade_id} → HOLD {held - args.filled_qty}주 / 신규 id={new_id} SOLD {args.filled_qty}주")
+
+    print("\n[검증]")
+    for r in conn.execute(
+        "SELECT id,strategy,code,status,qty,buy_price,sell_price FROM trades WHERE code=? ORDER BY id",
+        (row["code"],),
+    ):
+        print("  ", dict(r))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -103,6 +103,65 @@ def test_log_sell_by_strategy(virutal_trade_repository):
     assert df[df['strategy'] == "S1"].iloc[0]['status'] == "SOLD"
     assert df[df['strategy'] == "S2"].iloc[0]['status'] == "HOLD"
 
+
+def test_log_sell_partial_keeps_remainder_hold(virutal_trade_repository):
+    """부분 매도 시 잔량은 HOLD로 남고 매도분만 별도 SOLD row로 분리된다."""
+    virutal_trade_repository.log_buy("StrategyA", "005930", 10000, qty=10)
+    virutal_trade_repository.log_sell("005930", 11000, qty=4)
+
+    df = virutal_trade_repository._read()
+    holds = df[df["status"] == "HOLD"]
+    solds = df[df["status"] == "SOLD"]
+    assert len(holds) == 1
+    assert holds.iloc[0]["qty"] == 6
+    assert len(solds) == 1
+    assert solds.iloc[0]["qty"] == 4
+    assert solds.iloc[0]["sell_price"] == 11000
+
+
+def test_log_sell_partial_preserves_strategy_on_remainder(virutal_trade_repository):
+    """부분 매도 잔량은 원 전략 귀속을 유지한다 (broker_reconciled 고아화 방지)."""
+    virutal_trade_repository.log_buy("래리윌리엄스VBO", "086790", 133400, qty=14)
+    virutal_trade_repository.log_sell("086790", 131900, qty=7)
+
+    df = virutal_trade_repository._read()
+    remainder = df[df["status"] == "HOLD"].iloc[0]
+    realized = df[df["status"] == "SOLD"].iloc[0]
+    # 잔량이 매도분과 동일한 전략에 그대로 귀속되어야 한다 (미귀속 → broker_reconciled 고아화)
+    assert remainder["strategy"] == realized["strategy"]
+    assert remainder["strategy"] != "broker_reconciled"
+    assert remainder["qty"] == 7
+    assert remainder["buy_price"] == 133400
+
+
+def test_log_sell_without_qty_closes_entire_hold(virutal_trade_repository):
+    """qty 미지정 매도는 보유 전량 청산 (기존 호출부 하위호환)."""
+    virutal_trade_repository.log_buy("StrategyA", "005930", 10000, qty=10)
+    virutal_trade_repository.log_sell("005930", 11000)
+
+    df = virutal_trade_repository._read()
+    assert len(df) == 1
+    assert df.iloc[0]["status"] == "SOLD"
+    assert df.iloc[0]["qty"] == 10
+
+
+def test_log_sell_by_strategy_partial_splits_lot(virutal_trade_repository):
+    """전략 매칭 부분 매도도 lot을 분할하며 다른 전략 보유는 건드리지 않는다."""
+    virutal_trade_repository.log_buy("S1", "005930", 10000, qty=10)
+    virutal_trade_repository.log_buy("S2", "005930", 10000, qty=8)
+    virutal_trade_repository.log_sell_by_strategy("S1", "005930", 12000, qty=6)
+
+    df = virutal_trade_repository._read()
+    s1 = df[df["strategy"] == "S1"]
+    assert set(s1["status"]) == {"HOLD", "SOLD"}
+    assert s1[s1["status"] == "HOLD"].iloc[0]["qty"] == 4
+    assert s1[s1["status"] == "SOLD"].iloc[0]["qty"] == 6
+
+    s2 = df[df["strategy"] == "S2"]
+    assert len(s2) == 1
+    assert s2.iloc[0]["status"] == "HOLD"
+    assert s2.iloc[0]["qty"] == 8
+
 def test_get_all_trades_json_compatibility(virutal_trade_repository):
     """NaN 값이 None으로 변환되어 JSON 직렬화가 가능한지 확인"""
     virutal_trade_repository.log_buy("S1", "005930", 70000)

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1758,13 +1758,13 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         config_b = StrategySchedulerConfig(strategy=strategy_b, force_exit_on_close=False, interval_minutes=0)
         scheduler.register(config_b)
 
-        # 현재 시간: 15:05, 마감 시간: 15:30 (25분 남음 -> 강제청산 윈도우 이내, 컷오프 이전)
+        # 현재 시간: 15:02, 마감 시간: 15:30 (28분 남음 -> 1단계 tier(30분)만 발화, 최종 tier(25분) 이전)
         import pytz
         from datetime import datetime
         kst = pytz.timezone("Asia/Seoul")
-        now = kst.localize(datetime(2023, 1, 1, 15, 5))
+        now = kst.localize(datetime(2023, 1, 1, 15, 2))
         # 두 번째 루프에서는 쿨다운(60초) 이후 시점
-        now_after_cooldown = kst.localize(datetime(2023, 1, 1, 15, 6, 1))
+        now_after_cooldown = kst.localize(datetime(2023, 1, 1, 15, 3, 1))
         close_time = kst.localize(datetime(2023, 1, 1, 15, 30))
 
         tm.get_current_kst_time.side_effect = [now, now_after_cooldown]
@@ -1786,6 +1786,35 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
 
             # 전략 B는 일반 모드(False)로 실행되어야 함 (쿨다운 이후 두 번째 루프에서 실행)
             mock_run.assert_any_call(config_b, force_exit_only=False, force_exit_fraction=1.0)
+
+    def test_force_exit_final_tier_runs_before_order_cutoff(self):
+        """최종 강제청산 tier는 주문 컷오프보다 먼저 발화해야 한다 (마감 전 flat 보장).
+
+        최종 tier가 컷오프 이후에 잡히면 영구 미실행되어 잔량이 오버나이트로 유출된다.
+        """
+        final_tier_minutes = min(m for m, _ in StrategyScheduler.FORCE_EXIT_TIERS)
+        last_cumulative = max(c for _, c in StrategyScheduler.FORCE_EXIT_TIERS)
+
+        self.assertEqual(last_cumulative, 1.0)
+        self.assertGreater(
+            final_tier_minutes,
+            StrategyScheduler.ORDER_CUTOFF_MINUTES_BEFORE_CLOSE,
+            "최종 tier가 주문 컷오프 이후면 영구 미실행 → 잔량 오버나이트 유출",
+        )
+
+    def test_pending_force_exit_tier_reaches_full_exit_before_cutoff(self):
+        """1차 tier로 절반 청산된 뒤, 컷오프 이전에 잔량 전량 청산 tier가 발화한다."""
+        scheduler, _, _, _, _ = self._make_scheduler()
+        name = "전략A"
+        scheduler._force_exit_progress[name] = 0.5
+
+        minutes_just_before_cutoff = StrategyScheduler.ORDER_CUTOFF_MINUTES_BEFORE_CLOSE + 0.1
+        pending = scheduler._pending_force_exit_tier(name, minutes_just_before_cutoff)
+
+        self.assertIsNotNone(pending, "컷오프 이전에 잔량 전량 청산 tier가 발화해야 한다")
+        target, sell_fraction = pending
+        self.assertEqual(target, 1.0)
+        self.assertEqual(sell_fraction, 1.0)
 
     async def test_loop_skips_strategy_after_order_cutoff(self):
         """주문 컷오프 이후에는 일반 실행과 강제청산 모두 시그널을 만들지 않는다."""
@@ -1915,23 +1944,23 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         # 윈도우 밖(T-40): 발화 tier 없음
         assert scheduler._pending_force_exit_tier("S", 40) is None
 
-        # T-25: 1단계(30분,0.5)만 발화 → 현재 보유의 50% 매도
-        assert scheduler._pending_force_exit_tier("S", 25) == (0.5, 0.5)
+        # T-28: 1단계(30분,0.5)만 발화 → 현재 보유의 50% 매도
+        assert scheduler._pending_force_exit_tier("S", 28) == (0.5, 0.5)
 
-        # 진행률 0.5 기록 후 T-25 재호출: 동일 tier 재발화 안 함
+        # 진행률 0.5 기록 후 T-28 재호출: 동일 tier 재발화 안 함
         scheduler._force_exit_progress["S"] = 0.5
-        assert scheduler._pending_force_exit_tier("S", 25) is None
+        assert scheduler._pending_force_exit_tier("S", 28) is None
 
-        # T-10: 2단계(15분,1.0) 발화 → 잔여 전량(fraction=1.0)
-        target, fraction = scheduler._pending_force_exit_tier("S", 10)
+        # T-22: 2단계(25분,1.0) 발화 → 잔여 전량(fraction=1.0). 컷오프(20분) 이전이라 실제 주문 가능.
+        target, fraction = scheduler._pending_force_exit_tier("S", 22)
         assert target == 1.0 and abs(fraction - 1.0) < 1e-9
 
         # 진행률 1.0(전량 완료) 후: 더 이상 발화 없음
         scheduler._force_exit_progress["S"] = 1.0
-        assert scheduler._pending_force_exit_tier("S", 10) is None
+        assert scheduler._pending_force_exit_tier("S", 22) is None
 
-        # 1단계를 놓치고 T-10에 처음 진입: 곧장 누적 1.0 전량으로 catch-up
-        assert scheduler._pending_force_exit_tier("LATE", 10) == (1.0, 1.0)
+        # 1단계를 놓치고 T-22에 처음 진입: 곧장 누적 1.0 전량으로 catch-up
+        assert scheduler._pending_force_exit_tier("LATE", 22) == (1.0, 1.0)
 
     async def test_force_liquidate_partial_fraction_sells_floor(self):
         """sell_fraction<1.0 시 floor(qty*fraction) 수량만 매도한다."""


### PR DESCRIPTION
## 배경

2026-07-21 운영 요약의 "즉시 점검: broker_reconciled 보유 10종목의 전략 귀속/청산 책임" 항목을 추적한 결과, 귀속 누락이 아니라 **당일청산 전략이 매 청산마다 포지션의 절반을 조용히 오버나이트로 넘기고 있는 버그**의 증상이었다.

고아 포지션의 수량이 직전 매도 건의 정확히 절반이고 매입가가 정확히 일치한다:

| 종목 | 직전 매도 수량 | 고아 수량 | 매도 시각 |
|---|---|---|---|
| 피에스케이홀딩스(031980) | 12 | 6 | 15:10:04 |
| 유진테크(084370) | 10 | 5 | 09:19:24 |
| 하나금융지주(086790) | 14 | 7 | 15:10:04 |
| 현대해상(001450) | 51 | 26 | 15:10:08 |

7월 생성 고아 4건이 전부 이 패턴이며, tiered force-exit 도입일(2026-06-28, `todo_list.md:341`) 이후에만 나타난다. 5~6월 생성 6건은 패턴이 달라 별도 원인이다.

## 원인

**1. 최종 강제청산 tier 도달 불가**

`FORCE_EXIT_TIERS = [(30, 0.5), (15, 1.0)]` + `ORDER_CUTOFF_MINUTES_BEFORE_CLOSE = 20`, 마감 15:40 기준:

- tier1 = 15:10 → 누적 50% 청산
- tier2 = 15:25 → 나머지 전량. **그러나 주문 차단이 15:20부터라 영구 미실행**

98-99행 주석이 선언한 "마지막 tier 는 반드시 1.0(전량)으로 마감 전 flat 보장" 불변식이 구조적으로 깨져 있었다.

**2. `log_sell` 계열이 qty를 무시**

UPDATE 문이 qty를 쓰지 않고 lot 전체를 `status='SOLD'`로 뒤집는다. 절반만 팔려도 로컬에 HOLD가 남지 않아 (a) 잔량이 경보 없이 사라지고 (b) 다음 tier가 대상을 못 찾으며 (c) 손익이 전량 청산 가정으로 기록된다. 의도된 분할매도 경로(`partial_sell_ratio: 0.5` — first_pullback/HTF/오닐PP/OSB)도 같은 결함에 걸린다.

## 변경

- `FORCE_EXIT_TIERS` 최종 tier를 25분 전으로 이동 — 컷오프 이전에 발화
  - 컷오프 예외는 **두지 않음**. `test_loop_skips_strategy_after_order_cutoff`가 "컷오프 이후 강제청산도 시그널 없음"을 의도된 설계로 고정하고 있고, 동시호가 구간 판단 무의미라는 근거가 타당하다
- `log_sell` / `log_sell_with_result` / `log_sell_by_strategy` / `log_sell_by_strategy_with_result`: qty 기본값 `1` → `None`
  - `None` 또는 보유 수량 이상 → 전량 청산 (**기존 호출부 동작 100% 보존**)
  - 보유 수량 미만 → lot 분할: 매도분은 신규 SOLD row로, 원본 row는 잔량만 남긴 채 HOLD 유지 → 전략 귀속 보존
  - with_result 변형의 P&L도 실제 체결 수량 기준으로 교정 (기존 하드코딩 `1` → 과소계상)
- 호출부 변경 없음 — `fill_reconciliation_service`는 이미 실체결 `record_qty`를, 스케줄러는 `signal.qty`를 넘기고 있었다

## 테스트

신규 6건 (회귀 잠금 포함: 최종 tier의 minutes_before > 주문 컷오프 검증)
기존 2건은 tier 스케줄 변경에 맞춰 시각 조정 — 의도는 그대로 유지

```
pytest tests/unit_test        7021 passed
pytest tests/integration_test  264 passed
```

## 범위 밖

기존 고아 10종목 정리는 포함하지 않았다. 재생성 차단이 선행 조건이며, 7월 4건은 원 lot과 매입가가 일치해 기계적 재귀속이 가능하지만 5~6월 6건은 대응 매도 기록이 없어 별도 판단이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)