### PR TITLE
fix: size inverse ETF entries by sleeve budget

### DIFF
--- a/strategies/inverse_etf_regime_types.py
+++ b/strategies/inverse_etf_regime_types.py
@@ -10,6 +10,9 @@ class InverseEtfRegimeConfig(BaseStrategyConfig):
     KOSPI가 확인된 하락추세(bear)일 때만 -1x 인버스 ETF를 추세추종 매수해
     하락장에서 (-)베타 수익을 얻는다. long-only 7전략과 구조적으로 음의 상관.
     """
+    # 단일 1주 검증 모드가 아니라 슬리브 예산(position_size_pct)을 사용한다.
+    use_fixed_qty: bool = False
+
     # 종목 (KODEX 인버스, KOSPI200 일간 -1x). 곱버스(-2x)는 변동성 감쇠로 제외.
     inverse_etf_code: str = "114800"
     inverse_etf_name: str = "KODEX 인버스"

--- a/tests/unit_test/strategies/test_inverse_etf_regime_strategy.py
+++ b/tests/unit_test/strategies/test_inverse_etf_regime_strategy.py
@@ -99,6 +99,17 @@ async def test_scan_emits_buy_when_bear_and_trend_confirmed(bear_setup):
 
 
 @pytest.mark.asyncio
+async def test_scan_sizes_entry_by_configured_portfolio_fraction(bear_setup):
+    """인버스 슬리브는 고정 1주가 아니라 기본 3% 예산으로 진입한다."""
+    strat, _, _, _, _, _ = bear_setup
+
+    sig = (await strat.scan())[0]
+
+    # 기본값: 1,000만원 × 3% ÷ 10,000원 = 30주
+    assert sig.qty == 30
+
+
+@pytest.mark.asyncio
 async def test_scan_no_signal_when_not_bear(bear_setup):
     """레짐이 베어가 아니면(상승/횡보) 진입하지 않는다 — R-2 디코릴레이션 핵심."""
     strat, _, regime, _, _, _ = bear_setup


### PR DESCRIPTION
## Summary\n- use the inverse ETF sleeve budget instead of a fixed one-share entry\n- preserve order-level risk caps\n- add regression coverage for default 3% sizing\n\n## Verification\n- pytest tests/unit_test/strategies/test_inverse_etf_regime_strategy.py -v -n0\n- pytest tests/integration_test -v -n0