### PR TITLE
Fix DART disclosure alert misses

### DIFF
--- a/task/background/always_on/dart_disclosure_monitor_task.py
+++ b/task/background/always_on/dart_disclosure_monitor_task.py
@@ -10,6 +10,12 @@ from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
 from repositories.dart_disclosure_repository import StoredDisclosure
 from services.ai_disclosure_analyzer import AiDisclosureAnalysis
 from services.dart_disclosure_rule_service import DisclosureImportance
+from services.notification_service import NotificationCategory, NotificationLevel
+
+
+def _normalize_stock_code(code) -> str:
+    value = str(code or "").strip()
+    return value.zfill(6) if value.isdigit() else value
 
 
 class DartDisclosureMonitorTask(SchedulableTask):
@@ -25,6 +31,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
         market_clock,
         logger=None,
         ai_analyzer=None,
+        notification_service=None,
     ) -> None:
         self._client = client
         self._repository = repository
@@ -35,6 +42,7 @@ class DartDisclosureMonitorTask(SchedulableTask):
         self._market_clock = market_clock
         self._logger = logger or logging.getLogger(__name__)
         self._ai_analyzer = ai_analyzer
+        self._notification_service = notification_service
         self._ai_summary_cache: Dict[str, Optional[str]] = {}
         self._state = TaskState.IDLE
         self._tasks: List[asyncio.Task] = []
@@ -105,6 +113,11 @@ class DartDisclosureMonitorTask(SchedulableTask):
                         self._logger.error(
                             f"{self.task_name}: 공시 조회 실패 — {exc}", exc_info=True
                         )
+                        await self._emit_operational_alert(
+                            "공시 모니터 처리 실패",
+                            f"{type(exc).__name__}: {exc}",
+                            {"task": self.task_name},
+                        )
                 now = self._market_clock.get_current_kst_time()
                 await asyncio.sleep(self._interval_for(now))
         except asyncio.CancelledError:
@@ -125,13 +138,28 @@ class DartDisclosureMonitorTask(SchedulableTask):
             await self._send_digest_if_due(now, date)
 
             favorite_codes = {str(code) for code in await self._favorites.get_all()}
+            normalized_favorite_codes = {
+                _normalize_stock_code(code) for code in favorite_codes
+            }
             if not favorite_codes:
                 self._progress["last_success_at"] = now.isoformat()
                 return
 
             initialized = await self._repository.is_initialized()
             disclosures = await self._fetch_recent(date)
-            matching = [item for item in disclosures if item.stock_code in favorite_codes]
+            self._logger.info(
+                "%s: 공시 수신 완료 date=%s fetched=%d favorites=%d initialized=%s",
+                self.task_name,
+                date,
+                len(disclosures),
+                len(favorite_codes),
+                initialized,
+            )
+            matching = [
+                item
+                for item in disclosures
+                if _normalize_stock_code(item.stock_code) in normalized_favorite_codes
+            ]
             self._progress["matched_count"] = len(matching)
 
             baseline_items = []
@@ -139,6 +167,14 @@ class DartDisclosureMonitorTask(SchedulableTask):
                 if await self._repository.has_receipt(disclosure.receipt_no):
                     continue
                 preliminary = self._rules.evaluate(disclosure)
+                self._logger.info(
+                    "%s: 공시 분석 시작 receipt_no=%s stock_code=%s report=%s preliminary_score=%s",
+                    self.task_name,
+                    disclosure.receipt_no,
+                    disclosure.stock_code,
+                    disclosure.report_name,
+                    preliminary.score,
+                )
                 importance = preliminary
                 event_key = ""
                 ai_summary = None
@@ -161,6 +197,15 @@ class DartDisclosureMonitorTask(SchedulableTask):
                     suppress_immediate=not initialized,
                     event_key=event_key,
                     summary=ai_summary or "",
+                )
+                self._logger.info(
+                    "%s: 공시 분석 완료 receipt_no=%s stock_code=%s score=%s level=%s inserted=%s",
+                    self.task_name,
+                    disclosure.receipt_no,
+                    disclosure.stock_code,
+                    importance.score,
+                    importance.level,
+                    inserted,
                 )
                 if not initialized and inserted:
                     baseline_items.append(StoredDisclosure(disclosure, importance))
@@ -210,17 +255,54 @@ class DartDisclosureMonitorTask(SchedulableTask):
                     if analysis is not None:
                         ai_summary = analysis.summary
                     self._ai_summary_cache[receipt_no] = ai_summary
-            sent = await self._reporter.send_disclosure_alert(
-                item.disclosure, item.importance, ai_summary=ai_summary
+            self._logger.info(
+                "%s: 텔레그램 발송 시작 receipt_no=%s stock_code=%s score=%s",
+                self.task_name,
+                receipt_no,
+                item.disclosure.stock_code,
+                item.importance.score,
             )
+            try:
+                sent = await self._reporter.send_disclosure_alert(
+                    item.disclosure, item.importance, ai_summary=ai_summary
+                )
+            except Exception as exc:
+                sent = False
+                self._logger.error(
+                    "%s: 텔레그램 발송 예외 receipt_no=%s error=%s",
+                    self.task_name,
+                    receipt_no,
+                    exc,
+                    exc_info=True,
+                )
             if sent:
                 await self._repository.mark_immediate_sent(
                     receipt_no, now
                 )
                 self._ai_summary_cache.pop(receipt_no, None)
                 self._progress["sent_count"] += 1
+                self._logger.info(
+                    "%s: 텔레그램 발송 완료 receipt_no=%s", self.task_name, receipt_no
+                )
             else:
                 await self._repository.increment_send_retry(receipt_no)
+                self._logger.warning(
+                    "%s: 텔레그램 발송 실패, 다음 폴링에서 재시도 receipt_no=%s",
+                    self.task_name,
+                    receipt_no,
+                )
+                await self._emit_operational_alert(
+                    "공시 텔레그램 발송 실패",
+                    (
+                        f"receipt_no={receipt_no}, "
+                        f"stock_code={item.disclosure.stock_code}, "
+                        "다음 폴링에서 재시도합니다."
+                    ),
+                    {
+                        "receipt_no": receipt_no,
+                        "stock_code": item.disclosure.stock_code,
+                    },
+                )
 
     async def _analyze_actual_content(
         self,
@@ -305,3 +387,21 @@ class DartDisclosureMonitorTask(SchedulableTask):
             except (TypeError, ValueError):
                 pass
         return interval
+
+    async def _emit_operational_alert(
+        self, title: str, message: str, metadata: Optional[Dict] = None
+    ) -> None:
+        if self._notification_service is None:
+            return
+        try:
+            await self._notification_service.emit(
+                NotificationCategory.SYSTEM,
+                NotificationLevel.ERROR,
+                title,
+                message,
+                metadata or {},
+            )
+        except Exception as exc:
+            self._logger.error(
+                "%s: 운영 알림 발행 실패 — %s", self.task_name, exc, exc_info=True
+            )

--- a/tests/integration_test/test_it_dart_disclosure_pipeline.py
+++ b/tests/integration_test/test_it_dart_disclosure_pipeline.py
@@ -84,6 +84,82 @@ async def test_it_new_favorite_disclosure_is_sent_once_and_persisted(tmp_path):
     assert await repository.get_pending_immediate(70) == []
 
 
+async def test_it_zero_stripped_favorite_codes_match_dart_six_digit_codes(tmp_path):
+    def handler(request: httpx.Request):
+        return httpx.Response(
+            200,
+            json={
+                "status": "000",
+                "message": "정상",
+                "page_no": 1,
+                "page_count": 100,
+                "total_count": 2,
+                "total_page": 1,
+                "list": [
+                    {
+                        "corp_cls": "Y",
+                        "corp_name": "삼성전자",
+                        "corp_code": "00126380",
+                        "stock_code": "005930",
+                        "report_nm": "전환사채권발행결정",
+                        "rcept_no": "20260714001234",
+                        "flr_nm": "삼성전자",
+                        "rcept_dt": "20260714",
+                        "rm": "유",
+                    },
+                    {
+                        "corp_cls": "Y",
+                        "corp_name": "한미반도체",
+                        "corp_code": "00161383",
+                        "stock_code": "042700",
+                        "report_nm": "단일판매ㆍ공급계약체결",
+                        "rcept_no": "20260714005678",
+                        "flr_nm": "한미반도체",
+                        "rcept_dt": "20260714",
+                        "rm": "유",
+                    },
+                ],
+            },
+        )
+
+    favorites = FavoriteRepository(tmp_path / "favorites.db")
+    await favorites.add("5930")
+    await favorites.add("42700")
+    repository = DartDisclosureRepository(tmp_path / "dart.db")
+    await repository.mark_initialized()
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    config = SimpleNamespace(
+        poll_interval_sec=300,
+        off_hours_interval_sec=1800,
+        active_start_time="07:00",
+        active_end_time="19:30",
+        immediate_alert_score=70,
+        daily_digest_enabled=True,
+        daily_digest_time="19:40",
+        max_pages_per_poll=5,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        task = DartDisclosureMonitorTask(
+            client=DartDisclosureClient("test-key", http_client=http_client),
+            repository=repository,
+            favorite_repository=favorites,
+            rule_service=DartDisclosureRuleService(),
+            telegram_reporter=reporter,
+            config=config,
+            market_clock=_Clock(),
+            logger=MagicMock(),
+        )
+        await task._tick()
+
+    assert reporter._send_message.await_count == 2
+    sent_text = "\n".join(call.args[0] for call in reporter._send_message.await_args_list)
+    assert "삼성전자" in sent_text
+    assert "한미반도체" in sent_text
+    assert await repository.get_pending_immediate(70) == []
+
+
 async def test_it_actual_body_promotes_generic_title_to_immediate_alert(tmp_path):
     receipt_no = "20260720800314"
 

--- a/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_dart_disclosure_monitor_task.py
@@ -31,7 +31,15 @@ def _disclosure(code="005930", receipt_no="20260714000001", report_name="전환�
     )
 
 
-def _make_task(items, *, initialized=True, now=None, ai_analyzer=None):
+def _make_task(
+    items,
+    *,
+    initialized=True,
+    now=None,
+    ai_analyzer=None,
+    favorite_codes=None,
+    notification_service=None,
+):
     client = MagicMock()
     client.fetch_disclosures = AsyncMock(
         return_value=DartDisclosurePage(items, 1, 100, len(items), 1)
@@ -49,7 +57,9 @@ def _make_task(items, *, initialized=True, now=None, ai_analyzer=None):
     repo.get_pending_digest = AsyncMock(return_value=[])
     repo.mark_digest_sent = AsyncMock()
     favorites = MagicMock()
-    favorites.get_all = AsyncMock(return_value=["005930"])
+    favorites.get_all = AsyncMock(
+        return_value=["005930"] if favorite_codes is None else favorite_codes
+    )
     rule_service = MagicMock()
     rule_service.evaluate.return_value = DisclosureImportance(
         score=85, level="HIGH", reasons=["자금조달·주식 희석 관련 공시"]
@@ -77,6 +87,7 @@ def _make_task(items, *, initialized=True, now=None, ai_analyzer=None):
         market_clock=_Clock(now or datetime(2026, 7, 14, 10, 0, 0)),
         logger=MagicMock(),
         ai_analyzer=ai_analyzer,
+        notification_service=notification_service,
     )
     return SimpleNamespace(
         task=task,
@@ -116,6 +127,33 @@ async def test_new_favorite_disclosure_is_saved_and_immediately_reported():
     )
     deps.repo.mark_immediate_sent.assert_awaited_once()
     assert deps.task.get_progress()["sent_count"] == 1
+
+
+async def test_favorite_codes_are_zero_padded_before_matching_recent_missed_cases():
+    samsung = _disclosure(
+        code="005930",
+        receipt_no="20260714000001",
+        report_name="전환사채권발행결정",
+    )
+    hanmi = _disclosure(
+        code="042700",
+        receipt_no="20260714000002",
+        report_name="기업가치제고계획(자율공시)",
+    )
+    deps = _make_task(
+        [samsung, hanmi],
+        initialized=True,
+        favorite_codes=["5930", "42700"],
+    )
+
+    await deps.task._tick()
+
+    assert deps.repo.save_detected.await_count == 2
+    saved_codes = {
+        call.args[0].stock_code for call in deps.repo.save_detected.await_args_list
+    }
+    assert saved_codes == {"005930", "042700"}
+    assert deps.task.get_progress()["matched_count"] == 2
 
 
 async def test_ai_summary_is_attached_to_immediate_alert_when_analyzer_present():
@@ -219,6 +257,23 @@ async def test_failed_telegram_send_remains_pending_for_retry():
 
     deps.repo.mark_immediate_sent.assert_not_awaited()
     deps.repo.increment_send_retry.assert_awaited_once_with(disclosure.receipt_no)
+
+
+async def test_failed_telegram_send_emits_operational_alert_for_retry():
+    disclosure = _disclosure()
+    importance = DisclosureImportance(85, "HIGH", ["중요"])
+    notification_service = MagicMock()
+    notification_service.emit = AsyncMock()
+    deps = _make_task([disclosure], notification_service=notification_service)
+    deps.repo.get_pending_immediate.return_value = [StoredDisclosure(disclosure, importance)]
+    deps.reporter.send_disclosure_alert.return_value = False
+
+    await deps.task._tick()
+
+    deps.repo.increment_send_retry.assert_awaited_once_with(disclosure.receipt_no)
+    notification_service.emit.assert_awaited_once()
+    assert notification_service.emit.await_args.args[2] == "공시 텔레그램 발송 실패"
+    assert notification_service.emit.await_args.args[4]["receipt_no"] == disclosure.receipt_no
 
 
 async def test_digest_is_sent_once_at_configured_time():

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -274,6 +274,7 @@ class ServiceContainer:
                     market_clock=ctx.market_clock,
                     logger=ctx.logger,
                     ai_analyzer=ctx.ai_disclosure_analyzer,
+                    notification_service=ctx.notification_service,
                 )
 
         try:


### PR DESCRIPTION
﻿## Summary
- Fix DART disclosure watchlist matching when saved favorite codes omit leading zeroes
- Add trace logs across disclosure receive, analysis, and Telegram send stages
- Keep failed Telegram sends pending for retry and emit operational alerts on monitor/send failures
- Add unit and integration regression coverage for the Hanmi Semiconductor and Samsung Electronics missed-alert pattern

## Root Cause
Favorite stock codes could be stored as stripped numeric strings such as `5930` or `42700`, while OpenDART returns six-digit stock codes such as `005930` and `042700`. The monitor compared raw strings, so matching disclosures were skipped before analysis and Telegram delivery.

## Validation
- `pytest tests\unit_test\task\background\always_on\test_dart_disclosure_monitor_task.py -v`
- `pytest tests\integration_test\test_it_dart_disclosure_pipeline.py -v`
- `pytest tests\integration_test -v`
- `pytest tests\unit_test -v`
