### PR TITLE
홈 화면에 S&P 500 섹터 히트맵 추가

### DIFF
--- a/tests/frontend/run_market_heatmap_dom_tests.mjs
+++ b/tests/frontend/run_market_heatmap_dom_tests.mjs
@@ -1,0 +1,275 @@
+/*
+ * jsdom 기반 홈 화면 S&P500 히트맵(트리맵) 회귀 테스트.
+ *
+ * 실행: node run_market_heatmap_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { applyCommonStubs, test, assert, run } from "./harness.mjs";
+
+const HEATMAP_JS = process.env.MARKET_HEATMAP_JS_PATH
+  ? resolve(process.env.MARKET_HEATMAP_JS_PATH)
+  : resolve(import.meta.dirname, "../../view/web/static/js/market_heatmap.js");
+
+const SCAFFOLD = `
+<div class="card" id="market-heatmap-card">
+  <span id="market-heatmap-updated-at"></span>
+  <div id="market-heatmap"></div>
+</div>
+`;
+
+// 홈 경로('/')로 만들면 스크립트의 DOMContentLoaded 자동 초기화가 끼어들어 호출 수가 흔들린다.
+// 자동 초기화 자체는 아래 전용 테스트에서 홈 경로 창으로 검증한다.
+function makeWindow(fetchWithTimeout, url = "http://localhost/heatmap-test") {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url,
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+  applyCommonStubs(window);
+  window.fetchWithTimeout = fetchWithTimeout;
+  window.eval(readFileSync(HEATMAP_JS, "utf8"));
+  return window;
+}
+
+function success(data) {
+  return { ok: true, json: async () => ({ rt_cd: "0", data }) };
+}
+
+function marketMode(modes) {
+  return { ok: true, json: async () => ({ enabled_market_modes: modes }) };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+function item(overrides) {
+  return {
+    symbol: "AAA",
+    name: "테스트",
+    sector: "Technology",
+    price: 100,
+    change_rate: 1.0,
+    market_cap_usd: 1e11,
+    ...overrides,
+  };
+}
+
+function pct(el, prop) {
+  return Number.parseFloat(el.style[prop]);
+}
+
+test("시가총액이 큰 종목이 비례해서 큰 타일을 차지한다", async () => {
+  const window = makeWindow(async () => success({
+    items: [
+      item({ symbol: "BIG", market_cap_usd: 900 }),
+      item({ symbol: "SMALL", market_cap_usd: 100 }),
+    ],
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const doc = window.document;
+  const big = doc.querySelector('.heatmap-tile[data-symbol="BIG"]');
+  const small = doc.querySelector('.heatmap-tile[data-symbol="SMALL"]');
+  assert(big && small, "두 종목 타일이 모두 렌더되어야 함");
+
+  const bigArea = pct(big, "width") * pct(big, "height");
+  const smallArea = pct(small, "width") * pct(small, "height");
+  const ratio = bigArea / smallArea;
+  assert(ratio > 8.5 && ratio < 9.5, `면적비가 시총비(9:1)를 따라야 함 (실제 ${ratio.toFixed(2)})`);
+});
+
+test("섹터 블록이 시총 합계 내림차순으로 렌더된다", async () => {
+  const window = makeWindow(async () => success({
+    items: [
+      item({ symbol: "H1", sector: "Health Care", market_cap_usd: 300 }),
+      item({ symbol: "T1", sector: "Technology", market_cap_usd: 500 }),
+      item({ symbol: "T2", sector: "Technology", market_cap_usd: 400 }),
+      item({ symbol: "E1", sector: "Energy", market_cap_usd: 100 }),
+    ],
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const sectors = [...window.document.querySelectorAll(".heatmap-sector")]
+    .map(el => el.dataset.sector);
+  assert(
+    JSON.stringify(sectors) === JSON.stringify(["Technology", "Health Care", "Energy"]),
+    `섹터가 시총 합계순이어야 함 (실제 ${sectors.join(", ")})`,
+  );
+});
+
+test("모든 타일이 컨테이너 경계 안에 배치된다", async () => {
+  const window = makeWindow(async () => success({
+    items: [
+      item({ symbol: "A", sector: "Technology", market_cap_usd: 500 }),
+      item({ symbol: "B", sector: "Technology", market_cap_usd: 120 }),
+      item({ symbol: "C", sector: "Technology", market_cap_usd: 40 }),
+      item({ symbol: "D", sector: "Energy", market_cap_usd: 220 }),
+      item({ symbol: "E", sector: "Energy", market_cap_usd: 60 }),
+      item({ symbol: "F", sector: "Financials", market_cap_usd: 30 }),
+    ],
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const boxes = [
+    ...window.document.querySelectorAll(".heatmap-sector"),
+    ...window.document.querySelectorAll(".heatmap-tile"),
+  ];
+  assert(boxes.length === 9, `섹터 3 + 타일 6 이 렌더되어야 함 (실제 ${boxes.length})`);
+  boxes.forEach(box => {
+    const left = pct(box, "left");
+    const top = pct(box, "top");
+    const width = pct(box, "width");
+    const height = pct(box, "height");
+    assert([left, top, width, height].every(Number.isFinite), "좌표가 숫자여야 함");
+    assert(width > 0 && height > 0, "타일 크기는 0보다 커야 함");
+    assert(left >= -0.01 && top >= -0.01, "타일이 컨테이너 왼쪽/위를 벗어남");
+    assert(left + width <= 100.01 && top + height <= 100.01, "타일이 컨테이너 오른쪽/아래를 벗어남");
+  });
+});
+
+test("등락 방향에 따라 색 계열과 표기 부호가 갈린다", async () => {
+  const window = makeWindow(async () => success({
+    items: [
+      item({ symbol: "UP", change_rate: 3.5 }),
+      item({ symbol: "DOWN", change_rate: -2.1 }),
+      item({ symbol: "FLAT", change_rate: 0 }),
+      item({ symbol: "NULL", change_rate: null }),
+    ],
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const doc = window.document;
+  const bySymbol = symbol => doc.querySelector(`.heatmap-tile[data-symbol="${symbol}"]`);
+  assert(bySymbol("UP").dataset.direction === "up", "상승 타일 방향이 up 이어야 함");
+  assert(bySymbol("DOWN").dataset.direction === "down", "하락 타일 방향이 down 이어야 함");
+  assert(bySymbol("FLAT").dataset.direction === "flat", "보합 타일 방향이 flat 이어야 함");
+  assert(bySymbol("NULL").dataset.direction === "unknown", "등락률 없는 타일은 unknown 이어야 함");
+
+  const colors = new Set(["UP", "DOWN", "FLAT"].map(s => bySymbol(s).style.backgroundColor));
+  assert(colors.size === 3, "상승/하락/보합 색이 서로 달라야 함");
+  assert(bySymbol("UP").textContent.includes("+3.50%"), "상승 등락률에 + 부호가 붙어야 함");
+  assert(bySymbol("DOWN").textContent.includes("-2.10%"), "하락 등락률이 표시되어야 함");
+  assert(!bySymbol("NULL").textContent.includes("NaN"), "등락률 없음이 NaN 으로 노출됨");
+});
+
+test("응답 문자열을 HTML 이 아닌 텍스트로 렌더링한다", async () => {
+  const window = makeWindow(async () => success({
+    items: [item({
+      symbol: '<img id="injected-symbol" src=x>',
+      name: '<img id="injected-name" src=x>',
+      sector: '<img id="injected-sector" src=x>',
+    })],
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const target = window.document.getElementById("market-heatmap");
+  assert(!target.querySelector("#injected-symbol, #injected-name, #injected-sector"),
+    "응답 문자열이 HTML 로 해석됨");
+  assert(target.textContent.includes('<img id="injected-symbol" src=x>'),
+    "심볼이 텍스트로 표시되어야 함");
+});
+
+test("HTTP 오류는 JSON 파싱 없이 상태 안내를 표시한다", async () => {
+  let jsonCalled = false;
+  const window = makeWindow(async () => ({
+    ok: false,
+    status: 503,
+    json: async () => { jsonCalled = true; throw new Error("JSON 파싱 실패"); },
+  }));
+
+  await window.loadMarketHeatmap();
+
+  const target = window.document.getElementById("market-heatmap");
+  assert(jsonCalled === false, "HTTP 오류 응답은 JSON 으로 파싱하면 안 됨");
+  assert(target.textContent.includes("HTTP 503"), "HTTP 상태 안내가 표시되어야 함");
+});
+
+test("빈 목록과 비정상 응답을 사용자 안내로 처리한다", async () => {
+  const responses = [success({ items: [] }), { ok: true, json: async () => ({ rt_cd: "1", msg1: "수집 실패" }) }];
+  const window = makeWindow(async () => responses.shift());
+
+  await window.loadMarketHeatmap();
+  assert(window.document.getElementById("market-heatmap").textContent.includes("조회 결과가 없습니다"),
+    "빈 목록 안내가 표시되어야 함");
+
+  await window.loadMarketHeatmap();
+  assert(window.document.getElementById("market-heatmap").textContent.includes("수집 실패"),
+    "실패 사유가 표시되어야 함");
+});
+
+test("늦게 끝난 이전 요청이 최신 히트맵을 덮어쓰지 않는다", async () => {
+  const pending = [];
+  const window = makeWindow(() => {
+    const request = deferred();
+    pending.push(request);
+    return request.promise;
+  });
+
+  const first = window.loadMarketHeatmap();
+  const second = window.loadMarketHeatmap();
+  pending[1].resolve(success({ items: [item({ symbol: "NEW" })] }));
+  await second;
+  pending[0].resolve(success({ items: [item({ symbol: "OLD" })] }));
+  await first;
+
+  const target = window.document.getElementById("market-heatmap");
+  assert(target.querySelector('.heatmap-tile[data-symbol="NEW"]'), "최신 결과가 표시되어야 함");
+  assert(!target.querySelector('.heatmap-tile[data-symbol="OLD"]'), "이전 결과가 최신 결과를 덮어씀");
+});
+
+test("미국장이 비활성인 run 에서는 히트맵 카드를 감춘다", async () => {
+  const calls = [];
+  const window = makeWindow(async (url) => {
+    calls.push(url);
+    if (url.startsWith("/api/market-mode")) return marketMode(["domestic"]);
+    return success({ items: [item({})] });
+  });
+
+  await window.initMarketHeatmap();
+
+  assert(window.document.getElementById("market-heatmap-card").style.display === "none",
+    "미국장 비활성 시 카드가 감춰져야 함");
+  assert(!calls.some(url => url.startsWith("/api/overseas/")),
+    "비활성 상태에서 시가총액 API 를 호출하면 안 됨");
+});
+
+test("미국장이 활성이면 카드를 노출하고 히트맵을 조회한다", async () => {
+  const window = makeWindow(async (url) => {
+    if (url.startsWith("/api/market-mode")) return marketMode(["domestic", "overseas_us"]);
+    return success({ items: [item({ symbol: "MSFT" })], updated_at: 1767225600 });
+  });
+
+  await window.initMarketHeatmap();
+
+  const doc = window.document;
+  assert(doc.getElementById("market-heatmap-card").style.display !== "none", "카드가 노출되어야 함");
+  assert(doc.querySelector('.heatmap-tile[data-symbol="MSFT"]'), "히트맵 타일이 렌더되어야 함");
+  assert(doc.getElementById("market-heatmap-updated-at").textContent.includes("최신 업데이트"),
+    "업데이트 시각이 표시되어야 함");
+});
+
+test("홈 경로에서는 로드 시 자동으로 히트맵을 초기화한다", async () => {
+  const calls = [];
+  makeWindow(async (url) => {
+    calls.push(url);
+    if (url.startsWith("/api/market-mode")) return marketMode(["overseas_us"]);
+    return success({ items: [item({})] });
+  }, "http://localhost/");
+
+  await new Promise(done => setTimeout(done, 50));
+
+  assert(calls.some(url => url.startsWith("/api/market-mode")), "홈 진입 시 시장 활성 여부를 확인해야 함");
+  assert(calls.some(url => url.startsWith("/api/overseas/top-market-cap")), "홈 진입 시 히트맵을 조회해야 함");
+});
+
+await run();

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -1,0 +1,77 @@
+"""홈 화면 S&P500 히트맵의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
+
+import re
+from pathlib import Path
+
+
+def _heatmap_js() -> str:
+    return Path("view/web/static/js/market_heatmap.js").read_text(encoding="utf-8")
+
+
+def _home_template() -> str:
+    return Path("view/web/templates/index.html").read_text(encoding="utf-8")
+
+
+def test_home_template_hosts_heatmap_panel():
+    template = _home_template()
+
+    assert 'id="market-heatmap-card"' in template
+    assert 'id="market-heatmap"' in template
+    assert 'id="market-heatmap-updated-at"' in template
+    assert "/static/js/market_heatmap.js" in template
+
+
+def test_heatmap_styles_are_defined_in_home_template():
+    template = _home_template()
+
+    for selector in (
+        "#market-heatmap {",
+        ".heatmap-canvas",
+        ".heatmap-sector",
+        ".heatmap-sector-title",
+        ".heatmap-sector-body",
+        ".heatmap-tile",
+        ".heatmap-legend",
+    ):
+        assert selector in template, f"{selector} 스타일이 없음"
+
+
+def test_heatmap_reuses_overseas_market_cap_snapshot():
+    script = _heatmap_js()
+
+    # 별도 수집 없이 미국 시가총액 화면과 같은 스냅샷(TTL 캐시 공유)을 쓴다.
+    assert "/api/overseas/top-market-cap" in script
+    assert "HEATMAP_LIMIT = 500" in script
+    # 미국장이 꺼진 run 에서는 조회 대신 카드를 감춘다.
+    assert "/api/market-mode" in script
+    assert "overseas_us" in script
+
+
+def test_heatmap_renders_untrusted_strings_as_text():
+    script = _heatmap_js()
+
+    assert "escapeHtml" in script
+    for field in ("symbol", "name", "sector"):
+        assert f"row.{field}" in script
+
+
+def test_heatmap_legend_colors_match_script_palette():
+    script = _heatmap_js()
+    template = _home_template()
+
+    palette = set(re.findall(r"color: '(#[0-9a-f]{6})'", script))
+    assert len(palette) == 8, f"상승/하락 4단계 색이 정의되어야 함 (실제 {len(palette)}종)"
+    for color in palette:
+        assert color in template, f"범례에 {color} 가 빠져 스크립트와 어긋남"
+
+
+def test_heatmap_follows_domestic_up_red_convention():
+    script = _heatmap_js()
+
+    up_block = script.split("HEATMAP_UP_COLORS")[1].split("]")[0]
+    down_block = script.split("HEATMAP_DOWN_COLORS")[1].split("]")[0]
+    # 상승은 적색(R>B), 하락은 청색(B>R) 계열이어야 한다.
+    for hex_color in re.findall(r"#([0-9a-f]{6})", up_block):
+        assert int(hex_color[0:2], 16) > int(hex_color[4:6], 16), f"#{hex_color} 는 상승 색으로 부적절"
+    for hex_color in re.findall(r"#([0-9a-f]{6})", down_block):
+        assert int(hex_color[4:6], 16) > int(hex_color[0:2], 16), f"#{hex_color} 는 하락 색으로 부적절"

--- a/todo_list.md
+++ b/todo_list.md
@@ -260,6 +260,14 @@
 
 주요 파일: `view/web/templates/marketcap.html`, `view/web/static/js/marketcap.js`, `view/web/static/js/overseas.js`, `view/web/static/js/common.js`, `view/web/routes/stock.py`, `view/web/bootstrap/service_container.py`, `services/market_cap_gap_service.py`, `tests/frontend/`
 
+### M-4. 한국장 히트맵(트리맵) [미국장 완료 후속, 2026-07-31]
+
+홈 화면 S&P500 히트맵은 완료(`view/web/static/js/market_heatmap.js`, `/api/overseas/top-market-cap` 스냅샷 재사용, 백엔드 변경 없음). 한국장 히트맵은 아래 제약 때문에 별도 작업으로 남긴다.
+
+- [ ] 데이터 소스 결정: KIS 시가총액 랭킹(`/api/top-market-cap`)은 **실전 전용 + 상위 30종목**이라 전체 맵에 부족. `stocks.db daily_prices`(최근일 2,583종목, `market_cap`·`change_rate` 보유)를 쓰면 전 종목 맵이 되지만 **전일 종가 기준**(장중 실시간 아님).
+- [ ] 그룹 축 결정: `stock_classifications`에는 NAVER **테마만** 있고 `category_type='industry'`는 0건. 한 종목이 여러 테마에 중복 소속이라 트리맵의 배타적 그룹 요건에 맞지 않음 → (a) 섹터 블록 없이 시총순 단일 그리드, (b) 업종 분류 수집 신규 추가, (c) 테마 대표 1개 강제 배정(해석 왜곡 위험) 중 택1.
+- [ ] 위 결정 후 신규 엔드포인트 1개(daily_prices 집계) + `market_heatmap.js` 재사용(트리맵 레이아웃·색상 스케일은 시장 무관)으로 구현.
+
 ---
 
 ## 테마/분류 데이터

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -1,0 +1,285 @@
+/* view/web/static/js/market_heatmap.js — 홈 화면 S&P 500 섹터 히트맵(트리맵)
+ *
+ * 데이터는 미국 시가총액 화면과 같은 /api/overseas/top-market-cap 스냅샷을 쓴다.
+ * (Yahoo 스냅샷 1회로 sector/change_rate/market_cap_usd 가 모두 오고, 서비스 TTL 캐시를 공유한다.)
+ * 타일 좌표는 % 로만 계산해 컨테이너 크기와 무관하게 반응형으로 그린다.
+ *
+ * 색상은 국내 화면 컨벤션(상승=빨강, 하락=파랑)을 따른다.
+ */
+
+const HEATMAP_LIMIT = 500;
+const HEATMAP_REFRESH_MS = 5 * 60 * 1000;
+const HEATMAP_SECTOR_HEADER_PX = 16;
+// 타일이 이보다 작으면 글자가 넘쳐 겹치므로 텍스트를 생략한다(툴팁으로만 노출).
+const HEATMAP_MIN_LABEL_WIDTH_PCT = 4.5;
+const HEATMAP_MIN_LABEL_HEIGHT_PCT = 8;
+
+const HEATMAP_UP_COLORS = [
+    { min: 3, color: '#8f1a1a' },
+    { min: 2, color: '#b52626' },
+    { min: 1, color: '#d64545' },
+    { min: 0, color: '#e58080' },
+];
+const HEATMAP_DOWN_COLORS = [
+    { min: 3, color: '#12386f' },
+    { min: 2, color: '#2b5cb8' },
+    { min: 1, color: '#4a7fd4' },
+    { min: 0, color: '#84aee6' },
+];
+const HEATMAP_FLAT_COLOR = '#6b7280';
+const HEATMAP_UNKNOWN_COLOR = '#3f4650';
+
+let _heatmapRequestSequence = 0;
+let _heatmapRefreshTimer = null;
+
+function _heatmapNumber(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+function _heatmapRateText(rate) {
+    if (rate === null) return '-';
+    const sign = rate > 0 ? '+' : '';
+    return `${sign}${rate.toFixed(2)}%`;
+}
+
+function _heatmapDirection(rate) {
+    if (rate === null) return 'unknown';
+    if (rate > 0) return 'up';
+    if (rate < 0) return 'down';
+    return 'flat';
+}
+
+function _heatmapColor(rate) {
+    if (rate === null) return HEATMAP_UNKNOWN_COLOR;
+    if (rate === 0) return HEATMAP_FLAT_COLOR;
+    const scale = rate > 0 ? HEATMAP_UP_COLORS : HEATMAP_DOWN_COLORS;
+    const magnitude = Math.abs(rate);
+    return scale.find(step => magnitude >= step.min).color;
+}
+
+function _heatmapCapText(value) {
+    const number = _heatmapNumber(value);
+    if (number === null || number <= 0) return '-';
+    if (number >= 1e12) return `$${(number / 1e12).toFixed(2)}T`;
+    if (number >= 1e9) return `$${(number / 1e9).toFixed(2)}B`;
+    if (number >= 1e6) return `$${(number / 1e6).toFixed(2)}M`;
+    return `$${Math.round(number).toLocaleString()}`;
+}
+
+/**
+ * squarified treemap. cells 는 { key, weight } 배열(내림차순), rect 는 % 단위 사각형.
+ * 반환: [{ key, x, y, w, h }] (모두 % 단위)
+ */
+function _squarifyTreemap(cells, rect) {
+    const placed = [];
+    const remaining = cells.filter(cell => cell.weight > 0);
+    let { x, y, w, h } = rect;
+
+    while (remaining.length && w > 0 && h > 0) {
+        const totalWeight = remaining.reduce((sum, cell) => sum + cell.weight, 0);
+        const areaScale = (w * h) / totalWeight;
+        const side = Math.min(w, h);
+        const row = [];
+        let rowArea = 0;
+        let bestWorst = Infinity;
+
+        while (remaining.length) {
+            const area = remaining[0].weight * areaScale;
+            const nextArea = rowArea + area;
+            const areas = row.map(entry => entry.area).concat(area);
+            const worst = Math.max(
+                (nextArea * nextArea) / (side * side * Math.min(...areas)),
+                (side * side * Math.max(...areas)) / (nextArea * nextArea),
+            );
+            if (row.length && worst > bestWorst) break;
+            bestWorst = worst;
+            row.push({ cell: remaining.shift(), area });
+            rowArea = nextArea;
+        }
+
+        const thickness = rowArea / side;
+        let offset = 0;
+        const horizontal = w >= h;
+        row.forEach(({ cell, area }) => {
+            const length = area / thickness;
+            placed.push(horizontal
+                ? { key: cell.key, x, y: y + offset, w: thickness, h: length }
+                : { key: cell.key, x: x + offset, y, w: length, h: thickness });
+            offset += length;
+        });
+
+        if (horizontal) {
+            x += thickness;
+            w -= thickness;
+        } else {
+            y += thickness;
+            h -= thickness;
+        }
+    }
+
+    return placed;
+}
+
+function _groupBySector(items) {
+    const groups = new Map();
+    items.forEach(raw => {
+        const row = raw && typeof raw === 'object' ? raw : {};
+        const cap = _heatmapNumber(row.market_cap_usd);
+        if (cap === null || cap <= 0) return;
+        const sector = String(row.sector || '기타');
+        if (!groups.has(sector)) groups.set(sector, { sector, cap: 0, members: [] });
+        const group = groups.get(sector);
+        group.cap += cap;
+        group.members.push({
+            symbol: String(row.symbol ?? ''),
+            name: String(row.name ?? ''),
+            rate: _heatmapNumber(row.change_rate),
+            cap,
+        });
+    });
+
+    const groupList = [...groups.values()].sort((a, b) => b.cap - a.cap);
+    groupList.forEach(group => group.members.sort((a, b) => b.cap - a.cap));
+    return groupList;
+}
+
+function _heatmapTileHtml(member, box) {
+    const rateText = _heatmapRateText(member.rate);
+    const showLabel = box.w >= HEATMAP_MIN_LABEL_WIDTH_PCT && box.h >= HEATMAP_MIN_LABEL_HEIGHT_PCT;
+    const label = showLabel
+        ? `<span class="heatmap-tile-symbol">${escapeHtml(member.symbol)}</span>`
+          + `<span class="heatmap-tile-rate">${escapeHtml(rateText)}</span>`
+        : '';
+    const tooltip = `${member.symbol} ${member.name} | ${rateText} | ${_heatmapCapText(member.cap)}`;
+    return `
+        <div class="heatmap-tile"
+             data-symbol="${escapeHtml(member.symbol)}"
+             data-direction="${_heatmapDirection(member.rate)}"
+             title="${escapeHtml(tooltip)}"
+             style="left:${box.x.toFixed(4)}%; top:${box.y.toFixed(4)}%; width:${box.w.toFixed(4)}%; height:${box.h.toFixed(4)}%; background-color:${_heatmapColor(member.rate)};">
+            ${label}
+        </div>
+    `;
+}
+
+function _heatmapSectorHtml(group, box) {
+    const memberBoxes = _squarifyTreemap(
+        group.members.map((member, index) => ({ key: index, weight: member.cap })),
+        { x: 0, y: 0, w: 100, h: 100 },
+    );
+    const tiles = memberBoxes
+        .map(memberBox => _heatmapTileHtml(group.members[memberBox.key], memberBox))
+        .join('');
+
+    return `
+        <div class="heatmap-sector" data-sector="${escapeHtml(group.sector)}"
+             style="left:${box.x.toFixed(4)}%; top:${box.y.toFixed(4)}%; width:${box.w.toFixed(4)}%; height:${box.h.toFixed(4)}%;">
+            <div class="heatmap-sector-title">${escapeHtml(group.sector)}</div>
+            <div class="heatmap-sector-body" style="top:${HEATMAP_SECTOR_HEADER_PX}px;">${tiles}</div>
+        </div>
+    `;
+}
+
+function _renderHeatmapUpdatedAt(value) {
+    const el = document.getElementById('market-heatmap-updated-at');
+    if (!el) return;
+    const number = _heatmapNumber(value);
+    if (number === null || number <= 0) {
+        el.textContent = '최신 업데이트: --';
+        return;
+    }
+    const date = new Date(number * 1000);
+    el.textContent = Number.isNaN(date.getTime())
+        ? '최신 업데이트: --'
+        : `최신 업데이트: ${date.toLocaleString('ko-KR')}`;
+}
+
+function _renderMarketHeatmap(div, data) {
+    _renderHeatmapUpdatedAt(data.updated_at);
+
+    const groups = _groupBySector(Array.isArray(data.items) ? data.items : []);
+    if (!groups.length) {
+        div.innerHTML = '<p class="empty">조회 결과가 없습니다.</p>';
+        return;
+    }
+
+    const sectorBoxes = _squarifyTreemap(
+        groups.map((group, index) => ({ key: index, weight: group.cap })),
+        { x: 0, y: 0, w: 100, h: 100 },
+    );
+    div.innerHTML = `<div class="heatmap-canvas">${
+        sectorBoxes.map(box => _heatmapSectorHtml(groups[box.key], box)).join('')
+    }</div>`;
+}
+
+async function loadMarketHeatmap(options = {}) {
+    const requestSequence = ++_heatmapRequestSequence;
+    const isLatestRequest = () => requestSequence === _heatmapRequestSequence;
+
+    const div = document.getElementById('market-heatmap');
+    if (!div) return;
+    if (options.showLoading !== false) showLoading(div, 'S&P 500 히트맵 조회 중...');
+
+    try {
+        const res = await fetchWithTimeout(`/api/overseas/top-market-cap?limit=${HEATMAP_LIMIT}`, {}, 30000);
+        const { json, error } = await readJsonResponse(res);
+        if (!isLatestRequest()) return;
+
+        if (error) {
+            showError(div, `히트맵 조회 실패: ${error}`);
+            return;
+        }
+        if (json.rt_cd !== '0') {
+            showError(div, `실패: ${json.msg1 || '히트맵 조회에 실패했습니다.'}`);
+            return;
+        }
+        _renderMarketHeatmap(div, json.data || {});
+    } catch (e) {
+        console.error('[market-heatmap] 히트맵 조회 오류', e);
+        if (!isLatestRequest()) return;
+        showError(div, e.name === 'AbortError'
+            ? '요청 시간이 초과되었습니다. 다시 시도해주세요.'
+            : '히트맵을 불러오지 못했습니다. 다시 시도해주세요.');
+    }
+}
+
+async function _heatmapOverseasEnabled() {
+    try {
+        const res = await fetchWithTimeout('/api/market-mode', {}, 5000);
+        if (!res.ok) return false;
+        const json = await res.json();
+        return Array.isArray(json.enabled_market_modes) && json.enabled_market_modes.includes('overseas_us');
+    } catch (_) {
+        return false;
+    }
+}
+
+async function initMarketHeatmap() {
+    const card = document.getElementById('market-heatmap-card');
+    if (!card) return;
+
+    // 미국장이 꺼진 run 에서는 API 가 400 을 내므로, 오류 대신 카드를 감춘다.
+    if (!await _heatmapOverseasEnabled()) {
+        card.style.display = 'none';
+        return;
+    }
+    card.style.display = '';
+
+    await loadMarketHeatmap();
+    if (_heatmapRefreshTimer !== null) return;
+    _heatmapRefreshTimer = setInterval(() => {
+        void loadMarketHeatmap({ showLoading: false });
+    }, HEATMAP_REFRESH_MS);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.location.pathname !== '/') return;
+    void initMarketHeatmap();
+});
+
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/') return;
+    void initMarketHeatmap();
+});

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -17,11 +17,49 @@
         .home-menu-group { margin-top: 28px; text-align: left; }
         .home-menu-group h3 { margin-bottom: 12px; }
         .home-menu-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+        .heatmap-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 8px; flex-wrap: wrap; }
+        .heatmap-updated, .heatmap-legend-label { font-size: 0.78rem; color: var(--text-secondary); }
+        .heatmap-legend { display: inline-flex; align-items: center; gap: 2px; }
+        .heatmap-legend i { display: inline-block; width: 14px; height: 10px; }
+        .heatmap-legend-label { margin: 0 4px; }
+        #market-heatmap { position: relative; height: 520px; }
+        .heatmap-canvas { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
+        .heatmap-sector { position: absolute; }
+        .heatmap-sector-title {
+            position: absolute; top: 0; left: 0; right: 0; height: 16px; line-height: 16px;
+            font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
+            color: var(--text-secondary); white-space: nowrap; overflow: hidden;
+        }
+        .heatmap-sector-body { position: absolute; left: 0; right: 0; bottom: 0; }
+        .heatmap-tile {
+            position: absolute; box-sizing: border-box; overflow: hidden;
+            display: flex; flex-direction: column; align-items: center; justify-content: center;
+            border: 1px solid var(--bg-secondary); color: #fff;
+        }
+        .heatmap-tile-symbol { font-size: 0.72rem; font-weight: 700; line-height: 1.15; }
+        .heatmap-tile-rate { font-size: 0.66rem; line-height: 1.15; }
+        @media (max-width: 640px) { #market-heatmap { height: 380px; } }
     </style>
     <div class="section">
         <div class="card">
             <h2>시장 지수</h2>
             <div id="market-indices"></div>
+        </div>
+    </div>
+    <div class="section">
+        <div class="card" id="market-heatmap-card">
+            <h2>S&amp;P 500 히트맵</h2>
+            <div class="heatmap-toolbar">
+                <span id="market-heatmap-updated-at" class="heatmap-updated">최신 업데이트: --</span>
+                <span class="heatmap-legend">
+                    <span class="heatmap-legend-label">하락</span>
+                    <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
+                    <i style="background:#6b7280"></i>
+                    <i style="background:#e58080"></i><i style="background:#d64545"></i><i style="background:#b52626"></i><i style="background:#8f1a1a"></i>
+                    <span class="heatmap-legend-label">상승</span>
+                </span>
+            </div>
+            <div id="market-heatmap"></div>
         </div>
     </div>
     <div class="section">
@@ -101,4 +139,5 @@
 
 {% block scripts %}
 <script src="/static/js/market_indices.js?v=3"></script>
+<script src="/static/js/market_heatmap.js?v=1"></script>
 {% endblock %}


### PR DESCRIPTION
## 배경
홈 화면에 finviz 형태의 시장 히트맵(트리맵)을 요청받아 미국장부터 구현했다.

## 변경
- `view/web/static/js/market_heatmap.js` (신규): squarified 트리맵을 % 좌표로 직접 구현. 신규 라이브러리 의존성 없음.
- `view/web/templates/index.html`: '시장 지수' 카드 아래 히트맵 카드 + 범례 + 페이지 로컬 스타일, 스크립트 배선.
- `todo_list.md`: 한국장 히트맵을 M-4 로 분리 기록.

## 데이터
미국 시가총액 화면과 동일한 `/api/overseas/top-market-cap?limit=500` 스냅샷을 재사용한다.
응답에 `sector`·`change_rate`·`market_cap_usd` 가 이미 포함되고 서비스 TTL 캐시를 공유하므로 **백엔드 변경과 추가 외부 호출이 없다.**

## 동작
- 섹터 블록 → 종목 타일 2단 트리맵, 면적은 시가총액 비례.
- 색상은 국내 화면 컨벤션(상승=빨강, 하락=파랑) 4단계 + 보합(회색)/등락률 미상.
- 타일이 작으면 라벨 생략, 정보는 툴팁(심볼·종목명·등락률·시총)으로 유지.
- 5분 주기 갱신(로딩 표시 없이), 늦게 끝난 이전 요청은 시퀀스 가드로 무시.
- `overseas_us` 가 비활성인 run 에서는 API 400 대신 카드를 감춘다.

## 테스트
- `tests/frontend/run_market_heatmap_dom_tests.mjs` (신규, 11 케이스): 면적 비례, 섹터 정렬, 경계 이탈, 색/부호, XSS, HTTP 오류, 빈 목록, 요청 레이스, 비활성 시 카드 숨김, 홈 자동 초기화.
- `tests/unit_test/view/web/test_market_heatmap_contracts.py` (신규, 6 케이스): 템플릿-스크립트 배선, 스타일 선택자, 스냅샷 재사용, 범례 색과 스크립트 팔레트 일치, 상승=적색/하락=청색 컨벤션.
- `pytest tests/unit_test` 7,296 passed / `pytest tests/integration_test` 276 passed (jsdom 러너 포함).

## 한국장 (후속)
데이터는 있으나 (1) 실시간 시총 랭킹이 실전 전용·상위 30종목, (2) 분류 DB 에 업종이 없고 중복 소속 테마만 존재 → 그룹 축 결정이 필요해 `todo_list.md` M-4 로 분리했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
