### PR TITLE
미국장 종목 즐겨찾기 기능 추가

### DIFF
--- a/repositories/favorite_repository.py
+++ b/repositories/favorite_repository.py
@@ -4,10 +4,15 @@
 import aiosqlite
 from pathlib import Path
 
+MARKET_DOMESTIC = "domestic"
+MARKET_OVERSEAS_US = "overseas_us"
+
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS favorites (
-    code     TEXT PRIMARY KEY,
-    created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
+    code     TEXT NOT NULL,
+    market   TEXT NOT NULL DEFAULT 'domestic',
+    created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
+    PRIMARY KEY (code, market)
 )
 """
 
@@ -23,41 +28,61 @@ class FavoriteRepository:
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute(_CREATE_TABLE)
         await conn.commit()
+        await self._migrate_market_column(conn)
 
-    async def get_all(self) -> list[str]:
+    async def _migrate_market_column(self, conn: aiosqlite.Connection) -> None:
+        """market 컬럼이 없던 기존 DB를 복합키 스키마로 재작성한다 (기존 행은 domestic)."""
+        async with conn.execute("PRAGMA table_info(favorites)") as cur:
+            columns = [row[1] for row in await cur.fetchall()]
+        if "market" in columns:
+            return
+        await conn.execute("ALTER TABLE favorites RENAME TO favorites_legacy")
+        await conn.execute(_CREATE_TABLE)
+        await conn.execute(
+            "INSERT INTO favorites (code, market, created_at)"
+            f" SELECT code, '{MARKET_DOMESTIC}', created_at FROM favorites_legacy"
+        )
+        await conn.execute("DROP TABLE favorites_legacy")
+        await conn.commit()
+
+    async def get_all(self, market: str = MARKET_DOMESTIC) -> list[str]:
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             async with conn.execute(
-                "SELECT code FROM favorites ORDER BY created_at ASC, rowid ASC"
+                "SELECT code FROM favorites WHERE market = ?"
+                " ORDER BY created_at ASC, rowid ASC",
+                (market,),
             ) as cur:
                 rows = await cur.fetchall()
         return [row[0] for row in rows]
 
-    async def add(self, code: str) -> bool:
+    async def add(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
         """종목 추가. 이미 존재하면 False 반환 (멱등성 보장)."""
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             cur = await conn.execute(
-                "INSERT OR IGNORE INTO favorites (code) VALUES (?)", (code,)
+                "INSERT OR IGNORE INTO favorites (code, market) VALUES (?, ?)",
+                (code, market),
             )
             await conn.commit()
             return cur.rowcount > 0
 
-    async def remove(self, code: str) -> bool:
+    async def remove(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
         """종목 제거. 없으면 False 반환."""
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             cur = await conn.execute(
-                "DELETE FROM favorites WHERE code = ?", (code,)
+                "DELETE FROM favorites WHERE code = ? AND market = ?", (code, market)
             )
             await conn.commit()
             return cur.rowcount > 0
 
-    async def is_favorite(self, code: str) -> bool:
+    async def is_favorite(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             async with conn.execute(
-                "SELECT 1 FROM favorites WHERE code = ? LIMIT 1", (code,)
+                "SELECT 1 FROM favorites WHERE code = ? AND market = ? LIMIT 1",
+                (code, market),
             ) as cur:
                 row = await cur.fetchone()
         return row is not None

--- a/repositories/overseas_stock_code_repository.py
+++ b/repositories/overseas_stock_code_repository.py
@@ -106,6 +106,10 @@ class OverseasStockCodeRepository:
             for _, row in self.df.iterrows()
         }
 
+    def get_meta(self, symbol: str) -> dict | None:
+        """심볼의 {name, exchange} 반환. 미등록이면 None."""
+        return self.symbol_to_meta.get(str(symbol).upper())
+
     def all_symbols(self) -> list:
         """전 심볼 리스트 반환 (클라이언트 자동완성용)."""
         return [

--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -2,8 +2,14 @@
 관심종목 서비스 - 비즈니스 로직 담당.
 """
 import asyncio
-from repositories.favorite_repository import FavoriteRepository
+from repositories.favorite_repository import (
+    FavoriteRepository,
+    MARKET_DOMESTIC,
+    MARKET_OVERSEAS_US,
+)
 from repositories.stock_code_repository import StockCodeRepository
+
+_DEFAULT_OVERSEAS_EXCHANGE = "NASD"
 
 
 def _extract_price_rate(data) -> tuple:
@@ -24,26 +30,28 @@ class FavoriteService:
         stock_query_service=None,
         stock_repository=None,
         rs_rating_service=None,
+        overseas_stock_code_repository=None,
     ):
         self.repository = repository
         self.stock_code_repository = stock_code_repository
         self.stock_query_service = stock_query_service
         self.stock_repository = stock_repository
         self.rs_rating_service = rs_rating_service
+        self.overseas_stock_code_repository = overseas_stock_code_repository
 
-    async def get_all(self) -> list:
-        return await self.repository.get_all()
+    async def get_all(self, market: str = MARKET_DOMESTIC) -> list:
+        return await self.repository.get_all(market=market)
 
-    async def add(self, code: str) -> bool:
-        return await self.repository.add(code)
+    async def add(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        return await self.repository.add(code, market=market)
 
-    async def remove(self, code: str) -> bool:
-        return await self.repository.remove(code)
+    async def remove(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        return await self.repository.remove(code, market=market)
 
-    async def is_favorite(self, code: str) -> bool:
-        return await self.repository.is_favorite(code)
+    async def is_favorite(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        return await self.repository.is_favorite(code, market=market)
 
-    async def get_with_details(self) -> list:
+    async def get_with_details(self, market: str = MARKET_DOMESTIC) -> list:
         """관심종목 목록에 종목명·현재가·등락률을 포함하여 반환.
 
         1단계: StockRepository 메모리 캐시 (stock_price_repository, 즉시)
@@ -51,7 +59,10 @@ class FavoriteService:
         3단계: 개별 current_price API 호출 (5초 timeout, 실전/모의 공통)
         stock_query_service 없으면 종목명만 반환 (graceful degradation).
         """
-        codes = await self.repository.get_all()
+        if market == MARKET_OVERSEAS_US:
+            return await self._get_overseas_details()
+
+        codes = await self.repository.get_all(market=market)
         if not codes:
             return []
 
@@ -146,5 +157,52 @@ class FavoriteService:
             for code, stage in zip(result.keys(), stage_results):
                 if not isinstance(stage, Exception) and isinstance(stage, int) and stage > 0:
                     result[code]["minervini_stage"] = stage
+
+        return list(result.values())
+
+    async def _get_overseas_details(self) -> list:
+        """미국장 관심종목에 종목명·거래소·현재가·등락률을 붙여 반환.
+
+        해외는 실시간 스트림/일봉 스냅샷 경로가 없어 해외 현재가 API만 사용한다.
+        RS Rating·Minervini Stage는 국내 데이터 기반이라 항상 None이다.
+        """
+        symbols = await self.repository.get_all(market=MARKET_OVERSEAS_US)
+        if not symbols:
+            return []
+
+        result = {}
+        for symbol in symbols:
+            meta = None
+            if self.overseas_stock_code_repository:
+                meta = self.overseas_stock_code_repository.get_meta(symbol)
+            result[symbol] = {
+                "code": symbol,
+                "name": (meta or {}).get("name") or symbol,
+                "exchange": (meta or {}).get("exchange") or _DEFAULT_OVERSEAS_EXCHANGE,
+                "price": None,
+                "rate": None,
+                "rs_rating": None,
+                "minervini_stage": None,
+            }
+
+        if not self.stock_query_service:
+            return list(result.values())
+
+        async def _fetch(symbol):
+            try:
+                return await asyncio.wait_for(
+                    self.stock_query_service.get_overseas_price(
+                        symbol, exchange=result[symbol]["exchange"]
+                    ),
+                    timeout=5.0,
+                )
+            except Exception:
+                return None
+
+        responses = await asyncio.gather(*[_fetch(s) for s in symbols])
+        for symbol, resp in zip(symbols, responses):
+            if resp and resp.rt_cd == "0" and resp.data:
+                result[symbol]["price"] = getattr(resp.data, "price", None)
+                result[symbol]["rate"] = getattr(resp.data, "change_rate", None)
 
         return list(result.values())

--- a/tests/frontend/run_overseas_dom_tests.mjs
+++ b/tests/frontend/run_overseas_dom_tests.mjs
@@ -22,9 +22,15 @@ const SCAFFOLD = `
 <p id="overseas-status"></p>
 <button id="overseas-tab-overview" data-overseas-tab="overview" class="sub-tab-btn active"></button>
 <button id="overseas-tab-marketcap" data-overseas-tab="marketcap" class="sub-tab-btn"></button>
+<button id="overseas-tab-favorite" data-overseas-tab="favorite" class="sub-tab-btn"></button>
 <button id="overseas-tab-orders" data-overseas-tab="orders" class="sub-tab-btn"></button>
 <section id="overseas-panel-overview"></section>
 <section id="overseas-panel-marketcap" hidden><div id="overseas-marketcap-result"></div></section>
+<section id="overseas-panel-favorite" hidden>
+  <input id="overseas-fav-symbol" type="text">
+  <ul id="overseas-fav-autocomplete-list"></ul>
+  <table><tbody id="overseas-favorite-body"></tbody></table>
+</section>
 <section id="overseas-panel-orders" hidden></section>
 <input id="overseas-symbol" type="text">
 <select id="overseas-exchange"><option value="NASD">NASDAQ</option></select>
@@ -48,6 +54,7 @@ function makeWindow() {
   applyCommonStubs(window);
   window.fetchWithTimeout = async () => ({ ok: true, json: async () => ({}) });
   window.alert = () => {};
+  window.showToast = () => {};
 
   const script = window.document.createElement("script");
   script.textContent = readFileSync(OVERSEAS_JS, "utf8");
@@ -358,6 +365,117 @@ test("setOverseasTab 전환 시 가용성을 재확인해 버튼 상태를 갱�
   assert(btn.disabled === false, "회귀: 탭 전환 시 가용성 재확인으로 버튼이 활성화되지 않음");
   const status = window.document.getElementById("overseas-status").textContent;
   assert(status === "미국주식 기능이 활성화되어 있습니다.", "회귀: 상태 문구가 갱신되지 않음");
+});
+
+test("즐겨찾기 탭 전환 시 미국장 즐겨찾기 목록을 렌더한다", async () => {
+  const window = makeWindow();
+  const requested = [];
+  window.fetchWithTimeout = async (url) => {
+    requested.push(url);
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (url.includes("/api/favorite")) {
+      return { ok: true, json: async () => ([
+        { code: "AAPL", name: "Apple Inc.", exchange: "NASD", price: 190.5, rate: 1.23 },
+      ]) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+
+  await window.setOverseasTab("favorite");
+  await flush();
+
+  assert(
+    requested.some((url) => url.includes("/api/favorite?market=overseas_us")),
+    "회귀: 즐겨찾기 조회가 market=overseas_us 로 호출되지 않음",
+  );
+  const body = window.document.getElementById("overseas-favorite-body").textContent;
+  assert(body.includes("AAPL"), "심볼이 표시되어야 함");
+  assert(body.includes("Apple Inc."), "종목명이 표시되어야 함");
+  assert(body.includes("$190.50"), "현재가가 USD 로 표시되어야 함");
+  assert(body.includes("+1.23%"), "등락률이 표시되어야 함");
+});
+
+test("즐겨찾기 목록이 비면 안내 문구를 보여준다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return { ok: true, json: async () => ([]) };
+  };
+
+  await window.loadOverseasFavorites();
+  await flush();
+
+  const body = window.document.getElementById("overseas-favorite-body").textContent;
+  assert(body.includes("등록된 미국장 즐겨찾기가 없습니다."), "빈 목록 안내가 표시되어야 함");
+});
+
+test("심볼 추가는 대문자로 정규화해 POST 하고 목록을 새로고침한다", async () => {
+  const window = makeWindow();
+  const calls = [];
+  window.fetchWithTimeout = async (url, options = {}) => {
+    calls.push({ url, method: options.method || "GET" });
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (options.method === "POST") {
+      return { ok: true, json: async () => ({ success: true, added: true, market: "overseas_us" }) };
+    }
+    return { ok: true, json: async () => ([
+      { code: "TSLA", name: "Tesla", exchange: "NASD", price: 250, rate: -0.5 },
+    ]) };
+  };
+
+  window.document.getElementById("overseas-fav-symbol").value = " tsla ";
+  await window.addOverseasFavorite();
+  await flush();
+
+  assert(
+    calls.some((c) => c.method === "POST" && c.url === "/api/favorite/TSLA?market=overseas_us"),
+    `회귀: 심볼 정규화/마켓 파라미터가 잘못됨 (${JSON.stringify(calls)})`,
+  );
+  assert(
+    window.document.getElementById("overseas-favorite-body").textContent.includes("TSLA"),
+    "추가 후 목록이 새로고침되어야 함",
+  );
+  assert(window.document.getElementById("overseas-fav-symbol").value === "", "입력값이 비워져야 함");
+});
+
+test("삭제 버튼은 해당 심볼만 DELETE 하고 행을 제거한다", async () => {
+  const window = makeWindow();
+  const calls = [];
+  window.fetchWithTimeout = async (url, options = {}) => {
+    calls.push({ url, method: options.method || "GET" });
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (options.method === "DELETE") {
+      return { ok: true, json: async () => ({ success: true, removed: true }) };
+    }
+    return { ok: true, json: async () => ([
+      { code: "AAPL", name: "Apple Inc.", exchange: "NASD", price: 190.5, rate: 1.23 },
+      { code: "MSFT", name: "Microsoft", exchange: "NASD", price: 410, rate: 0.4 },
+    ]) };
+  };
+
+  await window.loadOverseasFavorites();
+  await flush();
+
+  const removeButtons = window.document.querySelectorAll("[data-overseas-fav-remove]");
+  assert(removeButtons.length === 2, "행마다 삭제 버튼이 있어야 함");
+  removeButtons[0].click();
+  await flush();
+
+  assert(
+    calls.some((c) => c.method === "DELETE" && c.url === "/api/favorite/AAPL?market=overseas_us"),
+    `회귀: 삭제 요청 URL 이 잘못됨 (${JSON.stringify(calls)})`,
+  );
+  const body = window.document.getElementById("overseas-favorite-body").textContent;
+  assert(!body.includes("AAPL"), "삭제한 행이 사라져야 함");
+  assert(body.includes("MSFT"), "다른 행은 남아야 함");
 });
 
 await run();

--- a/tests/unit_test/repositories/test_favorite_repository.py
+++ b/tests/unit_test/repositories/test_favorite_repository.py
@@ -3,7 +3,11 @@ FavoriteRepository 단위 테스트.
 """
 import pytest
 import aiosqlite
-from repositories.favorite_repository import FavoriteRepository
+from repositories.favorite_repository import (
+    FavoriteRepository,
+    MARKET_DOMESTIC,
+    MARKET_OVERSEAS_US,
+)
 
 
 @pytest.fixture
@@ -80,6 +84,53 @@ async def test_add_and_remove_cycle(repo):
     result = await repo.add("005930")
     assert result is True
     assert await repo.get_all() == ["005930"]
+
+
+async def test_overseas_market_is_separate_from_domestic(repo):
+    """미국장 심볼은 국내 목록에 섞이지 않는다."""
+    await repo.add("005930")
+    await repo.add("AAPL", market=MARKET_OVERSEAS_US)
+
+    assert await repo.get_all() == ["005930"]
+    assert await repo.get_all(market=MARKET_OVERSEAS_US) == ["AAPL"]
+
+
+async def test_same_code_can_exist_in_both_markets(repo):
+    """동일 코드라도 market이 다르면 각각 등록된다."""
+    assert await repo.add("TEST") is True
+    assert await repo.add("TEST", market=MARKET_OVERSEAS_US) is True
+
+    assert await repo.get_all(market=MARKET_DOMESTIC) == ["TEST"]
+    assert await repo.get_all(market=MARKET_OVERSEAS_US) == ["TEST"]
+
+
+async def test_remove_and_is_favorite_scoped_by_market(repo):
+    await repo.add("AAPL", market=MARKET_OVERSEAS_US)
+
+    assert await repo.is_favorite("AAPL") is False
+    assert await repo.is_favorite("AAPL", market=MARKET_OVERSEAS_US) is True
+    assert await repo.remove("AAPL") is False
+    assert await repo.remove("AAPL", market=MARKET_OVERSEAS_US) is True
+    assert await repo.get_all(market=MARKET_OVERSEAS_US) == []
+
+
+async def test_legacy_schema_migrates_to_domestic(tmp_path):
+    """market 컬럼이 없던 기존 DB는 domestic으로 마이그레이션된다."""
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            "CREATE TABLE favorites ("
+            " code TEXT PRIMARY KEY,"
+            " created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')))"
+        )
+        await conn.execute("INSERT INTO favorites (code) VALUES ('005930')")
+        await conn.commit()
+
+    repo = FavoriteRepository(db_path=db_path)
+
+    assert await repo.get_all() == ["005930"]
+    assert await repo.get_all(market=MARKET_OVERSEAS_US) == []
+    assert await repo.add("AAPL", market=MARKET_OVERSEAS_US) is True
 
 
 def test_init_with_default_db_path(monkeypatch, tmp_path):

--- a/tests/unit_test/services/test_favorite_service.py
+++ b/tests/unit_test/services/test_favorite_service.py
@@ -49,12 +49,17 @@ def service(mock_repo, mock_stock_code_repo):
 async def test_get_all_delegates(service, mock_repo):
     mock_repo.get_all.return_value = ["005930"]
     assert await service.get_all() == ["005930"]
-    mock_repo.get_all.assert_called_once()
+    mock_repo.get_all.assert_called_once_with(market="domestic")
+
+
+async def test_add_overseas_passes_market(service, mock_repo):
+    assert await service.add("AAPL", market="overseas_us") is True
+    mock_repo.add.assert_called_once_with("AAPL", market="overseas_us")
 
 
 async def test_add_delegates(service, mock_repo):
     assert await service.add("005930") is True
-    mock_repo.add.assert_called_once_with("005930")
+    mock_repo.add.assert_called_once_with("005930", market="domestic")
 
 
 async def test_add_duplicate_returns_false(service, mock_repo):
@@ -64,13 +69,13 @@ async def test_add_duplicate_returns_false(service, mock_repo):
 
 async def test_remove_delegates(service, mock_repo):
     assert await service.remove("005930") is True
-    mock_repo.remove.assert_called_once_with("005930")
+    mock_repo.remove.assert_called_once_with("005930", market="domestic")
 
 
 async def test_is_favorite_delegates(service, mock_repo):
     mock_repo.is_favorite.return_value = True
     assert await service.is_favorite("005930") is True
-    mock_repo.is_favorite.assert_called_once_with("005930")
+    mock_repo.is_favorite.assert_called_once_with("005930", market="domestic")
 
 
 async def test_get_with_details_empty(service, mock_repo):
@@ -253,3 +258,103 @@ async def test_get_with_details_minervini_stage_various(mock_repo, mock_stock_co
     mapping = {r["code"]: r for r in result}
     assert mapping["005930"]["minervini_stage"] == 2
     assert mapping["000660"]["minervini_stage"] in (None, 0)
+
+
+@pytest.fixture
+def mock_overseas_code_repo():
+    r = MagicMock()
+    r.get_meta.return_value = {"name": "Apple Inc.", "exchange": "NASD"}
+    return r
+
+
+class DummyOverseasSummary:
+    def __init__(self, price, change_rate):
+        self.price = price
+        self.change_rate = change_rate
+
+
+async def test_get_with_details_overseas_uses_overseas_price(
+    mock_repo, mock_stock_code_repo, mock_overseas_code_repo
+):
+    """미국장 목록은 해외 현재가 API와 해외 심볼 메타를 사용한다."""
+    mock_repo.get_all.return_value = ["AAPL"]
+    mock_query = AsyncMock()
+    mock_query.get_overseas_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="정상", data=DummyOverseasSummary(190.5, 1.23)
+    )
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        overseas_stock_code_repository=mock_overseas_code_repo,
+    )
+
+    result = await svc.get_with_details(market="overseas_us")
+
+    mock_repo.get_all.assert_called_once_with(market="overseas_us")
+    mock_query.get_overseas_price.assert_awaited_once_with("AAPL", exchange="NASD")
+    mock_query.get_current_price.assert_not_awaited()
+    assert result == [
+        {
+            "code": "AAPL",
+            "name": "Apple Inc.",
+            "exchange": "NASD",
+            "price": 190.5,
+            "rate": 1.23,
+            "rs_rating": None,
+            "minervini_stage": None,
+        }
+    ]
+
+
+async def test_get_with_details_overseas_without_meta_falls_back(
+    mock_repo, mock_stock_code_repo
+):
+    """심볼 메타가 없으면 심볼명 그대로, 거래소는 NASD 기본값을 쓴다."""
+    mock_repo.get_all.return_value = ["ZZZZ"]
+    overseas_repo = MagicMock()
+    overseas_repo.get_meta.return_value = None
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        overseas_stock_code_repository=overseas_repo,
+    )
+
+    result = await svc.get_with_details(market="overseas_us")
+
+    assert result[0]["name"] == "ZZZZ"
+    assert result[0]["exchange"] == "NASD"
+    assert result[0]["price"] is None
+
+
+async def test_get_with_details_overseas_price_failure_keeps_row(
+    mock_repo, mock_stock_code_repo, mock_overseas_code_repo
+):
+    """해외 시세 조회가 실패해도 종목 행은 유지된다."""
+    mock_repo.get_all.return_value = ["AAPL"]
+    mock_query = AsyncMock()
+    mock_query.get_overseas_price.side_effect = RuntimeError("boom")
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        overseas_stock_code_repository=mock_overseas_code_repo,
+    )
+
+    result = await svc.get_with_details(market="overseas_us")
+
+    assert len(result) == 1
+    assert result[0]["price"] is None
+    assert result[0]["rate"] is None
+
+
+async def test_get_with_details_overseas_empty(mock_repo, mock_stock_code_repo):
+    mock_repo.get_all.return_value = []
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+    )
+    assert await svc.get_with_details(market="overseas_us") == []

--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -50,7 +50,7 @@ async def test_add_favorite(web_client, mock_web_ctx):
         assert data["success"] is True
         assert data["added"] is True
         assert data["code"] == "005930"
-        mock_web_ctx.favorite_service.add.assert_called_once_with("005930")
+        mock_web_ctx.favorite_service.add.assert_called_once_with("005930", market="domestic")
 
 
 async def test_add_favorite_already_exists(web_client, mock_web_ctx):
@@ -99,7 +99,7 @@ async def test_remove_favorite(web_client, mock_web_ctx):
         data = response.json()
         assert data["success"] is True
         assert data["removed"] is True
-        mock_web_ctx.favorite_service.remove.assert_called_once_with("005930")
+        mock_web_ctx.favorite_service.remove.assert_called_once_with("005930", market="domestic")
 
 
 async def test_remove_favorite_not_found(web_client, mock_web_ctx):
@@ -130,6 +130,74 @@ async def test_remove_favorite_syncs_alert_cache_and_price_subscription(web_clie
 
         mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_awaited_once_with("005930")
         mock_web_ctx.price_subscription_service.remove_subscription.assert_awaited_once_with("005930", "favorite")
+
+
+async def test_get_favorite_list_overseas_passes_market(web_client, mock_web_ctx):
+    """GET /api/favorite?market=overseas_us - 미국장 목록을 조회한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.get_with_details = AsyncMock(return_value=[
+            {"code": "AAPL", "name": "Apple Inc.", "exchange": "NASD"},
+        ])
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.sync_subscriptions = AsyncMock()
+
+        response = web_client.get("/api/favorite?market=overseas_us")
+        assert response.status_code == 200
+        assert response.json()[0]["code"] == "AAPL"
+        mock_web_ctx.favorite_service.get_with_details.assert_awaited_once_with(
+            market="overseas_us"
+        )
+        # 해외는 실시간 구독 대상이 아니다.
+        mock_web_ctx.price_subscription_service.sync_subscriptions.assert_not_awaited()
+
+
+async def test_add_favorite_overseas_skips_alert_and_subscription(web_client, mock_web_ctx):
+    """POST /api/favorite/{symbol}?market=overseas_us - 알림/구독 연동을 건너뛴다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.add_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.add_subscription = AsyncMock()
+
+        response = web_client.post("/api/favorite/AAPL?market=overseas_us")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["added"] is True
+        assert data["market"] == "overseas_us"
+        mock_web_ctx.favorite_service.add.assert_called_once_with("AAPL", market="overseas_us")
+        mock_web_ctx.favorite_price_alert_service.add_favorite.assert_not_awaited()
+        mock_web_ctx.price_subscription_service.add_subscription.assert_not_awaited()
+
+
+async def test_remove_favorite_overseas_skips_alert_and_subscription(web_client, mock_web_ctx):
+    """DELETE /api/favorite/{symbol}?market=overseas_us - 알림/구독 정리를 건너뛴다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.remove = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.remove_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.remove_subscription = AsyncMock()
+
+        response = web_client.delete("/api/favorite/AAPL?market=overseas_us")
+        assert response.status_code == 200
+        mock_web_ctx.favorite_service.remove.assert_called_once_with("AAPL", market="overseas_us")
+        mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_not_awaited()
+        mock_web_ctx.price_subscription_service.remove_subscription.assert_not_awaited()
+
+
+async def test_favorite_rejects_unknown_market(web_client, mock_web_ctx):
+    """알 수 없는 market 값은 400으로 거절한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.get_with_details = AsyncMock(return_value=[])
+
+        response = web_client.get("/api/favorite?market=crypto")
+        assert response.status_code == 400
+        mock_web_ctx.favorite_service.get_with_details.assert_not_awaited()
 
 
 async def test_get_favorite_status_true(web_client, mock_web_ctx):

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -52,7 +52,11 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert 'id="overseas-tab-overview"' in response.text
             assert 'id="overseas-tab-marketcap"' in response.text
             assert 'id="overseas-tab-orders"' in response.text
+            assert 'id="overseas-tab-favorite"' in response.text
             assert 'id="overseas-panel-marketcap"' in response.text
+            assert 'id="overseas-panel-favorite"' in response.text
+            assert 'id="overseas-fav-symbol"' in response.text
+            assert 'id="overseas-favorite-body"' in response.text
             assert "/static/js/overseas.js" in response.text
         elif path == "/ranking":
             assert "상위 종목 랭킹" in response.text

--- a/view/web/routes/favorite.py
+++ b/view/web/routes/favorite.py
@@ -2,10 +2,22 @@
 관심종목 API 엔드포인트 (favorite.html).
 """
 import asyncio
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
+from repositories.favorite_repository import MARKET_DOMESTIC, MARKET_OVERSEAS_US
 from view.web.api_common import _get_ctx
 
 router = APIRouter(prefix="/favorite", tags=["favorite"])
+
+_ALLOWED_MARKETS = (MARKET_DOMESTIC, MARKET_OVERSEAS_US)
+
+
+def _validate_market(market: str) -> str:
+    if market not in _ALLOWED_MARKETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"market는 {', '.join(_ALLOWED_MARKETS)} 중 하나여야 합니다.",
+        )
+    return market
 
 
 def _ctx_attr(ctx, name: str, default=None):
@@ -16,13 +28,14 @@ def _ctx_attr(ctx, name: str, default=None):
 
 
 @router.get("")
-async def get_favorite_list():
+async def get_favorite_list(market: str = Query(MARKET_DOMESTIC)):
     """관심종목 목록 (종목명·현재가·등락률 포함) 반환."""
+    _validate_market(market)
     ctx = _get_ctx()
-    result = await ctx.favorite_service.get_with_details()
+    result = await ctx.favorite_service.get_with_details(market=market)
 
-    # 페이지 접속 시 LOW 우선순위로 SSE 구독 등록 (백그라운드)
-    if getattr(ctx, "price_subscription_service", None) and result:
+    # 페이지 접속 시 LOW 우선순위로 SSE 구독 등록 (백그라운드). 해외는 실시간 스트림 대상이 아니다.
+    if market == MARKET_DOMESTIC and getattr(ctx, "price_subscription_service", None) and result:
         async def _subscribe():
             try:
                 from services.price_subscription_service import SubscriptionPriority
@@ -41,11 +54,12 @@ async def get_favorite_list():
 
 
 @router.post("/{code}")
-async def add_favorite(code: str):
+async def add_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
     """관심종목 추가."""
+    _validate_market(market)
     ctx = _get_ctx()
-    added = await ctx.favorite_service.add(code)
-    if added:
+    added = await ctx.favorite_service.add(code, market=market)
+    if added and market == MARKET_DOMESTIC:
         alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
         if alert_service:
             await alert_service.add_favorite(code)
@@ -60,15 +74,16 @@ async def add_favorite(code: str):
                 )
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 추가 실패: {e}")
-    return {"success": True, "added": added, "code": code}
+    return {"success": True, "added": added, "code": code, "market": market}
 
 
 @router.delete("/{code}")
-async def remove_favorite(code: str):
+async def remove_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
     """관심종목 제거."""
+    _validate_market(market)
     ctx = _get_ctx()
-    removed = await ctx.favorite_service.remove(code)
-    if removed:
+    removed = await ctx.favorite_service.remove(code, market=market)
+    if removed and market == MARKET_DOMESTIC:
         alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
         if alert_service:
             await alert_service.remove_favorite(code)
@@ -78,11 +93,16 @@ async def remove_favorite(code: str):
                 await price_subscription_service.remove_subscription(code, "favorite")
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 제거 실패: {e}")
-    return {"success": True, "removed": removed, "code": code}
+    return {"success": True, "removed": removed, "code": code, "market": market}
 
 
 @router.get("/{code}/status")
-async def get_favorite_status(code: str):
+async def get_favorite_status(code: str, market: str = Query(MARKET_DOMESTIC)):
     """특정 종목의 관심종목 등록 여부 확인 (stock.js 버튼 초기 상태용)."""
+    _validate_market(market)
     ctx = _get_ctx()
-    return {"code": code, "is_favorite": await ctx.favorite_service.is_favorite(code)}
+    return {
+        "code": code,
+        "market": market,
+        "is_favorite": await ctx.favorite_service.is_favorite(code, market=market),
+    }

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -88,7 +88,7 @@ async function _refreshOverseasAvailability() {
 }
 
 async function setOverseasTab(tabName) {
-    const tabs = ['overview', 'marketcap', 'orders'];
+    const tabs = ['overview', 'marketcap', 'favorite', 'orders'];
     if (!tabs.includes(tabName)) return;
 
     tabs.forEach(name => {
@@ -105,6 +105,7 @@ async function setOverseasTab(tabName) {
     void _refreshOverseasAvailability();
 
     if (tabName === 'marketcap') await loadOverseasMarketCap();
+    if (tabName === 'favorite') await loadOverseasFavorites();
 }
 
 async function loadOverseasQuote() {
@@ -454,9 +455,122 @@ async function cancelOverseasOrder(orderNo, symbol, exchange, qty) {
     }
 }
 
+/* ── 미국장 즐겨찾기 ── */
+
+let _overseasFavoriteData = [];
+
+function _initOverseasFavoriteAutocomplete() {
+    if (typeof StockAutocomplete !== 'function') return;
+    if (!document.getElementById('overseas-fav-symbol')) return;
+
+    StockAutocomplete({
+        inputId: 'overseas-fav-symbol',
+        listId: 'overseas-fav-autocomplete-list',
+        valueKey: 's',
+        readyEvent: 'all-overseas-stocks-ready',
+        getInitial: () => window.ALL_OVERSEAS_STOCKS || null,
+        searchImpl: _overseasStockSearch,
+        formatItem: stock => `${stock.s} — ${stock.n} (${stock.e})`,
+        onSelect: symbol => {
+            const input = document.getElementById('overseas-fav-symbol');
+            if (input) input.value = symbol;
+        },
+        onConfirm: () => { void addOverseasFavorite(); },
+    });
+}
+
+function _buildOverseasFavoriteRow(item) {
+    const rate = Number(item.rate);
+    const rateClass = rate > 0 ? 'price-up' : (rate < 0 ? 'price-down' : '');
+    const rateStr = Number.isFinite(rate) ? `${rate > 0 ? '+' : ''}${rate.toFixed(2)}%` : '-';
+    const symbol = escapeHtml(item.code || '');
+    return `<tr>
+        <td style="font-weight:bold;">${symbol}</td>
+        <td>${escapeHtml(item.name || '-')}</td>
+        <td>${escapeHtml(item.exchange || '-')}</td>
+        <td class="${rateClass}">${_formatUsd(item.price)}</td>
+        <td class="${rateClass}">${rateStr}</td>
+        <td><button type="button" class="btn btn-sm" data-overseas-fav-remove data-symbol="${symbol}">삭제</button></td>
+    </tr>`;
+}
+
+function renderOverseasFavoriteTable() {
+    const tbody = document.getElementById('overseas-favorite-body');
+    if (!tbody) return;
+
+    if (!_overseasFavoriteData.length) {
+        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center; color:var(--text-secondary);">등록된 미국장 즐겨찾기가 없습니다.</td></tr>';
+        return;
+    }
+
+    tbody.innerHTML = _overseasFavoriteData.map(_buildOverseasFavoriteRow).join('');
+    tbody.querySelectorAll('[data-overseas-fav-remove]').forEach(button => {
+        button.addEventListener('click', () => removeOverseasFavorite(button.dataset.symbol || ''));
+    });
+}
+
+async function loadOverseasFavorites() {
+    const tbody = document.getElementById('overseas-favorite-body');
+    if (!tbody) return;
+    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
+
+    try {
+        const res = await fetchWithTimeout('/api/favorite?market=overseas_us', {}, 12000);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        _overseasFavoriteData = await res.json() || [];
+        renderOverseasFavoriteTable();
+    } catch (e) {
+        console.error('[overseas] 즐겨찾기 조회 오류', e);
+        tbody.innerHTML = `<tr><td colspan="6" style="text-align:center; color:#ff6b6b;">불러오기 실패: ${escapeHtml(e.message)}</td></tr>`;
+    }
+}
+
+async function addOverseasFavorite() {
+    const input = document.getElementById('overseas-fav-symbol');
+    const symbol = _overseasSymbolValue('overseas-fav-symbol');
+    if (!symbol) { showToast('심볼을 입력하세요.', 'error'); return; }
+
+    try {
+        const res = await fetchWithTimeout(
+            `/api/favorite/${encodeURIComponent(symbol)}?market=overseas_us`,
+            { method: 'POST' },
+            12000,
+        );
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.detail || `HTTP ${res.status}`);
+        if (!json.added) { showToast('이미 등록된 종목입니다.', 'error'); return; }
+
+        if (input) input.value = '';
+        showToast('미국장 즐겨찾기에 추가되었습니다.', 'success');
+        await loadOverseasFavorites();
+    } catch (e) {
+        showToast(`추가 실패: ${e.message}`, 'error');
+    }
+}
+
+async function removeOverseasFavorite(symbol) {
+    if (!symbol) return;
+    try {
+        const res = await fetchWithTimeout(
+            `/api/favorite/${encodeURIComponent(symbol)}?market=overseas_us`,
+            { method: 'DELETE' },
+            12000,
+        );
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.detail || `HTTP ${res.status}`);
+
+        _overseasFavoriteData = _overseasFavoriteData.filter(item => item.code !== symbol);
+        renderOverseasFavoriteTable();
+        showToast('미국장 즐겨찾기에서 삭제되었습니다.', 'success');
+    } catch (e) {
+        showToast(`삭제 실패: ${e.message}`, 'error');
+    }
+}
+
 function initOverseasPage() {
     _refreshOverseasRealBanner();
     void _refreshOverseasAvailability();
+    _initOverseasFavoriteAutocomplete();
     if (!window.__overseasRealBannerTimer) {
         window.__overseasRealBannerTimer = setInterval(_refreshOverseasRealBanner, 3000);
     }

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -22,6 +22,7 @@
         <div class="overseas-tabs" role="tablist" aria-label="미국주식 메뉴">
             <button type="button" id="overseas-tab-overview" class="sub-tab-btn active" data-overseas-tab="overview" onclick="setOverseasTab('overview')">시장 개요</button>
             <button type="button" id="overseas-tab-marketcap" class="sub-tab-btn" data-overseas-tab="marketcap" onclick="setOverseasTab('marketcap')">주요 대형주</button>
+            {% if can_operate %}<button type="button" id="overseas-tab-favorite" class="sub-tab-btn" data-overseas-tab="favorite" onclick="setOverseasTab('favorite')">즐겨찾기</button>{% endif %}
             {% if can_operate %}<button type="button" id="overseas-tab-orders" class="sub-tab-btn" data-overseas-tab="orders" onclick="setOverseasTab('orders')">보유·주문</button>{% endif %}
         </div>
     </div>
@@ -61,6 +62,33 @@
         </div>
         <div id="overseas-marketcap-result"></div>
     </section>
+
+    {% if can_operate %}<section id="overseas-panel-favorite" class="overseas-panel" hidden>
+        <div class="card">
+            <h2>미국장 즐겨찾기</h2>
+            <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+                <div style="position:relative; flex:1; min-width:200px;">
+                    <input type="text" id="overseas-fav-symbol" placeholder="예: AAPL / Apple" maxlength="12"
+                           autocomplete="off" style="width:100%; box-sizing:border-box;">
+                    <ul id="overseas-fav-autocomplete-list" class="autocomplete-list" style="display:none;"></ul>
+                </div>
+                <button class="btn" data-overseas-required onclick="addOverseasFavorite()">★ 추가</button>
+                <button class="btn" data-overseas-required onclick="loadOverseasFavorites()">새로고침</button>
+            </div>
+        </div>
+        <div class="card">
+            <div class="table-container">
+                <table class="data-table">
+                    <thead>
+                        <tr><th>심볼</th><th>종목명</th><th>거래소</th><th>현재가</th><th>등락률</th><th>액션</th></tr>
+                    </thead>
+                    <tbody id="overseas-favorite-body">
+                        <tr><td colspan="6" style="text-align:center; color:var(--text-secondary);">로딩 중...</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>{% endif %}
 
     {% if can_operate %}<section id="overseas-panel-orders" class="overseas-panel" hidden>
         <div class="card">
@@ -114,5 +142,5 @@
 {% block scripts %}
 <script src="/static/js/autocomplete.js?v=2"></script>
 <script src="/static/js/overseas_autocomplete.js?v=1"></script>
-<script src="/static/js/overseas.js?v=5"></script>
+<script src="/static/js/overseas.js?v=6"></script>
 {% endblock %}

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -134,6 +134,7 @@ class WebAppContext:
         self.favorite_service = FavoriteService(
             repository=self.favorite_repo,
             stock_code_repository=self.stock_code_repository,
+            overseas_stock_code_repository=self.overseas_stock_code_repository,
         )
         self.favorite_price_alert_service: FavoritePriceAlertService = None
         self.account_snapshot_cache: AccountSnapshotCache = None


### PR DESCRIPTION
## 요약

미국장(overseas_us) 종목도 즐겨찾기에 등록/조회/삭제할 수 있게 한다.

`favorites` 테이블에 `market` 컬럼을 추가하고 PK를 `(code, market)` 복합키로 바꿔 국내/미국 관심종목을 분리 저장한다. 기존 DB는 `market` 컬럼 유무를 보고 `domestic` 으로 마이그레이션한다.

## UI 배치

`base.html` 네비게이션이 한국장/미국장을 분리하고 `/favorite` 은 한국장 메뉴 안에 있으므로, 기존 `/favorite` 페이지는 국내 전용으로 그대로 두고 **`/overseas` 페이지에 "즐겨찾기" 탭을 추가**했다 (기존 시장개요·주요대형주·보유주문 탭 패턴 재사용).

## 변경 내용

| 계층 | 변경 |
|---|---|
| `FavoriteRepository` | `market` 컬럼 + 복합키, legacy 스키마 마이그레이션, `get_all/add/remove/is_favorite(market=)` |
| `OverseasStockCodeRepository` | `get_meta(symbol)` 추가 (종목명·거래소 조회) |
| `FavoriteService` | `overseas_stock_code_repository` 주입, `get_with_details(market=)` 에서 미국장은 `get_overseas_price` 로 시세 조회 |
| `/api/favorite` | `market` 쿼리 파라미터 (허용값 외 400), POST/DELETE 응답에 `market` 포함 |
| `/overseas` 화면 | 즐겨찾기 탭·패널, 심볼 자동완성(기존 해외 심볼 목록 재사용), 추가/삭제/새로고침 |

## 설계 메모

- `get_all()` 기본값이 `domestic` 이라 기존 소비자(DART 공시 모니터, 가격 알림 서비스, `scripts/check_*_ai.py`)는 호출부 변경 없이 동작이 그대로다.
- 해외는 실시간 웹소켓 스트림/일봉 스냅샷 경로가 없으므로 SSE 구독·가격 알림 연동은 `domestic` 분기 안에서만 수행한다.
- RS Rating·Minervini Stage 는 국내 데이터 기반이라 미국장 행에서는 항상 `None`.

## 테스트

- 단위 7184개 통과 (`pytest tests/unit_test`)
- 통합 267개 통과 (`pytest tests/integration_test`)
- jsdom 회귀 `run_overseas_dom_tests.mjs` 15/15 — 즐겨찾기 렌더·빈 목록·추가(심볼 대문자 정규화)·삭제 4건 신규
- 신규 단위 테스트: market 분리 저장, 동일 코드 양 시장 공존, legacy 스키마 마이그레이션, 해외 시세 조회 성공/실패/메타 없음, 라우트 market 파라미터 및 400 거절

🤖 Generated with [Claude Code](https://claude.com/claude-code)
