### PR TITLE
Fix favorite price alert code normalization

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -192,7 +192,10 @@ class FavoritePriceAlertService:
 
     @staticmethod
     def _normalize_code(code) -> str:
-        return str(code or "").strip()
+        normalized = str(code or "").strip()
+        if normalized.isdigit() and len(normalized) <= 6:
+            return normalized.zfill(6)
+        return normalized
 
     @staticmethod
     def _to_float(value) -> Optional[float]:

--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -12,6 +12,13 @@ from repositories.stock_code_repository import StockCodeRepository
 _DEFAULT_OVERSEAS_EXCHANGE = "NASD"
 
 
+def _normalize_domestic_code(code: str) -> str:
+    normalized = str(code or "").strip()
+    if normalized.isdigit() and len(normalized) <= 6:
+        return normalized.zfill(6)
+    return normalized
+
+
 def _extract_price_rate(data) -> tuple:
     """API 응답 dict 또는 dataclass에서 (stck_prpr, prdy_ctrt) 추출."""
     if isinstance(data, dict):
@@ -40,15 +47,41 @@ class FavoriteService:
         self.overseas_stock_code_repository = overseas_stock_code_repository
 
     async def get_all(self, market: str = MARKET_DOMESTIC) -> list:
-        return await self.repository.get_all(market=market)
+        codes = await self.repository.get_all(market=market)
+        if market != MARKET_DOMESTIC:
+            return codes
+        normalized_codes = []
+        seen = set()
+        for code in codes:
+            normalized = _normalize_domestic_code(code)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            normalized_codes.append(normalized)
+        return normalized_codes
 
     async def add(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        if market == MARKET_DOMESTIC:
+            code = _normalize_domestic_code(code)
         return await self.repository.add(code, market=market)
 
     async def remove(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        if market == MARKET_DOMESTIC:
+            normalized = _normalize_domestic_code(code)
+            removed = await self.repository.remove(normalized, market=market)
+            if removed or normalized == str(code or "").strip():
+                return removed
+            return await self.repository.remove(str(code or "").strip(), market=market)
         return await self.repository.remove(code, market=market)
 
     async def is_favorite(self, code: str, market: str = MARKET_DOMESTIC) -> bool:
+        if market == MARKET_DOMESTIC:
+            normalized = _normalize_domestic_code(code)
+            if await self.repository.is_favorite(normalized, market=market):
+                return True
+            if normalized != str(code or "").strip():
+                return await self.repository.is_favorite(str(code or "").strip(), market=market)
+            return False
         return await self.repository.is_favorite(code, market=market)
 
     async def get_with_details(self, market: str = MARKET_DOMESTIC) -> list:
@@ -62,7 +95,7 @@ class FavoriteService:
         if market == MARKET_OVERSEAS_US:
             return await self._get_overseas_details()
 
-        codes = await self.repository.get_all(market=market)
+        codes = await self.get_all(market=market)
         if not codes:
             return []
 

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -30,6 +30,20 @@ async def test_alerts_when_favorite_rate_crosses_positive_five_percent():
 
 
 @pytest.mark.asyncio
+async def test_alerts_when_saved_favorite_code_is_not_zero_padded():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["5930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.12")
+
+    notifications.emit.assert_awaited_once()
+    assert notifications.emit.call_args.kwargs["metadata"]["code"] == "005930"
+
+
+@pytest.mark.asyncio
 async def test_does_not_repeat_same_five_percent_bucket_until_next_bucket():
     repo = MagicMock()
     repo.get_all = AsyncMock(return_value=["005930"])

--- a/tests/unit_test/services/test_favorite_service.py
+++ b/tests/unit_test/services/test_favorite_service.py
@@ -52,13 +52,19 @@ async def test_get_all_delegates(service, mock_repo):
     mock_repo.get_all.assert_called_once_with(market="domestic")
 
 
+async def test_get_all_normalizes_domestic_codes_for_realtime_subscription(service, mock_repo):
+    mock_repo.get_all.return_value = ["5930", "000660"]
+
+    assert await service.get_all() == ["005930", "000660"]
+
+
 async def test_add_overseas_passes_market(service, mock_repo):
     assert await service.add("AAPL", market="overseas_us") is True
     mock_repo.add.assert_called_once_with("AAPL", market="overseas_us")
 
 
 async def test_add_delegates(service, mock_repo):
-    assert await service.add("005930") is True
+    assert await service.add("5930") is True
     mock_repo.add.assert_called_once_with("005930", market="domestic")
 
 
@@ -72,10 +78,26 @@ async def test_remove_delegates(service, mock_repo):
     mock_repo.remove.assert_called_once_with("005930", market="domestic")
 
 
+async def test_remove_falls_back_to_legacy_unpadded_code(service, mock_repo):
+    mock_repo.remove.side_effect = [False, True]
+
+    assert await service.remove("5930") is True
+    assert mock_repo.remove.await_args_list[0].args == ("005930",)
+    assert mock_repo.remove.await_args_list[1].args == ("5930",)
+
+
 async def test_is_favorite_delegates(service, mock_repo):
     mock_repo.is_favorite.return_value = True
     assert await service.is_favorite("005930") is True
     mock_repo.is_favorite.assert_called_once_with("005930", market="domestic")
+
+
+async def test_is_favorite_checks_legacy_unpadded_code(service, mock_repo):
+    mock_repo.is_favorite.side_effect = [False, True]
+
+    assert await service.is_favorite("5930") is True
+    assert mock_repo.is_favorite.await_args_list[0].args == ("005930",)
+    assert mock_repo.is_favorite.await_args_list[1].args == ("5930",)
 
 
 async def test_get_with_details_empty(service, mock_repo):


### PR DESCRIPTION
## Summary
- Normalize domestic favorite codes to 6 digits for realtime subscription and alert matching
- Keep legacy unpadded favorite rows removable/checkable
- Add regression tests for unpadded saved codes triggering 5% alerts

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v