### PR TITLE
Fix alerts and subscription status display

### DIFF
--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -78,6 +78,27 @@ def _telegram_html_to_parts(text: str) -> tuple[str, str]:
     return lines[0], "\n".join(lines[1:])
 
 
+def _format_disclosure_ai_summary_html(summary_text: str) -> str:
+    if not summary_text:
+        return ""
+
+    sentence_match = re.search(r".*?[.!?](?:\s|$)", summary_text, re.DOTALL)
+    if sentence_match:
+        end = sentence_match.end()
+    else:
+        first_line = summary_text.splitlines()[0] if summary_text.splitlines() else summary_text
+        end = len(first_line)
+
+    lead = summary_text[:end].rstrip()
+    rest = summary_text[end:]
+    if not lead:
+        return html.escape(summary_text, quote=False)
+    return (
+        f"<b>{html.escape(lead, quote=False)}</b>"
+        f"{html.escape(rest, quote=False)}"
+    )
+
+
 class TelegramNotifier:
     """Telegram 알림을 비동기적으로 전송하는 핸들러 클래스입니다."""
 
@@ -623,7 +644,8 @@ class TelegramReporter:
                 summary_text = (
                     summary_text[: _DISCLOSURE_AI_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
                 )
-            ai_block = f"🤖 <b>AI 요약</b>\n{html.escape(summary_text, quote=False)}\n\n"
+            ai_summary_html = _format_disclosure_ai_summary_html(summary_text)
+            ai_block = f"🤖 <b>AI 요약</b>\n{ai_summary_html}\n\n"
         message = (
             "🚨 <b>관심종목 중요 공시</b>\n\n"
             f"<b>{company} ({stock_code})</b>\n"

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -5,7 +5,9 @@
 장마감 후 기본 랭킹 캐시를 관리한다.
 """
 import asyncio
+import json
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, TYPE_CHECKING
@@ -61,6 +63,7 @@ class RankingTask(AfterMarketTask):
         worker_pool: Optional[WorkerPool] = None,
         stock_classification_repository=None,
         period_ranking_repository=None,
+        ranking_report_state_path: Optional[str] = None,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -77,6 +80,9 @@ class RankingTask(AfterMarketTask):
         self._telegram_reporter = telegram_reporter
         self._stock_classification_repository = stock_classification_repository
         self._period_ranking_repository = period_ranking_repository
+        self._ranking_report_state_path = ranking_report_state_path or os.path.join(
+            "data", "ranking_report_state.json"
+        )
         self._suspend_event: asyncio.Event = asyncio.Event()
         self._suspend_event.set()  # 초기에는 실행 가능 상태
 
@@ -499,13 +505,7 @@ class RankingTask(AfterMarketTask):
                 for key, value in rankings_for_report.items()
             }
             self._daily_theme_report_rankings["report_date"] = target_date
-            if self._telegram_reporter:
-                self._logger.info("텔레그램 랭킹 리포트 전송 시작")
-                try:
-                    await self._telegram_reporter.send_ranking_report(rankings_for_report, report_date=target_date)
-                    self._logger.info("텔레그램 랭킹 리포트 전송 완료")
-                except Exception as e:
-                    self._logger.error(f"텔레그램 랭킹 리포트 전송 중 오류: {e}", exc_info=True)
+            await self._send_ranking_report_once(rankings_for_report, target_date)
         except Exception as e:
             self._logger.error(f"투자자 랭킹 갱신 실패: {e}", exc_info=True)
             if self._notification_service:
@@ -513,6 +513,54 @@ class RankingTask(AfterMarketTask):
         finally:
             self._is_refreshing = False
             self._progress["running"] = False
+
+    def _load_last_ranking_report_date(self) -> Optional[str]:
+        try:
+            with open(self._ranking_report_state_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            value = data.get("last_ranking_report_date")
+            return str(value) if value else None
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            self._logger.warning(f"랭킹 리포트 발송 상태 로드 실패: {e}")
+            return None
+
+    def _save_last_ranking_report_date(self, target_date: str) -> None:
+        try:
+            directory = os.path.dirname(self._ranking_report_state_path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(self._ranking_report_state_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {"last_ranking_report_date": str(target_date)},
+                    f,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except Exception as e:
+            self._logger.warning(f"랭킹 리포트 발송 상태 저장 실패: {e}")
+
+    async def _send_ranking_report_once(self, rankings_for_report: Dict, target_date: str) -> None:
+        if not self._telegram_reporter:
+            return
+
+        last_report_date = self._load_last_ranking_report_date()
+        if last_report_date == str(target_date):
+            self._logger.info(f"텔레그램 랭킹 리포트 이미 전송 완료 ({target_date}) — 스킵")
+            return
+
+        self._logger.info("텔레그램 랭킹 리포트 전송 시작")
+        try:
+            result = await self._telegram_reporter.send_ranking_report(
+                rankings_for_report,
+                report_date=target_date,
+            )
+            if result is not False:
+                self._save_last_ranking_report_date(target_date)
+            self._logger.info("텔레그램 랭킹 리포트 전송 완료")
+        except Exception as e:
+            self._logger.error(f"텔레그램 랭킹 리포트 전송 중 오류: {e}", exc_info=True)
 
     @staticmethod
     def _build_ranking(results: List[Dict], pbmn_field: str, top_n: int = 30):

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from task.background.after_market.ranking_task import RankingTask
 
 
-def _make_task() -> RankingTask:
+def _make_task(**kwargs) -> RankingTask:
     broker = MagicMock()
     stock_repo = MagicMock()
     stock_repo.df = MagicMock()
@@ -14,6 +14,7 @@ def _make_task() -> RankingTask:
         broker_api_wrapper=broker,
         stock_code_repository=stock_repo,
         logger=MagicMock(),
+        **kwargs,
     )
     return task
 
@@ -102,3 +103,32 @@ async def test_execute_sets_state_running_then_idle():
 
     assert TaskState.RUNNING in states_during
     assert task.state == TaskState.IDLE
+
+
+async def test_send_ranking_report_skips_same_trading_date_after_restart(tmp_path):
+    state_path = tmp_path / "ranking_report_state.json"
+
+    first_reporter = MagicMock()
+    first_reporter.send_ranking_report = AsyncMock()
+    first_task = _make_task(
+        telegram_reporter=first_reporter,
+        ranking_report_state_path=str(state_path),
+    )
+
+    await first_task._send_ranking_report_once({"foreign_buy": []}, "20260722")
+
+    first_reporter.send_ranking_report.assert_awaited_once_with(
+        {"foreign_buy": []},
+        report_date="20260722",
+    )
+
+    restarted_reporter = MagicMock()
+    restarted_reporter.send_ranking_report = AsyncMock()
+    restarted_task = _make_task(
+        telegram_reporter=restarted_reporter,
+        ranking_report_state_path=str(state_path),
+    )
+
+    await restarted_task._send_ranking_report_once({"foreign_buy": []}, "20260722")
+
+    restarted_reporter.send_ranking_report.assert_not_called()

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -75,6 +75,30 @@ async def test_send_disclosure_alert_emphasizes_key_labels():
     assert "<b>접수일:</b> 20260714" in message
 
 
+async def test_send_disclosure_alert_bolds_first_ai_summary_sentence():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    stored = _stored("단일판매ㆍ공급계약체결", 75)
+
+    await reporter.send_disclosure_alert(
+        stored.disclosure,
+        stored.importance,
+        ai_summary=(
+            "삼성전기는 글로벌 대형기업과 약 2,951억 원 규모의 MLCC 공급 계약을 체결했습니다. "
+            "계약 상대방은 비밀유지 요청에 따라 공개가 유보됩니다.\n\n"
+            "판정 근거\n"
+            "• 핵심 사업 공급 계약입니다."
+        ),
+    )
+
+    message = reporter._send_message.await_args.args[0]
+    assert (
+        "<b>삼성전기는 글로벌 대형기업과 약 2,951억 원 규모의 MLCC 공급 계약을 체결했습니다.</b>"
+        in message
+    )
+    assert "계약 상대방은 비밀유지 요청에 따라 공개가 유보됩니다." in message
+
+
 async def test_send_disclosure_alert_truncates_oversized_ai_summary():
     reporter = TelegramReporter("token", "chat")
     reporter._send_message = AsyncMock(return_value=True)

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -66,7 +66,7 @@ def mock_deps():
 
 
 @pytest.fixture
-def bg_service(mock_deps):
+def bg_service(mock_deps, tmp_path):
     broker, mapper, env, logger, market_clock, market_calendar_service = mock_deps
     
     market_data_service = AsyncMock()
@@ -79,6 +79,7 @@ def bg_service(mock_deps):
         market_clock=market_clock,
         market_data_service=market_data_service,
         market_calendar_service=market_calendar_service,
+        ranking_report_state_path=str(tmp_path / "ranking_report_state.json"),
     )
 
 

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -1454,6 +1454,76 @@ def test_get_subscription_status_received_at_populated(web_client, mock_web_ctx)
     assert data["pending_by_priority"]["HIGH"][0]["received_at"] == 1700000000.0
 
 
+def test_get_subscription_status_websocket_tick_implies_active(web_client, mock_web_ctx):
+    """ACK 상태가 active에 반영되지 않았어도 websocket tick이 있으면 active로 노출한다."""
+    mock_svc = MagicMock()
+    mock_svc.get_status.return_value = {
+        "active_count": 0,
+        "max_subscriptions": 40,
+        "active_codes_price": [],
+        "active_codes_pt": [],
+        "pending_count": 1,
+        "pending_by_priority": {
+            "HIGH": [],
+            "MEDIUM": [],
+            "LOW": ["001450"],
+        },
+    }
+    mock_web_ctx.price_subscription_service = mock_svc
+    mock_web_ctx.streaming_service.get_cached_realtime_price = MagicMock(return_value={
+        "price": "37100",
+        "received_at": 1784752235.0,
+        "quality_reason": "websocket",
+    })
+    mock_web_ctx.stock_code_repository.get_name_by_code.return_value = "현대해상"
+
+    response = web_client.get("/api/subscriptions/status")
+
+    data = response.json()["data"]
+    assert data["active_count"] == 1
+    assert data["active_codes_price"] == ["001450"]
+    row = data["pending_by_priority"]["LOW"][0]
+    assert row["active"] is True
+    assert row["received_at"] == 1784752235.0
+    assert row["price_source"] == "websocket"
+
+
+def test_get_subscription_status_rest_snapshot_does_not_imply_active(web_client, mock_web_ctx):
+    """REST 스냅샷 현재가는 표시하되 실시간 수신/active로 오인하지 않는다."""
+    mock_svc = MagicMock()
+    mock_svc.get_status.return_value = {
+        "active_count": 0,
+        "max_subscriptions": 40,
+        "active_codes_price": [],
+        "active_codes_pt": [],
+        "pending_count": 1,
+        "pending_by_priority": {
+            "HIGH": ["005930"],
+            "MEDIUM": [],
+            "LOW": [],
+        },
+    }
+    mock_web_ctx.price_subscription_service = mock_svc
+    mock_web_ctx.streaming_service.get_cached_realtime_price = MagicMock(return_value={
+        "price": "260500",
+        "received_at": 1784752211.0,
+        "quality_reason": "rest_snapshot",
+    })
+    mock_web_ctx.stock_code_repository.get_name_by_code.return_value = "삼성전자"
+
+    response = web_client.get("/api/subscriptions/status")
+
+    data = response.json()["data"]
+    assert data["active_count"] == 0
+    assert data["active_codes_price"] == []
+    row = data["pending_by_priority"]["HIGH"][0]
+    assert row["active"] is False
+    assert row["price"] == "260500"
+    assert row["received_at"] is None
+    assert row["snapshot_at"] == 1784752211.0
+    assert row["price_source"] == "rest_snapshot"
+
+
 def test_get_subscription_status_inactive_code(web_client, mock_web_ctx):
     """active 상태가 아닌 종목은 active=False로 반환된다."""
     mock_svc = MagicMock()

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -678,7 +678,26 @@ def get_subscription_status():
         except Exception:
             pass
 
-    pending_count = len(set().union(*pending_by_priority.values()))
+    def _get_price_info(code: str):
+        if not streaming_svc:
+            return None
+        try:
+            return streaming_svc.get_cached_realtime_price(code)
+        except Exception:
+            return None
+
+    all_pending_codes = set().union(*pending_by_priority.values())
+    price_info_by_code = {
+        code: _get_price_info(code)
+        for code in all_pending_codes
+    }
+    websocket_received_codes = {
+        code for code, info in price_info_by_code.items()
+        if isinstance(info, dict) and info.get("quality_reason") == "websocket"
+    }
+    active_codes_price.update(websocket_received_codes)
+
+    pending_count = len(all_pending_codes)
     active_set = active_codes_price | active_codes_pt
     active_count = len(active_codes_price) + len(active_codes_pt)
 
@@ -686,18 +705,26 @@ def get_subscription_status():
         result = []
         for code in codes:
             name = ctx.stock_code_repository.get_name_by_code(code) or code
-            price_info = streaming_svc.get_cached_realtime_price(code) if streaming_svc else None
+            price_info = price_info_by_code.get(code)
             received_at = None
+            snapshot_at = None
             price = None
+            price_source = None
             if isinstance(price_info, dict):
-                received_at = price_info.get("received_at")
+                price_source = price_info.get("quality_reason")
+                if price_source == "rest_snapshot":
+                    snapshot_at = price_info.get("received_at")
+                else:
+                    received_at = price_info.get("received_at")
                 price = price_info.get("price")
             result.append({
                 "code": code,
                 "name": name,
                 "active": code in active_set, # 병합된 active_set을 통해 활성화 여부 확인
                 "received_at": received_at,
+                "snapshot_at": snapshot_at,
                 "price": price,
+                "price_source": price_source,
             })
         return result
 

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -739,7 +739,9 @@ function renderSubTable() {
             : '<span style="color:#aaa;">-</span>';
         const received = item.received_at
             ? formatTimestamp(item.received_at)
-            : '<span style="color:#aaa;">-</span>';
+            : item.snapshot_at
+                ? `<span title="REST 스냅샷 갱신 시각">스냅샷 ${formatTimestamp(item.snapshot_at)}</span>`
+                : '<span style="color:#aaa;">-</span>';
         return `
             <tr>
                 <td style="font-weight:bold; color:var(--accent);">


### PR DESCRIPTION
﻿## Summary
- Prevent after-market ranking reports from being resent for the same trading date after midnight or app restart.
- Clarify realtime price subscription status by separating websocket ticks from REST snapshots.
- Bold the first key sentence in AI disclosure summaries for faster Telegram scanning.

## Root Cause
- Ranking report send state was only in memory, so a restart after midnight could resend the previous trading day's report.
- Subscription status rendered cached price data as a realtime receive timestamp regardless of whether it came from websocket or REST snapshot.
- Disclosure AI summaries were escaped as plain HTML text, so no emphasis could be shown inside the summary body.

## Validation
- `pytest tests/unit_test/scheduler/test_ranking_task_execute.py -v` passed.
- `pytest tests/unit_test/scheduler -v` passed.
- `pytest tests/unit_test/view/web/routes/test_web_routes_system.py -v` passed.
- `pytest tests/unit_test/view/web/static/js/test_js_files.py -v` passed.
- `pytest tests/unit_test/services/test_dart_disclosure_telegram.py -q --tb=short` passed.
- `pytest tests/integration_test -q --tb=short` passed: 264 passed.

## Notes
- Full `pytest tests/unit_test -v` previously timed out in this Windows environment with no output; targeted unit suites and full integration passed.
