### PR TITLE
Fix ranking report premarket resend

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -732,7 +732,12 @@ class RankingTask(AfterMarketTask):
                 return
             cache_key = (str(target_date), self.DEFAULT_PERIOD_RANKING_DAYS)
             needs_period = cache_key not in self._period_ranking_cache
+            can_recover_investor_report = self._can_recover_investor_report_on_startup(
+                str(target_date)
+            )
             needs_investor = (
+                can_recover_investor_report
+                and
                 self._last_collected_date != str(target_date)
                 and self._load_last_ranking_report_date() != str(target_date)
             )
@@ -749,6 +754,23 @@ class RankingTask(AfterMarketTask):
             raise
         except Exception as e:
             self._logger.warning(f"기간수급 self-heal 실패: {e}")
+
+    def _can_recover_investor_report_on_startup(self, target_date: str) -> bool:
+        """장전 재시작에서 전 거래일 랭킹 리포트가 재발송되는 것을 막는다."""
+        if self._market_clock is None:
+            return True
+        try:
+            today = str(self._market_clock.get_current_kst_date_str())
+            if today != str(target_date):
+                self._logger.info(
+                    f"투자자 랭킹 리포트 self-heal 스킵 — "
+                    f"현재일({today})과 대상 거래일({target_date}) 불일치"
+                )
+                return False
+            return self._market_clock.get_seconds_until_market_close() < 0
+        except Exception as e:
+            self._logger.warning(f"투자자 랭킹 리포트 self-heal 시간 확인 실패: {e}")
+            return False
 
     def _peek_period_ranking(self, cache_key: tuple[str, int]) -> Optional[List[Dict]]:
         """메모리 → DB 순으로 즉시 반환 가능한 기간수급 결과를 찾는다."""

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -165,3 +165,45 @@ async def test_startup_self_heal_skips_investor_report_when_already_sent_but_pre
 
     task.refresh_investor_ranking.assert_not_awaited()
     task.prewarm_period_ranking.assert_awaited_once_with("20260724")
+
+
+async def test_startup_self_heal_does_not_resend_previous_trading_date_report_before_open():
+    """다음 거래일 장전에는 전날 랭킹 리포트 복구 발송을 하지 않는다."""
+    task = _make_task()
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260730")
+    clock = MagicMock()
+    clock.get_current_kst_date_str.return_value = "20260731"
+    clock.get_seconds_until_market_close.return_value = 27_600  # 08:00 -> 15:40
+    task._mcs = mcs
+    task._market_clock = clock
+    task._load_last_ranking_report_date = MagicMock(return_value="20260729")
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.refresh_investor_ranking.assert_not_awaited()
+    task.prewarm_period_ranking.assert_awaited_once_with("20260730")
+
+
+async def test_startup_self_heal_recovers_same_day_report_after_close():
+    """당일 장마감 이후 시작한 경우에만 누락된 랭킹 리포트를 복구한다."""
+    task = _make_task()
+    mcs = MagicMock()
+    mcs.is_market_open_now = AsyncMock(return_value=False)
+    mcs.get_latest_trading_date = AsyncMock(return_value="20260730")
+    clock = MagicMock()
+    clock.get_current_kst_date_str.return_value = "20260730"
+    clock.get_seconds_until_market_close.return_value = -3_600
+    task._mcs = mcs
+    task._market_clock = clock
+    task._load_last_ranking_report_date = MagicMock(return_value="20260729")
+    task.refresh_investor_ranking = AsyncMock()
+    task.prewarm_period_ranking = AsyncMock()
+
+    await task._period_ranking_self_heal()
+
+    task.refresh_investor_ranking.assert_awaited_once()
+    task.prewarm_period_ranking.assert_awaited_once_with("20260730")


### PR DESCRIPTION
## Summary
- prevent startup self-heal from resending the previous trading day's ranking report before market open
- keep same-day after-close recovery behavior for missed ranking reports
- add tests for premarket skip and same-day after-close recovery

## Tests
- python -m pytest tests/unit_test/scheduler/test_ranking_task_execute.py -v -n0
- python -m pytest tests/unit_test/task/background/after_market/test_ranking_task.py tests/unit_test/scheduler/test_after_market_loop.py tests/unit_test/scheduler/test_time_dispatcher.py -v -n0
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v -n0

Note: parallel integration run initially had one unrelated VBO cache test failure; the same test passed when rerun directly, and the full integration suite passed with -n0.