### PR TITLE
Route favorite price alerts to report bot

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -130,6 +130,7 @@ class FavoritePriceAlertService:
                 "threshold_pct": threshold_pct,
                 "dedup_key": f"favorite_price:{normalized}:{threshold_pct}",
                 "force_external": True,
+                "telegram_channel": "report",
             },
         )
         return True
@@ -154,6 +155,7 @@ class FavoritePriceAlertService:
                 "is_upper_limit": True,
                 "dedup_key": f"favorite_price:{code}:upper_limit",
                 "force_external": True,
+                "telegram_channel": "report",
             },
         )
         return True

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -44,6 +44,7 @@ class MarketStatusAlertService:
             "exchange": exchange,
             "reason": reason,
             "market_status": dict(data),
+            "telegram_channel": "report",
         }
 
         self._active_keys_by_code.setdefault(code, set()).add(dedup_key)

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -102,12 +102,23 @@ def _format_disclosure_ai_summary_html(summary_text: str) -> str:
 class TelegramNotifier:
     """Telegram 알림을 비동기적으로 전송하는 핸들러 클래스입니다."""
 
-    def __init__(self, strategy_bot_token: str, backlog_bot_token: str, chat_id: str, history_repository=None):
+    def __init__(
+        self,
+        strategy_bot_token: str,
+        backlog_bot_token: str,
+        chat_id: str,
+        history_repository=None,
+        report_bot_token: Optional[str] = None,
+    ):
         self.strategy_bot_token = strategy_bot_token
         self.backlog_bot_token = backlog_bot_token
         self.chat_id = chat_id
         self.strategy_api_url = f"https://api.telegram.org/bot{self.strategy_bot_token}/sendMessage"
         self.backlog_api_url = f"https://api.telegram.org/bot{self.backlog_bot_token}/sendMessage"
+        self.report_api_url = (
+            f"https://api.telegram.org/bot{report_bot_token}/sendMessage"
+            if report_bot_token else None
+        )
         self._history_repository = history_repository
         # 허용할 카테고리 목록 설정 (기본값: STRATEGY, BACKGROUND, SYSTEM)
         self.allowed_categories = [NotificationCategory.STRATEGY, NotificationCategory.BACKGROUND, NotificationCategory.SYSTEM]
@@ -118,9 +129,16 @@ class TelegramNotifier:
         if self.allowed_categories is not None and event.category not in self.allowed_categories:
             return
         
+        metadata = event.metadata or {}
+        is_report_channel = metadata.get("telegram_channel") == "report"
         api_url = None
-        if event.category == NotificationCategory.STRATEGY:
+        source = "backlog"
+        if is_report_channel and self.report_api_url:
+            api_url = self.report_api_url
+            source = "report"
+        elif event.category == NotificationCategory.STRATEGY:
             api_url = self.strategy_api_url
+            source = "strategy"
         elif event.category == NotificationCategory.BACKGROUND or \
             event.category == NotificationCategory.SYSTEM:
             api_url = self.backlog_api_url
@@ -181,7 +199,7 @@ class TelegramNotifier:
                         try:
                             self._history_repository.record(
                                 sent_at=event.timestamp,
-                                source="strategy" if event.category == NotificationCategory.STRATEGY else "backlog",
+                                source=source,
                                 title=event.title,
                                 message=event.message,
                                 level=event.level.value,

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -27,6 +27,7 @@ async def test_alerts_when_favorite_rate_crosses_positive_five_percent():
     assert "75,000원" in args[3]
     assert kwargs["metadata"]["threshold_pct"] == 5
     assert kwargs["metadata"]["force_external"] is True
+    assert kwargs["metadata"]["telegram_channel"] == "report"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -46,8 +46,10 @@ async def test_market_status_alert_service_reports_sidecar_warning():
     })
 
     args = operator_alert.report.await_args.args
+    kwargs = operator_alert.report.await_args.kwargs
     assert args[1] == "market_status:sidecar:KRX:005930"
     assert args[2] == "warning"
+    assert kwargs["metadata"]["telegram_channel"] == "report"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -74,6 +74,34 @@ def test_init(telegram_notifier):
     assert telegram_notifier.strategy_api_url == "https://api.telegram.org/bottest_strategy_bot_token/sendMessage"
     assert telegram_notifier.backlog_api_url == "https://api.telegram.org/bottest_backlog_bot_token/sendMessage"
 
+
+@pytest.mark.asyncio
+async def test_handle_event_routes_report_channel_to_report_bot():
+    notifier = TelegramNotifier(
+        strategy_bot_token="strategy",
+        backlog_bot_token="backlog",
+        chat_id="chat",
+        report_bot_token="report",
+    )
+    event = NotificationEvent(
+        id="favorite",
+        timestamp="2026-07-31T11:00:00+09:00",
+        category=NotificationCategory.SYSTEM,
+        level=NotificationLevel.WARNING,
+        title="[관심종목] 삼성전자 +5% 상승",
+        message="005930 삼성전자 현재 75,000원, 전일대비 +5.12%",
+        metadata={"telegram_channel": "report"},
+    )
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        response = AsyncMock()
+        response.status = 200
+        mock_post.return_value.__aenter__.return_value = response
+
+        await notifier.handle_event(event)
+
+    assert mock_post.call_args.args[0] == notifier.report_api_url
+
 @pytest.mark.asyncio
 async def test_handle_event_success(telegram_notifier, sample_event):
     """텔레그램 메시지 전송 성공 테스트 (200 OK)"""

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -687,6 +687,7 @@ def test_load_config_and_env_with_telegram(mock_deps):
         strategy_bot_token="TEST_STRATEGY_TOKEN",
         chat_id="TEST_CHAT_ID",
         history_repository=mock_deps["telegram_history"].return_value,
+        report_bot_token="TEST_REPORT_TOKEN",
     )  # Notifier
     mock_deps["tr"].assert_called_once_with(
         report_bot_token="TEST_REPORT_TOKEN",

--- a/view/web/bootstrap/config_bootstrap.py
+++ b/view/web/bootstrap/config_bootstrap.py
@@ -123,6 +123,7 @@ class ConfigBootstrap:
                 strategy_bot_token=telegram_strategy_bot_token,
                 chat_id=telegram_chat_id,
                 history_repository=ctx.telegram_notification_repository,
+                report_bot_token=telegram_report_bot_token,
             )
             ctx.notification_service.register_external_handler(
                 ctx.telegram_notifier.handle_event


### PR DESCRIPTION
## What changed
- Route favorite price threshold and upper-limit alerts through the Telegram report bot.
- Preserve the existing web notification event and external-delivery queue.
- Add regression coverage for report-channel routing.

## Why
Favorite alerts were sent to the separate backlog bot while the user monitors the report bot for intraday alerts.

## Validation
- Targeted unit tests: 60 passed.
- Integration tests: 276 passed.