### PR TITLE
Fix market regime data freshness

### DIFF
--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -554,7 +554,15 @@ class MarketDataService:
         if not raw or raw.rt_cd != ErrorCode.SUCCESS.value: return raw
         return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data=self._normalize_ohlcv_rows(raw.data))
 
-    async def get_recent_daily_ohlcv(self, code: str, limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE, end_date: Optional[str] = None, start_date: Optional[str] = None, exchange: Exchange = Exchange.KRX) -> List[Dict[str, Any]]:
+    async def get_recent_daily_ohlcv(
+        self,
+        code: str,
+        limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE,
+        end_date: Optional[str] = None,
+        start_date: Optional[str] = None,
+        exchange: Exchange = Exchange.KRX,
+        force_refresh: bool = False,
+    ) -> List[Dict[str, Any]]:
         """
         최근 'limit'개 *거래일* 일봉을 반환.
         API는 시작/종료일 범위를 요구하므로 넉넉한 범위로 받아서 슬라이스로 limit개 보장.
@@ -571,8 +579,9 @@ class MarketDataService:
         t_start = self.pm.start_timer()
         current_ed_dt = datetime.strptime(end_date, "%Y%m%d") if end_date else self._market_clock.get_current_kst_time()
 
-        # DB-first: start_date가 지정되지 않은 경우에만 시도 (end_date가 있어도 DB 데이터 슬라이싱으로 대응)
-        if not start_date and self._stock_repo:
+        # DB-first: start_date/강제 갱신이 지정되지 않은 경우에만 시도
+        # (end_date가 있어도 DB 데이터 슬라이싱으로 대응)
+        if not start_date and not force_refresh and self._stock_repo:
             fetch_limit = 600 if end_date else limit
             stock_data = await self._stock_repo.get_stock_data(code, ohlcv_limit=fetch_limit, caller="get_recent_daily_ohlcv")
             if stock_data:

--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from common.date_utils import previous_trading_day_str
 from common.types import ErrorCode
 from core.market_clock import MarketClock
 from services.stock_query_service import StockQueryService
@@ -46,6 +47,7 @@ class RegimeSnapshot:
     max_daily_drop_pct: float
     ma_values: List[float] = field(default_factory=list)
     fail_detail: str = ""
+    data_date: str = ""       # 판정에 사용한 마지막 확정 일봉 날짜 (YYYYMMDD)
 
 
 class MarketRegimeService:
@@ -118,10 +120,26 @@ class MarketRegimeService:
         period = self._cfg.ma_period
         days = self._cfg.rising_days
 
-        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(etf_code, limit=period + days + 5)
+        force_refresh = as_of_date is None
+        query_end_date = as_of_date
+        if force_refresh:
+            now = self._tm.get_current_kst_time()
+            query_end_date = (
+                previous_trading_day_str(now)
+                if self._tm.is_market_operating_hours()
+                else now.strftime("%Y%m%d")
+            )
+
+        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(
+            etf_code,
+            limit=period + days + 5,
+            end_date=query_end_date,
+            force_refresh=force_refresh,
+        )
         ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
         if as_of_date:
             ohlcv = [r for r in ohlcv if r.get("date", "") <= as_of_date]
+        data_date = ohlcv[-1].get("date", "") if ohlcv else ""
 
         if not ohlcv or len(ohlcv) < period + days:
             snap = RegimeSnapshot(
@@ -134,6 +152,7 @@ class MarketRegimeService:
                 max_daily_drop_pct=0.0,
                 ma_values=[],
                 fail_detail="insufficient data",
+                data_date=data_date,
             )
             logger.debug({
                 "event": "market_regime_check",
@@ -193,6 +212,7 @@ class MarketRegimeService:
             max_daily_drop_pct=round(max_daily_drop_pct, 3),
             ma_values=[round(v, 2) for v in ma_values],
             fail_detail=fail_detail,
+            data_date=data_date,
         )
         logger.debug({
             "event": "market_regime_check",

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1031,6 +1031,7 @@ class OneilUniverseService:
 
                 ma_str = " ➔ ".join([f"{v:.2f}" for v in snap.ma_values])
                 msg = f"• 지수: {market} ({code})\n• 상태: {status_text}\n"
+                msg += f"• 데이터 기준일: {snap.data_date or '확인 불가'}\n"
                 if not is_rising and snap.fail_detail:
                     msg += f"• 사유: {snap.fail_detail}\n"
                 msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1244,14 +1244,27 @@ class StockQueryService:
             self.logger.error(f"{stock_code} OHLCV+지표 통합 조회 중 오류: {e}", exc_info=True)
             return ResCommonResponse(rt_cd=ErrorCode.UNKNOWN_ERROR.value, msg1=str(e), data=None)
 
-    async def get_recent_daily_ohlcv(self, stock_code: str, limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE, end_date: Optional[str] = None, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+    async def get_recent_daily_ohlcv(
+        self,
+        stock_code: str,
+        limit: int = DynamicConfig.OHLCV.DAILY_ITEMCHARTPRICE_MAX_RANGE,
+        end_date: Optional[str] = None,
+        exchange: Exchange = Exchange.KRX,
+        force_refresh: bool = False,
+    ) -> ResCommonResponse:
         """
         타겟 종목의 최근 일봉을 limit개 반환.
         TradingService.get_recent_daily_ohlcv를 래핑하여 ResCommonResponse 형태로 통일.
         exchange 가 해외(NASD/NYSE/AMEX)면 해외 일봉 API로 위임된다.
         """
         try:
-            rows = await self.market_data_service.get_recent_daily_ohlcv(stock_code, limit=limit, end_date=end_date, exchange=exchange)
+            rows = await self.market_data_service.get_recent_daily_ohlcv(
+                stock_code,
+                limit=limit,
+                end_date=end_date,
+                exchange=exchange,
+                force_refresh=force_refresh,
+            )
             if not rows:
                 return ResCommonResponse(rt_cd=ErrorCode.EMPTY_VALUES.value, msg1="데이터 없음", data=[])
             return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="성공", data=rows)

--- a/tests/unit_test/services/test_market_data_service.py
+++ b/tests/unit_test/services/test_market_data_service.py
@@ -896,6 +896,44 @@ async def test_get_recent_daily_ohlcv_db_first_when_sufficient(trading_service_f
 
 
 @pytest.mark.asyncio
+async def test_get_recent_daily_ohlcv_force_refresh_bypasses_stale_db(trading_service_fixture, mock_deps):
+    """force_refresh=True이면 DB 건수가 충분해도 API에서 최신 일봉을 다시 조회한다."""
+    broker = mock_deps.broker
+    service = trading_service_fixture
+    mock_deps.stock_repo.get_stock_data.return_value = {
+        "ohlcv": [
+            {"date": f"2025010{i}", "open": 100, "high": 110, "low": 90, "close": 105, "volume": 1000}
+            for i in range(1, 6)
+        ],
+        "historical_complete": True,
+    }
+    broker.inquire_daily_itemchartprice.return_value = ResCommonResponse(
+        rt_cd="0",
+        msg1="OK",
+        data=[
+            {
+                "stck_bsop_date": "20260513",
+                "stck_clpr": "120",
+                "stck_oprc": "115",
+                "stck_hgpr": "125",
+                "stck_lwpr": "110",
+                "acml_vol": "1000",
+            }
+        ],
+    )
+
+    result = await service.get_recent_daily_ohlcv(
+        "069500",
+        limit=5,
+        end_date="20260513",
+        force_refresh=True,
+    )
+
+    broker.inquire_daily_itemchartprice.assert_awaited()
+    assert result[-1]["date"] == "20260513"
+
+
+@pytest.mark.asyncio
 async def test_get_recent_daily_ohlcv_no_api_call_during_market_hours_when_db_full(trading_service_fixture, mock_deps):
     """장중(is_market_open=True) + ohlcv_update_task로 DB가 완전히 채워진 상태에서
     get_recent_daily_ohlcv 호출 시 OHLCV API(inquire_daily_itemchartprice)가 절대 호출되지 않아야 한다.

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -27,6 +27,7 @@ def _make_service(closes, *, today="20260514"):
     )
     tm = MagicMock()
     tm.get_current_kst_time = MagicMock(return_value=datetime.strptime(today, "%Y%m%d"))
+    tm.is_market_operating_hours = MagicMock(return_value=False)
     cfg = MarketRegimeConfig(
         kospi_etf_code="069500",
         kosdaq_etf_code="229200",
@@ -52,6 +53,25 @@ async def test_classify_rising_returns_bull():
     assert snap.trend_status == "rising"
     assert snap.regime_label == "bull"
     assert snap.is_rising is True
+
+
+@pytest.mark.asyncio
+async def test_classify_live_forces_fresh_closed_ohlcv():
+    """실시간 국면 판정은 오래된 DB 캐시 대신 직전 확정 일봉을 강제 조회한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes)
+    svc._tm.get_current_kst_time.return_value = datetime(2026, 5, 14, 11, 21)
+    svc._tm.is_market_operating_hours.return_value = True
+
+    snap = await svc.classify("KOSPI")
+
+    sqs.get_recent_daily_ohlcv.assert_awaited_once_with(
+        "069500",
+        limit=12,
+        end_date="20260513",
+        force_refresh=True,
+    )
+    assert snap.data_date == "20260108"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1775,7 +1775,7 @@ async def test_update_market_timing_emits_notifications(mock_deps):
             market=market, trend_status="rising" if is_rising else "hard_decline",
             regime_label="bull" if is_rising else "bear", snapshot_date="20260514",
             is_rising=is_rising, net_change_pct=0.0, max_daily_drop_pct=0.0,
-            ma_values=ma_values, fail_detail=fail,
+            ma_values=ma_values, fail_detail=fail, data_date="20260514",
         )
 
     service._regime_svc.classify = AsyncMock(side_effect=[
@@ -1796,6 +1796,7 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     }
     assert "KOSDAQ" in call_kwargs["message"]
     assert "KOSPI" in call_kwargs["message"]
+    assert call_kwargs["message"].count("데이터 기준일: 20260514") == 2
     assert "MA decline" in call_kwargs["message"]
 
 

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -1633,7 +1633,13 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         # Assert
         from common.types import Exchange
-        self.mock_market_data_service.get_recent_daily_ohlcv.assert_awaited_once_with("005930", limit=10, end_date=None, exchange=Exchange.KRX)
+        self.mock_market_data_service.get_recent_daily_ohlcv.assert_awaited_once_with(
+            "005930",
+            limit=10,
+            end_date=None,
+            exchange=Exchange.KRX,
+            force_refresh=False,
+        )
         self.assertEqual(result.rt_cd, ErrorCode.SUCCESS.value)
         self.assertEqual(result.data, rows)
 


### PR DESCRIPTION
﻿## What changed

- Added an explicit `force_refresh` path for recent daily OHLCV queries.
- Made live market-regime classification bypass stale DB-first ETF data.
- During market hours, calculate the regime from the previous completed trading-day candle; outside market hours, query through the current date.
- Added the actual OHLCV data date to regime snapshots and market-timing notifications.
- Added regression tests for stale DB bypass, closed-candle selection, forwarding, and notification output.

## Why

Market timing used KODEX 200 and KODEX KOSDAQ 150 as index proxies, but the after-market OHLCV collector excludes ETFs. Because the recent-OHLCV path accepted any sufficiently large DB result without checking freshness, old ETF rows from April and June were repeatedly classified as the July market regime.

## Impact

Live strategy scans now use freshly fetched, completed ETF daily candles. If a fresh API query fails, the regime fails closed instead of silently accepting stale data. Notifications expose the data date so operators can verify freshness immediately.

## Validation

- `pytest tests/unit_test -v` ? 7,278 passed
- `pytest tests/integration_test -v` ? 271 passed
