### PR TITLE
fix: deduplicate favorite price threshold alerts

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -24,7 +24,6 @@ class FavoritePriceAlertService:
         threshold_step_pct: float = 5.0,
         upper_limit_rate_pct: float = 29.5,
         favorite_cache_ttl_sec: float = 30.0,
-        alert_cooldown_sec: float = 300.0,
         logger=None,
     ) -> None:
         self._favorite_repository = favorite_repository
@@ -33,12 +32,10 @@ class FavoritePriceAlertService:
         self._threshold_step_pct = float(threshold_step_pct)
         self._upper_limit_rate_pct = float(upper_limit_rate_pct)
         self._favorite_cache_ttl_sec = float(favorite_cache_ttl_sec)
-        self._alert_cooldown_sec = float(alert_cooldown_sec)
         self._logger = logger or logging.getLogger(__name__)
         self._favorite_codes: set[str] = set()
         self._favorite_cache_ts: float = 0.0
         self._last_alert_bucket: dict[str, int] = {}
-        self._last_alert_ts_by_bucket: dict[tuple[str, int], float] = {}
         self._upper_limit_alerted_codes: set[str] = set()
 
     async def add_favorite(self, code: str) -> None:
@@ -54,8 +51,6 @@ class FavoritePriceAlertService:
             return
         self._favorite_codes.discard(normalized)
         self._last_alert_bucket.pop(normalized, None)
-        for key in [key for key in self._last_alert_ts_by_bucket if key[0] == normalized]:
-            self._last_alert_ts_by_bucket.pop(key, None)
         self._upper_limit_alerted_codes.discard(normalized)
 
     async def handle_price_tick(
@@ -92,22 +87,11 @@ class FavoritePriceAlertService:
 
         bucket = self._rate_bucket(rate_value)
         if bucket == 0:
-            self._last_alert_bucket[normalized] = 0
             return False
         if self._last_alert_bucket.get(normalized) == bucket:
             return False
 
         self._last_alert_bucket[normalized] = bucket
-        cooldown_key = (normalized, bucket)
-        now = time.monotonic()
-        last_alert_ts = self._last_alert_ts_by_bucket.get(cooldown_key, 0.0)
-        if (
-            self._alert_cooldown_sec > 0
-            and last_alert_ts > 0
-            and now - last_alert_ts < self._alert_cooldown_sec
-        ):
-            return False
-        self._last_alert_ts_by_bucket[cooldown_key] = now
 
         threshold_pct = int(bucket * self._threshold_step_pct)
         name = self._stock_name(normalized)

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -67,17 +67,48 @@ async def test_does_not_repeat_bucket_when_rate_chatters_around_threshold():
     repo.get_all = AsyncMock(return_value=["005930"])
     notifications = MagicMock()
     notifications.emit = AsyncMock()
-    svc = FavoritePriceAlertService(
-        repo,
-        notifications,
-        alert_cooldown_sec=300.0,
-    )
+    svc = FavoritePriceAlertService(repo, notifications)
 
     await svc.handle_price_tick("005930", price="70000", rate="-5.01")
     await svc.handle_price_tick("005930", price="70050", rate="-4.99")
     await svc.handle_price_tick("005930", price="70000", rate="-5.02")
 
     notifications.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_does_not_repeat_five_percent_after_retracing_without_another_alert_bucket():
+    """+5% 알림 뒤 +6%를 거쳐 +5%로 돌아와도 같은 알림을 반복하지 않는다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.01")
+    await svc.handle_price_tick("005930", price="75600", rate="6.00")
+    await svc.handle_price_tick("005930", price="75000", rate="5.02")
+
+    notifications.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_realerts_five_percent_after_ten_percent_alert():
+    """+10% 알림이 끼어들면 +5% 재진입은 새 등락 단계로 한 번 알린다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.01")
+    await svc.handle_price_tick("005930", price="78500", rate="10.01")
+    await svc.handle_price_tick("005930", price="75000", rate="5.02")
+
+    assert [
+        call.kwargs["metadata"]["threshold_pct"]
+        for call in notifications.emit.await_args_list
+    ] == [5, 10, 5]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- suppress repeated alert buckets even after a small retracement\n- allow a lower threshold alert after a different threshold alert\n- remove time-based bucket cooldown that blocked the requested sequence\n\n## Verification\n- pytest tests/unit_test -v\n- pytest tests/integration_test -v -n0