### PR TITLE
Add public demo mode and exact-origin CORS

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -24,6 +24,9 @@ deployment:
   public_mode: false
   demo_mode: false
   allow_live_trading: false
+  # GitHub Pages UI를 분리할 때만 정확한 origin을 지정하세요.
+  cors_allowed_origins: []
+  cors_allow_credentials: false
   # 공개 주소의 호스트명만 명시하세요. "*"는 public_mode에서 거부됩니다.
   allowed_hosts:
     - "127.0.0.1"

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -3,6 +3,7 @@ import yaml
 import os
 import json
 from typing import Dict, Any, Literal, Optional, List
+from urllib.parse import urlsplit
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 # config.yaml 및 tr_ids_config.yaml 파일 경로 설정
@@ -49,11 +50,35 @@ class DeploymentConfig(BaseModel):
     public_mode: bool = False
     demo_mode: bool = False
     allow_live_trading: bool = False
+    cors_allowed_origins: List[str] = Field(default_factory=list)
+    cors_allow_credentials: bool = False
     allowed_hosts: List[str] = Field(
         default_factory=lambda: ["127.0.0.1", "localhost"]
     )
 
     model_config = {"extra": "allow"}
+
+    @model_validator(mode="after")
+    def validate_cors_origins(self):
+        for origin in self.cors_allowed_origins:
+            parsed = urlsplit(origin)
+            if (
+                origin == "*"
+                or "*" in origin
+                or parsed.scheme not in {"http", "https"}
+                or not parsed.netloc
+                or parsed.path not in {"", "/"}
+                or parsed.query
+                or parsed.fragment
+            ):
+                raise ValueError(
+                    "deployment.cors_allowed_origins에는 정확한 HTTP(S) origin만 허용됩니다."
+                )
+        if self.cors_allow_credentials and not self.cors_allowed_origins:
+            raise ValueError(
+                "cors_allow_credentials=true이면 cors_allowed_origins가 필요합니다."
+            )
+        return self
 
 
 class CacheConfig(BaseModel):
@@ -532,6 +557,10 @@ class AppConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_public_mode_security(self):
+        if self.deployment.cors_allow_credentials and not self.auth.secure_cookie:
+            raise ValueError(
+                "credential CORS에서는 auth.secure_cookie=true가 필요합니다."
+            )
         if not self.deployment.public_mode:
             return self
         if not self.use_login:

--- a/data/demo/sample_data.json
+++ b/data/demo/sample_data.json
@@ -1,0 +1,59 @@
+{
+  "stocks": {
+    "005930": {
+      "code": "005930",
+      "stck_shrn_iscd": "005930",
+      "name": "삼성전자",
+      "stck_prpr": "72400",
+      "prdy_vrss": "800",
+      "prdy_ctrt": "1.12"
+    },
+    "000660": {
+      "code": "000660",
+      "stck_shrn_iscd": "000660",
+      "name": "SK하이닉스",
+      "stck_prpr": "198500",
+      "prdy_vrss": "-1500",
+      "prdy_ctrt": "-0.75"
+    }
+  },
+  "balance": {
+    "output1": [
+      {
+        "pdno": "005930",
+        "prdt_name": "삼성전자",
+        "hldg_qty": "10",
+        "pchs_avg_pric": "70000",
+        "prpr": "72400",
+        "evlu_pfls_rt": "3.43"
+      }
+    ],
+    "output2": [
+      {
+        "dnca_tot_amt": "5000000",
+        "scts_evlu_amt": "724000",
+        "tot_evlu_amt": "5724000"
+      }
+    ]
+  },
+  "virtual_history": {
+    "trades": [
+      {
+        "strategy": "데모 전략",
+        "code": "005930",
+        "stock_name": "삼성전자",
+        "buy_date": "2026-07-01",
+        "buy_price": 70000,
+        "qty": 10,
+        "current_price": 72400,
+        "return_rate": 3.43,
+        "status": "HOLD",
+        "demo": true
+      }
+    ],
+    "summary_agg": {},
+    "cumulative_returns": {},
+    "daily_changes": {},
+    "weekly_changes": {}
+  }
+}

--- a/services/demo_market_data_service.py
+++ b/services/demo_market_data_service.py
@@ -1,0 +1,69 @@
+"""외부 broker와 분리된 공개 데모 데이터 서비스."""
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class DemoMarketDataService:
+    def __init__(self, data_path: str | Path | None = None):
+        path = (
+            Path(data_path)
+            if data_path is not None
+            else Path(__file__).resolve().parents[1] / "data" / "demo" / "sample_data.json"
+        )
+        with path.open("r", encoding="utf-8") as stream:
+            self._data = json.load(stream)
+        self._orders: list[dict] = []
+
+    def get_stock_price(self, code: str) -> dict:
+        stock = self._data.get("stocks", {}).get(str(code))
+        if stock is None:
+            return {
+                "rt_cd": "1",
+                "msg1": "데모 데이터에 없는 종목입니다.",
+                "data": None,
+            }
+        result = copy.deepcopy(stock)
+        result["demo"] = True
+        return {"rt_cd": "0", "msg1": "성공", "data": result}
+
+    def get_balance(self, *, exchange: str = "KRX") -> dict:
+        data = copy.deepcopy(self._data.get("balance", {}))
+        return {
+            "rt_cd": "0",
+            "msg1": "성공",
+            "data": data,
+            "account_info": {
+                "number": "DEMO-0000",
+                "type": "데모",
+                "exchange": exchange,
+            },
+        }
+
+    def get_virtual_history(self) -> dict:
+        return copy.deepcopy(self._data.get("virtual_history", {"trades": []}))
+
+    def place_order(self, *, code: str, side: str, qty: str, price: str) -> dict:
+        order_no = f"DEMO-{len(self._orders) + 1:04d}"
+        order = {
+            "ord_no": order_no,
+            "code": str(code),
+            "side": str(side),
+            "qty": str(qty),
+            "price": str(price),
+            "status": "RECORDED",
+            "demo": True,
+            "ordered_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._orders.append(order)
+        return {
+            "rt_cd": "0",
+            "msg1": "데모 주문이 기록되었습니다.",
+            "data": copy.deepcopy(order),
+        }
+
+    def get_orders(self) -> list[dict]:
+        return copy.deepcopy(self._orders)

--- a/tests/unit_test/config/test_config_loader.py
+++ b/tests/unit_test/config/test_config_loader.py
@@ -423,6 +423,38 @@ def test_public_deployment_defaults_fail_closed():
     assert cfg.deployment.public_mode is False
     assert cfg.deployment.demo_mode is False
     assert cfg.deployment.allow_live_trading is False
+    assert cfg.deployment.cors_allowed_origins == []
+    assert cfg.deployment.cors_allow_credentials is False
+
+
+def test_demo_cors_accepts_exact_https_origin():
+    cfg = _minimal_app_config(
+        deployment={
+            "demo_mode": True,
+            "cors_allowed_origins": ["https://kyungsoona.github.io"],
+            "cors_allow_credentials": True,
+        },
+        auth={"secure_cookie": True},
+    )
+
+    assert cfg.deployment.cors_allowed_origins == [
+        "https://kyungsoona.github.io"
+    ]
+    assert cfg.deployment.cors_allow_credentials is True
+
+
+@pytest.mark.parametrize(
+    "origin",
+    ["*", "https://*.github.io", "https://example.com/path"],
+)
+def test_demo_cors_rejects_non_exact_origin(origin):
+    with pytest.raises(ValidationError):
+        _minimal_app_config(
+            deployment={
+                "demo_mode": True,
+                "cors_allowed_origins": [origin],
+            }
+        )
 
 
 def test_auth_security_defaults_are_bounded():

--- a/tests/unit_test/services/test_demo_market_data_service.py
+++ b/tests/unit_test/services/test_demo_market_data_service.py
@@ -1,0 +1,34 @@
+from services.demo_market_data_service import DemoMarketDataService
+
+
+def test_demo_market_data_returns_isolated_samples_and_records_virtual_order(
+    tmp_path,
+):
+    data_path = tmp_path / "demo.json"
+    data_path.write_text(
+        """
+{
+  "stocks": {"005930": {"code": "005930", "name": "삼성전자", "stck_prpr": "70000"}},
+  "balance": {"output1": [], "output2": [{"tot_evlu_amt": "10000000"}]},
+  "virtual_history": {"trades": [{"code": "005930", "status": "HOLD"}]}
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    service = DemoMarketDataService(data_path=data_path)
+
+    price = service.get_stock_price("005930")
+    balance = service.get_balance(exchange="KRX")
+    history = service.get_virtual_history()
+    order = service.place_order(
+        code="005930", side="buy", qty="2", price="70000"
+    )
+
+    assert price["data"]["stck_prpr"] == "70000"
+    assert balance["data"]["output2"][0]["tot_evlu_amt"] == "10000000"
+    assert history["trades"][0]["code"] == "005930"
+    assert order["data"]["demo"] is True
+    assert service.get_orders()[0]["code"] == "005930"
+
+    price["data"]["stck_prpr"] = "1"
+    assert service.get_stock_price("005930")["data"]["stck_prpr"] == "70000"

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -310,6 +310,45 @@ def test_public_mode_rejects_untrusted_host(mock_web_app_context_cls):
     assert response.status_code == 400
 
 
+def test_demo_cors_allows_only_configured_origin(mock_web_app_context_cls):
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {
+        "use_login": False,
+        "deployment": {
+            "demo_mode": True,
+            "cors_allowed_origins": ["https://kyungsoona.github.io"],
+            "cors_allow_credentials": True,
+        },
+    }
+
+    with TestClient(app) as client:
+        with patch("view.web.api_common._ctx", mock_ctx):
+            allowed = client.options(
+                "/api/auth/login",
+                headers={
+                    "Origin": "https://kyungsoona.github.io",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "content-type,x-csrf-token",
+                },
+            )
+            denied = client.options(
+                "/api/auth/login",
+                headers={
+                    "Origin": "https://attacker.example",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+
+    assert allowed.status_code == 204
+    assert (
+        allowed.headers["access-control-allow-origin"]
+        == "https://kyungsoona.github.io"
+    )
+    assert allowed.headers["access-control-allow-credentials"] == "true"
+    assert denied.status_code == 400
+    assert "access-control-allow-origin" not in denied.headers
+
+
 def test_all_page_routers(mock_web_app_context_cls):
     """모든 페이지 라우터들이 200 정상 응답을 하는지 테스트"""
     mock_ctx = MagicMock()

--- a/tests/unit_test/view/web/routes/test_web_routes_balance.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_balance.py
@@ -28,6 +28,32 @@ async def test_get_balance(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_demo_mode_balance_does_not_call_broker_service(
+    web_client, mock_web_ctx
+):
+    mock_web_ctx.full_config["deployment"] = {"demo_mode": True}
+    mock_web_ctx.demo_market_data_service.get_balance.return_value = {
+        "rt_cd": "0",
+        "msg1": "성공",
+        "data": {"output1": [], "output2": [{"tot_evlu_amt": "10000000"}]},
+        "account_info": {
+            "number": "DEMO-0000",
+            "type": "데모",
+            "exchange": "KRX",
+        },
+    }
+
+    response = web_client.get("/api/balance")
+
+    assert response.status_code == 200
+    assert response.json()["account_info"]["type"] == "데모"
+    mock_web_ctx.demo_market_data_service.get_balance.assert_called_once_with(
+        exchange="KRX"
+    )
+    mock_web_ctx.stock_query_service.handle_get_account_balance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_public_mode_masks_balance_json_without_mutating_service_response(web_client, mock_web_ctx):
     source = {"tot_evlu_amt": "1000000", "ord_no": "0000123456"}
     mock_web_ctx.full_config["deployment"] = {"public_mode": True}

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -67,6 +67,33 @@ async def test_place_order_sell(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_demo_mode_order_is_recorded_without_order_service(
+    web_client, mock_web_ctx
+):
+    mock_web_ctx.full_config["deployment"] = {"demo_mode": True}
+    mock_web_ctx.demo_market_data_service.place_order.return_value = {
+        "rt_cd": "0",
+        "msg1": "데모 주문이 기록되었습니다.",
+        "data": {"ord_no": "DEMO-0001", "demo": True},
+    }
+
+    response = web_client.post(
+        "/api/order",
+        json={"code": "005930", "price": "70000", "qty": "2", "side": "buy"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["demo"] is True
+    mock_web_ctx.demo_market_data_service.place_order.assert_called_once_with(
+        code="005930",
+        side="buy",
+        qty="2",
+        price="70000",
+    )
+    mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_place_order_invalid_side(web_client, mock_web_ctx):
     """POST /api/order 잘못된 side 테스트"""
     payload = {"code": "005930", "price": "70000", "qty": "10", "side": "invalid"}

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -40,7 +40,32 @@ async def test_get_stock_price(web_client, mock_web_ctx):
     assert json_resp["data"]["market"] == "KOSPI"
     mock_web_ctx.stock_code_repository.get_market_by_code.assert_called_once_with("005930")
     from common.types import Exchange
-    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX)
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with(
+        "005930",
+        caller="stock.py - get_stock_price",
+        exchange=Exchange.KRX,
+    )
+
+
+@pytest.mark.asyncio
+async def test_demo_mode_stock_price_does_not_call_broker_service(
+    web_client, mock_web_ctx
+):
+    mock_web_ctx.full_config["deployment"] = {"demo_mode": True}
+    mock_web_ctx.demo_market_data_service.get_stock_price.return_value = {
+        "rt_cd": "0",
+        "msg1": "성공",
+        "data": {"code": "005930", "stck_prpr": "70000", "demo": True},
+    }
+
+    response = web_client.get("/api/stock/005930")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["demo"] is True
+    mock_web_ctx.demo_market_data_service.get_stock_price.assert_called_once_with(
+        "005930"
+    )
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_virtual.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_virtual.py
@@ -308,6 +308,25 @@ async def test_get_virtual_history_complex(web_client, mock_web_ctx):
 
 
 @pytest.mark.asyncio
+async def test_demo_mode_virtual_history_uses_sample_data(
+    web_client, mock_web_ctx
+):
+    sample = {
+        "trades": [{"code": "005930", "status": "HOLD", "demo": True}],
+        "weekly_changes": {},
+    }
+    mock_web_ctx.full_config["deployment"] = {"demo_mode": True}
+    mock_web_ctx.demo_market_data_service.get_virtual_history.return_value = sample
+
+    response = web_client.get("/api/virtual/history")
+
+    assert response.status_code == 200
+    assert response.json()["trades"][0]["demo"] is True
+    mock_web_ctx.demo_market_data_service.get_virtual_history.assert_called_once_with()
+    mock_web_ctx.virtual_trade_service.get_all_trades.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_virtual_history_sold_hold_return_rate(web_client, mock_web_ctx):
     """GET /api/virtual/history SOLD 거래에 미매도 가정 수익률(hold_return_rate) 포함 검증"""
     web_api._PRICE_CACHE.clear()

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -380,6 +380,27 @@ def test_public_mode_does_not_start_background_tasks(mock_deps):
     assert ctx.streaming_service._callback != ctx._web_realtime_callback
 
 
+@pytest.mark.asyncio
+async def test_demo_mode_initializes_without_broker_or_scheduler(mock_deps):
+    ctx = WebAppContext(None)
+    ctx.full_config = {"deployment": {"demo_mode": True}}
+    ctx.env = MagicMock()
+    ctx._bootstrap_broker = AsyncMock()
+    ctx._bootstrap_services = MagicMock()
+    ctx._bootstrap_schedulers = MagicMock()
+
+    result = await ctx.initialize_services(is_paper_trading=True)
+
+    assert result is True
+    assert ctx.initialized is True
+    assert ctx.broker is None
+    assert ctx.demo_market_data_service is not None
+    ctx.env.set_trading_mode.assert_not_called()
+    ctx._bootstrap_broker.assert_not_awaited()
+    ctx._bootstrap_services.assert_not_called()
+    ctx._bootstrap_schedulers.assert_not_called()
+
+
 def test_web_realtime_callback(mock_deps):
     """웹소켓 콜백 처리 테스트"""
     ctx = WebAppContext(None)

--- a/view/web/deployment_policy.py
+++ b/view/web/deployment_policy.py
@@ -22,6 +22,24 @@ def is_public_mode(ctx) -> bool:
     return _config_get(deployment, "public_mode", False) is True
 
 
+def is_demo_mode(ctx) -> bool:
+    deployment = config_section(ctx, "deployment")
+    return _config_get(deployment, "demo_mode", False) is True
+
+
+def cors_policy(ctx) -> tuple[set[str], bool]:
+    deployment = config_section(ctx, "deployment")
+    origins = {
+        str(origin).strip().rstrip("/")
+        for origin in _config_get(deployment, "cors_allowed_origins", [])
+        if str(origin).strip()
+    }
+    allow_credentials = bool(
+        _config_get(deployment, "cors_allow_credentials", False)
+    )
+    return origins, allow_credentials
+
+
 def is_host_allowed(ctx, host_header: str) -> bool:
     if not is_public_mode(ctx):
         return True

--- a/view/web/routes/auth.py
+++ b/view/web/routes/auth.py
@@ -10,7 +10,7 @@ from view.web.api_common import (
     get_auth_config,
     get_authenticated_principal,
 )
-from view.web.deployment_policy import is_public_mode
+from view.web.deployment_policy import cors_policy, is_public_mode
 from view.web.security import (
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
@@ -45,6 +45,8 @@ async def login(request: Request, username: str = Form(...), password: str = For
         )
         max_age = int(_config_get(auth_config, "session_max_age_seconds", 3600))
         secure_cookie = bool(_config_get(auth_config, "secure_cookie", False)) or is_public_mode(_get_ctx())
+        _, cross_origin_credentials = cors_policy(_get_ctx())
+        same_site = "none" if cross_origin_credentials else "strict"
         response = JSONResponse(
             content={
                 "success": True,
@@ -58,7 +60,7 @@ async def login(request: Request, username: str = Form(...), password: str = For
             max_age=max_age,
             httponly=True,
             secure=secure_cookie,
-            samesite="strict",
+            samesite=same_site,
             path="/",
         )
         response.set_cookie(
@@ -67,7 +69,7 @@ async def login(request: Request, username: str = Form(...), password: str = For
             max_age=max_age,
             httponly=False,
             secure=secure_cookie,
-            samesite="strict",
+            samesite=same_site,
             path="/",
         )
         return response

--- a/view/web/routes/balance.py
+++ b/view/web/routes/balance.py
@@ -6,7 +6,7 @@ from common.overseas_types import OverseasExchange
 from common.types import Exchange
 from view.web.api_common import _get_ctx, _serialize_response
 from view.web.data_masking import mask_sensitive_data
-from view.web.deployment_policy import is_public_mode
+from view.web.deployment_policy import is_demo_mode, is_public_mode
 from view.web.market_mode_utils import enabled_market_modes_of, is_market_enabled, market_mode_of
 
 router = APIRouter()
@@ -21,6 +21,12 @@ async def get_balance(exchange: str = Query("KRX")):
         exchange_enum = Exchange(exchange.upper())
     except ValueError:
         exchange_enum = Exchange.KRX
+    if is_demo_mode(ctx):
+        result = ctx.demo_market_data_service.get_balance(
+            exchange=exchange_enum.value
+        )
+        ctx.pm.log_timer("get_balance", t_start)
+        return result
     resp = await ctx.stock_query_service.handle_get_account_balance(exchange=exchange_enum)
 
     # 1. 기존 응답 직렬화

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -7,7 +7,12 @@ from common.overseas_types import OverseasOrderRequest, OverseasCancelRequest
 from common.types import ErrorCode, ResCommonResponse
 from view.web.api_common import _get_ctx, _serialize_response, OrderRequest, require_role
 from view.web.authorization import ADMIN
-from view.web.deployment_policy import config_section, config_value, live_trading_block
+from view.web.deployment_policy import (
+    config_section,
+    config_value,
+    is_demo_mode,
+    live_trading_block,
+)
 from view.web.market_mode_utils import is_market_enabled
 
 router = APIRouter()
@@ -41,6 +46,16 @@ async def place_order(req: OrderRequest, request: Request):
     ctx = _get_ctx()
     t_start = ctx.pm.start_timer()
 
+    if req.side not in {"buy", "sell"}:
+        raise HTTPException(status_code=400, detail="side는 'buy' 또는 'sell'이어야 합니다.")
+    if is_demo_mode(ctx):
+        return ctx.demo_market_data_service.place_order(
+            code=req.code,
+            side=req.side,
+            qty=req.qty,
+            price=req.price,
+        )
+
     if _is_real_trading_mode(ctx):
         blocked_response = _live_trading_block_response(ctx)
         if blocked_response is not None:
@@ -66,9 +81,6 @@ async def place_order(req: OrderRequest, request: Request):
             source="manual:수동매매",
             finalize_immediately=False,
         )
-    else:
-        raise HTTPException(status_code=400, detail="side는 'buy' 또는 'sell'이어야 합니다.")
-
     ctx.pm.log_timer("place_order", t_start)
     return _serialize_response(resp)
 

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -17,6 +17,7 @@ from services.price_subscription_service import SubscriptionPriority
 from view.web.api_common import _get_ctx, _serialize_response, EnvironmentRequest
 import view.web.api_common as api_common
 from view.web.market_mode_utils import enabled_market_modes_of, is_market_enabled, market_mode_of
+from view.web.deployment_policy import is_demo_mode
 
 router = APIRouter()
 
@@ -408,6 +409,8 @@ async def get_ai_news_review(code: str):
 async def get_stock_price(code: str, exchange: str = Query("KRX")):
     """현재가 조회. 종목명이 들어오면 종목코드로 변환 후 조회. exchange=KRX|NXT|UN 선택 가능."""
     ctx = _get_ctx()
+    if is_demo_mode(ctx):
+        return ctx.demo_market_data_service.get_stock_price(code)
     # 숫자가 아닌 입력(종목명)이면 코드로 변환
     if not code.isdigit():
         resolved = ctx.stock_code_repository.get_code_by_name(code)

--- a/view/web/routes/virtual.py
+++ b/view/web/routes/virtual.py
@@ -570,6 +570,10 @@ def _aggregate_virtual_data(trades, vm, apply_cost):
 async def get_virtual_history(force_code: str = None, apply_cost: bool = True):
     """가상 매매 전체 기록 조회 (force_code 지정 시 해당 종목은 캐시 무시)"""
     ctx = _get_ctx()
+    from view.web.deployment_policy import is_demo_mode
+
+    if is_demo_mode(ctx):
+        return ctx.demo_market_data_service.get_virtual_history()
     async with ctx.pm.profile_async("get_virtual_history"):
         return await _get_virtual_history_impl(ctx, force_code, apply_cost)
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -108,6 +108,7 @@ class WebAppContext:
         self.stock_query_service: StockQueryService = None
         self.streaming_service: StreamingService = None
         self.order_execution_service: OrderExecutionService = None
+        self.demo_market_data_service = None
         self.kill_switch_service: KillSwitchService = None
         self.operator_alert_service: OperatorAlertService = None
         self.rejection_distribution_service: RejectionDistributionService = None
@@ -252,6 +253,17 @@ class WebAppContext:
 
     async def initialize_services(self, is_paper_trading: bool = True):
         """서비스 레이어 초기화."""
+        from view.web.deployment_policy import is_demo_mode
+
+        if is_demo_mode(self):
+            from services.demo_market_data_service import DemoMarketDataService
+
+            self.demo_market_data_service = DemoMarketDataService()
+            self.broker = None
+            self.initialized = True
+            self.logger.info("웹 앱: 외부 broker 없이 데모 서비스 초기화 완료")
+            return True
+
         self.env.set_trading_mode(is_paper_trading)
         if not await self._bootstrap_broker(is_paper_trading):
             return False
@@ -360,6 +372,10 @@ class WebAppContext:
 
     def initialize_scheduler(self):
         """전략 스케줄러 생성 및 전략 등록. StrategyFactory 에 위임."""
+        from view.web.deployment_policy import is_demo_mode
+
+        if is_demo_mode(self):
+            return
         from view.web.bootstrap.strategy_factory import StrategyFactory
         StrategyFactory(self).build()
 
@@ -404,10 +420,10 @@ class WebAppContext:
 
     def start_background_tasks(self):
         """백그라운드 태스크 시작 — BackgroundScheduler에 위임."""
-        from view.web.deployment_policy import is_public_mode
+        from view.web.deployment_policy import is_demo_mode, is_public_mode
 
-        if is_public_mode(self):
-            self.logger.info("공개 모드: 백그라운드 태스크 시작을 건너뜁니다.")
+        if is_public_mode(self) or is_demo_mode(self):
+            self.logger.info("공개/데모 모드: 백그라운드 태스크 시작을 건너뜁니다.")
             return
 
         # StreamingService에 콜백 등록 (내부 저장 → 재연결 시에도 자동 유지됨)

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -7,7 +7,7 @@ import uuid
 from contextlib import asynccontextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from fastapi import FastAPI, HTTPException, Request, APIRouter
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -16,7 +16,7 @@ from view.web.web_app_initializer import WebAppContext
 import view.web.web_api as web_api
 import view.web.api_common as api_common
 from view.web.authorization import ADMIN, OPERATOR, VIEWER, role_allows
-from view.web.deployment_policy import is_host_allowed
+from view.web.deployment_policy import cors_policy, is_host_allowed
 
 # ── 진단 전용 HTTP 서버 (포트 8001, 별도 OS 스레드) ──────────────────────
 # asyncio 이벤트 루프가 완전히 블록되어도 응답 가능.
@@ -204,6 +204,56 @@ async def public_host_middleware(request: Request, call_next):
     return await call_next(request)
 
 
+async def exact_origin_cors_middleware(request: Request, call_next):
+    origin = request.headers.get("origin")
+    ctx = api_common._ctx
+    if not origin or ctx is None:
+        return await call_next(request)
+
+    allowed_origins, allow_credentials = cors_policy(ctx)
+    normalized_origin = origin.rstrip("/")
+    if normalized_origin not in allowed_origins:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "Origin is not allowed"},
+        )
+
+    allowed_methods = "GET, POST, OPTIONS"
+    allowed_headers = {"content-type", "x-csrf-token"}
+    if request.method == "OPTIONS":
+        requested_method = request.headers.get(
+            "access-control-request-method", ""
+        ).upper()
+        requested_headers = {
+            header.strip().lower()
+            for header in request.headers.get(
+                "access-control-request-headers", ""
+            ).split(",")
+            if header.strip()
+        }
+        if (
+            requested_method not in {"GET", "POST"}
+            or not requested_headers.issubset(allowed_headers)
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "CORS preflight is not allowed"},
+            )
+        response = Response(status_code=204)
+    else:
+        response = await call_next(request)
+
+    response.headers["Access-Control-Allow-Origin"] = normalized_origin
+    response.headers["Access-Control-Allow-Methods"] = allowed_methods
+    response.headers["Access-Control-Allow-Headers"] = (
+        "Content-Type, X-CSRF-Token"
+    )
+    response.headers["Vary"] = "Origin"
+    if allow_credentials:
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+    return response
+
+
 # --- Foreground 우선순위 미들웨어 ---
 # Broker API를 호출하는 라우트만 foreground로 래핑하여
 # 백그라운드 태스크(RankingTask, WebSocketWatchdog 등)와의 API rate limit 경합을 방지한다.
@@ -279,6 +329,7 @@ app.middleware("http")(foreground_priority_middleware)
 app.middleware("http")(api_auth_middleware)
 app.middleware("http")(request_tracker_middleware)
 app.middleware("http")(public_host_middleware)
+app.middleware("http")(exact_origin_cors_middleware)
 
 
 # 2. 정적 파일 및 템플릿 설정


### PR DESCRIPTION
## What changed

- Add a broker-independent demo market data service and tracked sample data for stock price, balance, virtual history, and simulated order responses.
- Route supported web APIs through the demo service while skipping broker, scheduler, and background-task startup in demo mode.
- Add validated exact-origin CORS configuration, restricted preflight handling, and credential-aware cookie SameSite behavior.
- Add regression coverage for configuration validation, CORS behavior, demo initialization, and demo route responses.

## Why

The remaining local changes were not present on `main`. They are one coherent public deployment change: allow the web app to run without brokerage credentials in demo mode while permitting only explicitly configured browser origins.

A required `data/demo/sample_data.json` file was hidden by the repository's `/data` ignore rule, so it is explicitly included in this PR; without it demo initialization would fail at runtime.

## Impact

Default deployment behavior is unchanged. Demo mode avoids external broker access and records demo orders in memory. Credentialed cross-origin access requires explicit HTTP(S) origins and secure cookies.

## Validation

- `python -m pytest tests/unit_test -v` - 7116 passed
- `python -m pytest tests/integration_test -v` - 266 passed
