### PR TITLE
페이지 HTML 응답에 Cache-Control: no-store 적용

### DIFF
--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -142,3 +142,32 @@ def test_home_groups_market_and_common_entry_points(web_client_with_fake_ctx):
     assert 'data-home-market="domestic"' in page.text
     assert 'data-home-market="overseas_us"' in page.text
     assert 'data-home-market="common"' in page.text
+
+
+def test_page_documents_are_not_browser_cached(web_client_with_fake_ctx):
+    """페이지 HTML 은 캐시 버스팅 수단이 없어 no-store 로 내려야 한다.
+
+    문서가 캐시되면 정적 파일 ?v= 를 올려도 예전 마크업이 남아 새 UI 가 안 보인다.
+    """
+    for page_path in PAGE_PATHS:
+        page = web_client_with_fake_ctx.get(page_path)
+
+        assert page.status_code == 200
+        assert "no-store" in page.headers.get("cache-control", ""), (
+            f"{page_path} 문서 응답에 no-store 가 없다"
+        )
+
+
+def test_static_assets_keep_browser_caching(web_client_with_fake_ctx):
+    """정적 파일은 ?v= 로 캐시 버스팅하므로 no-store 를 적용하지 않는다."""
+    client = web_client_with_fake_ctx
+    refs = _local_static_refs(client.get("/stock").text)
+
+    assert refs, "테스트 전제: /stock 이 정적 파일을 참조해야 한다"
+    for static_path in refs:
+        asset = client.get(static_path)
+
+        assert asset.status_code == 200
+        assert "no-store" not in asset.headers.get("cache-control", ""), (
+            f"{static_path} 에 no-store 가 붙어 정적 캐싱이 무력화됐다"
+        )

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -132,6 +132,48 @@ def test_overseas_static_js_exposes_manual_workflow():
     assert "loadOverseasQuote" in script
     assert "placeOverseasOrder" in script
 
+def test_pages_are_not_browser_cached(web_client, mock_web_ctx):
+    """페이지 HTML 은 캐시 버스팅 수단이 없어(정적 파일만 ?v=), no-store 로 내려야 한다.
+
+    이게 없으면 배포 후에도 브라우저 휴리스틱 캐시 때문에 예전 화면이 남는다
+    (실제로 미국장 즐겨찾기 탭이 안 보인다는 보고가 있었다).
+    """
+    mock_web_ctx.full_config = {"use_login": False}
+
+    for path, _ in PAGES:
+        response = web_client.get(path)
+
+        assert response.status_code == 200
+        assert "no-store" in response.headers.get("cache-control", ""), (
+            f"{path} 응답에 no-store 가 없어 예전 화면이 캐시될 수 있다"
+        )
+
+
+def test_login_page_is_not_browser_cached(web_client, mock_web_ctx):
+    """로그인 페이지가 캐시되면 로그인 후에도 로그인 화면이 남을 수 있다."""
+    mock_web_ctx.full_config = {"use_login": True, "auth": {"secret_key": "secret_token"}}
+    web_client.cookies.clear()
+
+    response = web_client.get("/stock")
+
+    assert response.status_code == 200
+    assert "Investment Login" in response.text
+    assert "no-store" in response.headers.get("cache-control", "")
+
+
+def test_forbidden_page_is_not_browser_cached(web_client, mock_web_ctx):
+    """권한 부족 응답이 캐시되면 권한 승급 후에도 403 화면이 남을 수 있다."""
+    auth_config = {"secret_key": "secret_token", "session_max_age_seconds": 3600}
+    mock_web_ctx.full_config = {"use_login": True, "auth": auth_config}
+    token, _ = issue_session(auth_config, "reader", role="viewer")
+    web_client.cookies.set(SESSION_COOKIE_NAME, token)
+
+    response = web_client.get("/balance")
+
+    assert response.status_code == 403
+    assert "no-store" in response.headers.get("cache-control", "")
+
+
 def test_pages_show_login_page_when_unauthorized(web_client, mock_web_ctx):
     """로그인 기능 활성화 시 토큰 없이 접근하면 로그인 페이지가 렌더링되는지 테스트"""
     # 로그인 활성화 설정

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -377,6 +377,18 @@ def _page_role(request: Request, ctx) -> str:
     return claims.role if claims is not None else ""
 
 
+def _no_store(response):
+    """페이지 HTML 은 캐시 버스팅 수단이 없어 항상 재검증하게 만든다.
+
+    정적 파일은 `?v=` 로 갱신을 강제하지만 문서 자체에는 그런 수단이 없다.
+    브라우저 휴리스틱 캐시에 문서가 걸리면 `?v=` 를 올려도 예전 마크업이 남아
+    새 UI 가 보이지 않는다(미국장 즐겨찾기 탭 미표시 사례). 로그인/권한부족
+    응답도 같은 이유로 캐시되면 안 된다.
+    """
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
 # 공통 페이지 렌더링 함수 (로그인 체크 포함)
 async def render_page(
     request: Request,
@@ -389,19 +401,19 @@ async def render_page(
     try:
         ctx = web_api._get_ctx()
     except Exception:
-        return templates.TemplateResponse(request, "login.html")
+        return _no_store(templates.TemplateResponse(request, "login.html"))
 
     if not _is_page_authorized(request, ctx):
-        return templates.TemplateResponse(request, "login.html")
+        return _no_store(templates.TemplateResponse(request, "login.html"))
 
     user_role = _page_role(request, ctx)
     if not role_allows(user_role, required_role):
-        return templates.TemplateResponse(
+        return _no_store(templates.TemplateResponse(
             request,
             "login.html",
             {"authorization_error": "이 페이지에 접근할 권한이 부족합니다."},
             status_code=403,
-        )
+        ))
 
     claims = api_common.get_session_claims(request, ctx=ctx)
     context = {
@@ -414,7 +426,7 @@ async def render_page(
     }
     if extra_context:
         context.update(extra_context)
-    return templates.TemplateResponse(request, template_name, context)
+    return _no_store(templates.TemplateResponse(request, template_name, context))
 
 # 4. 페이지 라우팅
 @page_router.get("/")


### PR DESCRIPTION
## 배경

미국장 즐겨찾기 탭이 안 보인다는 보고를 조사했는데, **코드 결함이 아니었습니다.** 실행 중인 서버는 정상이었습니다:

```bash
curl -s http://localhost:8000/overseas | grep -o 'data-overseas-tab="[a-z_]*"'
# overview / marketcap / favorite / orders  ← 4개 모두 존재
```

브로커 없이 페이지를 실제 렌더해 브라우저로 확인한 결과도 정상 (탭 `display:inline-block` 87×39px, 클릭 시 패널 1160×265 노출, 900px 좁은 창에서도 4개 탭 미클립).

진짜 원인은 **페이지 문서 응답에 캐시 헤더가 하나도 없다**는 점이었습니다. 정적 파일은 `?v=6` 으로 갱신을 강제하지만 문서에는 그런 수단이 없어, 브라우저 휴리스틱 캐시에 문서가 걸리면 `?v=` 를 올려도 예전 마크업(탭 3개)이 남습니다. 이번 한 번이 아니라 **UI 를 바꿀 때마다 재발하는 구조**입니다.

## 변경 내용

`render_page` 의 네 반환 지점을 `_no_store` 로 감쌉니다 — 정상 렌더 / ctx 없음 / 미인증 / 권한부족. 페이지 라우팅이 전부 이 함수를 통과하므로 한 곳만 고치면 됩니다.

로그인·403 응답까지 포함한 이유는, 그것들이 캐시되면 **로그인 후에도 로그인 화면이 남거나 권한 승급 후에도 403 이 남을** 수 있기 때문입니다.

**정적 파일은 손대지 않았습니다.** `?v=` 캐시 버스팅이 이미 있고, no-store 를 붙이면 매 페이지 로드마다 CSS/JS 전부를 재다운로드하게 됩니다.

## 테스트

단위 **7287개** / 통합 **273개** 통과. 회귀 잠금:

| 테스트 | 내용 |
|---|---|
| `test_pages_are_not_browser_cached` | 전 페이지 문서에 no-store (단위) |
| `test_page_documents_are_not_browser_cached` | 전 페이지 문서에 no-store (통합, 실제 app) |
| `test_login_page_is_not_browser_cached` | 로그인 응답에도 no-store |
| `test_forbidden_page_is_not_browser_cached` | 403 응답에도 no-store |
| `test_static_assets_keep_browser_caching` | 정적 파일에는 no-store 미적용 — 나중에 미들웨어로 전역 적용되는 회귀 방지 |

## 적용 방법

이 변경은 서버 재시작이 필요합니다. 재시작 전까지는 **Ctrl+Shift+R** 로 즐겨찾기 탭을 확인할 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
