### PR TITLE
Fix WebSocket recovery after order notice failure

### DIFF
--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -38,6 +38,8 @@ class StreamingService:
     BrokerAPIWrapper를 통해 실제 WebSocket API에 위임한다.
     """
 
+    ORDER_NOTICE_HEALTH_GRACE_SEC = 0.1
+
     def __init__(
         self,
         broker_api_wrapper: "BrokerAPIWrapper",
@@ -65,6 +67,7 @@ class StreamingService:
         self._PRINT_THROTTLE_SEC: float = 0.5
         self._callback = None  # 재연결 시 콜백 유실 방지용 저장
         self._connect_lock = asyncio.Lock()
+        self._order_notice_auto_subscribe_disabled = False
 
         # Observer 레지스트리: data_type → [handler, ...]
         self._handlers: Dict[str, List[Callable[[dict], None]]] = {}
@@ -132,12 +135,45 @@ class StreamingService:
             if result and self._streaming_logger:
                 self._streaming_logger.log_connect()
             if result:
-                try:
-                    await self.subscribe_order_notice()
-                except Exception as e:
-                    self.logger.warning(f"체결통보 구독 실패: {e}")
+                receive_alive_before_order_notice = self._is_websocket_receive_alive()
+                if not await self._subscribe_order_notice_safely(
+                    receive_alive_before_order_notice
+                ):
+                    return False
                 await self._subscribe_market_status_monitors()
             return result
+
+    async def _subscribe_order_notice_safely(self, receive_alive_before: bool) -> bool:
+        if self._order_notice_auto_subscribe_disabled:
+            return True
+
+        try:
+            await self.subscribe_order_notice()
+        except Exception as e:
+            self.logger.warning(f"체결통보 구독 실패: {e}")
+            return True
+
+        if not receive_alive_before:
+            return True
+
+        await asyncio.sleep(self.ORDER_NOTICE_HEALTH_GRACE_SEC)
+        if self._is_websocket_receive_alive():
+            return True
+
+        self._order_notice_auto_subscribe_disabled = True
+        self.logger.warning(
+            "체결통보 구독 후 WebSocket 수신 태스크 종료 감지. "
+            "체결통보 자동 구독을 비활성화하고 WebSocket을 재연결합니다."
+        )
+        try:
+            await self.broker.disconnect_websocket()
+        except Exception as e:
+            self.logger.warning(f"체결통보 실패 복구 중 WebSocket 해제 실패: {e}")
+
+        result = await self.broker.connect_websocket(self._callback)
+        if result and self._streaming_logger:
+            self._streaming_logger.log_connect()
+        return bool(result)
 
     def _is_websocket_receive_alive(self) -> bool:
         checker = getattr(self.broker, "is_websocket_receive_alive", None)

--- a/tests/unit_test/services/test_streaming_service.py
+++ b/tests/unit_test/services/test_streaming_service.py
@@ -136,6 +136,31 @@ async def test_connect_websocket_logs_order_notice_subscription_failure(
 
 
 @pytest.mark.asyncio
+async def test_connect_websocket_recovers_when_order_notice_kills_receive_task(
+    mock_broker, mock_logger, mock_market_clock, mock_market_data_service
+):
+    """체결통보 구독 직후 연결이 죽으면 체결통보를 끄고 재연결해 스트림 구독을 살린다."""
+    mock_broker.connect_websocket.return_value = True
+    mock_broker.is_websocket_receive_alive.side_effect = [False, True, False]
+    service = StreamingService(
+        broker_api_wrapper=mock_broker,
+        logger=mock_logger,
+        market_clock=mock_market_clock,
+        market_data_service=mock_market_data_service,
+    )
+
+    assert await service.connect_websocket() is True
+
+    assert mock_broker.connect_websocket.await_count == 2
+    mock_broker.disconnect_websocket.assert_awaited_once()
+    mock_broker.subscribe_order_notice.assert_awaited_once()
+    assert service._order_notice_auto_subscribe_disabled is True
+    assert "체결통보 구독 후 WebSocket 수신 태스크 종료" in str(
+        mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
 async def test_connect_websocket_no_callback(streaming_service, mock_broker):
     """connect_websocket: 콜백 없이 호출 시 None이 전달됨"""
     await streaming_service.connect_websocket()
@@ -156,7 +181,7 @@ async def test_connect_websocket_skips_duplicate_when_receive_alive(streaming_se
 async def test_connect_websocket_serializes_concurrent_calls(streaming_service, mock_broker):
     """동시 connect 요청은 하나만 브로커에 전달하고 후속 요청은 살아있는 연결을 재사용한다."""
     release = asyncio.Event()
-    mock_broker.is_websocket_receive_alive.side_effect = [False, True]
+    mock_broker.is_websocket_receive_alive.side_effect = [False, True, True, True]
 
     async def slow_connect(callback):
         await release.wait()


### PR DESCRIPTION
## Summary
- detect when order-notice subscription kills the WebSocket receive task
- disable automatic order-notice subscription for the current process after that failure and reconnect so price/PT streams can subscribe
- add regression coverage for the recovery path

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v