### PR TITLE
Fix favorite price threshold alerts

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -22,6 +22,7 @@ class FavoritePriceAlertService:
         stock_code_repository=None,
         *,
         threshold_step_pct: float = 5.0,
+        upper_limit_rate_pct: float = 29.5,
         favorite_cache_ttl_sec: float = 30.0,
         logger=None,
     ) -> None:
@@ -29,11 +30,13 @@ class FavoritePriceAlertService:
         self._notification_service = notification_service
         self._stock_code_repository = stock_code_repository
         self._threshold_step_pct = float(threshold_step_pct)
+        self._upper_limit_rate_pct = float(upper_limit_rate_pct)
         self._favorite_cache_ttl_sec = float(favorite_cache_ttl_sec)
         self._logger = logger or logging.getLogger(__name__)
         self._favorite_codes: set[str] = set()
         self._favorite_cache_ts: float = 0.0
         self._last_alert_bucket: dict[str, int] = {}
+        self._upper_limit_alerted_codes: set[str] = set()
 
     async def add_favorite(self, code: str) -> None:
         normalized = self._normalize_code(code)
@@ -48,8 +51,17 @@ class FavoritePriceAlertService:
             return
         self._favorite_codes.discard(normalized)
         self._last_alert_bucket.pop(normalized, None)
+        self._upper_limit_alerted_codes.discard(normalized)
 
-    async def handle_price_tick(self, code: str, *, price, rate) -> bool:
+    async def handle_price_tick(
+        self,
+        code: str,
+        *,
+        price,
+        rate,
+        sign=None,
+        is_upper_limit: bool = False,
+    ) -> bool:
         """실시간 현재가 틱을 평가하고 알림 발행 여부를 반환한다."""
         normalized = self._normalize_code(code)
         if not normalized or self._notification_service is None:
@@ -64,6 +76,14 @@ class FavoritePriceAlertService:
         rate_value = self._to_float(rate)
         if rate_value is None:
             return False
+        rate_value = self._apply_kis_sign(rate_value, sign)
+
+        if self._is_upper_limit(rate_value, sign=sign, is_upper_limit=is_upper_limit):
+            if normalized in self._upper_limit_alerted_codes:
+                return False
+            self._upper_limit_alerted_codes.add(normalized)
+            return await self._emit_upper_limit_alert(normalized, price, rate_value)
+        self._upper_limit_alerted_codes.discard(normalized)
 
         bucket = self._rate_bucket(rate_value)
         if bucket == 0:
@@ -98,6 +118,30 @@ class FavoritePriceAlertService:
         )
         return True
 
+    async def _emit_upper_limit_alert(self, code: str, price, rate_value: float) -> bool:
+        name = self._stock_name(code)
+        signed_rate = self._format_signed_pct(rate_value)
+        formatted_price = self._format_price(price)
+
+        await self._notification_service.emit(
+            NotificationCategory.SYSTEM,
+            NotificationLevel.WARNING,
+            f"[관심종목] {name} 상한가",
+            f"{code} {name} 현재 {formatted_price}, 전일대비 {signed_rate}",
+            metadata={
+                "alert_type": "favorite_upper_limit",
+                "code": code,
+                "name": name,
+                "price": self._to_float(price),
+                "rate": rate_value,
+                "threshold_pct": 30,
+                "is_upper_limit": True,
+                "dedup_key": f"favorite_price:{code}:upper_limit",
+                "force_external": True,
+            },
+        )
+        return True
+
     async def _refresh_favorites(self, *, force: bool = False) -> None:
         now = time.monotonic()
         if (
@@ -121,6 +165,22 @@ class FavoritePriceAlertService:
         if bucket < 1:
             return 0
         return bucket if rate > 0 else -bucket
+
+    def _is_upper_limit(self, rate: float, *, sign=None, is_upper_limit: bool = False) -> bool:
+        if is_upper_limit:
+            return True
+        if str(sign or "").strip() == "1":
+            return True
+        return self._upper_limit_rate_pct > 0 and rate >= self._upper_limit_rate_pct
+
+    @staticmethod
+    def _apply_kis_sign(rate: float, sign) -> float:
+        sign_value = str(sign or "").strip()
+        if sign_value in {"4", "5"} and rate > 0:
+            return -rate
+        if sign_value in {"1", "2"} and rate < 0:
+            return abs(rate)
+        return rate
 
     def _stock_name(self, code: str) -> str:
         if self._stock_code_repository is None:

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -229,6 +229,8 @@ class PriceStreamService:
                         stock_code,
                         price=current_price,
                         rate=realtime_data.get('전일대비율'),
+                        sign=realtime_data.get('전일대비부호'),
+                        is_upper_limit=self._is_upper_limit_tick(realtime_data),
                     )
                 )
             except RuntimeError:
@@ -265,6 +267,16 @@ class PriceStreamService:
             return None
         source = "websocket" if cached.get("quality_reason") == "websocket" else "rest"
         return MarketSnapshot.from_legacy_dict(code, cached, source=source)
+
+    @staticmethod
+    def _is_upper_limit_tick(realtime_data: dict) -> bool:
+        if str(realtime_data.get('전일대비부호') or '').strip() == '1':
+            return True
+        for key in ('실시간가격제한구분', '가격제한구분', '실시간상한가'):
+            value = str(realtime_data.get(key) or '').strip().upper()
+            if value in {'1', 'Y', 'U', 'UPPER', 'UPPER_LIMIT', '상한가'}:
+                return True
+        return False
 
     def cache_conclusion_snapshot(self, code: str, execution_strength_pct: float) -> None:
         """체결강도 REST 응답을 캐시에 저장한다."""

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -62,6 +62,41 @@ async def test_alerts_negative_five_percent_bucket():
 
 
 @pytest.mark.asyncio
+async def test_applies_kis_negative_sign_to_unsigned_rate():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="70000", rate="5.01", sign="5")
+
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert "-5%" in args[2]
+    assert kwargs["metadata"]["threshold_pct"] == -5
+    assert kwargs["metadata"]["rate"] == -5.01
+
+
+@pytest.mark.asyncio
+async def test_alerts_upper_limit_separately_from_twenty_five_percent_bucket():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="82000", rate="25.10", sign="2")
+    await svc.handle_price_tick("005930", price="85000", rate="29.92", sign="1")
+
+    assert notifications.emit.await_count == 2
+    second_args, second_kwargs = notifications.emit.await_args_list[1]
+    assert "상한가" in second_args[2]
+    assert second_kwargs["metadata"]["alert_type"] == "favorite_upper_limit"
+    assert second_kwargs["metadata"]["is_upper_limit"] is True
+
+
+@pytest.mark.asyncio
 async def test_ignores_non_favorite_and_invalid_rate():
     repo = MagicMock()
     repo.get_all = AsyncMock(return_value=["000660"])

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -325,6 +325,35 @@ async def test_on_price_tick_schedules_favorite_price_alert(mock_stock_repo, moc
         "005930",
         price="75000",
         rate="5.12",
+        sign=None,
+        is_upper_limit=False,
+    )
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_on_price_tick_passes_sign_and_upper_limit_to_favorite_price_alert(mock_stock_repo, mock_logger):
+    alert_service = MagicMock()
+    alert_service.handle_price_tick = AsyncMock()
+    service = PriceStreamService(
+        stock_repo=mock_stock_repo,
+        logger=mock_logger,
+        favorite_price_alert_service=alert_service,
+    )
+
+    service.on_price_tick({
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '85000',
+        '전일대비율': '29.92',
+        '전일대비부호': '1',
+    })
+
+    alert_service.handle_price_tick.assert_called_once_with(
+        "005930",
+        price="85000",
+        rate="29.92",
+        sign="1",
+        is_upper_limit=True,
     )
     await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary
- pass KIS price sign and upper-limit state into favorite price alerts
- emit a separate upper-limit alert instead of relying on the 25% bucket
- cover negative unsigned KIS rates and upper-limit ticks with unit tests

## Tests
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v