### PR TITLE
Add market status safety alerts

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -407,6 +407,10 @@ class BrokerAPIWrapper:
         """프로그램매매 구독 ACK 확정을 기다립니다."""
         return await self._client.wait_for_program_trading_ack(stock_code, timeout)
 
+    async def wait_market_status_ack(self, stock_code: str, timeout: float = None) -> bool:
+        """장운영정보 구독 ACK 확정을 기다립니다."""
+        return await self._client.wait_for_market_status_ack(stock_code, timeout)
+
     async def subscribe_realtime_quote(self, stock_code: str) -> Any:  # 실제 반환 값에 따라 타입 변경
         """실시간 호가 데이터 구독합니다 (KoreaInvestWebSocketAPI 위임)."""
         return await self._client.subscribe_realtime_quote(stock_code)
@@ -428,3 +432,9 @@ class BrokerAPIWrapper:
 
     async def unsubscribe_program_trading(self, stock_code: str):
         return await self._client.unsubscribe_program_trading(stock_code)
+
+    async def subscribe_market_status(self, stock_code: str):
+        return await self._client.subscribe_market_status(stock_code)
+
+    async def unsubscribe_market_status(self, stock_code: str):
+        return await self._client.unsubscribe_market_status(stock_code)

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -326,6 +326,10 @@ class KoreaInvestApiClient:
         """프로그램매매 구독 ACK 확정을 기다립니다."""
         return await self._websocketAPI.wait_for_program_trading_ack(stock_code, timeout)
 
+    async def wait_for_market_status_ack(self, stock_code: str, timeout: float = None) -> bool:
+        """장운영정보 구독 ACK 확정을 기다립니다."""
+        return await self._websocketAPI.wait_for_market_status_ack(stock_code, timeout)
+
     async def subscribe_realtime_quote(self, stock_code) -> Any:
         """실시간 주식호가 데이터를 구독합니다."""
         return await self._websocketAPI.subscribe_realtime_quote(stock_code)
@@ -351,3 +355,9 @@ class KoreaInvestApiClient:
 
     async def unsubscribe_program_trading(self, stock_code: str):
         return await self._websocketAPI.unsubscribe_program_trading(stock_code)
+
+    async def subscribe_market_status(self, stock_code: str):
+        return await self._websocketAPI.subscribe_market_status(stock_code)
+
+    async def unsubscribe_market_status(self, stock_code: str):
+        return await self._websocketAPI.unsubscribe_market_status(stock_code)

--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -85,6 +85,7 @@ class KoreaInvestWebSocketAPI:
         self._rt_tr_unified_realtime_price = None
         self._rt_tr_realtime_quote = None
         self._rt_program_trading_tr_ids = set()
+        self._rt_market_status_tr_ids = set()
 
     def _aes_cbc_base64_dec(self, key, iv, cipher_text):
         """
@@ -288,6 +289,7 @@ class KoreaInvestWebSocketAPI:
         if message and (message.startswith('0|') or message.startswith('1|')):  # 실시간 데이터 (0: 일반, 1: 체결통보)
             recvstr = message.split('|')
             tr_id = recvstr[1]  # 두 번째 요소가 TR_ID
+            tr_key = recvstr[2]  # 세 번째 요소가 구독 키
             data_body = recvstr[3]  # 네 번째 요소가 실제 데이터 본문
 
             self._logger.debug("받은 TR_ID: %s", tr_id)
@@ -363,6 +365,13 @@ class KoreaInvestWebSocketAPI:
             elif tr_id in self._rt_program_trading_tr_ids:
                 parsed_data = self._parse_program_trading_data(data_body)
                 message_type = 'realtime_program_trading'
+            elif tr_id in self._rt_market_status_tr_ids:
+                parsed_data = self._parse_market_status_data(
+                    data_body,
+                    include_stock_code=(tr_id != "H0UNMKO0"),
+                    stock_code=tr_key,
+                )
+                message_type = 'market_status'
 
             # [추가] 파싱된 데이터 디버그 로그 (데이터 내용 확인용) — lazy 포맷팅으로 매 틱 repr 생성 방지
             self._logger.debug("WS 수신 데이터 파싱: Type=%s, TR_ID=%s, Data=%s", message_type, tr_id, parsed_data)
@@ -718,11 +727,37 @@ class KoreaInvestWebSocketAPI:
         values = data_str.split('^')
         return dict(zip(keys, values[:len(keys)]))
 
+    def _parse_market_status_data(
+        self,
+        data_str: str,
+        include_stock_code: bool = True,
+        stock_code: str = "",
+    ) -> dict:
+        """H0STMKO0/H0NXMKO0/H0UNMKO0 (국내주식 장운영정보)를 파싱합니다."""
+        if include_stock_code:
+            menulist = "유가증권단축종목코드|거래정지여부|거래정지사유내용|장운영구분코드|예상장운영구분코드|임의연장구분코드|동시호가배분처리구분코드|종목상태구분코드|VI적용구분코드|시간외단일가VI적용구분코드|거래소구분코드"
+        else:
+            menulist = "거래정지여부|거래정지사유내용|장운영구분코드|예상장운영구분코드|임의연장구분코드|동시호가배분처리구분코드|종목상태구분코드|VI적용구분코드|시간외단일가VI적용구분코드|거래소구분코드"
+        keys = menulist.split('|')
+        values = data_str.split('^')
+        parsed = dict(zip(keys, values[:len(keys)]))
+        if not include_stock_code:
+            parsed["유가증권단축종목코드"] = stock_code
+        return parsed
+
     def _get_program_trading_tr_ids(self) -> set[str]:
         websocket_config = self._env.active_config.get('tr_ids', {}).get('websocket', {})
         return {
             websocket_config.get('realtime_program_trading', 'H0STPGM0'),
             websocket_config.get('nxt_realtime_program_trading', 'H0NXPGM0'),
+        }
+
+    def _get_market_status_tr_ids(self) -> set[str]:
+        websocket_config = self._env.active_config.get('tr_ids', {}).get('websocket', {})
+        return {
+            websocket_config.get('market_status', 'H0STMKO0'),
+            websocket_config.get('nxt_market_status', 'H0NXMKO0'),
+            websocket_config.get('unified_market_status', 'H0UNMKO0'),
         }
 
     def _cache_realtime_tr_ids(self) -> None:
@@ -734,6 +769,7 @@ class KoreaInvestWebSocketAPI:
         self._rt_tr_unified_realtime_price = ws_cfg.get('unified_realtime_price', 'H0UNCNT0')
         self._rt_tr_realtime_quote = ws_cfg['realtime_quote']
         self._rt_program_trading_tr_ids = self._get_program_trading_tr_ids()
+        self._rt_market_status_tr_ids = self._get_market_status_tr_ids()
         self._rt_tr_cached = True
 
     async def subscribe_program_trading(self, stock_code: str):
@@ -746,6 +782,18 @@ class KoreaInvestWebSocketAPI:
         """국내주식 실시간 프로그램매매 동향 (H0STPGM0) 구독 해지."""
         tr_id = self._env.active_config['tr_ids']['websocket'].get('realtime_program_trading', 'H0STPGM0')
         self._logger.info(f"[프로그램매매] 종목 {stock_code} 구독 해지 요청 ({tr_id})...")
+        return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
+
+    async def subscribe_market_status(self, stock_code: str):
+        """국내주식 장운영정보(H0UNMKO0)를 구독합니다."""
+        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
+        self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 요청 ({tr_id})...")
+        return await self.send_realtime_request(tr_id, stock_code, tr_type="1")
+
+    async def unsubscribe_market_status(self, stock_code: str):
+        """국내주식 장운영정보(H0UNMKO0) 구독을 해지합니다."""
+        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
+        self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 해지 요청 ({tr_id})...")
         return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
 
     async def _resubscribe_all(self):
@@ -935,6 +983,11 @@ class KoreaInvestWebSocketAPI:
     async def wait_for_program_trading_ack(self, stock_code, timeout: float = None) -> bool:
         """프로그램매매(H0STPGM0) 구독 ACK 확정을 기다린다."""
         tr_id = self._env.active_config['tr_ids']['websocket'].get('realtime_program_trading', 'H0STPGM0')
+        return await self.wait_for_subscription_ack(tr_id, stock_code, timeout)
+
+    async def wait_for_market_status_ack(self, stock_code, timeout: float = None) -> bool:
+        """장운영정보(H0UNMKO0) 구독 ACK 확정을 기다린다."""
+        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
         return await self.wait_for_subscription_ack(tr_id, stock_code, timeout)
 
     async def subscribe_realtime_price(self, stock_code):

--- a/common/operator_alert_types.py
+++ b/common/operator_alert_types.py
@@ -27,6 +27,7 @@ class AlertSource(str, Enum):
     DATA_QUALITY = "DATA_QUALITY"
     STRATEGY_PERF = "STRATEGY_PERF"
     INDICATOR = "INDICATOR"
+    MARKET_STATUS = "MARKET_STATUS"
 
 
 # severity 순서 (낮을수록 심각)

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -191,6 +191,12 @@ notifications:
       STRATEGY: ["warning", "error", "critical"]
       API: ["error", "critical"]
 
+# 시장 안전장치 알림. 장운영정보 웹소켓(H0UNMKO0)을 대표 종목에 구독해
+# 거래정지 사유에 사이드카/서킷브레이커가 포함되면 SYSTEM 알림을 발행한다.
+market_status_alert:
+  enabled: true
+  monitor_codes: ["005930"]
+
 # OpenDART 관심종목 공시 알림 (API 키 발급 후 enabled=true)
 dart_disclosure:
   enabled: false

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -63,6 +63,8 @@ tr_ids:
     order_notice_real: H0STCNI0 # 국내주식 체결통보 TR ID (실전)
     order_notice_paper: H0STCNI9 # 국내주식 체결통보 TR ID (모의)
     realtime_program_trading: "H0STPGM0"  # 프로그램매매 TR ID (KRX)
+    market_status: H0STMKO0       # 장운영정보 TR ID (KRX)
+    unified_market_status: H0UNMKO0 # 장운영정보 TR ID (KRX+NXT 통합)
     nxt_realtime_price: H0NXCNT0       # 실시간 주식체결 TR ID (NXT)
     nxt_realtime_quote: H0NXASP0       # 실시간 주식호가 TR ID (NXT)
     nxt_realtime_program_trading: H0NXPGM0  # 프로그램매매 TR ID (NXT)

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -1,0 +1,93 @@
+"""장운영정보 실시간 이벤트를 운영자 알림으로 변환한다."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from common.operator_alert_types import AlertSource
+
+
+class MarketStatusAlertService:
+    """KIS 장운영정보(H0* MKO0)에서 시장 안전장치 발동을 감지한다."""
+
+    _CIRCUIT_KEYWORDS = ("서킷", "circuit", "매매거래중단", "거래중단")
+    _SIDECAR_KEYWORDS = ("사이드카", "sidecar")
+
+    def __init__(
+        self,
+        operator_alert_service=None,
+        notification_service=None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._operator_alert_service = operator_alert_service
+        self._notification_service = notification_service
+        self._logger = logger or logging.getLogger(__name__)
+        self._active_keys_by_code: dict[str, set[str]] = {}
+
+    async def on_market_status(self, data: dict[str, Any]) -> None:
+        """StreamingService handler entrypoint."""
+        event_type = self._classify_event(data)
+        if event_type is None:
+            await self._resolve_for_code(data)
+            return
+
+        code = str(data.get("유가증권단축종목코드") or data.get("종목코드") or "UNKNOWN")
+        exchange = str(data.get("거래소구분코드") or data.get("EXCH_CLS_CODE") or "UNKNOWN")
+        reason = str(data.get("거래정지사유내용") or "").strip()
+        dedup_key = f"market_status:{event_type}:{exchange}:{code}"
+        severity = "critical" if event_type == "circuit_breaker" else "warning"
+        title = "서킷브레이커 감지" if event_type == "circuit_breaker" else "사이드카 감지"
+        message = f"{exchange} {code}: {reason or '장운영정보 특수 상태 감지'}"
+        metadata = {
+            "event_type": event_type,
+            "stock_code": code,
+            "exchange": exchange,
+            "reason": reason,
+            "market_status": dict(data),
+        }
+
+        self._active_keys_by_code.setdefault(code, set()).add(dedup_key)
+        if self._operator_alert_service is not None:
+            await self._operator_alert_service.report(
+                AlertSource.MARKET_STATUS,
+                dedup_key,
+                severity,
+                title,
+                message,
+                metadata=metadata,
+            )
+            return
+
+        if self._notification_service is not None:
+            from services.notification_service import NotificationCategory, NotificationLevel
+
+            level = NotificationLevel.CRITICAL if severity == "critical" else NotificationLevel.WARNING
+            await self._notification_service.emit(
+                NotificationCategory.SYSTEM,
+                level,
+                title,
+                message,
+                metadata=metadata,
+            )
+
+    def _classify_event(self, data: dict[str, Any]) -> Optional[str]:
+        reason = str(data.get("거래정지사유내용") or "").lower()
+        if any(keyword.lower() in reason for keyword in self._SIDECAR_KEYWORDS):
+            return "sidecar"
+        if any(keyword.lower() in reason for keyword in self._CIRCUIT_KEYWORDS):
+            return "circuit_breaker"
+        return None
+
+    async def _resolve_for_code(self, data: dict[str, Any]) -> None:
+        if self._operator_alert_service is None:
+            return
+        code = str(data.get("유가증권단축종목코드") or data.get("종목코드") or "")
+        if not code:
+            return
+        active_keys = self._active_keys_by_code.pop(code, set())
+        for dedup_key in active_keys:
+            await self._operator_alert_service.resolve(
+                AlertSource.MARKET_STATUS,
+                dedup_key,
+                "장운영정보 정상화",
+            )

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -48,6 +48,8 @@ class StreamingService:
         price_stream_service: Optional["PriceStreamService"] = None,
         streaming_stock_repo: Optional["StreamingStockRepo"] = None,
         data_quality_service=None,
+        market_status_alert_service=None,
+        market_status_monitor_codes: Optional[list[str]] = None,
     ):
         self.broker = broker_api_wrapper
         self.logger = logger
@@ -57,6 +59,8 @@ class StreamingService:
         self._price_stream_service: Optional["PriceStreamService"] = None
         self._streaming_stock_repo: Optional["StreamingStockRepo"] = streaming_stock_repo
         self._data_quality_service = data_quality_service
+        self._market_status_alert_service = market_status_alert_service
+        self._market_status_monitor_codes = list(market_status_monitor_codes or [])
         self._last_console_print_time: float = 0.0
         self._PRINT_THROTTLE_SEC: float = 0.5
         self._callback = None  # 재연결 시 콜백 유실 방지용 저장
@@ -70,6 +74,8 @@ class StreamingService:
 
         if price_stream_service is not None:
             self.set_price_stream_service(price_stream_service)
+        if market_status_alert_service is not None:
+            self.register_handler('market_status', market_status_alert_service.on_market_status)
 
     # ── 의존성 주입 ───────────────────────────────────────────────
 
@@ -130,6 +136,7 @@ class StreamingService:
                     await self.subscribe_order_notice()
                 except Exception as e:
                     self.logger.warning(f"체결통보 구독 실패: {e}")
+                await self._subscribe_market_status_monitors()
             return result
 
     def _is_websocket_receive_alive(self) -> bool:
@@ -164,6 +171,30 @@ class StreamingService:
         if not callable(waiter):
             return True
         return await waiter(code, timeout)
+
+    async def subscribe_market_status(self, code: str):
+        """장운영정보 실시간 구독 (BrokerAPIWrapper 위임)."""
+        return await self.broker.subscribe_market_status(code)
+
+    async def unsubscribe_market_status(self, code: str):
+        """장운영정보 실시간 구독 해지 (BrokerAPIWrapper 위임)."""
+        return await self.broker.unsubscribe_market_status(code)
+
+    async def wait_market_status_ack(self, code: str, timeout: float = None) -> bool:
+        """장운영정보 구독 ACK 확정을 기다린다."""
+        waiter = getattr(self.broker, "wait_market_status_ack", None)
+        if not callable(waiter):
+            return True
+        return await waiter(code, timeout)
+
+    async def _subscribe_market_status_monitors(self) -> None:
+        for code in self._market_status_monitor_codes:
+            try:
+                sent = await self.subscribe_market_status(code)
+                if sent and not await self.wait_market_status_ack(code):
+                    self.logger.warning(f"장운영정보 구독 ACK 미확정: {code}")
+            except Exception as e:
+                self.logger.warning(f"장운영정보 구독 실패 ({code}): {e}")
 
     async def subscribe_realtime_price(self, code: str):
         """실시간 체결가 구독 (BrokerAPIWrapper 위임)."""

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -40,6 +40,7 @@ def websocket_api_instance():
             "websocket": {
                 "realtime_price": "H0STCNT0",
                 "realtime_quote": "H0STASP0",
+                "unified_market_status": "H0UNMKO0",
                 "order_notice_real": "H0STCNI0",
                 "order_notice_paper": "H0STCNI9"
             }
@@ -2763,6 +2764,34 @@ def test_parse_program_trading_data(websocket_api_instance):
     assert result["순매수거래대금"] == "10000"
 
 
+def test_parse_market_status_data(websocket_api_instance):
+    api = websocket_api_instance
+    data_str = "005930^Y^서킷브레이커 발동으로 매매거래중단^2^0^0^0^00^0^0^KRX"
+
+    result = api._parse_market_status_data(data_str, include_stock_code=True)
+
+    assert result["유가증권단축종목코드"] == "005930"
+    assert result["거래정지여부"] == "Y"
+    assert result["거래정지사유내용"] == "서킷브레이커 발동으로 매매거래중단"
+    assert result["거래소구분코드"] == "KRX"
+
+
+def test_handle_websocket_message_market_status_success(websocket_api_instance):
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+    data_str = "Y^사이드카 발동^2^0^0^0^00^0^0^KRX"
+    message = f"0|H0UNMKO0|005930|{data_str}"
+
+    api._handle_websocket_message(message)
+
+    api.on_realtime_message_callback.assert_called_once()
+    result = api.on_realtime_message_callback.call_args[0][0]
+    assert result["type"] == "market_status"
+    assert result["tr_id"] == "H0UNMKO0"
+    assert result["data"]["유가증권단축종목코드"] == "005930"
+    assert result["data"]["거래정지사유내용"] == "사이드카 발동"
+
+
 def test_is_receive_alive_true_and_false(websocket_api_instance):
     api = websocket_api_instance
     done_task = MagicMock()
@@ -2825,6 +2854,8 @@ async def test_subscribe_unsubscribe_wrappers(websocket_api_instance):
         await api.unsubscribe_program_trading("005930")
         await api.subscribe_unified_price("005930")
         await api.unsubscribe_unified_price("005930")
+        await api.subscribe_market_status("005930")
+        await api.unsubscribe_market_status("005930")
 
     assert mock_send.await_args_list[0].args == ("H0STPGM0", "005930")
     assert mock_send.await_args_list[0].kwargs == {"tr_type": "1"}
@@ -2834,6 +2865,10 @@ async def test_subscribe_unsubscribe_wrappers(websocket_api_instance):
     assert mock_send.await_args_list[2].kwargs == {"tr_type": "1"}
     assert mock_send.await_args_list[3].args == ("H0UNCNT0", "005930")
     assert mock_send.await_args_list[3].kwargs == {"tr_type": "2"}
+    assert mock_send.await_args_list[4].args == ("H0UNMKO0", "005930")
+    assert mock_send.await_args_list[4].kwargs == {"tr_type": "1"}
+    assert mock_send.await_args_list[5].args == ("H0UNMKO0", "005930")
+    assert mock_send.await_args_list[5].kwargs == {"tr_type": "2"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from common.operator_alert_types import AlertSource
+from services.market_status_alert_service import MarketStatusAlertService
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_reports_circuit_breaker():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",
+        "거래정지여부": "Y",
+        "거래정지사유내용": "서킷브레이커 발동으로 매매거래중단",
+        "거래소구분코드": "KRX",
+    })
+
+    operator_alert.report.assert_awaited_once()
+    args = operator_alert.report.await_args.args
+    kwargs = operator_alert.report.await_args.kwargs
+    assert args[0] == AlertSource.MARKET_STATUS
+    assert args[1] == "market_status:circuit_breaker:KRX:005930"
+    assert args[2] == "critical"
+    assert "서킷브레이커" in args[3]
+    assert kwargs["metadata"]["event_type"] == "circuit_breaker"
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_reports_sidecar_warning():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",
+        "거래정지여부": "N",
+        "거래정지사유내용": "매도 사이드카 발동",
+        "거래소구분코드": "KRX",
+    })
+
+    args = operator_alert.report.await_args.args
+    assert args[1] == "market_status:sidecar:KRX:005930"
+    assert args[2] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_ignores_normal_status():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",
+        "거래정지여부": "N",
+        "거래정지사유내용": "",
+        "거래소구분코드": "KRX",
+    })
+
+    operator_alert.report.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_resolves_active_alert_on_normal_status():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",
+        "거래정지여부": "Y",
+        "거래정지사유내용": "서킷브레이커 발동",
+        "거래소구분코드": "KRX",
+    })
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",
+        "거래정지여부": "N",
+        "거래정지사유내용": "",
+        "거래소구분코드": "KRX",
+    })
+
+    operator_alert.resolve.assert_awaited_once_with(
+        AlertSource.MARKET_STATUS,
+        "market_status:circuit_breaker:KRX:005930",
+        "장운영정보 정상화",
+    )

--- a/view/web/bootstrap/realtime_bootstrap.py
+++ b/view/web/bootstrap/realtime_bootstrap.py
@@ -11,6 +11,7 @@ from services.price_stream_service import PriceStreamService
 from services.price_subscription_service import PriceSubscriptionService
 from services.strategy_event_router import StrategyEventRouter
 from services.streaming_service import StreamingService
+from services.market_status_alert_service import MarketStatusAlertService
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -29,6 +30,26 @@ class RealtimeBootstrap:
             self._disable()
             return
 
+        market_status_cfg = config.get("market_status_alert", {}) if isinstance(config, dict) else {}
+        market_status_enabled = (
+            market_status_cfg.get("enabled", True)
+            if isinstance(market_status_cfg, dict)
+            else True
+        )
+        monitor_codes = (
+            market_status_cfg.get("monitor_codes", ["005930"])
+            if isinstance(market_status_cfg, dict)
+            else ["005930"]
+        )
+        ctx.market_status_alert_service = (
+            MarketStatusAlertService(
+                operator_alert_service=ctx.operator_alert_service,
+                notification_service=ctx.notification_service,
+                logger=ctx.logger,
+            )
+            if market_status_enabled
+            else None
+        )
         ctx.streaming_service = StreamingService(
             broker_api_wrapper=ctx.broker,
             logger=ctx.logger,
@@ -36,6 +57,8 @@ class RealtimeBootstrap:
             market_data_service=ctx.market_data_service,
             streaming_logger=ctx.streaming_event_logger,
             data_quality_service=ctx.data_quality_service,
+            market_status_alert_service=ctx.market_status_alert_service,
+            market_status_monitor_codes=monitor_codes if market_status_enabled else [],
         )
         ctx.event_shadow_journal_service = EventShadowJournalService(
             log_root="logs/strategies",
@@ -122,3 +145,4 @@ class RealtimeBootstrap:
         ctx.streaming_stock_repo = None
         ctx.price_subscription_service = None
         ctx.websocket_watchdog_task = None
+        ctx.market_status_alert_service = None

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -172,6 +172,7 @@ class WebAppContext:
         self.foreground_scheduler: ForegroundScheduler = None
         self._mcs: MarketCalendarService = None
         self.notification_service: NotificationService = None
+        self.market_status_alert_service = None
         self.telegram_notification_repository = None
         self.strategy_diagnostic_report_repository = None
         self.notification_queue_task: NotificationQueueTask = None


### PR DESCRIPTION
## Summary
- Parse KIS market status websocket messages and expose subscribe/ACK wrappers
- Add MarketStatusAlertService for sidecar/circuit-breaker detection with operator-alert dedup/resolve
- Wire default monitoring through realtime bootstrap and document config

## Tests
- pytest tests/unit_test -v
- pytest tests/integration_test -v