### PR TITLE
Use one WebSocket slot for program trading ticks

### DIFF
--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -30,7 +30,7 @@ from typing import Dict, Iterable, Optional, Set
 class StreamingType(str, Enum):
     """WebSocket 구독 TR_ID 타입."""
     UNIFIED_PRICE = "unified_price"      # H0UNCNT0 — 통합 체결가 (40개 한도)
-    PROGRAM_TRADING = "program_trading"  # H0STPGM0 + H0STCNT0 동반 (소수, 제한 없음)
+    PROGRAM_TRADING = "program_trading"  # H0STPGM0 프로그램매매 tick
 
 
 class StreamingStockRepo:

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -55,7 +55,7 @@ class SubscriptionPolicy:
       - 우선순위가 동일하면 종목코드 오름차순으로 결정적(deterministic) 선택
     """
 
-    MAX_WS_SLOTS = 40  # KIS 웹소켓 최대 구독 한도 (PT=2슬롯, Price=1슬롯)
+    MAX_WS_SLOTS = 40  # KIS 웹소켓 최대 구독 한도 (PT=1슬롯, Price=1슬롯)
 
     def __init__(
         self,
@@ -112,8 +112,8 @@ class SubscriptionPolicy:
         구독을 요청합니다. 
         단, CRITICAL(프로그램 매매) 요청 시 슬롯이 부족하면 밀어내지 않고 False(거절)를 반환합니다.
         """
-        # 1. 시뮬레이션: 이 요청을 수용했을 때 총 슬롯 계산 (PT = 2, Price = 1)
-        required_slots = 2 if stream_type == StreamingType.PROGRAM_TRADING else 1
+        # 1. 시뮬레이션: 이 요청을 수용했을 때 총 슬롯 계산 (PT = 1, Price = 1)
+        required_slots = 1
         current_used_slots = self._calculate_used_slots()
         
         if priority == SubscriptionPriority.CRITICAL and (current_used_slots + required_slots > self.MAX_WS_SLOTS):
@@ -290,14 +290,13 @@ class SubscriptionPolicy:
 
             slots_needed = 0
             if is_pt:
-                slots_needed += 2  # H0STPGM0 + H0UNCNT0 companion price
+                slots_needed += 1  # H0STPGM0 only; price is supplied by independent subscription/REST fallback.
             elif is_price:
                 slots_needed += 1
 
             if available_slots >= slots_needed:
                 if is_pt:
                     desired_pt.add(code)
-                    desired_price.add(code)
                 elif is_price:
                     desired_price.add(code)
                 available_slots -= slots_needed
@@ -473,15 +472,13 @@ class SubscriptionPolicy:
     def _calculate_used_slots(self) -> int:
         """
         현재 사용 중인 웹소켓 슬롯 개수를 계산합니다.
-        (일반 호가/체결(Price) = 1슬롯, 프로그램 매매(PT) = 2슬롯)
+        (일반 호가/체결(Price) = 1슬롯, 프로그램 매매(PT) = 1슬롯)
         """
-        missing_companion_price = self._active_codes_pt - self._active_codes_price
         return (
             self._external_reserved_slots
             +
             len(self._active_codes_price)
             + len(self._active_codes_pt)
-            + len(missing_companion_price)
         )
 
 # Backward-compatibility alias

--- a/task/background/intraday/program_capture_subscription_task.py
+++ b/task/background/intraday/program_capture_subscription_task.py
@@ -20,7 +20,7 @@ class ProgramCaptureSubscriptionTask(SchedulableTask):
 
     안전 설계:
       - SubscriptionPriority.LOW → 트레이딩용 price 구독(HIGH/MEDIUM)을 밀어내지
-        않으며(PT=2슬롯/종목), 30분마다 제한된 묶음을 순환한다.
+        않으며(PT=1슬롯/종목), 30분마다 제한된 묶음을 순환한다.
       - PT가 없는 우선주는 PRICE 전용으로 구독해 호가·체결강도만 수집한다.
       - 수동 UI로 이미 PT desired인 종목은 대상에서 제외해 해지/영속 상태 간섭을 막는다.
       - 구독 목록을 scheduler_store에 영속화 — 크래시 잔재를 재시작 시 카테고리로
@@ -31,7 +31,7 @@ class ProgramCaptureSubscriptionTask(SchedulableTask):
     PRICE_CATEGORY_KEY = "microstructure_capture_price"
     CHECK_INTERVAL_SEC = 60
     ROTATION_INTERVAL_MINUTES = 30
-    MAX_CODES = 10  # PT=2슬롯/종목 — 캡처용 상한 (트레이딩 슬롯 여유 보존)
+    MAX_CODES = 10  # 캡처용 상한 (트레이딩 슬롯 여유 보존)
 
     def __init__(
         self,

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -42,7 +42,7 @@ class WebSocketWatchdogTask(SchedulableTask):
     REALTIME_HEALTH_CHECK_END_HOUR = 15
     REALTIME_HEALTH_CHECK_END_MINUTE = 20
     # PT 복원 절대 상한. 실제 상한은 현재 PRICE 요청과 최소 예약 슬롯을 반영해 더 낮아질 수 있다.
-    PT_RESTORE_MAX_CODES = 18
+    PT_RESTORE_MAX_CODES = 30
     ORDER_NOTICE_RESERVED_SLOTS = 1
     MIN_PRICE_RESERVED_SLOTS = 10
 
@@ -538,7 +538,7 @@ class WebSocketWatchdogTask(SchedulableTask):
             0,
             max_slots - self.ORDER_NOTICE_RESERVED_SLOTS - price_slots,
         )
-        return min(self.PT_RESTORE_MAX_CODES, available_for_pt // 2)
+        return min(self.PT_RESTORE_MAX_CODES, available_for_pt)
 
     async def _restore_all_subscriptions(self, reset_connection: bool = True) -> None:
         """
@@ -546,7 +546,7 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         핵심 순서:
           1. PT/H0UNCNT0 active 상태 초기화 (브로커 연결 리셋 → 내부 상태도 리셋)
-          2. PT + H0UNCNT0 재구독
+          2. PT 재구독
           3. 가격 정책 active 상태 초기화 후 _rebalance()로 재구독
              (단순 _rebalance() 호출만 하면 _active_codes에 이전 상태가 남아
               "이미 구독됨"으로 판단해 브로커에 subscribe를 보내지 않는 버그 방지)
@@ -564,7 +564,7 @@ class WebSocketWatchdogTask(SchedulableTask):
             await self._streaming_stock_repo.clear_active(StreamingType.PROGRAM_TRADING)
             await self._streaming_stock_repo.clear_active(StreamingType.UNIFIED_PRICE)
 
-        # ── 2. PT + H0STCNT0 복원 ─────────────────────────────────
+        # ── 2. PT 복원 ────────────────────────────────────────────
         all_pt_codes = sorted(self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)) if self._streaming_stock_repo else []
         sources = {}
         if self._streaming_stock_repo:
@@ -609,7 +609,7 @@ class WebSocketWatchdogTask(SchedulableTask):
 
         if self._price_subscription_service:
             reserved_slots = (
-                len(pt_codes) * 2
+                len(pt_codes)
                 + self.ORDER_NOTICE_RESERVED_SLOTS
             )
             reserve = getattr(self._price_subscription_service, "set_external_reserved_slots", None)

--- a/tests/unit_test/services/test_subscription_policy.py
+++ b/tests/unit_test/services/test_subscription_policy.py
@@ -124,7 +124,7 @@ async def test_add_remove_subscription(policy, mock_streaming_stock_repo):
 @pytest.mark.asyncio
 async def test_add_subscription_critical_rejection(policy, mock_streaming_logger):
     """프로그램 매매(CRITICAL) 슬롯 부족 시 거절(Rejection) 동작 검증"""
-    policy._calculate_used_slots = MagicMock(return_value=39) # 남은 슬롯 1개 (PT는 2슬롯 필요)
+    policy._calculate_used_slots = MagicMock(return_value=40) # 남은 슬롯 없음 (PT는 1슬롯 필요)
     
     result = await policy.add_subscription("000660", SubscriptionPriority.CRITICAL, "pt_req", StreamingType.PROGRAM_TRADING)
     assert result is False
@@ -220,7 +220,7 @@ def test_is_streaming_and_get_status(policy):
 @pytest.mark.asyncio
 async def test_rebalance_slot_allocation(policy, mock_streaming_logger):
     """슬롯 한도 초과 시 타입에 따른 할당 및 Dropped 로직 검증"""
-    policy.MAX_WS_SLOTS = 3 # PT 1개(2슬롯) + Price 1개(1슬롯) 들어가면 꽉 참
+    policy.MAX_WS_SLOTS = 2 # PT 1개(1슬롯) + Price 1개(1슬롯) 들어가면 꽉 참
     policy._refs = {
         "PT_CODE": {"pt": {"priority": SubscriptionPriority.CRITICAL, "type": StreamingType.PROGRAM_TRADING}},
         "PRICE_1": {"p1": {"priority": SubscriptionPriority.HIGH, "type": StreamingType.UNIFIED_PRICE}},
@@ -229,18 +229,19 @@ async def test_rebalance_slot_allocation(policy, mock_streaming_logger):
     
     await policy._rebalance()
     
-    # PT_CODE(2) + PRICE_1(1) = 3슬롯 사용 완료
+    # PT_CODE(1) + PRICE_1(1) = 2슬롯 사용 완료
     assert "PT_CODE" in policy._active_codes_pt
+    assert "PT_CODE" not in policy._active_codes_price
     assert "PRICE_1" in policy._active_codes_price
     assert "PRICE_2" not in policy._active_codes_price
     mock_streaming_logger.log_dropped_subscriptions.assert_called() # Dropped 경고 로깅
 
 
 @pytest.mark.asyncio
-async def test_rebalance_program_trading_subscribes_companion_unified_price(
+async def test_rebalance_program_trading_subscribes_only_program_tick(
     policy, mock_streaming, mock_streaming_stock_repo
 ):
-    """PROGRAM_TRADING 요청은 PT와 통합 체결가 2개 구독을 함께 활성화한다."""
+    """PROGRAM_TRADING 요청은 companion 체결가 없이 PT tick만 활성화한다."""
     policy._refs = {
         "005930": {
             "program_capture": {
@@ -253,12 +254,11 @@ async def test_rebalance_program_trading_subscribes_companion_unified_price(
     await policy._rebalance()
 
     mock_streaming.subscribe_program_trading.assert_awaited_once_with("005930")
-    mock_streaming.subscribe_unified_price.assert_awaited_once_with("005930")
+    mock_streaming.subscribe_unified_price.assert_not_awaited()
     assert "005930" in policy._active_codes_pt
-    assert "005930" in policy._active_codes_price
+    assert "005930" not in policy._active_codes_price
     mock_streaming_stock_repo.mark_active.assert_any_await("005930", StreamingType.PROGRAM_TRADING)
-    mock_streaming_stock_repo.mark_active.assert_any_await("005930", StreamingType.UNIFIED_PRICE)
-    assert policy._calculate_used_slots() == 2
+    assert policy._calculate_used_slots() == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -232,11 +232,11 @@ async def test_restore_reduces_pt_codes_to_preserve_requested_price_slots(
     ):
         await svc._restore_all_subscriptions()
 
-    # 40슬롯 - PRICE 20 - 주문통보 1 = 19슬롯이므로 PT(2슬롯)는 9종목만 복원한다.
-    assert svc._streaming_service.subscribe_program_trading.await_count == 9
+    # 40슬롯 - PRICE 20 - 주문통보 1 = 19슬롯이고, PT는 1슬롯이므로 cap(18)까지 복원한다.
+    assert svc._streaming_service.subscribe_program_trading.await_count == 18
     mock_price_subscription_service.set_external_reserved_slots.assert_called_once_with(19)
-    assert len(svc._capacity_pending_pt_codes) == 9
-    assert svc._streaming_logger.log_pt_capacity_pending.call_args.kwargs["max_codes"] == 9
+    assert len(svc._capacity_pending_pt_codes) == 0
+    svc._streaming_logger.log_pt_capacity_pending.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -264,9 +264,9 @@ async def test_restore_reserves_minimum_price_slots_without_current_price_reques
     ):
         await svc._restore_all_subscriptions()
 
-    # 40슬롯 - PRICE 최소 10 - 주문통보 1 = 29슬롯 → PT 최대 14종목.
-    assert svc._streaming_service.subscribe_program_trading.await_count == 14
-    mock_price_subscription_service.set_external_reserved_slots.assert_called_once_with(29)
+    # 40슬롯 - PRICE 최소 10 - 주문통보 1 = 29슬롯이고, PT는 1슬롯이므로 cap(18)까지 복원한다.
+    assert svc._streaming_service.subscribe_program_trading.await_count == 18
+    mock_price_subscription_service.set_external_reserved_slots.assert_called_once_with(19)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -263,14 +263,13 @@ async def test_program_trading_subscription(mock_deps):
     await ctx.start_program_trading("005930")
     ctx.streaming_service.connect_websocket.assert_awaited_once()
     ctx.streaming_service.subscribe_program_trading.assert_awaited_with("005930")
-    ctx.streaming_service.subscribe_unified_price.assert_awaited_with("005930")
+    ctx.streaming_service.subscribe_unified_price.assert_not_awaited()
     ctx.streaming_stock_repo.mark_desired.assert_called_with(
         "005930",
         StreamingType.PROGRAM_TRADING,
         source="manual",
     )
     ctx.streaming_stock_repo.mark_active.assert_any_call("005930", StreamingType.PROGRAM_TRADING)
-    ctx.streaming_stock_repo.mark_active.assert_any_call("005930", StreamingType.UNIFIED_PRICE)
 
     # 2. 중복 구독 시도 (API 호출 없어야 함)
     ctx.streaming_stock_repo.get_desired.side_effect = (
@@ -284,7 +283,6 @@ async def test_program_trading_subscription(mock_deps):
     ctx.streaming_service.unsubscribe_program_trading.assert_awaited_with("005930")
     ctx.streaming_stock_repo.unmark_desired.assert_called_with("005930", StreamingType.PROGRAM_TRADING)
     ctx.streaming_stock_repo.mark_inactive.assert_any_call("005930", StreamingType.PROGRAM_TRADING)
-    ctx.streaming_stock_repo.mark_inactive.assert_any_call("005930", StreamingType.UNIFIED_PRICE)
 
 @pytest.mark.asyncio
 async def test_market_clock_methods(mock_deps):
@@ -913,14 +911,16 @@ async def test_start_program_trading_reconnect_existing_desired(mock_deps):
 
 
 @pytest.mark.asyncio
-async def test_start_program_trading_subscription_failure_cleans_partial_success(mock_deps):
-    """PT 구독만 성공하고 가격 구독이 실패하면 PT 구독을 해제한다."""
+async def test_start_program_trading_does_not_require_companion_price_subscription(mock_deps):
+    """PT 구독 성공은 companion 체결가 구독 없이도 성공으로 처리한다."""
     ctx = WebAppContext(None)
     ctx.pm = MagicMock()
     ctx.pm.start_timer.return_value = 0.0
     ctx.logger = MagicMock()
     ctx.streaming_stock_repo = MagicMock()
     ctx.streaming_stock_repo.get_desired.return_value = set()
+    ctx.streaming_stock_repo.mark_desired = AsyncMock()
+    ctx.streaming_stock_repo.mark_active = AsyncMock()
     ctx.streaming_service = MagicMock()
     ctx.streaming_service.connect_websocket = AsyncMock(return_value=True)
     ctx.streaming_service.subscribe_program_trading = AsyncMock(return_value=True)
@@ -931,8 +931,9 @@ async def test_start_program_trading_subscription_failure_cleans_partial_success
 
     result = await ctx.start_program_trading("005930")
 
-    assert result is False
-    ctx.streaming_service.unsubscribe_program_trading.assert_awaited_once_with("005930")
+    assert result is True
+    ctx.streaming_service.subscribe_unified_price.assert_not_awaited()
+    ctx.streaming_service.unsubscribe_program_trading.assert_not_awaited()
     ctx.streaming_service.unsubscribe_unified_price.assert_not_awaited()
 
 
@@ -1150,7 +1151,7 @@ async def test_refresh_price_from_rest_quality_and_invalid_output_edges(mock_dep
 
 @pytest.mark.asyncio
 async def test_start_program_trading_connection_failure_price_only_cleanup_and_exception(mock_deps):
-    """프로그램매매 구독 시작의 연결 실패, 가격 구독만 성공, 예외 경로를 확인한다."""
+    """프로그램매매 구독 시작의 연결 실패, PT 전송 실패, 예외 경로를 확인한다."""
     ctx = WebAppContext(None)
     ctx.pm = MagicMock()
     ctx.pm.start_timer.return_value = 0.0
@@ -1171,7 +1172,8 @@ async def test_start_program_trading_connection_failure_price_only_cleanup_and_e
     ctx.streaming_service.unsubscribe_unified_price = AsyncMock()
 
     assert await ctx.start_program_trading("005930") is False
-    ctx.streaming_service.unsubscribe_unified_price.assert_awaited_once_with("005930")
+    ctx.streaming_service.subscribe_unified_price.assert_not_awaited()
+    ctx.streaming_service.unsubscribe_unified_price.assert_not_awaited()
 
     ctx.streaming_service.connect_websocket = AsyncMock(side_effect=RuntimeError("boom"))
     assert await ctx.start_program_trading("005930") is False
@@ -1202,7 +1204,7 @@ async def test_start_program_trading_requires_program_ack_before_marking_active(
 
     ctx.streaming_stock_repo.mark_active.assert_not_awaited()
     ctx.streaming_service.unsubscribe_program_trading.assert_awaited_once_with("005930")
-    ctx.streaming_service.unsubscribe_unified_price.assert_awaited_once_with("005930")
+    ctx.streaming_service.unsubscribe_unified_price.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_program_trading.py
+++ b/tests/unit_test/view/web/test_web_app_program_trading.py
@@ -60,19 +60,18 @@ async def test_start_program_trading_success(mock_ctx):
 
     assert result is True
     mock_ctx.streaming_service.subscribe_program_trading.assert_called_once_with(code)
-    mock_ctx.streaming_service.subscribe_unified_price.assert_called_once_with(code)
+    mock_ctx.streaming_service.subscribe_unified_price.assert_not_called()
     mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(
         code,
         StreamingType.PROGRAM_TRADING,
         source="manual",
     )
     mock_ctx.streaming_stock_repo.mark_active.assert_any_call(code, StreamingType.PROGRAM_TRADING)
-    mock_ctx.streaming_stock_repo.mark_active.assert_any_call(code, StreamingType.UNIFIED_PRICE)
 
 
 @pytest.mark.asyncio
-async def test_start_program_trading_partial_fail(mock_ctx):
-    """구독 하나만 성공하고 하나는 실패 시 롤백 및 실패 반환 확인"""
+async def test_start_program_trading_ignores_companion_price_failure(mock_ctx):
+    """PT 구독이 성공하면 companion 체결가 실패 여부와 무관하게 성공한다."""
     code = "005930"
     mock_ctx.streaming_stock_repo.get_desired.return_value = set()
     mock_ctx.streaming_service.subscribe_program_trading.return_value = True
@@ -80,10 +79,14 @@ async def test_start_program_trading_partial_fail(mock_ctx):
 
     result = await mock_ctx.start_program_trading(code)
 
-    assert result is False
-    mock_ctx.streaming_stock_repo.mark_desired.assert_not_called()
-    # 성공했던 PT 구독 해지 롤백 확인
-    mock_ctx.streaming_service.unsubscribe_program_trading.assert_called_once_with(code)
+    assert result is True
+    mock_ctx.streaming_service.subscribe_unified_price.assert_not_called()
+    mock_ctx.streaming_stock_repo.mark_desired.assert_called_once_with(
+        code,
+        StreamingType.PROGRAM_TRADING,
+        source="manual",
+    )
+    mock_ctx.streaming_service.unsubscribe_program_trading.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -637,13 +637,7 @@ class WebAppContext:
                 sub_pt_success = await self.streaming_service.wait_program_trading_ack(code)
             self.pm.log_timer(f"subscribe_program_trading({code})", t_sub_pt)
 
-            t_sub_price = self.pm.start_timer()
-            sub_price_success = await self.streaming_service.subscribe_unified_price(code)
-            if sub_price_success:
-                sub_price_success = await self.streaming_service.wait_unified_price_ack(code)
-            self.pm.log_timer(f"subscribe_unified_price({code})", t_sub_price)
-
-            if sub_pt_success and sub_price_success:
+            if sub_pt_success:
                 if self.streaming_stock_repo:
                     await self.streaming_stock_repo.mark_desired(
                         code,
@@ -651,16 +645,12 @@ class WebAppContext:
                         source="manual",
                     )
                     await self.streaming_stock_repo.mark_active(code, StreamingType.PROGRAM_TRADING)
-                    await self.streaming_stock_repo.mark_active(code, StreamingType.UNIFIED_PRICE)
                 self.logger.info(f"프로그램매매 신규 구독 성공: {code}")
                 return True
             else:
-                # 하나라도 실패하면, 성공했을 수 있는 다른 구독을 해지하여 상태를 정리한다.
-                self.logger.warning(f"프로그램매매 구독 실패 (pt: {sub_pt_success}, price: {sub_price_success}) - {code}")
+                self.logger.warning(f"프로그램매매 구독 실패 (pt: {sub_pt_success}) - {code}")
                 if sub_pt_sent:
                     await self.streaming_service.unsubscribe_program_trading(code)
-                if sub_price_success:
-                    await self.streaming_service.unsubscribe_unified_price(code)
                 return False
 
         except Exception as e:
@@ -668,7 +658,7 @@ class WebAppContext:
             return False
 
     def _has_independent_price_subscription(self, code: str) -> bool:
-        """PT companion이 아닌 별도 통합 체결가 구독 수요가 있는지 확인한다."""
+        """PT와 무관한 별도 통합 체결가 구독 수요가 있는지 확인한다."""
         if not code:
             return False
 


### PR DESCRIPTION
## Summary
- Treat PROGRAM_TRADING subscriptions as one WebSocket slot instead of requiring a companion price subscription.
- Stop manual program-trading starts from subscribing/ack-checking unified price ticks.
- Update startup restore capacity to count one slot per PT code and raise the restore cap accordingly.

## Tests
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v`