### PR TITLE
Add favorite price threshold alerts

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -1,0 +1,162 @@
+"""관심종목 실시간 등락률 알림 서비스."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+from services.notification_service import (
+    NotificationCategory,
+    NotificationLevel,
+    NotificationService,
+)
+
+
+class FavoritePriceAlertService:
+    """관심종목이 전일대비율 5% 단위 구간을 새로 밟을 때 알림을 발행한다."""
+
+    def __init__(
+        self,
+        favorite_repository,
+        notification_service: Optional[NotificationService],
+        stock_code_repository=None,
+        *,
+        threshold_step_pct: float = 5.0,
+        favorite_cache_ttl_sec: float = 30.0,
+        logger=None,
+    ) -> None:
+        self._favorite_repository = favorite_repository
+        self._notification_service = notification_service
+        self._stock_code_repository = stock_code_repository
+        self._threshold_step_pct = float(threshold_step_pct)
+        self._favorite_cache_ttl_sec = float(favorite_cache_ttl_sec)
+        self._logger = logger or logging.getLogger(__name__)
+        self._favorite_codes: set[str] = set()
+        self._favorite_cache_ts: float = 0.0
+        self._last_alert_bucket: dict[str, int] = {}
+
+    async def add_favorite(self, code: str) -> None:
+        normalized = self._normalize_code(code)
+        if not normalized:
+            return
+        await self._refresh_favorites(force=True)
+        self._favorite_codes.add(normalized)
+
+    async def remove_favorite(self, code: str) -> None:
+        normalized = self._normalize_code(code)
+        if not normalized:
+            return
+        self._favorite_codes.discard(normalized)
+        self._last_alert_bucket.pop(normalized, None)
+
+    async def handle_price_tick(self, code: str, *, price, rate) -> bool:
+        """실시간 현재가 틱을 평가하고 알림 발행 여부를 반환한다."""
+        normalized = self._normalize_code(code)
+        if not normalized or self._notification_service is None:
+            return False
+        if self._threshold_step_pct <= 0:
+            return False
+
+        await self._refresh_favorites()
+        if normalized not in self._favorite_codes:
+            return False
+
+        rate_value = self._to_float(rate)
+        if rate_value is None:
+            return False
+
+        bucket = self._rate_bucket(rate_value)
+        if bucket == 0:
+            self._last_alert_bucket[normalized] = 0
+            return False
+        if self._last_alert_bucket.get(normalized) == bucket:
+            return False
+
+        self._last_alert_bucket[normalized] = bucket
+        threshold_pct = int(bucket * self._threshold_step_pct)
+        name = self._stock_name(normalized)
+        direction = "상승" if threshold_pct > 0 else "하락"
+        signed_threshold = self._format_signed_pct(threshold_pct)
+        signed_rate = self._format_signed_pct(rate_value)
+        formatted_price = self._format_price(price)
+
+        await self._notification_service.emit(
+            NotificationCategory.SYSTEM,
+            NotificationLevel.WARNING,
+            f"[관심종목] {name} {signed_threshold} {direction}",
+            f"{normalized} {name} 현재 {formatted_price}, 전일대비 {signed_rate}",
+            metadata={
+                "alert_type": "favorite_price_threshold",
+                "code": normalized,
+                "name": name,
+                "price": self._to_float(price),
+                "rate": rate_value,
+                "threshold_pct": threshold_pct,
+                "dedup_key": f"favorite_price:{normalized}:{threshold_pct}",
+                "force_external": True,
+            },
+        )
+        return True
+
+    async def _refresh_favorites(self, *, force: bool = False) -> None:
+        now = time.monotonic()
+        if (
+            not force
+            and self._favorite_cache_ts > 0
+            and now - self._favorite_cache_ts < self._favorite_cache_ttl_sec
+        ):
+            return
+        try:
+            codes = await self._favorite_repository.get_all()
+        except Exception as exc:
+            self._logger.warning(f"관심종목 알림용 목록 조회 실패: {exc}")
+            return
+        self._favorite_codes = {
+            normalized for code in codes if (normalized := self._normalize_code(code))
+        }
+        self._favorite_cache_ts = now
+
+    def _rate_bucket(self, rate: float) -> int:
+        bucket = int(abs(rate) // self._threshold_step_pct)
+        if bucket < 1:
+            return 0
+        return bucket if rate > 0 else -bucket
+
+    def _stock_name(self, code: str) -> str:
+        if self._stock_code_repository is None:
+            return code
+        try:
+            return self._stock_code_repository.get_name_by_code(code) or code
+        except Exception:
+            return code
+
+    @staticmethod
+    def _normalize_code(code) -> str:
+        return str(code or "").strip()
+
+    @staticmethod
+    def _to_float(value) -> Optional[float]:
+        try:
+            text = str(value).strip().replace(",", "")
+            if not text:
+                return None
+            return float(text)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _format_price(cls, value) -> str:
+        number = cls._to_float(value)
+        if number is None:
+            return "-"
+        if number.is_integer():
+            return f"{int(number):,}원"
+        return f"{number:,.2f}원"
+
+    @staticmethod
+    def _format_signed_pct(value: float | int) -> str:
+        number = float(value)
+        sign = "+" if number > 0 else ""
+        if number.is_integer():
+            return f"{sign}{int(number)}%"
+        return f"{sign}{number:.2f}%"

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -35,6 +35,7 @@ class PriceStreamService:
         logger=None,
         data_quality_service=None,
         notification_service=None,
+        favorite_price_alert_service=None,
         event_router=None,
         execution_strength_recorder=None,
         orderbook_recorder=None,
@@ -43,6 +44,7 @@ class PriceStreamService:
         self._logger = logger or logging.getLogger(__name__)
         self._data_quality_service = data_quality_service
         self._notification_service = notification_service
+        self._favorite_price_alert_service = favorite_price_alert_service
         self._event_router = event_router
         self._execution_strength_recorder = execution_strength_recorder
         self._orderbook_recorder = orderbook_recorder
@@ -218,6 +220,21 @@ class PriceStreamService:
                     q.put_nowait(tick)
                 except asyncio.QueueFull:
                     pass
+
+        if self._favorite_price_alert_service is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(
+                    self._favorite_price_alert_service.handle_price_tick(
+                        stock_code,
+                        price=current_price,
+                        rate=realtime_data.get('전일대비율'),
+                    )
+                )
+            except RuntimeError:
+                pass
+            except Exception as e:
+                self._logger.warning(f"관심종목 가격 알림 평가 실패: {e}")
 
         if self._event_router is not None:
             try:

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.favorite_price_alert_service import FavoritePriceAlertService
+from services.notification_service import NotificationCategory, NotificationLevel
+
+
+@pytest.mark.asyncio
+async def test_alerts_when_favorite_rate_crosses_positive_five_percent():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    stock_codes = MagicMock()
+    stock_codes.get_name_by_code.return_value = "삼성전자"
+    svc = FavoritePriceAlertService(repo, notifications, stock_codes)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.12")
+
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert args[:2] == (NotificationCategory.SYSTEM, NotificationLevel.WARNING)
+    assert "삼성전자" in args[2]
+    assert "+5%" in args[2]
+    assert "75,000원" in args[3]
+    assert kwargs["metadata"]["threshold_pct"] == 5
+    assert kwargs["metadata"]["force_external"] is True
+
+
+@pytest.mark.asyncio
+async def test_does_not_repeat_same_five_percent_bucket_until_next_bucket():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.12")
+    await svc.handle_price_tick("005930", price="75200", rate="5.44")
+    await svc.handle_price_tick("005930", price="78500", rate="10.02")
+
+    assert notifications.emit.await_count == 2
+    assert notifications.emit.await_args_list[1].kwargs["metadata"]["threshold_pct"] == 10
+
+
+@pytest.mark.asyncio
+async def test_alerts_negative_five_percent_bucket():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="70000", rate="-5.01")
+
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert "-5%" in args[2]
+    assert kwargs["metadata"]["threshold_pct"] == -5
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_favorite_and_invalid_rate():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["000660"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="6.00")
+    await svc.handle_price_tick("000660", price="150000", rate="bad")
+
+    notifications.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_favorite_update_cache_and_reset_alert_state():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=[])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.add_favorite("005930")
+    await svc.handle_price_tick("005930", price="75000", rate="5.10")
+    await svc.remove_favorite("005930")
+    await svc.handle_price_tick("005930", price="75100", rate="10.10")
+
+    notifications.emit.assert_awaited_once()

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from services.price_stream_service import PriceStreamService
 from services.data_quality_service import DataQualityResult
 
@@ -304,6 +304,29 @@ def test_on_price_tick_broadcasts_even_if_repo_fails(price_stream_service, mock_
     tick = q.get_nowait()
     assert tick["price"] == 75000.0
     assert tick["volume"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_on_price_tick_schedules_favorite_price_alert(mock_stock_repo, mock_logger):
+    alert_service = MagicMock()
+    alert_service.handle_price_tick = AsyncMock()
+    service = PriceStreamService(
+        stock_repo=mock_stock_repo,
+        logger=mock_logger,
+        favorite_price_alert_service=alert_service,
+    )
+
+    service.on_price_tick({
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '75000',
+        '전일대비율': '5.12',
+    })
+    alert_service.handle_price_tick.assert_called_once_with(
+        "005930",
+        price="75000",
+        rate="5.12",
+    )
+    await asyncio.sleep(0)
 
 
 def test_mark_subscription_requested_and_get_subscription_age(price_stream_service):

--- a/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
@@ -12,11 +12,13 @@ def test_realtime_bootstrap_builds_streaming_chain():
         kill_switch_service=MagicMock(), stock_repository=MagicMock(),
         notification_service=MagicMock(), operator_alert_service=MagicMock(),
         program_trading_stream_service=MagicMock(), pm=MagicMock(),
+        favorite_repo=MagicMock(), stock_code_repository=MagicMock(),
     )
     ctx.program_trading_stream_service.load_snapshot.return_value = {}
 
     with patch("view.web.bootstrap.realtime_bootstrap.StreamingService") as streaming, \
          patch("view.web.bootstrap.realtime_bootstrap.OrderbookSnapshotRepository") as orderbook_repo, \
+         patch("view.web.bootstrap.realtime_bootstrap.FavoritePriceAlertService") as favorite_alert, \
          patch("view.web.bootstrap.realtime_bootstrap.PriceStreamService") as price_stream, \
          patch("view.web.bootstrap.realtime_bootstrap.PriceSubscriptionService") as subscriptions, \
          patch("view.web.bootstrap.realtime_bootstrap.WebSocketWatchdogTask") as watchdog:
@@ -24,6 +26,8 @@ def test_realtime_bootstrap_builds_streaming_chain():
 
     assert ctx.streaming_service is streaming.return_value
     assert ctx.orderbook_snapshot_repo is orderbook_repo.return_value
+    assert ctx.favorite_price_alert_service is favorite_alert.return_value
+    assert price_stream.call_args.kwargs["favorite_price_alert_service"] is favorite_alert.return_value
     assert price_stream.call_args.kwargs["orderbook_recorder"] is orderbook_repo.return_value
     assert ctx.price_stream_service is price_stream.return_value
     assert ctx.price_subscription_service is subscriptions.return_value

--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -41,6 +41,8 @@ async def test_add_favorite(web_client, mock_web_ctx):
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = None
+        mock_web_ctx.price_subscription_service = None
 
         response = web_client.post("/api/favorite/005930")
         assert response.status_code == 200
@@ -56,10 +58,32 @@ async def test_add_favorite_already_exists(web_client, mock_web_ctx):
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.add = AsyncMock(return_value=False)
+        mock_web_ctx.favorite_price_alert_service = None
+        mock_web_ctx.price_subscription_service = None
 
         response = web_client.post("/api/favorite/005930")
         assert response.status_code == 200
         assert response.json()["added"] is False
+
+
+async def test_add_favorite_syncs_alert_cache_and_price_subscription(web_client, mock_web_ctx):
+    """POST /api/favorite/{code} - 추가 시 가격 알림 캐시와 구독을 동기화한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.add_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.add_subscription = AsyncMock()
+
+        response = web_client.post("/api/favorite/005930")
+        assert response.status_code == 200
+
+        mock_web_ctx.favorite_price_alert_service.add_favorite.assert_awaited_once_with("005930")
+        mock_web_ctx.price_subscription_service.add_subscription.assert_awaited_once()
+        args = mock_web_ctx.price_subscription_service.add_subscription.await_args.args
+        assert args[0] == "005930"
+        assert args[2] == "favorite"
 
 
 async def test_remove_favorite(web_client, mock_web_ctx):
@@ -67,6 +91,8 @@ async def test_remove_favorite(web_client, mock_web_ctx):
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.remove = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = None
+        mock_web_ctx.price_subscription_service = None
 
         response = web_client.delete("/api/favorite/005930")
         assert response.status_code == 200
@@ -81,10 +107,29 @@ async def test_remove_favorite_not_found(web_client, mock_web_ctx):
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.remove = AsyncMock(return_value=False)
+        mock_web_ctx.favorite_price_alert_service = None
+        mock_web_ctx.price_subscription_service = None
 
         response = web_client.delete("/api/favorite/999999")
         assert response.status_code == 200
         assert response.json()["removed"] is False
+
+
+async def test_remove_favorite_syncs_alert_cache_and_price_subscription(web_client, mock_web_ctx):
+    """DELETE /api/favorite/{code} - 삭제 시 가격 알림 캐시와 구독을 정리한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.remove = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.remove_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.remove_subscription = AsyncMock()
+
+        response = web_client.delete("/api/favorite/005930")
+        assert response.status_code == 200
+
+        mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_awaited_once_with("005930")
+        mock_web_ctx.price_subscription_service.remove_subscription.assert_awaited_once_with("005930", "favorite")
 
 
 async def test_get_favorite_status_true(web_client, mock_web_ctx):

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -733,6 +733,8 @@ async def test_initialize_price_subscriptions_holdings_no_broker_call(mock_deps)
     mock_vts = MagicMock()
     mock_vts.get_holds.return_value = []
     ctx.virtual_trade_service = mock_vts
+    ctx.favorite_service = MagicMock()
+    ctx.favorite_service.get_all = AsyncMock(return_value=[])
 
     await ctx._initialize_price_subscriptions()
 
@@ -768,8 +770,12 @@ async def test_initialize_price_subscriptions_premium_extracts_code(mock_deps, t
          patch("os.path.exists", return_value=True):
         await ctx._initialize_price_subscriptions()
 
-    mock_price_svc.sync_subscriptions.assert_called_once()
-    call_kwargs = mock_price_svc.sync_subscriptions.call_args[1]
+    premium_calls = [
+        call for call in mock_price_svc.sync_subscriptions.call_args_list
+        if call.kwargs.get("category_key") == "strategy_premium"
+    ]
+    assert len(premium_calls) == 1
+    call_kwargs = premium_calls[0].kwargs
     codes = call_kwargs["codes"]
     # 문자열 코드만 들어있어야 함 (dict 아님)
     assert all(isinstance(c, str) for c in codes), f"dict가 섞임: {codes}"
@@ -795,12 +801,19 @@ async def test_initialize_price_subscriptions_premium_no_dict_leakage(mock_deps,
     mock_vts = MagicMock()
     mock_vts.get_holds.return_value = []
     ctx.virtual_trade_service = mock_vts
+    ctx.favorite_service = MagicMock()
+    ctx.favorite_service.get_all = AsyncMock(return_value=[])
 
     with patch("os.path.join", return_value=str(premium_file)), \
          patch("os.path.exists", return_value=True):
         await ctx._initialize_price_subscriptions()
 
-    call_kwargs = mock_price_svc.sync_subscriptions.call_args[1]
+    premium_calls = [
+        call for call in mock_price_svc.sync_subscriptions.call_args_list
+        if call.kwargs.get("category_key") == "strategy_premium"
+    ]
+    assert len(premium_calls) == 1
+    call_kwargs = premium_calls[0].kwargs
     codes = call_kwargs["codes"]
     for c in codes:
         assert not isinstance(c, dict), f"codes에 dict 포함: {c}"

--- a/view/web/bootstrap/realtime_bootstrap.py
+++ b/view/web/bootstrap/realtime_bootstrap.py
@@ -6,6 +6,7 @@ from repositories.execution_strength_repo import ExecutionStrengthRepository
 from repositories.orderbook_snapshot_repo import OrderbookSnapshotRepository
 from repositories.streaming_stock_repo import StreamingStockRepo
 from services.event_shadow_journal_service import EventShadowJournalService
+from services.favorite_price_alert_service import FavoritePriceAlertService
 from services.price_stream_service import PriceStreamService
 from services.price_subscription_service import PriceSubscriptionService
 from services.strategy_event_router import StrategyEventRouter
@@ -60,11 +61,18 @@ class RealtimeBootstrap:
             if orderbook_capture_enabled
             else None
         )
+        ctx.favorite_price_alert_service = FavoritePriceAlertService(
+            favorite_repository=ctx.favorite_repo,
+            notification_service=ctx.notification_service,
+            stock_code_repository=ctx.stock_code_repository,
+            logger=ctx.logger,
+        )
         ctx.price_stream_service = PriceStreamService(
             stock_repo=ctx.stock_repository,
             logger=ctx.logger,
             data_quality_service=ctx.data_quality_service,
             notification_service=ctx.notification_service,
+            favorite_price_alert_service=ctx.favorite_price_alert_service,
             event_router=ctx.strategy_event_router,
             execution_strength_recorder=ctx.execution_strength_repo,
             orderbook_recorder=ctx.orderbook_snapshot_repo,
@@ -110,6 +118,7 @@ class RealtimeBootstrap:
         ctx.execution_strength_repo = None
         ctx.orderbook_snapshot_repo = None
         ctx.price_stream_service = None
+        ctx.favorite_price_alert_service = None
         ctx.streaming_stock_repo = None
         ctx.price_subscription_service = None
         ctx.websocket_watchdog_task = None

--- a/view/web/routes/favorite.py
+++ b/view/web/routes/favorite.py
@@ -8,6 +8,13 @@ from view.web.api_common import _get_ctx
 router = APIRouter(prefix="/favorite", tags=["favorite"])
 
 
+def _ctx_attr(ctx, name: str, default=None):
+    """MagicMock 테스트 컨텍스트에서 미정의 속성이 truthy Mock으로 생기는 것을 피한다."""
+    if hasattr(ctx, "__dict__"):
+        return ctx.__dict__.get(name, default)
+    return getattr(ctx, name, default)
+
+
 @router.get("")
 async def get_favorite_list():
     """관심종목 목록 (종목명·현재가·등락률 포함) 반환."""
@@ -38,6 +45,21 @@ async def add_favorite(code: str):
     """관심종목 추가."""
     ctx = _get_ctx()
     added = await ctx.favorite_service.add(code)
+    if added:
+        alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
+        if alert_service:
+            await alert_service.add_favorite(code)
+        price_subscription_service = _ctx_attr(ctx, "price_subscription_service")
+        if price_subscription_service:
+            try:
+                from services.price_subscription_service import SubscriptionPriority
+                await price_subscription_service.add_subscription(
+                    code,
+                    SubscriptionPriority.LOW,
+                    "favorite",
+                )
+            except Exception as e:
+                ctx.logger.warning(f"관심종목 구독 추가 실패: {e}")
     return {"success": True, "added": added, "code": code}
 
 
@@ -46,6 +68,16 @@ async def remove_favorite(code: str):
     """관심종목 제거."""
     ctx = _get_ctx()
     removed = await ctx.favorite_service.remove(code)
+    if removed:
+        alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
+        if alert_service:
+            await alert_service.remove_favorite(code)
+        price_subscription_service = _ctx_attr(ctx, "price_subscription_service")
+        if price_subscription_service:
+            try:
+                await price_subscription_service.remove_subscription(code, "favorite")
+            except Exception as e:
+                ctx.logger.warning(f"관심종목 구독 제거 실패: {e}")
     return {"success": True, "removed": removed, "code": code}
 
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -21,6 +21,7 @@ from repositories.overseas_stock_code_repository import OverseasStockCodeReposit
 from repositories.rs_rating_repository import RSRatingRepository
 from repositories.favorite_repository import FavoriteRepository
 from services.favorite_service import FavoriteService
+from services.favorite_price_alert_service import FavoritePriceAlertService
 from services.indicator_service import IndicatorService
 from core.market_clock import MarketClock
 from core.logger import Logger, get_strategy_logger, get_streaming_logger
@@ -134,6 +135,7 @@ class WebAppContext:
             repository=self.favorite_repo,
             stock_code_repository=self.stock_code_repository,
         )
+        self.favorite_price_alert_service: FavoritePriceAlertService = None
         self.account_snapshot_cache: AccountSnapshotCache = None
         self.api_budget_limiter = ApiBudgetLimiter()
         self.risk_gate_service: RiskGateService = None
@@ -335,6 +337,18 @@ class WebAppContext:
                     )
         except Exception as e:
             self.logger.warning(f"프리미엄 종목 구독 초기화 실패: {e}")
+
+        # 3. 관심종목 → LOW 구독 (알림 및 관심종목 페이지 최신가용)
+        try:
+            favorite_codes = await self.favorite_service.get_all() if self.favorite_service else []
+            if favorite_codes:
+                await self.price_subscription_service.sync_subscriptions(
+                    codes=favorite_codes,
+                    category_key="favorite",
+                    priority=SubscriptionPriority.LOW,
+                )
+        except Exception as e:
+            self.logger.warning(f"관심종목 구독 초기화 실패: {e}")
 
     def get_env_type(self) -> str:
         if self.env is None:


### PR DESCRIPTION
﻿## What changed
- Added favorite stock price threshold alerts based on realtime `전일대비율` ticks.
- Alerts fire when a favorite newly enters each +/-5% bucket, such as +5%, +10%, -5%, and -10%.
- Synced favorite add/remove and app startup with LOW-priority realtime price subscriptions.

## Impact
- Favorite stocks can emit web notification events and external Telegram-routed notifications when enabled.
- Duplicate alerts are suppressed within the same 5% bucket until the stock moves to another bucket or resets below +/-5%.

## Validation
- `python -m pytest tests/unit_test -q`
- `python -m pytest tests/integration_test -q`
