### PR TITLE
Fix favorite price alert subscriptions

### DIFF
--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -14,8 +14,8 @@ StreamingService와의 역할 구분:
 
 우선순위 카테고리:
   - HIGH   : 보유 종목 (Portfolio) — category_key: "portfolio"
-  - MEDIUM : 전략 감시 종목 (Strategy watchlist, premium stocks) — category_key: "strategy_*"
-  - LOW    : 관심종목은 "favorite", 웹 UI 조회 종목 — category_key: "ui_*"
+  - MEDIUM : 전략 감시 종목, 프리미엄 종목, 관심종목 알림 — category_key: "strategy_*", "favorite"
+  - LOW    : 웹 UI 조회 종목 — category_key: "ui_*"
 """
 from __future__ import annotations
 
@@ -37,8 +37,8 @@ if TYPE_CHECKING:
 class SubscriptionPriority(IntEnum):
     CRITICAL = 0  # 프로그램 매매 (절대 밀어내기 불가)
     HIGH = 1      # Portfolio (보유 종목)
-    MEDIUM = 2    # Strategy watchlist / premium stocks
-    LOW = 3       # UI page view / watchlist page
+    MEDIUM = 2    # Strategy watchlist / premium stocks / favorite alerts
+    LOW = 3       # UI page view
 
 
 class SubscriptionPolicy:

--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -4,6 +4,7 @@
 import asyncio
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
+from services.price_subscription_service import SubscriptionPriority
 from view.web import web_api
 
 
@@ -83,6 +84,7 @@ async def test_add_favorite_syncs_alert_cache_and_price_subscription(web_client,
         mock_web_ctx.price_subscription_service.add_subscription.assert_awaited_once()
         args = mock_web_ctx.price_subscription_service.add_subscription.await_args.args
         assert args[0] == "005930"
+        assert args[1] == SubscriptionPriority.MEDIUM
         assert args[2] == "favorite"
 
 
@@ -245,6 +247,7 @@ async def test_get_favorite_list_with_subscription(web_client, mock_web_ctx):
         _, kwargs = mock_sub_svc.sync_subscriptions.call_args
         assert kwargs["codes"] == ["005930"]
         assert kwargs["category_key"] == "favorite"
+        assert kwargs["priority"] == SubscriptionPriority.MEDIUM
 
 
 async def test_get_favorite_list_subscription_exception(web_client, mock_web_ctx):

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -819,6 +819,33 @@ async def test_initialize_price_subscriptions_premium_no_dict_leakage(mock_deps,
         assert not isinstance(c, dict), f"codes에 dict 포함: {c}"
 
 
+@pytest.mark.asyncio
+async def test_initialize_price_subscriptions_restores_favorites(mock_deps):
+    """기동 시 기존 관심종목을 알림용 MEDIUM 우선순위 가격 구독으로 복원한다."""
+    from services.price_subscription_service import SubscriptionPriority
+
+    ctx = WebAppContext(None)
+
+    mock_price_svc = AsyncMock()
+    ctx.price_subscription_service = mock_price_svc
+    ctx.virtual_trade_service = MagicMock()
+    ctx.virtual_trade_service.get_holds.return_value = []
+    ctx.favorite_service = MagicMock()
+    ctx.favorite_service.get_all = AsyncMock(return_value=["005930", "000660"])
+
+    with patch("os.path.exists", return_value=False):
+        await ctx._initialize_price_subscriptions()
+
+    favorite_calls = [
+        call for call in mock_price_svc.sync_subscriptions.call_args_list
+        if call.kwargs.get("category_key") == "favorite"
+    ]
+    assert len(favorite_calls) == 1
+    call_kwargs = favorite_calls[0].kwargs
+    assert call_kwargs["codes"] == ["005930", "000660"]
+    assert call_kwargs["priority"] == SubscriptionPriority.MEDIUM
+
+
 def test_get_cache_stats_delegates_and_handles_missing_repo(mock_deps):
     """StockRepository가 있으면 cache stats를 위임하고, 없으면 빈 dict를 반환."""
     ctx = WebAppContext(None)

--- a/view/web/routes/favorite.py
+++ b/view/web/routes/favorite.py
@@ -34,7 +34,7 @@ async def get_favorite_list(market: str = Query(MARKET_DOMESTIC)):
     ctx = _get_ctx()
     result = await ctx.favorite_service.get_with_details(market=market)
 
-    # 페이지 접속 시 LOW 우선순위로 SSE 구독 등록 (백그라운드). 해외는 실시간 스트림 대상이 아니다.
+    # 페이지 접속 시 알림용 MEDIUM 우선순위로 SSE 구독 등록 (백그라운드). 해외는 실시간 스트림 대상이 아니다.
     if market == MARKET_DOMESTIC and getattr(ctx, "price_subscription_service", None) and result:
         async def _subscribe():
             try:
@@ -43,7 +43,7 @@ async def get_favorite_list(market: str = Query(MARKET_DOMESTIC)):
                 await ctx.price_subscription_service.sync_subscriptions(
                     codes=codes,
                     category_key="favorite",
-                    priority=SubscriptionPriority.LOW,
+                    priority=SubscriptionPriority.MEDIUM,
                 )
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 등록 실패: {e}")
@@ -69,7 +69,7 @@ async def add_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
                 from services.price_subscription_service import SubscriptionPriority
                 await price_subscription_service.add_subscription(
                     code,
-                    SubscriptionPriority.LOW,
+                    SubscriptionPriority.MEDIUM,
                     "favorite",
                 )
             except Exception as e:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -340,15 +340,21 @@ class WebAppContext:
         except Exception as e:
             self.logger.warning(f"프리미엄 종목 구독 초기화 실패: {e}")
 
-        # 3. 관심종목 → LOW 구독 (알림 및 관심종목 페이지 최신가용)
+        # 3. 관심종목 → MEDIUM 구독 (5% 변동폭 알림용)
         try:
             favorite_codes = await self.favorite_service.get_all() if self.favorite_service else []
+            favorite_codes = [
+                str(code).strip()
+                for code in favorite_codes
+                if str(code or "").strip()
+            ]
             if favorite_codes:
                 await self.price_subscription_service.sync_subscriptions(
                     codes=favorite_codes,
                     category_key="favorite",
-                    priority=SubscriptionPriority.LOW,
+                    priority=SubscriptionPriority.MEDIUM,
                 )
+                self.logger.info(f"관심종목 구독 초기화 완료: {len(favorite_codes)}개")
         except Exception as e:
             self.logger.warning(f"관심종목 구독 초기화 실패: {e}")
 


### PR DESCRIPTION
## Summary
- restore existing favorite stocks into realtime price subscriptions on startup
- treat favorite alert subscriptions as MEDIUM priority so 5% threshold alerts are less likely to be dropped by websocket slot pressure
- add route/startup tests for favorite subscription priority

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v