### PR TITLE
Refresh overseas market cap periodically

### DIFF
--- a/services/overseas_market_stats_service.py
+++ b/services/overseas_market_stats_service.py
@@ -33,6 +33,7 @@ class OverseasMarketStatsService:
         logger=None,
         ttl_sec: float = 300.0,
         clock=time.monotonic,
+        wall_clock=time.time,
     ):
         # 유니버스는 첫 조회 시점에 만든다. 구성종목 DB 가 없으면 생성에 외부 다운로드가
         # 따라붙는데, 이를 웹 시작 경로에 두면 아무도 안 보는 화면 때문에 부팅이 늦어진다.
@@ -43,8 +44,10 @@ class OverseasMarketStatsService:
         self._logger = logger or logging.getLogger(__name__)
         self._ttl_sec = ttl_sec
         self._clock = clock
+        self._wall_clock = wall_clock
         self._lock = asyncio.Lock()
         self._cached_at: Optional[float] = None
+        self._updated_at: Optional[float] = None
         self._snapshots: list = []
         self._fx_rate: Optional[float] = None
 
@@ -64,11 +67,11 @@ class OverseasMarketStatsService:
         universe = self._get_universe()
         symbols = universe.all_symbols() if universe else []
         if not symbols:
-            return [], None
+            return [], None, None
 
         async with self._lock:
             if self._cached_at is not None and (self._clock() - self._cached_at) <= self._ttl_sec:
-                return self._snapshots, self._fx_rate
+                return self._snapshots, self._fx_rate, self._updated_at
 
             snapshots, fx_rate = await asyncio.gather(
                 self._provider.fetch_snapshots(symbols),
@@ -77,7 +80,8 @@ class OverseasMarketStatsService:
             self._snapshots = snapshots
             self._fx_rate = fx_rate
             self._cached_at = self._clock()
-            return self._snapshots, self._fx_rate
+            self._updated_at = self._wall_clock()
+            return self._snapshots, self._fx_rate, self._updated_at
 
     async def _fetch_fx_rate(self) -> Optional[float]:
         try:
@@ -89,7 +93,7 @@ class OverseasMarketStatsService:
 
     async def get_top_market_cap(self, limit: int = 30) -> dict:
         """시가총액 상위 종목. market_cap 이 없는 심볼은 제외한다."""
-        snapshots, fx_rate = await self.get_snapshots()
+        snapshots, fx_rate, updated_at = await self.get_snapshots()
         ranked = sorted(
             (snap for snap in snapshots if snap.market_cap > 0),
             key=lambda snap: snap.market_cap,
@@ -100,7 +104,7 @@ class OverseasMarketStatsService:
             self._to_item(snap, rank, fx_rate)
             for rank, snap in enumerate(ranked, 1)
         ]
-        return {"fx_rate": fx_rate, "items": items}
+        return {"fx_rate": fx_rate, "items": items, "updated_at": updated_at}
 
     async def get_ranking(self, category: str, limit: int = 30) -> dict:
         """등락률/거래량/거래대금 랭킹. 시가총액 화면과 스냅샷 캐시를 공유한다."""
@@ -109,14 +113,14 @@ class OverseasMarketStatsService:
             raise ValueError(f"지원하지 않는 미국장 랭킹 구분: {category}")
         key, descending = sort
 
-        snapshots, fx_rate = await self.get_snapshots()
+        snapshots, fx_rate, updated_at = await self.get_snapshots()
         ranked = sorted(snapshots, key=key, reverse=descending)[:limit]
 
         items = [
             self._to_item(snap, rank, fx_rate)
             for rank, snap in enumerate(ranked, 1)
         ]
-        return {"fx_rate": fx_rate, "items": items}
+        return {"fx_rate": fx_rate, "items": items, "updated_at": updated_at}
 
     def _to_item(self, snap, rank: int, fx_rate: Optional[float]) -> dict:
         meta = self._universe.get_meta(snap.symbol) if self._universe else None

--- a/tests/frontend/run_overseas_marketcap_dom_tests.mjs
+++ b/tests/frontend/run_overseas_marketcap_dom_tests.mjs
@@ -21,6 +21,7 @@ const SCAFFOLD = `
   <button class="btn ranking-tab active" data-limit="30"></button>
   <button class="btn ranking-tab" data-limit="50"></button>
   <button class="btn ranking-tab" data-limit="100"></button>
+  <span id="overseas-marketcap-updated-at"></span>
   <div id="overseas-marketcap-result"></div>
 </div>
 `;
@@ -55,8 +56,8 @@ async function makeWindow() {
   return window;
 }
 
-function okPayload(items, fxRate = 1400) {
-  return { ok: true, json: async () => ({ rt_cd: "0", msg1: "OK", data: { fx_rate: fxRate, items } }) };
+function okPayload(items, fxRate = 1400, updatedAt = 1_800_000_000) {
+  return { ok: true, json: async () => ({ rt_cd: "0", msg1: "OK", data: { fx_rate: fxRate, items, updated_at: updatedAt } }) };
 }
 
 const APPLE = {
@@ -79,6 +80,17 @@ test("시가총액 행을 순위·심볼·섹터·USD/원화로 렌더한다", a
   assert(text.includes("+1.23%"), "등락률이 소수 2자리로 표시되어야 함");
   assert(text.includes("$3.00T"), "회귀: USD 시가총액 축약 표기 실패");
   assert(text.includes("4,200조"), "회귀: 원화 환산이 조/억 표기로 표시되지 않음");
+});
+
+test("서버의 updated_at 을 최신 업데이트 시간으로 표시한다", async () => {
+  const window = await makeWindow();
+  window.fetchWithTimeout = async () => okPayload([APPLE], 1400, Date.UTC(2026, 6, 31, 13, 5, 30) / 1000);
+
+  await window.loadOverseasTopMarketCap(30);
+
+  const text = window.document.getElementById("overseas-marketcap-updated-at").textContent;
+  assert(text.includes("최신 업데이트"), "최신 업데이트 라벨이 표시되어야 함");
+  assert(text.includes("2026"), "updated_at 시간이 사용자가 읽을 수 있는 시간으로 표시되어야 함");
 });
 
 test("limit 탭 전환이 요청 쿼리와 active 클래스에 반영된다", async () => {
@@ -168,6 +180,28 @@ test("외부 문자열은 HTML 로 해석되지 않는다", async () => {
 
   assert(window.__pwned === undefined, "회귀: 종목명이 HTML 로 해석됨");
   assert(window.__pwned2 === undefined, "회귀: 섹터가 스크립트로 해석됨");
+});
+
+test("페이지 초기화 시 5분마다 현재 limit 으로 자동 갱신한다", async () => {
+  const intervals = [];
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/overseas-marketcap",
+    runScripts: "dangerously",
+  });
+  const { window } = dom;
+  applyCommonStubs(window);
+  window.fetchWithTimeout = async () => okPayload([APPLE]);
+  window.setInterval = (fn, ms) => {
+    intervals.push({ fn, ms });
+    return intervals.length;
+  };
+
+  const script = window.document.createElement("script");
+  script.textContent = readFileSync(PAGE_JS, "utf8");
+  window.document.body.appendChild(script);
+  await flush();
+
+  assert(intervals.some((item) => item.ms === 300000), "5분 자동 갱신 타이머가 등록되어야 함");
 });
 
 await run();

--- a/tests/unit_test/services/test_overseas_market_stats_service.py
+++ b/tests/unit_test/services/test_overseas_market_stats_service.py
@@ -76,6 +76,48 @@ async def test_top_market_cap_includes_sector_and_krw_conversion(service):
     assert item["market_cap_krw"] == int(4_000_000_000_000 * 1400.0)
 
 
+async def test_top_market_cap_includes_cached_snapshot_updated_at(universe, provider):
+    now = [0.0]
+    wall_now = [1_800_000_000.0]
+    service = OverseasMarketStatsService(
+        universe_factory=lambda: universe,
+        provider=provider,
+        ttl_sec=300,
+        clock=lambda: now[0],
+        wall_clock=lambda: wall_now[0],
+    )
+
+    first = await service.get_top_market_cap(limit=1)
+    wall_now[0] = 1_800_000_123.0
+    now[0] = 299.0
+    second = await service.get_top_market_cap(limit=1)
+
+    assert first["updated_at"] == 1_800_000_000.0
+    assert second["updated_at"] == 1_800_000_000.0
+    assert provider.fetch_snapshots.await_count == 1
+
+
+async def test_top_market_cap_updated_at_changes_after_ttl(universe, provider):
+    now = [0.0]
+    wall_now = [1_800_000_000.0]
+    service = OverseasMarketStatsService(
+        universe_factory=lambda: universe,
+        provider=provider,
+        ttl_sec=300,
+        clock=lambda: now[0],
+        wall_clock=lambda: wall_now[0],
+    )
+
+    first = await service.get_top_market_cap(limit=1)
+    wall_now[0] = 1_800_000_400.0
+    now[0] = 301.0
+    second = await service.get_top_market_cap(limit=1)
+
+    assert first["updated_at"] == 1_800_000_000.0
+    assert second["updated_at"] == 1_800_000_400.0
+    assert provider.fetch_snapshots.await_count == 2
+
+
 async def test_krw_is_none_when_fx_unavailable(universe, provider):
     provider.fetch_usdkrw = AsyncMock(return_value=None)
     service = OverseasMarketStatsService(
@@ -150,7 +192,7 @@ async def test_empty_universe_returns_empty_without_calling_provider(provider):
 
     result = await service.get_top_market_cap()
 
-    assert result == {"fx_rate": None, "items": []}
+    assert result == {"fx_rate": None, "items": [], "updated_at": None}
     provider.fetch_snapshots.assert_not_awaited()
 
 
@@ -303,4 +345,4 @@ async def test_ranking_empty_universe_returns_empty(provider):
         universe_factory=lambda: empty, provider=provider, clock=lambda: 0.0
     )
 
-    assert (await service.get_ranking("rise")) == {"fx_rate": None, "items": []}
+    assert (await service.get_ranking("rise")) == {"fx_rate": None, "items": [], "updated_at": None}

--- a/view/web/static/js/overseas_marketcap.js
+++ b/view/web/static/js/overseas_marketcap.js
@@ -1,6 +1,9 @@
 /* view/web/static/js/overseas_marketcap.js — 미국 시가총액 상위 종목 (S&P 500 유니버스) */
 
 let _overseasCapRequestSequence = 0;
+let _overseasCapCurrentLimit = 30;
+let _overseasCapRefreshTimer = null;
+const OVERSEAS_MARKETCAP_REFRESH_MS = 5 * 60 * 1000;
 
 function _capNumber(value) {
     if (value === null || value === undefined || value === '') return null;
@@ -39,8 +42,22 @@ function _capRate(value) {
     return { color, text: `${sign}${normalized.toFixed(2)}%` };
 }
 
+function _formatCapUpdatedAt(value) {
+    const number = _capNumber(value);
+    if (number === null || number <= 0) return '최신 업데이트: --';
+    const date = new Date(number * 1000);
+    if (Number.isNaN(date.getTime())) return '최신 업데이트: --';
+    return `최신 업데이트: ${date.toLocaleString('ko-KR')}`;
+}
+
+function _renderCapUpdatedAt(value) {
+    const el = document.getElementById('overseas-marketcap-updated-at');
+    if (el) el.textContent = _formatCapUpdatedAt(value);
+}
+
 function _renderOverseasMarketCap(div, data) {
     const items = Array.isArray(data.items) ? data.items : [];
+    _renderCapUpdatedAt(data.updated_at);
     if (!items.length) {
         div.innerHTML = '<p class="empty">조회 결과가 없습니다.</p>';
         return;
@@ -74,9 +91,11 @@ function _renderOverseasMarketCap(div, data) {
     `;
 }
 
-async function loadOverseasTopMarketCap(limit = 30) {
+async function loadOverseasTopMarketCap(limit = 30, options = {}) {
     const requestSequence = ++_overseasCapRequestSequence;
     const isLatestRequest = () => requestSequence === _overseasCapRequestSequence;
+    const shouldShowLoading = options.showLoading !== false;
+    _overseasCapCurrentLimit = Number(limit) || 30;
 
     document.querySelectorAll('#section-overseas-marketcap .ranking-tab').forEach(button => {
         button.classList.toggle('active', Number(button.dataset.limit) === Number(limit));
@@ -84,7 +103,7 @@ async function loadOverseasTopMarketCap(limit = 30) {
 
     const div = document.getElementById('overseas-marketcap-result');
     if (!div) return;
-    showLoading(div, '미국 시가총액 조회 중...');
+    if (shouldShowLoading) showLoading(div, '미국 시가총액 조회 중...');
 
     try {
         const res = await fetchWithTimeout(`/api/overseas/top-market-cap?limit=${encodeURIComponent(limit)}`, {}, 30000);
@@ -109,12 +128,20 @@ async function loadOverseasTopMarketCap(limit = 30) {
     }
 }
 
+function initOverseasMarketCapPage() {
+    void loadOverseasTopMarketCap(_overseasCapCurrentLimit);
+    if (_overseasCapRefreshTimer !== null) return;
+    _overseasCapRefreshTimer = setInterval(() => {
+        void loadOverseasTopMarketCap(_overseasCapCurrentLimit, { showLoading: false });
+    }, OVERSEAS_MARKETCAP_REFRESH_MS);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     if (window.location.pathname !== '/overseas-marketcap') return;
-    void loadOverseasTopMarketCap(30);
+    initOverseasMarketCapPage();
 });
 
 document.addEventListener('pjax:ready', (e) => {
     if (e.detail?.path !== '/overseas-marketcap') return;
-    void loadOverseasTopMarketCap(30);
+    initOverseasMarketCapPage();
 });

--- a/view/web/templates/overseas_marketcap.html
+++ b/view/web/templates/overseas_marketcap.html
@@ -5,6 +5,7 @@
         <div class="card">
             <h2>미국 시가총액 상위 종목</h2>
             <p class="small">S&amp;P 500 구성종목을 시가총액(USD) 기준으로 정렬합니다.</p>
+            <p id="overseas-marketcap-updated-at" class="small">최신 업데이트: --</p>
             <div class="form-row">
                 <button class="btn ranking-tab active" data-limit="30" onclick="loadOverseasTopMarketCap(30)">상위 30</button>
                 <button class="btn ranking-tab" data-limit="50" onclick="loadOverseasTopMarketCap(50)">상위 50</button>
@@ -16,5 +17,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/overseas_marketcap.js?v=1"></script>
+<script src="/static/js/overseas_marketcap.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show the latest snapshot update time on the overseas market cap page
- Auto-refresh the page every 5 minutes using the current limit tab
- Keep browser refresh/button reloads on the existing server-side 5 minute cache instead of forcing a fresh provider update

## Tests
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v