### PR TITLE
Fix VBO restart force exit window

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -2305,7 +2305,26 @@ class StrategyScheduler:
                 else:
                     for cfg in self._strategies:
                         if cfg.strategy.name in restored and self._get_strategy_holdings(cfg):
-                            await self._run_strategy(cfg, exits_only=True)
+                            in_force_exit_window = (
+                                cfg.force_exit_on_close
+                                and isinstance(close_time, datetime)
+                                and now >= close_time - timedelta(
+                                    minutes=self.FORCE_EXIT_MINUTES_BEFORE
+                                )
+                            )
+                            if in_force_exit_window:
+                                # 재시작 직후에는 다음 tier 실행을 보장할 수 없다.
+                                # 따라서 당일청산 전략은 남은 수량을 즉시 전량 청산한다.
+                                self._force_exit_progress[cfg.strategy.name] = 1.0
+                                self._logger.info(
+                                    f"[Scheduler] {cfg.strategy.name}: 재시작 복원 중 "
+                                    "마감 전 강제 청산 구간 진입 — 전량 시장가 청산"
+                                )
+                                await self._run_strategy(
+                                    cfg, force_exit_only=True, force_exit_fraction=1.0
+                                )
+                            else:
+                                await self._run_strategy(cfg, exits_only=True)
 
                 self._task = asyncio.create_task(self._loop())
 

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -1597,6 +1597,40 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
         run_strategy.assert_not_awaited()
         self.assertTrue(scheduler._running)
 
+    async def test_restore_state_in_force_exit_window_liquidates_all_holdings(self):
+        """마감 전 강제청산 구간 재시작은 즉시 전량 청산한다.
+
+        재시작 직후 일반 check_exits만 실행하면 전략별 EOD 조건을 기다리는 동안
+        다음 재시작 또는 주문 컷오프를 맞을 수 있다.
+        """
+        scheduler, vm, _, tm, mcs = self._make_scheduler()
+        now = datetime(2026, 7, 30, 15, 12, 0)
+        tm.get_current_kst_time.return_value = now
+        tm.get_market_close_time.return_value = datetime(2026, 7, 30, 15, 40, 0)
+        mcs.is_market_open_now.return_value = True
+        strategy = MockStrategy(name="래리윌리엄스VBO")
+        config = StrategySchedulerConfig(
+            strategy=strategy,
+            interval_minutes=5,
+            force_exit_on_close=True,
+        )
+        scheduler.register(config)
+        vm.get_holds_by_strategy.return_value = [{"code": "316140", "qty": 59}]
+        scheduler._store.load_state.return_value = {
+            "enabled_strategies": ["래리윌리엄스VBO"],
+            "current_positions": [],
+            "strategy_configs": {},
+        }
+
+        with patch.object(scheduler, "_run_strategy", new_callable=AsyncMock) as run_strategy, \
+             patch.object(scheduler, "_loop", new_callable=AsyncMock):
+            await scheduler.restore_state()
+
+        run_strategy.assert_awaited_once_with(
+            config, force_exit_only=True, force_exit_fraction=1.0,
+        )
+        self.assertEqual(scheduler._force_exit_progress["래리윌리엄스VBO"], 1.0)
+
     async def test_restore_state_before_market_open_skips_exit_only(self):
         """장 시작 전 복원은 주문하지 않고 메인 루프가 개장 후 청산을 맡는다."""
         scheduler, vm, _, tm, mcs = self._make_scheduler()


### PR DESCRIPTION
## Summary\n- force full liquidation for same-day strategies restored during the pre-close force-exit window\n- retain order cutoff protection after 15:20\n- add restart-window regression coverage\n\n## Validation\n- targeted scheduler restore tests (3 passed)\n- pytest tests/integration_test -v (276 passed)\n- pytest tests/unit_test -v timed out after 124s without output (pre-existing suite hang)