### PR TITLE
Add KOSPI/KOSDAQ index threshold alerts

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -197,6 +197,12 @@ market_status_alert:
   enabled: true
   monitor_codes: ["000000"]
 
+# 코스피·코스닥 지수의 ±5% 급변과 -8% 서킷브레이커 1단계 접근을 1분마다 사전경고한다.
+# 실제 거래소 발동 여부는 위 장운영정보 알림이 별도로 확정한다.
+market_index_alert:
+  enabled: true
+  poll_interval_sec: 60
+
 # OpenDART 관심종목 공시 알림 (API 키 발급 후 enabled=true)
 dart_disclosure:
   enabled: false

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -191,11 +191,11 @@ notifications:
       STRATEGY: ["warning", "error", "critical"]
       API: ["error", "critical"]
 
-# 시장 안전장치 알림. 장운영정보 웹소켓(H0UNMKO0)을 대표 종목에 구독해
-# 거래정지 사유에 사이드카/서킷브레이커가 포함되면 SYSTEM 알림을 발행한다.
+# 시장 안전장치 알림. 장운영정보 웹소켓(H0UNMKO0)을 전체 시장 키(000000)에 구독해
+# 코스피/코스닥의 매수·매도 사이드카와 서킷브레이커를 SYSTEM 알림으로 발행한다.
 market_status_alert:
   enabled: true
-  monitor_codes: ["005930"]
+  monitor_codes: ["000000"]
 
 # OpenDART 관심종목 공시 알림 (API 키 발급 후 enabled=true)
 dart_disclosure:

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -23,6 +23,7 @@ class MarketStatusAlertService:
         self._notification_service = notification_service
         self._logger = logger or logging.getLogger(__name__)
         self._active_keys_by_code: dict[str, set[str]] = {}
+        self._active_index_keys_by_code: dict[str, set[str]] = {}
 
     async def on_market_status(self, data: dict[str, Any]) -> None:
         """StreamingService handler entrypoint."""
@@ -75,6 +76,62 @@ class MarketStatusAlertService:
                 metadata=metadata,
             )
 
+    async def on_index_change(self, index_code: str, index_name: str, change_rate: float) -> None:
+        """코스피/코스닥 지수 등락률 기반의 사전경고를 발행한다."""
+        direction = "up" if change_rate >= 0 else "down"
+        active_keys = self._active_index_keys_by_code.setdefault(index_code, set())
+        expected_keys: set[str] = set()
+
+        if abs(change_rate) >= 5.0:
+            key = f"market_index:move_5:{direction}:{index_code}"
+            expected_keys.add(key)
+            await self._report_index_alert(
+                key=key, severity="warning",
+                title=f"{index_name} {self._direction_label(direction)} 5% 이상 등락",
+                index_code=index_code, index_name=index_name, change_rate=change_rate,
+                threshold_pct=5.0, event_type="move_5",
+            )
+        if change_rate <= -8.0:
+            key = f"market_index:fall_8:{index_code}"
+            expected_keys.add(key)
+            await self._report_index_alert(
+                key=key, severity="critical",
+                title=f"{index_name} 하락 8% 이상 — 서킷브레이커 경고",
+                index_code=index_code, index_name=index_name, change_rate=change_rate,
+                threshold_pct=8.0, event_type="fall_8",
+            )
+
+        if self._operator_alert_service is not None:
+            for key in active_keys - expected_keys:
+                await self._operator_alert_service.resolve(
+                    AlertSource.MARKET_STATUS, key, "지수 등락률 정상화"
+                )
+        self._active_index_keys_by_code[index_code] = expected_keys
+
+    async def _report_index_alert(
+        self, *, key: str, severity: str, title: str, index_code: str,
+        index_name: str, change_rate: float, threshold_pct: float, event_type: str,
+    ) -> None:
+        metadata = {
+            "event_type": event_type, "index_code": index_code,
+            "index_name": index_name, "change_rate": change_rate,
+            "threshold_pct": threshold_pct, "pre_alert": True,
+            "telegram_channel": "report",
+        }
+        message = f"{index_name}({index_code}) 전일 대비 {change_rate:+.2f}%"
+        if self._operator_alert_service is not None:
+            await self._operator_alert_service.report(
+                AlertSource.MARKET_STATUS, key, severity, title, message, metadata=metadata,
+            )
+            return
+        if self._notification_service is not None:
+            from services.notification_service import NotificationCategory, NotificationLevel
+
+            level = NotificationLevel.CRITICAL if severity == "critical" else NotificationLevel.WARNING
+            await self._notification_service.emit(
+                NotificationCategory.SYSTEM, level, title, message, metadata=metadata,
+            )
+
     def _classify_event(self, data: dict[str, Any]) -> Optional[str]:
         reason = str(data.get("거래정지사유내용") or "").lower()
         if any(keyword.lower() in reason for keyword in self._SIDECAR_KEYWORDS):
@@ -94,7 +151,7 @@ class MarketStatusAlertService:
 
     @staticmethod
     def _direction_label(direction: Optional[str]) -> str:
-        return {"buy": "매수", "sell": "매도"}.get(direction, "")
+        return {"buy": "매수", "sell": "매도", "up": "상승", "down": "하락"}.get(direction, "")
 
     async def _resolve_for_code(self, data: dict[str, Any]) -> None:
         if self._operator_alert_service is None:

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -34,15 +34,19 @@ class MarketStatusAlertService:
         code = str(data.get("유가증권단축종목코드") or data.get("종목코드") or "UNKNOWN")
         exchange = str(data.get("거래소구분코드") or data.get("EXCH_CLS_CODE") or "UNKNOWN")
         reason = str(data.get("거래정지사유내용") or "").strip()
-        dedup_key = f"market_status:{event_type}:{exchange}:{code}"
+        direction = self._classify_direction(reason)
+        direction_key = f":{direction}" if direction else ""
+        dedup_key = f"market_status:{event_type}{direction_key}:{exchange}:{code}"
         severity = "critical" if event_type == "circuit_breaker" else "warning"
-        title = "서킷브레이커 감지" if event_type == "circuit_breaker" else "사이드카 감지"
+        event_name = "서킷브레이커" if event_type == "circuit_breaker" else "사이드카"
+        title = f"{self._direction_label(direction)} {event_name} 감지".strip()
         message = f"{exchange} {code}: {reason or '장운영정보 특수 상태 감지'}"
         metadata = {
             "event_type": event_type,
             "stock_code": code,
             "exchange": exchange,
             "reason": reason,
+            "direction": direction,
             "market_status": dict(data),
             "telegram_channel": "report",
         }
@@ -78,6 +82,19 @@ class MarketStatusAlertService:
         if any(keyword.lower() in reason for keyword in self._CIRCUIT_KEYWORDS):
             return "circuit_breaker"
         return None
+
+    @staticmethod
+    def _classify_direction(reason: str) -> Optional[str]:
+        normalized = reason.lower()
+        if "매수" in reason or "buy" in normalized:
+            return "buy"
+        if "매도" in reason or "sell" in normalized:
+            return "sell"
+        return None
+
+    @staticmethod
+    def _direction_label(direction: Optional[str]) -> str:
+        return {"buy": "매수", "sell": "매도"}.get(direction, "")
 
     async def _resolve_for_code(self, data: dict[str, Any]) -> None:
         if self._operator_alert_service is None:

--- a/task/background/intraday/market_index_threshold_alert_task.py
+++ b/task/background/intraday/market_index_threshold_alert_task.py
@@ -1,0 +1,108 @@
+"""코스피/코스닥 지수 급변 사전경고 태스크."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from common.types import ErrorCode
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+
+
+class MarketIndexThresholdAlertTask(SchedulableTask):
+    """1분봉 지수 시세로 ±5%, -8% 등락률을 감시한다."""
+
+    CHECK_INTERVAL_SEC = 60
+    _INDICES = (("0001", "코스피"), ("1001", "코스닥"))
+    _DOWN_SIGNS = {"4", "5", "-", "D", "DOWN"}
+
+    def __init__(self, *, broker, market_status_alert_service, market_clock,
+                 market_calendar_service=None, check_interval_sec: Optional[int] = None,
+                 logger=None) -> None:
+        self._broker = broker
+        self._alert_service = market_status_alert_service
+        self._market_clock = market_clock
+        self._mcs = market_calendar_service
+        self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def task_name(self) -> str:
+        return "market_index_threshold_alert"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.HIGH
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    def get_progress(self) -> dict:
+        return {"running": self._state == TaskState.RUNNING}
+
+    async def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+        self._task = None
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                if self._state != TaskState.SUSPENDED:
+                    self._state = TaskState.RUNNING
+                    await self._tick()
+                    if self._state == TaskState.RUNNING:
+                        self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error("%s: loop error — %s", self.task_name, exc, exc_info=True)
+            await asyncio.sleep(self._check_interval_sec)
+
+    async def _tick(self) -> None:
+        if not await self._is_market_open_now():
+            return
+        for index_code, index_name in self._INDICES:
+            response = await self._broker.inquire_time_indexchartprice(index_code, 60)
+            if response.rt_cd != ErrorCode.SUCCESS.value:
+                self._logger.warning("%s: %s 지수 조회 실패 — %s", self.task_name, index_name, response.msg1)
+                continue
+            summary = (response.data or {}).get("summary") or {}
+            change_rate = self._signed_change_rate(summary)
+            if change_rate is None:
+                self._logger.warning("%s: %s 등락률 누락", self.task_name, index_name)
+                continue
+            await self._alert_service.on_index_change(index_code, index_name, change_rate)
+
+    async def _is_market_open_now(self) -> bool:
+        now = self._market_clock.get_current_kst_time()
+        if not self._market_clock.is_market_operating_hours(now):
+            return False
+        if self._mcs is None:
+            return True
+        return await self._mcs.is_business_day(now.strftime("%Y%m%d"))
+
+    @classmethod
+    def _signed_change_rate(cls, summary: dict) -> Optional[float]:
+        try:
+            rate = float(str(summary.get("bstp_nmix_prdy_ctrt") or "").replace(",", ""))
+        except (TypeError, ValueError):
+            return None
+        sign = str(summary.get("prdy_vrss_sign") or "").upper()
+        return -abs(rate) if sign in cls._DOWN_SIGNS else rate

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -122,3 +122,27 @@ async def test_market_status_alert_service_resolves_active_alert_on_normal_statu
         "market_status:circuit_breaker:KRX:005930",
         "장운영정보 정상화",
     )
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_reports_index_thresholds_and_resolves_them():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_index_change("0001", "코스피", -8.2)
+
+    assert operator_alert.report.await_count == 2
+    assert operator_alert.report.await_args_list[0].args[1] == "market_index:move_5:down:0001"
+    assert operator_alert.report.await_args_list[0].args[2] == "warning"
+    assert operator_alert.report.await_args_list[1].args[1] == "market_index:fall_8:0001"
+    assert operator_alert.report.await_args_list[1].args[2] == "critical"
+
+    await service.on_index_change("0001", "코스피", -1.0)
+
+    assert {call.args[1] for call in operator_alert.resolve.await_args_list} == {
+        "market_index:move_5:down:0001",
+        "market_index:fall_8:0001",
+    }

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -47,9 +47,35 @@ async def test_market_status_alert_service_reports_sidecar_warning():
 
     args = operator_alert.report.await_args.args
     kwargs = operator_alert.report.await_args.kwargs
-    assert args[1] == "market_status:sidecar:KRX:005930"
+    assert args[1] == "market_status:sidecar:sell:KRX:005930"
     assert args[2] == "warning"
     assert kwargs["metadata"]["telegram_channel"] == "report"
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_distinguishes_buy_and_sell_sidecars():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "000000",
+        "거래정지사유내용": "매수 사이드카 발동",
+        "거래소구분코드": "KOSPI",
+    })
+    await service.on_market_status({
+        "유가증권단축종목코드": "000000",
+        "거래정지사유내용": "매도 사이드카 발동",
+        "거래소구분코드": "KOSPI",
+    })
+
+    assert operator_alert.report.await_count == 2
+    assert operator_alert.report.await_args_list[0].args[1] == "market_status:sidecar:buy:KOSPI:000000"
+    assert operator_alert.report.await_args_list[1].args[1] == "market_status:sidecar:sell:KOSPI:000000"
+    assert operator_alert.report.await_args_list[0].args[3] == "매수 사이드카 감지"
+    assert operator_alert.report.await_args_list[1].args[3] == "매도 사이드카 감지"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_market_index_threshold_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_market_index_threshold_alert_task.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
+
+
+@pytest.mark.asyncio
+async def test_tick_forwards_signed_kospi_and_kosdaq_change_rates():
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock(side_effect=[
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={"summary": {"bstp_nmix_prdy_ctrt": "5.1", "prdy_vrss_sign": "2"}},
+        ),
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={"summary": {"bstp_nmix_prdy_ctrt": "8.2", "prdy_vrss_sign": "5"}},
+        ),
+    ])
+    alert_service = MagicMock()
+    alert_service.on_index_change = AsyncMock()
+    market_clock = MagicMock()
+    market_clock.get_current_kst_time.return_value = datetime(2026, 8, 3, 10, 0)
+    market_clock.is_market_operating_hours.return_value = True
+    market_calendar = MagicMock()
+    market_calendar.is_business_day = AsyncMock(return_value=True)
+    task = MarketIndexThresholdAlertTask(
+        broker=broker,
+        market_status_alert_service=alert_service,
+        market_clock=market_clock,
+        market_calendar_service=market_calendar,
+        logger=MagicMock(),
+    )
+
+    await task._tick()
+
+    assert broker.inquire_time_indexchartprice.await_args_list[0].args == ("0001", 60)
+    assert broker.inquire_time_indexchartprice.await_args_list[1].args == ("1001", 60)
+    assert alert_service.on_index_change.await_args_list[0].args == ("0001", "코스피", 5.1)
+    assert alert_service.on_index_change.await_args_list[1].args == ("1001", "코스닥", -8.2)

--- a/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_realtime_bootstrap.py
@@ -25,6 +25,7 @@ def test_realtime_bootstrap_builds_streaming_chain():
         RealtimeBootstrap(ctx).run(config={}, needs_realtime=True)
 
     assert ctx.streaming_service is streaming.return_value
+    assert streaming.call_args.kwargs["market_status_monitor_codes"] == ["000000"]
     assert ctx.orderbook_snapshot_repo is orderbook_repo.return_value
     assert ctx.favorite_price_alert_service is favorite_alert.return_value
     assert price_stream.call_args.kwargs["favorite_price_alert_service"] is favorite_alert.return_value

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -53,6 +53,7 @@ def _make_fake_context(runtime_mode: RuntimeMode = RuntimeMode.ALL):
         "market_cap_gap_report_kr_task", "market_cap_gap_report_us_task",
         "microstructure_capture_task", "program_capture_subscription_task",
         "theme_intraday_leader_alert_task",
+        "market_index_threshold_alert_task",
         "ytd_ranking_report_task",
     ]:
         task = MagicMock()
@@ -93,11 +94,11 @@ def test_creates_foreground_even_in_batch_only_mode(patched_scheduler_deps):
 
 # ---------- mode=ALL 회귀 (현행 동작 100% 유지) ----------
 
-def test_all_mode_registers_24_tasks_to_background(patched_scheduler_deps):
+def test_all_mode_registers_25_tasks_to_background(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.ALL)
     _run(ctx)
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 24
+    assert bg.register.call_count == 25
 
 
 def test_all_mode_registers_15_tasks_to_time_dispatcher(patched_scheduler_deps):
@@ -183,6 +184,7 @@ def test_trading_only_registers_intraday_and_watchdog(patched_scheduler_deps):
         "opening_position_reconcile_task",
         "cache_warmup_task",
         "theme_intraday_leader_alert_task",
+        "market_index_threshold_alert_task",
         "websocket_watchdog_task",
     }
 
@@ -251,4 +253,4 @@ def test_skips_none_tasks(patched_scheduler_deps):
     # 둘 다 -1 감소한다.
     assert ctx.time_dispatcher.register_task.call_count == 14
     bg = patched_scheduler_deps["BackgroundScheduler"].return_value
-    assert bg.register.call_count == 23
+    assert bg.register.call_count == 24

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -25,6 +25,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "OneilUniverseService", "NaverFinanceScraperService",
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "ThemeIntradayLeaderAlertTask",
+    "MarketIndexThresholdAlertTask",
     "USMarketCalendarService",
     "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",

--- a/view/web/bootstrap/realtime_bootstrap.py
+++ b/view/web/bootstrap/realtime_bootstrap.py
@@ -37,9 +37,9 @@ class RealtimeBootstrap:
             else True
         )
         monitor_codes = (
-            market_status_cfg.get("monitor_codes", ["005930"])
+            market_status_cfg.get("monitor_codes", ["000000"])
             if isinstance(market_status_cfg, dict)
-            else ["005930"]
+            else ["000000"]
         )
         ctx.market_status_alert_service = (
             MarketStatusAlertService(

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -113,6 +113,7 @@ class SchedulerBootstrap:
         self._register(ctx.opening_position_reconcile_task, TaskPriority.HIGH)
         self._register(ctx.cache_warmup_task)
         self._register(self._optional_task("theme_intraday_leader_alert_task"))
+        self._register(self._optional_task("market_index_threshold_alert_task"))
 
     def _register_batch_tasks(self) -> None:
         ctx = self._ctx

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -69,6 +69,7 @@ from task.background.intraday.opening_position_reconcile_task import OpeningPosi
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
+from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
@@ -680,6 +681,24 @@ class ServiceContainer:
                 needs_trading
                 and ctx.ranking_task is not None
                 and ctx.theme_daily_leader_service is not None
+            ) else None
+
+            index_alert_cfg = config_dict.get("market_index_alert", {})
+            index_alert_enabled = (
+                index_alert_cfg.get("enabled", True)
+                if isinstance(index_alert_cfg, dict) else True
+            )
+            ctx.market_index_threshold_alert_task = MarketIndexThresholdAlertTask(
+                broker=ctx.broker,
+                market_status_alert_service=ctx.market_status_alert_service,
+                market_clock=ctx.market_clock,
+                market_calendar_service=ctx._mcs,
+                check_interval_sec=index_alert_cfg.get("poll_interval_sec", 60),
+                logger=ctx.logger,
+            ) if (
+                needs_trading
+                and index_alert_enabled
+                and ctx.market_status_alert_service is not None
             ) else None
 
             if needs_web:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -174,6 +174,7 @@ class WebAppContext:
         self._mcs: MarketCalendarService = None
         self.notification_service: NotificationService = None
         self.market_status_alert_service = None
+        self.market_index_threshold_alert_task = None
         self.telegram_notification_repository = None
         self.strategy_diagnostic_report_repository = None
         self.notification_queue_task: NotificationQueueTask = None


### PR DESCRIPTION
## Summary
- Add a 60-second KOSPI/KOSDAQ index monitor using 1-minute index candles.
- Alert at absolute 5% daily movement and critically warn at 8% downside.
- Keep these pre-alerts separate from confirmed exchange Sidecar/Circuit Breaker events.

## Validation
- pytest tests/unit_test -v — 7,324 passed
- pytest tests/integration_test/test_it_operator_dashboard.py tests/integration_test/test_it_web_api_paper.py -q -n0 — 53 passed