### PR TITLE
Fix favorite price alert reliability

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -24,6 +24,7 @@ class FavoritePriceAlertService:
         threshold_step_pct: float = 5.0,
         upper_limit_rate_pct: float = 29.5,
         favorite_cache_ttl_sec: float = 30.0,
+        alert_cooldown_sec: float = 300.0,
         logger=None,
     ) -> None:
         self._favorite_repository = favorite_repository
@@ -32,10 +33,12 @@ class FavoritePriceAlertService:
         self._threshold_step_pct = float(threshold_step_pct)
         self._upper_limit_rate_pct = float(upper_limit_rate_pct)
         self._favorite_cache_ttl_sec = float(favorite_cache_ttl_sec)
+        self._alert_cooldown_sec = float(alert_cooldown_sec)
         self._logger = logger or logging.getLogger(__name__)
         self._favorite_codes: set[str] = set()
         self._favorite_cache_ts: float = 0.0
         self._last_alert_bucket: dict[str, int] = {}
+        self._last_alert_ts_by_bucket: dict[tuple[str, int], float] = {}
         self._upper_limit_alerted_codes: set[str] = set()
 
     async def add_favorite(self, code: str) -> None:
@@ -51,6 +54,8 @@ class FavoritePriceAlertService:
             return
         self._favorite_codes.discard(normalized)
         self._last_alert_bucket.pop(normalized, None)
+        for key in [key for key in self._last_alert_ts_by_bucket if key[0] == normalized]:
+            self._last_alert_ts_by_bucket.pop(key, None)
         self._upper_limit_alerted_codes.discard(normalized)
 
     async def handle_price_tick(
@@ -93,6 +98,17 @@ class FavoritePriceAlertService:
             return False
 
         self._last_alert_bucket[normalized] = bucket
+        cooldown_key = (normalized, bucket)
+        now = time.monotonic()
+        last_alert_ts = self._last_alert_ts_by_bucket.get(cooldown_key, 0.0)
+        if (
+            self._alert_cooldown_sec > 0
+            and last_alert_ts > 0
+            and now - last_alert_ts < self._alert_cooldown_sec
+        ):
+            return False
+        self._last_alert_ts_by_bucket[cooldown_key] = now
+
         threshold_pct = int(bucket * self._threshold_step_pct)
         name = self._stock_name(normalized)
         direction = "상승" if threshold_pct > 0 else "하락"

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -56,6 +56,7 @@ class SubscriptionPolicy:
     """
 
     MAX_WS_SLOTS = 40  # KIS 웹소켓 최대 구독 한도 (PT=1슬롯, Price=1슬롯)
+    _PERSISTENT_PRICE_CATEGORIES = frozenset({"favorite"})
 
     def __init__(
         self,
@@ -156,11 +157,13 @@ class SubscriptionPolicy:
 
         REST fallback이 필요한 수준이면 해당 가격 구독은 신뢰하지 않고,
         다음 조회부터 StockRepository의 streaming TTL 우회를 타지 않도록 정리한다.
+        다만 관심종목 알림은 지속 구독 의도를 보존하고 연결만 새로 맺는다.
         """
         if not code:
             return False
 
         removed = False
+        preserved_price_ref = False
         if code in self._refs:
             price_categories = [
                 category_key
@@ -168,12 +171,15 @@ class SubscriptionPolicy:
                 if request.get("type") == StreamingType.UNIFIED_PRICE
             ]
             for category_key in price_categories:
+                if category_key in self._PERSISTENT_PRICE_CATEGORIES:
+                    preserved_price_ref = True
+                    continue
                 self._refs[code].pop(category_key, None)
                 removed = True
             if not self._refs.get(code):
                 self._refs.pop(code, None)
 
-        if self._streaming_stock_repo:
+        if self._streaming_stock_repo and code not in self._refs:
             await self._streaming_stock_repo.unmark_desired(code, StreamingType.UNIFIED_PRICE)
 
         unsubscribed = False
@@ -186,7 +192,10 @@ class SubscriptionPolicy:
             if self._streaming_stock_repo:
                 await self._streaming_stock_repo.mark_inactive(code, StreamingType.UNIFIED_PRICE)
 
-        if self._streaming_logger and not unsubscribed:
+        if preserved_price_ref:
+            await self._rebalance()
+
+        if self._streaming_logger and not unsubscribed and not preserved_price_ref:
             self._streaming_logger.log_unsubscribe(
                 code=code,
                 active_count=len(self._active_codes_price) + len(self._active_codes_pt),

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -60,6 +60,26 @@ async def test_does_not_repeat_same_five_percent_bucket_until_next_bucket():
 
 
 @pytest.mark.asyncio
+async def test_does_not_repeat_bucket_when_rate_chatters_around_threshold():
+    """5% 경계를 짧게 왕복해도 같은 구간 알림은 쿨다운 동안 한 번만 발행한다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(
+        repo,
+        notifications,
+        alert_cooldown_sec=300.0,
+    )
+
+    await svc.handle_price_tick("005930", price="70000", rate="-5.01")
+    await svc.handle_price_tick("005930", price="70050", rate="-4.99")
+    await svc.handle_price_tick("005930", price="70000", rate="-5.02")
+
+    notifications.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_alerts_negative_five_percent_bucket():
     repo = MagicMock()
     repo.get_all = AsyncMock(return_value=["005930"])

--- a/tests/unit_test/services/test_price_subscription_service.py
+++ b/tests/unit_test/services/test_price_subscription_service.py
@@ -163,6 +163,37 @@ async def test_drop_unhealthy_price_subscription_removes_all_price_refs(svc, moc
     mock_stock_repo.unmark_streaming.assert_called_once_with("005930")
 
 
+async def test_drop_unhealthy_price_subscription_preserves_and_reconnects_favorite(
+    svc, mock_streaming, mock_stock_repo
+):
+    """비정상 스트림을 끊어도 관심종목 의도는 보존하고 즉시 재구독한다."""
+    await svc.add_subscription(
+        "009150",
+        SubscriptionPriority.MEDIUM,
+        "favorite",
+        StreamingType.UNIFIED_PRICE,
+    )
+    await svc.add_subscription(
+        "009150",
+        SubscriptionPriority.MEDIUM,
+        "strategy_oneil",
+        StreamingType.UNIFIED_PRICE,
+    )
+    mock_streaming.reset_mock()
+    mock_stock_repo.reset_mock()
+
+    removed = await svc.drop_unhealthy_price_subscription(
+        "009150",
+        reason="stale_snapshot",
+    )
+
+    assert removed is True
+    assert set(svc._refs["009150"]) == {"favorite"}
+    assert svc.is_streaming("009150")
+    mock_streaming.unsubscribe_unified_price.assert_awaited_once_with("009150")
+    mock_streaming.subscribe_unified_price.assert_awaited_once_with("009150")
+
+
 # ── sync_subscriptions ────────────────────────────────────────────────────
 
 async def test_sync_subscriptions_atomic_replace(svc, mock_streaming):


### PR DESCRIPTION
## 변경 사항
- 관심종목 가격 스트림이 오래된 스냅샷으로 판정되면 일시 구독만 제거하고, 관심종목 구독 의도는 보존해 즉시 재연결합니다.
- 5% 경계 부근에서 등락률이 왕복할 때 같은 구간 알림이 반복되지 않도록 종목·구간별 5분 쿨다운을 적용합니다.
- 스트림 재연결과 경계 왕복 중복 알림을 검증하는 회귀 테스트를 추가했습니다.

## 원인
비정상 가격 스트림 정리 과정에서 `favorite` 구독 참조까지 영구 제거되어 이후 해당 종목의 틱이 알림 서비스에 전달되지 않았습니다. 또한 5% 경계 아래로 잠깐 내려가면 알림 구간이 즉시 초기화되어 같은 구간 알림이 반복될 수 있었습니다.

## 영향
오래된 관심종목 스트림은 자동 복구되며, 새 5% 구간 알림은 유지하면서 동일 구간의 짧은 반복 알림만 억제합니다.

## 검증
- `pytest tests/unit_test -v` — 7,280 passed
- `pytest tests/integration_test -v` — 271 passed