### PR TITLE
Unify overseas favorite navigation

### DIFF
--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -19,6 +19,7 @@ PAGE_PATHS = [
     "/balance",
     "/order",
     "/overseas",
+    "/overseas-favorite",
     "/overseas-marketcap",
     "/overseas-ranking",
     "/ranking",
@@ -97,6 +98,7 @@ def test_rendered_pages_reference_served_static_assets(web_client_with_fake_ctx)
         ("/balance", "domestic"),
         ("/order", "domestic"),
         ("/overseas", "overseas_us"),
+        ("/overseas-favorite", "overseas_us"),
         ("/overseas-marketcap", "overseas_us"),
         ("/overseas-ranking", "overseas_us"),
         ("/virtual", "common"),
@@ -123,6 +125,15 @@ def test_navigation_separates_domestic_overseas_and_common_areas(web_client_with
     assert 'data-nav-market="common"' in page.text
     assert '>한국장<' in page.text
     assert '>미국장<' in page.text
+
+
+def test_overseas_favorite_uses_feature_navigation(web_client_with_fake_ctx):
+    page = web_client_with_fake_ctx.get("/overseas-favorite")
+
+    assert page.status_code == 200
+    assert 'href="/overseas-favorite" class="active">즐겨찾기</a>' in page.text
+    assert 'id="overseas-panel-favorite"' in page.text
+    assert 'id="overseas-tab-favorite"' not in page.text
 
 
 def test_stock_page_is_domestic_only(web_client_with_fake_ctx):

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -10,6 +10,7 @@ PAGES = [
     ("/balance", "balance"),
     ("/order", "order"),
     ("/overseas", "overseas"),
+    ("/overseas-favorite", "overseas_favorite"),
     ("/overseas-marketcap", "overseas_marketcap"),
     ("/overseas-ranking", "overseas_ranking"),
     ("/ranking", "ranking"),
@@ -54,9 +55,16 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert 'id="overseas-tab-overview"' in response.text
             assert 'id="overseas-tab-marketcap"' in response.text
             assert 'id="overseas-tab-orders"' in response.text
-            assert 'id="overseas-tab-favorite"' in response.text
+            assert 'id="overseas-tab-favorite"' not in response.text
             assert 'id="overseas-panel-marketcap"' in response.text
             assert 'id="overseas-panel-favorite"' in response.text
+            assert 'id="overseas-fav-symbol"' in response.text
+            assert 'id="overseas-favorite-body"' in response.text
+            assert "/static/js/overseas.js" in response.text
+        elif path == "/overseas-favorite":
+            assert "미국장 즐겨찾기" in response.text
+            assert 'id="overseas-panel-favorite"' in response.text
+            assert 'id="overseas-tab-favorite"' not in response.text
             assert 'id="overseas-fav-symbol"' in response.text
             assert 'id="overseas-favorite-body"' in response.text
             assert "/static/js/overseas.js" in response.text

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -108,6 +108,11 @@ async function setOverseasTab(tabName) {
     if (tabName === 'favorite') await loadOverseasFavorites();
 }
 
+function _initialOverseasTab() {
+    if (window.location.pathname === '/overseas-favorite') return 'favorite';
+    return 'overview';
+}
+
 async function loadOverseasQuote() {
     const symbol = _overseasSymbolValue('overseas-symbol');
     const exchange = _overseasExchangeValue('overseas-exchange');
@@ -571,17 +576,19 @@ function initOverseasPage() {
     _refreshOverseasRealBanner();
     void _refreshOverseasAvailability();
     _initOverseasFavoriteAutocomplete();
+    const initialTab = _initialOverseasTab();
+    if (initialTab !== 'overview') void setOverseasTab(initialTab);
     if (!window.__overseasRealBannerTimer) {
         window.__overseasRealBannerTimer = setInterval(_refreshOverseasRealBanner, 3000);
     }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (window.location.pathname !== '/overseas') return;
+    if (!['/overseas', '/overseas-favorite'].includes(window.location.pathname)) return;
     initOverseasPage();
 });
 
 document.addEventListener('pjax:ready', (e) => {
-    if (e.detail?.path !== '/overseas') return;
+    if (!['/overseas', '/overseas-favorite'].includes(e.detail?.path)) return;
     initOverseasPage();
 });

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -94,6 +94,7 @@
         {% if can_operate %}<a href="/program" class="{% if active_page == 'program' %}active{% endif %}">프로그램매매</a>{% endif %}
     {% elif view_market == 'overseas_us' %}
         <a href="/overseas" class="{% if active_page == 'overseas' %}active{% endif %}">미국장 개요·거래</a>
+        {% if can_operate %}<a href="/overseas-favorite" class="{% if active_page == 'overseas_favorite' %}active{% endif %}">즐겨찾기</a>{% endif %}
         <a href="/overseas-marketcap" class="{% if active_page == 'overseas_marketcap' %}active{% endif %}">시가총액</a>
         <a href="/overseas-ranking" class="{% if active_page == 'overseas_ranking' %}active{% endif %}">랭킹</a>
     {% else %}

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -22,7 +22,6 @@
         <div class="overseas-tabs" role="tablist" aria-label="미국주식 메뉴">
             <button type="button" id="overseas-tab-overview" class="sub-tab-btn active" data-overseas-tab="overview" onclick="setOverseasTab('overview')">시장 개요</button>
             <button type="button" id="overseas-tab-marketcap" class="sub-tab-btn" data-overseas-tab="marketcap" onclick="setOverseasTab('marketcap')">주요 대형주</button>
-            {% if can_operate %}<button type="button" id="overseas-tab-favorite" class="sub-tab-btn" data-overseas-tab="favorite" onclick="setOverseasTab('favorite')">즐겨찾기</button>{% endif %}
             {% if can_operate %}<button type="button" id="overseas-tab-orders" class="sub-tab-btn" data-overseas-tab="orders" onclick="setOverseasTab('orders')">보유·주문</button>{% endif %}
         </div>
     </div>

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -503,6 +503,16 @@ async def order(request: Request):
 async def overseas(request: Request):
     return await render_page(request, "overseas.html", "overseas", view_market="overseas_us")
 
+@page_router.get("/overseas-favorite")
+async def overseas_favorite(request: Request):
+    return await render_page(
+        request,
+        "overseas.html",
+        "overseas_favorite",
+        view_market="overseas_us",
+        required_role=OPERATOR,
+    )
+
 @page_router.get("/overseas-marketcap")
 async def overseas_marketcap(request: Request):
     return await render_page(


### PR DESCRIPTION
## Summary
- Add an overseas favorite page entry to the market feature navigation
- Reuse the existing overseas favorite panel at /overseas-favorite
- Remove the duplicate in-card favorite tab and update page/render tests

## Tests
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v