### PR TITLE
기간수급: 단일 스윕으로 전 구간(1/3/5/10/20D) 파생

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -47,6 +47,8 @@ class RankingTask(AfterMarketTask):
     PERIOD_RANKING_ALLOWED_DAYS = {1, 3, 5, 10, 20}
     PERIOD_RANKING_ALLOWED_METRICS = {"amount", "qty"}
     DEFAULT_PERIOD_RANKING_DAYS = 5
+    # 전 종목 순회 1회로 함께 채우는 구간들 (API 호출 수는 구간 수와 무관)
+    PERIOD_RANKING_PREWARM_DAYS = (1, 3, 5, 10, 20)
 
     def __init__(
         self,
@@ -102,7 +104,8 @@ class RankingTask(AfterMarketTask):
         self._is_refreshing: bool = False
         self._last_collected_date: Optional[str] = None
         self._period_ranking_cache: Dict[tuple[str, int], List[Dict]] = {}
-        self._period_ranking_tasks: Dict[tuple[str, int], asyncio.Task] = {}
+        # 스윕 1회가 전 구간을 채우므로 진행 중 태스크는 거래일 단위로 관리한다
+        self._period_ranking_tasks: Dict[str, asyncio.Task] = {}
         self._period_ranking_intraday_keys: set[tuple[str, int]] = set()
 
         # 기본 랭킹 캐시 (상승/하락/거래량/거래대금) — 장마감 후 1회
@@ -697,14 +700,23 @@ class RankingTask(AfterMarketTask):
         target_date: str,
         days: int = DEFAULT_PERIOD_RANKING_DAYS,
     ) -> None:
-        """장 마감 배치의 유휴 구간에서 기본 기간수급 캐시를 미리 생성한다."""
+        """장 마감 배치의 유휴 구간에서 기간수급 캐시를 미리 생성한다.
+
+        스윕 1회가 전 구간(PERIOD_RANKING_PREWARM_DAYS)을 함께 채운다.
+        """
         cache_key = (str(target_date), days)
         if cache_key in self._period_ranking_cache:
             return
-        self._logger.info(f"기간수급 랭킹 캐시 예열 시작: {target_date}, {days}일")
+        self._logger.info(
+            f"기간수급 랭킹 캐시 예열 시작: {target_date}, {list(self.PERIOD_RANKING_PREWARM_DAYS)}일"
+        )
         await self._get_or_collect_period_ranking(cache_key)
+        warmed = [
+            d for d in self.PERIOD_RANKING_PREWARM_DAYS
+            if (str(target_date), d) in self._period_ranking_cache
+        ]
         if cache_key in self._period_ranking_cache:
-            self._logger.info(f"기간수급 랭킹 캐시 예열 완료: {target_date}, {days}일")
+            self._logger.info(f"기간수급 랭킹 캐시 예열 완료: {target_date}, {warmed}일")
         else:
             self._logger.warning(f"기간수급 랭킹 캐시 예열 미완료: {target_date}, {days}일")
 
@@ -751,8 +763,8 @@ class RankingTask(AfterMarketTask):
         return None
 
     def _trigger_period_ranking_collection(self, cache_key: tuple[str, int]) -> None:
-        """기간수급 수집을 백그라운드로 시작한다 (이미 진행 중이면 no-op)."""
-        if cache_key in self._period_ranking_tasks:
+        """기간수급 수집을 백그라운드로 시작한다 (같은 날짜 스윕이 진행 중이면 no-op)."""
+        if cache_key[0] in self._period_ranking_tasks:
             return
         self._logger.info(
             f"기간수급 캐시 없음 → 온디맨드 백그라운드 수집 트리거: {cache_key[0]}, {cache_key[1]}일"
@@ -805,44 +817,59 @@ class RankingTask(AfterMarketTask):
         if results is not None:
             return results
 
-        task = self._period_ranking_tasks.get(cache_key)
+        target_date, days = cache_key
+        task = self._period_ranking_tasks.get(target_date)
         if task is None:
-            target_date, days = cache_key
             task = asyncio.create_task(
-                self._collect_period_investor_program_ranking(target_date, days)
+                self._collect_period_investor_program_ranking(target_date)
             )
-            self._period_ranking_tasks[cache_key] = task
+            self._period_ranking_tasks[target_date] = task
         try:
-            results, is_complete = await task
+            results_by_days, is_complete = await task
         finally:
-            if task.done() and self._period_ranking_tasks.get(cache_key) is task:
-                self._period_ranking_tasks.pop(cache_key, None)
+            if task.done() and self._period_ranking_tasks.get(target_date) is task:
+                self._period_ranking_tasks.pop(target_date, None)
 
         if is_complete:
-            self._period_ranking_cache[cache_key] = results
-            if self._mcs and await self._mcs.is_market_open_now():
-                # 장중 수집분은 당일 부분 데이터 — 장 마감 시 무효화·재수집 대상으로 표시
-                self._period_ranking_intraday_keys.add(cache_key)
-            else:
-                await self._save_period_ranking_to_db(cache_key, results)
-        return results
+            # 장중 수집분은 당일 부분 데이터 — 장 마감 시 무효화·재수집 대상으로 표시
+            is_intraday = bool(self._mcs and await self._mcs.is_market_open_now())
+            for bucket_days, bucket_results in results_by_days.items():
+                bucket_key = (str(target_date), bucket_days)
+                self._period_ranking_cache[bucket_key] = bucket_results
+                if is_intraday:
+                    self._period_ranking_intraday_keys.add(bucket_key)
+                else:
+                    await self._save_period_ranking_to_db(bucket_key, bucket_results)
+        return results_by_days.get(days, [])
 
     async def _collect_period_investor_program_ranking(
         self,
         target_date: str,
-        days: int,
-    ) -> tuple[List[Dict], bool]:
-        """기간 수급 원천 데이터를 수집한다. 불완전한 결과는 캐시하지 않는다."""
+        days_list: tuple[int, ...] = PERIOD_RANKING_PREWARM_DAYS,
+    ) -> tuple[Dict[int, List[Dict]], bool]:
+        """기간 수급 원천을 1회 순회로 수집해 구간별 결과를 파생한다.
+
+        투자자/프로그램 일별 API는 요청에 기간이 없고 응답을 잘라 쓰는 구조라
+        (days는 output[:days] 슬라이스) 호출 수가 구간 수와 무관하다.
+        따라서 최장 구간으로 한 번만 순회하고 짧은 구간은 같은 행에서 합산한다.
+        불완전한 결과는 캐시하지 않는다.
+        """
+        days_list = tuple(sorted(set(days_list)))
+        max_days = max(days_list)
+        results_by_days: Dict[int, List[Dict]] = {d: [] for d in days_list}
+
         all_stocks = self._load_all_stocks()
         if not all_stocks:
-            return [], True
+            return results_by_days, True
 
-        recent_trading_dates = await self._get_recent_trading_dates(target_date, days)
-        recent_trading_date_set = set(recent_trading_dates)
+        # 구간별 거래일 창은 각각 계산한다 (캘린더 캐시 기반이라 비용이 낮다)
+        trading_dates_by_days = {
+            d: await self._get_recent_trading_dates(target_date, d) for d in days_list
+        }
+        date_sets = {d: set(dates) for d, dates in trading_dates_by_days.items()}
+        observed_by_days: Dict[int, set] = {d: {str(target_date)} for d in days_list}
         industry_map = await self._load_industry_map()
-        results: List[Dict] = []
         is_complete = True
-        observed_trading_dates = {str(target_date)}
         start_time = time.time()
         processed = 0
         self._period_progress = {
@@ -858,11 +885,11 @@ class RankingTask(AfterMarketTask):
                 await self._suspend_event.wait()
 
                 investor_tasks = [
-                    self._fetch_with_retry(self._broker.get_investor_trade_by_stock_daily_multi, code, target_date, days)
+                    self._fetch_with_retry(self._broker.get_investor_trade_by_stock_daily_multi, code, target_date, max_days)
                     for code, _, _ in chunk
                 ]
                 program_tasks = [
-                    self._fetch_with_retry(self._broker.get_program_trade_by_stock_daily_multi, code, target_date, days)
+                    self._fetch_with_retry(self._broker.get_program_trade_by_stock_daily_multi, code, target_date, max_days)
                     for code, _, _ in chunk
                 ]
                 all_responses = await asyncio.gather(
@@ -883,88 +910,115 @@ class RankingTask(AfterMarketTask):
                         is_complete = False
                         continue
 
-                    investor_rows = investor_resp.data if investor_resp and isinstance(investor_resp.data, list) else []
-                    program_rows = program_resp.data if program_resp and isinstance(program_resp.data, list) else []
-                    if recent_trading_date_set:
-                        investor_rows = [
-                            row for row in investor_rows
-                            if isinstance(row, dict) and str(row.get("stck_bsop_date") or "") in recent_trading_date_set
-                        ]
-                        program_rows = [
-                            row for row in program_rows
-                            if isinstance(row, dict) and str(row.get("stck_bsop_date") or "") in recent_trading_date_set
-                        ]
-                    for row in [*investor_rows, *program_rows]:
-                        if not isinstance(row, dict):
-                            continue
-                        trading_date = str(row.get("stck_bsop_date") or "")
-                        if len(trading_date) == 8 and trading_date.isdigit():
-                            observed_trading_dates.add(trading_date)
+                    all_investor_rows = [
+                        row for row in (investor_resp.data if isinstance(investor_resp.data, list) else [])
+                        if isinstance(row, dict)
+                    ]
+                    all_program_rows = [
+                        row for row in (program_resp.data if isinstance(program_resp.data, list) else [])
+                        if isinstance(row, dict)
+                    ]
 
-                    frgn_qty = self._sum_rows(investor_rows, "frgn_ntby_qty")
-                    orgn_qty = self._sum_rows(investor_rows, "orgn_ntby_qty")
-                    frgn_pbmn_mil = self._sum_rows(investor_rows, "frgn_ntby_tr_pbmn")
-                    orgn_pbmn_mil = self._sum_rows(investor_rows, "orgn_ntby_tr_pbmn")
-                    program_qty = self._sum_rows(program_rows, "whol_smtn_ntby_qty")
-                    program_pbmn_won = self._sum_rows(program_rows, "whol_smtn_ntby_tr_pbmn")
+                    for days in days_list:
+                        investor_rows = self._rows_for_period(all_investor_rows, date_sets[days], days)
+                        program_rows = self._rows_for_period(all_program_rows, date_sets[days], days)
+                        for row in [*investor_rows, *program_rows]:
+                            trading_date = str(row.get("stck_bsop_date") or "")
+                            if len(trading_date) == 8 and trading_date.isdigit():
+                                observed_by_days[days].add(trading_date)
 
-                    frgn_pbmn_won = frgn_pbmn_mil * 1_000_000
-                    orgn_pbmn_won = orgn_pbmn_mil * 1_000_000
-                    combined_pbmn_won = frgn_pbmn_won + orgn_pbmn_won + program_pbmn_won
-                    combined_qty = frgn_qty + orgn_qty + program_qty
-
-                    if combined_pbmn_won <= 0 and combined_qty <= 0:
-                        continue
-
-                    first_investor = investor_rows[0] if investor_rows and isinstance(investor_rows[0], dict) else {}
-                    first_program = program_rows[0] if program_rows and isinstance(program_rows[0], dict) else {}
-                    stck_prpr = first_investor.get("stck_prpr") or first_program.get("stck_clpr") or "0"
-                    acml_tr_pbmn = first_investor.get("acml_tr_pbmn") or first_program.get("acml_tr_pbmn") or "0"
-
-                    results.append({
-                        "stck_shrn_iscd": code,
-                        "hts_kor_isnm": name,
-                        "industry": industry_map.get(code, "-"),
-                        "period_days": str(days),
-                        "stck_prpr": str(stck_prpr or "0"),
-                        "prdy_ctrt": str(first_investor.get("prdy_ctrt") or first_program.get("prdy_ctrt") or "0"),
-                        "prdy_vrss": str(first_investor.get("prdy_vrss") or first_program.get("prdy_vrss") or "0"),
-                        "prdy_vrss_sign": str(first_investor.get("prdy_vrss_sign") or first_program.get("prdy_vrss_sign") or ""),
-                        "acml_tr_pbmn": str(acml_tr_pbmn or "0"),
-                        "frgn_period_ntby_qty": str(frgn_qty),
-                        "orgn_period_ntby_qty": str(orgn_qty),
-                        "program_period_ntby_qty": str(program_qty),
-                        "combined_period_ntby_qty": str(combined_qty),
-                        "frgn_period_ntby_tr_pbmn": str(frgn_pbmn_mil),
-                        "orgn_period_ntby_tr_pbmn": str(orgn_pbmn_mil),
-                        "program_period_ntby_tr_pbmn": str(program_pbmn_won // 1_000_000),
-                        "combined_period_ntby_tr_pbmn": str(combined_pbmn_won // 1_000_000),
-                        "frgn_period_ntby_tr_pbmn_won": str(frgn_pbmn_won),
-                        "orgn_period_ntby_tr_pbmn_won": str(orgn_pbmn_won),
-                        "program_period_ntby_tr_pbmn_won": str(program_pbmn_won),
-                        "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
-                    })
+                        item = self._build_period_ranking_item(
+                            code, name, days, industry_map.get(code, "-"), investor_rows, program_rows
+                        )
+                        if item:
+                            results_by_days[days].append(item)
 
                 processed += len(chunk)
                 elapsed = time.time() - start_time
+                collected = len(results_by_days[max_days])
                 self._period_progress.update({
                     "processed": processed,
-                    "collected": len(results),
+                    "collected": collected,
                     "elapsed": round(elapsed, 1),
                 })
                 if processed % 400 == 0 or processed >= len(all_stocks):
                     self._logger.info(
                         f"기간수급 진행: {processed}/{len(all_stocks)} "
-                        f"({processed / len(all_stocks) * 100:.1f}%) | 수집: {len(results)} | 소요: {elapsed:.1f}s"
+                        f"({processed / len(all_stocks) * 100:.1f}%) | 수집: {collected} | 소요: {elapsed:.1f}s"
                     )
         finally:
             self._period_progress["running"] = False
 
-        earliest_trading_date = recent_trading_dates[0] if recent_trading_dates else min(observed_trading_dates)
-        for result in results:
-            result["earliest_trading_date"] = earliest_trading_date
+        for days in days_list:
+            recent_trading_dates = trading_dates_by_days[days]
+            earliest_trading_date = (
+                recent_trading_dates[0] if recent_trading_dates else min(observed_by_days[days])
+            )
+            for result in results_by_days[days]:
+                result["earliest_trading_date"] = earliest_trading_date
 
-        return results, is_complete
+        return results_by_days, is_complete
+
+    @staticmethod
+    def _rows_for_period(rows: List[Dict], date_set: set, days: int) -> List[Dict]:
+        """구간에 해당하는 행만 추린다. 거래일 계산이 불가하면 최신 N행으로 대체한다."""
+        if date_set:
+            return [row for row in rows if str(row.get("stck_bsop_date") or "") in date_set]
+        return rows[:days]
+
+    def _build_period_ranking_item(
+        self,
+        code: str,
+        name: str,
+        days: int,
+        industry: str,
+        investor_rows: List[Dict],
+        program_rows: List[Dict],
+    ) -> Optional[Dict]:
+        """구간 행 합산 결과를 랭킹 항목으로 만든다. 순매수가 없으면 None."""
+        frgn_qty = self._sum_rows(investor_rows, "frgn_ntby_qty")
+        orgn_qty = self._sum_rows(investor_rows, "orgn_ntby_qty")
+        frgn_pbmn_mil = self._sum_rows(investor_rows, "frgn_ntby_tr_pbmn")
+        orgn_pbmn_mil = self._sum_rows(investor_rows, "orgn_ntby_tr_pbmn")
+        program_qty = self._sum_rows(program_rows, "whol_smtn_ntby_qty")
+        program_pbmn_won = self._sum_rows(program_rows, "whol_smtn_ntby_tr_pbmn")
+
+        frgn_pbmn_won = frgn_pbmn_mil * 1_000_000
+        orgn_pbmn_won = orgn_pbmn_mil * 1_000_000
+        combined_pbmn_won = frgn_pbmn_won + orgn_pbmn_won + program_pbmn_won
+        combined_qty = frgn_qty + orgn_qty + program_qty
+
+        if combined_pbmn_won <= 0 and combined_qty <= 0:
+            return None
+
+        first_investor = investor_rows[0] if investor_rows else {}
+        first_program = program_rows[0] if program_rows else {}
+        stck_prpr = first_investor.get("stck_prpr") or first_program.get("stck_clpr") or "0"
+        acml_tr_pbmn = first_investor.get("acml_tr_pbmn") or first_program.get("acml_tr_pbmn") or "0"
+
+        return {
+            "stck_shrn_iscd": code,
+            "hts_kor_isnm": name,
+            "industry": industry,
+            "period_days": str(days),
+            "stck_prpr": str(stck_prpr or "0"),
+            "prdy_ctrt": str(first_investor.get("prdy_ctrt") or first_program.get("prdy_ctrt") or "0"),
+            "prdy_vrss": str(first_investor.get("prdy_vrss") or first_program.get("prdy_vrss") or "0"),
+            "prdy_vrss_sign": str(first_investor.get("prdy_vrss_sign") or first_program.get("prdy_vrss_sign") or ""),
+            "acml_tr_pbmn": str(acml_tr_pbmn or "0"),
+            "frgn_period_ntby_qty": str(frgn_qty),
+            "orgn_period_ntby_qty": str(orgn_qty),
+            "program_period_ntby_qty": str(program_qty),
+            "combined_period_ntby_qty": str(combined_qty),
+            "frgn_period_ntby_tr_pbmn": str(frgn_pbmn_mil),
+            "orgn_period_ntby_tr_pbmn": str(orgn_pbmn_mil),
+            "program_period_ntby_tr_pbmn": str(program_pbmn_won // 1_000_000),
+            "combined_period_ntby_tr_pbmn": str(combined_pbmn_won // 1_000_000),
+            "frgn_period_ntby_tr_pbmn_won": str(frgn_pbmn_won),
+            "orgn_period_ntby_tr_pbmn_won": str(orgn_pbmn_won),
+            "program_period_ntby_tr_pbmn_won": str(program_pbmn_won),
+            "combined_period_ntby_tr_pbmn_won": str(combined_pbmn_won),
+        }
 
     async def _get_recent_trading_dates(self, target_date: str, days: int) -> List[str]:
         """시장 캘린더 기준 target_date 포함 최근 N거래일을 오래된 순으로 반환한다."""

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_buckets.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_buckets.py
@@ -1,0 +1,140 @@
+"""RankingTask 기간수급 전 구간 파생 테스트.
+
+배경: 투자자/프로그램 일별 API는 요청에 기간이 없고 응답을 잘라 쓰는 구조라
+(days는 output[:days] 슬라이스일 뿐) 1D 스윕과 20D 스윕의 API 호출 수가 같다.
+따라서 전 종목 순회는 최장 구간 기준 1회만 하고 나머지 구간은 같은 행에서 파생한다.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+from common.types import ResCommonResponse
+from task.background.after_market.ranking_task import RankingTask
+
+TRADING_DATES = [
+    "20260707", "20260708", "20260709", "20260710", "20260713",
+    "20260714", "20260715", "20260716", "20260717", "20260720",
+    "20260721", "20260722", "20260723", "20260724", "20260727",
+    "20260728", "20260729", "20260730", "20260731", "20260803",
+]  # 오래된 순 20거래일 (마지막이 기준일)
+
+
+def _make_task(period_repo=None, mcs=None) -> RankingTask:
+    broker = MagicMock()
+    stock_repo = MagicMock()
+    stock_repo.df = MagicMock()
+    stock_repo.df.iterrows.return_value = iter([])
+    return RankingTask(
+        broker_api_wrapper=broker,
+        stock_code_repository=stock_repo,
+        logger=MagicMock(),
+        market_calendar_service=mcs,
+        period_ranking_repository=period_repo,
+    )
+
+
+def _investor_rows() -> list[dict]:
+    """최신일부터 과거 순. 하루당 외국인 1주, 기관 1주 순매수."""
+    return [
+        {
+            "stck_bsop_date": date,
+            "stck_prpr": "70000",
+            "frgn_ntby_qty": "1",
+            "orgn_ntby_qty": "1",
+            "frgn_ntby_tr_pbmn": "1",
+            "orgn_ntby_tr_pbmn": "1",
+        }
+        for date in reversed(TRADING_DATES)
+    ]
+
+
+def _program_rows() -> list[dict]:
+    return [
+        {
+            "stck_bsop_date": date,
+            "whol_smtn_ntby_qty": "1",
+            "whol_smtn_ntby_tr_pbmn": "1000000",
+        }
+        for date in reversed(TRADING_DATES)
+    ]
+
+
+def _stub_sweep(task: RankingTask, count: int = 2) -> MagicMock:
+    stocks = [(f"0059{i:02d}", f"종목{i}", "KOSPI") for i in range(count)]
+    task._load_all_stocks = MagicMock(return_value=stocks)
+    task._load_industry_map = AsyncMock(return_value={})
+    task._get_recent_trading_dates = AsyncMock(
+        side_effect=lambda date, days: TRADING_DATES[-days:]
+    )
+
+    async def _fetch(api_call, code, target_date, days):
+        rows = _program_rows() if "program" in str(api_call) else _investor_rows()
+        return ResCommonResponse(rt_cd="0", msg1="정상", data=rows[:days])
+
+    fetch_mock = AsyncMock(side_effect=_fetch)
+    task._fetch_with_retry = fetch_mock
+    return fetch_mock
+
+
+async def test_single_sweep_fills_every_bucket():
+    task = _make_task()
+    _stub_sweep(task, count=2)
+
+    buckets, is_complete = await task._collect_period_investor_program_ranking("20260803")
+
+    assert is_complete is True
+    assert set(buckets) == set(RankingTask.PERIOD_RANKING_PREWARM_DAYS)
+    for days in RankingTask.PERIOD_RANKING_PREWARM_DAYS:
+        assert len(buckets[days]) == 2, f"{days}일 구간 결과 누락"
+
+
+async def test_sweep_api_call_count_is_independent_of_bucket_count():
+    """구간이 5개여도 종목당 호출은 투자자 1 + 프로그램 1 뿐이어야 한다."""
+    task = _make_task()
+    fetch_mock = _stub_sweep(task, count=3)
+
+    await task._collect_period_investor_program_ranking("20260803")
+
+    assert fetch_mock.await_count == 3 * 2
+
+
+async def test_buckets_sum_only_their_own_trading_dates():
+    """3일 구간은 최근 3거래일만, 20일 구간은 20거래일 전부를 합산한다."""
+    task = _make_task()
+    _stub_sweep(task, count=1)
+
+    buckets, _ = await task._collect_period_investor_program_ranking("20260803")
+
+    # 하루당 외국인 1주 → 구간 일수만큼 누적
+    assert buckets[3][0]["frgn_period_ntby_qty"] == "3"
+    assert buckets[5][0]["frgn_period_ntby_qty"] == "5"
+    assert buckets[20][0]["frgn_period_ntby_qty"] == "20"
+    assert buckets[3][0]["period_days"] == "3"
+    assert buckets[3][0]["earliest_trading_date"] == TRADING_DATES[-3]
+    assert buckets[20][0]["earliest_trading_date"] == TRADING_DATES[0]
+
+
+async def test_get_or_collect_caches_and_saves_every_bucket():
+    repo = MagicMock()
+    repo.get.return_value = None
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    task = _make_task(period_repo=repo, mcs=mcs)
+    task._collect_period_investor_program_ranking = AsyncMock(
+        return_value=({3: [{"a": "3"}], 5: [{"a": "5"}]}, True)
+    )
+
+    results = await task._get_or_collect_period_ranking(("20260803", 3))
+
+    assert results == [{"a": "3"}]
+    assert task._period_ranking_cache[("20260803", 3)] == [{"a": "3"}]
+    assert task._period_ranking_cache[("20260803", 5)] == [{"a": "5"}]
+    assert repo.save.call_count == 2
+
+
+async def test_second_bucket_request_reuses_in_flight_sweep():
+    """다른 구간 요청이 같은 날짜의 스윕을 중복 시작하지 않는다."""
+    task = _make_task(mcs=None)
+    task._period_ranking_tasks["20260803"] = MagicMock()  # 스윕 진행 중 시뮬레이션
+
+    task._trigger_period_ranking_collection(("20260803", 3))
+
+    assert not task._tasks, "이미 진행 중이면 새 스윕을 만들지 않는다"

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_persistence.py
@@ -54,7 +54,7 @@ async def test_get_or_collect_saves_complete_results_to_db():
     repo.get.return_value = None
     task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], True)
+        return_value=({5: [{"a": "1"}]}, True)
     )
 
     results = await task._get_or_collect_period_ranking(("20260714", 5))
@@ -68,7 +68,7 @@ async def test_get_or_collect_skips_db_save_during_market_open():
     repo.get.return_value = None
     task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=True))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], True)
+        return_value=({5: [{"a": "1"}]}, True)
     )
 
     await task._get_or_collect_period_ranking(("20260714", 5))
@@ -83,7 +83,7 @@ async def test_get_or_collect_does_not_save_incomplete_results():
     repo.get.return_value = None
     task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], False)
+        return_value=({5: [{"a": "1"}]}, False)
     )
 
     await task._get_or_collect_period_ranking(("20260714", 5))
@@ -97,7 +97,7 @@ async def test_get_or_collect_db_error_falls_back_to_collect():
     repo.get.side_effect = RuntimeError("db broken")
     task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=False))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], True)
+        return_value=({5: [{"a": "1"}]}, True)
     )
 
     results = await task._get_or_collect_period_ranking(("20260714", 5))
@@ -114,7 +114,7 @@ async def test_intraday_collection_marked_for_invalidation():
     repo.get.return_value = None
     task = _make_task(period_repo=repo, mcs=_make_mcs(market_open=True))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], True)
+        return_value=({5: [{"a": "1"}]}, True)
     )
 
     await task._get_or_collect_period_ranking(("20260714", 5))
@@ -126,7 +126,7 @@ async def test_intraday_collection_marked_for_invalidation():
 async def test_after_close_collection_not_marked_intraday():
     task = _make_task(mcs=_make_mcs(market_open=False))
     task._collect_period_investor_program_ranking = AsyncMock(
-        return_value=([{"a": "1"}], True)
+        return_value=({5: [{"a": "1"}]}, True)
     )
 
     await task._get_or_collect_period_ranking(("20260714", 5))
@@ -175,7 +175,7 @@ async def test_get_period_returns_collecting_immediately_on_cache_miss():
     task = _make_task(mcs=_make_mcs(market_open=False, latest_date="20260714"))
     task._collect_period_investor_program_ranking = AsyncMock(
         return_value=(
-            [{"hts_kor_isnm": "삼성전자", "combined_period_ntby_tr_pbmn_won": "100"}],
+            {5: [{"hts_kor_isnm": "삼성전자", "combined_period_ntby_tr_pbmn_won": "100"}]},
             True,
         )
     )
@@ -213,7 +213,7 @@ async def test_get_period_returns_db_data_without_collecting():
 async def test_trigger_period_collection_dedups_in_progress():
     task = _make_task(mcs=_make_mcs())
     key = ("20260714", 5)
-    task._period_ranking_tasks[key] = MagicMock()  # 수집 진행 중 시뮬레이션
+    task._period_ranking_tasks["20260714"] = MagicMock()  # 수집 진행 중 시뮬레이션
 
     task._trigger_period_ranking_collection(key)
 

--- a/tests/unit_test/task/background/after_market/test_ranking_task_period_progress.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task_period_progress.py
@@ -66,12 +66,12 @@ async def test_period_progress_reaches_total_after_collection():
     task = _make_task()
     _stub_collection(task, count=20)
 
-    results, _ = await task._collect_period_investor_program_ranking("20260727", 3)
+    buckets, _ = await task._collect_period_investor_program_ranking("20260727")
 
     progress = task.get_period_ranking_progress()
     assert progress["total"] == 20
     assert progress["processed"] == 20
-    assert progress["collected"] == len(results)
+    assert progress["collected"] == len(buckets[max(buckets)])
     assert progress["running"] is False
 
 
@@ -86,7 +86,7 @@ async def test_period_progress_reports_partial_progress_while_running():
 
     task._fetch_with_retry = AsyncMock(side_effect=_capture)
 
-    await task._collect_period_investor_program_ranking("20260727", 3)
+    await task._collect_period_investor_program_ranking("20260727")
 
     assert snapshots, "수집 중 진행률 스냅샷이 있어야 한다"
     assert all(s["running"] is True for s in snapshots)
@@ -102,7 +102,7 @@ async def test_period_progress_clears_running_on_error():
     task._suspend_event.wait = AsyncMock(side_effect=RuntimeError("boom"))
 
     try:
-        await task._collect_period_investor_program_ranking("20260727", 3)
+        await task._collect_period_investor_program_ranking("20260727")
     except RuntimeError:
         pass
 
@@ -113,7 +113,7 @@ async def test_period_progress_is_separate_from_investor_progress():
     task = _make_task()
     _stub_collection(task, count=20)
 
-    await task._collect_period_investor_program_ranking("20260727", 3)
+    await task._collect_period_investor_program_ranking("20260727")
 
     assert task.get_investor_ranking_progress()["total"] == 0
     assert task.get_period_ranking_progress()["total"] == 20


### PR DESCRIPTION
## 배경
`/ranking` 기간수급 탭에서 예열되지 않은 구간(3D 등)을 고르면 전 종목(~2,800개) 온디맨드 수집이 시작돼 12분을 기다려야 한다. 구간별로 예열 태스크를 나눠 도는 방식을 검토했으나, API 계약을 확인한 결과 불필요한 낭비였다.

**투자자/프로그램 일별 API는 요청 파라미터에 기간이 없다.** `days`는 받아온 응답을 자르는 클라이언트 슬라이스일 뿐이다 (`output2[:days]`, `output[:days]` — korea_invest_quotations_api.py). 즉 1D 스윕과 20D 스윕의 HTTP 호출 수가 완전히 같다. 구간별 스윕 5회는 같은 데이터를 5번 사는 셈(약 28,000콜 + 마감 후 창 60분 추가 점유)이다.

## 변경
한 번의 순회에서 1/3/5/10/20D를 모두 파생한다.

- `_collect_period_investor_program_ranking`: `days: int` → `days_list`, 구간별 결과 dict 반환. 종목당 호출은 그대로 투자자 1 + 프로그램 1.
- 구간별 거래일 창은 각각 계산한다(`is_business_day`는 캘린더 캐시 기반이라 저비용). 최장 구간 리스트를 잘라 쓰는 방식은 캘린더가 20거래일을 못 채울 때 짧은 구간까지 동반 degrade 돼서 채택하지 않았다 — 기존 단일 구간 수치와 동일함을 기존 테스트(거래정지 종목 케이스)가 보증한다.
- 종목 1건 합산을 `_build_period_ranking_item` / `_rows_for_period`로 분리 (구간당 1회씩 호출되므로 인라인이면 4중 중첩).
- `_get_or_collect_period_ranking`이 전 구간을 캐시·DB에 채운다. 진행 중 스윕 dedup 키를 `(date, days)` → `date`로 변경 — 안 바꾸면 3D 요청과 5D 요청이 각자 스윕을 띄운다.
- `PeriodRankingRepository`는 `(trade_date, days)` PK라 스키마 변경 없음. 재시작 후에도 5개 구간 전부 DB에서 즉시 복원된다.

**효과**: 마감 후 예열 1회(~12분)로 전 구간이 준비된다. **API 호출 증가 0건.**

## 테스트
- 신규 `test_ranking_task_period_buckets.py` (5건) — 전 구간 채움, 호출 수가 구간 수와 무관(`await_count == 종목수 × 2`), 구간별 날짜 창 합산(3D=3일치/20D=20일치), 구간별 캐시·DB 저장, 중복 스윕 방지
- 기존 기간수급 테스트를 새 반환 계약(구간 dict)에 맞춰 갱신
- `pytest tests/unit_test` 7138 passed / `pytest tests/integration_test` 266 passed / jsdom 2/2

## 후속 (이 PR 범위 밖)
DB 저장이 스윕당 5회로 늘었다. `PeriodRankingRepository.save`는 동기 sqlite + `json.dumps`(구간당 ~2,800건)라 이벤트 루프를 잠깐 잡는다. 마감 후 12분 스윕 뒤 1회뿐이라 이번엔 두었고, 필요하면 `asyncio.to_thread`로 분리하면 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)