### PR TITLE
홈 화면 시장 지수 패널 (국장·미장·원자재)

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -143,6 +143,13 @@ class BrokerAPIWrapper:
         return await self._client.inquire_daily_itemchartprice(stock_code, start_date=start_date, end_date=end_date,
                                                                fid_period_div_code=fid_period_div_code,
                                                                exchange=exchange, **kwargs)
+
+    async def inquire_daily_indexchartprice(self, index_code: str, start_date: str, end_date: str,
+                                            period: str = 'D') -> ResCommonResponse:
+        """국내업종 기간별 지수 시세를 조회합니다 (KoreaInvestApiQuotations 위임)."""
+        return await self._client.inquire_daily_indexchartprice(index_code, start_date=start_date,
+                                                                end_date=end_date, period=period)
+
     async def inquire_time_itemchartprice(
         self, *, stock_code: str, input_hour_1: str,
         pw_data_incu_yn: str = "Y", etc_cls_code: str = "0"

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -172,6 +172,12 @@ class KoreaInvestApiClient:
                                                                    fid_period_div_code=fid_period_div_code,
                                                                    exchange=exchange)
 
+    async def inquire_daily_indexchartprice(self, index_code: str, start_date: str, end_date: str,
+                                            period: str = 'D') -> ResCommonResponse:
+        """국내업종(코스피/코스닥) 기간별 지수 시세를 조회합니다. ResCommonResponse를 반환합니다."""
+        return await self._quotations.inquire_daily_indexchartprice(index_code, start_date=start_date,
+                                                                    end_date=end_date, period=period)
+
     async def inquire_time_itemchartprice(
         self,
         *,

--- a/brokers/korea_investment/korea_invest_params_provider.py
+++ b/brokers/korea_investment/korea_invest_params_provider.py
@@ -84,6 +84,30 @@ class DailyItemChartPriceParams:
     def to_dict(self) -> Dict[str, str]:
         return asdict(self)
 
+
+@dataclass(frozen=True)
+class DailyIndexChartPriceParams:
+    """국내업종 기간별 지수 시세. 주식과 달리 시장분류가 "U" 이고 수정주가 항목이 없다."""
+    fid_cond_mrkt_div_code: str  # 업종/지수는 "U"
+    fid_input_iscd: str  # 업종코드 (코스피 0001 / 코스닥 1001)
+    fid_input_date_1: str  # 조회 시작일
+    fid_input_date_2: str  # 조회 종료일
+    fid_period_div_code: str  # 일/주/월/년
+
+    @classmethod
+    def daily_indexchartprice(cls, index_code: str, start_date: str, end_date: str, period: str):
+        return cls(
+            fid_cond_mrkt_div_code="U",
+            fid_input_iscd=index_code,
+            fid_input_date_1=tm.to_yyyymmdd(start_date),
+            fid_input_date_2=tm.to_yyyymmdd(end_date),
+            fid_period_div_code=period,
+        )
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
 @dataclass(frozen=True)
 class TimeItemChartPriceParams:
     fid_cond_mrkt_div_code: str  # 보통 "J"
@@ -734,6 +758,10 @@ class Params:
     def daily_itemchartprice(stock_code: str, start_date: str, end_date: str, period: str, market: MarketCode = "J", adj: Literal["0", "1"] = "0") -> \
             Dict[str, str]:
         return DailyItemChartPriceParams.daily_itemchartprice(stock_code, start_date, end_date, period, market, adj).to_dict()
+
+    @staticmethod
+    def daily_indexchartprice(index_code: str, start_date: str, end_date: str, period: str) -> Dict[str, str]:
+        return DailyIndexChartPriceParams.daily_indexchartprice(index_code, start_date, end_date, period).to_dict()
 
     @staticmethod
     def time_itemchartprice(stock_code: str, input_hour: str,

--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -464,6 +464,51 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
             data=chart_data_items
         )
 
+    async def inquire_daily_indexchartprice(self, index_code: str,
+                                            start_date: str,
+                                            end_date: str,
+                                            period: str = 'D') -> ResCommonResponse:
+        """
+        국내업종(코스피 0001 / 코스닥 1001) 기간별 지수 시세를 조회합니다.
+        TRID: FHKUP03500100
+        data 에 {"summary": output1(현재가/등락 요약), "candles": output2(기간별 시세)} 를 담아 반환합니다.
+        """
+        valid_period_codes = {"D", "W", "M", "Y"}
+        if period not in valid_period_codes:
+            error_msg = f"지원하지 않는 period: {period}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=error_msg, data=None)
+
+        tr_id = self._trid_provider.quotations(TrIdLeaf.DAILY_INDEXCHARTPRICE)
+        params = Params.daily_indexchartprice(index_code, start_date, end_date, period)
+
+        with self._headers.temp(tr_id=tr_id):
+            response_data: ResCommonResponse = await self.call_api(
+                "GET", EndpointKey.DAILY_INDEXCHARTPRICE, params=params
+            )
+
+        if response_data.rt_cd != ErrorCode.SUCCESS.value:
+            error_msg = f"지수 시세 API 응답 비정상 (index_code: {index_code}), 응답: {response_data.data}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=error_msg, data=None)
+
+        raw = response_data.data if isinstance(response_data.data, dict) else {}
+        summary = raw.get("output1") or {}
+        candles = raw.get("output2") or []
+        if not isinstance(candles, list):
+            candles = [candles] if candles else []
+
+        if not candles:
+            warning_msg = f"지수 시세 데이터가 비어있음 (index_code: {index_code})"
+            self._logger.warning(warning_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.MISSING_KEY.value, msg1=warning_msg, data=None)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="지수 시세 조회 성공",
+            data={"summary": summary, "candles": candles},
+        )
+
     async def inquire_time_itemchartprice(
         self,
         stock_code: str,

--- a/brokers/korea_investment/korea_invest_trid_keys.py
+++ b/brokers/korea_investment/korea_invest_trid_keys.py
@@ -14,6 +14,7 @@ class TrIdLeaf(str, Enum):
     MULTI_PRICE = "multi_price"
 
     DAILY_ITEMCHARTPRICE =      "inquire_daily_itemchartprice"           # 기간별 시세 (일/주/월/년)
+    DAILY_INDEXCHARTPRICE =     "inquire_daily_indexchartprice"          # 국내업종 기간별 지수 시세
     TIME_ITEMCHARTPRICE =       "inquire_time_itemchartprice"             # 당일 분봉 조회
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice" # 일별 분봉 조회
     FINANCIAL_RATIO = "financial_ratio"  # 기업 재무비율

--- a/brokers/korea_investment/korea_invest_url_keys.py
+++ b/brokers/korea_investment/korea_invest_url_keys.py
@@ -13,6 +13,7 @@ class EndpointKey(str, Enum):
     ETF_INFO = "etf_info"
     MULTI_PRICE = "multi_price"
     DAILY_ITEMCHARTPRICE = "inquire_daily_itemchartprice"
+    DAILY_INDEXCHARTPRICE = "inquire_daily_indexchartprice"
     TIME_ITEMCHARTPRICE = "inquire_time_itemchartprice"
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice"
     FINANCIAL_RATIO = "financial_ratio"

--- a/config/kis_config.yaml
+++ b/config/kis_config.yaml
@@ -14,6 +14,7 @@ paths:
   etf_info: /uapi/etfetn/v1/quotations/inquire-price
   multi_price: /uapi/domestic-stock/v1/quotations/intstock-multprice
   inquire_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice      # 기간별 시세 (일/주/월/년)
+  inquire_daily_indexchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice    # 국내업종 기간별 지수 시세 (코스피/코스닥)
   inquire_time_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice        # 당일 분봉 조회
   inquire_time_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice # 일변 분봉 조회
   financial_ratio: /uapi/domestic-stock/v1/finance/financial-ratio  # 기업 재무비율 (영업이익 등)

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -17,6 +17,7 @@ tr_ids:
     multi_price: FHKST11300006
 
     inquire_daily_itemchartprice:      FHKST03010100 # 기간별 시세 (일/주/월/년)
+    inquire_daily_indexchartprice:     FHKUP03500100 # 국내업종 기간별 지수 시세 (코스피 0001 / 코스닥 1001)
     inquire_time_itemchartprice:       FHKST03010200 # 당일 분봉 조회
     inquire_time_daily_itemchartprice: FHKST03010230 # 일변 분봉 조회 (모의 미지원)
     financial_ratio: FHKST66430300  # 기업 재무비율 (KIS 문서 확인 필요, 실전 전용 가능성)

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1,6 +1,7 @@
 # app/stock_query_service.py
 from __future__ import annotations
 import time
+from datetime import timedelta
 from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
 from common.overseas_types import OverseasExchange
 from common.types import ErrorCode, ResCommonResponse, ResTopMarketCapApiItem, ResBasicStockInfo, \
@@ -11,6 +12,14 @@ from core.performance_profiler import PerformanceProfiler
 from services.data_quality_service import DataQualityService
 from services.notification_service import NotificationService, NotificationCategory, NotificationLevel
 from services.market_data_service import MarketDataService
+
+
+def _to_float(value) -> Optional[float]:
+    """KIS 문자열 숫자를 float 로 변환한다. 빈 값/비정상 값은 None."""
+    try:
+        return float(str(value).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return None
 
 
 class StockQueryService:
@@ -1397,3 +1406,52 @@ class StockQueryService:
 
         self.pm.log_timer(f"StockQueryService.get_day_intraday_minutes_list({stock_code}, {batches}배치)", t_start, threshold=1.0)
         return collected
+
+    # ── 국내 지수 (홈 화면 지수 패널) ──────────────────────────────────────
+    DOMESTIC_INDEX_NAMES = {"0001": "코스피", "1001": "코스닥"}
+
+    async def get_index_chart(self, index_code: str, days: int = 60) -> ResCommonResponse:
+        """코스피/코스닥 지수의 현재값·등락과 최근 일별 종가를 조회한다.
+
+        홈 화면 지수 패널이 쓰는 형태({code,name,current,change,change_rate,points})로 정규화한다.
+        """
+        if index_code not in self.DOMESTIC_INDEX_NAMES:
+            msg = f"지원하지 않는 지수 코드: {index_code}"
+            self.logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=None)
+
+        now = self.market_clock.get_current_kst_time()
+        end_date = now.strftime("%Y%m%d")
+        # 주말/휴장일을 감안해 넉넉히 조회한 뒤 days 개로 자른다.
+        start_date = (now - timedelta(days=days * 2)).strftime("%Y%m%d")
+
+        resp = await self.broker.inquire_daily_indexchartprice(
+            index_code, start_date=start_date, end_date=end_date
+        )
+        if resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp
+
+        raw = resp.data or {}
+        summary = raw.get("summary") or {}
+        points = []
+        for candle in raw.get("candles") or []:
+            date = str(candle.get("stck_bsop_date") or "")
+            close = _to_float(candle.get("bstp_nmix_prpr"))
+            if not date or close is None:
+                continue
+            points.append({"date": date, "close": close})
+
+        # KIS 는 최신순으로 주므로 차트용으로 과거→현재로 뒤집는다.
+        points.sort(key=lambda p: p["date"])
+        if len(points) > days:
+            points = points[-days:]
+
+        data = {
+            "code": index_code,
+            "name": summary.get("hts_kor_isnm") or self.DOMESTIC_INDEX_NAMES[index_code],
+            "current": _to_float(summary.get("bstp_nmix_prpr")),
+            "change": _to_float(summary.get("bstp_nmix_prdy_vrss")),
+            "change_rate": _to_float(summary.get("bstp_nmix_prdy_ctrt")),
+            "points": points,
+        }
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="지수 조회 성공", data=data)

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -1,0 +1,116 @@
+/*
+ * jsdom 기반 홈 화면 글로벌 지수 패널 회귀 테스트.
+ *
+ * 실행: node run_market_indices_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { applyCommonStubs, test, assert, run } from "./harness.mjs";
+
+const MARKET_INDICES_JS = process.env.MARKET_INDICES_JS_PATH
+  ? resolve(process.env.MARKET_INDICES_JS_PATH)
+  : resolve(import.meta.dirname, "../../view/web/static/js/market_indices.js");
+
+const EXPECTED_SYMBOLS = [
+  "NASDAQ:NDX",
+  "NASDAQ:SOX",
+  "CBOE:VIX",
+  "TVC:DXY",
+  "TVC:GOLD",
+  "TVC:USOIL",
+  "TVC:US10Y",
+  "TVC:US02Y",
+];
+
+const WIDGET_SRC =
+  "https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js";
+
+const SCAFFOLD = `<div id="market-indices" class="market-indices-grid"></div>`;
+
+function makeWindow() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/",
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+  applyCommonStubs(window);
+  window.eval(readFileSync(MARKET_INDICES_JS, "utf8"));
+  return window;
+}
+
+test("설정된 지수마다 카드가 하나씩 생성된다", () => {
+  const window = makeWindow();
+
+  window.renderMarketIndices();
+
+  const cards = window.document.querySelectorAll("#market-indices .market-index-card");
+  assert(cards.length === EXPECTED_SYMBOLS.length,
+    `카드 ${EXPECTED_SYMBOLS.length}개가 생성되어야 함 (실제 ${cards.length}개)`);
+
+  const symbols = Array.from(cards).map(card => card.dataset.symbol);
+  EXPECTED_SYMBOLS.forEach(symbol => {
+    assert(symbols.includes(symbol), `${symbol} 카드가 없음`);
+  });
+});
+
+test("각 카드가 라벨과 TradingView 위젯 스크립트를 함께 심는다", () => {
+  const window = makeWindow();
+
+  window.renderMarketIndices();
+
+  const cards = window.document.querySelectorAll("#market-indices .market-index-card");
+  for (const card of cards) {
+    const label = card.querySelector(".market-index-label");
+    assert(label && label.textContent.trim().length > 0,
+      `${card.dataset.symbol} 카드에 라벨이 없음`);
+
+    const script = card.querySelector(".tradingview-widget-container script");
+    assert(script, `${card.dataset.symbol} 카드에 위젯 스크립트가 없음`);
+    assert(script.src === WIDGET_SRC,
+      `${card.dataset.symbol} 위젯 스크립트 src 가 다름: ${script.src}`);
+
+    const config = JSON.parse(script.textContent);
+    assert(config.symbol === card.dataset.symbol,
+      `${card.dataset.symbol} 위젯 설정의 symbol 이 다름: ${config.symbol}`);
+    assert(config.colorTheme === "light", "위젯 테마는 앱과 동일한 light 여야 함");
+  }
+});
+
+test("위젯 스크립트 로드 실패 시 안내 문구로 대체한다", () => {
+  const window = makeWindow();
+  window.renderMarketIndices();
+
+  const card = window.document.querySelector("#market-indices .market-index-card");
+  const script = card.querySelector(".tradingview-widget-container script");
+  script.dispatchEvent(new window.Event("error"));
+
+  assert(!card.querySelector(".tradingview-widget-container script"),
+    "실패한 위젯 스크립트가 남아 있음");
+  const fallback = card.querySelector(".market-index-error");
+  assert(fallback && fallback.textContent.includes("불러오지 못"),
+    "위젯 로드 실패 안내가 표시되어야 함");
+});
+
+test("다시 렌더링해도 카드가 중복되지 않는다", () => {
+  const window = makeWindow();
+
+  window.renderMarketIndices();
+  window.renderMarketIndices();
+
+  const cards = window.document.querySelectorAll("#market-indices .market-index-card");
+  assert(cards.length === EXPECTED_SYMBOLS.length,
+    `재렌더링 후에도 카드는 ${EXPECTED_SYMBOLS.length}개여야 함 (실제 ${cards.length}개)`);
+});
+
+test("컨테이너가 없는 화면에서는 아무 일도 하지 않는다", () => {
+  const window = makeWindow();
+  window.document.getElementById("market-indices").remove();
+
+  window.renderMarketIndices();
+
+  assert(!window.document.querySelector(".market-index-card"),
+    "컨테이너가 없으면 카드를 만들면 안 됨");
+});
+
+await run();

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -1,5 +1,8 @@
 /*
- * jsdom 기반 홈 화면 글로벌 지수 패널 회귀 테스트.
+ * jsdom 기반 홈 화면 지수 패널 회귀 테스트.
+ *
+ * 국장은 KIS API(/api/market-index/*) + Chart.js, 미장/원자재는 TradingView 위젯으로
+ * 렌더링 경로가 다르므로 두 경로를 모두 검증한다.
  *
  * 실행: node run_market_indices_dom_tests.mjs
  */
@@ -12,76 +15,218 @@ const MARKET_INDICES_JS = process.env.MARKET_INDICES_JS_PATH
   ? resolve(process.env.MARKET_INDICES_JS_PATH)
   : resolve(import.meta.dirname, "../../view/web/static/js/market_indices.js");
 
-const EXPECTED_SYMBOLS = [
-  "NASDAQ:NDX",
-  "NASDAQ:SOX",
-  "CBOE:VIX",
-  "TVC:DXY",
-  "TVC:GOLD",
-  "TVC:USOIL",
-  "TVC:US10Y",
-  "TVC:US02Y",
+const EXPECTED_GROUPS = [
+  { title: "국장", kind: "kis", keys: ["0001", "1001"] },
+  {
+    title: "미장",
+    kind: "widget",
+    // 거래소 실지수(SP:SPX, NASDAQ:NDX, CBOE:VIX ...)는 무료 임베드에서 차단되므로
+    // 실제로 시세가 그려지는 CFD/ETF 심볼만 쓴다.
+    keys: [
+      "CAPITALCOM:US100",
+      "CAPITALCOM:US500",
+      "NASDAQ:SOXX",
+      "CAPITALCOM:VIX",
+      "CAPITALCOM:DXY",
+    ],
+  },
+  { title: "원자재", kind: "widget", keys: ["TVC:GOLD", "TVC:USOIL", "CBOE:DRAM"] },
+];
+
+const BLOCKED_SYMBOLS = [
+  "KRX:KOSPI", "KRX:KOSDAQ", "SP:SPX", "NASDAQ:NDX",
+  "NASDAQ:SOX", "CBOE:VIX", "TVC:DXY", "TVC:US10Y", "TVC:US02Y",
 ];
 
 const WIDGET_SRC =
   "https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js";
 
-const SCAFFOLD = `<div id="market-indices" class="market-indices-grid"></div>`;
+const SCAFFOLD = `<div id="market-indices"></div>`;
 
-function makeWindow() {
+async function makeWindow(fetchWithTimeout) {
   const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
     url: "http://localhost/",
     runScripts: "outside-only",
   });
   const { window } = dom;
+  // 실제 페이지처럼 DOM 준비 후 스크립트를 평가한다.
+  // (loading 중에 eval 하면 스크립트가 건 DOMContentLoaded 렌더가 명시 렌더에 겹친다)
+  if (window.document.readyState === "loading") {
+    await new Promise(resolve => window.document.addEventListener("DOMContentLoaded", resolve));
+  }
   applyCommonStubs(window);
+  window.fetchWithTimeout = fetchWithTimeout || (async () => success(indexPayload()));
+  // Chart.js 는 CDN 로드라 jsdom 에서는 생성 호출만 기록한다.
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
+  window.currentCharts = [];
+  window.__charts = [];
+  window.Chart = function (ctx, config) {
+    window.__charts.push({ ctx, config });
+    this.destroy = () => {};
+  };
   window.eval(readFileSync(MARKET_INDICES_JS, "utf8"));
   return window;
 }
 
-test("설정된 지수마다 카드가 하나씩 생성된다", () => {
-  const window = makeWindow();
+function indexPayload(overrides) {
+  return Object.assign({
+    code: "0001",
+    name: "코스피",
+    current: 2650.15,
+    change: 12.3,
+    change_rate: 0.47,
+    points: [
+      { date: "20260724", close: 2637.85 },
+      { date: "20260727", close: 2650.15 },
+    ],
+  }, overrides || {});
+}
 
-  window.renderMarketIndices();
+function success(data) {
+  return { ok: true, json: async () => ({ rt_cd: "0", data }) };
+}
 
-  const cards = window.document.querySelectorAll("#market-indices .market-index-card");
-  assert(cards.length === EXPECTED_SYMBOLS.length,
-    `카드 ${EXPECTED_SYMBOLS.length}개가 생성되어야 함 (실제 ${cards.length}개)`);
+function groupsOf(window) {
+  return Array.from(window.document.querySelectorAll("#market-indices .market-index-group"));
+}
 
-  const symbols = Array.from(cards).map(card => card.dataset.symbol);
-  EXPECTED_SYMBOLS.forEach(symbol => {
-    assert(symbols.includes(symbol), `${symbol} 카드가 없음`);
+function expectedGroupsOf(window) {
+  const groups = groupsOf(window);
+  assert(groups.length === EXPECTED_GROUPS.length,
+    `그룹 ${EXPECTED_GROUPS.length}개가 생성되어야 함 (실제 ${groups.length}개)`);
+  return groups;
+}
+
+test("국장·미장·원자재 그룹이 순서대로 렌더링된다", async () => {
+  const window = await makeWindow();
+
+  await window.renderMarketIndices();
+
+  expectedGroupsOf(window).forEach((group, i) => {
+    const title = group.querySelector(".market-index-group-title");
+    assert(title && title.textContent.trim() === EXPECTED_GROUPS[i].title,
+      `${i}번째 그룹 제목이 ${EXPECTED_GROUPS[i].title} 이어야 함 (실제 ${title && title.textContent})`);
   });
 });
 
-test("각 카드가 라벨과 TradingView 위젯 스크립트를 함께 심는다", () => {
-  const window = makeWindow();
+test("각 그룹이 자기 시장의 지수만 담는다", async () => {
+  const window = await makeWindow();
 
-  window.renderMarketIndices();
+  await window.renderMarketIndices();
 
-  const cards = window.document.querySelectorAll("#market-indices .market-index-card");
-  for (const card of cards) {
-    const label = card.querySelector(".market-index-label");
-    assert(label && label.textContent.trim().length > 0,
-      `${card.dataset.symbol} 카드에 라벨이 없음`);
+  expectedGroupsOf(window).forEach((group, i) => {
+    const expected = EXPECTED_GROUPS[i];
+    const cards = Array.from(group.querySelectorAll(".market-index-card"));
+    assert(cards.length === expected.keys.length,
+      `${expected.title} 그룹은 ${expected.keys.length}개여야 함 (실제 ${cards.length}개)`);
+    cards.forEach(card => {
+      assert(card.dataset.kind === expected.kind,
+        `${expected.title} 카드 종류가 ${expected.kind} 이어야 함 (실제 ${card.dataset.kind})`);
+    });
+    const keys = cards.map(card => card.dataset.key);
+    expected.keys.forEach(key => {
+      assert(keys.includes(key), `${expected.title} 그룹에 ${key} 가 없음`);
+    });
+  });
+});
 
+test("임베드가 차단되는 거래소 실지수 심볼을 쓰지 않는다", async () => {
+  const window = await makeWindow();
+
+  await window.renderMarketIndices();
+
+  const source = readFileSync(MARKET_INDICES_JS, "utf8");
+  BLOCKED_SYMBOLS.forEach(symbol => {
+    assert(!source.includes(`'${symbol}'`) && !source.includes(`"${symbol}"`),
+      `${symbol} 은 무료 임베드에서 차트가 표시되지 않는 심볼임`);
+  });
+});
+
+test("미장·원자재 카드는 TradingView 위젯 스크립트를 심는다", async () => {
+  const window = await makeWindow();
+
+  await window.renderMarketIndices();
+
+  const widgetCards = window.document.querySelectorAll('.market-index-card[data-kind="widget"]');
+  assert(widgetCards.length === 8, `위젯 카드는 8개여야 함 (실제 ${widgetCards.length}개)`);
+
+  for (const card of widgetCards) {
     const script = card.querySelector(".tradingview-widget-container script");
-    assert(script, `${card.dataset.symbol} 카드에 위젯 스크립트가 없음`);
-    assert(script.src === WIDGET_SRC,
-      `${card.dataset.symbol} 위젯 스크립트 src 가 다름: ${script.src}`);
-
+    assert(script, `${card.dataset.key} 카드에 위젯 스크립트가 없음`);
+    assert(script.src === WIDGET_SRC, `${card.dataset.key} 위젯 src 가 다름: ${script.src}`);
     const config = JSON.parse(script.textContent);
-    assert(config.symbol === card.dataset.symbol,
-      `${card.dataset.symbol} 위젯 설정의 symbol 이 다름: ${config.symbol}`);
+    assert(config.symbol === card.dataset.key,
+      `${card.dataset.key} 위젯 설정 symbol 이 다름: ${config.symbol}`);
     assert(config.colorTheme === "light", "위젯 테마는 앱과 동일한 light 여야 함");
   }
 });
 
-test("위젯 스크립트 로드 실패 시 안내 문구로 대체한다", () => {
-  const window = makeWindow();
-  window.renderMarketIndices();
+test("국장 카드는 KIS API 를 조회해 값과 차트를 그린다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    const code = url.endsWith("1001") ? "1001" : "0001";
+    return success(indexPayload({
+      code,
+      name: code === "0001" ? "코스피" : "코스닥",
+      current: code === "0001" ? 2650.15 : 870.4,
+    }));
+  });
 
-  const card = window.document.querySelector("#market-indices .market-index-card");
+  await window.renderMarketIndices();
+
+  assert(requested.some(u => u.includes("/api/market-index/0001")), "코스피 API 를 호출하지 않음");
+  assert(requested.some(u => u.includes("/api/market-index/1001")), "코스닥 API 를 호출하지 않음");
+
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  assert(kospi.textContent.includes("2,650.15"), `코스피 현재값이 표시되지 않음: ${kospi.textContent}`);
+  assert(kospi.textContent.includes("+0.47%"), `코스피 등락률이 표시되지 않음: ${kospi.textContent}`);
+  assert(kospi.querySelector("canvas"), "코스피 차트 캔버스가 없음");
+  assert(window.__charts.length === 2, `Chart 인스턴스는 2개여야 함 (실제 ${window.__charts.length}개)`);
+});
+
+test("스파크라인 색은 등락률 부호를 따른다", async () => {
+  const window = await makeWindow(async (url) => success(indexPayload({
+    // 60일 추세는 우상향이지만 당일은 하락인 경우
+    change: -4.2,
+    change_rate: url.endsWith("1001") ? -0.48 : 0.47,
+  })));
+
+  await window.renderMarketIndices();
+
+  const colors = window.__charts.map(c => c.config.data.datasets[0].borderColor);
+  assert(colors.includes("#ff4757"), "상승 지수는 상승색이어야 함");
+  assert(colors.includes("#3742fa"), "하락 지수는 하락색이어야 함");
+});
+
+test("국장 API 실패는 카드별 안내로 degrade 한다", async () => {
+  const window = await makeWindow(async () => ({ ok: false, status: 503, json: async () => ({}) }));
+
+  await window.renderMarketIndices();
+
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  assert(kospi.querySelector(".market-index-error"), "국장 카드에 실패 안내가 없음");
+  assert(!kospi.querySelector("canvas"), "실패한 카드에 차트를 그리면 안 됨");
+  // 국장이 실패해도 미장/원자재 위젯은 살아 있어야 한다.
+  assert(window.document.querySelectorAll('.market-index-card[data-kind="widget"]').length === 8,
+    "국장 실패가 위젯 카드까지 없앰");
+});
+
+test("국장 응답에 포인트가 없으면 차트를 그리지 않는다", async () => {
+  const window = await makeWindow(async () => success(indexPayload({ points: [] })));
+
+  await window.renderMarketIndices();
+
+  assert(window.__charts.length === 0, "포인트가 없는데 Chart 를 생성함");
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  assert(kospi.textContent.includes("2,650.15"), "포인트가 없어도 현재값은 표시되어야 함");
+});
+
+test("위젯 스크립트 로드 실패 시 안내 문구로 대체한다", async () => {
+  const window = await makeWindow();
+  await window.renderMarketIndices();
+
+  const card = window.document.querySelector('.market-index-card[data-kind="widget"]');
   const script = card.querySelector(".tradingview-widget-container script");
   script.dispatchEvent(new window.Event("error"));
 
@@ -92,25 +237,28 @@ test("위젯 스크립트 로드 실패 시 안내 문구로 대체한다", () =
     "위젯 로드 실패 안내가 표시되어야 함");
 });
 
-test("다시 렌더링해도 카드가 중복되지 않는다", () => {
-  const window = makeWindow();
+test("다시 렌더링해도 그룹과 카드가 중복되지 않는다", async () => {
+  const window = await makeWindow();
 
-  window.renderMarketIndices();
-  window.renderMarketIndices();
+  await window.renderMarketIndices();
+  await window.renderMarketIndices();
 
+  assert(groupsOf(window).length === EXPECTED_GROUPS.length, "재렌더링 후 그룹이 중복됨");
+  const total = EXPECTED_GROUPS.reduce((sum, g) => sum + g.keys.length, 0);
   const cards = window.document.querySelectorAll("#market-indices .market-index-card");
-  assert(cards.length === EXPECTED_SYMBOLS.length,
-    `재렌더링 후에도 카드는 ${EXPECTED_SYMBOLS.length}개여야 함 (실제 ${cards.length}개)`);
+  assert(cards.length === total, `재렌더링 후에도 카드는 ${total}개여야 함 (실제 ${cards.length}개)`);
 });
 
-test("컨테이너가 없는 화면에서는 아무 일도 하지 않는다", () => {
-  const window = makeWindow();
+test("컨테이너가 없는 화면에서는 아무 일도 하지 않는다", async () => {
+  let fetched = false;
+  const window = await makeWindow(async () => { fetched = true; return success(indexPayload()); });
   window.document.getElementById("market-indices").remove();
 
-  window.renderMarketIndices();
+  await window.renderMarketIndices();
 
   assert(!window.document.querySelector(".market-index-card"),
     "컨테이너가 없으면 카드를 만들면 안 됨");
+  assert(!fetched, "컨테이너가 없으면 API 도 호출하면 안 됨");
 });
 
 await run();

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_chart.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_chart.py
@@ -1,0 +1,118 @@
+"""국내업종(코스피/코스닥) 기간별 지수 시세 조회 단위 테스트."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from brokers.korea_investment.korea_invest_quotations_api import KoreaInvestApiQuotations
+from brokers.korea_investment.korea_invest_url_keys import EndpointKey
+from common.types import ResCommonResponse, ErrorCode
+
+
+@pytest.fixture
+def quotations():
+    mock_env = MagicMock()
+    mock_env.active_config = {
+        "api_key": "dummy-key",
+        "api_secret_key": "dummy-secret",
+        "base_url": "https://mock-base",
+        "custtype": "P",
+        "paths": {"inquire_daily_indexchartprice": "/mock/indexchartprice"},
+        "params": {},
+        "market_code": "J",
+    }
+
+    trid_provider = MagicMock()
+    trid_provider.quotations.return_value = "FHKUP03500100"
+
+    with patch("brokers.korea_investment.korea_invest_api_base.httpx.AsyncClient"):
+        api = KoreaInvestApiQuotations(
+            env=mock_env,
+            logger=MagicMock(),
+            market_clock=MagicMock(),
+            header_provider=MagicMock(),
+            url_provider=MagicMock(),
+            trid_provider=trid_provider,
+        )
+    return api
+
+
+def _api_response(output1=None, output2=None):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data={
+            "output1": output1 if output1 is not None else {},
+            "output2": output2 if output2 is not None else [],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_chart_returns_summary_and_candles(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(
+        output1={
+            "hts_kor_isnm": "코스피",
+            "bstp_nmix_prpr": "2650.15",
+            "bstp_nmix_prdy_vrss": "12.30",
+            "prdy_vrss_sign": "2",
+            "bstp_nmix_prdy_ctrt": "0.47",
+        },
+        output2=[
+            {"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "20260724", "bstp_nmix_prpr": "2637.85"},
+        ],
+    ))
+
+    result = await quotations.inquire_daily_indexchartprice("0001", "20260601", "20260727")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["summary"]["hts_kor_isnm"] == "코스피"
+    assert len(result.data["candles"]) == 2
+    assert result.data["candles"][0]["stck_bsop_date"] == "20260727"
+
+
+@pytest.mark.asyncio
+async def test_index_chart_sends_index_market_params(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(output2=[{"stck_bsop_date": "20260727"}]))
+
+    await quotations.inquire_daily_indexchartprice("1001", "20260601", "20260727")
+
+    args, kwargs = quotations.call_api.call_args
+    assert args[0] == "GET"
+    assert args[1] == EndpointKey.DAILY_INDEXCHARTPRICE
+    params = kwargs["params"]
+    # 업종/지수는 시장분류 "U" 로 조회해야 한다 (주식 "J" 아님).
+    assert params["fid_cond_mrkt_div_code"] == "U"
+    assert params["fid_input_iscd"] == "1001"
+    assert params["fid_input_date_1"] == "20260601"
+    assert params["fid_input_date_2"] == "20260727"
+    assert params["fid_period_div_code"] == "D"
+
+
+@pytest.mark.asyncio
+async def test_index_chart_rejects_unsupported_period(quotations):
+    quotations.call_api = AsyncMock()
+
+    result = await quotations.inquire_daily_indexchartprice("0001", "20260601", "20260727", period="X")
+
+    assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+    quotations.call_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_index_chart_propagates_api_error(quotations):
+    quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None,
+    ))
+
+    result = await quotations.inquire_daily_indexchartprice("0001", "20260601", "20260727")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.asyncio
+async def test_index_chart_reports_empty_candles(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(output1={"bstp_nmix_prpr": "2650"}, output2=[]))
+
+    result = await quotations.inquire_daily_indexchartprice("0001", "20260601", "20260727")
+
+    assert result.rt_cd == ErrorCode.MISSING_KEY.value

--- a/tests/unit_test/services/test_stock_query_index_chart.py
+++ b/tests/unit_test/services/test_stock_query_index_chart.py
@@ -1,0 +1,96 @@
+"""홈 지수 패널용 국내 지수 조회 서비스 단위 테스트."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.stock_query_service import StockQueryService
+from common.types import ResCommonResponse, ErrorCode
+
+
+def _service(broker):
+    return StockQueryService(
+        market_data_service=MagicMock(),
+        logger=MagicMock(),
+        market_clock=MagicMock(),
+        broker_api_wrapper=broker,
+    )
+
+
+def _broker_response(summary=None, candles=None):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data={
+            "summary": summary if summary is not None else {},
+            "candles": candles if candles is not None else [],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_chart_normalizes_summary_and_points():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={
+            "hts_kor_isnm": "코스피",
+            "bstp_nmix_prpr": "2650.15",
+            "bstp_nmix_prdy_vrss": "12.30",
+            "bstp_nmix_prdy_ctrt": "0.47",
+        },
+        candles=[
+            {"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "20260724", "bstp_nmix_prpr": "2637.85"},
+        ],
+    ))
+
+    result = await _service(broker).get_index_chart("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["code"] == "0001"
+    assert result.data["name"] == "코스피"
+    assert result.data["current"] == pytest.approx(2650.15)
+    assert result.data["change"] == pytest.approx(12.30)
+    assert result.data["change_rate"] == pytest.approx(0.47)
+    # KIS 는 최신순으로 주므로 차트용으로 과거→현재 순서여야 한다.
+    assert [p["date"] for p in result.data["points"]] == ["20260724", "20260727"]
+    assert result.data["points"][-1]["close"] == pytest.approx(2650.15)
+
+
+@pytest.mark.asyncio
+async def test_index_chart_rejects_unknown_index_code():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock()
+
+    result = await _service(broker).get_index_chart("9999")
+
+    assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.inquire_daily_indexchartprice.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_index_chart_propagates_broker_failure():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None,
+    ))
+
+    result = await _service(broker).get_index_chart("0001")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.asyncio
+async def test_index_chart_skips_unparsable_candles():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={"bstp_nmix_prpr": "2650.15"},
+        candles=[
+            {"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "", "bstp_nmix_prpr": ""},
+            {"stck_bsop_date": "20260724", "bstp_nmix_prpr": "invalid"},
+        ],
+    ))
+
+    result = await _service(broker).get_index_chart("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert [p["date"] for p in result.data["points"]] == ["20260727"]

--- a/tests/unit_test/view/web/test_market_indices_contracts.py
+++ b/tests/unit_test/view/web/test_market_indices_contracts.py
@@ -1,17 +1,38 @@
-"""홈 화면 글로벌 지수 패널의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
+"""홈 화면 시장 지수 패널의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
 
 from pathlib import Path
 
-EXPECTED_SYMBOLS = [
+# 미장/원자재는 TradingView 위젯. 거래소 실지수는 무료 임베드가 차단하므로
+# 실제로 시세가 그려지는 CFD/ETF 심볼만 쓴다.
+EXPECTED_WIDGET_SYMBOLS = [
+    "CAPITALCOM:US100",
+    "CAPITALCOM:US500",
+    "NASDAQ:SOXX",
+    "CAPITALCOM:VIX",
+    "CAPITALCOM:DXY",
+    "TVC:GOLD",
+    "TVC:USOIL",
+    "CBOE:DRAM",
+]
+
+# 위젯에서 "이 심볼은 트레이딩뷰에서만 쓸 수 있습니다"로 막히는 심볼 (회귀 방지)
+BLOCKED_WIDGET_SYMBOLS = [
+    "KRX:KOSPI",
+    "KRX:KOSDAQ",
+    "SP:SPX",
     "NASDAQ:NDX",
     "NASDAQ:SOX",
     "CBOE:VIX",
     "TVC:DXY",
-    "TVC:GOLD",
-    "TVC:USOIL",
     "TVC:US10Y",
     "TVC:US02Y",
 ]
+
+EXPECTED_GROUP_TITLES = ["국장", "미장", "원자재"]
+
+
+def _market_indices_js() -> str:
+    return Path("view/web/static/js/market_indices.js").read_text(encoding="utf-8")
 
 
 def test_home_template_hosts_market_indices_panel():
@@ -19,18 +40,49 @@ def test_home_template_hosts_market_indices_panel():
 
     assert 'id="market-indices"' in template
     assert "/static/js/market_indices.js" in template
+    # 국장 스파크라인은 Chart.js 를 쓴다.
+    assert "chart.js" in template
 
 
-def test_market_indices_js_covers_all_symbols():
-    script = Path("view/web/static/js/market_indices.js").read_text(encoding="utf-8")
+def test_market_indices_js_covers_all_widget_symbols():
+    script = _market_indices_js()
 
-    for symbol in EXPECTED_SYMBOLS:
+    for symbol in EXPECTED_WIDGET_SYMBOLS:
         assert symbol in script, f"{symbol} 지수 설정이 없음"
     assert "embed-widget-mini-symbol-overview.js" in script
+
+
+def test_market_indices_js_avoids_blocked_widget_symbols():
+    script = _market_indices_js()
+
+    for symbol in BLOCKED_WIDGET_SYMBOLS:
+        assert f"'{symbol}'" not in script and f'"{symbol}"' not in script, (
+            f"{symbol} 은 무료 임베드에서 차트가 표시되지 않는 심볼임"
+        )
+
+
+def test_market_indices_js_declares_market_groups():
+    script = _market_indices_js()
+
+    for title in EXPECTED_GROUP_TITLES:
+        assert f"'{title}'" in script, f"{title} 그룹 설정이 없음"
+
+
+def test_domestic_indices_use_kis_api_not_widget():
+    script = _market_indices_js()
+
+    assert "/api/market-index/" in script
+    assert "'0001'" in script and "'1001'" in script
 
 
 def test_market_indices_styles_are_defined():
     css = Path("view/web/static/css/style.css").read_text(encoding="utf-8")
 
-    assert ".market-indices-grid" in css
-    assert ".market-index-card" in css
+    for selector in (
+        ".market-indices-grid",
+        ".market-index-card",
+        ".market-index-group-title",
+        ".market-index-value",
+        ".market-index-spark",
+    ):
+        assert selector in css, f"{selector} 스타일이 없음"

--- a/tests/unit_test/view/web/test_market_indices_contracts.py
+++ b/tests/unit_test/view/web/test_market_indices_contracts.py
@@ -1,0 +1,36 @@
+"""홈 화면 글로벌 지수 패널의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
+
+from pathlib import Path
+
+EXPECTED_SYMBOLS = [
+    "NASDAQ:NDX",
+    "NASDAQ:SOX",
+    "CBOE:VIX",
+    "TVC:DXY",
+    "TVC:GOLD",
+    "TVC:USOIL",
+    "TVC:US10Y",
+    "TVC:US02Y",
+]
+
+
+def test_home_template_hosts_market_indices_panel():
+    template = Path("view/web/templates/index.html").read_text(encoding="utf-8")
+
+    assert 'id="market-indices"' in template
+    assert "/static/js/market_indices.js" in template
+
+
+def test_market_indices_js_covers_all_symbols():
+    script = Path("view/web/static/js/market_indices.js").read_text(encoding="utf-8")
+
+    for symbol in EXPECTED_SYMBOLS:
+        assert symbol in script, f"{symbol} 지수 설정이 없음"
+    assert "embed-widget-mini-symbol-overview.js" in script
+
+
+def test_market_indices_styles_are_defined():
+    css = Path("view/web/static/css/style.css").read_text(encoding="utf-8")
+
+    assert ".market-indices-grid" in css
+    assert ".market-index-card" in css

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -156,6 +156,14 @@ async def get_stock_rs_rating(code: str):
     return _serialize_response(resp)
 
 
+@router.get("/market-index/{index_code}")
+async def get_market_index(index_code: str):
+    """코스피(0001)/코스닥(1001) 지수의 현재값·등락·최근 일별 종가. 홈 화면 지수 패널용."""
+    ctx = _get_ctx()
+    resp = await ctx.stock_query_service.get_index_chart(index_code)
+    return _serialize_response(resp)
+
+
 @router.get("/stock/{code}/stage")
 async def get_stock_stage(code: str):
     """종목의 Minervini Stage 조회 (1~4단계, 0=미계산)"""

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -953,3 +953,29 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     opacity: 0.4;
     cursor: not-allowed;
 }
+
+/* 홈 글로벌 지수 패널 */
+.market-indices-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 12px;
+}
+.market-index-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 12px;
+}
+.market-index-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+.market-index-error {
+    margin: 0;
+    padding: 40px 0;
+    text-align: center;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -954,7 +954,18 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     cursor: not-allowed;
 }
 
-/* 홈 글로벌 지수 패널 */
+/* 홈 시장 지수 패널 */
+.market-index-group + .market-index-group {
+    margin-top: 18px;
+}
+.market-index-group-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border);
+}
 .market-indices-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
@@ -971,6 +982,27 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     font-weight: 600;
     color: var(--text-secondary);
     margin-bottom: 6px;
+}
+.market-index-body {
+    height: 150px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+.market-index-value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.market-index-change {
+    font-size: 0.82rem;
+    margin-top: 2px;
+    color: var(--text-secondary);
+}
+.market-index-spark {
+    margin-top: 8px;
+    width: 100%;
+    max-height: 70px;
 }
 .market-index-error {
     margin: 0;

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -1,0 +1,72 @@
+// 홈 화면 글로벌 지수 패널 (market_indices.js)
+// 지수별 TradingView mini-symbol-overview 위젯을 임베드한다.
+// KIS Open API 로는 SOX/VIX/달러인덱스/금/유가/미국채 금리를 조달할 수 없어 위젯을 사용한다.
+
+const MARKET_INDEX_WIDGETS = [
+    { label: '나스닥100', symbol: 'NASDAQ:NDX' },
+    { label: '필라델피아 반도체', symbol: 'NASDAQ:SOX' },
+    { label: 'VIX 변동성', symbol: 'CBOE:VIX' },
+    { label: '달러인덱스', symbol: 'TVC:DXY' },
+    { label: '금', symbol: 'TVC:GOLD' },
+    { label: 'WTI 유가', symbol: 'TVC:USOIL' },
+    { label: '미국 10년물', symbol: 'TVC:US10Y' },
+    { label: '미국 2년물', symbol: 'TVC:US02Y' },
+];
+
+const MARKET_INDEX_WIDGET_SRC =
+    'https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js';
+
+function buildMarketIndexCard(doc, entry) {
+    const card = doc.createElement('div');
+    card.className = 'market-index-card';
+    card.dataset.symbol = entry.symbol;
+
+    const label = doc.createElement('div');
+    label.className = 'market-index-label';
+    label.textContent = entry.label;
+    card.appendChild(label);
+
+    const container = doc.createElement('div');
+    container.className = 'tradingview-widget-container';
+    const slot = doc.createElement('div');
+    slot.className = 'tradingview-widget-container__widget';
+    container.appendChild(slot);
+
+    const script = doc.createElement('script');
+    script.async = true;
+    script.src = MARKET_INDEX_WIDGET_SRC;
+    script.textContent = JSON.stringify({
+        symbol: entry.symbol,
+        width: '100%',
+        height: 150,
+        locale: 'kr',
+        dateRange: '1D',
+        colorTheme: 'light',
+        isTransparent: true,
+        autosize: false,
+        largeChartUrl: '',
+    });
+    script.addEventListener('error', () => {
+        container.innerHTML = '';
+        const fallback = doc.createElement('p');
+        fallback.className = 'market-index-error';
+        fallback.textContent = '지수 데이터를 불러오지 못했습니다.';
+        container.appendChild(fallback);
+    });
+    container.appendChild(script);
+
+    card.appendChild(container);
+    return card;
+}
+
+function renderMarketIndices() {
+    const target = document.getElementById('market-indices');
+    if (!target) return;
+
+    target.innerHTML = '';
+    MARKET_INDEX_WIDGETS.forEach(entry => {
+        target.appendChild(buildMarketIndexCard(document, entry));
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderMarketIndices);

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -1,30 +1,71 @@
-// 홈 화면 글로벌 지수 패널 (market_indices.js)
-// 지수별 TradingView mini-symbol-overview 위젯을 임베드한다.
-// KIS Open API 로는 SOX/VIX/달러인덱스/금/유가/미국채 금리를 조달할 수 없어 위젯을 사용한다.
+// 홈 화면 지수 패널 (market_indices.js)
+//
+// 국장(코스피/코스닥)은 KIS API + Chart.js 로 직접 그린다.
+//   - TradingView 무료 임베드는 KRX 심볼을 전부 차단한다("이 심볼은 트레이딩뷰에서만 쓸 수 있습니다").
+// 미장/원자재는 TradingView mini-symbol-overview 위젯을 쓴다.
+//   - KIS Open API 가 SOX/VIX/달러인덱스/금/유가 시세를 제공하지 않는다.
+//   - 거래소 실지수(SP:SPX, NASDAQ:NDX, CBOE:VIX ...)도 임베드가 차단되므로
+//     실제로 시세가 그려지는 CFD/ETF 심볼만 쓴다.
 
-const MARKET_INDEX_WIDGETS = [
-    { label: '나스닥100', symbol: 'NASDAQ:NDX' },
-    { label: '필라델피아 반도체', symbol: 'NASDAQ:SOX' },
-    { label: 'VIX 변동성', symbol: 'CBOE:VIX' },
-    { label: '달러인덱스', symbol: 'TVC:DXY' },
-    { label: '금', symbol: 'TVC:GOLD' },
-    { label: 'WTI 유가', symbol: 'TVC:USOIL' },
-    { label: '미국 10년물', symbol: 'TVC:US10Y' },
-    { label: '미국 2년물', symbol: 'TVC:US02Y' },
+const MARKET_INDEX_GROUPS = [
+    {
+        title: '국장',
+        kind: 'kis',
+        entries: [
+            { label: '코스피', code: '0001' },
+            { label: '코스닥', code: '1001' },
+        ],
+    },
+    {
+        title: '미장',
+        kind: 'widget',
+        entries: [
+            { label: '나스닥100', symbol: 'CAPITALCOM:US100' },
+            { label: 'S&P500', symbol: 'CAPITALCOM:US500' },
+            { label: '반도체 ETF (SOX 추종)', symbol: 'NASDAQ:SOXX' },
+            { label: 'VIX 변동성', symbol: 'CAPITALCOM:VIX' },
+            { label: '달러인덱스', symbol: 'CAPITALCOM:DXY' },
+        ],
+    },
+    {
+        title: '원자재',
+        kind: 'widget',
+        entries: [
+            { label: '금', symbol: 'TVC:GOLD' },
+            { label: 'WTI 유가', symbol: 'TVC:USOIL' },
+            { label: '메모리 반도체 ETF', symbol: 'CBOE:DRAM' },
+        ],
+    },
 ];
 
 const MARKET_INDEX_WIDGET_SRC =
     'https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js';
 
-function buildMarketIndexCard(doc, entry) {
+const MARKET_INDEX_LOAD_ERROR = '지수 데이터를 불러오지 못했습니다.';
+
+function _marketIndexCardShell(doc, kind, key, label) {
     const card = doc.createElement('div');
     card.className = 'market-index-card';
-    card.dataset.symbol = entry.symbol;
+    card.dataset.kind = kind;
+    card.dataset.key = key;
 
-    const label = doc.createElement('div');
-    label.className = 'market-index-label';
-    label.textContent = entry.label;
-    card.appendChild(label);
+    const title = doc.createElement('div');
+    title.className = 'market-index-label';
+    title.textContent = label;
+    card.appendChild(title);
+
+    return card;
+}
+
+function _marketIndexError(doc) {
+    const message = doc.createElement('p');
+    message.className = 'market-index-error';
+    message.textContent = MARKET_INDEX_LOAD_ERROR;
+    return message;
+}
+
+function buildMarketIndexWidgetCard(doc, entry) {
+    const card = _marketIndexCardShell(doc, 'widget', entry.symbol, entry.label);
 
     const container = doc.createElement('div');
     container.className = 'tradingview-widget-container';
@@ -48,10 +89,7 @@ function buildMarketIndexCard(doc, entry) {
     });
     script.addEventListener('error', () => {
         container.innerHTML = '';
-        const fallback = doc.createElement('p');
-        fallback.className = 'market-index-error';
-        fallback.textContent = '지수 데이터를 불러오지 못했습니다.';
-        container.appendChild(fallback);
+        container.appendChild(_marketIndexError(doc));
     });
     container.appendChild(script);
 
@@ -59,14 +97,118 @@ function buildMarketIndexCard(doc, entry) {
     return card;
 }
 
-function renderMarketIndices() {
+function _formatIndexValue(value) {
+    return Number.isFinite(value)
+        ? value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+        : '-';
+}
+
+function _formatIndexChange(change, rate) {
+    if (!Number.isFinite(rate)) return { text: '-', className: '' };
+    const sign = rate > 0 ? '+' : '';
+    const delta = Number.isFinite(change) ? `${sign}${_formatIndexValue(change)} ` : '';
+    const className = rate > 0 ? 'text-red' : (rate < 0 ? 'text-blue' : '');
+    return { text: `${delta}(${sign}${rate.toFixed(2)}%)`.replace(' (', ' ('), className };
+}
+
+function _renderIndexSparkline(canvas, data) {
+    if (typeof Chart === 'undefined' || !data.points.length) return;
+
+    // 함께 표시하는 등락률과 색이 어긋나지 않도록 등락률 기준으로 칠한다.
+    const color = Number.isFinite(data.changeRate) && data.changeRate < 0 ? '#3742fa' : '#ff4757';
+    const chart = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+            labels: data.points.map(p => p.date),
+            datasets: [{
+                data: data.points.map(p => p.close),
+                borderColor: color,
+                borderWidth: 1.5,
+                pointRadius: 0,
+                fill: false,
+                tension: 0.15,
+            }],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: false,
+            plugins: { legend: { display: false }, tooltip: { enabled: false } },
+            scales: { x: { display: false }, y: { display: false } },
+        },
+    });
+    window.currentCharts = window.currentCharts || [];
+    window.currentCharts.push(chart);
+}
+
+async function buildMarketIndexKisCard(doc, entry) {
+    const card = _marketIndexCardShell(doc, 'kis', entry.code, entry.label);
+
+    const body = doc.createElement('div');
+    body.className = 'market-index-body';
+    card.appendChild(body);
+
+    const res = await fetchWithTimeout(`/api/market-index/${entry.code}`);
+    const { json, error } = await readJsonResponse(res);
+    const data = json && json.rt_cd === '0' ? json.data : null;
+    if (error || !data) {
+        body.appendChild(_marketIndexError(doc));
+        return card;
+    }
+
+    const value = doc.createElement('div');
+    value.className = 'market-index-value';
+    value.textContent = _formatIndexValue(data.current);
+    body.appendChild(value);
+
+    const change = _formatIndexChange(data.change, data.change_rate);
+    const changeEl = doc.createElement('div');
+    changeEl.className = `market-index-change ${change.className}`.trim();
+    changeEl.textContent = change.text;
+    body.appendChild(changeEl);
+
+    const points = Array.isArray(data.points) ? data.points : [];
+    if (points.length) {
+        const canvas = doc.createElement('canvas');
+        canvas.className = 'market-index-spark';
+        canvas.height = 70;
+        body.appendChild(canvas);
+        _renderIndexSparkline(canvas, { points, changeRate: data.change_rate });
+    }
+
+    return card;
+}
+
+async function buildMarketIndexGroup(doc, group) {
+    const section = doc.createElement('section');
+    section.className = 'market-index-group';
+
+    const title = doc.createElement('h3');
+    title.className = 'market-index-group-title';
+    title.textContent = group.title;
+    section.appendChild(title);
+
+    const grid = doc.createElement('div');
+    grid.className = 'market-indices-grid';
+    const cards = group.kind === 'kis'
+        ? await Promise.all(group.entries.map(entry => buildMarketIndexKisCard(doc, entry)))
+        : group.entries.map(entry => buildMarketIndexWidgetCard(doc, entry));
+    cards.forEach(card => grid.appendChild(card));
+    section.appendChild(grid);
+
+    return section;
+}
+
+async function renderMarketIndices() {
     const target = document.getElementById('market-indices');
     if (!target) return;
 
+    const sections = await Promise.all(
+        MARKET_INDEX_GROUPS.map(group => buildMarketIndexGroup(document, group))
+    );
+
     target.innerHTML = '';
-    MARKET_INDEX_WIDGETS.forEach(entry => {
-        target.appendChild(buildMarketIndexCard(document, entry));
-    });
+    sections.forEach(section => target.appendChild(section));
 }
 
 document.addEventListener('DOMContentLoaded', renderMarketIndices);

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=13">
+    <link rel="stylesheet" href="/static/css/style.css?v=15">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=12">
+    <link rel="stylesheet" href="/static/css/style.css?v=13">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block head_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+{% endblock %}
+
 {% block content %}
     <style>
         .menu-card {
@@ -16,8 +20,8 @@
     </style>
     <div class="section">
         <div class="card">
-            <h2>글로벌 지수</h2>
-            <div id="market-indices" class="market-indices-grid"></div>
+            <h2>시장 지수</h2>
+            <div id="market-indices"></div>
         </div>
     </div>
     <div class="section">
@@ -96,5 +100,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_indices.js?v=1"></script>
+<script src="/static/js/market_indices.js?v=3"></script>
 {% endblock %}

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -15,6 +15,12 @@
         .home-menu-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
     </style>
     <div class="section">
+        <div class="card">
+            <h2>글로벌 지수</h2>
+            <div id="market-indices" class="market-indices-grid"></div>
+        </div>
+    </div>
+    <div class="section">
         <div class="card" style="text-align: center; padding: 48px 24px;">
             <h2 style="margin-bottom: 12px;">Investment</h2>
             <p style="color: var(--text-secondary); margin-bottom: 32px;">한국투자증권 Open API 기반 주식 자동매매 시스템</p>
@@ -87,4 +93,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/market_indices.js?v=1"></script>
 {% endblock %}


### PR DESCRIPTION
## 요약
홈(`/`) 상단에 시장 지수 패널을 추가하고 **국장 / 미장 / 원자재** 세 그룹으로 나눴다.

| 그룹 | 지수 | 소스 |
| --- | --- | --- |
| 국장 | 코스피(0001), 코스닥(1001) | **KIS API** + Chart.js |
| 미장 | 나스닥100, S&P500, 반도체 ETF(SOX 추종), VIX, 달러인덱스 | TradingView 위젯 |
| 원자재 | 금, WTI 유가, 메모리 반도체 ETF | TradingView 위젯 |

## TradingView 무료 임베드는 거래소 실지수를 차단한다
후보 심볼 20종을 브라우저에서 실측한 결과, 거래소 실지수는 차트 대신 **"이 심볼은 트레이딩뷰에서만 쓸 수 있습니다"** 만 표시된다.

- **차단**: `KRX:KOSPI`, `KRX:KOSDAQ`, `KRX:069500`, `SP:SPX`, `NASDAQ:NDX`, `NASDAQ:SOX`, `CBOE:VIX`, `TVC:DXY`, `TVC:US10Y`, `TVC:US02Y`, `CBOT:ZN1!`
- **정상**: `CAPITALCOM:US100`/`US500`/`VIX`/`DXY`, `NASDAQ:SOXX`, `TVC:GOLD`, `TVC:USOIL`, `CBOE:DRAM`, `AMEX:EWY`

대응:
- 미장·원자재 → 실제로 그려지는 CFD/ETF 심볼로 교체. 차단 심볼 재유입을 막는 회귀 테스트를 붙였다.
- 국장 → KRX 는 ETF 까지 통째로 차단되어 위젯으로 불가능. **KIS API 로 직접 구현**했다.
- 미국채 10년·2년 → 금리 지표는 차단되고 채권 ETF 가격만 가능한데, 금리와 방향이 반대(금리↑=가격↓)라 오독 위험이 커 **제외**했다.

## 국장: KIS 국내업종 기간별 지수 시세 신규 배선
`inquire-daily-indexchartprice`(TR `FHKUP03500100`)를 프로젝트에 새로 연결했다. 이 TR 하나가 현재값·등락 요약(output1)과 일별 시세(output2)를 함께 준다.

- `config/kis_config.yaml`, `config/tr_ids_config.yaml` — 경로 + TR ID
- `korea_invest_url_keys.py`, `korea_invest_trid_keys.py` — 키 추가
- `korea_invest_params_provider.py` — `DailyIndexChartPriceParams` (업종은 시장분류 `"U"`, 수정주가 항목 없음)
- `korea_invest_quotations_api.py` → `korea_invest_client.py` → `broker_api_wrapper.py` 위임
- `services/stock_query_service.py` — `get_index_chart()` 정규화 (`{code,name,current,change,change_rate,points}`, 과거→현재 정렬)
- `view/web/routes/stock.py` — `GET /api/market-index/{index_code}`

## 프런트
- `view/web/static/js/market_indices.js` — 그룹별 렌더. 국장은 API+Chart.js 스파크라인(색은 등락률 부호를 따름), 미장·원자재는 위젯. 둘 다 실패 시 카드별 안내로 degrade
- `view/web/templates/index.html` — 패널 섹션, Chart.js(head_scripts), 스크립트 v=3
- `view/web/static/css/style.css` — 그룹/카드/값/스파크라인 스타일
- `view/web/templates/base.html` — style.css 캐시 버전 v=15

## 테스트
신규:
- `tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_chart.py` — TR·파라미터(`fid_cond_mrkt_div_code="U"`)·매핑·에러/빈 응답
- `tests/unit_test/services/test_stock_query_index_chart.py` — 정규화, 정렬, 미지원 코드 거부, 파싱 불가 캔들 skip

갱신:
- `tests/frontend/run_market_indices_dom_tests.mjs` — 위젯/KIS 두 경로, 차단 심볼 회귀 가드, 스파크라인 색, degrade, 재렌더링 멱등
- `tests/unit_test/view/web/test_market_indices_contracts.py` — 차단 심볼 사용 금지 계약

실행 결과:
- `pytest tests/unit_test` — **7154 passed**
- `pytest tests/integration_test` — **267 passed**
- `node tests/frontend/run_market_indices_dom_tests.mjs` — **11/11 passed**

## 브라우저 검증
정적 미리보기(실제 `style.css` + `market_indices.js`, 국장은 API 스텁)에서 10개 카드 전부 실제 값·차트 렌더링 확인, `.market-index-error` 0건, 1280px 4열 그리드·가로 스크롤 없음.

## 남는 제약
- 미장·원자재는 외부 스크립트(`s3.tradingview.com`) 의존이라 오프라인/차단 시 안내 문구로 degrade하고, 데이터가 내부 DB 에 남지 않아 전략에서 재사용할 수 없다.
- 나스닥100·S&P500·VIX·달러인덱스는 실지수가 아니라 **CFD 호가**, 필라델피아 반도체는 **SOXX ETF 가격**이라 실지수와 값이 다르다(방향은 같음).
- `CBOE:DRAM`은 Roundhill Memory ETF 로 DRAM 계약가격이 아니라 메모리 반도체 업종 주가다. TradingView 에 DRAM 현물/고정거래가 지수는 없다.
- `inquire-daily-indexchartprice` 의 모의투자 지원 여부는 KIS 문서에 실전 전용 표기가 없어 지원으로 보고 배선했다. 모의 환경에서 실패하면 카드가 안내 문구로 degrade 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)