### PR TITLE
fix: NXT 현재가 조회 fid_input_date_1 누락 수정

### DIFF
--- a/brokers/korea_investment/korea_invest_params_provider.py
+++ b/brokers/korea_investment/korea_invest_params_provider.py
@@ -712,7 +712,11 @@ class Params:
 
     @staticmethod
     def inquire_price(stock_code: str, market: MarketCode = "J") -> Dict[str, str]:
-        return InquirePriceParams.of(stock_code, market).to_dict()
+        params = InquirePriceParams.of(stock_code, market).to_dict()
+        if market == "NX":
+            # NXT 현재가 조회는 KIS가 fid_input_date_1을 요구한다 (누락 시 "ERROR INPUT FIELD NOT FOUND [FID_INPUT_DATE_1]").
+            params["fid_input_date_1"] = tm.get_current_kst_date_str()
+        return params
 
     @staticmethod
     def inquire_conclusion(stock_code: str, market: MarketCode = "J") -> Dict[str, str]:

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -187,6 +187,35 @@ async def test_get_current_price_accepts_single_item_output_list(mock_quotations
 
 
 @pytest.mark.asyncio
+async def test_get_current_price_nxt_includes_fid_input_date_1(mock_quotations):
+    """NXT(exchange=NXT) 현재가 조회는 KIS가 요구하는 fid_input_date_1을 포함해야 한다.
+
+    실전 로그 확인: fid_input_date_1 누락 시 KIS가
+    'ERROR INPUT FIELD NOT FOUND [FID_INPUT_DATE_1]'로 거부한다 (2026-07-23).
+    """
+    from common.types import Exchange
+
+    output = _BASE_DUMMY_DATA.copy()
+    output.update({
+        "stck_prpr": "432000",
+        "stck_oprc": "467500",
+        "prdy_ctrt": "-7.50",
+    })
+    mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상 처리",
+        data={"output": output},
+    ))
+
+    await mock_quotations.get_current_price("000660", exchange=Exchange.NXT)
+
+    _, kwargs = mock_quotations.call_api.call_args
+    params = kwargs["params"]
+    assert params["fid_cond_mrkt_div_code"] == "NX"
+    assert params.get("fid_input_date_1")
+
+
+@pytest.mark.asyncio
 async def test_get_price_summary_open_price_zero(mock_quotations):
     # Mock 반환 값을 ResCommonResponse 형식으로 변경
     mock_output = _create_dummy_output({


### PR DESCRIPTION
## Summary
- NXT(exchange=NXT) 현재가 조회 시 KIS가 `fid_input_date_1` 필드를 요구하는데 누락되어 `ERROR INPUT FIELD NOT FOUND [FID_INPUT_DATE_1]`로 거부당하는 문제 수정 (`services/data_quality_service.py`를 거쳐 최종적으로 웹 UI에는 "데이터 품질 검증 실패: rest_failed (100)"로 표시됨)
- 2026-07-23 실전 로그(`logs/common/20260723_082740_debug_5.log:14846-14861`)로 근본 원인 확인: `fid_cond_mrkt_div_code=NX`로 조회 시에만 발생, KRX(J)는 영향 없음
- `Params.inquire_price()`에서 market이 `NX`일 때만 `fid_input_date_1`(오늘 KST 날짜)을 추가하도록 수정

## Test plan
- [x] 신규 단위 테스트 추가: `test_get_current_price_nxt_includes_fid_input_date_1` (수정 전 실패 → 수정 후 통과 확인)
- [x] `pytest tests/unit_test -q` — 7031 passed
- [x] `pytest tests/integration_test -q` — 264 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)