### PR TITLE
Recover missed ranking refresh on startup

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -697,7 +697,7 @@ class RankingTask(AfterMarketTask):
             self._logger.warning(f"기간수급 랭킹 캐시 예열 미완료: {target_date}, {days}일")
 
     async def _period_ranking_self_heal(self) -> None:
-        """시작 시 당일 기간수급 캐시가 없으면 DB 복원 또는 예열한다 (장중 제외)."""
+        """시작 시 누락된 최신 거래일 랭킹 리포트/기간수급을 복구한다 (장중 제외)."""
         try:
             if self._mcs is None:
                 return
@@ -707,10 +707,20 @@ class RankingTask(AfterMarketTask):
             if not target_date:
                 return
             cache_key = (str(target_date), self.DEFAULT_PERIOD_RANKING_DAYS)
-            if cache_key in self._period_ranking_cache:
+            needs_period = cache_key not in self._period_ranking_cache
+            needs_investor = (
+                self._last_collected_date != str(target_date)
+                and self._load_last_ranking_report_date() != str(target_date)
+            )
+            if not needs_period and not needs_investor:
                 return
             async with self._running_state():
-                await self.prewarm_period_ranking(str(target_date))
+                if needs_investor:
+                    self._logger.info(f"투자자 랭킹 미전송분 복구 시작: {target_date}")
+                    await self.refresh_investor_ranking()
+                    self._last_collected_date = str(target_date)
+                if needs_period:
+                    await self.prewarm_period_ranking(str(target_date))
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -132,3 +132,36 @@ async def test_send_ranking_report_skips_same_trading_date_after_restart(tmp_pat
     await restarted_task._send_ranking_report_once({"foreign_buy": []}, "20260722")
 
     restarted_reporter.send_ranking_report.assert_not_called()
+
+
+async def test_startup_self_heal_recovers_missed_investor_report_and_period_ranking():
+    task = _make_task()
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260724")
+    task._mcs = mcs
+    task._load_last_ranking_report_date = MagicMock(return_value="20260723")
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.refresh_investor_ranking.assert_awaited_once()
+    task.prewarm_period_ranking.assert_awaited_once_with("20260724")
+    assert task._last_collected_date == "20260724"
+
+
+async def test_startup_self_heal_skips_investor_report_when_already_sent_but_prewarms_period():
+    task = _make_task()
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260724")
+    task._mcs = mcs
+    task._load_last_ranking_report_date = MagicMock(return_value="20260724")
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.refresh_investor_ranking.assert_not_awaited()
+    task.prewarm_period_ranking.assert_awaited_once_with("20260724")


### PR DESCRIPTION
## Summary
- Recover missed investor ranking reports on RankingTask startup when the latest trading date was not reported
- Keep period ranking startup self-heal so missing latest-date period caches are restored or prewarmed
- Add regression coverage for missed startup recovery and already-sent report dedupe

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests\\unit_test\\scheduler\\test_ranking_task_execute.py -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests\\unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests\\integration_test -v