### PR TITLE
feat: complete public deployment phase 1

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -19,6 +19,33 @@ paper_websocket_url: "ws://ops.koreainvestment.com:31000"
 # 실전/모의 선택 (true: 모의, false: 실전)
 is_paper_trading: true
 
+# 외부 공개 정책. 모든 값은 누락 시 fail-close 기본값을 사용합니다.
+deployment:
+  public_mode: false
+  demo_mode: false
+  allow_live_trading: false
+  # 공개 주소의 호스트명만 명시하세요. "*"는 public_mode에서 거부됩니다.
+  allowed_hosts:
+    - "127.0.0.1"
+    - "localhost"
+
+# 웹 서버와 단일 운영자 인증
+web:
+  host: "127.0.0.1"
+  port: 8000
+use_login: true
+auth:
+  username: "admin"
+  # python scripts/hash_web_password.py 실행 결과로 교체하세요.
+  password_hash: "pbkdf2_sha256$310000$REPLACE_WITH_GENERATED_SALT$REPLACE_WITH_GENERATED_HASH"
+  # 충분히 긴 무작위 세션 서명 키로 교체하고 저장소에 커밋하지 마세요.
+  secret_key: "REPLACE_WITH_RANDOM_SESSION_SIGNING_KEY"
+  session_max_age_seconds: 3600
+  login_max_failures: 5
+  login_lockout_seconds: 60
+  # HTTPS reverse proxy를 사용하는 외부 공개 환경에서는 반드시 true.
+  secure_cookie: false
+
 # 운영 profile (P0 0-7): 실전 모드에서 어떤 overlay 를 적용할지 결정.
 #   canary       : 총 노출 5%, 동시 보유 2종, 1주문 1M — 실계좌 소액 검증 단계 (docs/canary_procedure.md 기준)
 #   real_limited : 총 노출 30%, 동시 보유 5종 — canary 통과 후 별도 ack 거쳐 진입하는 중간 단계

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -17,6 +17,30 @@ class WebConfig(BaseModel):
     host: str
     port: int = Field(..., ge=1, le=65535, description="웹 서버 포트 (1~65535)")
 
+
+class AuthConfig(BaseModel):
+    username: Optional[str] = None
+    password_hash: Optional[str] = None
+    secret_key: Optional[str] = None
+    session_max_age_seconds: int = Field(default=3600, ge=60, le=86400)
+    secure_cookie: bool = False
+    login_max_failures: int = Field(default=5, ge=1, le=20)
+    login_lockout_seconds: int = Field(default=60, ge=1, le=3600)
+
+    model_config = {"extra": "allow"}
+
+
+class DeploymentConfig(BaseModel):
+    public_mode: bool = False
+    demo_mode: bool = False
+    allow_live_trading: bool = False
+    allowed_hosts: List[str] = Field(
+        default_factory=lambda: ["127.0.0.1", "localhost"]
+    )
+
+    model_config = {"extra": "allow"}
+
+
 class CacheConfig(BaseModel):
     base_dir: str = ".cache"
     enabled_methods: List[str] = Field(default_factory=list)
@@ -421,6 +445,7 @@ class AppConfig(BaseModel):
     
     # Flags
     is_paper_trading: bool = True
+    use_login: bool = True
 
     # Operating profile (P0 0-7): canary 5% 노출 vs real_limited 30% vs real_full 95% 운영 한도 분리.
     # paper 모드에서는 base 값을 사용하므로 profile 무관. real 모드에서 overlay 선택.
@@ -432,6 +457,8 @@ class AppConfig(BaseModel):
 
     # Sub-configs
     web: WebConfig
+    auth: AuthConfig = Field(default_factory=AuthConfig)
+    deployment: DeploymentConfig = Field(default_factory=DeploymentConfig)
     cache: CacheConfig = Field(default_factory=CacheConfig)
     kill_switch: KillSwitchConfig = Field(default_factory=KillSwitchConfig)
     risk_gate: RiskGateConfig = Field(default_factory=RiskGateConfig)
@@ -486,6 +513,32 @@ class AppConfig(BaseModel):
         if self.market_mode not in normalized:
             normalized.append(self.market_mode)
         self.enabled_market_modes = normalized
+        return self
+
+    @model_validator(mode="after")
+    def validate_public_mode_security(self):
+        if not self.deployment.public_mode:
+            return self
+        if not self.use_login:
+            raise ValueError("public_mode에서는 use_login=true가 필요합니다.")
+        if not self.auth.username:
+            raise ValueError("public_mode에서는 auth.username이 필요합니다.")
+        if not (
+            isinstance(self.auth.password_hash, str)
+            and self.auth.password_hash.startswith("pbkdf2_sha256$")
+        ):
+            raise ValueError("public_mode에서는 PBKDF2 auth.password_hash가 필요합니다.")
+        if not isinstance(self.auth.secret_key, str) or len(self.auth.secret_key) < 32:
+            raise ValueError("public_mode에서는 32자 이상의 auth.secret_key가 필요합니다.")
+        if not self.auth.secure_cookie:
+            raise ValueError("public_mode에서는 auth.secure_cookie=true가 필요합니다.")
+        if not self.deployment.allowed_hosts or any(
+            not host.strip() or host.strip() == "*"
+            for host in self.deployment.allowed_hosts
+        ):
+            raise ValueError(
+                "public_mode에서는 deployment.allowed_hosts에 명시적 호스트가 필요합니다."
+            )
         return self
 
     def __getitem__(self, item):

--- a/core/logger.py
+++ b/core/logger.py
@@ -19,6 +19,7 @@ from core.loggers.cache_event_logger import CacheEventLogger
 from core.loggers.strategy_info_filter import StrategyInfoFilter
 from core.loggers.app_logger import Logger
 from core.loggers.async_handler import DictPreservingQueueHandler
+from core.loggers.sensitive_data_filter import SensitiveDataFilter
 
 _active_listeners = []
 
@@ -55,6 +56,7 @@ def setup_async_logger(logger: logging.Logger, file_handler: logging.Handler):
     """파일 I/O를 백그라운드 스레드로 위임하는 비동기 큐 세팅"""
     log_queue = queue.Queue(-1)
     queue_handler = DictPreservingQueueHandler(log_queue)
+    queue_handler.addFilter(SensitiveDataFilter())
     logger.addHandler(queue_handler)
 
     listener = QueueListener(log_queue, file_handler, respect_handler_level=True)

--- a/core/loggers/app_logger.py
+++ b/core/loggers/app_logger.py
@@ -9,6 +9,7 @@ from core.loggers.log_config import get_log_timestamp, LOG_MAX_BYTES, LOG_BACKUP
 from core.loggers.size_time_rotating_file_handler import SizeTimeRotatingFileHandler
 from core.loggers.strategy_info_filter import StrategyInfoFilter
 from core.loggers.async_handler import DictPreservingQueueHandler
+from core.loggers.sensitive_data_filter import SensitiveDataFilter
 
 class Logger:
     """
@@ -109,6 +110,7 @@ class Logger:
         
         log_queue = queue.Queue(-1)
         queue_handler = DictPreservingQueueHandler(log_queue)
+        queue_handler.addFilter(SensitiveDataFilter())
         logger.addHandler(queue_handler)
 
         listener = QueueListener(log_queue, file_handler, respect_handler_level=True)

--- a/core/loggers/sensitive_data_filter.py
+++ b/core/loggers/sensitive_data_filter.py
@@ -1,0 +1,59 @@
+"""로그 레코드의 이름 있는 인증 비밀을 제거한다."""
+import logging
+import re
+
+_NAMED_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|api[_-]?secret|secret[_-]?key|access[_-]?token|"
+    r"refresh[_-]?token|password|authorization)\b(\s*[:=]\s*)([\"']?)([^,\s\"']+)([\"']?)"
+)
+
+
+def redact_sensitive_text(text) -> str:
+    raw = str(text)
+
+    def _replace(match: re.Match) -> str:
+        quote = match.group(3)
+        closing_quote = quote if quote and match.group(5) else ""
+        return f"{match.group(1)}{match.group(2)}{quote}[REDACTED]{closing_quote}"
+
+    return _NAMED_SECRET_RE.sub(_replace, raw)
+
+
+def _redact_structure(value):
+    if isinstance(value, dict):
+        result = {}
+        for key, item in value.items():
+            normalized = str(key).lower()
+            if any(
+                part in normalized
+                for part in (
+                    "api_key",
+                    "api_secret",
+                    "secret_key",
+                    "access_token",
+                    "refresh_token",
+                    "password",
+                    "authorization",
+                )
+            ):
+                result[key] = "[REDACTED]"
+            else:
+                result[key] = _redact_structure(item)
+        return result
+    if isinstance(value, list):
+        return [_redact_structure(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_structure(item) for item in value)
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+    return value
+
+
+class SensitiveDataFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, (dict, list, tuple)):
+            record.msg = _redact_structure(record.msg)
+        else:
+            record.msg = redact_sensitive_text(record.getMessage())
+        record.args = ()
+        return True

--- a/docs/public_deployment_plan.md
+++ b/docs/public_deployment_plan.md
@@ -30,13 +30,13 @@
 ## 구현 현황
 
 - Phase 0: 구현 및 단위·통합 테스트 완료
-- Phase 1: 미구현
+- Phase 1: 구현 및 전체 단위·통합 테스트 완료
 - Phase 2: 미구현
 - Phase 3: 미구현
 
 Phase 0에서는 API·SSE·WebSocket 공통 인증, 인증 fail-open 제거, 인증 전 `/balance` 조회 차단, Kill Switch 감사 주체에서 토큰 원문 제거, API 라우트 중복 제거와 구조 검사를 적용했다.
 
-현재 인증 쿠키는 Phase 0의 임시 정적 토큰 방식이다. 서명·만료 세션, CSRF, 비밀번호 해시, 로그인 실패 제한이 구현되기 전에는 외부 공개 MVP가 완료된 것으로 판단하지 않는다.
+Phase 1에서는 임시 정적 토큰을 서명·만료 세션으로 교체하고 CSRF, 비밀번호 해시, 로그인 실패 제한, 공개 모드, 실전 주문 master gate, 응답·로그 마스킹, 위험 작업 차단과 trusted host 검증을 구현했다. 전체 단위·통합 테스트까지 통과했으므로 공개 안전 MVP 구현을 완료한 것으로 판단한다.
 
 ## 단계별 구현 범위
 
@@ -124,6 +124,8 @@ deployment:
   public_mode: false
   demo_mode: false
   allow_live_trading: false
+  allowed_hosts:
+    - "trade.example.com"
 ```
 
 `deployment.allow_live_trading`을 국내·해외 실전 주문의 **단일 전역 master gate**로 사용한다. 기존 `overseas_stock.allow_live_trading`은 설정 이원화를 막기 위해 폐기한다.
@@ -136,6 +138,7 @@ deployment:
 - 자동매매 백그라운드 태스크 비활성화
 - 서버 종료·재시작과 강제 배치 실행 비활성화
 - 계좌, 잔고, 주문 정보 마스킹
+- `deployment.allowed_hosts`에 없는 Host 요청 거부
 
 대상 파일:
 

--- a/docs/public_deployment_runbook.md
+++ b/docs/public_deployment_runbook.md
@@ -1,0 +1,103 @@
+# 외부 공개 배포 Runbook
+
+## 배포 방식
+
+이 앱의 FastAPI 서버는 GitHub Pages에서 실행할 수 없다. GitHub Pages는 정적 HTML, CSS, JavaScript만 제공하므로 FastAPI는 별도 서버나 클라우드에 배포해야 한다.
+
+운영 앱은 다음 구성을 권장한다.
+
+```text
+Internet -> HTTPS reverse proxy -> FastAPI (127.0.0.1:8000)
+```
+
+로컬 PC의 포트와 방화벽을 인터넷에 직접 개방하지 않는다. 클라우드 VM 또는 사설 서버에서 reverse proxy를 두고 FastAPI는 loopback에만 바인딩한다. 공개 UI와 API는 가능한 한 같은 origin으로 유지한다.
+
+## 사전 조건
+
+- Python 3.10 이상과 프로젝트 의존성 설치
+- 모의투자 전용 API 키와 계좌 사용
+- `config/config.yaml` 및 `token_*.json`을 저장소와 이미지에 포함하지 않음
+- HTTPS 인증서가 적용된 reverse proxy
+- 단일 Uvicorn worker
+
+현재 세션 무효화 목록과 로그인 실패 제한은 프로세스 메모리에 저장된다. 여러 worker나 여러 인스턴스를 사용하면 상태가 공유되지 않으므로 Phase 1에서는 worker를 하나만 사용한다.
+
+## 보안 설정
+
+1. 비밀번호 해시를 생성한다.
+
+```powershell
+python scripts/hash_web_password.py
+```
+
+2. 최소 32자의 예측 불가능한 세션 서명 키를 별도로 생성한다.
+
+3. `config/config.yaml`에 다음 값을 설정한다.
+
+```yaml
+is_paper_trading: true
+use_login: true
+
+deployment:
+  public_mode: true
+  demo_mode: false
+  allow_live_trading: false
+  allowed_hosts:
+    - "trade.example.com"
+
+web:
+  host: "127.0.0.1"
+  port: 8000
+
+auth:
+  username: "operator"
+  password_hash: "pbkdf2_sha256$..."
+  secret_key: "32자 이상의 무작위 비밀"
+  session_max_age_seconds: 3600
+  login_max_failures: 5
+  login_lockout_seconds: 60
+  secure_cookie: true
+```
+
+`public_mode=true`에서는 로그인, PBKDF2 비밀번호 해시, 32자 이상 서명 키, secure cookie와 명시적 allowed host가 없으면 설정 로드가 실패한다. `allowed_hosts: ["*"]`는 허용되지 않는다.
+
+## Reverse Proxy
+
+- 외부에서는 HTTPS만 허용하고 HTTP는 HTTPS로 리다이렉트한다.
+- FastAPI 포트는 외부 방화벽에서 차단하고 reverse proxy에서만 접근시킨다.
+- 요청 본문 크기, 연결 시간과 읽기 시간 제한을 둔다.
+- 로그인과 API 경로에 추가 rate limit을 적용한다.
+- 전달 IP 헤더는 신뢰하는 reverse proxy 한 단계에서만 설정한다.
+
+앱은 기본적으로 직접 연결된 client IP를 로그인 제한 키로 사용한다. 임의 클라이언트가 보낸 `X-Forwarded-For`를 신뢰하도록 Uvicorn의 proxy header 범위를 넓히지 않는다.
+
+별도 GitHub Pages UI처럼 다른 origin을 사용할 경우 현재 구성 그대로는 지원 대상이 아니다. Phase 3에서 정확한 origin만 허용하는 CORS 정책, credential cookie와 CSRF 동작을 함께 설계한다. 운영 앱에는 `Access-Control-Allow-Origin: *`를 사용하지 않는다.
+
+## 배포 전 검증
+
+```powershell
+pytest tests/unit_test -v
+pytest tests/integration_test -v
+git status -sb
+```
+
+브라우저와 별도 HTTP 클라이언트에서 다음을 확인한다.
+
+- 비로그인 API 요청이 `401` 또는 `403`
+- 변조되거나 만료된 세션이 거부됨
+- CSRF 헤더 없는 상태 변경 요청이 거부됨
+- 등록하지 않은 Host 요청이 `400`
+- 국내·해외 실전 주문이 공개 모드에서 차단됨
+- 종료, 재시작, force-update, scheduler, limits, kill-switch 변경이 차단됨
+- 잔고 페이지와 JSON, 시스템 상태 및 로그에 계좌·금액·토큰이 노출되지 않음
+- WebSocket과 SSE가 로그인 세션 없이 연결되지 않음
+
+## 운영 및 비상 대응
+
+세션 서명 키를 교체하면 기존 세션은 모두 무효화된다. 비밀번호 또는 세션 키 유출이 의심되면 서비스를 외부에서 먼저 격리하고 키와 비밀번호를 교체한 뒤 재시작한다.
+
+증권사 API 키가 노출된 경우에는 애플리케이션 설정만 바꾸지 말고 증권사에서 키를 폐기·재발급한다. 관련 토큰 파일과 로그도 격리한다.
+
+비정상 주문 징후가 있으면 reverse proxy 접근을 차단하고 프로세스를 중지한 뒤 증권사 채널에서 미체결 주문과 계좌 상태를 직접 확인한다. 공개 모드의 Kill Switch 변경 API는 차단되므로 원격 API 호출을 비상 중지 수단으로 간주하지 않는다.
+
+복구 시에는 모의투자, `public_mode=true`, `allow_live_trading=false`로 먼저 기동한다. 인증, 마스킹, 위험 작업 차단 검증을 다시 통과한 뒤에만 공개 접근을 복원한다.

--- a/scripts/hash_web_password.py
+++ b/scripts/hash_web_password.py
@@ -1,0 +1,22 @@
+"""웹 로그인용 PBKDF2 비밀번호 해시를 생성한다."""
+from getpass import getpass
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from view.web.security import hash_password
+
+
+def main() -> None:
+    password = getpass("Web password: ")
+    confirmation = getpass("Confirm password: ")
+    if password != confirmation:
+        raise SystemExit("Passwords do not match.")
+    print(hash_password(password))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -439,7 +439,16 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from view.web.routes import router as api_router
 import view.web.api_common as api_common
+from view.web.security import reset_security_state
+from tests.web_auth_helpers import authenticated_client_options
 from common.types import ResCommonResponse
+
+
+@pytest.fixture(autouse=True)
+def reset_integration_web_security():
+    reset_security_state()
+    yield
+    reset_security_state()
 
 
 def _build_mock_web_ctx(is_paper: bool = True):
@@ -449,7 +458,18 @@ def _build_mock_web_ctx(is_paper: bool = True):
     """
     mock_ctx = MagicMock()
     mock_ctx.initialized = True
-    mock_ctx.full_config = {"use_login": False, "auth": {"secret_key": "test-token"}}
+    mock_ctx.full_config = {
+        "use_login": False,
+        "auth": {
+            "username": "test-operator",
+            "secret_key": "test-token",
+            "session_max_age_seconds": 3600,
+        },
+        "deployment": {
+            "public_mode": False,
+            "allow_live_trading": True,
+        },
+    }
 
     # env 설정
     mock_ctx.env.is_paper_trading = is_paper
@@ -508,7 +528,7 @@ def mock_real_ctx():
 def paper_client(web_app, mock_paper_ctx):
     """모의투자 모드 TestClient. 테스트 전후 api_common._ctx를 정리."""
     api_common.set_ctx(mock_paper_ctx)
-    with TestClient(web_app, cookies={"access_token": "test-token"}) as client:
+    with TestClient(web_app, **authenticated_client_options(mock_paper_ctx)) as client:
         yield client
     api_common.set_ctx(None)
 
@@ -517,7 +537,7 @@ def paper_client(web_app, mock_paper_ctx):
 def real_client(web_app, mock_real_ctx):
     """실전투자 모드 TestClient."""
     api_common.set_ctx(mock_real_ctx)
-    with TestClient(web_app, cookies={"access_token": "test-token"}) as client:
+    with TestClient(web_app, **authenticated_client_options(mock_real_ctx)) as client:
         yield client
     api_common.set_ctx(None)
 
@@ -691,7 +711,7 @@ async def deep_paper_ctx(test_logger, web_app, mocker, tmp_path):
             async with AsyncClient(
                 transport=transport,
                 base_url="http://testserver",
-                cookies={"access_token": "test-token"},
+                **authenticated_client_options(web_ctx),
             ) as client:
                 web_ctx._test_client = client
                 yield web_ctx

--- a/tests/integration_test/test_it_kill_switch_api.py
+++ b/tests/integration_test/test_it_kill_switch_api.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from view.web.routes import router as api_router
 from view.web import api_common
+from tests.web_auth_helpers import authenticated_client_options
 
 
 def _make_ks_service(is_tripped: bool = False):
@@ -40,7 +41,14 @@ _SECRET = "test-token"
 def _make_ctx(ks_service):
     mock_ctx = MagicMock()
     mock_ctx.initialized = True
-    mock_ctx.full_config = {"use_login": False, "auth": {"secret_key": _SECRET}}
+    mock_ctx.full_config = {
+        "use_login": False,
+        "auth": {
+            "username": "test-operator",
+            "secret_key": _SECRET,
+            "session_max_age_seconds": 3600,
+        },
+    }
     mock_ctx.env.active_config = {"auth": {"secret_key": _SECRET}}
     mock_ctx.kill_switch_service = ks_service
     return mock_ctx
@@ -57,8 +65,9 @@ def web_app():
 def ks_client(web_app):
     """Kill Switch 서비스가 정상 상태인 테스트 클라이언트."""
     ks_svc = _make_ks_service(is_tripped=False)
-    api_common.set_ctx(_make_ctx(ks_svc))
-    with TestClient(web_app, cookies={"access_token": _SECRET}) as client:
+    ctx = _make_ctx(ks_svc)
+    api_common.set_ctx(ctx)
+    with TestClient(web_app, **authenticated_client_options(ctx)) as client:
         yield client, ks_svc
     api_common.set_ctx(None)
 
@@ -67,8 +76,9 @@ def ks_client(web_app):
 def ks_tripped_client(web_app):
     """Kill Switch가 트립된 상태의 테스트 클라이언트."""
     ks_svc = _make_ks_service(is_tripped=True)
-    api_common.set_ctx(_make_ctx(ks_svc))
-    with TestClient(web_app, cookies={"access_token": _SECRET}) as client:
+    ctx = _make_ctx(ks_svc)
+    api_common.set_ctx(ctx)
+    with TestClient(web_app, **authenticated_client_options(ctx)) as client:
         yield client, ks_svc
     api_common.set_ctx(None)
 
@@ -76,8 +86,9 @@ def ks_tripped_client(web_app):
 @pytest.fixture
 def no_ks_client(web_app):
     """Kill Switch 서비스가 None인 테스트 클라이언트 (503 검증용)."""
-    api_common.set_ctx(_make_ctx(ks_service=None))
-    with TestClient(web_app, cookies={"access_token": _SECRET}) as client:
+    ctx = _make_ctx(ks_service=None)
+    api_common.set_ctx(ctx)
+    with TestClient(web_app, **authenticated_client_options(ctx)) as client:
         yield client
     api_common.set_ctx(None)
 

--- a/tests/integration_test/test_it_operator_dashboard.py
+++ b/tests/integration_test/test_it_operator_dashboard.py
@@ -17,6 +17,7 @@ from view.web.routes import router as api_router
 from view.web import api_common
 from common.operator_alert_types import AlertSource, AlertTransition
 from services.operator_alert_service import OperatorAlertService
+from tests.web_auth_helpers import authenticated_client_options
 
 
 # ── 픽스처 ─────────────────────────────────────────────────────────
@@ -47,7 +48,14 @@ def _make_ks_status(is_tripped: bool = False):
 def _make_ctx(operator_alert_svc, ks_is_tripped=False):
     mock_ctx = MagicMock()
     mock_ctx.initialized = True
-    mock_ctx.full_config = {"use_login": False, "auth": {"secret_key": "test"}}
+    mock_ctx.full_config = {
+        "use_login": False,
+        "auth": {
+            "username": "test-operator",
+            "secret_key": "test",
+            "session_max_age_seconds": 3600,
+        },
+    }
     mock_ctx.operator_alert_service = operator_alert_svc
     mock_ctx.kill_switch_service = MagicMock()
     mock_ctx.kill_switch_service.get_status.return_value = _make_ks_status(ks_is_tripped)
@@ -79,7 +87,7 @@ def web_app():
 def client(web_app, alert_svc):
     ctx = _make_ctx(alert_svc)
     api_common.set_ctx(ctx)
-    with TestClient(web_app, cookies={"access_token": "test"}) as c:
+    with TestClient(web_app, **authenticated_client_options(ctx)) as c:
         yield c, alert_svc
     api_common.set_ctx(None)
 
@@ -89,7 +97,7 @@ def client_tripped(web_app, alert_svc):
     """Kill Switch가 트립된 상태."""
     ctx = _make_ctx(alert_svc, ks_is_tripped=True)
     api_common.set_ctx(ctx)
-    with TestClient(web_app, cookies={"access_token": "test"}) as c:
+    with TestClient(web_app, **authenticated_client_options(ctx)) as c:
         yield c, alert_svc
     api_common.set_ctx(None)
 
@@ -126,7 +134,7 @@ async def test_status_shows_active_alert_after_report(web_app, alert_svc):
     ctx = _make_ctx(alert_svc, ks_is_tripped=True)
     api_common.set_ctx(ctx)
     try:
-        with TestClient(web_app, cookies={"access_token": "test"}) as c:
+        with TestClient(web_app, **authenticated_client_options(ctx)) as c:
             r = c.get("/api/operator/status")
         assert r.status_code == 200
         data = r.json()
@@ -150,7 +158,7 @@ async def test_alerts_history_after_report(web_app, alert_svc):
     ctx = _make_ctx(alert_svc)
     api_common.set_ctx(ctx)
     try:
-        with TestClient(web_app, cookies={"access_token": "test"}) as c:
+        with TestClient(web_app, **authenticated_client_options(ctx)) as c:
             r = c.get("/api/operator/alerts")
         assert r.status_code == 200
         data = r.json()
@@ -168,7 +176,7 @@ async def test_alerts_source_filter(web_app, alert_svc):
     ctx = _make_ctx(alert_svc)
     api_common.set_ctx(ctx)
     try:
-        with TestClient(web_app, cookies={"access_token": "test"}) as c:
+        with TestClient(web_app, **authenticated_client_options(ctx)) as c:
             r = c.get("/api/operator/alerts?source=KILL_SWITCH")
         data = r.json()
         assert all(h["source"] == "KILL_SWITCH" for h in data["alerts"])
@@ -187,7 +195,7 @@ async def test_resolve_endpoint(web_app, alert_svc, notif):
     ctx = _make_ctx(alert_svc)
     api_common.set_ctx(ctx)
     try:
-        with TestClient(web_app, cookies={"access_token": "test"}) as c:
+        with TestClient(web_app, **authenticated_client_options(ctx)) as c:
             r = c.post("/api/operator/alerts/kill_switch%3Aglobal/resolve?reason=운영자+해제")
         assert r.status_code == 200
         data = r.json()
@@ -202,7 +210,7 @@ async def test_resolve_nonexistent_returns_false(web_app, alert_svc):
     ctx = _make_ctx(alert_svc)
     api_common.set_ctx(ctx)
     try:
-        with TestClient(web_app, cookies={"access_token": "test"}) as c:
+        with TestClient(web_app, **authenticated_client_options(ctx)) as c:
             r = c.post("/api/operator/alerts/kill_switch%3Aglobal/resolve")
         data = r.json()
         assert data["resolved"] is False

--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -768,7 +768,8 @@ class TestWebAppContextInitialization:
             # 실제 ctx를 FastAPI 앱에 연결
             api_common.set_ctx(ctx)
             try:
-                with TestClient(web_app, cookies={"access_token": "test-token"}) as client:
+                from tests.web_auth_helpers import authenticated_client_options
+                with TestClient(web_app, **authenticated_client_options(ctx)) as client:
                     # /api/status는 실제 WebAppContext 메서드를 호출
                     resp = client.get("/api/status")
                     assert resp.status_code == 200

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -17,6 +17,8 @@ from common.types import Exchange, ResCommonResponse
 import view.web.api_common as api_common
 from view.web.routes import stock as stock_routes
 import view.web.web_main as web_main
+from tests.web_auth_helpers import authenticated_client_options
+from view.web.security import hash_password
 
 
 class _ForegroundContext(AbstractAsyncContextManager):
@@ -57,7 +59,18 @@ def clear_web_state():
 @pytest.fixture
 def fake_web_ctx():
     ctx = MagicMock()
-    ctx.full_config = {"use_login": False, "auth": {"secret_key": "test-token"}}
+    ctx.full_config = {
+        "use_login": False,
+        "auth": {
+            "username": "test-operator",
+            "secret_key": "test-token",
+            "session_max_age_seconds": 3600,
+        },
+        "deployment": {
+            "public_mode": False,
+            "allow_live_trading": True,
+        },
+    }
     ctx.initialized = True
     ctx.env = SimpleNamespace(
         is_paper_trading=True,
@@ -140,7 +153,7 @@ def fake_web_ctx():
 @pytest.fixture
 def client_with_fake_lifespan(fake_web_ctx, mocker):
     mocker.patch.object(web_main, "WebAppContext", return_value=fake_web_ctx)
-    with TestClient(web_main.app, cookies={"access_token": "test-token"}) as client:
+    with TestClient(web_main.app, **authenticated_client_options(fake_web_ctx)) as client:
         yield client
 
 
@@ -248,8 +261,9 @@ def test_real_app_login_gate_and_auth_cookie_allow_page(client_with_fake_lifespa
         "use_login": True,
         "auth": {
             "username": "tester",
-            "password": "secret",
+            "password_hash": hash_password("secret", iterations=1_000),
             "secret_key": "test-token",
+            "session_max_age_seconds": 3600,
         },
     }
 
@@ -271,7 +285,9 @@ def test_real_app_login_gate_and_auth_cookie_allow_page(client_with_fake_lifespa
     )
     assert login.status_code == 200
     assert login.json() == {"success": True}
-    assert "access_token=test-token" in login.headers["set-cookie"]
+    assert "access_token=" in login.headers["set-cookie"]
+    assert "access_token=test-token" not in login.headers["set-cookie"]
+    assert "csrf_token=" in login.headers["set-cookie"]
 
     allowed = client_with_fake_lifespan.get("/order")
     assert allowed.status_code == 200

--- a/tests/integration_test/view/web/static/js/test_it_js_static_files.py
+++ b/tests/integration_test/view/web/static/js/test_it_js_static_files.py
@@ -27,3 +27,12 @@ def test_pjax_updates_market_navigation_and_view_context():
     assert "data-view-market" in source
     assert "newMarketNav" in source
     assert "newFeatureNav" in source
+
+
+def test_common_fetch_adds_csrf_header_to_same_origin_state_changes():
+    source = (JS_ROOT / "common.js").read_text(encoding="utf-8")
+
+    assert "csrf_token" in source
+    assert "X-CSRF-Token" in source
+    assert "POST" in source
+    assert "window.fetch" in source

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -417,6 +417,55 @@ def test_app_config_default_operating_profile_is_canary():
     assert cfg.operating_profile == "canary"
 
 
+def test_public_deployment_defaults_fail_closed():
+    cfg = _minimal_app_config()
+
+    assert cfg.deployment.public_mode is False
+    assert cfg.deployment.demo_mode is False
+    assert cfg.deployment.allow_live_trading is False
+
+
+def test_auth_security_defaults_are_bounded():
+    cfg = _minimal_app_config()
+
+    assert cfg.auth.session_max_age_seconds == 3600
+    assert cfg.auth.login_max_failures == 5
+    assert cfg.auth.login_lockout_seconds == 60
+
+
+def test_public_mode_rejects_incomplete_auth_security():
+    with pytest.raises(ValidationError):
+        _minimal_app_config(deployment={"public_mode": True})
+
+
+def test_public_mode_accepts_hardened_auth_config():
+    cfg = _minimal_app_config(
+        use_login=True,
+        deployment={"public_mode": True},
+        auth={
+            "username": "operator",
+            "password_hash": "pbkdf2_sha256$310000$c2FsdA$ZGlnZXN0",
+            "secret_key": "x" * 32,
+            "secure_cookie": True,
+        },
+    )
+
+    assert cfg.deployment.public_mode is True
+
+
+def test_public_mode_rejects_wildcard_allowed_host():
+    with pytest.raises(ValidationError):
+        _minimal_app_config(
+            deployment={"public_mode": True, "allowed_hosts": ["*"]},
+            auth={
+                "username": "operator",
+                "password_hash": "pbkdf2_sha256$310000$c2FsdA$ZGlnZXN0",
+                "secret_key": "x" * 32,
+                "secure_cookie": True,
+            },
+        )
+
+
 def test_app_config_accepts_real_limited_profile():
     cfg = _minimal_app_config(operating_profile="real_limited")
     assert cfg.operating_profile == "real_limited"

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -124,11 +124,32 @@ def test_app():
     app.include_router(page_router)
     return app
 
+
+@pytest.fixture(autouse=True)
+def reset_web_security_state():
+    from view.web.security import reset_security_state
+
+    reset_security_state()
+    yield
+    reset_security_state()
+
+
 @pytest.fixture
-def web_client(test_app):
+def web_client(test_app, mock_web_ctx):
     """기본 인증 상태의 FastAPI TestClient."""
+    from view.web.security import (
+        CSRF_COOKIE_NAME,
+        CSRF_HEADER_NAME,
+        SESSION_COOKIE_NAME,
+        issue_session,
+    )
+
     client = TestClient(test_app)
-    client.cookies.set("access_token", "secret")
+    auth_config = mock_web_ctx.full_config["auth"]
+    token, claims = issue_session(auth_config, auth_config["username"])
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, claims.csrf_token)
+    client.headers[CSRF_HEADER_NAME] = claims.csrf_token
     return client
 
 @pytest.fixture
@@ -168,8 +189,9 @@ def mock_web_ctx():
         "use_login": False,
         "auth": {
             "username": "admin",
-            "password": "password",
+            "password_hash": "pbkdf2_sha256$1000$dGVzdC1zYWx0$g6Aj4gLe-oXHKKyKO49OLB_39eXQeY4yWadcnOdTVjU",
             "secret_key": "secret",
+            "session_max_age_seconds": 3600,
         },
     }
     

--- a/tests/unit_test/view/test_foreground_middleware.py
+++ b/tests/unit_test/view/test_foreground_middleware.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient, ASGITransport
 
 # 미들웨어에서 사용하는 경로 판별 함수를 직접 테스트
 from view.web.web_main import _needs_foreground
+from view.web.security import SESSION_COOKIE_NAME, issue_session
 
 
 # --- _needs_foreground 경로 판별 테스트 ---
@@ -84,7 +85,12 @@ class _FakeContextManager:
 def _make_mock_ctx(with_fg=True):
     """ForegroundScheduler가 포함된 mock WebAppContext 생성."""
     ctx = MagicMock()
-    ctx.full_config = {"auth": {"secret_key": "test-token"}}
+    ctx.full_config = {
+        "auth": {
+            "secret_key": "test-token",
+            "session_max_age_seconds": 3600,
+        }
+    }
 
     if with_fg:
         ctx.foreground_scheduler = MagicMock()
@@ -115,6 +121,12 @@ def _make_mock_ctx(with_fg=True):
     return ctx
 
 
+def _auth_cookies(ctx):
+    auth_config = ctx.full_config["auth"]
+    token, _ = issue_session(auth_config, "test-operator")
+    return {SESSION_COOKIE_NAME: token}
+
+
 @pytest.mark.asyncio
 async def test_middleware_calls_foreground_on_api_route():
     """Broker API 경로 요청 시 fg.context()가 호출된다."""
@@ -126,7 +138,7 @@ async def test_middleware_calls_foreground_on_api_route():
         async with AsyncClient(
             transport=transport,
             base_url="http://test",
-            cookies={"access_token": "test-token"},
+            cookies=_auth_cookies(mock_ctx),
         ) as client:
             resp = await client.get("/api/balance")
 
@@ -145,7 +157,7 @@ async def test_middleware_skips_foreground_on_excluded_route():
         async with AsyncClient(
             transport=transport,
             base_url="http://test",
-            cookies={"access_token": "test-token"},
+            cookies=_auth_cookies(mock_ctx),
         ) as client:
             resp = await client.get("/api/ranking/progress")
 
@@ -164,7 +176,7 @@ async def test_middleware_graceful_without_foreground_scheduler():
         async with AsyncClient(
             transport=transport,
             base_url="http://test",
-            cookies={"access_token": "test-token"},
+            cookies=_auth_cookies(mock_ctx),
         ) as client:
             resp = await client.get("/api/balance")
             assert resp.status_code == 200

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -6,6 +6,7 @@ import time
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi.testclient import TestClient
 import view.web.api_common as api_common
+from view.web.security import SESSION_COOKIE_NAME, issue_session
 from view.web.web_main import (
     app,
     lifespan,
@@ -14,6 +15,14 @@ from view.web.web_main import (
     _is_ignorable_connection_reset,
     _needs_foreground,
 )
+
+
+def _authenticate_client(client, ctx):
+    auth_config = ctx.full_config["auth"]
+    auth_config.setdefault("session_max_age_seconds", 3600)
+    token, _ = issue_session(auth_config, "test-operator")
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+
 
 # --- Fixtures ---
 @pytest.fixture
@@ -122,7 +131,7 @@ def test_render_page_success(mock_web_app_context_cls):
     
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "correct_token")
+            _authenticate_client(client, mock_ctx)
             
             response = client.get("/")
             
@@ -264,7 +273,7 @@ def test_foreground_priority_middleware(mock_web_app_context_cls):
     mock_ctx.full_config = {"auth": {"secret_key": "test-token"}}
     
     with TestClient(app, raise_server_exceptions=False) as client:
-        client.cookies.set("access_token", "test-token")
+        _authenticate_client(client, mock_ctx)
         with patch("view.web.api_common._ctx", mock_ctx):
             client.get("/api/stock/123")
             mock_fg.context.assert_called()
@@ -284,6 +293,23 @@ def test_unauthenticated_api_does_not_enter_foreground(mock_web_app_context_cls)
     mock_ctx.foreground_scheduler.context.assert_not_called()
 
 
+def test_public_mode_rejects_untrusted_host(mock_web_app_context_cls):
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {
+        "deployment": {
+            "public_mode": True,
+            "allowed_hosts": ["trade.example.com"],
+        },
+        "auth": {"secret_key": "test-token"},
+    }
+
+    with TestClient(app) as client:
+        with patch("view.web.api_common._ctx", mock_ctx):
+            response = client.get("/", headers={"host": "evil.example.com"})
+
+    assert response.status_code == 400
+
+
 def test_all_page_routers(mock_web_app_context_cls):
     """모든 페이지 라우터들이 200 정상 응답을 하는지 테스트"""
     mock_ctx = MagicMock()
@@ -294,7 +320,7 @@ def test_all_page_routers(mock_web_app_context_cls):
     
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "correct_token")
+            _authenticate_client(client, mock_ctx)
             pages = ["/stock", "/balance", "/order", "/ranking", "/marketcap", "/virtual", "/scheduler", "/strategy-reports", "/program", "/system", "/favorite"]
             for page in pages:
                 response = client.get(page)
@@ -307,6 +333,7 @@ def test_logout(mock_web_app_context_cls):
         response = client.get("/logout", follow_redirects=False)
         assert response.status_code == 307
         assert "access_token" in response.headers.get("set-cookie", "")
+        assert "csrf_token" in response.headers.get("set-cookie", "")
 
 
 # --- /balance 페이지 테스트 ---
@@ -394,7 +421,7 @@ def test_balance_paper_trading_with_account_number(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -405,6 +432,30 @@ def test_balance_paper_trading_with_account_number(mock_web_app_context_cls):
     assert data["account_info"]["exchange"] == "KRX"
 
 
+def test_public_mode_masks_balance_initial_data(mock_web_app_context_cls):
+    mock_ctx, _ = _make_balance_ctx(
+        is_paper_trading=True,
+        acc_no_field="stock_account_number",
+        acc_no_value="1234567890",
+    )
+    mock_ctx.full_config["deployment"] = {
+        "public_mode": True,
+        "allowed_hosts": ["testserver"],
+    }
+    fake_result = {"data": {"tot_evlu_amt": "1000000", "ord_no": "0000123456"}}
+
+    with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
+         patch("view.web.api_common._serialize_response", return_value=fake_result):
+        with TestClient(app) as client:
+            _authenticate_client(client, mock_ctx)
+            response = client.get("/balance")
+
+    data = _parse_initial_data(response.text)
+    assert data["data"]["tot_evlu_amt"] is None
+    assert data["data"]["ord_no"] == "******3456"
+    assert data["account_info"]["number"] == "******7890"
+
+
 def test_balance_real_trading_with_cano(mock_web_app_context_cls):
     """실전투자 환경, CANO로 계좌번호 조회 테스트"""
     mock_ctx, _ = _make_balance_ctx(is_paper_trading=False, acc_no_field="CANO", acc_no_value="55443322")
@@ -413,7 +464,7 @@ def test_balance_real_trading_with_cano(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -432,7 +483,7 @@ def test_balance_acc_no_from_env_attribute(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -450,7 +501,7 @@ def test_balance_acc_no_fallback_to_default(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -477,7 +528,7 @@ def test_balance_env_via_broker(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -499,7 +550,7 @@ def test_balance_no_env_no_account_info(mock_web_app_context_cls):
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx), \
          patch("view.web.api_common._serialize_response", return_value=fake_result):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200
@@ -519,7 +570,7 @@ def test_balance_exception_fallback_renders_page(mock_web_app_context_cls):
 
     with patch("view.web.web_api._get_ctx", return_value=mock_ctx):
         with TestClient(app) as client:
-            client.cookies.set("access_token", "tok")
+            _authenticate_client(client, mock_ctx)
             response = client.get("/balance")
 
     assert response.status_code == 200

--- a/tests/unit_test/view/web/routes/test_web_routes_auth.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_auth.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock
 from fastapi import HTTPException, Request, WebSocketException
 from view.web import web_api
+from view.web.security import CSRF_COOKIE_NAME, hash_password, issue_session
 
 
 def test_login_success(web_client, mock_web_ctx):
@@ -20,6 +21,51 @@ def test_login_failure(web_client, mock_web_ctx):
     response = web_client.post("/api/auth/login", data={"username": "wrong", "password": "wrong"})
     assert response.status_code == 401
     assert response.json()["success"] is False
+
+
+def test_login_issues_signed_expiring_session_and_csrf_cookie(web_client, mock_web_ctx):
+    mock_web_ctx.full_config["auth"] = {
+        "username": "admin",
+        "password_hash": hash_password("password", iterations=1_000),
+        "secret_key": "signing-secret",
+        "session_max_age_seconds": 900,
+    }
+    web_client.cookies.clear()
+
+    response = web_client.post(
+        "/api/auth/login",
+        data={"username": "admin", "password": "password"},
+    )
+
+    assert response.status_code == 200
+    assert response.cookies["access_token"] != "signing-secret"
+    assert response.cookies[CSRF_COOKIE_NAME]
+    set_cookie = response.headers.get_list("set-cookie")
+    assert any("HttpOnly" in value and "Max-Age=900" in value for value in set_cookie)
+
+
+def test_repeated_login_failures_are_rate_limited(web_client, mock_web_ctx):
+    mock_web_ctx.full_config["auth"] = {
+        "username": "admin",
+        "password_hash": hash_password("password", iterations=1_000),
+        "secret_key": "signing-secret",
+        "login_max_failures": 2,
+        "login_lockout_seconds": 60,
+    }
+    web_client.cookies.clear()
+
+    for _ in range(2):
+        response = web_client.post(
+            "/api/auth/login",
+            data={"username": "admin", "password": "wrong"},
+        )
+        assert response.status_code == 401
+
+    response = web_client.post(
+        "/api/auth/login",
+        data={"username": "admin", "password": "password"},
+    )
+    assert response.status_code == 429
 
 
 def test_get_ctx_uninitialized(web_client):
@@ -38,9 +84,11 @@ def test_get_ctx_uninitialized(web_client):
 def test_check_auth(mock_web_ctx):
     """check_auth 함수 테스트"""
     mock_request = MagicMock(spec=Request)
-    mock_request.cookies = {"access_token": "secret"}
+    auth_config = {"secret_key": "secret", "session_max_age_seconds": 3600}
+    token, _ = issue_session(auth_config, "admin")
+    mock_request.cookies = {"access_token": token}
 
-    mock_web_ctx.full_config = {"auth": {"secret_key": "secret"}}
+    mock_web_ctx.full_config = {"auth": auth_config}
     mock_web_ctx.env.active_config = {}
 
     # Success
@@ -90,6 +138,19 @@ def test_sensitive_api_rejects_request_without_cookie(web_client, mock_web_ctx):
     )
 
     assert response.status_code == 401
+    mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
+
+
+def test_state_changing_api_rejects_missing_csrf(web_client, mock_web_ctx):
+    web_client.cookies.pop(CSRF_COOKIE_NAME)
+    web_client.headers.pop("X-CSRF-Token")
+
+    response = web_client.post(
+        "/api/order",
+        json={"code": "005930", "price": "70000", "qty": "1", "side": "buy"},
+    )
+
+    assert response.status_code == 403
     mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
 
 

--- a/tests/unit_test/view/web/routes/test_web_routes_balance.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_balance.py
@@ -28,6 +28,26 @@ async def test_get_balance(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_public_mode_masks_balance_json_without_mutating_service_response(web_client, mock_web_ctx):
+    source = {"tot_evlu_amt": "1000000", "ord_no": "0000123456"}
+    mock_web_ctx.full_config["deployment"] = {"public_mode": True}
+    mock_web_ctx.env.active_config = {"stock_account_number": "1234567890"}
+    mock_web_ctx.stock_query_service.handle_get_account_balance.return_value = ResCommonResponse(
+        rt_cd="0",
+        msg1="Success",
+        data=source,
+    )
+
+    response = web_client.get("/api/balance")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["tot_evlu_amt"] is None
+    assert response.json()["data"]["ord_no"] == "******3456"
+    assert response.json()["account_info"]["number"] == "******7890"
+    assert source["tot_evlu_amt"] == "1000000"
+
+
+@pytest.mark.asyncio
 async def test_get_balance_fallback_env(web_client, mock_web_ctx):
     """GET /api/balance 환경 설정 폴백 테스트"""
     mock_web_ctx.stock_query_service.handle_get_account_balance.return_value = ResCommonResponse(

--- a/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 async def test_reset_strategy_kill_switch_success(web_client, mock_web_ctx):
     """단일 전략 Kill Switch 해제 — 200 + reset_strategy 위임."""
     mock_web_ctx.kill_switch_service.reset_strategy = AsyncMock()
-    web_client.cookies.set("access_token", "secret")
 
     resp = web_client.post("/api/kill-switch/reset-strategy/momentum")
 
@@ -25,7 +24,6 @@ async def test_reset_strategy_kill_switch_success(web_client, mock_web_ctx):
 async def test_reset_strategy_kill_switch_service_unavailable(web_client, mock_web_ctx):
     """Kill Switch 서비스 미초기화 시 503."""
     mock_web_ctx.kill_switch_service = None
-    web_client.cookies.set("access_token", "secret")
 
     resp = web_client.post("/api/kill-switch/reset-strategy/momentum")
 

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -51,6 +51,10 @@ async def test_place_order_invalid_side(web_client, mock_web_ctx):
 @pytest.mark.asyncio
 async def test_real_order_without_confirmation_is_blocked(web_client, mock_web_ctx):
     mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": False,
+        "allow_live_trading": True,
+    }
 
     payload = {"code": "005930", "price": "70000", "qty": "10", "side": "buy"}
     response = web_client.post("/api/order", json=payload)
@@ -62,6 +66,10 @@ async def test_real_order_without_confirmation_is_blocked(web_client, mock_web_c
 @pytest.mark.asyncio
 async def test_real_order_with_confirmation_calls_service(web_client, mock_web_ctx):
     mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": False,
+        "allow_live_trading": True,
+    }
     mock_web_ctx.order_execution_service.handle_buy_stock.return_value = ResCommonResponse(
         rt_cd="0", msg1="Order Placed", data={"ord_no": "12345"}
     )
@@ -77,6 +85,54 @@ async def test_real_order_with_confirmation_calls_service(web_client, mock_web_c
 
     assert response.status_code == 200
     mock_web_ctx.order_execution_service.handle_buy_stock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_real_order_requires_global_live_trading_gate(web_client, mock_web_ctx):
+    mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": False,
+        "allow_live_trading": False,
+    }
+
+    response = web_client.post(
+        "/api/order",
+        json={
+            "code": "005930",
+            "price": "70000",
+            "qty": "10",
+            "side": "buy",
+            "real_order_confirmation": "REAL",
+        },
+    )
+
+    assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert response.json()["data"]["rule"] == "global_live_trading_disabled"
+    mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_mode_blocks_real_order_even_when_gate_enabled(web_client, mock_web_ctx):
+    mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": True,
+        "allow_live_trading": True,
+    }
+
+    response = web_client.post(
+        "/api/order",
+        json={
+            "code": "005930",
+            "price": "70000",
+            "qty": "10",
+            "side": "buy",
+            "real_order_confirmation": "REAL",
+        },
+    )
+
+    assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
+    assert response.json()["data"]["rule"] == "public_mode_live_trading_blocked"
+    mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -217,6 +273,13 @@ async def test_place_overseas_real_order_requires_allow_live_trading(web_client,
     """실전 해외주문은 allow_live_trading=False이면 정책 차단 응답을 반환한다."""
     mock_web_ctx.market_mode = "overseas_us"
     mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": False,
+        "allow_live_trading": True,
+    }
+    mock_web_ctx.full_config["overseas_stock"] = {
+        "allow_live_trading": False,
+    }
 
     payload = {
         "symbol": "AAPL",
@@ -269,6 +332,7 @@ async def test_place_overseas_real_order_requires_confirmation_when_live_allowed
     mock_web_ctx.env.is_paper_trading = False
     mock_web_ctx.full_config = SimpleNamespace(
         auth=SimpleNamespace(secret_key="secret"),
+        deployment=SimpleNamespace(public_mode=False, allow_live_trading=True),
         overseas_stock=SimpleNamespace(
             allow_live_trading=True,
             enabled_exchanges=["NASD", "NYSE", "AMEX"],
@@ -340,6 +404,13 @@ async def test_cancel_overseas_real_order_requires_allow_live_trading(web_client
     """실전 해외주문 취소도 allow_live_trading=False이면 정책 차단 응답을 반환한다."""
     mock_web_ctx.market_mode = "overseas_us"
     mock_web_ctx.env.is_paper_trading = False
+    mock_web_ctx.full_config["deployment"] = {
+        "public_mode": False,
+        "allow_live_trading": True,
+    }
+    mock_web_ctx.full_config["overseas_stock"] = {
+        "allow_live_trading": False,
+    }
 
     payload = {
         "symbol": "AAPL",

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -246,6 +246,24 @@ def test_get_operations_status_pnl_breakdown(web_client, mock_web_ctx):
     assert pnl["day"]["baseline_date"] == "2026-04-29"
 
 
+def test_public_mode_masks_operations_financial_values(web_client, mock_web_ctx):
+    mock_web_ctx.full_config["deployment"] = {"public_mode": True}
+    mock_web_ctx.account_snapshot_cache = MagicMock()
+    mock_web_ctx.account_snapshot_cache._snapshot = AccountSnapshot(
+        total_equity=10_000_000,
+        available_cash=3_000_000,
+        positions={"005930": 4_000_000},
+        fetched_at=datetime(2026, 4, 30, 15, 30),
+    )
+
+    response = web_client.get("/api/system/operations/status")
+
+    evaluation = response.json()["data"]["pnl"]["evaluation"]
+    assert evaluation["broker_total_equity"] is None
+    assert evaluation["available_cash"] is None
+    assert evaluation["position_eval_amount"] is None
+
+
 def test_get_operations_status_includes_after_market_reconcile(web_client, mock_web_ctx):
     task = MagicMock()
     task.get_progress.return_value = {
@@ -315,6 +333,19 @@ def test_shutdown_server_schedules_termination(web_client, mock_web_ctx, monkeyp
     body = response.json()
     assert body["success"] is True
     assert called.get("hit") is True
+
+
+def test_public_mode_blocks_shutdown(web_client, mock_web_ctx, monkeypatch):
+    from view.web.routes import system
+
+    mock_web_ctx.full_config["deployment"] = {"public_mode": True}
+    called = {}
+    monkeypatch.setattr(system, "_schedule_shutdown", lambda *a, **k: called.setdefault("hit", True))
+
+    response = web_client.post("/api/system/shutdown")
+
+    assert response.status_code == 403
+    assert called == {}
 
 
 def test_terminate_process_falls_back_to_os_exit(monkeypatch):
@@ -871,6 +902,19 @@ async def test_force_ranking_update_success(web_client, mock_web_ctx):
     # 백그라운드 Task가 실행될 수 있도록 제어권 양보
     await asyncio.sleep(0)
     mock_task.force_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_public_mode_blocks_force_update(web_client, mock_web_ctx):
+    mock_web_ctx.full_config["deployment"] = {"public_mode": True}
+    mock_web_ctx.ranking_task = MagicMock()
+    mock_web_ctx.ranking_task.force_run = AsyncMock()
+
+    response = web_client.post("/api/background/ranking/force-update")
+
+    assert response.status_code == 403
+    mock_web_ctx.ranking_task.force_run.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_force_ranking_update_running(web_client, mock_web_ctx):

--- a/tests/unit_test/view/web/test_data_masking.py
+++ b/tests/unit_test/view/web/test_data_masking.py
@@ -1,0 +1,54 @@
+import logging
+
+from core.loggers.sensitive_data_filter import SensitiveDataFilter
+from view.web.data_masking import mask_sensitive_data, redact_sensitive_text
+
+
+def test_mask_sensitive_data_redacts_nested_values_without_mutating_source():
+    source = {
+        "account_info": {"number": "1234567890"},
+        "data": {
+            "tot_evlu_amt": "1000000",
+            "available_cash": 500000,
+            "ord_no": "0000123456",
+            "api_key": "top-secret",
+            "positions": [{"code": "005930", "qty": 2}],
+        },
+    }
+
+    masked = mask_sensitive_data(source)
+
+    assert masked["account_info"]["number"] == "******7890"
+    assert masked["data"]["tot_evlu_amt"] is None
+    assert masked["data"]["available_cash"] is None
+    assert masked["data"]["ord_no"] == "******3456"
+    assert masked["data"]["api_key"] == "[REDACTED]"
+    assert masked["data"]["positions"][0]["code"] == "005930"
+    assert source["data"]["tot_evlu_amt"] == "1000000"
+    assert source["data"]["api_key"] == "top-secret"
+
+
+def test_redact_sensitive_text_removes_named_secrets():
+    text = 'api_key="abc123" access_token=token-value password: hunter2'
+
+    redacted = redact_sensitive_text(text)
+
+    assert "abc123" not in redacted
+    assert "token-value" not in redacted
+    assert "hunter2" not in redacted
+    assert redacted.count("[REDACTED]") == 3
+
+
+def test_sensitive_data_log_filter_redacts_formatted_arguments():
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="access_token=%s",
+        args=("token-value",),
+        exc_info=None,
+    )
+
+    assert SensitiveDataFilter().filter(record) is True
+    assert record.getMessage() == "access_token=[REDACTED]"

--- a/tests/unit_test/view/web/test_security.py
+++ b/tests/unit_test/view/web/test_security.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+
+import pytest
+
+from view.web import security
+from view.web.deployment_policy import is_public_operation_blocked
+
+
+@pytest.fixture(autouse=True)
+def reset_security_state():
+    security.reset_security_state()
+    yield
+    security.reset_security_state()
+
+
+def _auth_config(**overrides):
+    config = {
+        "secret_key": "signing-key",
+        "session_max_age_seconds": 3600,
+        "login_max_failures": 3,
+        "login_lockout_seconds": 60,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_password_hash_round_trip_and_plaintext_rejection():
+    encoded = security.hash_password("correct horse")
+
+    assert encoded.startswith("pbkdf2_sha256$")
+    assert security.verify_password("correct horse", encoded) is True
+    assert security.verify_password("wrong", encoded) is False
+    assert security.verify_password("correct horse", "correct horse") is False
+
+
+def test_signed_session_rejects_tampering_and_expiration():
+    token, claims = security.issue_session(_auth_config(), "operator")
+
+    assert token != "signing-key"
+    assert security.verify_session(token, _auth_config()).username == "operator"
+    assert security.verify_session(token + "tampered", _auth_config()) is None
+    assert security.verify_session(
+        token,
+        _auth_config(session_max_age_seconds=-1),
+    ) is None
+    assert claims.csrf_token
+
+
+def test_revoked_session_is_rejected():
+    token, claims = security.issue_session(_auth_config(), "operator")
+
+    security.revoke_session(claims.session_id)
+
+    assert security.verify_session(token, _auth_config()) is None
+
+
+def test_csrf_requires_session_cookie_header_match():
+    token, claims = security.issue_session(_auth_config(), "operator")
+    connection = SimpleNamespace(
+        cookies={
+            security.SESSION_COOKIE_NAME: token,
+            security.CSRF_COOKIE_NAME: claims.csrf_token,
+        },
+        headers={security.CSRF_HEADER_NAME: claims.csrf_token},
+    )
+
+    assert security.verify_csrf(connection, claims) is True
+
+    connection.headers = {security.CSRF_HEADER_NAME: "wrong"}
+    assert security.verify_csrf(connection, claims) is False
+
+
+def test_login_attempt_limiter_locks_and_resets(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(security.time, "monotonic", lambda: now[0])
+    limiter = security.LoginAttemptLimiter()
+    config = _auth_config(login_max_failures=2, login_lockout_seconds=30)
+    key = ("127.0.0.1", "operator")
+
+    assert limiter.is_blocked(key, config) is False
+    limiter.record_failure(key, config)
+    limiter.record_failure(key, config)
+    assert limiter.is_blocked(key, config) is True
+
+    now[0] += 31
+    assert limiter.is_blocked(key, config) is False
+    limiter.record_failure(key, config)
+    limiter.record_success(key)
+    assert limiter.is_blocked(key, config) is False
+
+
+def test_public_mode_blocks_position_sizing_limits_read():
+    ctx = SimpleNamespace(
+        full_config={"deployment": {"public_mode": True}},
+    )
+
+    assert is_public_operation_blocked(
+        ctx,
+        "/api/position-sizing/limits",
+        "GET",
+    ) is True

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -364,6 +364,22 @@ def test_start_background_tasks_does_not_duplicate_price_subscription_init(mock_
     mock_create_task.assert_not_called()
 
 
+def test_public_mode_does_not_start_background_tasks(mock_deps):
+    ctx = WebAppContext(None)
+    ctx.full_config = {"deployment": {"public_mode": True}}
+    ctx.background_scheduler = MagicMock()
+    ctx.background_scheduler.start_all = AsyncMock()
+    ctx.streaming_service = MagicMock()
+    ctx.price_subscription_service = MagicMock()
+
+    with patch("view.web.web_app_initializer.asyncio.create_task") as mock_create_task:
+        ctx.start_background_tasks()
+
+    mock_create_task.assert_not_called()
+    ctx.background_scheduler.start_all.assert_not_awaited()
+    assert ctx.streaming_service._callback != ctx._web_realtime_callback
+
+
 def test_web_realtime_callback(mock_deps):
     """웹소켓 콜백 처리 테스트"""
     ctx = WebAppContext(None)

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock
+from view.web.security import SESSION_COOKIE_NAME, issue_session
 
 # 페이지별 라우트와 예상되는 active_page 값 매핑
 PAGES = [
@@ -142,10 +143,12 @@ def test_balance_page_authenticates_before_account_lookup(web_client, mock_web_c
 def test_pages_render_success_with_login(web_client, mock_web_ctx):
     """로그인 기능 활성화 시 올바른 토큰으로 접근하면 페이지가 렌더링되는지 테스트"""
     # 로그인 활성화 설정
-    mock_web_ctx.full_config = {"use_login": True, "auth": {"secret_key": "secret_token"}}
-    
+    auth_config = {"secret_key": "secret_token", "session_max_age_seconds": 3600}
+    mock_web_ctx.full_config = {"use_login": True, "auth": auth_config}
+
     # 올바른 쿠키 설정
-    web_client.cookies.set("access_token", "secret_token")
+    token, _ = issue_session(auth_config, "test-operator")
+    web_client.cookies.set(SESSION_COOKIE_NAME, token)
     
     for path, _ in PAGES:
         response = web_client.get(path)

--- a/tests/web_auth_helpers.py
+++ b/tests/web_auth_helpers.py
@@ -1,0 +1,29 @@
+"""웹 통합 테스트용 서명 세션 클라이언트 옵션."""
+from view.web.security import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    SESSION_COOKIE_NAME,
+    issue_session,
+)
+
+
+def authenticated_client_options(ctx):
+    full_config = ctx.full_config
+    auth_config = (
+        full_config.get("auth", {})
+        if isinstance(full_config, dict)
+        else getattr(full_config, "auth", None)
+    )
+    username = (
+        auth_config.get("username", "test-operator")
+        if isinstance(auth_config, dict)
+        else getattr(auth_config, "username", None) or "test-operator"
+    )
+    token, claims = issue_session(auth_config, username)
+    return {
+        "cookies": {
+            SESSION_COOKIE_NAME: token,
+            CSRF_COOKIE_NAME: claims.csrf_token,
+        },
+        "headers": {CSRF_HEADER_NAME: claims.csrf_token},
+    }

--- a/view/web/api_common.py
+++ b/view/web/api_common.py
@@ -1,11 +1,10 @@
 """
 웹 API 공통 유틸리티: 컨텍스트 관리, 응답 직렬화, 인증, Pydantic 모델.
 """
-import secrets
-
 from fastapi import HTTPException, WebSocketException, status
 from pydantic import BaseModel
 from starlette.requests import HTTPConnection
+from view.web import security
 
 _ctx = None  # 전역 변수로 선언
 
@@ -47,15 +46,20 @@ def get_auth_value(key: str, default=None, *, ctx=None):
     return _config_get(auth_config, key, default)
 
 
-def is_authenticated(connection: HTTPConnection, *, ctx=None) -> bool:
-    expected_token = get_auth_value("secret_key", ctx=ctx)
-    token = connection.cookies.get("access_token")
+def get_auth_config(*, ctx=None):
+    if ctx is None:
+        ctx = _get_ctx()
+    return _config_get(ctx.full_config, "auth", {})
 
-    if not isinstance(expected_token, str) or not expected_token:
-        return False
-    if not isinstance(token, str) or not token:
-        return False
-    return secrets.compare_digest(token, expected_token)
+
+def get_session_claims(connection: HTTPConnection, *, ctx=None):
+    auth_config = get_auth_config(ctx=ctx)
+    token = connection.cookies.get(security.SESSION_COOKIE_NAME)
+    return security.verify_session(token, auth_config)
+
+
+def is_authenticated(connection: HTTPConnection, *, ctx=None) -> bool:
+    return get_session_claims(connection, ctx=ctx) is not None
 
 
 def check_auth(connection: HTTPConnection):
@@ -70,20 +74,66 @@ def check_auth(connection: HTTPConnection):
 
 def get_authenticated_operator(connection: HTTPConnection) -> str:
     """감사 로그에 토큰 원문 대신 비민감 운영자 식별자를 반환한다."""
-    check_auth(connection)
-    username = get_auth_value("username")
-    if isinstance(username, str) and username:
-        return username
-    return "authenticated-user"
+    claims = get_session_claims(connection)
+    if claims is None:
+        check_auth(connection)
+    return claims.username
+
+
+def check_csrf(connection: HTTPConnection) -> bool:
+    """상태 변경 요청의 세션 결합 CSRF 토큰을 검증한다."""
+    claims = get_session_claims(connection)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if not security.verify_csrf(connection, claims):
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
+    return True
+
+
+def check_csrf_for_unsafe_request(connection: HTTPConnection) -> bool:
+    """HTTP 상태 변경 메서드에만 CSRF 검증을 적용한다."""
+    scope = getattr(connection, "scope", {})
+    if not isinstance(scope, dict) or scope.get("type") != "http":
+        return True
+    if scope.get("method", "GET").upper() in {"POST", "PUT", "PATCH", "DELETE"}:
+        return check_csrf(connection)
+    return True
+
+
+def check_public_operation_allowed(connection: HTTPConnection) -> bool:
+    from view.web.deployment_policy import is_public_operation_blocked
+
+    scope = getattr(connection, "scope", {})
+    if not isinstance(scope, dict):
+        return True
+    if is_public_operation_blocked(
+        _get_ctx(),
+        str(scope.get("path", "")),
+        str(scope.get("method", "GET")),
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="공개 모드에서는 이 운영 작업을 실행할 수 없습니다.",
+        )
+    return True
 
 
 def _serialize_response(resp):
     """ResCommonResponse를 JSON 직렬화 가능한 dict로 변환."""
     if resp is None:
-        return {"rt_cd": "999", "msg1": "응답 없음", "data": None}
-    if hasattr(resp, 'to_dict'):
-        return resp.to_dict()
-    return {"rt_cd": str(resp.rt_cd), "msg1": str(resp.msg1), "data": resp.data}
+        result = {"rt_cd": "999", "msg1": "응답 없음", "data": None}
+    elif hasattr(resp, 'to_dict'):
+        result = resp.to_dict()
+    else:
+        result = {"rt_cd": str(resp.rt_cd), "msg1": str(resp.msg1), "data": resp.data}
+
+    if _ctx is not None:
+        from view.web.data_masking import mask_sensitive_data
+        from view.web.deployment_policy import is_public_mode
+
+        if is_public_mode(_ctx):
+            return mask_sensitive_data(result)
+    return result
 
 
 def _serialize_list_items(items):

--- a/view/web/data_masking.py
+++ b/view/web/data_masking.py
@@ -1,0 +1,81 @@
+"""공개 응답과 로그의 민감정보 마스킹."""
+from __future__ import annotations
+
+from core.loggers.sensitive_data_filter import redact_sensitive_text
+
+_SECRET_PARTS = (
+    "api_key",
+    "api_secret",
+    "secret_key",
+    "access_token",
+    "refresh_token",
+    "password",
+    "authorization",
+)
+_ACCOUNT_KEYS = {
+    "account_number",
+    "stock_account_number",
+    "paper_stock_account_number",
+    "cano",
+    "acnt_no",
+}
+_ORDER_KEYS = {
+    "ord_no",
+    "order_no",
+    "odno",
+    "execution_no",
+    "fill_no",
+}
+_MONEY_PARTS = (
+    "amount",
+    "cash",
+    "asset",
+    "equity",
+    "evlu",
+    "_amt",
+    "pnl_won",
+    "평가금액",
+    "총자산",
+    "현금",
+)
+
+def _mask_identifier(value) -> str:
+    text = str(value)
+    if len(text) <= 4:
+        return text
+    return "*" * (len(text) - 4) + text[-4:]
+
+
+def _is_secret_key(key: str) -> bool:
+    return any(part in key for part in _SECRET_PARTS)
+
+
+def _is_money_key(key: str) -> bool:
+    return any(part in key for part in _MONEY_PARTS)
+
+
+def mask_sensitive_data(value, *, parent_key: str = ""):
+    """중첩 응답을 복사하면서 공개 가능한 형태로 변환한다."""
+    if isinstance(value, dict):
+        result = {}
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            normalized = key.lower()
+            if _is_secret_key(normalized):
+                result[raw_key] = "[REDACTED]"
+            elif normalized in _ACCOUNT_KEYS or (
+                parent_key == "account_info" and normalized == "number"
+            ):
+                result[raw_key] = _mask_identifier(item)
+            elif normalized in _ORDER_KEYS:
+                result[raw_key] = _mask_identifier(item)
+            elif _is_money_key(normalized):
+                result[raw_key] = None
+            else:
+                result[raw_key] = mask_sensitive_data(item, parent_key=normalized)
+        return result
+    if isinstance(value, list):
+        return [mask_sensitive_data(item, parent_key=parent_key) for item in value]
+    if isinstance(value, tuple):
+        return tuple(mask_sensitive_data(item, parent_key=parent_key) for item in value)
+    return value

--- a/view/web/deployment_policy.py
+++ b/view/web/deployment_policy.py
@@ -1,0 +1,90 @@
+"""외부 공개 모드와 실전 주문 master gate 정책."""
+from __future__ import annotations
+
+
+def _config_get(config, key: str, default=None):
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+config_value = _config_get
+
+
+def config_section(ctx, name: str):
+    return _config_get(getattr(ctx, "full_config", None), name, None)
+
+
+def is_public_mode(ctx) -> bool:
+    deployment = config_section(ctx, "deployment")
+    return _config_get(deployment, "public_mode", False) is True
+
+
+def is_host_allowed(ctx, host_header: str) -> bool:
+    if not is_public_mode(ctx):
+        return True
+
+    host = host_header.strip().lower().rstrip(".")
+    if host.startswith("["):
+        closing_bracket = host.find("]")
+        host = host[1:closing_bracket] if closing_bracket >= 0 else ""
+    elif ":" in host:
+        candidate, port = host.rsplit(":", 1)
+        if port.isdigit():
+            host = candidate
+
+    deployment = config_section(ctx, "deployment")
+    allowed_hosts = _config_get(deployment, "allowed_hosts", [])
+    normalized = {
+        str(allowed).strip().lower().rstrip(".")
+        for allowed in allowed_hosts
+        if str(allowed).strip()
+    }
+    return host in normalized
+
+
+def live_trading_block(ctx, *, require_legacy_overseas_gate: bool = False):
+    """실전 주문 차단 시 ``(rule, message)``를, 허용 시 ``None``을 반환한다."""
+    deployment = config_section(ctx, "deployment")
+    if bool(_config_get(deployment, "public_mode", False)):
+        return (
+            "public_mode_live_trading_blocked",
+            "공개 모드에서는 실전 주문이 차단됩니다.",
+        )
+    if not bool(_config_get(deployment, "allow_live_trading", False)):
+        return (
+            "global_live_trading_disabled",
+            "실전 주문은 deployment.allow_live_trading=true 설정 전까지 차단됩니다.",
+        )
+    if require_legacy_overseas_gate:
+        overseas = config_section(ctx, "overseas_stock")
+        if not bool(_config_get(overseas, "allow_live_trading", False)):
+            return (
+                "overseas_live_trading_disabled",
+                "해외 설정 마이그레이션 중에는 overseas_stock.allow_live_trading=true도 필요합니다.",
+            )
+    return None
+
+
+def is_public_operation_blocked(ctx, path: str, method: str) -> bool:
+    if not is_public_mode(ctx):
+        return False
+    method = method.upper()
+    if path == "/api/position-sizing/limits":
+        return True
+    if method not in {"POST", "PUT", "PATCH", "DELETE"}:
+        return False
+    if path in {"/api/system/shutdown", "/api/system/restart"}:
+        return True
+    if path.endswith("/force-update"):
+        return True
+    return any(
+        path.startswith(prefix)
+        for prefix in (
+            "/api/scheduler/",
+            "/api/position-sizing/limits",
+            "/api/kill-switch/",
+        )
+    )

--- a/view/web/routes/__init__.py
+++ b/view/web/routes/__init__.py
@@ -3,7 +3,11 @@
 각 페이지별 라우터를 하나의 router로 결합하여 export.
 """
 from fastapi import APIRouter, Depends
-from view.web.api_common import check_auth
+from view.web.api_common import (
+    check_auth,
+    check_csrf_for_unsafe_request,
+    check_public_operation_allowed,
+)
 
 from view.web.routes.auth import router as auth_router
 from view.web.routes.stock import router as stock_router
@@ -24,7 +28,13 @@ from view.web.routes.operator_dashboard import router as operator_dashboard_rout
 from view.web.routes.ai import router as ai_router
 
 router = APIRouter(prefix="/api")
-protected_router = APIRouter(dependencies=[Depends(check_auth)])
+protected_router = APIRouter(
+    dependencies=[
+        Depends(check_auth),
+        Depends(check_csrf_for_unsafe_request),
+        Depends(check_public_operation_allowed),
+    ]
+)
 
 router.include_router(auth_router)
 protected_router.include_router(stock_router)

--- a/view/web/routes/auth.py
+++ b/view/web/routes/auth.py
@@ -1,36 +1,70 @@
-"""
-인증 관련 API 엔드포인트 (login.html).
-"""
-from fastapi import APIRouter, Form, Response
+"""인증 관련 API 엔드포인트 (login.html)."""
+import secrets
+
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import JSONResponse
-from view.web.api_common import get_auth_value
+
+from view.web.api_common import get_auth_config, _config_get, _get_ctx
+from view.web.deployment_policy import is_public_mode
+from view.web.security import (
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    issue_session,
+    login_attempt_limiter,
+    verify_password,
+)
 
 router = APIRouter()
 
 
 @router.post("/auth/login")
-async def login(response: Response, username: str = Form(...), password: str = Form(...)):
-    expected_username = get_auth_value("username")
-    expected_password = get_auth_value("password")
-    secret_key = get_auth_value("secret_key")
+async def login(request: Request, username: str = Form(...), password: str = Form(...)):
+    auth_config = get_auth_config()
+    expected_username = _config_get(auth_config, "username")
+    password_hash = _config_get(auth_config, "password_hash")
+    secret_key = _config_get(auth_config, "secret_key")
+    client_ip = request.client.host if request.client else "unknown"
+    attempt_key = (client_ip, username)
+
+    if login_attempt_limiter.is_blocked(attempt_key, auth_config):
+        return JSONResponse(
+            content={"success": False, "msg": "로그인을 처리할 수 없습니다. 잠시 후 다시 시도하세요."},
+            status_code=429,
+        )
 
     credentials_configured = all(
         isinstance(value, str) and bool(value)
-        for value in (expected_username, expected_password, secret_key)
+        for value in (expected_username, password_hash, secret_key)
     )
-    if (
-        credentials_configured
-        and username == expected_username
-        and password == expected_password
-    ):
+    username_matches = (
+        isinstance(expected_username, str)
+        and secrets.compare_digest(username, expected_username)
+    )
+    if credentials_configured and username_matches and verify_password(password, password_hash):
+        login_attempt_limiter.record_success(attempt_key)
+        token, claims = issue_session(auth_config, expected_username)
+        max_age = int(_config_get(auth_config, "session_max_age_seconds", 3600))
+        secure_cookie = bool(_config_get(auth_config, "secure_cookie", False)) or is_public_mode(_get_ctx())
         response = JSONResponse(content={"success": True})
-        # 쿠키 설정
         response.set_cookie(
-            key="access_token",
-            value=secret_key,
+            key=SESSION_COOKIE_NAME,
+            value=token,
+            max_age=max_age,
             httponly=True,
-            samesite="lax" # 로컬 테스트 시 안정성 위함
+            secure=secure_cookie,
+            samesite="strict",
+            path="/",
+        )
+        response.set_cookie(
+            key=CSRF_COOKIE_NAME,
+            value=claims.csrf_token,
+            max_age=max_age,
+            httponly=False,
+            secure=secure_cookie,
+            samesite="strict",
+            path="/",
         )
         return response
 
+    login_attempt_limiter.record_failure(attempt_key, auth_config)
     return JSONResponse(content={"success": False, "msg": "아이디 또는 비밀번호가 틀렸습니다."}, status_code=401)

--- a/view/web/routes/balance.py
+++ b/view/web/routes/balance.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, Query, HTTPException
 from common.overseas_types import OverseasExchange
 from common.types import Exchange
 from view.web.api_common import _get_ctx, _serialize_response
+from view.web.data_masking import mask_sensitive_data
+from view.web.deployment_policy import is_public_mode
 from view.web.market_mode_utils import enabled_market_modes_of, is_market_enabled, market_mode_of
 
 router = APIRouter()
@@ -68,6 +70,8 @@ async def get_balance(exchange: str = Query("KRX")):
             "exchange": exchange_enum.value,
         }
 
+    if is_public_mode(ctx):
+        result = mask_sensitive_data(result)
     ctx.pm.log_timer("get_balance", t_start)
     return result
 

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -6,6 +6,7 @@ from fastapi import Query
 from common.overseas_types import OverseasOrderRequest, OverseasCancelRequest
 from common.types import ErrorCode, ResCommonResponse
 from view.web.api_common import _get_ctx, _serialize_response, OrderRequest
+from view.web.deployment_policy import config_section, config_value, live_trading_block
 from view.web.market_mode_utils import is_market_enabled
 
 router = APIRouter()
@@ -16,14 +17,35 @@ def _is_real_trading_mode(ctx) -> bool:
     return not bool(getattr(env, "is_paper_trading", True))
 
 
+def _live_trading_block_response(ctx, *, overseas: bool = False):
+    blocked = live_trading_block(
+        ctx,
+        require_legacy_overseas_gate=overseas,
+    )
+    if blocked is None:
+        return None
+    rule, message = blocked
+    return _serialize_response(
+        ResCommonResponse(
+            rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
+            msg1=message,
+            data={"rule": rule},
+        )
+    )
+
+
 @router.post("/order")
 async def place_order(req: OrderRequest):
     """매수/매도 주문. 가상 매매 기록은 실제 체결 확인 후 OrderExecutionService가 처리한다."""
     ctx = _get_ctx()
     t_start = ctx.pm.start_timer()
 
-    if _is_real_trading_mode(ctx) and req.real_order_confirmation != "REAL":
-        raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
+    if _is_real_trading_mode(ctx):
+        blocked_response = _live_trading_block_response(ctx)
+        if blocked_response is not None:
+            return blocked_response
+        if req.real_order_confirmation != "REAL":
+            raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
 
     # 1. 실제/모의 투자 주문 전송
     if req.side == "buy":
@@ -56,21 +78,16 @@ async def place_overseas_order(req: OverseasOrderRequest):
     if not is_market_enabled(ctx, "overseas_us"):
         raise HTTPException(status_code=400, detail="해외주식 주문은 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
 
-    cfg = getattr(getattr(ctx, "full_config", None), "overseas_stock", None)
-    enabled_exchanges = set(getattr(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
+    cfg = config_section(ctx, "overseas_stock")
+    enabled_exchanges = set(config_value(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
     if req.exchange.value not in enabled_exchanges:
         raise HTTPException(status_code=400, detail="활성화되지 않은 해외 거래소입니다.")
     if req.currency != "USD":
         raise HTTPException(status_code=400, detail="v1은 USD 주문만 지원합니다.")
     if _is_real_trading_mode(ctx):
-        if not bool(getattr(cfg, "allow_live_trading", False)):
-            return _serialize_response(
-                ResCommonResponse(
-                    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
-                    msg1="실전 해외주식 주문은 overseas_stock.allow_live_trading=true 설정 전까지 차단됩니다.",
-                    data={"rule": "overseas_live_trading_disabled"},
-                )
-            )
+        blocked_response = _live_trading_block_response(ctx, overseas=True)
+        if blocked_response is not None:
+            return blocked_response
         if req.real_order_confirmation != "REAL":
             raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
 
@@ -91,19 +108,14 @@ async def cancel_overseas_order(req: OverseasCancelRequest):
     if not is_market_enabled(ctx, "overseas_us"):
         raise HTTPException(status_code=400, detail="해외주식 주문 취소는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
 
-    cfg = getattr(getattr(ctx, "full_config", None), "overseas_stock", None)
-    enabled_exchanges = set(getattr(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
+    cfg = config_section(ctx, "overseas_stock")
+    enabled_exchanges = set(config_value(cfg, "enabled_exchanges", ["NASD", "NYSE", "AMEX"]))
     if req.exchange.value not in enabled_exchanges:
         raise HTTPException(status_code=400, detail="활성화되지 않은 해외 거래소입니다.")
     if _is_real_trading_mode(ctx):
-        if not bool(getattr(cfg, "allow_live_trading", False)):
-            return _serialize_response(
-                ResCommonResponse(
-                    rt_cd=ErrorCode.ORDER_POLICY_BLOCKED.value,
-                    msg1="실전 해외주식 주문 취소는 overseas_stock.allow_live_trading=true 설정 전까지 차단됩니다.",
-                    data={"rule": "overseas_live_trading_disabled"},
-                )
-            )
+        blocked_response = _live_trading_block_response(ctx, overseas=True)
+        if blocked_response is not None:
+            return blocked_response
         if req.real_order_confirmation != "REAL":
             raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
 

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -228,7 +228,7 @@ def get_operations_status():
         except Exception:
             api_budget = None
 
-    return {
+    result = {
         "success": True,
         "data": {
             "active_strategy_count": active_strategy_count,
@@ -244,6 +244,10 @@ def get_operations_status():
             "api_budget": api_budget,
         },
     }
+    from view.web.data_masking import mask_sensitive_data
+    from view.web.deployment_policy import is_public_mode
+
+    return mask_sensitive_data(result) if is_public_mode(ctx) else result
 
 
 def _to_float(value, default: float = 0.0) -> float:

--- a/view/web/security.py
+++ b/view/web/security.py
@@ -1,0 +1,196 @@
+"""웹 인증의 비밀번호, 세션, CSRF, 로그인 제한 primitives."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import time
+from dataclasses import dataclass
+
+from itsdangerous import BadData, URLSafeTimedSerializer
+
+SESSION_COOKIE_NAME = "access_token"
+CSRF_COOKIE_NAME = "csrf_token"
+CSRF_HEADER_NAME = "X-CSRF-Token"
+
+_SESSION_SALT = "investment.web.session.v1"
+_PASSWORD_SCHEME = "pbkdf2_sha256"
+_PASSWORD_ITERATIONS = 310_000
+
+
+def _config_get(config, key: str, default=None):
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def hash_password(password: str, *, iterations: int = _PASSWORD_ITERATIONS) -> str:
+    """PBKDF2-SHA256 형식으로 비밀번호를 해시한다."""
+    if not isinstance(password, str) or not password:
+        raise ValueError("password must be a non-empty string")
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        iterations,
+    )
+    return f"{_PASSWORD_SCHEME}${iterations}${_b64encode(salt)}${_b64encode(digest)}"
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    """지원하는 해시 형식만 검증하며 평문 설정은 허용하지 않는다."""
+    if not isinstance(password, str) or not isinstance(encoded, str):
+        return False
+    try:
+        scheme, raw_iterations, raw_salt, raw_digest = encoded.split("$", 3)
+        if scheme != _PASSWORD_SCHEME:
+            return False
+        iterations = int(raw_iterations)
+        salt = _b64decode(raw_salt)
+        expected = _b64decode(raw_digest)
+    except (TypeError, ValueError):
+        return False
+    actual = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        iterations,
+    )
+    return hmac.compare_digest(actual, expected)
+
+
+@dataclass(frozen=True)
+class SessionClaims:
+    username: str
+    session_id: str
+    csrf_token: str
+
+
+_active_sessions: dict[str, float] = {}
+
+
+def _serializer(auth_config) -> URLSafeTimedSerializer | None:
+    secret_key = _config_get(auth_config, "secret_key")
+    if not isinstance(secret_key, str) or not secret_key:
+        return None
+    return URLSafeTimedSerializer(secret_key=secret_key, salt=_SESSION_SALT)
+
+
+def issue_session(auth_config, username: str) -> tuple[str, SessionClaims]:
+    """서명 세션을 발급하고 현재 프로세스의 활성 세션으로 등록한다."""
+    serializer = _serializer(auth_config)
+    if serializer is None:
+        raise ValueError("auth.secret_key is required")
+    max_age = int(_config_get(auth_config, "session_max_age_seconds", 3600))
+    if max_age <= 0:
+        raise ValueError("session_max_age_seconds must be positive")
+
+    claims = SessionClaims(
+        username=username,
+        session_id=secrets.token_urlsafe(24),
+        csrf_token=secrets.token_urlsafe(32),
+    )
+    token = serializer.dumps(
+        {
+            "sub": claims.username,
+            "sid": claims.session_id,
+            "csrf": claims.csrf_token,
+        }
+    )
+    _active_sessions[claims.session_id] = time.time() + max_age
+    return token, claims
+
+
+def verify_session(token: str | None, auth_config) -> SessionClaims | None:
+    """세션 서명·만료·활성 상태를 모두 검증한다."""
+    serializer = _serializer(auth_config)
+    if serializer is None or not isinstance(token, str) or not token:
+        return None
+    try:
+        max_age = int(_config_get(auth_config, "session_max_age_seconds", 3600))
+        payload = serializer.loads(token, max_age=max_age)
+        claims = SessionClaims(
+            username=payload["sub"],
+            session_id=payload["sid"],
+            csrf_token=payload["csrf"],
+        )
+    except (BadData, KeyError, TypeError, ValueError):
+        return None
+
+    expires_at = _active_sessions.get(claims.session_id)
+    if expires_at is None or expires_at <= time.time():
+        _active_sessions.pop(claims.session_id, None)
+        return None
+    return claims
+
+
+def revoke_session(session_id: str) -> None:
+    _active_sessions.pop(session_id, None)
+
+
+def verify_csrf(connection, claims: SessionClaims) -> bool:
+    cookie_token = connection.cookies.get(CSRF_COOKIE_NAME)
+    header_token = connection.headers.get(CSRF_HEADER_NAME)
+    if not isinstance(cookie_token, str) or not isinstance(header_token, str):
+        return False
+    return (
+        secrets.compare_digest(cookie_token, claims.csrf_token)
+        and secrets.compare_digest(header_token, claims.csrf_token)
+    )
+
+
+class LoginAttemptLimiter:
+    """프로세스 내 IP·사용자 조합별 로그인 실패 제한."""
+
+    def __init__(self) -> None:
+        self._attempts: dict[tuple[str, str], tuple[int, float]] = {}
+
+    def is_blocked(self, key: tuple[str, str], auth_config) -> bool:
+        count, locked_until = self._attempts.get(key, (0, 0.0))
+        now = time.monotonic()
+        if locked_until > now:
+            return True
+        if locked_until:
+            self._attempts.pop(key, None)
+        return False
+
+    def record_failure(self, key: tuple[str, str], auth_config) -> None:
+        max_failures = max(1, int(_config_get(auth_config, "login_max_failures", 5)))
+        lockout_seconds = max(
+            1,
+            int(_config_get(auth_config, "login_lockout_seconds", 60)),
+        )
+        count, locked_until = self._attempts.get(key, (0, 0.0))
+        if locked_until and locked_until <= time.monotonic():
+            count = 0
+        count += 1
+        if count >= max_failures:
+            locked_until = time.monotonic() + lockout_seconds
+        self._attempts[key] = (count, locked_until)
+
+    def record_success(self, key: tuple[str, str]) -> None:
+        self._attempts.pop(key, None)
+
+    def clear(self) -> None:
+        self._attempts.clear()
+
+
+login_attempt_limiter = LoginAttemptLimiter()
+
+
+def reset_security_state() -> None:
+    """테스트와 프로세스 재초기화를 위한 메모리 상태 초기화."""
+    _active_sessions.clear()
+    login_attempt_limiter.clear()

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -1,5 +1,35 @@
 /* view/web/static/js/common.js — 공통 유틸리티, 상태 갱신, 환경 전환 */
 
+const nativeFetch = window.fetch.bind(window);
+const csrfProtectedMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function readCookie(name) {
+    const prefix = `${encodeURIComponent(name)}=`;
+    const item = document.cookie.split('; ').find(part => part.startsWith(prefix));
+    return item ? decodeURIComponent(item.slice(prefix.length)) : null;
+}
+
+window.fetch = function csrfFetch(input, options = {}) {
+    const isRequest = typeof Request !== 'undefined' && input instanceof Request;
+    const requestMethod = isRequest ? input.method : 'GET';
+    const method = String(options.method || requestMethod).toUpperCase();
+    const requestUrl = isRequest ? input.url : String(input);
+    const isSameOrigin = new URL(requestUrl, window.location.href).origin === window.location.origin;
+
+    if (isSameOrigin && csrfProtectedMethods.has(method)) {
+        const csrfToken = readCookie('csrf_token');
+        if (csrfToken) {
+            const sourceHeaders = options.headers || (isRequest ? input.headers : undefined);
+            const headers = new Headers(sourceHeaders);
+            if (!headers.has('X-CSRF-Token')) {
+                headers.set('X-CSRF-Token', csrfToken);
+            }
+            options = { ...options, headers };
+        }
+    }
+    return nativeFetch(input, options);
+};
+
 // ==========================================
 // 유틸리티 함수
 // ==========================================

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -404,6 +404,12 @@ class WebAppContext:
 
     def start_background_tasks(self):
         """백그라운드 태스크 시작 — BackgroundScheduler에 위임."""
+        from view.web.deployment_policy import is_public_mode
+
+        if is_public_mode(self):
+            self.logger.info("공개 모드: 백그라운드 태스크 시작을 건너뜁니다.")
+            return
+
         # StreamingService에 콜백 등록 (내부 저장 → 재연결 시에도 자동 유지됨)
         if self.streaming_service:
             self.streaming_service._callback = self._web_realtime_callback

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -15,6 +15,7 @@ from fastapi.templating import Jinja2Templates
 from view.web.web_app_initializer import WebAppContext
 import view.web.web_api as web_api
 import view.web.api_common as api_common
+from view.web.deployment_policy import is_host_allowed
 
 # ── 진단 전용 HTTP 서버 (포트 8001, 별도 OS 스레드) ──────────────────────
 # asyncio 이벤트 루프가 완전히 블록되어도 응답 가능.
@@ -195,6 +196,13 @@ async def request_tracker_middleware(request: Request, call_next):
             del rec[0]
 
 
+async def public_host_middleware(request: Request, call_next):
+    ctx = api_common._ctx
+    if ctx is not None and not is_host_allowed(ctx, request.headers.get("host", "")):
+        return JSONResponse(status_code=400, content={"detail": "Invalid host"})
+    return await call_next(request)
+
+
 # --- Foreground 우선순위 미들웨어 ---
 # Broker API를 호출하는 라우트만 foreground로 래핑하여
 # 백그라운드 태스크(RankingTask, WebSocketWatchdog 등)와의 API rate limit 경합을 방지한다.
@@ -257,6 +265,8 @@ async def api_auth_middleware(request: Request, call_next):
     if path.startswith("/api/") and path not in _AUTH_EXEMPT_API_PATHS:
         try:
             api_common.check_auth(request)
+            api_common.check_csrf_for_unsafe_request(request)
+            api_common.check_public_operation_allowed(request)
         except HTTPException as exc:
             return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
     return await call_next(request)
@@ -266,6 +276,7 @@ async def api_auth_middleware(request: Request, call_next):
 app.middleware("http")(foreground_priority_middleware)
 app.middleware("http")(api_auth_middleware)
 app.middleware("http")(request_tracker_middleware)
+app.middleware("http")(public_host_middleware)
 
 
 # 2. 정적 파일 및 템플릿 설정
@@ -339,6 +350,10 @@ async def balance(request: Request):
                 "type": "모의투자" if getattr(env, 'is_paper_trading', False) else "실전투자",
                 "exchange": "KRX",
             }
+        from view.web.data_masking import mask_sensitive_data
+        from view.web.deployment_policy import is_public_mode
+        if is_public_mode(ctx):
+            result = mask_sensitive_data(result)
         initial_data = result
     except Exception:
         pass
@@ -397,10 +412,16 @@ async def strategy_reports(request: Request):
 
 # 5. 로그아웃
 @page_router.get("/logout")
-async def logout():
+async def logout(request: Request):
     from fastapi.responses import RedirectResponse
+    from view.web import security
+
+    claims = api_common.get_session_claims(request)
+    if claims is not None:
+        security.revoke_session(claims.session_id)
     response = RedirectResponse(url="/")
-    response.delete_cookie("access_token")
+    response.delete_cookie(security.SESSION_COOKIE_NAME, path="/")
+    response.delete_cookie(security.CSRF_COOKIE_NAME, path="/")
     return response
 
 app.include_router(page_router)


### PR DESCRIPTION
## 변경 내용

- 정적 공유 비밀 쿠키를 PBKDF2 비밀번호 검증, 서명·만료 세션, 로그아웃 무효화 구조로 교체했습니다.
- 상태 변경 API에 CSRF 검증을 적용하고 로그인 실패 제한을 추가했습니다.
- `public_mode`와 국내·해외 실전 주문 전역 master gate를 도입했습니다.
- 공개 모드에서 백그라운드 작업, 시스템 제어, 강제 갱신, 스케줄러·Kill Switch·포지션 한도 작업을 차단합니다.
- 잔고 JSON, 서버 렌더 데이터, 시스템 상태와 로그의 민감정보를 마스킹합니다.
- 명시적 trusted host 검증과 설정 fail-close 검증을 추가했습니다.
- 설정 예시, 비밀번호 해시 도구와 외부 공개 배포 런북을 추가했습니다.

## 배경

Phase 0에서 API·SSE·WebSocket 인증 경계를 먼저 닫았지만 정적 세션 토큰, CSRF 부재, 평문 비밀번호, 로그인 무차단, 공개 모드 부재가 남아 있었습니다. Phase 1은 역할 기반 권한 이전의 단일 운영자 공개 안전 MVP를 완성합니다.

## 검증

- `pytest tests/unit_test -q`: 7,071 passed, 1 existing warning
- `pytest tests/integration_test -q`: 265 passed
- `git diff --check`
- 변경 Python 파일 `py_compile`

## 후속 작업

- Phase 2: viewer/operator/admin 역할 기반 권한과 공유 사용자 저장소
- Phase 3: 실제 자격 증명과 분리된 공개 데모 서비스 및 필요 시 exact-origin CORS
