### PR TITLE
fix: use_login=false 환경에서 모든 /api 요청이 401로 막히던 문제 수정

### DIFF
--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -293,6 +293,20 @@ def test_unauthenticated_api_does_not_enter_foreground(mock_web_app_context_cls)
     mock_ctx.foreground_scheduler.context.assert_not_called()
 
 
+def test_login_disabled_allows_api_without_session(mock_web_app_context_cls):
+    """use_login=false면 인증 미들웨어가 세션 없는 API 요청을 차단하지 않는다."""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {"use_login": False, "auth": {"secret_key": "test-token"}}
+    mock_ctx.foreground_scheduler = None
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with patch("view.web.api_common._ctx", mock_ctx):
+            response = client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "admin"
+
+
 def test_public_mode_rejects_untrusted_host(mock_web_app_context_cls):
     mock_ctx = MagicMock()
     mock_ctx.full_config = {

--- a/tests/unit_test/view/web/routes/test_web_routes_auth.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_auth.py
@@ -15,6 +15,7 @@ from view.web.security import (
 
 
 def _authenticate_as(web_client, mock_web_ctx, username, role):
+    mock_web_ctx.full_config["use_login"] = True  # 역할 검사는 로그인이 켜진 환경에서만 적용된다
     auth_config = mock_web_ctx.full_config["auth"]
     users = auth_config.setdefault("users", [])
     if not any(user["username"] == username for user in users):
@@ -260,6 +261,7 @@ def test_sensitive_api_rejects_request_without_cookie(web_client, mock_web_ctx):
 
 
 def test_state_changing_api_rejects_missing_csrf(web_client, mock_web_ctx):
+    mock_web_ctx.full_config["use_login"] = True
     web_client.cookies.pop(CSRF_COOKIE_NAME)
     web_client.headers.pop("X-CSRF-Token")
 
@@ -270,6 +272,29 @@ def test_state_changing_api_rejects_missing_csrf(web_client, mock_web_ctx):
 
     assert response.status_code == 403
     mock_web_ctx.order_execution_service.handle_buy_stock.assert_not_awaited()
+
+
+def test_api_allows_local_admin_when_login_disabled(test_app, mock_web_ctx):
+    """use_login=false면 세션 없이도 API가 로컬 관리자 신원으로 동작한다."""
+    from fastapi.testclient import TestClient
+
+    mock_web_ctx.full_config["use_login"] = False
+    client = TestClient(test_app)
+
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    assert response.json() == {"username": "local", "role": "admin"}
+
+
+def test_api_requires_session_when_login_enabled(test_app, mock_web_ctx):
+    """use_login=true면 세션 없는 API 요청은 계속 401로 차단된다."""
+    from fastapi.testclient import TestClient
+
+    mock_web_ctx.full_config["use_login"] = True
+    client = TestClient(test_app)
+
+    assert client.get("/api/auth/me").status_code == 401
 
 
 def test_serialize_helpers():

--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -155,3 +155,21 @@ async def test_get_favorite_list_subscription_exception(web_client, mock_web_ctx
         
         mock_web_ctx.logger.warning.assert_called_once()
         assert "Subscription Error" in mock_web_ctx.logger.warning.call_args[0][0]
+
+
+async def test_favorite_api_allows_unauthenticated_when_login_disabled(test_app, mock_web_ctx):
+    """use_login=false(로컬 실행)면 세션 쿠키 없이도 관심종목 API를 사용할 수 있다."""
+    from fastapi.testclient import TestClient
+
+    mock_web_ctx.full_config["use_login"] = False
+    mock_web_ctx.favorite_service = MagicMock()
+    mock_web_ctx.favorite_service.get_with_details = AsyncMock(return_value=[])
+    mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
+    mock_web_ctx.price_subscription_service = None
+
+    client = TestClient(test_app)  # 세션 쿠키·CSRF 토큰 없음
+
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        assert client.get("/api/favorite").status_code == 200
+        # CSRF 토큰이 없어도 상태 변경 요청이 통과해야 한다
+        assert client.post("/api/favorite/005930").status_code == 200

--- a/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_kill_switch.py
@@ -33,6 +33,7 @@ async def test_reset_strategy_kill_switch_service_unavailable(web_client, mock_w
 @pytest.mark.asyncio
 async def test_reset_strategy_kill_switch_requires_auth(web_client, mock_web_ctx):
     """인증 쿠키가 없으면 401."""
+    mock_web_ctx.full_config["use_login"] = True
     web_client.cookies.clear()
 
     resp = web_client.post("/api/kill-switch/reset-strategy/momentum")

--- a/tests/unit_test/view/web/routes/test_web_routes_program.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_program.py
@@ -271,6 +271,7 @@ def test_websocket_echo_endpoint_requires_auth(web_client, mock_web_ctx):
     from anyio import ClosedResourceError
     from starlette.websockets import WebSocketDisconnect
 
+    mock_web_ctx.full_config["use_login"] = True
     web_client.cookies.clear()
 
     with pytest.raises((WebSocketDisconnect, ClosedResourceError)) as exc:

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -324,6 +324,7 @@ def test_shutdown_server_schedules_termination(web_client, mock_web_ctx, monkeyp
     """종료 엔드포인트는 200으로 응답하고 프로세스 종료를 예약한다(실제 종료는 훅으로 분리)."""
     from view.web.routes import system
 
+    mock_web_ctx.full_config["use_login"] = True  # rbac 감사 로그는 로그인이 켜진 환경에서만 남는다
     called = {}
     monkeypatch.setattr(system, "_schedule_shutdown", lambda *a, **k: called.setdefault("hit", True))
 

--- a/tests/unit_test/view/web/static/js/test_common_js_session_expiry.py
+++ b/tests/unit_test/view/web/static/js/test_common_js_session_expiry.py
@@ -1,0 +1,95 @@
+"""common.js의 세션 만료(401) 처리 동작 테스트 (Node 실행)."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+DRIVER = """
+const fs = require('fs');
+const vm = require('vm');
+
+function run({ userRole, status, path }) {
+    const reloads = [];
+    const doc = {
+        body: { dataset: { userRole }, classList: { add() {} }, setAttribute() {} },
+        cookie: '',
+        addEventListener: () => {},
+        querySelectorAll: () => [],
+        querySelector: () => null,
+        getElementById: () => null,
+        createElement: () => ({ style: {}, classList: { add() {} }, setAttribute() {}, appendChild() {} }),
+        dispatchEvent: () => {},
+    };
+    const win = {
+        fetch: async () => ({ status, ok: status < 400 }),
+        location: {
+            href: 'http://localhost:8000/favorite',
+            origin: 'http://localhost:8000',
+            reload: () => reloads.push(1),
+        },
+        addEventListener: () => {},
+        history: { pushState() {} },
+    };
+    const sandbox = {
+        window: win,
+        document: doc,
+        console,
+        setTimeout: (fn) => { fn(); return 0; },
+        clearTimeout: () => {},
+        setInterval: () => 0,
+        URL,
+        Headers: class { has() { return false; } set() {} },
+        navigator: { sendBeacon: () => {} },
+    };
+    sandbox.globalThis = sandbox;
+    vm.runInNewContext(fs.readFileSync(SOURCE, 'utf-8'), sandbox, { filename: 'common.js' });
+    return sandbox.window.fetch(path).then(() => reloads.length);
+}
+
+const SOURCE = process.argv[2];
+
+Promise.all([
+    run({ userRole: 'admin', status: 401, path: '/api/favorite' }),
+    run({ userRole: '', status: 401, path: '/api/favorite' }),
+    run({ userRole: 'admin', status: 200, path: '/api/favorite' }),
+    run({ userRole: 'admin', status: 401, path: '/favorite' }),
+]).then(([expired, loginPage, ok, pageRequest]) => {
+    console.log(JSON.stringify({ expired, loginPage, ok, pageRequest }));
+});
+"""
+
+
+def _run_driver(tmp_path: Path) -> dict:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is required for JavaScript behaviour checks")
+
+    driver_path = tmp_path / "session_expiry_driver.js"
+    driver_path.write_text(DRIVER, encoding="utf-8")
+    result = subprocess.run(
+        [node, str(driver_path), str(Path("view/web/static/js/common.js").resolve())],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_expired_session_triggers_relogin_prompt(tmp_path):
+    """401 응답을 받으면 로그인 화면으로 되돌려 재로그인을 안내한다."""
+    assert _run_driver(tmp_path)["expired"] == 1
+
+
+def test_unauthorized_is_ignored_outside_authenticated_page(tmp_path):
+    """로그인 화면(역할 없음)·정상 응답·페이지 요청에서는 새로고침하지 않는다."""
+    outcome = _run_driver(tmp_path)
+
+    assert outcome["loginPage"] == 0
+    assert outcome["ok"] == 0
+    assert outcome["pageRequest"] == 0

--- a/view/web/api_common.py
+++ b/view/web/api_common.py
@@ -8,6 +8,9 @@ from view.web import security
 
 _ctx = None  # 전역 변수로 선언
 
+# use_login=false(로컬 단독 실행)에서 감사 로그에 남길 신원
+LOCAL_PRINCIPAL_USERNAME = "local"
+
 # API 호출 실패 시 대처를 위한 전역 가격 캐시 (메모리)
 _PRICE_CACHE = {}  # {code: (price, rate, timestamp)}
 
@@ -75,8 +78,29 @@ def is_authenticated(connection: HTTPConnection, *, ctx=None) -> bool:
     return get_session_claims(connection, ctx=ctx) is not None
 
 
+def is_login_required(*, ctx=None) -> bool:
+    """use_login=false(로컬 단독 실행)면 페이지와 동일하게 API 인증도 적용하지 않는다."""
+    if ctx is None:
+        ctx = _get_ctx()
+    return bool(_config_get(ctx.full_config, "use_login", True))
+
+
+def _local_principal():
+    """use_login=false 환경에서 사용할 로컬 관리자 신원."""
+    from view.web.authorization import ADMIN
+
+    return security.SessionClaims(
+        username=LOCAL_PRINCIPAL_USERNAME,
+        role=ADMIN,
+        session_id=LOCAL_PRINCIPAL_USERNAME,
+        csrf_token="",
+    )
+
+
 def check_auth(connection: HTTPConnection):
     """로그인 여부를 확인하는 공통 함수."""
+    if not is_login_required():
+        return True
     if not is_authenticated(connection):
         scope = getattr(connection, "scope", {})
         if isinstance(scope, dict) and scope.get("type") == "websocket":
@@ -87,16 +111,14 @@ def check_auth(connection: HTTPConnection):
 
 def get_authenticated_operator(connection: HTTPConnection) -> str:
     """감사 로그에 토큰 원문 대신 비민감 운영자 식별자를 반환한다."""
-    claims = get_session_claims(connection)
-    if claims is None:
-        check_auth(connection)
-    return claims.username
+    return get_authenticated_principal(connection).username
 
 
 def get_authenticated_principal(connection: HTTPConnection):
     claims = get_session_claims(connection)
     if claims is None:
-        check_auth(connection)
+        check_auth(connection)  # 인증이 필요한 환경이면 여기서 401
+        return _local_principal()
     return claims
 
 
@@ -159,6 +181,8 @@ def require_role(connection: HTTPConnection, required_role: str):
 def check_role_for_request(connection: HTTPConnection) -> bool:
     from view.web.authorization import required_role_for_request
 
+    if not is_login_required():
+        return True
     scope = getattr(connection, "scope", {})
     if not isinstance(scope, dict):
         raise HTTPException(status_code=403, detail="Authorization scope unavailable")
@@ -172,6 +196,8 @@ def check_role_for_request(connection: HTTPConnection) -> bool:
 
 def check_csrf(connection: HTTPConnection) -> bool:
     """상태 변경 요청의 세션 결합 CSRF 토큰을 검증한다."""
+    if not is_login_required():
+        return True
     claims = get_session_claims(connection)
     if claims is None:
         raise HTTPException(status_code=401, detail="Unauthorized")

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -27,12 +27,25 @@ function readCookie(name) {
     return item ? decodeURIComponent(item.slice(prefix.length)) : null;
 }
 
+let _sessionExpiredHandled = false;
+
+function handleUnauthorizedApiResponse(response) {
+    // 세션 만료 시 각 페이지가 'HTTP 401'만 노출하는 대신 재로그인을 안내한다.
+    if (response.status !== 401 || _sessionExpiredHandled) return;
+    if (!document.body?.dataset.userRole) return;  // 로그인 화면에서는 안내하지 않음
+    _sessionExpiredHandled = true;
+    showToast('세션이 만료되었습니다. 다시 로그인해 주세요.', 'error');
+    setTimeout(() => window.location.reload(), 1500);
+}
+
 window.fetch = function csrfFetch(input, options = {}) {
     const isRequest = typeof Request !== 'undefined' && input instanceof Request;
     const requestMethod = isRequest ? input.method : 'GET';
     const method = String(options.method || requestMethod).toUpperCase();
     const requestUrl = isRequest ? input.url : String(input);
-    const isSameOrigin = new URL(requestUrl, window.location.href).origin === window.location.origin;
+    const parsedUrl = new URL(requestUrl, window.location.href);
+    const isSameOrigin = parsedUrl.origin === window.location.origin;
+    const isApiRequest = isSameOrigin && parsedUrl.pathname.startsWith('/api/');
 
     if (isSameOrigin && csrfProtectedMethods.has(method)) {
         const csrfToken = readCookie('csrf_token');
@@ -45,7 +58,11 @@ window.fetch = function csrfFetch(input, options = {}) {
             options = { ...options, headers };
         }
     }
-    return nativeFetch(input, options);
+    if (!isApiRequest) return nativeFetch(input, options);
+    return nativeFetch(input, options).then((response) => {
+        handleUnauthorizedApiResponse(response);
+        return response;
+    });
 };
 
 // ==========================================

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -48,7 +48,7 @@
     {% block head_scripts %}
     <!-- 차트 라이브러리는 필요한 페이지에서만 로드 -->
     {% endblock %}
-    <script src="/static/js/common.js?v=10"></script>
+    <script src="/static/js/common.js?v=11"></script>
 </head>
 <body data-view-market="{{ view_market|default('common') }}" data-user-role="{{ user_role|default('') }}">
 


### PR DESCRIPTION
## 문제

로컬 설정(`config/config.yaml`의 `use_login: false`)으로 실행하면 즐겨찾기 목록이 `불러오기 실패: HTTP 401`로 표시된다. 즐겨찾기만의 문제가 아니라 **모든 `/api/*` 요청이 401**이다.

원인은 인증 경계의 비대칭이다:
- 페이지: `web_main._is_page_authorized()`가 `use_login`을 존중 → 로그인 없이 렌더링됨
- API: `api_auth_middleware` + `protected_router`의 `check_auth`/`check_role_for_request`/`check_csrf`는 `use_login`을 보지 않고 항상 세션을 요구

그래서 화면은 정상적으로 뜨는데 그 안의 모든 API 호출만 401이 된다 (#710, #712 이후 회귀).

## 변경

- `view/web/api_common.py`
  - `is_login_required()` 추가. `check_auth` / `check_role_for_request` / `check_csrf`가 `use_login=false`면 검사를 건너뛴다 — 페이지 계층의 `_page_role()`(ADMIN 취급)과 동일한 정책.
  - `get_authenticated_principal()`은 세션이 없고 인증도 불필요한 경우 로컬 신원(`local`/`admin`)을 반환한다. 기존 코드는 이 경로에서 `None.username` 크래시가 났다.
  - `get_authenticated_operator()`는 principal 조회로 위임(중복 제거).
- `view/web/static/js/common.js` (개선)
  - `/api` 응답이 401이면 각 페이지가 `HTTP 401`만 노출하는 대신, 재로그인 안내 토스트를 띄우고 로그인 화면으로 되돌린다. 로그인 화면(`data-user-role` 없음)에서는 동작하지 않아 리로드 루프가 생기지 않는다.
  - `base.html`의 캐시 버스터 `v=10 → v=11`.

## 보안 영향

`public_mode: true`는 `config_loader`가 `use_login: true`를 강제하므로(ValueError) 공개 배포 경로의 인증·RBAC·CSRF는 그대로다. `use_login=false`는 로컬 단독 실행 전용 플래그이고, 이미 페이지 계층이 같은 방식으로 동작해 왔다.

## 테스트

- 신규: `use_login=false`에서 세션·CSRF 없이 `/api/favorite` GET/POST 통과, `/api/auth/me`가 `local`/`admin` 반환, 미들웨어 레벨 통과 검증
- 신규 회귀 가드: `use_login=true`면 세션 없는 API는 계속 401
- 신규: `common.js` 401 처리 Node 동작 테스트 (만료 시 1회 리로드 / 로그인 화면·정상 응답·페이지 요청에서는 미동작)
- 기존 RBAC·CSRF 테스트는 `use_login=true`를 명시하도록 조정 (역할 검사는 로그인이 켜진 환경의 동작)
- `pytest tests/unit_test`: 7122 passed / `pytest tests/integration_test`: 266 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)