### PR TITLE
지수 카드에 기간 선택(1일/1주/1개월/1년) + x축 눈금 추가

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -150,6 +150,12 @@ class BrokerAPIWrapper:
         return await self._client.inquire_daily_indexchartprice(index_code, start_date=start_date,
                                                                 end_date=end_date, period=period)
 
+    async def inquire_time_indexchartprice(self, index_code: str,
+                                           interval_seconds: int = 600) -> ResCommonResponse:
+        """국내업종 분봉 지수 시세를 조회합니다 (KoreaInvestApiQuotations 위임)."""
+        return await self._client.inquire_time_indexchartprice(index_code,
+                                                               interval_seconds=interval_seconds)
+
     async def inquire_time_itemchartprice(
         self, *, stock_code: str, input_hour_1: str,
         pw_data_incu_yn: str = "Y", etc_cls_code: str = "0"

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -178,6 +178,12 @@ class KoreaInvestApiClient:
         return await self._quotations.inquire_daily_indexchartprice(index_code, start_date=start_date,
                                                                     end_date=end_date, period=period)
 
+    async def inquire_time_indexchartprice(self, index_code: str,
+                                           interval_seconds: int = 600) -> ResCommonResponse:
+        """국내업종(코스피/코스닥) 분봉 지수 시세를 조회합니다. ResCommonResponse를 반환합니다."""
+        return await self._quotations.inquire_time_indexchartprice(index_code,
+                                                                   interval_seconds=interval_seconds)
+
     async def inquire_time_itemchartprice(
         self,
         *,

--- a/brokers/korea_investment/korea_invest_params_provider.py
+++ b/brokers/korea_investment/korea_invest_params_provider.py
@@ -109,6 +109,32 @@ class DailyIndexChartPriceParams:
 
 
 @dataclass(frozen=True)
+class TimeIndexChartPriceParams:
+    """국내업종 분봉 지수 시세. 주식 분봉과 달리 fid_input_hour_1 이 "봉 간격(초)" 이다.
+
+    실측: 60 → 1분봉 100개, 600 → 10분봉 40개(09:00~15:30 전 구간), 1800 → 30분봉 14개.
+    """
+    fid_cond_mrkt_div_code: str  # 업종/지수는 "U"
+    fid_input_iscd: str  # 업종코드 (코스피 0001 / 코스닥 1001)
+    fid_input_hour_1: str  # 봉 간격(초)
+    fid_pw_data_incu_yn: str  # 과거 데이터 포함 여부 (N = 당일만)
+    fid_etc_cls_code: str  # 기타 구분 코드 ("0")
+
+    @classmethod
+    def time_indexchartprice(cls, index_code: str, interval_seconds: int, include_past: str = "N"):
+        return cls(
+            fid_cond_mrkt_div_code="U",
+            fid_input_iscd=index_code,
+            fid_input_hour_1=str(interval_seconds),
+            fid_pw_data_incu_yn=include_past,
+            fid_etc_cls_code="0",
+        )
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class TimeItemChartPriceParams:
     fid_cond_mrkt_div_code: str  # 보통 "J"
     fid_input_iscd: str  # 종목코드
@@ -762,6 +788,10 @@ class Params:
     @staticmethod
     def daily_indexchartprice(index_code: str, start_date: str, end_date: str, period: str) -> Dict[str, str]:
         return DailyIndexChartPriceParams.daily_indexchartprice(index_code, start_date, end_date, period).to_dict()
+
+    @staticmethod
+    def time_indexchartprice(index_code: str, interval_seconds: int, include_past: str = "N") -> Dict[str, str]:
+        return TimeIndexChartPriceParams.time_indexchartprice(index_code, interval_seconds, include_past).to_dict()
 
     @staticmethod
     def time_itemchartprice(stock_code: str, input_hour: str,

--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -509,6 +509,54 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
             data={"summary": summary, "candles": candles},
         )
 
+    # 분봉 응답에는 실제 시각이 아닌 집계용 센티널 행이 섞여 온다.
+    _INDEX_MINUTE_SENTINEL_HOURS = {"999999", "888888"}
+
+    async def inquire_time_indexchartprice(self, index_code: str,
+                                           interval_seconds: int = 600) -> ResCommonResponse:
+        """
+        국내업종(코스피 0001 / 코스닥 1001) 분봉 지수 시세를 조회합니다.
+        TRID: FHKUP03500200
+        interval_seconds 는 봉 간격(초)이며 600(10분봉)이면 정규장 전 구간이 한 번에 담깁니다.
+        data 에 {"summary": output1, "candles": output2(과거→현재)} 를 담아 반환합니다.
+        """
+        tr_id = self._trid_provider.quotations(TrIdLeaf.TIME_INDEXCHARTPRICE)
+        params = Params.time_indexchartprice(index_code, interval_seconds)
+
+        with self._headers.temp(tr_id=tr_id):
+            response_data: ResCommonResponse = await self.call_api(
+                "GET", EndpointKey.TIME_INDEXCHARTPRICE, params=params
+            )
+
+        if response_data.rt_cd != ErrorCode.SUCCESS.value:
+            error_msg = f"지수 분봉 API 응답 비정상 (index_code: {index_code}), 응답: {response_data.data}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=error_msg, data=None)
+
+        raw = response_data.data if isinstance(response_data.data, dict) else {}
+        summary = raw.get("output1") or {}
+        candles = raw.get("output2") or []
+        if not isinstance(candles, list):
+            candles = [candles] if candles else []
+        candles = [
+            candle for candle in candles
+            if str(candle.get("stck_cntg_hour") or "") not in self._INDEX_MINUTE_SENTINEL_HOURS
+        ]
+
+        if not candles:
+            warning_msg = f"지수 분봉 데이터가 비어있음 (index_code: {index_code})"
+            self._logger.warning(warning_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.MISSING_KEY.value, msg1=warning_msg, data=None)
+
+        # KIS 는 최신순으로 주므로 차트용으로 과거→현재로 뒤집는다.
+        candles.sort(key=lambda c: (str(c.get("stck_bsop_date") or ""), str(c.get("stck_cntg_hour") or "")))
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="지수 분봉 조회 성공",
+            data={"summary": summary, "candles": candles},
+        )
+
     async def inquire_time_itemchartprice(
         self,
         stock_code: str,

--- a/brokers/korea_investment/korea_invest_trid_keys.py
+++ b/brokers/korea_investment/korea_invest_trid_keys.py
@@ -15,6 +15,7 @@ class TrIdLeaf(str, Enum):
 
     DAILY_ITEMCHARTPRICE =      "inquire_daily_itemchartprice"           # 기간별 시세 (일/주/월/년)
     DAILY_INDEXCHARTPRICE =     "inquire_daily_indexchartprice"          # 국내업종 기간별 지수 시세
+    TIME_INDEXCHARTPRICE =      "inquire_time_indexchartprice"           # 국내업종 분봉 지수 시세
     TIME_ITEMCHARTPRICE =       "inquire_time_itemchartprice"             # 당일 분봉 조회
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice" # 일별 분봉 조회
     FINANCIAL_RATIO = "financial_ratio"  # 기업 재무비율

--- a/brokers/korea_investment/korea_invest_url_keys.py
+++ b/brokers/korea_investment/korea_invest_url_keys.py
@@ -14,6 +14,7 @@ class EndpointKey(str, Enum):
     MULTI_PRICE = "multi_price"
     DAILY_ITEMCHARTPRICE = "inquire_daily_itemchartprice"
     DAILY_INDEXCHARTPRICE = "inquire_daily_indexchartprice"
+    TIME_INDEXCHARTPRICE = "inquire_time_indexchartprice"
     TIME_ITEMCHARTPRICE = "inquire_time_itemchartprice"
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice"
     FINANCIAL_RATIO = "financial_ratio"

--- a/config/kis_config.yaml
+++ b/config/kis_config.yaml
@@ -15,6 +15,7 @@ paths:
   multi_price: /uapi/domestic-stock/v1/quotations/intstock-multprice
   inquire_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice      # 기간별 시세 (일/주/월/년)
   inquire_daily_indexchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice    # 국내업종 기간별 지수 시세 (코스피/코스닥)
+  inquire_time_indexchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-indexchartprice      # 국내업종 분봉 지수 시세 (코스피/코스닥)
   inquire_time_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice        # 당일 분봉 조회
   inquire_time_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice # 일변 분봉 조회
   financial_ratio: /uapi/domestic-stock/v1/finance/financial-ratio  # 기업 재무비율 (영업이익 등)

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -18,6 +18,7 @@ tr_ids:
 
     inquire_daily_itemchartprice:      FHKST03010100 # 기간별 시세 (일/주/월/년)
     inquire_daily_indexchartprice:     FHKUP03500100 # 국내업종 기간별 지수 시세 (코스피 0001 / 코스닥 1001)
+    inquire_time_indexchartprice:      FHKUP03500200 # 국내업종 분봉 지수 시세 (FID_INPUT_HOUR_1 = 봉 간격(초))
     inquire_time_itemchartprice:       FHKST03010200 # 당일 분봉 조회
     inquire_time_daily_itemchartprice: FHKST03010230 # 일변 분봉 조회 (모의 미지원)
     financial_ratio: FHKST66430300  # 기업 재무비율 (KIS 문서 확인 필요, 실전 전용 가능성)

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1410,45 +1410,71 @@ class StockQueryService:
     # ── 국내 지수 (홈 화면 지수 패널) ──────────────────────────────────────
     DOMESTIC_INDEX_NAMES = {"0001": "코스피", "1001": "코스닥"}
 
-    async def get_index_chart(self, index_code: str, days: int = 60) -> ResCommonResponse:
-        """코스피/코스닥 지수의 현재값·등락과 최근 일별 종가를 조회한다.
+    # 기간별 조회 방식. KIS 기간별 지수(FHKUP03500100)는 범위와 무관하게 최대 50행만 주므로
+    # 1년은 일봉이 아니라 주봉으로 받는다(50주 ≈ 1년).
+    INDEX_CHART_PERIODS = {
+        "1D": {"kind": "minute", "interval_seconds": 600},
+        "1W": {"kind": "daily", "div": "D", "limit": 5, "lookback_days": 14},
+        "1M": {"kind": "daily", "div": "D", "limit": 22, "lookback_days": 45},
+        "1Y": {"kind": "daily", "div": "W", "limit": 50, "lookback_days": 400},
+    }
 
-        홈 화면 지수 패널이 쓰는 형태({code,name,current,change,change_rate,points})로 정규화한다.
+    async def get_index_chart(self, index_code: str, period: str = "1D") -> ResCommonResponse:
+        """코스피/코스닥 지수의 현재값·등락과 선택 기간의 종가 시리즈를 조회한다.
+
+        홈 화면 지수 패널이 쓰는 형태({code,name,period,current,change,change_rate,points})로
+        정규화한다. period="1D" 이면 각 point 에 분봉 시각("time")이 함께 담긴다.
         """
         if index_code not in self.DOMESTIC_INDEX_NAMES:
             msg = f"지원하지 않는 지수 코드: {index_code}"
             self.logger.warning(msg)
             return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=None)
 
-        now = self.market_clock.get_current_kst_time()
-        end_date = now.strftime("%Y%m%d")
-        # 주말/휴장일을 감안해 넉넉히 조회한 뒤 days 개로 자른다.
-        start_date = (now - timedelta(days=days * 2)).strftime("%Y%m%d")
+        spec = self.INDEX_CHART_PERIODS.get(period)
+        if spec is None:
+            msg = f"지원하지 않는 지수 조회 기간: {period}"
+            self.logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=None)
 
-        resp = await self.broker.inquire_daily_indexchartprice(
-            index_code, start_date=start_date, end_date=end_date
-        )
+        if spec["kind"] == "minute":
+            resp = await self.broker.inquire_time_indexchartprice(
+                index_code, interval_seconds=spec["interval_seconds"]
+            )
+        else:
+            now = self.market_clock.get_current_kst_time()
+            resp = await self.broker.inquire_daily_indexchartprice(
+                index_code,
+                start_date=(now - timedelta(days=spec["lookback_days"])).strftime("%Y%m%d"),
+                end_date=now.strftime("%Y%m%d"),
+                period=spec["div"],
+            )
         if resp.rt_cd != ErrorCode.SUCCESS.value:
             return resp
 
         raw = resp.data or {}
         summary = raw.get("summary") or {}
+        is_minute = spec["kind"] == "minute"
         points = []
         for candle in raw.get("candles") or []:
             date = str(candle.get("stck_bsop_date") or "")
             close = _to_float(candle.get("bstp_nmix_prpr"))
             if not date or close is None:
                 continue
-            points.append({"date": date, "close": close})
+            point = {"date": date, "close": close}
+            if is_minute:
+                point["time"] = str(candle.get("stck_cntg_hour") or "")
+            points.append(point)
 
         # KIS 는 최신순으로 주므로 차트용으로 과거→현재로 뒤집는다.
-        points.sort(key=lambda p: p["date"])
-        if len(points) > days:
-            points = points[-days:]
+        points.sort(key=lambda p: (p["date"], p.get("time", "")))
+        limit = spec.get("limit")
+        if limit and len(points) > limit:
+            points = points[-limit:]
 
         data = {
             "code": index_code,
             "name": summary.get("hts_kor_isnm") or self.DOMESTIC_INDEX_NAMES[index_code],
+            "period": period,
             "current": _to_float(summary.get("bstp_nmix_prpr")),
             "change": _to_float(summary.get("bstp_nmix_prdy_vrss")),
             "change_rate": _to_float(summary.get("bstp_nmix_prdy_ctrt")),

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -199,6 +199,34 @@ test("스파크라인 색은 등락률 부호를 따른다", async () => {
   assert(colors.includes("#3742fa"), "하락 지수는 하락색이어야 함");
 });
 
+test("국장 스파크라인은 x축에 날짜 눈금을 표시한다", async () => {
+  const window = await makeWindow();
+
+  await window.renderMarketIndices();
+
+  const config = window.__charts[0].config;
+  assert(config.options.scales.x.display === true, "국장 차트 x축이 표시되지 않음");
+  assert(config.data.labels.join(",") === "07/24,07/27",
+    `x축 라벨이 MM/DD 형식이어야 함 (실제 ${config.data.labels.join(",")})`);
+  assert(config.options.scales.y.display === false, "y축은 계속 숨겨야 함");
+});
+
+test("x축 눈금은 조밀해지지 않도록 개수를 제한한다", async () => {
+  const points = Array.from({ length: 60 }, (_, i) => ({
+    date: `202605${String((i % 28) + 1).padStart(2, "0")}`,
+    close: 2600 + i,
+  }));
+  const window = await makeWindow(async () => success(indexPayload({ points })));
+
+  await window.renderMarketIndices();
+
+  const ticks = window.__charts[0].config.options.scales.x.ticks;
+  assert(ticks.autoSkip === true, "x축 눈금 autoSkip 이 꺼져 있음");
+  assert(ticks.maxTicksLimit > 1 && ticks.maxTicksLimit <= 6,
+    `x축 눈금 개수 제한이 비합리적임 (실제 ${ticks.maxTicksLimit})`);
+  assert(ticks.maxRotation === 0, "좁은 카드에서 라벨이 기울면 안 됨");
+});
+
 test("국장 API 실패는 카드별 안내로 degrade 한다", async () => {
   const window = await makeWindow(async () => ({ ok: false, status: 503, json: async () => ({}) }));
 

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -61,8 +61,9 @@ async function makeWindow(fetchWithTimeout) {
   window.currentCharts = [];
   window.__charts = [];
   window.Chart = function (ctx, config) {
-    window.__charts.push({ ctx, config });
-    this.destroy = () => {};
+    const record = { ctx, config, destroyed: false };
+    window.__charts.push(record);
+    this.destroy = () => { record.destroyed = true; };
   };
   window.eval(readFileSync(MARKET_INDICES_JS, "utf8"));
   return window;
@@ -165,7 +166,7 @@ test("국장 카드는 KIS API 를 조회해 값과 차트를 그린다", async 
   const requested = [];
   const window = await makeWindow(async (url) => {
     requested.push(url);
-    const code = url.endsWith("1001") ? "1001" : "0001";
+    const code = url.includes("/1001") ? "1001" : "0001";
     return success(indexPayload({
       code,
       name: code === "0001" ? "코스피" : "코스닥",
@@ -189,7 +190,7 @@ test("스파크라인 색은 등락률 부호를 따른다", async () => {
   const window = await makeWindow(async (url) => success(indexPayload({
     // 60일 추세는 우상향이지만 당일은 하락인 경우
     change: -4.2,
-    change_rate: url.endsWith("1001") ? -0.48 : 0.47,
+    change_rate: url.includes("/1001") ? -0.48 : 0.47,
   })));
 
   await window.renderMarketIndices();
@@ -225,6 +226,110 @@ test("x축 눈금은 조밀해지지 않도록 개수를 제한한다", async ()
   assert(ticks.maxTicksLimit > 1 && ticks.maxTicksLimit <= 6,
     `x축 눈금 개수 제한이 비합리적임 (실제 ${ticks.maxTicksLimit})`);
   assert(ticks.maxRotation === 0, "좁은 카드에서 라벨이 기울면 안 됨");
+});
+
+function minutePayload() {
+  return indexPayload({
+    period: "1D",
+    points: [
+      { date: "20260729", time: "090000", close: 2640.1 },
+      { date: "20260729", time: "091000", close: 2645.0 },
+      { date: "20260729", time: "092000", close: 2650.15 },
+    ],
+  });
+}
+
+test("국장 카드는 기간 선택 버튼을 갖고 기본은 1D 로 조회한다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    return success(minutePayload());
+  });
+
+  await window.renderMarketIndices();
+
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  const buttons = Array.from(kospi.querySelectorAll(".market-index-period"));
+  assert(buttons.map(b => b.dataset.period).join(",") === "1D,1W,1M,1Y",
+    `기간 버튼이 1D,1W,1M,1Y 여야 함 (실제 ${buttons.map(b => b.dataset.period)})`);
+  assert(buttons[0].classList.contains("active"), "기본 기간 1D 가 선택 표시되어야 함");
+  assert(requested.every(u => u.includes("period=1D")),
+    `기본 조회가 period=1D 여야 함 (실제 ${requested})`);
+  // 미장 위젯 카드에는 기간 버튼을 붙이지 않는다(위젯이 자체 제공).
+  const widget = window.document.querySelector('.market-index-card[data-kind="widget"]');
+  assert(!widget.querySelector(".market-index-period"), "위젯 카드에 기간 버튼이 붙음");
+});
+
+test("1D 는 x축에 분봉 시각을 표시한다", async () => {
+  const window = await makeWindow(async () => success(minutePayload()));
+
+  await window.renderMarketIndices();
+
+  const labels = window.__charts[0].config.data.labels;
+  assert(labels.join(",") === "09:00,09:10,09:20",
+    `1D x축 라벨이 HH:MM 이어야 함 (실제 ${labels.join(",")})`);
+});
+
+test("기간 버튼을 누르면 그 기간으로 다시 조회하고 차트를 교체한다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    return success(url.includes("period=1D") ? minutePayload() : indexPayload({ period: "1M" }));
+  });
+  await window.renderMarketIndices();
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  const before = window.__charts.length;
+
+  const monthly = kospi.querySelector('.market-index-period[data-period="1M"]');
+  await window.selectMarketIndexPeriod(kospi, "0001", "1M");
+
+  assert(requested.some(u => u.includes("/api/market-index/0001?period=1M")),
+    `1M 재조회를 하지 않음 (실제 ${requested})`);
+  assert(monthly.classList.contains("active"), "선택한 기간 버튼이 활성화되어야 함");
+  assert(!kospi.querySelector('.market-index-period[data-period="1D"]').classList.contains("active"),
+    "이전 기간 버튼이 활성 상태로 남음");
+  // 이전 차트는 파기하고 캔버스도 하나만 남아야 한다.
+  // (두 국장 카드가 동시에 렌더되므로 인덱스가 아니라 파기된 개수로 확인한다)
+  const destroyed = window.__charts.filter(chart => chart.destroyed);
+  assert(destroyed.length === 1, `교체한 카드의 이전 차트 1개만 파기되어야 함 (실제 ${destroyed.length}개)`);
+  assert(window.currentCharts.length === before,
+    `currentCharts 가 누적되면 안 됨 (before ${before}, after ${window.currentCharts.length})`);
+  assert(kospi.querySelectorAll("canvas").length === 1,
+    `카드에 캔버스가 하나만 있어야 함 (실제 ${kospi.querySelectorAll("canvas").length}개)`);
+  assert(window.__charts[before].config.data.labels.join(",") === "07/24,07/27",
+    "1M 로 바꾸면 x축이 날짜 라벨이어야 함");
+});
+
+test("기간 버튼 클릭도 같은 재조회 경로를 탄다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    return success(url.includes("period=1D") ? minutePayload() : indexPayload({ period: "1Y" }));
+  });
+  await window.renderMarketIndices();
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+
+  kospi.querySelector('.market-index-period[data-period="1Y"]').click();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert(requested.some(u => u.includes("period=1Y")), `클릭으로 1Y 조회를 못함 (실제 ${requested})`);
+});
+
+test("기간 재조회가 실패하면 그 카드만 안내로 degrade 한다", async () => {
+  let first = true;
+  const window = await makeWindow(async () => {
+    if (first) { first = false; return success(minutePayload()); }
+    return { ok: false, status: 503, json: async () => ({}) };
+  });
+  await window.renderMarketIndices();
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+
+  await window.selectMarketIndexPeriod(kospi, "0001", "1M");
+
+  assert(kospi.querySelector(".market-index-error"), "재조회 실패 안내가 없음");
+  assert(!kospi.querySelector("canvas"), "재조회 실패 시 이전 차트가 남음");
+  // 기간 버튼은 남아 있어야 다시 시도할 수 있다.
+  assert(kospi.querySelectorAll(".market-index-period").length === 4, "실패 후 기간 버튼이 사라짐");
 });
 
 test("국장 API 실패는 카드별 안내로 degrade 한다", async () => {

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_chart.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_chart.py
@@ -116,3 +116,62 @@ async def test_index_chart_reports_empty_candles(quotations):
     result = await quotations.inquire_daily_indexchartprice("0001", "20260601", "20260727")
 
     assert result.rt_cd == ErrorCode.MISSING_KEY.value
+
+
+@pytest.mark.asyncio
+async def test_index_minute_chart_sends_interval_as_input_hour(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(
+        output2=[{"stck_bsop_date": "20260729", "stck_cntg_hour": "090000", "bstp_nmix_prpr": "2640"}],
+    ))
+
+    await quotations.inquire_time_indexchartprice("1001", interval_seconds=600)
+
+    args, kwargs = quotations.call_api.call_args
+    assert args[1] == EndpointKey.TIME_INDEXCHARTPRICE
+    params = kwargs["params"]
+    assert params["fid_cond_mrkt_div_code"] == "U"
+    assert params["fid_input_iscd"] == "1001"
+    # 이 TR 에서 fid_input_hour_1 은 조회 시각이 아니라 봉 간격(초)이다.
+    assert params["fid_input_hour_1"] == "600"
+    assert params["fid_pw_data_incu_yn"] == "N"
+
+
+@pytest.mark.asyncio
+async def test_index_minute_chart_drops_sentinel_rows_and_sorts(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(
+        output1={"hts_kor_isnm": "코스피"},
+        output2=[
+            # KIS 는 최신순으로 주고, 집계용 센티널 시각이 섞여 온다.
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "999999", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "888888", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "091000", "bstp_nmix_prpr": "2650.15"},
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "090000", "bstp_nmix_prpr": "2640.10"},
+        ],
+    ))
+
+    result = await quotations.inquire_time_indexchartprice("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert [c["stck_cntg_hour"] for c in result.data["candles"]] == ["090000", "091000"]
+
+
+@pytest.mark.asyncio
+async def test_index_minute_chart_reports_when_only_sentinels(quotations):
+    quotations.call_api = AsyncMock(return_value=_api_response(
+        output2=[{"stck_bsop_date": "20260729", "stck_cntg_hour": "999999", "bstp_nmix_prpr": "2650"}],
+    ))
+
+    result = await quotations.inquire_time_indexchartprice("0001")
+
+    assert result.rt_cd == ErrorCode.MISSING_KEY.value
+
+
+@pytest.mark.asyncio
+async def test_index_minute_chart_propagates_api_error(quotations):
+    quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None,
+    ))
+
+    result = await quotations.inquire_time_indexchartprice("0001")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value

--- a/tests/unit_test/services/test_stock_query_index_chart.py
+++ b/tests/unit_test/services/test_stock_query_index_chart.py
@@ -42,7 +42,7 @@ async def test_index_chart_normalizes_summary_and_points():
         ],
     ))
 
-    result = await _service(broker).get_index_chart("0001")
+    result = await _service(broker).get_index_chart("0001", period="1M")
 
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert result.data["code"] == "0001"
@@ -53,6 +53,76 @@ async def test_index_chart_normalizes_summary_and_points():
     # KIS 는 최신순으로 주므로 차트용으로 과거→현재 순서여야 한다.
     assert [p["date"] for p in result.data["points"]] == ["20260724", "20260727"]
     assert result.data["points"][-1]["close"] == pytest.approx(2650.15)
+
+
+@pytest.mark.asyncio
+async def test_index_chart_1d_uses_minute_api_and_keeps_time():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock()
+    broker.inquire_time_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={"hts_kor_isnm": "코스피", "bstp_nmix_prpr": "2650.15"},
+        candles=[
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "090000", "bstp_nmix_prpr": "2640.10"},
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "091000", "bstp_nmix_prpr": "2650.15"},
+        ],
+    ))
+
+    result = await _service(broker).get_index_chart("0001", period="1D")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["period"] == "1D"
+    broker.inquire_daily_indexchartprice.assert_not_called()
+    # 10분봉이면 정규장 전 구간이 한 번에 담긴다.
+    assert broker.inquire_time_indexchartprice.await_args.kwargs["interval_seconds"] == 600
+    assert [p["time"] for p in result.data["points"]] == ["090000", "091000"]
+    assert result.data["points"][-1]["close"] == pytest.approx(2650.15)
+
+
+@pytest.mark.asyncio
+async def test_index_chart_1y_uses_weekly_candles():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={"bstp_nmix_prpr": "2650.15"},
+        candles=[{"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2650.15"}],
+    ))
+
+    result = await _service(broker).get_index_chart("0001", period="1Y")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert broker.inquire_daily_indexchartprice.await_args.kwargs["period"] == "W"
+    # 분봉이 아니므로 시각은 붙지 않는다.
+    assert "time" not in result.data["points"][0]
+
+
+@pytest.mark.asyncio
+async def test_index_chart_1m_trims_to_period_length():
+    candles = [
+        {"stck_bsop_date": f"202607{day:02d}", "bstp_nmix_prpr": str(2600 + day)}
+        for day in range(1, 31)
+    ]
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={"bstp_nmix_prpr": "2630.0"}, candles=candles,
+    ))
+
+    result = await _service(broker).get_index_chart("0001", period="1M")
+
+    assert broker.inquire_daily_indexchartprice.await_args.kwargs["period"] == "D"
+    assert len(result.data["points"]) == 22
+    assert result.data["points"][-1]["date"] == "20260730"
+
+
+@pytest.mark.asyncio
+async def test_index_chart_rejects_unknown_period():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock()
+    broker.inquire_time_indexchartprice = AsyncMock()
+
+    result = await _service(broker).get_index_chart("0001", period="10Y")
+
+    assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.inquire_daily_indexchartprice.assert_not_called()
+    broker.inquire_time_indexchartprice.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -73,7 +143,7 @@ async def test_index_chart_propagates_broker_failure():
         rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None,
     ))
 
-    result = await _service(broker).get_index_chart("0001")
+    result = await _service(broker).get_index_chart("0001", period="1M")
 
     assert result.rt_cd == ErrorCode.API_ERROR.value
 
@@ -90,7 +160,7 @@ async def test_index_chart_skips_unparsable_candles():
         ],
     ))
 
-    result = await _service(broker).get_index_chart("0001")
+    result = await _service(broker).get_index_chart("0001", period="1M")
 
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert [p["date"] for p in result.data["points"]] == ["20260727"]

--- a/tests/unit_test/view/web/test_market_indices_contracts.py
+++ b/tests/unit_test/view/web/test_market_indices_contracts.py
@@ -84,5 +84,15 @@ def test_market_indices_styles_are_defined():
         ".market-index-group-title",
         ".market-index-value",
         ".market-index-spark",
+        ".market-index-period",
     ):
         assert selector in css, f"{selector} 스타일이 없음"
+
+
+def test_domestic_index_period_selector_is_wired():
+    script = _market_indices_js()
+
+    for period in ("'1D'", "'1W'", "'1M'", "'1Y'"):
+        assert period in script, f"{period} 기간 설정이 없음"
+    # 기간은 쿼리 파라미터로 서버에 전달된다.
+    assert "?period=" in script

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -157,10 +157,13 @@ async def get_stock_rs_rating(code: str):
 
 
 @router.get("/market-index/{index_code}")
-async def get_market_index(index_code: str):
-    """코스피(0001)/코스닥(1001) 지수의 현재값·등락·최근 일별 종가. 홈 화면 지수 패널용."""
+async def get_market_index(index_code: str, period: str = "1D"):
+    """코스피(0001)/코스닥(1001) 지수의 현재값·등락·기간별 종가. 홈 화면 지수 패널용.
+
+    period: 1D(10분봉) / 1W / 1M / 1Y
+    """
     ctx = _get_ctx()
-    resp = await ctx.stock_query_service.get_index_chart(index_code)
+    resp = await ctx.stock_query_service.get_index_chart(index_code, period=period)
     return _serialize_response(resp)
 
 

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -1002,7 +1002,8 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 .market-index-spark {
     margin-top: 8px;
     width: 100%;
-    max-height: 70px;
+    /* x축 날짜 눈금이 들어가므로 선 영역(70px) + 라벨 높이만큼 잡는다. */
+    max-height: 88px;
 }
 .market-index-error {
     margin: 0;

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -983,6 +983,28 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     color: var(--text-secondary);
     margin-bottom: 6px;
 }
+.market-index-period-bar {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 6px;
+}
+.market-index-period {
+    flex: 1;
+    padding: 3px 0;
+    font-family: inherit;
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+}
+.market-index-period:hover { color: var(--text-primary); }
+.market-index-period.active {
+    color: #fff;
+    background: var(--accent);
+    border-color: var(--accent);
+}
 .market-index-body {
     height: 150px;
     display: flex;

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -111,6 +111,11 @@ function _formatIndexChange(change, rate) {
     return { text: `${delta}(${sign}${rate.toFixed(2)}%)`.replace(' (', ' ('), className };
 }
 
+function _formatIndexDate(value) {
+    const raw = String(value || '');
+    return raw.length === 8 ? `${raw.slice(4, 6)}/${raw.slice(6, 8)}` : raw;
+}
+
 function _renderIndexSparkline(canvas, data) {
     if (typeof Chart === 'undefined' || !data.points.length) return;
 
@@ -119,7 +124,7 @@ function _renderIndexSparkline(canvas, data) {
     const chart = new Chart(canvas.getContext('2d'), {
         type: 'line',
         data: {
-            labels: data.points.map(p => p.date),
+            labels: data.points.map(p => _formatIndexDate(p.date)),
             datasets: [{
                 data: data.points.map(p => p.close),
                 borderColor: color,
@@ -134,7 +139,22 @@ function _renderIndexSparkline(canvas, data) {
             maintainAspectRatio: false,
             animation: false,
             plugins: { legend: { display: false }, tooltip: { enabled: false } },
-            scales: { x: { display: false }, y: { display: false } },
+            scales: {
+                // 좁은 카드라 눈금을 몇 개로 제한하고 라벨은 눕힌 채로 둔다.
+                x: {
+                    display: true,
+                    grid: { display: false },
+                    border: { display: false },
+                    ticks: {
+                        autoSkip: true,
+                        maxTicksLimit: 5,
+                        maxRotation: 0,
+                        minRotation: 0,
+                        font: { size: 9 },
+                    },
+                },
+                y: { display: false },
+            },
         },
     });
     window.currentCharts = window.currentCharts || [];
@@ -171,7 +191,7 @@ async function buildMarketIndexKisCard(doc, entry) {
     if (points.length) {
         const canvas = doc.createElement('canvas');
         canvas.className = 'market-index-spark';
-        canvas.height = 70;
+        canvas.height = 88;
         body.appendChild(canvas);
         _renderIndexSparkline(canvas, { points, changeRate: data.change_rate });
     }

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -38,6 +38,17 @@ const MARKET_INDEX_GROUPS = [
     },
 ];
 
+// 국장 카드 기간 선택. KIS 기간별 지수 API 가 범위와 무관하게 최대 50행만 주므로
+// 1Y 는 서버에서 주봉으로 받는다. 1D 는 10분봉이라 x축이 시각으로 바뀐다.
+const MARKET_INDEX_PERIODS = [
+    { key: '1D', label: '1일' },
+    { key: '1W', label: '1주' },
+    { key: '1M', label: '1개월' },
+    { key: '1Y', label: '1년' },
+];
+
+const MARKET_INDEX_DEFAULT_PERIOD = '1D';
+
 const MARKET_INDEX_WIDGET_SRC =
     'https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js';
 
@@ -111,9 +122,12 @@ function _formatIndexChange(change, rate) {
     return { text: `${delta}(${sign}${rate.toFixed(2)}%)`.replace(' (', ' ('), className };
 }
 
-function _formatIndexDate(value) {
-    const raw = String(value || '');
-    return raw.length === 8 ? `${raw.slice(4, 6)}/${raw.slice(6, 8)}` : raw;
+// 분봉 응답에만 time 이 담기므로 라벨 형식은 요청한 기간이 아니라 받은 데이터를 보고 정한다.
+function _formatIndexPointLabel(point) {
+    const time = String(point.time || '');
+    if (time.length >= 4) return `${time.slice(0, 2)}:${time.slice(2, 4)}`;
+    const date = String(point.date || '');
+    return date.length === 8 ? `${date.slice(4, 6)}/${date.slice(6, 8)}` : date;
 }
 
 function _renderIndexSparkline(canvas, data) {
@@ -124,7 +138,7 @@ function _renderIndexSparkline(canvas, data) {
     const chart = new Chart(canvas.getContext('2d'), {
         type: 'line',
         data: {
-            labels: data.points.map(p => _formatIndexDate(p.date)),
+            labels: data.points.map(_formatIndexPointLabel),
             datasets: [{
                 data: data.points.map(p => p.close),
                 borderColor: color,
@@ -159,21 +173,52 @@ function _renderIndexSparkline(canvas, data) {
     });
     window.currentCharts = window.currentCharts || [];
     window.currentCharts.push(chart);
+    return chart;
 }
 
-async function buildMarketIndexKisCard(doc, entry) {
-    const card = _marketIndexCardShell(doc, 'kis', entry.code, entry.label);
+function _buildMarketIndexPeriodBar(doc, card, code) {
+    const bar = doc.createElement('div');
+    bar.className = 'market-index-period-bar';
 
-    const body = doc.createElement('div');
-    body.className = 'market-index-body';
-    card.appendChild(body);
+    MARKET_INDEX_PERIODS.forEach(period => {
+        const button = doc.createElement('button');
+        button.type = 'button';
+        button.className = 'market-index-period';
+        button.dataset.period = period.key;
+        button.textContent = period.label;
+        if (period.key === MARKET_INDEX_DEFAULT_PERIOD) button.classList.add('active');
+        button.addEventListener('click', () => selectMarketIndexPeriod(card, code, period.key));
+        bar.appendChild(button);
+    });
 
-    const res = await fetchWithTimeout(`/api/market-index/${entry.code}`);
+    return bar;
+}
+
+function _destroyMarketIndexChart(card) {
+    if (!card._indexChart) return;
+    try { card._indexChart.destroy(); } catch (_) { /* 이미 파기된 차트 */ }
+    if (window.currentCharts) {
+        window.currentCharts = window.currentCharts.filter(chart => chart !== card._indexChart);
+    }
+    card._indexChart = null;
+}
+
+async function selectMarketIndexPeriod(card, code, period) {
+    const doc = card.ownerDocument;
+    card.querySelectorAll('.market-index-period').forEach(button => {
+        button.classList.toggle('active', button.dataset.period === period);
+    });
+
+    const body = card.querySelector('.market-index-body');
+    const res = await fetchWithTimeout(`/api/market-index/${code}?period=${period}`);
     const { json, error } = await readJsonResponse(res);
     const data = json && json.rt_cd === '0' ? json.data : null;
+
+    _destroyMarketIndexChart(card);
+    body.innerHTML = '';
     if (error || !data) {
         body.appendChild(_marketIndexError(doc));
-        return card;
+        return;
     }
 
     const value = doc.createElement('div');
@@ -193,9 +238,19 @@ async function buildMarketIndexKisCard(doc, entry) {
         canvas.className = 'market-index-spark';
         canvas.height = 88;
         body.appendChild(canvas);
-        _renderIndexSparkline(canvas, { points, changeRate: data.change_rate });
+        card._indexChart = _renderIndexSparkline(canvas, { points, changeRate: data.change_rate });
     }
+}
 
+async function buildMarketIndexKisCard(doc, entry) {
+    const card = _marketIndexCardShell(doc, 'kis', entry.code, entry.label);
+    card.appendChild(_buildMarketIndexPeriodBar(doc, card, entry.code));
+
+    const body = doc.createElement('div');
+    body.className = 'market-index-body';
+    card.appendChild(body);
+
+    await selectMarketIndexPeriod(card, entry.code, MARKET_INDEX_DEFAULT_PERIOD);
     return card;
 }
 


### PR DESCRIPTION
## 문제
홈 화면 지수 패널의 코스피/코스닥 스파크라인은 x축이 `display: false` 라 어느 기간을 보고 있는지 알 수 없었고, 기간을 고를 수도 없었다. 같은 패널의 미장/원자재 TradingView 위젯은 시간 라벨과 1D 뷰를 제공하므로 국장 카드만 비어 보였다.

## KIS 실측으로 확인한 제약
설계에 직접 영향을 준 두 가지를 라이브 API probe 로 확인했다.

1. **국내업종 분봉(FHKUP03500200)의 `FID_INPUT_HOUR_1` 은 조회 시각이 아니라 봉 간격(초)** 이다.
   - `60` → 1분봉 100개(13:54~15:32만 커버), `600` → 10분봉 40개(**09:00~15:30 전 구간**), `1800` → 30분봉 14개
   - 시각(`153000`, `093000`)을 넣으면 3행만 돌아온다 → 1D 는 `600` 사용
   - 응답에 집계용 센티널 시각(`999999`/`888888`)이 섞여 오므로 걸러낸다
2. **기간별 지수(FHKUP03500100)는 조회 범위와 무관하게 최대 50행만 준다.**
   - `D`: 50거래일(≈2.4개월)이 상한, `W`: 50주(≈1년), `M`: 50개월
   - 그래서 **1년은 일봉이 아니라 주봉으로** 받는다. 기존 `days=60` 슬라이스는 애초에 걸리지 않던 죽은 코드였다.

## 변경
**백엔드** — `inquire_time_indexchartprice` 신설 (params/trid/url/quotations/client/wrapper 배선)
- `GET /api/market-index/{code}?period=1D|1W|1M|1Y`
- 기간 매핑: `1D`=10분봉 / `1W`=일봉 5 / `1M`=일봉 22 / `1Y`=주봉 50
- 1D 응답의 각 point 에만 `time`(HHMMSS)이 담긴다

**프론트엔드** — 국장 카드에 기간 버튼 4개(기본 1D, 미장 위젯 카드에는 붙이지 않음)
- x축 표시. 좁은 카드라 `autoSkip` + `maxTicksLimit: 5` + 회전 없음, 그리드/보더는 끔. y축은 계속 숨김
- 라벨 형식은 **요청한 기간이 아니라 응답 point 의 `time` 유무**로 정한다 → `09:10` 또는 `07/24`
- 기간 전환 시 이전 Chart 를 destroy 하고 `window.currentCharts` 에서 제거(누수 방지)
- 라벨 높이만큼 캔버스/CSS 확보 (70 → 88px)

## 검증
- `pytest tests/unit_test` — **7267 passed**
- `pytest tests/integration_test` — **271 passed**
- `node tests/frontend/run_market_indices_dom_tests.mjs` — **18/18** (기간 버튼·기본 1D·시각 라벨·차트 교체·재조회 실패 degrade 회귀 추가)
- 실서비스 경로 실측 (`StockQueryService.get_index_chart`, 코스피/코스닥 각 4기간):

  | period | n | 구간 |
  |---|---|---|
  | 1D | 40 | 09:00~15:30 |
  | 1W | 5 | 07/23~07/29 |
  | 1M | 22 | 06/29~07/29 |
  | 1Y | 50 | 08/18~07/27 (주봉) |

  잘못된 기간(`10Y`)은 INVALID_INPUT 으로 거부
- 브라우저 실측(정적 자산 + 응답 스텁): 1D 눈금 `09:00 10:20 11:40 13:00 14:20`, 1M 전환 시 `07/01 07/06 …` 로 교체·활성 버튼 이동·캔버스 1개 유지·`currentCharts` 누적 없음(4→4)

> 웹 서버 프로세스는 실행 중인 사용자 것이라 재시작하지 않았다. 백엔드는 라이브 KIS API + 서비스 계층 실측으로, 프론트는 정적 자산 실측 + jsdom 으로 검증했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)