### PR TITLE
Fix favorite route realtime subscription code normalization

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -88,6 +88,28 @@ async def test_add_favorite_syncs_alert_cache_and_price_subscription(web_client,
         assert args[2] == "favorite"
 
 
+async def test_add_favorite_unpadded_domestic_code_subscribes_padded_code(web_client, mock_web_ctx):
+    """POST /api/favorite/{code} - 0 없는 국내 코드는 실시간 구독에 6자리로 전달한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.add_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.add_subscription = AsyncMock()
+
+        response = web_client.post("/api/favorite/5930")
+        assert response.status_code == 200
+        assert response.json()["code"] == "005930"
+
+        mock_web_ctx.favorite_service.add.assert_awaited_once_with("5930", market="domestic")
+        mock_web_ctx.favorite_price_alert_service.add_favorite.assert_awaited_once_with("005930")
+        args = mock_web_ctx.price_subscription_service.add_subscription.await_args.args
+        assert args[0] == "005930"
+        assert args[1] == SubscriptionPriority.MEDIUM
+        assert args[2] == "favorite"
+
+
 async def test_remove_favorite(web_client, mock_web_ctx):
     """DELETE /api/favorite/{code} - 삭제 성공"""
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
@@ -132,6 +154,31 @@ async def test_remove_favorite_syncs_alert_cache_and_price_subscription(web_clie
 
         mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_awaited_once_with("005930")
         mock_web_ctx.price_subscription_service.remove_subscription.assert_awaited_once_with("005930", "favorite")
+
+
+async def test_remove_favorite_unpadded_domestic_code_removes_padded_subscription(web_client, mock_web_ctx):
+    """DELETE /api/favorite/{code} - 0 없는 국내 코드는 6자리 구독을 정리한다."""
+    with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.favorite_service = MagicMock()
+        mock_web_ctx.favorite_service.remove = AsyncMock(return_value=True)
+        mock_web_ctx.favorite_price_alert_service = MagicMock()
+        mock_web_ctx.favorite_price_alert_service.remove_favorite = AsyncMock()
+        mock_web_ctx.price_subscription_service = MagicMock()
+        mock_web_ctx.price_subscription_service.remove_subscription = AsyncMock()
+
+        response = web_client.delete("/api/favorite/5930")
+        assert response.status_code == 200
+        assert response.json()["code"] == "005930"
+
+        mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_awaited_once_with("005930")
+        assert mock_web_ctx.price_subscription_service.remove_subscription.await_args_list[0].args == (
+            "005930",
+            "favorite",
+        )
+        assert mock_web_ctx.price_subscription_service.remove_subscription.await_args_list[1].args == (
+            "5930",
+            "favorite",
+        )
 
 
 async def test_get_favorite_list_overseas_passes_market(web_client, mock_web_ctx):

--- a/view/web/routes/favorite.py
+++ b/view/web/routes/favorite.py
@@ -4,6 +4,7 @@
 import asyncio
 from fastapi import APIRouter, HTTPException, Query
 from repositories.favorite_repository import MARKET_DOMESTIC, MARKET_OVERSEAS_US
+from services.favorite_service import _normalize_domestic_code
 from view.web.api_common import _get_ctx
 
 router = APIRouter(prefix="/favorite", tags=["favorite"])
@@ -59,22 +60,23 @@ async def add_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
     _validate_market(market)
     ctx = _get_ctx()
     added = await ctx.favorite_service.add(code, market=market)
+    effective_code = _normalize_domestic_code(code) if market == MARKET_DOMESTIC else code
     if added and market == MARKET_DOMESTIC:
         alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
         if alert_service:
-            await alert_service.add_favorite(code)
+            await alert_service.add_favorite(effective_code)
         price_subscription_service = _ctx_attr(ctx, "price_subscription_service")
         if price_subscription_service:
             try:
                 from services.price_subscription_service import SubscriptionPriority
                 await price_subscription_service.add_subscription(
-                    code,
+                    effective_code,
                     SubscriptionPriority.MEDIUM,
                     "favorite",
                 )
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 추가 실패: {e}")
-    return {"success": True, "added": added, "code": code, "market": market}
+    return {"success": True, "added": added, "code": effective_code, "market": market}
 
 
 @router.delete("/{code}")
@@ -83,17 +85,20 @@ async def remove_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
     _validate_market(market)
     ctx = _get_ctx()
     removed = await ctx.favorite_service.remove(code, market=market)
+    effective_code = _normalize_domestic_code(code) if market == MARKET_DOMESTIC else code
     if removed and market == MARKET_DOMESTIC:
         alert_service = _ctx_attr(ctx, "favorite_price_alert_service")
         if alert_service:
-            await alert_service.remove_favorite(code)
+            await alert_service.remove_favorite(effective_code)
         price_subscription_service = _ctx_attr(ctx, "price_subscription_service")
         if price_subscription_service:
             try:
-                await price_subscription_service.remove_subscription(code, "favorite")
+                await price_subscription_service.remove_subscription(effective_code, "favorite")
+                if effective_code != code:
+                    await price_subscription_service.remove_subscription(code, "favorite")
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 제거 실패: {e}")
-    return {"success": True, "removed": removed, "code": code, "market": market}
+    return {"success": True, "removed": removed, "code": effective_code, "market": market}
 
 
 @router.get("/{code}/status")


### PR DESCRIPTION
## Summary
- Normalize domestic favorite codes before syncing route-level alert cache and realtime price subscriptions
- Return canonical 6-digit domestic code from favorite add/remove APIs
- Remove both canonical and legacy unpadded subscription refs when deleting an unpadded domestic code
- Add regression tests for /api/favorite/5930 add/remove paths

## Cause
The previous fix normalized stored favorites and alert matching, but POST /api/favorite/{code} still passed the original route parameter to PriceSubscriptionService. If the user added 5930, the API stored 005930 but subscribed realtime price with 5930, so KIS ticks never arrived and the 5% alert could not fire.

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/view/web/routes/test_web_routes_favorite.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_favorite_service.py tests/unit_test/services/test_favorite_price_alert_service.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v