### PR TITLE
fix: 즐겨찾기 등락률 0% 오표기 (틱 캐시에 전일대비율 전파)

### DIFF
--- a/repositories/stock_price_repository.py
+++ b/repositories/stock_price_repository.py
@@ -76,8 +76,12 @@ class StockPriceRepository:
             self._cache_logger.log_price_miss(code, caller, "not_found")
         return None
 
-    def update_current_price(self, code: str, current_price: float, volume: int = 0):
-        """WebSocket 틱 데이터로 현재가 캐시를 즉시 갱신합니다."""
+    def update_current_price(self, code: str, current_price: float, volume: int = 0, rate=None):
+        """WebSocket 틱 데이터로 현재가 캐시를 즉시 갱신합니다.
+
+        rate(전일대비율)가 전달되면 등락률(prdy_ctrt)도 함께 갱신하여
+        가격만 최신이고 등락률은 과거 값에 고정되는 문제를 방지합니다.
+        """
         cached = self._price_cache.get(code, count_stats=False, item_type="update_tick")
         if not cached:
             cached = {}
@@ -86,8 +90,11 @@ class StockPriceRepository:
         if "current_price_data" not in cached:
             # 틱만 수신된 경우 최소 구조로 캐시 생성 (_source="tick" 마킹)
             # stock_query_service는 _source 필드로 불완전 캐시를 식별할 수 있음
+            output = {"stck_prpr": str(int(current_price)), "acml_vol": str(volume)}
+            if rate is not None:
+                output["prdy_ctrt"] = str(rate)
             cached["current_price_data"] = {
-                "output": {"stck_prpr": str(int(current_price)), "acml_vol": str(volume)},
+                "output": output,
                 "_source": "tick",
             }
             cached["price_updated_at"] = time.time()
@@ -100,12 +107,16 @@ class StockPriceRepository:
             output["stck_prpr"] = str(int(current_price))
             if volume > 0:
                 output["acml_vol"] = str(volume)
+            if rate is not None:
+                output["prdy_ctrt"] = str(rate)
         elif output is not None:
             try:
                 before_price = getattr(output, "stck_prpr", None)
                 setattr(output, "stck_prpr", str(int(current_price)))
                 if volume > 0:
                     setattr(output, "acml_vol", str(volume))
+                if rate is not None:
+                    setattr(output, "prdy_ctrt", str(rate))
             except Exception:
                 pass
 

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -75,13 +75,13 @@ class StockRepository:
 
     # ── 실시간 틱 통합 업데이트 ───────────────────────────────────────────────────
 
-    def update_realtime_data(self, code: str, current_price: float, volume: int = 0):
+    def update_realtime_data(self, code: str, current_price: float, volume: int = 0, rate=None):
         """
         장 중에 수신된 WebSocket 틱 데이터를 메모리 캐시에 즉시 반영합니다.
-        - 현재가 캐시(price_repo) 갱신
+        - 현재가 캐시(price_repo) 갱신 (등락률 rate 포함)
         - OHLCV 당일 캔들(ohlcv_repo) 갱신
         """
-        self._price_repo.update_current_price(code, current_price, volume)
+        self._price_repo.update_current_price(code, current_price, volume, rate=rate)
         self._ohlcv_repo.update_today_candle(code, current_price, volume)
 
     # ── daily_prices (장마감 후 전종목 스냅샷) ──────────────────────────────────

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -194,7 +194,10 @@ class PriceStreamService:
         }
 
         try:
-            self._stock_repo.update_realtime_data(stock_code, float(current_price), vol_int)
+            self._stock_repo.update_realtime_data(
+                stock_code, float(current_price), vol_int,
+                rate=realtime_data.get('전일대비율'),
+            )
         except Exception as e:
             self._logger.warning(f"StockRepository 실시간 틱 캐시 갱신 실패: {e}")
 
@@ -326,7 +329,7 @@ class PriceStreamService:
         }
 
         try:
-            self._stock_repo.update_realtime_data(code, float(price), vol_int)
+            self._stock_repo.update_realtime_data(code, float(price), vol_int, rate=rate)
         except Exception as e:
             self._logger.warning(f"StockRepository 현재가 스냅샷 캐시 갱신 실패: {e}")
 

--- a/tests/unit_test/repositories/test_stock_price_repository.py
+++ b/tests/unit_test/repositories/test_stock_price_repository.py
@@ -435,6 +435,37 @@ class TestStockPriceRepository:
 
         assert broken.stck_prpr == "73000"
 
+    def test_update_current_price_stores_rate_on_new_tick_cache(self, price_repo):
+        """틱만 수신된 최초 캐시에도 등락률(prdy_ctrt)이 반영되어야 한다."""
+        price_repo.update_current_price("005930", 70123, volume=55, rate="5.41")
+
+        cached = price_repo._price_cache.get("005930", count_stats=False, item_type="check")
+        assert cached["current_price_data"]["output"]["prdy_ctrt"] == "5.41"
+
+    def test_update_current_price_refreshes_stale_rate(self, price_repo):
+        """기존 캐시의 오래된 등락률이 새 틱의 등락률로 갱신되어야 한다."""
+        price_repo._price_cache.put(
+            "005930",
+            {"current_price_data": {"output": {"stck_prpr": "70000", "prdy_ctrt": "0.00"}}, "price_updated_at": 1},
+        )
+
+        price_repo.update_current_price("005930", 71000, volume=99, rate="5.41")
+
+        cached = price_repo._price_cache.get("005930", count_stats=False, item_type="check")
+        assert cached["current_price_data"]["output"]["prdy_ctrt"] == "5.41"
+
+    def test_update_current_price_keeps_rate_when_not_provided(self, price_repo):
+        """rate 미전달 시 기존 등락률을 보존한다(회귀 방지)."""
+        price_repo._price_cache.put(
+            "005930",
+            {"current_price_data": {"output": {"stck_prpr": "70000", "prdy_ctrt": "3.10"}}, "price_updated_at": 1},
+        )
+
+        price_repo.update_current_price("005930", 71000, volume=99)
+
+        cached = price_repo._price_cache.get("005930", count_stats=False, item_type="check")
+        assert cached["current_price_data"]["output"]["prdy_ctrt"] == "3.10"
+
     def test_mark_unmark_streaming_and_cache_stats_expand(self, price_repo):
         price_repo.set_current_price("005930", {"output": {"stck_prpr": "70000"}})
         price_repo.mark_streaming("005930")

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -69,8 +69,8 @@ def test_on_price_tick_success(price_stream_service, mock_stock_repo):
     assert price_stream_service.get_last_tick_ts('005930') == cached['received_at']
     assert price_stream_service.get_last_any_tick_ts() == cached['received_at']
 
-    # 2. StockRepository.update_realtime_data 호출 확인
-    mock_stock_repo.update_realtime_data.assert_called_once_with('005930', 75000.0, 1500000)
+    # 2. StockRepository.update_realtime_data 호출 확인 (등락률 rate 포함)
+    mock_stock_repo.update_realtime_data.assert_called_once_with('005930', 75000.0, 1500000, rate='1.35')
 
 
 def test_on_price_tick_records_top_of_book(mock_stock_repo, mock_logger):
@@ -113,7 +113,7 @@ def test_on_price_tick_defaults(price_stream_service, mock_stock_repo):
     assert cached['rate'] == '0.00'
     assert cached['sign'] == '3'
 
-    mock_stock_repo.update_realtime_data.assert_called_once_with('000660', 150000.0, 0)
+    mock_stock_repo.update_realtime_data.assert_called_once_with('000660', 150000.0, 0, rate=None)
 
 
 def test_cache_price_snapshot_updates_cache_without_tick_tracking(price_stream_service, mock_stock_repo):
@@ -135,7 +135,7 @@ def test_cache_price_snapshot_updates_cache_without_tick_tracking(price_stream_s
     assert cached["sign"] == "2"
     assert price_stream_service.get_last_tick_ts("005930") == 0.0
     assert price_stream_service.get_last_any_tick_ts() == 0.0
-    mock_stock_repo.update_realtime_data.assert_called_once_with("005930", 71000.0, 3210)
+    mock_stock_repo.update_realtime_data.assert_called_once_with("005930", 71000.0, 3210, rate="0.71")
 
 
 def test_on_price_tick_stores_liquidity_fields(price_stream_service):


### PR DESCRIPTION
## 문제
장중 즐겨찾기(`/favorite`) 목록에서 등락률이 `0.00%`로 잘못 표기됨. 현재가는 실시간으로 움직이는데 등락률만 0%에 고정되는 종목이 발생.

## 원인
`FavoriteService.get_with_details()`는 1단계로 공유 인메모리 캐시(`StockRepository`)에서 등락률(`prdy_ctrt`)을 읽는다. 그러나 WebSocket 틱 처리 경로가 등락률을 캐시에 반영하지 않았다:

- 틱 데이터(`realtime_data`)에는 `전일대비율`이 들어있음 (`price_stream_service.py:183`)
- 하지만 `update_realtime_data(code, price, volume)` → `update_current_price`는 **현재가·거래량만** 갱신하고 `prdy_ctrt`는 버림
- 결과: 가격은 매 틱 최신화되나 등락률은 마지막 전체 조회(API) 시점 값(대개 장전 `0.00`)에 고정 → 잘못된 0% 표시

## 수정
틱/REST 스냅샷 갱신 경로에 `rate`를 함께 전파:
- `StockPriceRepository.update_current_price(..., rate=None)` — 최초 틱 캐시 및 기존 캐시 모두 `prdy_ctrt` 갱신 (미전달 시 기존 값 보존)
- `StockRepository.update_realtime_data(..., rate=None)` — 패스스루
- `price_stream_service.py` 틱/스냅샷 두 호출부에서 `전일대비율` 전달

## 검증
- 신규 단위 테스트 3건 (신규 틱 캐시 rate 저장 / 오래된 rate 갱신 / rate 미전달 시 보존)
- 기존 `test_price_stream_service` 호출 서명 검증 3건 갱신
- 단위(repositories/services 관련) + 통합 테스트 264건 전체 통과

## 범위 밖 (미수정)
장마감 후 DB 스냅샷 경로(`stock_ohlcv_repository.py:701`)는 `change_rate`가 null일 때 `"0"`으로 표기하나, 이는 별개의 after-hours 동작이라 이번 수정 범위에서 제외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)