### PR TITLE
Prevent duplicate virtual buy records

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -456,6 +456,30 @@ class VirtualTradeRepository:
             return "strategy = ?", (sid,)
         return "strategy IN (?, ?)", (sid, display)
 
+    def _has_same_buy_record(
+        self,
+        strategy_id: str,
+        code: str,
+        buy_date: str,
+        current_price,
+        qty: int,
+    ) -> bool:
+        where, params = self._strategy_filter(strategy_id)
+        row = self._db.execute(
+            f"""
+            SELECT 1 FROM trades
+            WHERE {where}
+              AND code=?
+              AND buy_date=?
+              AND buy_price=?
+              AND qty=?
+              AND status != 'FAILED'
+            LIMIT 1
+            """,
+            (*params, code, buy_date, float(current_price), int(qty)),
+        ).fetchone()
+        return row is not None
+
     # ---- 매수/매도 ----
 
     def log_buy(self, strategy_name: str, code: str, current_price, qty: int = 1,
@@ -491,6 +515,12 @@ class VirtualTradeRepository:
                 logger.info(f"[가상매매] {strategy_id}/{code} 이미 보유 중 — 매수 스킵")
                 return
             buy_date = self.tm.get_current_kst_time().strftime("%Y-%m-%d %H:%M:%S")
+            if self._has_same_buy_record(strategy_id, code, buy_date, current_price, qty):
+                logger.info(
+                    f"[가상매매] {strategy_id}/{code} 동일 매수 기록 존재 — 재처리 스킵 "
+                    f"(일시: {buy_date}, 가격: {current_price}, 수량: {qty})"
+                )
+                return
             with self._db:
                 self._db.execute(_INSERT_TRADE,
                     (strategy_id, code, buy_date, current_price, qty, None, None, 0.0, "HOLD", "",

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -63,6 +63,22 @@ def test_log_buy_duplicate_skips(virutal_trade_repository):
     df = virutal_trade_repository._read()
     assert len(df) == 1
 
+
+def test_log_buy_duplicate_terminal_replay_skips(virutal_trade_repository):
+    """동일 매수 체결 이벤트가 SOLD 이후 재처리되어도 원장에 중복 삽입하지 않는다."""
+    virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2026, 7, 27, 12, 8, 29)
+    virutal_trade_repository.log_buy("larry_williams_vbo", "316140", 33250, qty=30)
+
+    virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2026, 7, 27, 15, 10, 4)
+    virutal_trade_repository.log_sell_by_strategy("larry_williams_vbo", "316140", 33125, qty=30)
+
+    virutal_trade_repository.tm.get_current_kst_time.return_value = datetime(2026, 7, 27, 12, 8, 29)
+    virutal_trade_repository.log_buy("larry_williams_vbo", "316140", 33250, qty=30)
+
+    df = virutal_trade_repository._read()
+    assert len(df) == 1
+    assert df.iloc[0]["status"] == "SOLD"
+
 def test_log_buy_with_qty(virutal_trade_repository):
     """매수 시 수량(qty)이 정상적으로 기록되는지 확인"""
     virutal_trade_repository.log_buy("TestStrategy", "005930", 70000, qty=10)


### PR DESCRIPTION
﻿## What changed
- Added an idempotency check before inserting virtual buy records.
- Covered the case where the same buy fill event is replayed after the first row has already been sold.

## Why
The live journal showed duplicate LarryWilliamsVBO buy rows for the same Woori Financial Group fill: same strategy, code, buy timestamp, price, and quantity. The existing duplicate guard only checked active HOLD rows, so replayed terminal events could create duplicate SOLD rows.

## Validation
- `python -m pytest tests/unit_test/repositories/test_virtual_trade_repository.py::test_log_buy_duplicate_terminal_replay_skips -v`
- `python -m pytest tests/unit_test/repositories/test_virtual_trade_repository.py -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v`

Note: the first full integration run hit a transient Windows EPERM while Node read a jsdom file. The failing case passed on rerun, and the full integration suite then passed.
