### PR TITLE
기간수급 최근 거래일 범위 정정

### DIFF
--- a/repositories/period_ranking_repository.py
+++ b/repositories/period_ranking_repository.py
@@ -14,6 +14,8 @@ from typing import Dict, List, Optional, Union
 class PeriodRankingRepository:
     """기간수급 랭킹 결과를 (거래일, 조회일수) 키로 저장/조회한다."""
 
+    CALCULATION_VERSION = 2
+
     def __init__(self, db_path: Union[str, Path] = "data/period_ranking.db"):
         self._db_path = str(db_path)
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
@@ -24,20 +26,28 @@ class PeriodRankingRepository:
                     trade_date TEXT NOT NULL,
                     days INTEGER NOT NULL,
                     results TEXT NOT NULL,
+                    calculation_version INTEGER NOT NULL DEFAULT 2,
                     updated_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
                     PRIMARY KEY (trade_date, days)
                 )
                 """
             )
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(period_ranking)")}
+            if "calculation_version" not in columns:
+                conn.execute(
+                    "ALTER TABLE period_ranking ADD COLUMN "
+                    "calculation_version INTEGER NOT NULL DEFAULT 1"
+                )
 
     def save(self, trade_date: str, days: int, results: List[Dict]) -> None:
         """결과를 저장하고 이전 거래일 행은 정리한다 (조회는 항상 최신 거래일 기준)."""
         payload = json.dumps(results, ensure_ascii=False)
         with sqlite3.connect(self._db_path) as conn:
             conn.execute(
-                "INSERT OR REPLACE INTO period_ranking (trade_date, days, results, updated_at) "
-                "VALUES (?, ?, ?, datetime('now', 'localtime'))",
-                (str(trade_date), int(days), payload),
+                "INSERT OR REPLACE INTO period_ranking "
+                "(trade_date, days, results, calculation_version, updated_at) "
+                "VALUES (?, ?, ?, ?, datetime('now', 'localtime'))",
+                (str(trade_date), int(days), payload, self.CALCULATION_VERSION),
             )
             conn.execute(
                 "DELETE FROM period_ranking WHERE trade_date < ?",
@@ -48,8 +58,9 @@ class PeriodRankingRepository:
         """저장된 결과를 반환한다. 없으면 None."""
         with sqlite3.connect(self._db_path) as conn:
             row = conn.execute(
-                "SELECT results FROM period_ranking WHERE trade_date = ? AND days = ?",
-                (str(trade_date), int(days)),
+                "SELECT results FROM period_ranking "
+                "WHERE trade_date = ? AND days = ? AND calculation_version = ?",
+                (str(trade_date), int(days), self.CALCULATION_VERSION),
             ).fetchone()
         if not row:
             return None

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -7,7 +7,7 @@
 import asyncio
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Dict, Optional, TYPE_CHECKING
 
 from brokers.broker_api_wrapper import BrokerAPIWrapper
@@ -767,6 +767,8 @@ class RankingTask(AfterMarketTask):
         if not all_stocks:
             return [], True
 
+        recent_trading_dates = await self._get_recent_trading_dates(target_date, days)
+        recent_trading_date_set = set(recent_trading_dates)
         industry_map = await self._load_industry_map()
         results: List[Dict] = []
         is_complete = True
@@ -803,6 +805,15 @@ class RankingTask(AfterMarketTask):
 
                 investor_rows = investor_resp.data if investor_resp and isinstance(investor_resp.data, list) else []
                 program_rows = program_resp.data if program_resp and isinstance(program_resp.data, list) else []
+                if recent_trading_date_set:
+                    investor_rows = [
+                        row for row in investor_rows
+                        if isinstance(row, dict) and str(row.get("stck_bsop_date") or "") in recent_trading_date_set
+                    ]
+                    program_rows = [
+                        row for row in program_rows
+                        if isinstance(row, dict) and str(row.get("stck_bsop_date") or "") in recent_trading_date_set
+                    ]
                 for row in [*investor_rows, *program_rows]:
                     if not isinstance(row, dict):
                         continue
@@ -854,11 +865,32 @@ class RankingTask(AfterMarketTask):
                     "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
                 })
 
-        earliest_trading_date = min(observed_trading_dates)
+        earliest_trading_date = recent_trading_dates[0] if recent_trading_dates else min(observed_trading_dates)
         for result in results:
             result["earliest_trading_date"] = earliest_trading_date
 
         return results, is_complete
+
+    async def _get_recent_trading_dates(self, target_date: str, days: int) -> List[str]:
+        """시장 캘린더 기준 target_date 포함 최근 N거래일을 오래된 순으로 반환한다."""
+        if self._mcs is None:
+            return []
+
+        current = datetime.strptime(str(target_date), "%Y%m%d")
+        trading_dates: List[str] = []
+        max_lookback_days = days * 3 + 15
+        for _ in range(max_lookback_days):
+            date_str = current.strftime("%Y%m%d")
+            if await self._mcs.is_business_day(date_str):
+                trading_dates.append(date_str)
+                if len(trading_dates) == days:
+                    return sorted(trading_dates)
+            current -= timedelta(days=1)
+
+        self._logger.warning(
+            f"{target_date} 기준 최근 {days}거래일 계산 실패 — API 응답 날짜로 대체합니다."
+        )
+        return []
 
     async def get_trading_value_ranking(self, limit: int = 30) -> ResCommonResponse:
         """투자자 데이터 기반 거래대금 랭킹 반환 (캐시에서 즉시)."""

--- a/tests/unit_test/repositories/test_period_ranking_repository.py
+++ b/tests/unit_test/repositories/test_period_ranking_repository.py
@@ -1,4 +1,7 @@
 """PeriodRankingRepository — 기간수급 랭킹 SQLite 영속화 테스트."""
+import json
+import sqlite3
+
 import pytest
 
 from repositories.period_ranking_repository import PeriodRankingRepository
@@ -40,3 +43,22 @@ def test_save_prunes_older_trade_dates(repo):
     repo.save("20260714", 5, [{"a": "new"}])
     assert repo.get("20260713", 5) is None
     assert repo.get("20260714", 5) == [{"a": "new"}]
+
+
+def test_legacy_calculation_results_are_invalidated(tmp_path):
+    """시장 거래일 필터 도입 전 계산 결과는 재시작 시 복원하지 않는다."""
+    db_path = tmp_path / "period_ranking.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE period_ranking ("
+            "trade_date TEXT NOT NULL, days INTEGER NOT NULL, results TEXT NOT NULL, "
+            "updated_at TEXT NOT NULL, PRIMARY KEY (trade_date, days))"
+        )
+        conn.execute(
+            "INSERT INTO period_ranking VALUES (?, ?, ?, datetime('now'))",
+            ("20260721", 5, json.dumps([{"earliest_trading_date": "20260623"}])),
+        )
+
+    migrated_repo = PeriodRankingRepository(db_path=db_path)
+
+    assert migrated_repo.get("20260721", 5) is None

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -4,6 +4,7 @@ RankingTask 단위 테스트.
 """
 import asyncio
 import time
+from datetime import datetime
 import pytest
 import pandas as pd
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -38,7 +39,7 @@ def _make_program_multi_response(rows):
     return ResCommonResponse(
         rt_cd=ErrorCode.SUCCESS.value,
         msg1="OK",
-        data=rows,
+        data=[dict({"stck_bsop_date": "20250101"}, **row) for row in rows],
     )
 
 
@@ -57,7 +58,9 @@ def mock_deps():
     market_clock = MagicMock()
     market_calendar_service = AsyncMock(spec=MarketCalendarService)
     market_calendar_service.is_market_open_now = AsyncMock(return_value=False) # 기본: 장 마감 상태 (갱신 허용)
-    market_calendar_service.is_business_day = AsyncMock(return_value=True) # 기본: 영업일
+    market_calendar_service.is_business_day = AsyncMock(
+        side_effect=lambda date: datetime.strptime(date, "%Y%m%d").weekday() < 5
+    )
     market_calendar_service.get_latest_trading_date = AsyncMock(return_value="20250101")
     return broker, mapper, env, logger, market_clock, market_calendar_service
 
@@ -120,7 +123,7 @@ def _make_investor_multi_response(rows):
     return ResCommonResponse(
         rt_cd=ErrorCode.SUCCESS.value,
         msg1="OK",
-        data=rows,
+        data=[dict({"stck_bsop_date": "20250101"}, **row) for row in rows],
     )
 
 # ==============================================================================
@@ -327,12 +330,43 @@ async def test_period_investor_program_ranking_defaults_to_combined_amount(bg_se
     assert resp.rt_cd == ErrorCode.SUCCESS.value
     assert [item["hts_kor_isnm"] for item in resp.data] == ["SK하이닉스", "삼성전자"]
     assert resp.data[0]["combined_period_ntby_tr_pbmn_won"] == "920000000"
-    assert resp.data[1]["combined_period_ntby_tr_pbmn_won"] == "470000000"
+    assert resp.data[1]["combined_period_ntby_tr_pbmn_won"] == "370000000"
     assert all(item["hts_kor_isnm"] != "NAVER" for item in resp.data)
     assert resp.data[0]["industry"] == "IT"
     assert resp.data[1]["industry"] == "반도체"
     assert all(item["latest_trading_date"] == "20250101" for item in resp.data)
-    assert resp.data[1]["earliest_trading_date"] == "20241224"
+    assert resp.data[1]["earliest_trading_date"] == "20241226"
+
+
+@pytest.mark.asyncio
+async def test_period_investor_program_ranking_uses_market_window_not_stale_stock_dates(bg_service, mock_deps):
+    """거래정지 종목의 과거 응답은 최근 N거래일 범위와 합산을 오염시키지 않는다."""
+    broker, mapper, _, _, _, market_calendar_service = mock_deps
+    mapper.df = _make_stock_df([("005930", "삼성전자", "KOSPI")])
+    recent_dates = {"20260715", "20260716", "20260717", "20260720", "20260721"}
+    market_calendar_service.get_latest_trading_date.return_value = "20260721"
+    market_calendar_service.is_business_day = AsyncMock(
+        side_effect=lambda date: date in recent_dates
+    )
+    broker.get_investor_trade_by_stock_daily_multi = AsyncMock(
+        return_value=_make_investor_multi_response([
+            {"stck_bsop_date": "20260721", "frgn_ntby_qty": "10", "orgn_ntby_qty": "0", "frgn_ntby_tr_pbmn": "100", "orgn_ntby_tr_pbmn": "0"},
+            {"stck_bsop_date": "20260623", "frgn_ntby_qty": "999", "orgn_ntby_qty": "0", "frgn_ntby_tr_pbmn": "999", "orgn_ntby_tr_pbmn": "0"},
+        ])
+    )
+    broker.get_program_trade_by_stock_daily_multi = AsyncMock(
+        return_value=_make_program_multi_response([
+            {"stck_bsop_date": "20260721", "whol_smtn_ntby_qty": "20", "whol_smtn_ntby_tr_pbmn": "200000000"},
+            {"stck_bsop_date": "20260623", "whol_smtn_ntby_qty": "999", "whol_smtn_ntby_tr_pbmn": "999000000"},
+        ])
+    )
+
+    await bg_service.prewarm_period_ranking("20260721")
+    resp = await bg_service.get_period_investor_program_net_buy_ranking(days=5)
+
+    assert resp.data[0]["earliest_trading_date"] == "20260715"
+    assert resp.data[0]["combined_period_ntby_qty"] == "30"
+    assert resp.data[0]["combined_period_ntby_tr_pbmn_won"] == "300000000"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 변경 사항

- 시장 캘린더를 기준으로 최근 N거래일 날짜 집합을 계산합니다.
- 투자자·프로그램 수급 응답에서 해당 거래일 범위 밖의 오래된 행을 합산 대상에서 제외합니다.
- 화면의 시작일을 전체 종목 응답의 최솟값이 아니라 실제 최근 N거래일의 첫날로 제공합니다.
- 계산 버전을 SQLite에 저장해 기존의 잘못 계산된 캐시를 자동 무효화하고 재수집합니다.

## 원인

전체 종목의 API 응답 날짜를 합친 뒤 최솟값을 시작일로 사용해, 거래정지·거래부진 종목이 반환한 과거 날짜 하나가 전체 기간 표시와 합산을 오염시켰습니다.

## 영향

`최근 5거래일 (2026-06-23 ~ 2026-07-21)`처럼 과도하게 긴 기간이 표시되던 문제가 해결되며, 합산 수급도 실제 시장의 최근 5거래일에 한정됩니다.

## 검증

- `pytest tests/unit_test -v` — 7,023 passed
- `pytest tests/integration_test -v` — 264 passed
- 관련 기간수급 테스트 — 111 passed
