### PR TITLE
홈 화면에 국내 시가총액 히트맵 추가

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -502,6 +502,44 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository daily_prices 전종목 조회 실패: {e}")
             return []
 
+    async def get_market_cap_snapshot(self, limit: int = 300, market: Optional[str] = None) -> List[Dict]:
+        """최신 거래일의 시가총액 상위 종목 스냅샷 (국내 히트맵용).
+
+        정지주는 시가총액 0원 행으로 저장되므로 면적 계산에서 제외한다.
+        market: "KOSPI"/"KOSDAQ" 지정 시 해당 시장으로 필터링, None/"ALL"이면 전체.
+        """
+        try:
+            async with self._get_read_connection() as conn:
+                async with conn.execute("SELECT MAX(trade_date) FROM daily_prices") as cursor:
+                    latest_row = await cursor.fetchone()
+                latest_date = latest_row[0] if latest_row and latest_row[0] else None
+                if not latest_date:
+                    return []
+
+                market_filter = ""
+                params = [latest_date]
+                if market and market != "ALL":
+                    market_filter = "AND market = ?"
+                    params.append(market)
+                params.append(limit)
+
+                async with conn.execute(
+                    f"""
+                    SELECT * FROM daily_prices
+                    WHERE trade_date = ?
+                      AND market_cap > 0
+                      {market_filter}
+                    ORDER BY market_cap DESC
+                    LIMIT ?
+                    """,
+                    params,
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+        except Exception as e:
+            self._logger.error(f"StockOhlcvRepository 시가총액 스냅샷 조회 실패: {e}")
+            return []
+
     async def get_ytd_return_ranking(self, limit: int = 100, market: Optional[str] = None) -> List[Dict]:
         """최신 거래일(daily_prices)과 연초 첫 종가(ohlcv)를 비교한 YTD 수익률 랭킹.
 

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -106,6 +106,10 @@ class StockRepository:
         """최신 거래일 기준 YTD 수익률 랭킹 조회."""
         return await self._ohlcv_repo.get_ytd_return_ranking(limit=limit, market=market)
 
+    async def get_market_cap_snapshot(self, limit: int = 300, market: Optional[str] = None) -> List[Dict]:
+        """최신 거래일 기준 시가총액 상위 스냅샷 조회 (국내 히트맵용)."""
+        return await self._ohlcv_repo.get_market_cap_snapshot(limit=limit, market=market)
+
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
         """is_newhigh 및 is_historical_newhigh 컬럼 업데이트."""
         await self._ohlcv_repo.update_newhigh_fields(trade_date, records)

--- a/tests/frontend/run_market_heatmap_dom_tests.mjs
+++ b/tests/frontend/run_market_heatmap_dom_tests.mjs
@@ -17,6 +17,10 @@ const SCAFFOLD = `
   <span id="market-heatmap-updated-at"></span>
   <div id="market-heatmap"></div>
 </div>
+<div class="card" id="domestic-heatmap-card">
+  <span id="domestic-heatmap-updated-at"></span>
+  <div id="domestic-heatmap"></div>
+</div>
 `;
 
 // 홈 경로('/')로 만들면 스크립트의 DOMContentLoaded 자동 초기화가 끼어들어 호출 수가 흔들린다.
@@ -258,6 +262,73 @@ test("미국장이 활성이면 카드를 노출하고 히트맵을 조회한다
     "업데이트 시각이 표시되어야 함");
 });
 
+function domesticItem(overrides) {
+  return { code: "005930", name: "삼성전자", change_rate: "-0.72", market_cap: 12101797, market: "KOSPI", ...overrides };
+}
+
+test("국내 히트맵은 섹터 블록 없이 시총순 타일만 그린다", async () => {
+  const window = makeWindow(async () => success({
+    trade_date: "20260730",
+    items: [
+      domesticItem({ code: "005930", name: "삼성전자", market_cap: 900 }),
+      domesticItem({ code: "000660", name: "SK하이닉스", market_cap: 100 }),
+    ],
+  }));
+
+  await window.loadDomesticHeatmap();
+
+  const doc = window.document;
+  const target = doc.getElementById("domestic-heatmap");
+  assert(!target.querySelector(".heatmap-sector-title"), "국내 맵에는 섹터 헤더가 없어야 함");
+  assert(target.querySelectorAll(".heatmap-tile").length === 2, "종목 타일이 렌더되어야 함");
+
+  const big = target.querySelector('.heatmap-tile[data-symbol="005930"]');
+  const small = target.querySelector('.heatmap-tile[data-symbol="000660"]');
+  const ratio = (pct(big, "width") * pct(big, "height")) / (pct(small, "width") * pct(small, "height"));
+  assert(ratio > 8.5 && ratio < 9.5, `면적비가 시총비(9:1)를 따라야 함 (실제 ${ratio.toFixed(2)})`);
+  assert(big.textContent.includes("삼성전자"), "국내 타일은 종목명을 표시해야 함");
+});
+
+test("국내 히트맵은 종가 기준일을 명시한다", async () => {
+  const window = makeWindow(async () => success({ trade_date: "20260730", items: [domesticItem({})] }));
+
+  await window.loadDomesticHeatmap();
+
+  const label = window.document.getElementById("domestic-heatmap-updated-at").textContent;
+  assert(label.includes("2026-07-30"), `기준일이 표시되어야 함 (실제 ${label})`);
+  assert(label.includes("종가"), "장중 오해를 막기 위해 종가 기준임을 밝혀야 함");
+});
+
+test("국내 히트맵의 빈 스냅샷과 응답 문자열을 안전하게 처리한다", async () => {
+  const responses = [
+    success({ trade_date: null, items: [] }),
+    success({ trade_date: "20260730", items: [domesticItem({ name: '<img id="injected-kr" src=x>' })] }),
+  ];
+  const window = makeWindow(async () => responses.shift());
+
+  await window.loadDomesticHeatmap();
+  assert(window.document.getElementById("domestic-heatmap").textContent.includes("조회 결과가 없습니다"),
+    "빈 스냅샷 안내가 표시되어야 함");
+
+  await window.loadDomesticHeatmap();
+  const target = window.document.getElementById("domestic-heatmap");
+  assert(!target.querySelector("#injected-kr"), "응답 문자열이 HTML 로 해석됨");
+  assert(target.textContent.includes('<img id="injected-kr" src=x>'), "종목명이 텍스트로 표시되어야 함");
+});
+
+test("국내 조회가 미국 히트맵을 덮어쓰지 않는다", async () => {
+  const window = makeWindow(async (url) => (url.startsWith("/api/heatmap/domestic")
+    ? success({ trade_date: "20260730", items: [domesticItem({ code: "005930" })] })
+    : success({ items: [item({ symbol: "MSFT" })] })));
+
+  await window.loadMarketHeatmap();
+  await window.loadDomesticHeatmap();
+
+  const doc = window.document;
+  assert(doc.querySelector('#market-heatmap .heatmap-tile[data-symbol="MSFT"]'), "미국 히트맵이 유지되어야 함");
+  assert(doc.querySelector('#domestic-heatmap .heatmap-tile[data-symbol="005930"]'), "국내 히트맵이 렌더되어야 함");
+});
+
 test("홈 경로에서는 로드 시 자동으로 히트맵을 초기화한다", async () => {
   const calls = [];
   makeWindow(async (url) => {
@@ -269,7 +340,8 @@ test("홈 경로에서는 로드 시 자동으로 히트맵을 초기화한다",
   await new Promise(done => setTimeout(done, 50));
 
   assert(calls.some(url => url.startsWith("/api/market-mode")), "홈 진입 시 시장 활성 여부를 확인해야 함");
-  assert(calls.some(url => url.startsWith("/api/overseas/top-market-cap")), "홈 진입 시 히트맵을 조회해야 함");
+  assert(calls.some(url => url.startsWith("/api/overseas/top-market-cap")), "홈 진입 시 미국 히트맵을 조회해야 함");
+  assert(calls.some(url => url.startsWith("/api/heatmap/domestic")), "홈 진입 시 국내 히트맵을 조회해야 함");
 });
 
 await run();

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -1024,3 +1024,65 @@ class TestCacheLoggerPaths:
         })
         repo.update_today_candle("A001", 120)
         logger.log_today_candle.assert_called_once()
+
+
+class TestGetMarketCapSnapshot:
+    """get_market_cap_snapshot: 국내 히트맵용 최신 거래일 시총 스냅샷."""
+
+    @pytest.mark.asyncio
+    async def test_returns_latest_date_ordered_by_market_cap(self, repo):
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("OLD", market_cap=9_999_999)])
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", name="중형주", market_cap=500),
+            _make_snapshot("A002", name="대형주", market_cap=900),
+            _make_snapshot("A003", name="소형주", market_cap=100),
+        ])
+
+        result = await repo.get_market_cap_snapshot(limit=10)
+
+        assert [row["code"] for row in result] == ["A002", "A001", "A003"]
+        assert all(row["trade_date"] == "20260714" for row in result)
+
+    @pytest.mark.asyncio
+    async def test_applies_limit(self, repo):
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300),
+            _make_snapshot("A002", market_cap=200),
+            _make_snapshot("A003", market_cap=100),
+        ])
+
+        result = await repo.get_market_cap_snapshot(limit=2)
+
+        assert [row["code"] for row in result] == ["A001", "A002"]
+
+    @pytest.mark.asyncio
+    async def test_excludes_non_positive_market_cap(self, repo):
+        """정지주는 시총 0원 행으로 저장되므로 히트맵 면적 계산에서 제외한다."""
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300),
+            _make_snapshot("HALT", market_cap=0),
+        ])
+
+        result = await repo.get_market_cap_snapshot(limit=10)
+
+        assert [row["code"] for row in result] == ["A001"]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_market(self, repo):
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300, market="KOSPI"),
+            _make_snapshot("A002", market_cap=200, market="KOSDAQ"),
+        ])
+
+        result = await repo.get_market_cap_snapshot(limit=10, market="KOSDAQ")
+
+        assert [row["code"] for row in result] == ["A002"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_snapshots(self, repo):
+        assert await repo.get_market_cap_snapshot() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_read_error(self, repo, monkeypatch):
+        _broken_read_ctx(repo, monkeypatch)
+        assert await repo.get_market_cap_snapshot() == []

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -519,3 +519,52 @@ async def test_get_period_ranking_progress_no_ranking_task(web_client, mock_web_
     body = response.json()
     assert body["running"] is False
     assert body["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap(web_client, mock_web_ctx):
+    """GET /api/heatmap/domestic 은 저장된 시총 스냅샷을 기준일과 함께 반환한다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "-0.72", "market_cap": 12101797,
+         "trade_date": "20260730", "market": "KOSPI", "current_price": 70000},
+    ])
+
+    response = web_client.get("/api/heatmap/domestic?limit=300")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["trade_date"] == "20260730"
+    assert body["data"]["items"] == [{
+        "code": "005930",
+        "name": "삼성전자",
+        "change_rate": "-0.72",
+        "market_cap": 12101797,
+        "market": "KOSPI",
+    }]
+    mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_awaited_once_with(limit=300, market=None)
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_with_market_filter(web_client, mock_web_ctx):
+    """GET /api/heatmap/domestic?market=KOSDAQ 는 market 필터를 저장소에 전달한다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[])
+
+    response = web_client.get("/api/heatmap/domestic?limit=100&market=KOSDAQ")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"] == {"trade_date": None, "items": []}
+    mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_awaited_once_with(limit=100, market="KOSDAQ")
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_without_repository(web_client, mock_web_ctx):
+    """저장소가 없으면 실패 코드로 응답한다."""
+    mock_web_ctx.stock_repository = None
+
+    response = web_client.get("/api/heatmap/domestic")
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] != "0"

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -21,11 +21,29 @@ def test_home_template_hosts_heatmap_panel():
     assert "/static/js/market_heatmap.js" in template
 
 
+def test_home_template_hosts_domestic_heatmap_panel():
+    template = _home_template()
+
+    assert 'id="domestic-heatmap-card"' in template
+    assert 'id="domestic-heatmap"' in template
+    assert 'id="domestic-heatmap-updated-at"' in template
+
+
+def test_domestic_heatmap_uses_daily_snapshot_and_shows_base_date():
+    script = _heatmap_js()
+
+    # 실시간 전종목 시세 소스가 없어 장마감 후 스냅샷을 쓴다 — 기준일을 감추지 않는다.
+    assert "/api/heatmap/domestic" in script
+    assert "기준일" in script and "종가" in script
+    # 배타적 업종 분류가 없으므로 섹터 블록 없이 단일 그룹으로 그린다.
+    assert "sector: null" in script
+
+
 def test_heatmap_styles_are_defined_in_home_template():
     template = _home_template()
 
     for selector in (
-        "#market-heatmap {",
+        "#market-heatmap, #domestic-heatmap {",
         ".heatmap-canvas",
         ".heatmap-sector",
         ".heatmap-sector-title",

--- a/todo_list.md
+++ b/todo_list.md
@@ -260,13 +260,19 @@
 
 주요 파일: `view/web/templates/marketcap.html`, `view/web/static/js/marketcap.js`, `view/web/static/js/overseas.js`, `view/web/static/js/common.js`, `view/web/routes/stock.py`, `view/web/bootstrap/service_container.py`, `services/market_cap_gap_service.py`, `tests/frontend/`
 
-### M-4. 한국장 히트맵(트리맵) [미국장 완료 후속, 2026-07-31]
+### M-4. 히트맵(트리맵) [미국장·국내 1단계 완료 — 업종 축만 잔여, 2026-07-31]
 
-홈 화면 S&P500 히트맵은 완료(`view/web/static/js/market_heatmap.js`, `/api/overseas/top-market-cap` 스냅샷 재사용, 백엔드 변경 없음). 한국장 히트맵은 아래 제약 때문에 별도 작업으로 남긴다.
+홈 화면 히트맵 2종 완료. 공용 렌더러는 `view/web/static/js/market_heatmap.js`.
 
-- [ ] 데이터 소스 결정: KIS 시가총액 랭킹(`/api/top-market-cap`)은 **실전 전용 + 상위 30종목**이라 전체 맵에 부족. `stocks.db daily_prices`(최근일 2,583종목, `market_cap`·`change_rate` 보유)를 쓰면 전 종목 맵이 되지만 **전일 종가 기준**(장중 실시간 아님).
-- [ ] 그룹 축 결정: `stock_classifications`에는 NAVER **테마만** 있고 `category_type='industry'`는 0건. 한 종목이 여러 테마에 중복 소속이라 트리맵의 배타적 그룹 요건에 맞지 않음 → (a) 섹터 블록 없이 시총순 단일 그리드, (b) 업종 분류 수집 신규 추가, (c) 테마 대표 1개 강제 배정(해석 왜곡 위험) 중 택1.
-- [ ] 위 결정 후 신규 엔드포인트 1개(daily_prices 집계) + `market_heatmap.js` 재사용(트리맵 레이아웃·색상 스케일은 시장 무관)으로 구현.
+- 미국: `/api/overseas/top-market-cap` 스냅샷 재사용(섹터 블록 2단, 백엔드 변경 없음).
+- 국내: `/api/heatmap/domestic` 신규(`StockOhlcvRepository.get_market_cap_snapshot`). 상위 200종목 = 전체 시총 91% 커버.
+  - **종가 기준**: 실시간 전종목 시세 소스가 없어 daily_prices 스냅샷을 쓴다. 확인한 대안 — KIS 랭킹은 실전 전용·상위 30, `theme_trading_value_snapshots`는 84종목·가격 없음, 전종목 폴링은 budget throttle 직격. 화면에 `기준일: YYYY-MM-DD 종가` 를 상시 표기해 장중 오해를 막는다.
+  - **섹터 블록 없음**: 배타적 업종 분류가 없어 시총순 단일 그리드로 그린다.
+
+잔여 — 국내 업종 축(선택):
+- [ ] KRX 업종지수 구성종목(`pykrx.stock.get_index_portfolio_deposit_file`)으로 배타적 업종 분류를 수집한다. `StockClassificationRepository`에 `category_type='industry'`로 적재하면 저장소·조회 코드를 그대로 재사용할 수 있고, `market_heatmap.js`는 `sector` 가 채워지면 자동으로 섹터 블록을 그린다.
+  - **선행 검증 필요**: 2026-07-31 확인 시 이 환경에서 pykrx 지수 API가 빈 응답이었다(`get_index_portfolio_deposit_file('1005')` IndexError, `get_market_cap_by_ticker` 컬럼 없음). 샌드박스 네트워크 제약인지 KRX 변경인지 실런타임에서 1회 spike 검증 후 착수.
+  - NAVER 테마를 대표 1개로 강제 배정하는 안은 채택하지 않는다(종목당 평균 2.7개 소속 → 임의 규칙이 화면 해석을 왜곡).
 
 ---
 

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -193,6 +193,39 @@ async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500), market: 
     }
 
 
+@router.get("/heatmap/domestic")
+async def get_domestic_heatmap(limit: int = Query(300, ge=1, le=1000), market: Optional[str] = Query(None)):
+    """국내 히트맵용 시가총액 스냅샷.
+
+    실시간 전종목 시세 소스가 없어 장마감 후 수집된 daily_prices 스냅샷을 쓴다.
+    기준일(trade_date)을 함께 반환해 화면이 장중에도 기준 시점을 표시할 수 있게 한다.
+    """
+    ctx = _get_ctx()
+    repository = getattr(ctx, "stock_repository", None)
+    if not repository:
+        return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "StockRepository 미설정", "data": None}
+
+    rows = await repository.get_market_cap_snapshot(limit=limit, market=market)
+    items = [
+        {
+            "code": row.get("code") or "",
+            "name": row.get("name") or "",
+            "change_rate": row.get("change_rate"),
+            "market_cap": row.get("market_cap"),
+            "market": row.get("market") or "",
+        }
+        for row in rows
+    ]
+    return {
+        "rt_cd": ErrorCode.SUCCESS.value,
+        "msg1": "국내 히트맵 조회 성공" if items else "저장된 시가총액 스냅샷이 없습니다.",
+        "data": {
+            "trade_date": rows[0].get("trade_date") if rows else None,
+            "items": items,
+        },
+    }
+
+
 @router.get("/ranking/{category}")
 async def get_ranking(category: str):
     """랭킹 조회 (rise/fall/volume/trading_value/foreign_buy/foreign_sell/inst_buy/inst_sell/prsn_buy/prsn_sell)."""

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -1,13 +1,18 @@
-/* view/web/static/js/market_heatmap.js — 홈 화면 S&P 500 섹터 히트맵(트리맵)
+/* view/web/static/js/market_heatmap.js — 홈 화면 히트맵(트리맵)
  *
- * 데이터는 미국 시가총액 화면과 같은 /api/overseas/top-market-cap 스냅샷을 쓴다.
- * (Yahoo 스냅샷 1회로 sector/change_rate/market_cap_usd 가 모두 오고, 서비스 TTL 캐시를 공유한다.)
+ * 미국: /api/overseas/top-market-cap 스냅샷을 쓴다. 미국 시가총액 화면과 같은 소스라
+ *       (Yahoo 스냅샷 1회로 sector/change_rate/market_cap_usd 가 모두 오고) TTL 캐시를 공유한다.
+ *       섹터 블록 → 종목 타일 2단으로 그린다.
+ * 국내: /api/heatmap/domestic (장마감 후 daily_prices 스냅샷). 실시간 전종목 시세 소스가 없어
+ *       종가 기준이며, 배타적 업종 분류도 아직 없어 섹터 블록 없이 시총순 타일만 그린다.
+ *
  * 타일 좌표는 % 로만 계산해 컨테이너 크기와 무관하게 반응형으로 그린다.
- *
  * 색상은 국내 화면 컨벤션(상승=빨강, 하락=파랑)을 따른다.
  */
 
 const HEATMAP_LIMIT = 500;
+// 상위 200종목이면 국내 전체 시총의 91% 를 덮으면서 가장 작은 타일도 10px 아래로 내려가지 않는다.
+const HEATMAP_DOMESTIC_LIMIT = 200;
 const HEATMAP_REFRESH_MS = 5 * 60 * 1000;
 const HEATMAP_SECTOR_HEADER_PX = 16;
 // 타일이 이보다 작으면 글자가 넘쳐 겹치므로 텍스트를 생략한다(툴팁으로만 노출).
@@ -122,7 +127,7 @@ function _squarifyTreemap(cells, rect) {
     return placed;
 }
 
-function _groupBySector(items) {
+function _overseasGroups(items) {
     const groups = new Map();
     items.forEach(raw => {
         const row = raw && typeof raw === 'object' ? raw : {};
@@ -134,9 +139,11 @@ function _groupBySector(items) {
         group.cap += cap;
         group.members.push({
             symbol: String(row.symbol ?? ''),
+            label: String(row.symbol ?? ''),
             name: String(row.name ?? ''),
             rate: _heatmapNumber(row.change_rate),
             cap,
+            capText: _heatmapCapText(cap),
         });
     });
 
@@ -145,14 +152,36 @@ function _groupBySector(items) {
     return groupList;
 }
 
+// 국내는 배타적 업종 분류가 없어(네이버 테마는 중복 소속) 섹터 블록 없이 단일 그룹으로 그린다.
+function _domesticGroups(items) {
+    const members = [];
+    items.forEach(raw => {
+        const row = raw && typeof raw === 'object' ? raw : {};
+        const cap = _heatmapNumber(row.market_cap);
+        if (cap === null || cap <= 0) return;
+        members.push({
+            symbol: String(row.code ?? ''),
+            label: String(row.name ?? ''),
+            name: String(row.name ?? ''),
+            rate: _heatmapNumber(row.change_rate),
+            cap,
+            capText: formatMarketCap(cap),
+        });
+    });
+    if (!members.length) return [];
+
+    members.sort((a, b) => b.cap - a.cap);
+    return [{ sector: null, cap: members.reduce((sum, m) => sum + m.cap, 0), members }];
+}
+
 function _heatmapTileHtml(member, box) {
     const rateText = _heatmapRateText(member.rate);
     const showLabel = box.w >= HEATMAP_MIN_LABEL_WIDTH_PCT && box.h >= HEATMAP_MIN_LABEL_HEIGHT_PCT;
     const label = showLabel
-        ? `<span class="heatmap-tile-symbol">${escapeHtml(member.symbol)}</span>`
+        ? `<span class="heatmap-tile-symbol">${escapeHtml(member.label)}</span>`
           + `<span class="heatmap-tile-rate">${escapeHtml(rateText)}</span>`
         : '';
-    const tooltip = `${member.symbol} ${member.name} | ${rateText} | ${_heatmapCapText(member.cap)}`;
+    const tooltip = `${member.symbol} ${member.name} | ${rateText} | ${member.capText}`;
     return `
         <div class="heatmap-tile"
              data-symbol="${escapeHtml(member.symbol)}"
@@ -173,33 +202,46 @@ function _heatmapSectorHtml(group, box) {
         .map(memberBox => _heatmapTileHtml(group.members[memberBox.key], memberBox))
         .join('');
 
+    // 섹터명이 없는 시장(국내)은 헤더 없이 타일이 블록 전체를 채운다.
+    const titled = Boolean(group.sector);
+    const sectorAttr = titled ? ` data-sector="${escapeHtml(group.sector)}"` : '';
+    const title = titled ? `<div class="heatmap-sector-title">${escapeHtml(group.sector)}</div>` : '';
+    const bodyTop = titled ? HEATMAP_SECTOR_HEADER_PX : 0;
+
     return `
-        <div class="heatmap-sector" data-sector="${escapeHtml(group.sector)}"
+        <div class="heatmap-sector"${sectorAttr}
              style="left:${box.x.toFixed(4)}%; top:${box.y.toFixed(4)}%; width:${box.w.toFixed(4)}%; height:${box.h.toFixed(4)}%;">
-            <div class="heatmap-sector-title">${escapeHtml(group.sector)}</div>
-            <div class="heatmap-sector-body" style="top:${HEATMAP_SECTOR_HEADER_PX}px;">${tiles}</div>
+            ${title}
+            <div class="heatmap-sector-body" style="top:${bodyTop}px;">${tiles}</div>
         </div>
     `;
 }
 
-function _renderHeatmapUpdatedAt(value) {
-    const el = document.getElementById('market-heatmap-updated-at');
-    if (!el) return;
-    const number = _heatmapNumber(value);
-    if (number === null || number <= 0) {
-        el.textContent = '최신 업데이트: --';
-        return;
-    }
+function _overseasCaption(data) {
+    const number = _heatmapNumber(data.updated_at);
+    if (number === null || number <= 0) return '최신 업데이트: --';
     const date = new Date(number * 1000);
-    el.textContent = Number.isNaN(date.getTime())
+    return Number.isNaN(date.getTime())
         ? '최신 업데이트: --'
         : `최신 업데이트: ${date.toLocaleString('ko-KR')}`;
 }
 
-function _renderMarketHeatmap(div, data) {
-    _renderHeatmapUpdatedAt(data.updated_at);
+// 장중에도 전일 종가가 보일 수 있으므로 기준일을 감추지 않는다.
+function _domesticCaption(data) {
+    const raw = String(data.trade_date || '');
+    if (!/^\d{8}$/.test(raw)) return '기준일: --';
+    return `기준일: ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)} 종가`;
+}
 
-    const groups = _groupBySector(Array.isArray(data.items) ? data.items : []);
+function _renderHeatmapCaption(elementId, text) {
+    const el = document.getElementById(elementId);
+    if (el) el.textContent = text;
+}
+
+function _renderHeatmap(div, source, data) {
+    _renderHeatmapCaption(source.captionId, source.caption(data));
+
+    const groups = source.toGroups(Array.isArray(data.items) ? data.items : []);
     if (!groups.length) {
         div.innerHTML = '<p class="empty">조회 결과가 없습니다.</p>';
         return;
@@ -214,16 +256,37 @@ function _renderMarketHeatmap(div, data) {
     }</div>`;
 }
 
-async function loadMarketHeatmap(options = {}) {
-    const requestSequence = ++_heatmapRequestSequence;
-    const isLatestRequest = () => requestSequence === _heatmapRequestSequence;
+const HEATMAP_OVERSEAS = {
+    targetId: 'market-heatmap',
+    captionId: 'market-heatmap-updated-at',
+    url: `/api/overseas/top-market-cap?limit=${HEATMAP_LIMIT}`,
+    loadingText: 'S&P 500 히트맵 조회 중...',
+    toGroups: _overseasGroups,
+    caption: _overseasCaption,
+    sequence: 0,
+};
 
-    const div = document.getElementById('market-heatmap');
+const HEATMAP_DOMESTIC = {
+    targetId: 'domestic-heatmap',
+    captionId: 'domestic-heatmap-updated-at',
+    url: `/api/heatmap/domestic?limit=${HEATMAP_DOMESTIC_LIMIT}`,
+    loadingText: '국내 히트맵 조회 중...',
+    toGroups: _domesticGroups,
+    caption: _domesticCaption,
+    sequence: 0,
+};
+
+// 두 맵이 같은 홈 화면에 있으므로 시퀀스 가드는 소스별로 따로 센다.
+async function _loadHeatmap(source, options = {}) {
+    const requestSequence = ++source.sequence;
+    const isLatestRequest = () => requestSequence === source.sequence;
+
+    const div = document.getElementById(source.targetId);
     if (!div) return;
-    if (options.showLoading !== false) showLoading(div, 'S&P 500 히트맵 조회 중...');
+    if (options.showLoading !== false) showLoading(div, source.loadingText);
 
     try {
-        const res = await fetchWithTimeout(`/api/overseas/top-market-cap?limit=${HEATMAP_LIMIT}`, {}, 30000);
+        const res = await fetchWithTimeout(source.url, {}, 30000);
         const { json, error } = await readJsonResponse(res);
         if (!isLatestRequest()) return;
 
@@ -235,7 +298,7 @@ async function loadMarketHeatmap(options = {}) {
             showError(div, `실패: ${json.msg1 || '히트맵 조회에 실패했습니다.'}`);
             return;
         }
-        _renderMarketHeatmap(div, json.data || {});
+        _renderHeatmap(div, source, json.data || {});
     } catch (e) {
         console.error('[market-heatmap] 히트맵 조회 오류', e);
         if (!isLatestRequest()) return;
@@ -243,6 +306,14 @@ async function loadMarketHeatmap(options = {}) {
             ? '요청 시간이 초과되었습니다. 다시 시도해주세요.'
             : '히트맵을 불러오지 못했습니다. 다시 시도해주세요.');
     }
+}
+
+async function loadMarketHeatmap(options = {}) {
+    await _loadHeatmap(HEATMAP_OVERSEAS, options);
+}
+
+async function loadDomesticHeatmap(options = {}) {
+    await _loadHeatmap(HEATMAP_DOMESTIC, options);
 }
 
 async function _heatmapOverseasEnabled() {
@@ -274,12 +345,23 @@ async function initMarketHeatmap() {
     }, HEATMAP_REFRESH_MS);
 }
 
+// 국내 맵은 하루 한 번 갱신되는 종가 스냅샷이라 주기 갱신을 걸지 않는다.
+async function initDomesticHeatmap() {
+    if (!document.getElementById('domestic-heatmap-card')) return;
+    await loadDomesticHeatmap();
+}
+
+function _initHomeHeatmaps() {
+    void initMarketHeatmap();
+    void initDomesticHeatmap();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     if (window.location.pathname !== '/') return;
-    void initMarketHeatmap();
+    _initHomeHeatmaps();
 });
 
 document.addEventListener('pjax:ready', (e) => {
     if (e.detail?.path !== '/') return;
-    void initMarketHeatmap();
+    _initHomeHeatmaps();
 });

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -22,7 +22,7 @@
         .heatmap-legend { display: inline-flex; align-items: center; gap: 2px; }
         .heatmap-legend i { display: inline-block; width: 14px; height: 10px; }
         .heatmap-legend-label { margin: 0 4px; }
-        #market-heatmap { position: relative; height: 520px; }
+        #market-heatmap, #domestic-heatmap { position: relative; height: 520px; }
         .heatmap-canvas { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
         .heatmap-sector { position: absolute; }
         .heatmap-sector-title {
@@ -38,7 +38,7 @@
         }
         .heatmap-tile-symbol { font-size: 0.72rem; font-weight: 700; line-height: 1.15; }
         .heatmap-tile-rate { font-size: 0.66rem; line-height: 1.15; }
-        @media (max-width: 640px) { #market-heatmap { height: 380px; } }
+        @media (max-width: 640px) { #market-heatmap, #domestic-heatmap { height: 380px; } }
     </style>
     <div class="section">
         <div class="card">
@@ -60,6 +60,22 @@
                 </span>
             </div>
             <div id="market-heatmap"></div>
+        </div>
+    </div>
+    <div class="section">
+        <div class="card" id="domestic-heatmap-card">
+            <h2>국내 시가총액 히트맵</h2>
+            <div class="heatmap-toolbar">
+                <span id="domestic-heatmap-updated-at" class="heatmap-updated">기준일: --</span>
+                <span class="heatmap-legend">
+                    <span class="heatmap-legend-label">하락</span>
+                    <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
+                    <i style="background:#6b7280"></i>
+                    <i style="background:#e58080"></i><i style="background:#d64545"></i><i style="background:#b52626"></i><i style="background:#8f1a1a"></i>
+                    <span class="heatmap-legend-label">상승</span>
+                </span>
+            </div>
+            <div id="domestic-heatmap"></div>
         </div>
     </div>
     <div class="section">
@@ -139,5 +155,5 @@
 
 {% block scripts %}
 <script src="/static/js/market_indices.js?v=3"></script>
-<script src="/static/js/market_heatmap.js?v=1"></script>
+<script src="/static/js/market_heatmap.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
M-4 1단계. 미국 히트맵(#748)의 트리맵 렌더러를 시장 무관 공용 경로로 정리하고, 국내 맵을 같은 렌더러 위에 올렸다.

## 데이터 소스: daily_prices 종가 스냅샷
실시간 전종목 시세 소스가 없어 장마감 후 스냅샷을 쓴다. 검토한 대안:

| 후보 | 실측 | 판정 |
|---|---|---|
| KIS 시총/등락률 랭킹 | 실전 전용 + 상위 30종목 | 맵으로 부족 |
| `theme_trading_value_snapshots` | 분당 수집이나 84종목·거래대금만(가격 없음) | 사용 불가 |
| 전종목 현재가 폴링 | 2,583콜/회 | budget throttle 직격 |
| `daily_prices` | 최신 거래일 2,572종목, market_cap·change_rate 보유 | **채택** |

장중에 전일 종가가 보일 수 있으므로 카드에 `기준일: YYYY-MM-DD 종가` 를 상시 표기한다.

## 그룹 축: 섹터 블록 없음
`stock_classifications` 에는 NAVER 테마만 있고 종목당 평균 2.7개 중복 소속이라 트리맵의 배타적 그룹 요건을 위반한다. 대표 1개 강제 배정은 임의 규칙이 화면 해석을 왜곡하므로 채택하지 않고, 시총순 단일 그리드로 그린다. 렌더러는 `sector` 가 채워지면 기존 섹터 블록 경로를 그대로 타므로, 이후 KRX 업종 분류를 붙이면 코드 변경 없이 블록이 생긴다(todo M-4 잔여).

## 변경
- `view/web/routes/ranking.py`: `GET /api/heatmap/domestic` 신규
- `repositories/stock_ohlcv_repository.py` / `stock_repository.py`: `get_market_cap_snapshot` (최신 거래일, `market_cap > 0` — 정지주 0원 행 제외)
- `view/web/static/js/market_heatmap.js`: 소스 descriptor(`HEATMAP_OVERSEAS` / `HEATMAP_DOMESTIC`)로 fetch·렌더 경로 공용화, 시퀀스 가드를 소스별로 분리(두 맵이 서로 덮어쓰지 않게), 섹터명 없는 시장은 헤더 없이 렌더
- `view/web/templates/index.html`: 국내 히트맵 카드 추가
- `todo_list.md`: M-4 갱신 (1단계 완료, 업종 축만 잔여)

## 표시 범위
상위 200종목 = 국내 전체 시총 **91%** 커버, 최소 타일 ~10px 유지. (300종목은 93.6% 커버지만 최소 타일이 8.7×5.9px 로 내려가 툴팁 조준이 어려움.)

## 테스트
- jsdom 15 케이스 (기존 11 + 국내 4: 섹터 헤더 부재·면적 비례·기준일 표기·빈 스냅샷/XSS·두 맵 독립성)
- 저장소 6 케이스, 라우트 3 케이스, 계약 8 케이스 신규/확장
- `pytest tests/unit_test` 7,307 passed / `pytest tests/integration_test` 276 passed

## 실데이터 확인
2026-07-30 종가 상위 200종목으로 헤드리스 렌더: 타일 200개가 캔버스 면적 100.0% 를 정확히 채우고, 종횡비 중앙값 1.07 (최대 1.50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
