### PR TITLE
fix: 랭킹 탭 전환 시 YTD 시장필터 잔존 제거

### DIFF
--- a/view/web/static/js/ranking.js
+++ b/view/web/static/js/ranking.js
@@ -154,6 +154,8 @@ function setRankingDirection(dir) {
     if (invRow) invRow.style.display = '';
     const periodRow = document.getElementById('period-investor-row');
     if (periodRow) periodRow.style.display = 'none';
+    const ytdMarketRow = document.getElementById('ytd-market-row');
+    if (ytdMarketRow) ytdMarketRow.style.display = 'none';
 
     document.querySelectorAll('.investor-toggle').forEach(b => {
         b.classList.toggle('active', _rankingSelectedInvestors.has(b.dataset.inv));
@@ -215,6 +217,8 @@ async function loadPeriodInvestorRanking() {
     if (invRow) invRow.style.display = 'none';
     const periodRow = document.getElementById('period-investor-row');
     if (periodRow) periodRow.style.display = '';
+    const ytdMarketRow = document.getElementById('ytd-market-row');
+    if (ytdMarketRow) ytdMarketRow.style.display = 'none';
 
     document.querySelectorAll('.period-days').forEach(b => {
         b.classList.toggle('active', parseInt(b.dataset.days || 0) === _rankingPeriodDays);
@@ -377,6 +381,8 @@ async function loadThemeLeaders() {
     if (invRow) invRow.style.display = 'none';
     const periodRow = document.getElementById('period-investor-row');
     if (periodRow) periodRow.style.display = 'none';
+    const ytdMarketRow = document.getElementById('ytd-market-row');
+    if (ytdMarketRow) ytdMarketRow.style.display = 'none';
 
     const div = document.getElementById('ranking-result');
     _showRankingSkeleton();


### PR DESCRIPTION
## 문제
랭킹 뷰에서 **YTD 상승률** 선택 후 **기간수급**(또는 순매수/순매도, 지금 테마)으로 전환해도 YTD 전용 시장필터(`전체/코스피/코스닥`, `#ytd-market-row`)가 화면에 남아 있었다.

## 원인
`loadRanking()`은 `ytd-market-row`를 `category === 'ytd'` 여부로 show/hide 처리하지만, `loadRanking`을 거치지 않는 별도 진입 함수들(순매수·순매도 / 기간수급 / 지금 테마)은 `investor-type-row`·`period-investor-row`만 토글하고 `ytd-market-row`는 건드리지 않아 이전 상태가 잔존했다.

## 수정
해당 세 진입점에서 `loadRanking`과 동일하게 `ytd-market-row`를 `display='none'`으로 숨김 (총 6줄 추가).

## 검증
브라우저 실측:
- YTD → 기간수급: `ytd-market-row` `none`, `period-investor-row` 표시 ✅
- YTD → 순매수: `ytd-market-row` `none`, `investor-type-row` 표시 ✅

> 순수 프론트엔드 JS DOM 토글 변경으로, 기존 Python 통합 테스트(jsdom 회귀 하네스는 stock.js만 커버)로는 검증 범위가 아니어서 브라우저 실측으로 대체 검증함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)