### PR TITLE
Prevent subscription startup blocking

### DIFF
--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -107,7 +107,8 @@ class SubscriptionPolicy:
 
     async def add_subscription(
         self, code: str, priority: SubscriptionPriority, 
-        category_key: str, stream_type: StreamingType = StreamingType.UNIFIED_PRICE
+        category_key: str, stream_type: StreamingType = StreamingType.UNIFIED_PRICE,
+        *, rebalance: bool = True,
     ) -> bool:
         """
         구독을 요청합니다. 
@@ -128,7 +129,8 @@ class SubscriptionPolicy:
         }
         
         # 3. 재조정 (Rebalance)
-        await self._rebalance()
+        if rebalance:
+            await self._rebalance()
         return True
 
     async def remove_subscription(self, code: str, category_key: str) -> None:
@@ -212,6 +214,8 @@ class SubscriptionPolicy:
         category_key: str,
         priority: SubscriptionPriority,
         stream_type: StreamingType = StreamingType.UNIFIED_PRICE,
+        *,
+        rebalance: bool = True,
     ) -> None:
         """
         카테고리 전체를 새 코드 목록으로 원자적으로 교체합니다.
@@ -245,7 +249,8 @@ class SubscriptionPolicy:
                     source="program",
                 )
 
-        await self._rebalance()
+        if rebalance:
+            await self._rebalance()
 
     def is_streaming(self, code: str) -> bool:
         """해당 종목이 현재 실시간 구독 중인지 여부."""

--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -425,10 +425,8 @@ class TestEnvironmentPaper:
         assert body["success"] is True
         assert body["env_type"] == "실전투자"
         mock_paper_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
-        mock_paper_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-        mock_paper_ctx.start_background_tasks.assert_called_once_with(
-            schedule_price_subscriptions=False,
-        )
+        mock_paper_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+        mock_paper_ctx.start_background_tasks.assert_called_once_with()
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, paper_client, mock_paper_ctx):

--- a/tests/integration_test/test_it_web_api_real.py
+++ b/tests/integration_test/test_it_web_api_real.py
@@ -390,10 +390,8 @@ class TestEnvironmentReal:
         assert body["success"] is True
         assert body["env_type"] == "모의투자"
         mock_real_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
-        mock_real_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-        mock_real_ctx.start_background_tasks.assert_called_once_with(
-            schedule_price_subscriptions=False,
-        )
+        mock_real_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+        mock_real_ctx.start_background_tasks.assert_called_once_with()
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, real_client, mock_real_ctx):

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -170,10 +170,8 @@ def test_web_main_lifespan_initializes_and_shutdowns_context(fake_web_ctx, mocke
         fake_web_ctx.scheduler.restore_state.assert_not_awaited()
         fake_web_ctx.order_execution_service.restore_state_from_broker.assert_awaited_once_with()
         fake_web_ctx.order_execution_service.reconcile_orders_with_broker.assert_awaited_once_with()
-        fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-        fake_web_ctx.start_background_tasks.assert_called_once_with(
-            schedule_price_subscriptions=False,
-        )
+        fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+        fake_web_ctx.start_background_tasks.assert_called_once_with()
         assert api_common._ctx is fake_web_ctx
 
     fake_web_ctx.shutdown.assert_awaited_once_with()
@@ -391,7 +389,5 @@ def test_real_app_environment_switch_requires_real_confirmation_and_restarts_ser
     assert allowed.status_code == 200
     assert allowed.json() == {"success": True, "env_type": "실전투자"}
     fake_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
-    fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-    fake_web_ctx.start_background_tasks.assert_called_once_with(
-        schedule_price_subscriptions=False,
-    )
+    fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+    fake_web_ctx.start_background_tasks.assert_called_once_with()

--- a/tests/unit_test/services/test_price_subscription_service.py
+++ b/tests/unit_test/services/test_price_subscription_service.py
@@ -217,6 +217,27 @@ async def test_sync_subscriptions_calls_rebalance_once(svc, mock_streaming):
     assert mock_streaming.subscribe_unified_price.call_count == 3
 
 
+async def test_register_only_subscriptions_do_not_start_websocket(svc, mock_streaming):
+    """기동 전 구독 의도 등록은 실제 WebSocket 구독을 시작하지 않는다."""
+    await svc.add_subscription(
+        "005930",
+        SubscriptionPriority.HIGH,
+        "portfolio",
+        StreamingType.UNIFIED_PRICE,
+        rebalance=False,
+    )
+    await svc.sync_subscriptions(
+        ["000660", "080220"],
+        "favorite",
+        SubscriptionPriority.MEDIUM,
+        rebalance=False,
+    )
+
+    assert set(svc._refs) == {"005930", "000660", "080220"}
+    mock_streaming.connect_websocket.assert_not_called()
+    mock_streaming.subscribe_unified_price.assert_not_awaited()
+
+
 # ── get_status ────────────────────────────────────────────────────────────
 
 async def test_get_status_reflects_current_state(svc):

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -72,10 +72,8 @@ async def test_lifespan_startup_shutdown(mock_web_app_context_cls, mock_web_api_
         # restore_state 는 BackgroundScheduler 어댑터에서 단일 진입하므로
         # lifespan 에서 직접 await 하지 않는다.
         mock_ctx.scheduler.restore_state.assert_not_awaited()
-        mock_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-        mock_ctx.start_background_tasks.assert_called_once_with(
-            schedule_price_subscriptions=False,
-        )
+        mock_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+        mock_ctx.start_background_tasks.assert_called_once_with()
     
     # Shutdown checks
     mock_ctx.shutdown.assert_awaited_once()

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -453,10 +453,8 @@ async def test_change_environment(web_client, mock_web_ctx):
     assert response.json()["success"] is True
     assert response.json()["env_type"] == "실전투자"
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
-    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-    mock_web_ctx.start_background_tasks.assert_called_once_with(
-        schedule_price_subscriptions=False,
-    )
+    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+    mock_web_ctx.start_background_tasks.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -478,10 +476,8 @@ async def test_change_environment_to_paper_does_not_require_confirmation(web_cli
 
     assert response.status_code == 200
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
-    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with()
-    mock_web_ctx.start_background_tasks.assert_called_once_with(
-        schedule_price_subscriptions=False,
-    )
+    mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
+    mock_web_ctx.start_background_tasks.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -619,6 +619,6 @@ async def change_environment(req: EnvironmentRequest):
     _status_cache_ts = 0.0
     if not success:
         raise HTTPException(status_code=500, detail="환경 전환 실패 (토큰 발급 오류)")
-    await ctx._initialize_price_subscriptions()
-    ctx.start_background_tasks(schedule_price_subscriptions=False)
+    await ctx._initialize_price_subscriptions(rebalance=False)
+    ctx.start_background_tasks()
     return {"success": True, "env_type": ctx.get_env_type()}

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -299,7 +299,7 @@ class WebAppContext:
         from view.web.bootstrap.scheduler_bootstrap import SchedulerBootstrap
         SchedulerBootstrap(self).run()
 
-    async def _initialize_price_subscriptions(self) -> None:
+    async def _initialize_price_subscriptions(self, *, rebalance: bool = True) -> None:
         """기동 시 포트폴리오(HIGH) 및 프리미엄 종목(MEDIUM) 구독을 초기화."""
         if not self.price_subscription_service:
             return
@@ -313,7 +313,11 @@ class WebAppContext:
                 code = item.get("code", "").strip()
                 if code:
                     await self.price_subscription_service.add_subscription(
-                        code, SubscriptionPriority.HIGH, "portfolio", StreamingType.UNIFIED_PRICE
+                        code,
+                        SubscriptionPriority.HIGH,
+                        "portfolio",
+                        StreamingType.UNIFIED_PRICE,
+                        rebalance=rebalance,
                     )
         except Exception as e:
             self.logger.warning(f"보유 종목 구독 초기화 실패: {e}")
@@ -336,6 +340,7 @@ class WebAppContext:
                         codes=codes,
                         category_key="strategy_premium",
                         priority=SubscriptionPriority.MEDIUM,
+                        rebalance=rebalance,
                     )
         except Exception as e:
             self.logger.warning(f"프리미엄 종목 구독 초기화 실패: {e}")
@@ -353,6 +358,7 @@ class WebAppContext:
                     codes=favorite_codes,
                     category_key="favorite",
                     priority=SubscriptionPriority.MEDIUM,
+                    rebalance=rebalance,
                 )
                 self.logger.info(f"관심종목 구독 초기화 완료: {len(favorite_codes)}개")
         except Exception as e:

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -135,13 +135,13 @@ async def lifespan(app: FastAPI):
         await ctx.order_execution_service.restore_state_from_broker()
         await ctx.order_execution_service.reconcile_orders_with_broker()
 
-    # 관심종목 구독은 다른 백그라운드 구독 작업과 경합하지 않도록 기동 중 완료한다.
+    # 관심종목 구독 의도는 기동 중 등록하고 실제 WebSocket 재조정은 백그라운드에서 수행한다.
     from view.web.deployment_policy import is_demo_mode, is_public_mode
     if not (is_public_mode(ctx) or is_demo_mode(ctx)):
-        await ctx._initialize_price_subscriptions()
+        await ctx._initialize_price_subscriptions(rebalance=False)
 
     # 백그라운드 태스크 시작 — StrategySchedulerTaskAdapter 가 restore_state() 호출
-    ctx.start_background_tasks(schedule_price_subscriptions=False)
+    ctx.start_background_tasks()
 
     print("=== 웹 서비스 초기화 완료 ===")
     yield


### PR DESCRIPTION
## What changed

- Add a register-only mode to subscription policy updates.
- Register portfolio, premium, and favorite subscription intent before startup completes without initiating WebSocket I/O.
- Run the actual subscription rebalance from the existing background initialization task.
- Apply the same sequencing after investment environment switches.
- Add regression coverage proving register-only initialization does not connect the WebSocket.

## Why

PR #742 awaited the full WebSocket rebalance during FastAPI lifespan startup. In the live runtime, the market-status subscription path raised inside its retry queue and left startup waiting indefinitely, so port 8000 never opened.

The favorite subscription intent still needs to exist before other background tasks begin, but network ACK handling must not block application availability.

## Impact

The application can finish startup immediately while favorite subscription intent is already registered. Actual WebSocket subscriptions continue in the managed background lifecycle.

## Validation

- Relevant unit/integration scenarios: 261 passed
- `pytest tests/unit_test -v`: 7,282 passed
- `pytest tests/integration_test -v`: 271 passed
