### PR TITLE
로컬 실행에서 same-origin 요청이 CORS 미들웨어에 막히는 문제 수정

### DIFF
--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -324,6 +324,62 @@ def test_public_mode_rejects_untrusted_host(mock_web_app_context_cls):
     assert response.status_code == 400
 
 
+def test_local_mode_allows_same_origin_request(mock_web_app_context_cls):
+    """cors_allowed_origins 미설정(로컬 실행)이어도 same-origin 요청은 통과해야 한다.
+
+    브라우저는 same-origin POST 에도 Origin 헤더를 보내므로, 허용 목록만 보고 막으면
+    웹 UI 의 모든 POST(재수행/종료/주문 등)가 400 으로 실패한다.
+    """
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {
+        "use_login": False,
+        "auth": {"secret_key": "test-token"},
+        "deployment": {"public_mode": False, "demo_mode": False},
+    }
+    mock_ctx.foreground_scheduler = None
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with patch("view.web.api_common._ctx", mock_ctx):
+            same_origin = client.get(
+                "/api/auth/me",
+                headers={"Origin": "http://localhost:8000", "Host": "localhost:8000"},
+            )
+            cross_origin = client.get(
+                "/api/auth/me",
+                headers={"Origin": "http://attacker.example", "Host": "localhost:8000"},
+            )
+
+    assert same_origin.status_code == 200
+    assert cross_origin.status_code == 400
+    assert cross_origin.json()["detail"] == "Origin is not allowed"
+
+
+def test_same_origin_is_allowed_regardless_of_port_and_scheme(mock_web_app_context_cls):
+    """same-origin 판정은 scheme+host+port 가 모두 일치할 때만 성립한다."""
+    mock_ctx = MagicMock()
+    mock_ctx.full_config = {
+        "use_login": False,
+        "auth": {"secret_key": "test-token"},
+        "deployment": {"public_mode": False, "demo_mode": False},
+    }
+    mock_ctx.foreground_scheduler = None
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with patch("view.web.api_common._ctx", mock_ctx):
+            other_port = client.get(
+                "/api/auth/me",
+                headers={"Origin": "http://localhost:9999", "Host": "localhost:8000"},
+            )
+            loopback_alias = client.get(
+                "/api/auth/me",
+                headers={"Origin": "http://127.0.0.1:8000", "Host": "127.0.0.1:8000"},
+            )
+
+    # 포트가 다르면 별개 출처다.
+    assert other_port.status_code == 400
+    assert loopback_alias.status_code == 200
+
+
 def test_demo_cors_allows_only_configured_origin(mock_web_app_context_cls):
     mock_ctx = MagicMock()
     mock_ctx.full_config = {

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -354,7 +354,7 @@ def test_local_mode_allows_same_origin_request(mock_web_app_context_cls):
     assert cross_origin.json()["detail"] == "Origin is not allowed"
 
 
-def test_same_origin_is_allowed_regardless_of_port_and_scheme(mock_web_app_context_cls):
+def test_same_origin_requires_matching_scheme_host_port(mock_web_app_context_cls):
     """same-origin 판정은 scheme+host+port 가 모두 일치할 때만 성립한다."""
     mock_ctx = MagicMock()
     mock_ctx.full_config = {
@@ -370,14 +370,21 @@ def test_same_origin_is_allowed_regardless_of_port_and_scheme(mock_web_app_conte
                 "/api/auth/me",
                 headers={"Origin": "http://localhost:9999", "Host": "localhost:8000"},
             )
-            loopback_alias = client.get(
+            other_host = client.get(
+                "/api/auth/me",
+                headers={"Origin": "http://localhost:8000", "Host": "127.0.0.1:8000"},
+            )
+            matching_loopback = client.get(
                 "/api/auth/me",
                 headers={"Origin": "http://127.0.0.1:8000", "Host": "127.0.0.1:8000"},
             )
 
     # 포트가 다르면 별개 출처다.
     assert other_port.status_code == 400
-    assert loopback_alias.status_code == 200
+    # 호스트 문자열이 다르면 별개 출처다 (localhost 와 127.0.0.1 을 같은 것으로 보지 않는다).
+    assert other_host.status_code == 400
+    # 자기 Host 와 정확히 일치하면 호스트 표기와 무관하게 same-origin 이다.
+    assert matching_loopback.status_code == 200
 
 
 def test_demo_cors_allows_only_configured_origin(mock_web_app_context_cls):

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -204,6 +204,19 @@ async def public_host_middleware(request: Request, call_next):
     return await call_next(request)
 
 
+def _is_same_origin(request: Request, normalized_origin: str) -> bool:
+    """Origin 이 요청 자신의 출처(scheme+host+port)와 같은지 판정한다.
+
+    브라우저는 same-origin POST 에도 Origin 을 붙이므로, 이를 허용 목록으로만 거르면
+    로컬 실행(cors_allowed_origins 미설정)에서 웹 UI 의 모든 POST 가 막힌다.
+    CORS 는 교차 출처를 막기 위한 장치이고, same-origin 위조 방지는 CSRF 토큰 검사가 담당한다.
+    """
+    host = request.headers.get("host", "").strip()
+    if not host:
+        return False
+    return normalized_origin.lower() == f"{request.url.scheme}://{host}".lower()
+
+
 async def exact_origin_cors_middleware(request: Request, call_next):
     origin = request.headers.get("origin")
     ctx = api_common._ctx
@@ -212,6 +225,8 @@ async def exact_origin_cors_middleware(request: Request, call_next):
 
     allowed_origins, allow_credentials = cors_policy(ctx)
     normalized_origin = origin.rstrip("/")
+    if _is_same_origin(request, normalized_origin):
+        return await call_next(request)
     if normalized_origin not in allowed_origins:
         return JSONResponse(
             status_code=400,


### PR DESCRIPTION
## 증상
웹 UI 의 **서버 재수행/종료 버튼이 `재시작 실패: Origin is not allowed` 로 실패**한다.
재시작뿐 아니라 브라우저에서 나가는 **모든 POST**(주문, kill switch, 환경 전환, market-mode 등)가 같은 이유로 400 이다.

## 원인
[#715](https://github.com/kyungsooNa/Investment/pull/715) 이 추가한 `exact_origin_cors_middleware` 가 `Origin` 헤더가 붙은 요청을 **허용 목록으로만** 거른다.

```python
allowed_origins, allow_credentials = cors_policy(ctx)
normalized_origin = origin.rstrip("/")
if normalized_origin not in allowed_origins:   # ← same-origin 예외 없음
    return JSONResponse(status_code=400, content={"detail": "Origin is not allowed"})
```

`cors_policy()` 는 `deployment.cors_allowed_origins` 를 읽는데, 로컬 실행 설정에는 이 키가 없어 **허용 목록이 빈 집합**이 된다. 그런데 브라우저는 same-origin POST 에도 `Origin` 을 붙이므로, 자기 자신이 보낸 요청이 전부 차단된다.

같은 파일의 host 검사(`is_host_allowed`)는 `public_mode` 가 아니면 무조건 통과시키는데 Origin 검사에는 그 예외가 없어서 생긴 비대칭이다.

재현 (로컬 설정 = `public_mode: false`, `demo_mode: false`, `cors_allowed_origins` 없음):

| 요청 | 수정 전 | 수정 후 |
| --- | --- | --- |
| `Origin` 없음 (curl) | 200 | 200 |
| `Origin: http://localhost:8000` (브라우저 same-origin) | **400** | 200 |
| `Origin: http://127.0.0.1:8000` (브라우저 same-origin) | **400** | 200 |
| `Origin: http://attacker.example` (교차 출처) | 400 | 400 |

## 수정
`Origin` 이 요청 자신의 출처(scheme+host+port)와 일치하면 통과시킨다. 교차 출처는 기존대로 허용 목록으로만 통과하므로 **demo/public 배포의 방어는 그대로**다.

same-origin 을 허용해도 CSRF 가 뚫리지 않는다 — 위조 요청 방어는 이미 별도 dependency 인 `check_csrf_for_unsafe_request`(X-CSRF-Token) 가 담당한다. CORS 는 교차 출처를 막는 장치다.

## 테스트
`tests/unit_test/view/test_web_main.py` 신규 2건:
- `test_local_mode_allows_same_origin_request` — 허용 목록 미설정이어도 same-origin 통과, 교차 출처는 여전히 400
- `test_same_origin_is_allowed_regardless_of_port_and_scheme` — 포트가 다르면 별개 출처로 차단, 루프백 별칭은 자기 Host 와 일치할 때만 통과

기존 `test_demo_cors_allows_only_configured_origin` 은 그대로 통과한다(회귀 없음).

실행 결과:
- `pytest tests/unit_test` — **7171 passed**
- `pytest tests/integration_test` — **267 passed**

## 범위
미들웨어 한 곳과 테스트만 건드렸다. 설정 파일은 바꾸지 않았다 — `cors_allowed_origins` 를 로컬에 추가해 우회할 수도 있지만, 그건 사용자마다 포트/호스트를 적어야 하는 데다 same-origin 이 막히는 것 자체가 버그라 근본 수정을 택했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)