### PR TITLE
Fix favorite alert startup and fallback

### DIFF
--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -499,6 +499,7 @@ def _build_mock_web_ctx(is_paper: bool = True):
 
     # initialize_services (환경 전환용)
     mock_ctx.initialize_services = AsyncMock(return_value=True)
+    mock_ctx._initialize_price_subscriptions = AsyncMock()
     mock_ctx.start_background_tasks = MagicMock()
 
     return mock_ctx

--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -425,7 +425,10 @@ class TestEnvironmentPaper:
         assert body["success"] is True
         assert body["env_type"] == "실전투자"
         mock_paper_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
-        mock_paper_ctx.start_background_tasks.assert_called_once()
+        mock_paper_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+        mock_paper_ctx.start_background_tasks.assert_called_once_with(
+            schedule_price_subscriptions=False,
+        )
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, paper_client, mock_paper_ctx):

--- a/tests/integration_test/test_it_web_api_real.py
+++ b/tests/integration_test/test_it_web_api_real.py
@@ -390,7 +390,10 @@ class TestEnvironmentReal:
         assert body["success"] is True
         assert body["env_type"] == "모의투자"
         mock_real_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
-        mock_real_ctx.start_background_tasks.assert_called_once()
+        mock_real_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+        mock_real_ctx.start_background_tasks.assert_called_once_with(
+            schedule_price_subscriptions=False,
+        )
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, real_client, mock_real_ctx):

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -84,6 +84,7 @@ def fake_web_ctx():
     ctx.initialize_services = AsyncMock(return_value=True)
     ctx.initialize_scheduler = MagicMock()
     ctx.ensure_strategy_states_loaded = AsyncMock()
+    ctx._initialize_price_subscriptions = AsyncMock()
     ctx.start_background_tasks = MagicMock()
     ctx.shutdown = AsyncMock()
 
@@ -169,7 +170,10 @@ def test_web_main_lifespan_initializes_and_shutdowns_context(fake_web_ctx, mocke
         fake_web_ctx.scheduler.restore_state.assert_not_awaited()
         fake_web_ctx.order_execution_service.restore_state_from_broker.assert_awaited_once_with()
         fake_web_ctx.order_execution_service.reconcile_orders_with_broker.assert_awaited_once_with()
-        fake_web_ctx.start_background_tasks.assert_called_once_with()
+        fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+        fake_web_ctx.start_background_tasks.assert_called_once_with(
+            schedule_price_subscriptions=False,
+        )
         assert api_common._ctx is fake_web_ctx
 
     fake_web_ctx.shutdown.assert_awaited_once_with()
@@ -368,6 +372,7 @@ def test_real_app_environment_switch_requires_real_confirmation_and_restarts_ser
     fake_web_ctx,
 ):
     fake_web_ctx.initialize_services.reset_mock()
+    fake_web_ctx._initialize_price_subscriptions.reset_mock()
     fake_web_ctx.start_background_tasks.reset_mock()
     fake_web_ctx.get_env_type.return_value = "실전투자"
 
@@ -386,4 +391,7 @@ def test_real_app_environment_switch_requires_real_confirmation_and_restarts_ser
     assert allowed.status_code == 200
     assert allowed.json() == {"success": True, "env_type": "실전투자"}
     fake_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
-    fake_web_ctx.start_background_tasks.assert_called_once_with()
+    fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+    fake_web_ctx.start_background_tasks.assert_called_once_with(
+        schedule_price_subscriptions=False,
+    )

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -171,6 +171,8 @@ def mock_web_ctx():
     ctx.streaming_service = AsyncMock()
     ctx.order_execution_service = AsyncMock()
     ctx.broker = AsyncMock()
+    ctx._initialize_price_subscriptions = AsyncMock()
+    ctx.start_background_tasks = MagicMock()
     ctx.virtual_trade_service = MagicMock()
     # [Fix] get_trade_amount가 연산에 사용되므로 float 반환 설정 (TypeError 방지)
     ctx.virtual_trade_service.get_trade_amount.side_effect = lambda p, q=1, **kwargs: float(p * q)

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -39,6 +39,7 @@ def mock_web_app_context_cls():
         mock_instance.scheduler.restore_state = AsyncMock()
         mock_instance.scheduler._running = True
         mock_instance.scheduler.stop = AsyncMock()
+        mock_instance._initialize_price_subscriptions = AsyncMock()
         mock_instance.start_background_tasks = MagicMock()
         mock_instance.shutdown = AsyncMock()
         oes = MagicMock()
@@ -71,7 +72,10 @@ async def test_lifespan_startup_shutdown(mock_web_app_context_cls, mock_web_api_
         # restore_state 는 BackgroundScheduler 어댑터에서 단일 진입하므로
         # lifespan 에서 직접 await 하지 않는다.
         mock_ctx.scheduler.restore_state.assert_not_awaited()
-        mock_ctx.start_background_tasks.assert_called_once()
+        mock_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+        mock_ctx.start_background_tasks.assert_called_once_with(
+            schedule_price_subscriptions=False,
+        )
     
     # Shutdown checks
     mock_ctx.shutdown.assert_awaited_once()

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -453,6 +453,10 @@ async def test_change_environment(web_client, mock_web_ctx):
     assert response.json()["success"] is True
     assert response.json()["env_type"] == "실전투자"
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
+    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+    mock_web_ctx.start_background_tasks.assert_called_once_with(
+        schedule_price_subscriptions=False,
+    )
 
 
 @pytest.mark.asyncio
@@ -474,6 +478,10 @@ async def test_change_environment_to_paper_does_not_require_confirmation(web_cli
 
     assert response.status_code == 200
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
+    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
+    mock_web_ctx.start_background_tasks.assert_called_once_with(
+        schedule_price_subscriptions=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -489,6 +489,37 @@ async def test_refresh_price_from_rest_caches_snapshot(mock_deps):
 
 
 @pytest.mark.asyncio
+async def test_refresh_price_from_rest_evaluates_favorite_alert(mock_deps):
+    """체결 틱이 없어 REST로 보강한 가격도 관심종목 등락률 알림을 평가한다."""
+    ctx = WebAppContext(None)
+    ctx.stock_query_service = MagicMock()
+    ctx.stock_query_service.get_current_price = AsyncMock(return_value=MagicMock(
+        rt_cd="0",
+        data={
+            "output": {
+                "stck_prpr": "50200",
+                "prdy_vrss": "-4900",
+                "prdy_ctrt": "-8.89",
+                "prdy_vrss_sign": "5",
+                "acml_vol": "1000",
+            }
+        },
+    ))
+    ctx.price_stream_service = MagicMock()
+    ctx.favorite_price_alert_service = MagicMock()
+    ctx.favorite_price_alert_service.handle_price_tick = AsyncMock()
+
+    await ctx._refresh_price_from_rest("080220")
+
+    ctx.favorite_price_alert_service.handle_price_tick.assert_awaited_once_with(
+        "080220",
+        price="50200",
+        rate="-8.89",
+        sign="5",
+    )
+
+
+@pytest.mark.asyncio
 async def test_refresh_price_from_rest_logs_rest_failed(mock_deps):
     """REST 현재가 조회 실패 시 rest_failed 원인을 남긴다."""
     ctx = WebAppContext(None)

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -619,5 +619,6 @@ async def change_environment(req: EnvironmentRequest):
     _status_cache_ts = 0.0
     if not success:
         raise HTTPException(status_code=500, detail="환경 전환 실패 (토큰 발급 오류)")
-    ctx.start_background_tasks()
+    await ctx._initialize_price_subscriptions()
+    ctx.start_background_tasks(schedule_price_subscriptions=False)
     return {"success": True, "env_type": ctx.get_env_type()}

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -440,7 +440,7 @@ class WebAppContext:
                 f"실전 모드 bootstrap 차단: 전략 state load 실패 — {names}"
             )
 
-    def start_background_tasks(self):
+    def start_background_tasks(self, *, schedule_price_subscriptions: bool = True):
         """백그라운드 태스크 시작 — BackgroundScheduler에 위임."""
         from view.web.deployment_policy import is_demo_mode, is_public_mode
 
@@ -455,7 +455,8 @@ class WebAppContext:
         if self.background_scheduler:
             asyncio.create_task(self.background_scheduler.start_all())
 
-        self._schedule_price_subscription_initialization()
+        if schedule_price_subscriptions:
+            self._schedule_price_subscription_initialization()
 
     def _schedule_price_subscription_initialization(self):
         """초기 가격 구독 task를 background lifecycle에 맞춰 시작한다."""
@@ -629,6 +630,13 @@ class WebAppContext:
             sign=_get("prdy_vrss_sign", "3"),
             volume=_get("acml_vol", "0"),
         )
+        if self.favorite_price_alert_service:
+            await self.favorite_price_alert_service.handle_price_tick(
+                code,
+                price=price,
+                rate=_get("prdy_ctrt", "0.00"),
+                sign=_get("prdy_vrss_sign", "3"),
+            )
 
     async def start_program_trading(self, code: str) -> bool:
         """프로그램매매 구독 시작 (웹소켓 연결 + 구독). 이미 구독 중이면 스킵."""

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -135,8 +135,13 @@ async def lifespan(app: FastAPI):
         await ctx.order_execution_service.restore_state_from_broker()
         await ctx.order_execution_service.reconcile_orders_with_broker()
 
+    # 관심종목 구독은 다른 백그라운드 구독 작업과 경합하지 않도록 기동 중 완료한다.
+    from view.web.deployment_policy import is_demo_mode, is_public_mode
+    if not (is_public_mode(ctx) or is_demo_mode(ctx)):
+        await ctx._initialize_price_subscriptions()
+
     # 백그라운드 태스크 시작 — StrategySchedulerTaskAdapter 가 restore_state() 호출
-    ctx.start_background_tasks()
+    ctx.start_background_tasks(schedule_price_subscriptions=False)
 
     print("=== 웹 서비스 초기화 완료 ===")
     yield


### PR DESCRIPTION
## What changed

- Await favorite, portfolio, and premium price subscriptions during application startup and environment switches.
- Prevent the background scheduler from scheduling the same subscription initialization a second time.
- Route validated force-fresh REST price snapshots through `FavoritePriceAlertService` when a subscribed symbol has no unified price tick.
- Add regression coverage for startup, environment switching, and REST fallback alert evaluation.

## Why

Favorite subscription initialization was fire-and-forget and could race with other websocket/background startup work. Favorites could therefore remain unsubscribed until the favorites API was opened. In addition, the forced REST fallback cached a valid current price but did not evaluate the favorite alert threshold, so no-tick symbols such as 080220 could miss a 5% move alert.

## Impact

Favorites are subscribed before other background tasks begin, including after an investment-environment switch. Symbols without a live unified price tick can now use the existing 5% bucket and cooldown alert behavior with the validated REST fallback price.

## Validation

- `pytest tests/unit_test -v` — 7,281 passed
- `pytest tests/integration_test -v` — 271 passed
