### PR TITLE
홈에서 히트맵 카드 제거 — 전용 페이지로 일원화

### DIFF
--- a/tests/frontend/run_market_heatmap_dom_tests.mjs
+++ b/tests/frontend/run_market_heatmap_dom_tests.mjs
@@ -1,5 +1,9 @@
 /*
- * jsdom 기반 홈 화면 S&P500 히트맵(트리맵) 회귀 테스트.
+ * jsdom 기반 히트맵 렌더 라이브러리(market_heatmap.js) 회귀 테스트.
+ *
+ * market_heatmap.js 는 화면 배선 없이 "소스(source) 를 받아 트리맵을 그리는" 라이브러리다.
+ * 여기서는 그 라이브러리 자체(트리맵 기하, 색상, 이스케이프, 경합 가드)를 검증하고,
+ * 탭/줌 등 화면 배선은 run_heatmap_page_dom_tests.mjs 가 맡는다.
  *
  * 실행: node run_market_heatmap_dom_tests.mjs
  */
@@ -13,21 +17,15 @@ const HEATMAP_JS = process.env.MARKET_HEATMAP_JS_PATH
   : resolve(import.meta.dirname, "../../view/web/static/js/market_heatmap.js");
 
 const SCAFFOLD = `
-<div class="card" id="market-heatmap-card">
-  <span id="market-heatmap-updated-at"></span>
-  <div id="market-heatmap"></div>
-</div>
-<div class="card" id="domestic-heatmap-card">
-  <span id="domestic-heatmap-updated-at"></span>
-  <div id="domestic-heatmap"></div>
-</div>
+<span id="overseas-caption"></span>
+<div id="overseas-panel"></div>
+<span id="domestic-caption"></span>
+<div id="domestic-panel"></div>
 `;
 
-// 홈 경로('/')로 만들면 스크립트의 DOMContentLoaded 자동 초기화가 끼어들어 호출 수가 흔들린다.
-// 자동 초기화 자체는 아래 전용 테스트에서 홈 경로 창으로 검증한다.
-function makeWindow(fetchWithTimeout, url = "http://localhost/heatmap-test") {
+function makeWindow(fetchWithTimeout) {
   const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
-    url,
+    url: "http://localhost/heatmap-test",
     runScripts: "outside-only",
   });
   const { window } = dom;
@@ -37,12 +35,33 @@ function makeWindow(fetchWithTimeout, url = "http://localhost/heatmap-test") {
   return window;
 }
 
-function success(data) {
-  return { ok: true, json: async () => ({ rt_cd: "0", data }) };
+// 화면 배선 없이 라이브러리를 직접 구동하기 위한 최소 소스.
+function overseasSource(window) {
+  return {
+    targetId: "overseas-panel",
+    captionId: "overseas-caption",
+    url: "/api/overseas/top-market-cap?limit=500",
+    loadingText: "조회 중...",
+    toGroups: window._overseasGroups,
+    caption: window._overseasCaption,
+    sequence: 0,
+  };
 }
 
-function marketMode(modes) {
-  return { ok: true, json: async () => ({ enabled_market_modes: modes }) };
+function domesticSource(window) {
+  return {
+    targetId: "domestic-panel",
+    captionId: "domestic-caption",
+    url: "/api/heatmap/domestic?limit=500",
+    loadingText: "조회 중...",
+    toGroups: window._domesticGroups,
+    caption: window._domesticCaption,
+    sequence: 0,
+  };
+}
+
+function success(data) {
+  return { ok: true, json: async () => ({ rt_cd: "0", data }) };
 }
 
 function deferred() {
@@ -75,7 +94,7 @@ test("시가총액이 큰 종목이 비례해서 큰 타일을 차지한다", as
     ],
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
   const doc = window.document;
   const big = doc.querySelector('.heatmap-tile[data-symbol="BIG"]');
@@ -98,7 +117,7 @@ test("섹터 블록이 시총 합계 내림차순으로 렌더된다", async () 
     ],
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
   const sectors = [...window.document.querySelectorAll(".heatmap-sector")]
     .map(el => el.dataset.sector);
@@ -120,7 +139,7 @@ test("모든 타일이 컨테이너 경계 안에 배치된다", async () => {
     ],
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
   const boxes = [
     ...window.document.querySelectorAll(".heatmap-sector"),
@@ -149,7 +168,7 @@ test("등락 방향에 따라 색 계열과 표기 부호가 갈린다", async (
     ],
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
   const doc = window.document;
   const bySymbol = symbol => doc.querySelector(`.heatmap-tile[data-symbol="${symbol}"]`);
@@ -174,9 +193,9 @@ test("응답 문자열을 HTML 이 아닌 텍스트로 렌더링한다", async (
     })],
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
-  const target = window.document.getElementById("market-heatmap");
+  const target = window.document.getElementById("overseas-panel");
   assert(!target.querySelector("#injected-symbol, #injected-name, #injected-sector"),
     "응답 문자열이 HTML 로 해석됨");
   assert(target.textContent.includes('<img id="injected-symbol" src=x>'),
@@ -191,9 +210,9 @@ test("HTTP 오류는 JSON 파싱 없이 상태 안내를 표시한다", async ()
     json: async () => { jsonCalled = true; throw new Error("JSON 파싱 실패"); },
   }));
 
-  await window.loadMarketHeatmap();
+  await window._loadHeatmap(overseasSource(window));
 
-  const target = window.document.getElementById("market-heatmap");
+  const target = window.document.getElementById("overseas-panel");
   assert(jsonCalled === false, "HTTP 오류 응답은 JSON 으로 파싱하면 안 됨");
   assert(target.textContent.includes("HTTP 503"), "HTTP 상태 안내가 표시되어야 함");
 });
@@ -201,13 +220,14 @@ test("HTTP 오류는 JSON 파싱 없이 상태 안내를 표시한다", async ()
 test("빈 목록과 비정상 응답을 사용자 안내로 처리한다", async () => {
   const responses = [success({ items: [] }), { ok: true, json: async () => ({ rt_cd: "1", msg1: "수집 실패" }) }];
   const window = makeWindow(async () => responses.shift());
+  const source = overseasSource(window);
 
-  await window.loadMarketHeatmap();
-  assert(window.document.getElementById("market-heatmap").textContent.includes("조회 결과가 없습니다"),
+  await window._loadHeatmap(source);
+  assert(window.document.getElementById("overseas-panel").textContent.includes("조회 결과가 없습니다"),
     "빈 목록 안내가 표시되어야 함");
 
-  await window.loadMarketHeatmap();
-  assert(window.document.getElementById("market-heatmap").textContent.includes("수집 실패"),
+  await window._loadHeatmap(source);
+  assert(window.document.getElementById("overseas-panel").textContent.includes("수집 실패"),
     "실패 사유가 표시되어야 함");
 });
 
@@ -218,48 +238,27 @@ test("늦게 끝난 이전 요청이 최신 히트맵을 덮어쓰지 않는다"
     pending.push(request);
     return request.promise;
   });
+  const source = overseasSource(window);
 
-  const first = window.loadMarketHeatmap();
-  const second = window.loadMarketHeatmap();
+  const first = window._loadHeatmap(source);
+  const second = window._loadHeatmap(source);
   pending[1].resolve(success({ items: [item({ symbol: "NEW" })] }));
   await second;
   pending[0].resolve(success({ items: [item({ symbol: "OLD" })] }));
   await first;
 
-  const target = window.document.getElementById("market-heatmap");
+  const target = window.document.getElementById("overseas-panel");
   assert(target.querySelector('.heatmap-tile[data-symbol="NEW"]'), "최신 결과가 표시되어야 함");
   assert(!target.querySelector('.heatmap-tile[data-symbol="OLD"]'), "이전 결과가 최신 결과를 덮어씀");
 });
 
-test("미국장이 비활성인 run 에서는 히트맵 카드를 감춘다", async () => {
-  const calls = [];
+test("미국장 활성 여부를 시장 모드로 판단한다", async () => {
   const window = makeWindow(async (url) => {
-    calls.push(url);
-    if (url.startsWith("/api/market-mode")) return marketMode(["domestic"]);
-    return success({ items: [item({})] });
+    assert(url.startsWith("/api/market-mode"), `시장 모드 API 를 호출해야 함 (실제 ${url})`);
+    return { ok: true, json: async () => ({ enabled_market_modes: ["domestic"] }) };
   });
 
-  await window.initMarketHeatmap();
-
-  assert(window.document.getElementById("market-heatmap-card").style.display === "none",
-    "미국장 비활성 시 카드가 감춰져야 함");
-  assert(!calls.some(url => url.startsWith("/api/overseas/")),
-    "비활성 상태에서 시가총액 API 를 호출하면 안 됨");
-});
-
-test("미국장이 활성이면 카드를 노출하고 히트맵을 조회한다", async () => {
-  const window = makeWindow(async (url) => {
-    if (url.startsWith("/api/market-mode")) return marketMode(["domestic", "overseas_us"]);
-    return success({ items: [item({ symbol: "MSFT" })], updated_at: 1767225600 });
-  });
-
-  await window.initMarketHeatmap();
-
-  const doc = window.document;
-  assert(doc.getElementById("market-heatmap-card").style.display !== "none", "카드가 노출되어야 함");
-  assert(doc.querySelector('.heatmap-tile[data-symbol="MSFT"]'), "히트맵 타일이 렌더되어야 함");
-  assert(doc.getElementById("market-heatmap-updated-at").textContent.includes("최신 업데이트"),
-    "업데이트 시각이 표시되어야 함");
+  assert(await window._heatmapOverseasEnabled() === false, "미국장이 없으면 false 여야 함");
 });
 
 function domesticItem(overrides) {
@@ -275,10 +274,10 @@ test("국내 히트맵은 섹터 블록 없이 시총순 타일만 그린다", a
     ],
   }));
 
-  await window.loadDomesticHeatmap();
+  await window._loadHeatmap(domesticSource(window));
 
   const doc = window.document;
-  const target = doc.getElementById("domestic-heatmap");
+  const target = doc.getElementById("domestic-panel");
   assert(!target.querySelector(".heatmap-sector-title"), "국내 맵에는 섹터 헤더가 없어야 함");
   assert(target.querySelectorAll(".heatmap-tile").length === 2, "종목 타일이 렌더되어야 함");
 
@@ -292,9 +291,9 @@ test("국내 히트맵은 섹터 블록 없이 시총순 타일만 그린다", a
 test("국내 히트맵은 종가 기준일을 명시한다", async () => {
   const window = makeWindow(async () => success({ trade_date: "20260730", items: [domesticItem({})] }));
 
-  await window.loadDomesticHeatmap();
+  await window._loadHeatmap(domesticSource(window));
 
-  const label = window.document.getElementById("domestic-heatmap-updated-at").textContent;
+  const label = window.document.getElementById("domestic-caption").textContent;
   assert(label.includes("2026-07-30"), `기준일이 표시되어야 함 (실제 ${label})`);
   assert(label.includes("종가"), "장중 오해를 막기 위해 종가 기준임을 밝혀야 함");
 });
@@ -305,43 +304,29 @@ test("국내 히트맵의 빈 스냅샷과 응답 문자열을 안전하게 처�
     success({ trade_date: "20260730", items: [domesticItem({ name: '<img id="injected-kr" src=x>' })] }),
   ];
   const window = makeWindow(async () => responses.shift());
+  const source = domesticSource(window);
 
-  await window.loadDomesticHeatmap();
-  assert(window.document.getElementById("domestic-heatmap").textContent.includes("조회 결과가 없습니다"),
+  await window._loadHeatmap(source);
+  assert(window.document.getElementById("domestic-panel").textContent.includes("조회 결과가 없습니다"),
     "빈 스냅샷 안내가 표시되어야 함");
 
-  await window.loadDomesticHeatmap();
-  const target = window.document.getElementById("domestic-heatmap");
+  await window._loadHeatmap(source);
+  const target = window.document.getElementById("domestic-panel");
   assert(!target.querySelector("#injected-kr"), "응답 문자열이 HTML 로 해석됨");
   assert(target.textContent.includes('<img id="injected-kr" src=x>'), "종목명이 텍스트로 표시되어야 함");
 });
 
-test("국내 조회가 미국 히트맵을 덮어쓰지 않는다", async () => {
+test("한 소스의 조회가 다른 소스의 히트맵을 덮어쓰지 않는다", async () => {
   const window = makeWindow(async (url) => (url.startsWith("/api/heatmap/domestic")
     ? success({ trade_date: "20260730", items: [domesticItem({ code: "005930" })] })
     : success({ items: [item({ symbol: "MSFT" })] })));
 
-  await window.loadMarketHeatmap();
-  await window.loadDomesticHeatmap();
+  await window._loadHeatmap(overseasSource(window));
+  await window._loadHeatmap(domesticSource(window));
 
   const doc = window.document;
-  assert(doc.querySelector('#market-heatmap .heatmap-tile[data-symbol="MSFT"]'), "미국 히트맵이 유지되어야 함");
-  assert(doc.querySelector('#domestic-heatmap .heatmap-tile[data-symbol="005930"]'), "국내 히트맵이 렌더되어야 함");
-});
-
-test("홈 경로에서는 로드 시 자동으로 히트맵을 초기화한다", async () => {
-  const calls = [];
-  makeWindow(async (url) => {
-    calls.push(url);
-    if (url.startsWith("/api/market-mode")) return marketMode(["overseas_us"]);
-    return success({ items: [item({})] });
-  }, "http://localhost/");
-
-  await new Promise(done => setTimeout(done, 50));
-
-  assert(calls.some(url => url.startsWith("/api/market-mode")), "홈 진입 시 시장 활성 여부를 확인해야 함");
-  assert(calls.some(url => url.startsWith("/api/overseas/top-market-cap")), "홈 진입 시 미국 히트맵을 조회해야 함");
-  assert(calls.some(url => url.startsWith("/api/heatmap/domestic")), "홈 진입 시 국내 히트맵을 조회해야 함");
+  assert(doc.querySelector('#overseas-panel .heatmap-tile[data-symbol="MSFT"]'), "미국 히트맵이 유지되어야 함");
+  assert(doc.querySelector('#domestic-panel .heatmap-tile[data-symbol="005930"]'), "국내 히트맵이 렌더되어야 함");
 });
 
 await run();

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -1,4 +1,4 @@
-"""홈 화면 S&P500 히트맵의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
+"""히트맵 전용 페이지(/heatmap)의 템플릿-스크립트 배선을 잠그는 정적 계약 테스트."""
 
 import re
 from pathlib import Path
@@ -24,35 +24,34 @@ def _heatmap_css() -> str:
     return Path("view/web/static/css/heatmap.css").read_text(encoding="utf-8")
 
 
-def test_home_template_hosts_heatmap_panel():
+def test_home_does_not_duplicate_heatmap_panels():
+    """히트맵은 전용 페이지가 소유한다 — 홈은 조회도 폴링도 하지 않는다."""
     template = _home_template()
 
-    assert 'id="market-heatmap-card"' in template
-    assert 'id="market-heatmap"' in template
-    assert 'id="market-heatmap-updated-at"' in template
-    assert "/static/js/market_heatmap.js" in template
+    for element_id in ("market-heatmap-card", "market-heatmap", "domestic-heatmap-card", "domestic-heatmap"):
+        assert f'id="{element_id}"' not in template, f"{element_id} 가 홈에 남아 중복 조회를 유발함"
+    assert "/static/js/market_heatmap.js" not in template
+    assert "/static/css/heatmap.css" not in template
 
 
-def test_home_template_hosts_domestic_heatmap_panel():
+def test_home_menu_links_to_heatmap_page():
     template = _home_template()
 
-    assert 'id="domestic-heatmap-card"' in template
-    assert 'id="domestic-heatmap"' in template
-    assert 'id="domestic-heatmap-updated-at"' in template
+    assert 'href="/heatmap"' in template, "홈에서 전용 페이지로 갈 수 있어야 함"
 
 
 def test_domestic_heatmap_uses_daily_snapshot_and_shows_base_date():
     script = _heatmap_js()
 
     # 실시간 전종목 시세 소스가 없어 장마감 후 스냅샷을 쓴다 — 기준일을 감추지 않는다.
-    assert "/api/heatmap/domestic" in script
+    assert "/api/heatmap/domestic" in _heatmap_page_js()
     assert "기준일" in script and "종가" in script
     # 배타적 업종 분류가 없으므로 섹터 블록 없이 단일 그룹으로 그린다.
     assert "sector: null" in script
 
 
-def test_heatmap_component_styles_live_in_one_shared_stylesheet():
-    """홈 미리보기와 전용 페이지가 같은 타일을 그리므로 컴포넌트 CSS 는 한 곳에만 둔다."""
+def test_heatmap_component_styles_live_in_a_stylesheet():
+    """타일/섹터/범례 스타일은 템플릿 인라인이 아니라 스타일시트가 소유한다."""
     css = _heatmap_css()
 
     for selector in (
@@ -64,27 +63,21 @@ def test_heatmap_component_styles_live_in_one_shared_stylesheet():
         ".heatmap-legend",
         ".heatmap-toolbar",
     ):
-        assert selector in css, f"{selector} 스타일이 공용 스타일시트에 없음"
+        assert selector in css, f"{selector} 스타일이 스타일시트에 없음"
 
-    for template in (_home_template(), _heatmap_page_template()):
-        assert "/static/css/heatmap.css" in template, "히트맵 공용 스타일시트가 연결되지 않음"
-        assert ".heatmap-tile {" not in template, "컴포넌트 CSS 가 템플릿에 복제되어 있음"
-
-
-def test_home_template_hosts_heatmap_layout_only():
-    """홈은 미리보기 높이만 소유한다(타일 스타일은 공용 시트)."""
-    template = _home_template()
-
-    assert "#market-heatmap, #domestic-heatmap {" in template
+    template = _heatmap_page_template()
+    assert "/static/css/heatmap.css" in template, "히트맵 스타일시트가 연결되지 않음"
+    assert ".heatmap-tile {" not in template, "컴포넌트 CSS 가 템플릿에 복제되어 있음"
 
 
 def test_heatmap_reuses_overseas_market_cap_snapshot():
-    script = _heatmap_js()
-
     # 별도 수집 없이 미국 시가총액 화면과 같은 스냅샷(TTL 캐시 공유)을 쓴다.
-    assert "/api/overseas/top-market-cap" in script
-    assert "HEATMAP_LIMIT = 500" in script
-    # 미국장이 꺼진 run 에서는 조회 대신 카드를 감춘다.
+    page_script = _heatmap_page_js()
+    assert "/api/overseas/top-market-cap" in page_script
+    assert "HEATMAP_PAGE_OVERSEAS_LIMIT = 500" in page_script
+
+    # 미국장이 꺼진 run 에서는 조회 대신 탭을 감춘다.
+    script = _heatmap_js()
     assert "/api/market-mode" in script
     assert "overseas_us" in script
 
@@ -102,9 +95,9 @@ def test_heatmap_legend_colors_match_script_palette():
 
     palette = set(re.findall(r"color: '(#[0-9a-f]{6})'", script))
     assert len(palette) == 8, f"상승/하락 4단계 색이 정의되어야 함 (실제 {len(palette)}종)"
-    for template in (_home_template(), _heatmap_page_template()):
-        for color in palette:
-            assert color in template, f"범례에 {color} 가 빠져 스크립트와 어긋남"
+    template = _heatmap_page_template()
+    for color in palette:
+        assert color in template, f"범례에 {color} 가 빠져 스크립트와 어긋남"
 
 
 def test_heatmap_page_hosts_market_tabs_and_panels():
@@ -157,10 +150,12 @@ def test_heatmap_zoom_scales_label_threshold():
     assert re.search(r"box\.h \* zoom", script), "라벨 기준이 줌 배율을 반영하지 않음"
 
 
-def test_home_cards_link_to_heatmap_page():
-    template = _home_template()
+def test_render_script_has_no_home_wiring():
+    """홈 미리보기를 걷어낸 뒤 남은 배선은 전용 페이지가 전부 소유한다."""
+    script = _heatmap_js()
 
-    assert template.count('href="/heatmap"') >= 2, "홈의 두 히트맵 카드에서 전용 페이지로 갈 수 있어야 함"
+    for symbol in ("initMarketHeatmap", "initDomesticHeatmap", "HEATMAP_REFRESH_MS", "setInterval"):
+        assert symbol not in script, f"{symbol} 가 남아 홈 전용 배선이 잔존함"
 
 
 def test_heatmap_follows_domestic_up_red_convention():

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -1,4 +1,7 @@
-/* view/web/static/js/market_heatmap.js — 홈 화면 히트맵(트리맵)
+/* view/web/static/js/market_heatmap.js — 히트맵(트리맵) 렌더 라이브러리
+ *
+ * 화면 배선은 갖지 않는다. 소스({ targetId, captionId, url, toGroups, caption, ... })를 받아
+ * 조회 → 트리맵 계산 → 렌더까지 하며, 어떤 소스를 언제 그릴지는 화면(heatmap_page.js)이 정한다.
  *
  * 미국: /api/overseas/top-market-cap 스냅샷을 쓴다. 미국 시가총액 화면과 같은 소스라
  *       (Yahoo 스냅샷 1회로 sector/change_rate/market_cap_usd 가 모두 오고) TTL 캐시를 공유한다.
@@ -10,10 +13,6 @@
  * 색상은 국내 화면 컨벤션(상승=빨강, 하락=파랑)을 따른다.
  */
 
-const HEATMAP_LIMIT = 500;
-// 상위 200종목이면 국내 전체 시총의 91% 를 덮으면서 가장 작은 타일도 10px 아래로 내려가지 않는다.
-const HEATMAP_DOMESTIC_LIMIT = 200;
-const HEATMAP_REFRESH_MS = 5 * 60 * 1000;
 const HEATMAP_SECTOR_HEADER_PX = 16;
 // 타일이 이보다 작으면 글자가 넘쳐 겹치므로 텍스트를 생략한다(툴팁으로만 노출).
 const HEATMAP_MIN_LABEL_WIDTH_PCT = 4.5;
@@ -35,7 +34,6 @@ const HEATMAP_FLAT_COLOR = '#6b7280';
 const HEATMAP_UNKNOWN_COLOR = '#3f4650';
 
 let _heatmapRequestSequence = 0;
-let _heatmapRefreshTimer = null;
 
 function _heatmapNumber(value) {
     if (value === null || value === undefined || value === '') return null;
@@ -260,27 +258,7 @@ function _renderHeatmap(div, source, data) {
     }</div>`;
 }
 
-const HEATMAP_OVERSEAS = {
-    targetId: 'market-heatmap',
-    captionId: 'market-heatmap-updated-at',
-    url: `/api/overseas/top-market-cap?limit=${HEATMAP_LIMIT}`,
-    loadingText: 'S&P 500 히트맵 조회 중...',
-    toGroups: _overseasGroups,
-    caption: _overseasCaption,
-    sequence: 0,
-};
-
-const HEATMAP_DOMESTIC = {
-    targetId: 'domestic-heatmap',
-    captionId: 'domestic-heatmap-updated-at',
-    url: `/api/heatmap/domestic?limit=${HEATMAP_DOMESTIC_LIMIT}`,
-    loadingText: '국내 히트맵 조회 중...',
-    toGroups: _domesticGroups,
-    caption: _domesticCaption,
-    sequence: 0,
-};
-
-// 두 맵이 같은 홈 화면에 있으므로 시퀀스 가드는 소스별로 따로 센다.
+// 한 화면에 여러 맵이 있을 수 있으므로 시퀀스 가드는 소스별로 따로 센다.
 async function _loadHeatmap(source, options = {}) {
     const requestSequence = ++source.sequence;
     const isLatestRequest = () => requestSequence === source.sequence;
@@ -314,14 +292,6 @@ async function _loadHeatmap(source, options = {}) {
     }
 }
 
-async function loadMarketHeatmap(options = {}) {
-    await _loadHeatmap(HEATMAP_OVERSEAS, options);
-}
-
-async function loadDomesticHeatmap(options = {}) {
-    await _loadHeatmap(HEATMAP_DOMESTIC, options);
-}
-
 async function _heatmapOverseasEnabled() {
     try {
         const res = await fetchWithTimeout('/api/market-mode', {}, 5000);
@@ -333,41 +303,3 @@ async function _heatmapOverseasEnabled() {
     }
 }
 
-async function initMarketHeatmap() {
-    const card = document.getElementById('market-heatmap-card');
-    if (!card) return;
-
-    // 미국장이 꺼진 run 에서는 API 가 400 을 내므로, 오류 대신 카드를 감춘다.
-    if (!await _heatmapOverseasEnabled()) {
-        card.style.display = 'none';
-        return;
-    }
-    card.style.display = '';
-
-    await loadMarketHeatmap();
-    if (_heatmapRefreshTimer !== null) return;
-    _heatmapRefreshTimer = setInterval(() => {
-        void loadMarketHeatmap({ showLoading: false });
-    }, HEATMAP_REFRESH_MS);
-}
-
-// 국내 맵은 하루 한 번 갱신되는 종가 스냅샷이라 주기 갱신을 걸지 않는다.
-async function initDomesticHeatmap() {
-    if (!document.getElementById('domestic-heatmap-card')) return;
-    await loadDomesticHeatmap();
-}
-
-function _initHomeHeatmaps() {
-    void initMarketHeatmap();
-    void initDomesticHeatmap();
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    if (window.location.pathname !== '/') return;
-    _initHomeHeatmaps();
-});
-
-document.addEventListener('pjax:ready', (e) => {
-    if (e.detail?.path !== '/') return;
-    _initHomeHeatmaps();
-});

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -17,50 +17,11 @@
         .home-menu-group { margin-top: 28px; text-align: left; }
         .home-menu-group h3 { margin-bottom: 12px; }
         .home-menu-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-        /* 타일/섹터/범례 스타일은 /static/css/heatmap.css (전용 페이지와 공용). 여기선 미리보기 높이만 정한다. */
-        #market-heatmap, #domestic-heatmap { position: relative; height: 520px; }
-        .heatmap-expand { font-size: 0.78rem; text-decoration: none; color: var(--accent, #4a90e2); white-space: nowrap; }
-        @media (max-width: 640px) { #market-heatmap, #domestic-heatmap { height: 380px; } }
     </style>
-    <link rel="stylesheet" href="/static/css/heatmap.css?v=1">
     <div class="section">
         <div class="card">
             <h2>시장 지수</h2>
             <div id="market-indices"></div>
-        </div>
-    </div>
-    <div class="section">
-        <div class="card" id="market-heatmap-card">
-            <h2>S&amp;P 500 히트맵</h2>
-            <div class="heatmap-toolbar">
-                <span id="market-heatmap-updated-at" class="heatmap-updated">최신 업데이트: --</span>
-                <a class="heatmap-expand" href="/heatmap">크게 보기 ↗</a>
-                <span class="heatmap-legend">
-                    <span class="heatmap-legend-label">하락</span>
-                    <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
-                    <i style="background:#6b7280"></i>
-                    <i style="background:#e58080"></i><i style="background:#d64545"></i><i style="background:#b52626"></i><i style="background:#8f1a1a"></i>
-                    <span class="heatmap-legend-label">상승</span>
-                </span>
-            </div>
-            <div id="market-heatmap"></div>
-        </div>
-    </div>
-    <div class="section">
-        <div class="card" id="domestic-heatmap-card">
-            <h2>국내 시가총액 히트맵</h2>
-            <div class="heatmap-toolbar">
-                <span id="domestic-heatmap-updated-at" class="heatmap-updated">기준일: --</span>
-                <a class="heatmap-expand" href="/heatmap">크게 보기 ↗</a>
-                <span class="heatmap-legend">
-                    <span class="heatmap-legend-label">하락</span>
-                    <i style="background:#12386f"></i><i style="background:#2b5cb8"></i><i style="background:#4a7fd4"></i><i style="background:#84aee6"></i>
-                    <i style="background:#6b7280"></i>
-                    <i style="background:#e58080"></i><i style="background:#d64545"></i><i style="background:#b52626"></i><i style="background:#8f1a1a"></i>
-                    <span class="heatmap-legend-label">상승</span>
-                </span>
-            </div>
-            <div id="domestic-heatmap"></div>
         </div>
     </div>
     <div class="section">
@@ -115,6 +76,10 @@
             <section class="home-menu-group" data-home-market="common">
                 <h3>공통</h3>
                 <div class="home-menu-grid">
+                <a href="/heatmap" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
+                    <div style="font-size: 1.5rem; margin-bottom: 8px;">🗺️</div>
+                    <div style="font-weight: 600;">시장 히트맵</div>
+                </a>
                 <a href="/virtual" class="card menu-card" style="text-decoration: none; padding: 20px; text-align: center;">
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">📊</div>
                     <div style="font-weight: 600;">모의투자 기록</div>
@@ -140,5 +105,4 @@
 
 {% block scripts %}
 <script src="/static/js/market_indices.js?v=3"></script>
-<script src="/static/js/market_heatmap.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
#752 후속. 전용 페이지 `/heatmap` 이 같은 히트맵을 더 크게, 확대까지 되게 보여주므로 홈 카드는 순수 중복이 됐다.

## 왜
- 홈은 랜딩 페이지라 방문할 때마다 국내 스냅샷 1회 + **미국 시총 5분 폴링**을 유발했다.
- 배선이 두 벌이라 히트맵을 손볼 때마다 양쪽을 맞춰야 했다.
- 홈에서 잃는 "한눈에 시장 분위기"는 **시장 지수 카드**가 이미 담당한다.

## 변경
- **index.html** — 히트맵 카드 2개, 인라인 스타일, 스크립트/스타일시트 링크 제거. 공통 메뉴에 "🗺️ 시장 히트맵" 카드를 넣어 진입점은 유지(상단 nav 의 "히트맵" 도 그대로).
- **market_heatmap.js** — 이번 제거로 고아가 된 홈 배선 삭제: `HEATMAP_OVERSEAS`/`HEATMAP_DOMESTIC` 소스, `loadMarketHeatmap`/`loadDomesticHeatmap`, `initMarketHeatmap`/`initDomesticHeatmap`, 5분 폴링 타이머, `'/'` DOMContentLoaded·pjax 리스너. 이제 **화면 배선 없는 렌더 라이브러리**로 남는다(367 → 305줄). `_heatmapOverseasEnabled` 는 전용 페이지가 계속 쓴다.
- **run_market_heatmap_dom_tests.mjs** — 홈 함수 대신 테스트가 직접 정의한 소스로 `_loadHeatmap` 을 구동하는 라이브러리 회귀 테스트로 전환. 트리맵 기하·섹터 정렬·경계·색상/부호·XSS·HTTP 오류·빈 응답·경합 가드는 **그대로 유지**했고, 홈 카드 표시/자동 초기화 케이스는 전용 페이지 스위트가 이미 덮으므로 뺐다.
- 계약 테스트: "홈에 히트맵 요소·스크립트가 없다" + "렌더 라이브러리에 홈 배선이 남아있지 않다" 로 회귀를 잠갔다.

## 테스트
- `run_market_heatmap_dom_tests.mjs` 13/13, `run_heatmap_page_dom_tests.mjs` 8/8
- `pytest tests/unit_test` 7318 passed / `pytest tests/integration_test` 277 passed

## 남겨둔 것
`market_heatmap.js` 의 `let _heatmapRequestSequence = 0;` 은 이번 변경 이전부터 아무 데서도 쓰이지 않는 데드 코드다. 이번 작업 범위 밖이라 건드리지 않았고, 정리 여부는 별도 판단이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
