### PR TITLE
히트맵 전용 페이지(/heatmap) 추가 — 한국/미국 탭 + 확대

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -1,0 +1,257 @@
+/*
+ * jsdom 기반 히트맵 전용 페이지(/heatmap) 회귀 테스트.
+ *
+ * 홈의 미리보기와 달리 전용 페이지는 (1) 한국/미국 탭 전환과 (2) 줌을 소유한다.
+ * 줌은 CSS transform 이 아니라 캔버스 크기 + 재렌더로 구현돼 있어(작은 타일의
+ * 라벨이 실제로 살아나야 함) 그 계약을 여기서 잠근다.
+ *
+ * 실행: node run_heatmap_page_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { applyCommonStubs, test, assert, run } from "./harness.mjs";
+
+const HEATMAP_JS = resolve(import.meta.dirname, "../../view/web/static/js/market_heatmap.js");
+const HEATMAP_PAGE_JS = resolve(import.meta.dirname, "../../view/web/static/js/heatmap_page.js");
+
+const SCAFFOLD = `
+<div class="heatmap-page-tabs">
+  <button type="button" id="heatmap-page-tab-domestic" class="sub-tab-btn active">한국</button>
+  <button type="button" id="heatmap-page-tab-overseas" class="sub-tab-btn">미국</button>
+</div>
+<div class="heatmap-toolbar">
+  <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
+  <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+  <span class="heatmap-zoom">
+    <button type="button" id="heatmap-page-zoom-out">−</button>
+    <span id="heatmap-page-zoom-level">100%</span>
+    <button type="button" id="heatmap-page-zoom-in">+</button>
+    <button type="button" id="heatmap-page-zoom-reset">초기화</button>
+  </span>
+</div>
+<div id="heatmap-page-viewport" class="heatmap-page-viewport">
+  <div id="heatmap-page-sizer" class="heatmap-page-sizer">
+    <div id="heatmap-page-domestic" class="heatmap-page-panel"></div>
+    <div id="heatmap-page-overseas" class="heatmap-page-panel" style="display:none;"></div>
+  </div>
+</div>
+`;
+
+// 전용 페이지 경로('/heatmap')로 만들면 DOMContentLoaded 자동 초기화가 끼어들어 호출 수가 흔들린다.
+// 자동 초기화는 아래 전용 테스트에서 실제 경로 창으로 검증한다.
+function makeWindow(fetchWithTimeout, url = "http://localhost/heatmap-test") {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url,
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+  applyCommonStubs(window);
+  window.fetchWithTimeout = fetchWithTimeout;
+  window.eval(readFileSync(HEATMAP_JS, "utf8"));
+  window.eval(readFileSync(HEATMAP_PAGE_JS, "utf8"));
+  return window;
+}
+
+function success(data) {
+  return { ok: true, json: async () => ({ rt_cd: "0", data }) };
+}
+
+function marketMode(modes) {
+  return { ok: true, json: async () => ({ enabled_market_modes: modes }) };
+}
+
+function domesticItem(overrides) {
+  return { code: "005930", name: "삼성전자", change_rate: "1.20", market_cap: 1000, market: "KOSPI", ...overrides };
+}
+
+function overseasItem(overrides) {
+  return { symbol: "AAA", name: "테스트", sector: "Technology", change_rate: 1.0, market_cap_usd: 1e11, ...overrides };
+}
+
+// 큰 종목 몇 개 + 꼬리 종목 다수 → 줌 1배에서는 라벨이 생략되는 타일이 반드시 생긴다.
+function domesticSnapshot() {
+  const items = [];
+  for (let i = 0; i < 6; i += 1) {
+    items.push(domesticItem({ code: `B${i}`, name: `대형${i}`, market_cap: 4000 - i * 100 }));
+  }
+  for (let i = 0; i < 40; i += 1) {
+    items.push(domesticItem({ code: `S${i}`, name: `소형${i}`, market_cap: 40 - i * 0.5 }));
+  }
+  return { trade_date: "20260731", items };
+}
+
+function labeledSymbols(window, targetId) {
+  return [...window.document.querySelectorAll(`#${targetId} .heatmap-tile`)]
+    .filter(tile => tile.querySelector(".heatmap-tile-symbol"))
+    .map(tile => tile.dataset.symbol);
+}
+
+function routed(handlers) {
+  return async (url) => {
+    const key = Object.keys(handlers).find(prefix => url.startsWith(prefix));
+    if (!key) throw new Error(`stub 되지 않은 요청: ${url}`);
+    return handlers[key]();
+  };
+}
+
+test("전용 페이지는 한국 히트맵부터 그리고 미국은 탭 전환 전까지 조회하지 않는다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})] }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+
+  const doc = window.document;
+  assert(doc.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 0, "한국 히트맵이 그려져야 함");
+  assert(!calls.some(url => url.startsWith("/api/overseas/")), "미국 탭 전환 전에는 미국 API 를 호출하면 안 됨");
+  assert(doc.getElementById("heatmap-page-overseas").style.display === "none", "미국 패널은 감춰져 있어야 함");
+  assert(doc.getElementById("heatmap-page-tab-domestic").classList.contains("active"), "한국 탭이 활성이어야 함");
+});
+
+test("미국 탭으로 전환하면 미국 히트맵을 조회하고 패널을 바꾼다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({
+      items: [overseasItem({ symbol: "MSFT" })],
+      updated_at: 1767225600,
+    }),
+  }));
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+
+  const doc = window.document;
+  assert(doc.querySelector('#heatmap-page-overseas .heatmap-tile[data-symbol="MSFT"]'), "미국 타일이 렌더되어야 함");
+  assert(doc.getElementById("heatmap-page-overseas").style.display !== "none", "미국 패널이 보여야 함");
+  assert(doc.getElementById("heatmap-page-domestic").style.display === "none", "한국 패널이 감춰져야 함");
+  assert(doc.getElementById("heatmap-page-tab-overseas").classList.contains("active"), "미국 탭이 활성이어야 함");
+  assert(!doc.getElementById("heatmap-page-tab-domestic").classList.contains("active"), "한국 탭 활성이 해제돼야 함");
+});
+
+test("탭마다 자기 기준 시각 캡션을 보여준다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})], updated_at: 1767225600 }),
+  }));
+
+  await window.initHeatmapPage();
+  const doc = window.document;
+  const krCaption = doc.getElementById("heatmap-page-domestic-caption");
+  const usCaption = doc.getElementById("heatmap-page-overseas-caption");
+
+  assert(krCaption.textContent.includes("2026-07-31"), `국내 기준일이 표시되어야 함 (실제 ${krCaption.textContent})`);
+  assert(krCaption.textContent.includes("종가"), "장중 오해를 막기 위해 종가 기준임을 밝혀야 함");
+  assert(usCaption.style.display === "none", "비활성 탭 캡션은 감춰져야 함");
+
+  await window.setHeatmapTab("overseas");
+  assert(usCaption.textContent.includes("최신 업데이트"), "미국 갱신 시각이 표시되어야 함");
+  assert(krCaption.style.display === "none", "탭 전환 시 이전 캡션이 감춰져야 함");
+});
+
+test("미국장이 비활성인 run 에서는 미국 탭을 감춘다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+
+  assert(window.document.getElementById("heatmap-page-tab-overseas").style.display === "none",
+    "미국장 비활성 시 탭이 감춰져야 함");
+  assert(!calls.some(url => url.startsWith("/api/overseas/")), "비활성 상태에서 미국 API 를 호출하면 안 됨");
+});
+
+test("줌을 올리면 캔버스가 커지고 작은 타일에도 라벨이 붙는다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+
+  await window.initHeatmapPage();
+  const doc = window.document;
+  const sizer = doc.getElementById("heatmap-page-sizer");
+  const before = labeledSymbols(window, "heatmap-page-domestic");
+  assert(sizer.style.width === "100%", `기본 줌은 100% 여야 함 (실제 ${sizer.style.width})`);
+  assert(before.length < doc.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length,
+    "기본 줌에서 라벨이 생략된 작은 타일이 있어야 테스트가 의미를 가짐");
+
+  window.zoomHeatmapPage(2);
+
+  const zoom = Number.parseFloat(sizer.style.width);
+  assert(zoom > 100, `줌 인 시 캔버스가 커져야 함 (실제 ${sizer.style.width})`);
+  assert(sizer.style.height === sizer.style.width, "가로/세로 배율이 같아야 트리맵 비율이 유지됨");
+  assert(doc.getElementById("heatmap-page-zoom-level").textContent === `${Math.round(zoom)}%`,
+    "줌 배율 표시가 캔버스 배율과 일치해야 함");
+
+  const after = labeledSymbols(window, "heatmap-page-domestic");
+  assert(after.length > before.length,
+    `줌 인 후 라벨이 늘어야 함 (${before.length} → ${after.length})`);
+  before.forEach(symbol => assert(after.includes(symbol), `${symbol} 라벨이 줌 인 후 사라짐`));
+});
+
+test("줌 변경은 데이터를 다시 조회하지 않는다", async () => {
+  let domesticCalls = 0;
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => { domesticCalls += 1; return success(domesticSnapshot()); },
+  }));
+
+  await window.initHeatmapPage();
+  assert(domesticCalls === 1, `초기 조회는 1회여야 함 (실제 ${domesticCalls})`);
+
+  window.zoomHeatmapPage(1);
+  window.zoomHeatmapPage(1);
+  window.resetHeatmapPageZoom();
+
+  assert(domesticCalls === 1, `줌은 재조회 없이 다시 그려야 함 (실제 ${domesticCalls})`);
+});
+
+test("줌은 상·하한을 벗어나지 않고 초기화로 100% 로 돌아온다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+
+  await window.initHeatmapPage();
+  const sizer = window.document.getElementById("heatmap-page-sizer");
+
+  window.zoomHeatmapPage(-1);
+  assert(sizer.style.width === "100%", `기본 배율 아래로 축소되면 안 됨 (실제 ${sizer.style.width})`);
+
+  for (let i = 0; i < 20; i += 1) window.zoomHeatmapPage(1);
+  const maxZoom = Number.parseFloat(sizer.style.width);
+  assert(Number.isFinite(maxZoom) && maxZoom > 100, "최대 배율이 유한한 값이어야 함");
+  window.zoomHeatmapPage(1);
+  assert(Number.parseFloat(sizer.style.width) === maxZoom, "최대 배율을 넘어서면 안 됨");
+
+  window.resetHeatmapPageZoom();
+  assert(sizer.style.width === "100%", "초기화하면 100% 로 돌아와야 함");
+  assert(window.document.getElementById("heatmap-page-zoom-level").textContent === "100%",
+    "초기화 후 배율 표시도 100% 여야 함");
+});
+
+test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {
+  const calls = [];
+  makeWindow(routed({
+    "/api/market-mode": () => { calls.push("/api/market-mode"); return marketMode(["domestic"]); },
+    "/api/heatmap/domestic": () => { calls.push("/api/heatmap/domestic"); return success(domesticSnapshot()); },
+  }), "http://localhost/heatmap");
+
+  await new Promise(done => setTimeout(done, 50));
+
+  assert(calls.includes("/api/market-mode"), "진입 시 시장 활성 여부를 확인해야 함");
+  assert(calls.includes("/api/heatmap/domestic"), "진입 시 한국 히트맵을 조회해야 함");
+});
+
+await run();

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -12,6 +12,18 @@ def _home_template() -> str:
     return Path("view/web/templates/index.html").read_text(encoding="utf-8")
 
 
+def _heatmap_page_template() -> str:
+    return Path("view/web/templates/heatmap.html").read_text(encoding="utf-8")
+
+
+def _heatmap_page_js() -> str:
+    return Path("view/web/static/js/heatmap_page.js").read_text(encoding="utf-8")
+
+
+def _heatmap_css() -> str:
+    return Path("view/web/static/css/heatmap.css").read_text(encoding="utf-8")
+
+
 def test_home_template_hosts_heatmap_panel():
     template = _home_template()
 
@@ -39,19 +51,31 @@ def test_domestic_heatmap_uses_daily_snapshot_and_shows_base_date():
     assert "sector: null" in script
 
 
-def test_heatmap_styles_are_defined_in_home_template():
-    template = _home_template()
+def test_heatmap_component_styles_live_in_one_shared_stylesheet():
+    """홈 미리보기와 전용 페이지가 같은 타일을 그리므로 컴포넌트 CSS 는 한 곳에만 둔다."""
+    css = _heatmap_css()
 
     for selector in (
-        "#market-heatmap, #domestic-heatmap {",
         ".heatmap-canvas",
         ".heatmap-sector",
         ".heatmap-sector-title",
         ".heatmap-sector-body",
         ".heatmap-tile",
         ".heatmap-legend",
+        ".heatmap-toolbar",
     ):
-        assert selector in template, f"{selector} 스타일이 없음"
+        assert selector in css, f"{selector} 스타일이 공용 스타일시트에 없음"
+
+    for template in (_home_template(), _heatmap_page_template()):
+        assert "/static/css/heatmap.css" in template, "히트맵 공용 스타일시트가 연결되지 않음"
+        assert ".heatmap-tile {" not in template, "컴포넌트 CSS 가 템플릿에 복제되어 있음"
+
+
+def test_home_template_hosts_heatmap_layout_only():
+    """홈은 미리보기 높이만 소유한다(타일 스타일은 공용 시트)."""
+    template = _home_template()
+
+    assert "#market-heatmap, #domestic-heatmap {" in template
 
 
 def test_heatmap_reuses_overseas_market_cap_snapshot():
@@ -75,12 +99,68 @@ def test_heatmap_renders_untrusted_strings_as_text():
 
 def test_heatmap_legend_colors_match_script_palette():
     script = _heatmap_js()
-    template = _home_template()
 
     palette = set(re.findall(r"color: '(#[0-9a-f]{6})'", script))
     assert len(palette) == 8, f"상승/하락 4단계 색이 정의되어야 함 (실제 {len(palette)}종)"
-    for color in palette:
-        assert color in template, f"범례에 {color} 가 빠져 스크립트와 어긋남"
+    for template in (_home_template(), _heatmap_page_template()):
+        for color in palette:
+            assert color in template, f"범례에 {color} 가 빠져 스크립트와 어긋남"
+
+
+def test_heatmap_page_hosts_market_tabs_and_panels():
+    template = _heatmap_page_template()
+
+    for element_id in (
+        "heatmap-page-tab-domestic",
+        "heatmap-page-tab-overseas",
+        "heatmap-page-domestic",
+        "heatmap-page-overseas",
+        "heatmap-page-domestic-caption",
+        "heatmap-page-overseas-caption",
+    ):
+        assert f'id="{element_id}"' in template, f"{element_id} 요소가 없음"
+    assert "setHeatmapTab('domestic')" in template
+    assert "setHeatmapTab('overseas')" in template
+
+
+def test_heatmap_page_hosts_zoom_controls():
+    template = _heatmap_page_template()
+
+    # 줌은 스크롤 가능한 viewport 안에서 캔버스(sizer)를 키우는 방식이라 두 요소가 모두 필요하다.
+    assert 'id="heatmap-page-viewport"' in template
+    assert 'id="heatmap-page-sizer"' in template
+    assert 'id="heatmap-page-zoom-level"' in template
+    assert "zoomHeatmapPage(1)" in template
+    assert "zoomHeatmapPage(-1)" in template
+    assert "resetHeatmapPageZoom()" in template
+
+
+def test_heatmap_page_reuses_home_render_script():
+    """트리맵 계산/색상은 market_heatmap.js 한 곳에만 두고 페이지 스크립트는 배선만 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert template.index("/static/js/market_heatmap.js") < template.index("/static/js/heatmap_page.js"), (
+        "공용 렌더 스크립트가 페이지 스크립트보다 먼저 로드돼야 함"
+    )
+    assert "_squarifyTreemap" not in page_script, "트리맵 계산이 페이지 스크립트에 복제됨"
+    assert "HEATMAP_UP_COLORS" not in page_script, "색상 팔레트가 페이지 스크립트에 복제됨"
+    assert "_domesticGroups" in page_script and "_overseasGroups" in page_script
+
+
+def test_heatmap_zoom_scales_label_threshold():
+    """줌은 타일만 키우는 게 아니라 라벨 생략 기준도 같이 완화해야 의미가 있다."""
+    script = _heatmap_js()
+
+    assert "HEATMAP_MIN_LABEL_WIDTH_PCT" in script
+    assert re.search(r"box\.w \* zoom", script), "라벨 기준이 줌 배율을 반영하지 않음"
+    assert re.search(r"box\.h \* zoom", script), "라벨 기준이 줌 배율을 반영하지 않음"
+
+
+def test_home_cards_link_to_heatmap_page():
+    template = _home_template()
+
+    assert template.count('href="/heatmap"') >= 2, "홈의 두 히트맵 카드에서 전용 페이지로 갈 수 있어야 함"
 
 
 def test_heatmap_follows_domestic_up_red_convention():

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -19,6 +19,7 @@ PAGES = [
     ("/scheduler", "scheduler"),
     ("/program", "program"),
     ("/system", "system"),
+    ("/heatmap", "heatmap"),
 ]
 
 def test_pages_render_success_no_login(web_client, mock_web_ctx):
@@ -106,6 +107,10 @@ def test_pages_render_success_no_login(web_client, mock_web_ctx):
             assert "프로그램매매 실시간 동향" in response.text
         elif path == "/system":
             assert "시스템 상태 모니터링" in response.text
+        elif path == "/heatmap":
+            assert "시장 히트맵" in response.text
+            assert 'id="heatmap-page-viewport"' in response.text
+            assert "/static/js/heatmap_page.js" in response.text
 
 
 def test_virtual_static_js_exposes_divergence_workflow():

--- a/view/web/static/css/heatmap.css
+++ b/view/web/static/css/heatmap.css
@@ -1,0 +1,26 @@
+/* view/web/static/css/heatmap.css — 히트맵(트리맵) 공용 컴포넌트 스타일
+ *
+ * 홈 미리보기(index.html)와 전용 페이지(heatmap.html)가 같은 마크업을 그리므로
+ * 타일/섹터/범례 스타일은 여기 한 곳에만 둔다. 컨테이너 크기(높이·줌)는 각 화면이 소유한다.
+ */
+
+.heatmap-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 8px; flex-wrap: wrap; }
+.heatmap-updated, .heatmap-legend-label { font-size: 0.78rem; color: var(--text-secondary); }
+.heatmap-legend { display: inline-flex; align-items: center; gap: 2px; }
+.heatmap-legend i { display: inline-block; width: 14px; height: 10px; }
+.heatmap-legend-label { margin: 0 4px; }
+.heatmap-canvas { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
+.heatmap-sector { position: absolute; }
+.heatmap-sector-title {
+    position: absolute; top: 0; left: 0; right: 0; height: 16px; line-height: 16px;
+    font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
+    color: var(--text-secondary); white-space: nowrap; overflow: hidden;
+}
+.heatmap-sector-body { position: absolute; left: 0; right: 0; bottom: 0; }
+.heatmap-tile {
+    position: absolute; box-sizing: border-box; overflow: hidden;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    border: 1px solid var(--bg-secondary); color: #fff;
+}
+.heatmap-tile-symbol { font-size: 0.72rem; font-weight: 700; line-height: 1.15; }
+.heatmap-tile-rate { font-size: 0.66rem; line-height: 1.15; }

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -1,0 +1,148 @@
+/* view/web/static/js/heatmap_page.js — 히트맵 전용 페이지(/heatmap)
+ *
+ * 트리맵 계산·색상·조회는 market_heatmap.js 를 그대로 재사용하고(먼저 로드돼야 한다),
+ * 이 파일은 전용 페이지가 추가로 가지는 두 가지만 소유한다.
+ *   1) 한국/미국 탭 전환 — 탭을 열 때 처음 한 번만 조회한다.
+ *   2) 줌 — CSS transform 이 아니라 캔버스(sizer) 자체를 키우고 다시 그린다.
+ *      transform 으로 확대하면 작은 타일의 생략된 라벨이 그대로 없기 때문에,
+ *      배율을 렌더에 넘겨 라벨 기준을 완화해야 확대의 의미가 있다.
+ */
+
+// 홈 미리보기(200종목)보다 넓게 잡는다 — 작은 타일은 확대로 읽을 수 있다.
+const HEATMAP_PAGE_DOMESTIC_LIMIT = 500;
+const HEATMAP_PAGE_OVERSEAS_LIMIT = 500;
+const HEATMAP_PAGE_ZOOM_STEPS = [1, 1.5, 2, 3, 4, 6, 8];
+
+let _heatmapPageZoomIndex = 0;
+
+function _heatmapPageZoom() {
+    return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
+}
+
+const HEATMAP_PAGE_SOURCES = {
+    domestic: {
+        targetId: 'heatmap-page-domestic',
+        captionId: 'heatmap-page-domestic-caption',
+        url: `/api/heatmap/domestic?limit=${HEATMAP_PAGE_DOMESTIC_LIMIT}`,
+        loadingText: '국내 히트맵 조회 중...',
+        toGroups: _domesticGroups,
+        caption: _domesticCaption,
+        zoom: _heatmapPageZoom,
+        sequence: 0,
+    },
+    overseas: {
+        targetId: 'heatmap-page-overseas',
+        captionId: 'heatmap-page-overseas-caption',
+        url: `/api/overseas/top-market-cap?limit=${HEATMAP_PAGE_OVERSEAS_LIMIT}`,
+        loadingText: 'S&P 500 히트맵 조회 중...',
+        toGroups: _overseasGroups,
+        caption: _overseasCaption,
+        zoom: _heatmapPageZoom,
+        sequence: 0,
+    },
+};
+
+function _heatmapPageShow(el, visible) {
+    if (el) el.style.display = visible ? '' : 'none';
+}
+
+async function setHeatmapTab(market) {
+    const source = HEATMAP_PAGE_SOURCES[market];
+    if (!source) return;
+
+    Object.keys(HEATMAP_PAGE_SOURCES).forEach(key => {
+        const active = key === market;
+        _heatmapPageShow(document.getElementById(HEATMAP_PAGE_SOURCES[key].targetId), active);
+        _heatmapPageShow(document.getElementById(HEATMAP_PAGE_SOURCES[key].captionId), active);
+        const tab = document.getElementById(`heatmap-page-tab-${key}`);
+        if (tab) tab.classList.toggle('active', active);
+    });
+
+    // 실패한 탭은 lastData 가 없으므로 다시 열 때 재시도된다.
+    if (!source.lastData) await _loadHeatmap(source);
+}
+
+// 확대/축소 후에도 보고 있던 지점이 화면 가운데에 남도록 스크롤 비율을 유지한다.
+function _heatmapPageCenterRatio(viewport) {
+    if (!viewport || !viewport.scrollWidth || !viewport.scrollHeight) return null;
+    return {
+        x: (viewport.scrollLeft + viewport.clientWidth / 2) / viewport.scrollWidth,
+        y: (viewport.scrollTop + viewport.clientHeight / 2) / viewport.scrollHeight,
+    };
+}
+
+function _restoreHeatmapPageCenter(viewport, anchor) {
+    if (!viewport || !anchor) return;
+    viewport.scrollLeft = Math.max(0, anchor.x * viewport.scrollWidth - viewport.clientWidth / 2);
+    viewport.scrollTop = Math.max(0, anchor.y * viewport.scrollHeight - viewport.clientHeight / 2);
+}
+
+function _applyHeatmapPageZoom() {
+    const zoom = _heatmapPageZoom();
+    const sizer = document.getElementById('heatmap-page-sizer');
+    if (sizer) {
+        sizer.style.width = `${zoom * 100}%`;
+        sizer.style.height = `${zoom * 100}%`;
+    }
+    const level = document.getElementById('heatmap-page-zoom-level');
+    if (level) level.textContent = `${Math.round(zoom * 100)}%`;
+
+    // 라벨 생략 기준이 배율에 걸려 있어, 이미 받아둔 응답으로 다시 그린다(재조회 없음).
+    Object.values(HEATMAP_PAGE_SOURCES).forEach(source => {
+        const div = document.getElementById(source.targetId);
+        if (div && source.lastData) _renderHeatmap(div, source, source.lastData);
+    });
+}
+
+function zoomHeatmapPage(step) {
+    const next = Math.min(
+        HEATMAP_PAGE_ZOOM_STEPS.length - 1,
+        Math.max(0, _heatmapPageZoomIndex + step),
+    );
+    if (next === _heatmapPageZoomIndex) return;
+
+    const viewport = document.getElementById('heatmap-page-viewport');
+    const anchor = _heatmapPageCenterRatio(viewport);
+    _heatmapPageZoomIndex = next;
+    _applyHeatmapPageZoom();
+    _restoreHeatmapPageCenter(viewport, anchor);
+}
+
+function resetHeatmapPageZoom() {
+    _heatmapPageZoomIndex = 0;
+    _applyHeatmapPageZoom();
+    const viewport = document.getElementById('heatmap-page-viewport');
+    if (viewport) {
+        viewport.scrollLeft = 0;
+        viewport.scrollTop = 0;
+    }
+}
+
+async function initHeatmapPage() {
+    if (!document.getElementById('heatmap-page-viewport')) return;
+
+    // pjax 재진입 시 이전 화면의 응답/배율이 남지 않도록 초기화한다.
+    Object.values(HEATMAP_PAGE_SOURCES).forEach(source => {
+        source.lastData = null;
+        source.sequence = 0;
+    });
+    _heatmapPageZoomIndex = 0;
+    _applyHeatmapPageZoom();
+
+    // 미국장이 꺼진 run 에서는 API 가 400 을 내므로 탭 자체를 감춘다.
+    if (!await _heatmapOverseasEnabled()) {
+        _heatmapPageShow(document.getElementById('heatmap-page-tab-overseas'), false);
+    }
+
+    await setHeatmapTab('domestic');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.location.pathname !== '/heatmap') return;
+    void initHeatmapPage();
+});
+
+document.addEventListener('pjax:ready', (e) => {
+    if (e.detail?.path !== '/heatmap') return;
+    void initHeatmapPage();
+});

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -174,9 +174,11 @@ function _domesticGroups(items) {
     return [{ sector: null, cap: members.reduce((sum, m) => sum + m.cap, 0), members }];
 }
 
-function _heatmapTileHtml(member, box) {
+// zoom 은 캔버스를 몇 배로 늘려 그리는지(전용 페이지의 확대 배율). 타일이 그만큼 커지므로
+// 라벨 생략 기준도 같이 완화해야 확대의 의미가 있다.
+function _heatmapTileHtml(member, box, zoom) {
     const rateText = _heatmapRateText(member.rate);
-    const showLabel = box.w >= HEATMAP_MIN_LABEL_WIDTH_PCT && box.h >= HEATMAP_MIN_LABEL_HEIGHT_PCT;
+    const showLabel = box.w * zoom >= HEATMAP_MIN_LABEL_WIDTH_PCT && box.h * zoom >= HEATMAP_MIN_LABEL_HEIGHT_PCT;
     const label = showLabel
         ? `<span class="heatmap-tile-symbol">${escapeHtml(member.label)}</span>`
           + `<span class="heatmap-tile-rate">${escapeHtml(rateText)}</span>`
@@ -193,13 +195,13 @@ function _heatmapTileHtml(member, box) {
     `;
 }
 
-function _heatmapSectorHtml(group, box) {
+function _heatmapSectorHtml(group, box, zoom) {
     const memberBoxes = _squarifyTreemap(
         group.members.map((member, index) => ({ key: index, weight: member.cap })),
         { x: 0, y: 0, w: 100, h: 100 },
     );
     const tiles = memberBoxes
-        .map(memberBox => _heatmapTileHtml(group.members[memberBox.key], memberBox))
+        .map(memberBox => _heatmapTileHtml(group.members[memberBox.key], memberBox, zoom))
         .join('');
 
     // 섹터명이 없는 시장(국내)은 헤더 없이 타일이 블록 전체를 채운다.
@@ -238,9 +240,11 @@ function _renderHeatmapCaption(elementId, text) {
     if (el) el.textContent = text;
 }
 
+// source.zoom 은 전용 페이지가 배율을 주입하는 훅. 홈 미리보기는 배율이 없어 1 이다.
 function _renderHeatmap(div, source, data) {
     _renderHeatmapCaption(source.captionId, source.caption(data));
 
+    const zoom = typeof source.zoom === 'function' ? source.zoom() : 1;
     const groups = source.toGroups(Array.isArray(data.items) ? data.items : []);
     if (!groups.length) {
         div.innerHTML = '<p class="empty">조회 결과가 없습니다.</p>';
@@ -252,7 +256,7 @@ function _renderHeatmap(div, source, data) {
         { x: 0, y: 0, w: 100, h: 100 },
     );
     div.innerHTML = `<div class="heatmap-canvas">${
-        sectorBoxes.map(box => _heatmapSectorHtml(groups[box.key], box)).join('')
+        sectorBoxes.map(box => _heatmapSectorHtml(groups[box.key], box, zoom)).join('')
     }</div>`;
 }
 
@@ -298,7 +302,9 @@ async function _loadHeatmap(source, options = {}) {
             showError(div, `실패: ${json.msg1 || '히트맵 조회에 실패했습니다.'}`);
             return;
         }
-        _renderHeatmap(div, source, json.data || {});
+        // 배율을 바꿀 때 재조회 없이 다시 그릴 수 있도록 마지막 응답을 소스에 남긴다.
+        source.lastData = json.data || {};
+        _renderHeatmap(div, source, source.lastData);
     } catch (e) {
         console.error('[market-heatmap] 히트맵 조회 오류', e);
         if (!isLatestRequest()) return;

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -99,6 +99,7 @@
         <a href="/overseas-ranking" class="{% if active_page == 'overseas_ranking' %}active{% endif %}">랭킹</a>
     {% else %}
         <a href="/" class="{% if active_page == 'home' %}active{% endif %}">홈</a>
+        <a href="/heatmap" class="{% if active_page == 'heatmap' %}active{% endif %}">히트맵</a>
         {% if can_operate %}<a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>{% endif %}
         {% if can_operate %}<a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>{% endif %}
         <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <link rel="stylesheet" href="/static/css/heatmap.css?v=1">
+    <style>
+        /* 줌은 viewport(스크롤 영역) 안에서 sizer 를 키우는 방식이라 viewport 높이가 고정돼야 한다. */
+        .heatmap-page-viewport { position: relative; overflow: auto; height: calc(100vh - 300px); min-height: 420px; }
+        .heatmap-page-sizer { position: relative; width: 100%; height: 100%; }
+        .heatmap-page-panel { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
+        .heatmap-page-tabs { margin-bottom: 12px; }
+        .heatmap-zoom { display: inline-flex; align-items: center; gap: 6px; }
+        .heatmap-zoom button {
+            min-width: 30px; padding: 3px 8px; cursor: pointer;
+            background: var(--bg-secondary); color: var(--text-primary);
+            border: 1px solid var(--border); border-radius: 5px; font-size: 0.85rem;
+        }
+        .heatmap-zoom button:hover { border-color: var(--accent, #4a90e2); }
+        #heatmap-page-zoom-level { font-size: 0.78rem; color: var(--text-secondary); min-width: 44px; text-align: center; }
+        @media (max-width: 640px) { .heatmap-page-viewport { height: calc(100vh - 340px); } }
+    </style>
+    <div class="section">
+        <div class="card">
+            <h2>시장 히트맵</h2>
+            <div class="heatmap-page-tabs" role="tablist" aria-label="히트맵 시장 선택">
+                <button type="button" id="heatmap-page-tab-domestic" class="sub-tab-btn active"
+                        onclick="setHeatmapTab('domestic')">한국</button>
+                <button type="button" id="heatmap-page-tab-overseas" class="sub-tab-btn"
+                        onclick="setHeatmapTab('overseas')">미국</button>
+            </div>
+            <div class="heatmap-toolbar">
+                <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
+                <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+                <span class="heatmap-zoom">
+                    <button type="button" onclick="zoomHeatmapPage(-1)" title="축소" aria-label="축소">−</button>
+                    <span id="heatmap-page-zoom-level">100%</span>
+                    <button type="button" onclick="zoomHeatmapPage(1)" title="확대" aria-label="확대">+</button>
+                    <button type="button" onclick="resetHeatmapPageZoom()" title="배율 초기화">초기화</button>
+                </span>
+                <span class="heatmap-legend">
+                    <span class="heatmap-legend-label">하락</span>
+                    <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
+                    <i style="background:#6b7280"></i>
+                    <i style="background:#e58080"></i><i style="background:#d64545"></i><i style="background:#b52626"></i><i style="background:#8f1a1a"></i>
+                    <span class="heatmap-legend-label">상승</span>
+                </span>
+            </div>
+            <div id="heatmap-page-viewport" class="heatmap-page-viewport">
+                <div id="heatmap-page-sizer" class="heatmap-page-sizer">
+                    <div id="heatmap-page-domestic" class="heatmap-page-panel"></div>
+                    <div id="heatmap-page-overseas" class="heatmap-page-panel" style="display:none;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/market_heatmap.js?v=3"></script>
+<script src="/static/js/heatmap_page.js?v=1"></script>
+{% endblock %}

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -17,29 +17,12 @@
         .home-menu-group { margin-top: 28px; text-align: left; }
         .home-menu-group h3 { margin-bottom: 12px; }
         .home-menu-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-        .heatmap-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 8px; flex-wrap: wrap; }
-        .heatmap-updated, .heatmap-legend-label { font-size: 0.78rem; color: var(--text-secondary); }
-        .heatmap-legend { display: inline-flex; align-items: center; gap: 2px; }
-        .heatmap-legend i { display: inline-block; width: 14px; height: 10px; }
-        .heatmap-legend-label { margin: 0 4px; }
+        /* 타일/섹터/범례 스타일은 /static/css/heatmap.css (전용 페이지와 공용). 여기선 미리보기 높이만 정한다. */
         #market-heatmap, #domestic-heatmap { position: relative; height: 520px; }
-        .heatmap-canvas { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
-        .heatmap-sector { position: absolute; }
-        .heatmap-sector-title {
-            position: absolute; top: 0; left: 0; right: 0; height: 16px; line-height: 16px;
-            font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
-            color: var(--text-secondary); white-space: nowrap; overflow: hidden;
-        }
-        .heatmap-sector-body { position: absolute; left: 0; right: 0; bottom: 0; }
-        .heatmap-tile {
-            position: absolute; box-sizing: border-box; overflow: hidden;
-            display: flex; flex-direction: column; align-items: center; justify-content: center;
-            border: 1px solid var(--bg-secondary); color: #fff;
-        }
-        .heatmap-tile-symbol { font-size: 0.72rem; font-weight: 700; line-height: 1.15; }
-        .heatmap-tile-rate { font-size: 0.66rem; line-height: 1.15; }
+        .heatmap-expand { font-size: 0.78rem; text-decoration: none; color: var(--accent, #4a90e2); white-space: nowrap; }
         @media (max-width: 640px) { #market-heatmap, #domestic-heatmap { height: 380px; } }
     </style>
+    <link rel="stylesheet" href="/static/css/heatmap.css?v=1">
     <div class="section">
         <div class="card">
             <h2>시장 지수</h2>
@@ -51,6 +34,7 @@
             <h2>S&amp;P 500 히트맵</h2>
             <div class="heatmap-toolbar">
                 <span id="market-heatmap-updated-at" class="heatmap-updated">최신 업데이트: --</span>
+                <a class="heatmap-expand" href="/heatmap">크게 보기 ↗</a>
                 <span class="heatmap-legend">
                     <span class="heatmap-legend-label">하락</span>
                     <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
@@ -67,6 +51,7 @@
             <h2>국내 시가총액 히트맵</h2>
             <div class="heatmap-toolbar">
                 <span id="domestic-heatmap-updated-at" class="heatmap-updated">기준일: --</span>
+                <a class="heatmap-expand" href="/heatmap">크게 보기 ↗</a>
                 <span class="heatmap-legend">
                     <span class="heatmap-legend-label">하락</span>
                     <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -599,6 +599,10 @@ async def operator_dashboard(request: Request):
 async def strategy_reports(request: Request):
     return await render_page(request, "strategy_reports.html", "strategy_reports")
 
+@page_router.get("/heatmap")
+async def heatmap(request: Request):
+    return await render_page(request, "heatmap.html", "heatmap")
+
 # 5. 로그아웃
 @page_router.get("/logout")
 async def logout(request: Request):


### PR DESCRIPTION
## 배경
홈의 히트맵 카드는 미리보기 크기(520px)라 상위 종목 외에는 타일이 작아 라벨이 대부분 생략된다. 작은 종목을 읽으려면 확대가 필요하다.

## 변경
- **`/heatmap` 전용 페이지 신설** — 화면 전체 높이를 쓰고, 한국/미국을 탭으로 나눈다. 탭은 열 때 처음 한 번만 조회한다(미국 탭 전환 전에는 미국 API 호출 없음). 공통 nav 와 홈 카드의 "크게 보기" 링크로 진입.
- **확대(100% ~ 800%)** — CSS `transform` 이 아니라 캔버스(sizer) 자체를 키우고 다시 그린다. transform 으로 확대하면 생략된 라벨이 그대로 없기 때문에, 배율을 렌더에 넘겨 라벨 생략 기준(`HEATMAP_MIN_LABEL_*`)도 같이 완화한다. 배율 변경 시 재조회는 없고(마지막 응답 재사용), 보던 지점이 화면 가운데 남도록 스크롤 비율을 유지한다.
- **CSS 공유** — 타일/섹터/범례 스타일을 `static/css/heatmap.css` 로 분리해 홈 미리보기와 전용 페이지가 공유한다. 컨테이너 크기(높이·배율)만 각 화면이 소유.
- 트리맵 계산·색상·조회는 `market_heatmap.js` 를 그대로 재사용하고 `heatmap_page.js` 는 탭/줌 배선만 한다.

홈 화면의 기존 히트맵 카드는 그대로 두었다.

## 테스트
- `tests/frontend/run_heatmap_page_dom_tests.mjs` 신규 (8케이스) — 탭 전환·최초 1회 조회, 미국장 비활성 시 탭 숨김, **확대 시 캔버스 확대 + 작은 타일 라벨 복원(21 → 95 → 200)**, 확대 시 재조회 없음, 배율 상·하한/초기화, 경로 진입 자동 초기화
- `test_market_heatmap_contracts.py` — 전용 페이지 템플릿/줌 컨트롤/공용 스타일시트 계약 추가, 렌더 로직 중복 금지 계약 추가
- `test_web_pages.py` — `/heatmap` 라우트 렌더 추가
- `pytest tests/unit_test` 7319 passed / `pytest tests/integration_test` 277 passed (신규 jsdom 러너 포함)

## 미검증
브라우저 프리뷰 pane 이 이 환경에서 렌더되지 않아(0x0, 컴포지팅 없음) 스크롤 기하(확대 시 스크롤바 생성)는 **육안 확인하지 못했다.** DOM 동작(배율 값, 라벨 복원, 재조회 없음)은 jsdom + 실브라우저 DOM 질의로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
