### PR TITLE
fix: PT 구독 현황 출처별 분류 + desired 잔재 누적 차단

### DIFF
--- a/repositories/streaming_stock_repo.py
+++ b/repositories/streaming_stock_repo.py
@@ -24,7 +24,7 @@ import sqlite3
 import threading
 import time
 from enum import Enum
-from typing import Dict, Iterable, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 
 class StreamingType(str, Enum):
@@ -231,6 +231,28 @@ class StreamingStockRepo:
                 self._pt_sources.pop(code, None)
         if stream_type == StreamingType.PROGRAM_TRADING:
             self._persist_pt_desired(code, add=False)
+
+    async def prune_orphan_pt_desired(self, owned_codes: Iterable[str]) -> List[str]:
+        """소유자가 사라진 PT desired 잔재를 제거한다.
+
+        owned_codes(구독 태스크가 영속화한 현재 배치)에 없으면서 출처가
+        program/legacy인 종목만 제거한다. 수동(manual) 구독은 보존한다.
+        재시작 시 DB에서 복원되지만 어떤 카테고리도 소유하지 않는 행이
+        pt_subscriptions에 무한 누적되는 것을 막는다.
+        """
+        owned = self._normalize_codes(owned_codes)
+        targets = sorted(
+            code for code in self._desired[StreamingType.PROGRAM_TRADING]
+            if code not in owned
+            and self._pt_sources.get(code, self.SOURCE_LEGACY) != self.SOURCE_MANUAL
+        )
+        if not targets:
+            return []
+        for code in targets:
+            await self.unmark_desired(code, StreamingType.PROGRAM_TRADING)
+        self.flush_pt_desired_sync()
+        self._logger.info(f"StreamingStockRepo: PT desired 잔재 {len(targets)}개 정리 {targets}")
+        return targets
 
     async def mark_active(self, code: str, stream_type: StreamingType) -> None:
         """브로커 구독 성공 후 활성 상태로 전환한다."""

--- a/task/background/intraday/program_capture_subscription_task.py
+++ b/task/background/intraday/program_capture_subscription_task.py
@@ -6,7 +6,7 @@ import logging
 from typing import Dict, List, Optional
 
 from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
-from repositories.streaming_stock_repo import StreamingType
+from repositories.streaming_stock_repo import StreamingStockRepo, StreamingType
 from services.subscription_policy import SubscriptionPriority
 from task.background.capture_candidates import resolve_capture_codes
 
@@ -165,6 +165,7 @@ class ProgramCaptureSubscriptionTask(SchedulableTask):
                 )
                 self._synced_price_codes = stored_price
                 self._synced_codes = list(dict.fromkeys(stored + stored_price))
+            await self._prune_orphan_pt_desired(stored)
             self._adopted = True
 
         if await self._is_market_open_now():
@@ -217,6 +218,20 @@ class ProgramCaptureSubscriptionTask(SchedulableTask):
             self._save_codes([], self._price_state_key)
             self._logger.info(f"{self.task_name}: 장외 — 캡처 후보 순환 구독 해지")
 
+    async def _prune_orphan_pt_desired(self, owned_codes: List[str]) -> None:
+        """재시작 시 소유자가 없는 PT desired 잔재를 정리한다 (수동 구독은 보존)."""
+        if self._streaming_stock_repo is None:
+            return
+        try:
+            pruned = await self._streaming_stock_repo.prune_orphan_pt_desired(owned_codes)
+        except Exception as exc:
+            self._logger.warning(f"{self.task_name}: PT desired 잔재 정리 실패 — {exc}")
+            return
+        if pruned:
+            self._logger.info(
+                f"{self.task_name}: PT desired 잔재 {len(pruned)}종목 정리 — {pruned}"
+            )
+
     async def _is_market_open_now(self) -> bool:
         now = self._market_clock.get_current_kst_time()
         if not self._market_clock.is_market_operating_hours(now):
@@ -239,15 +254,21 @@ class ProgramCaptureSubscriptionTask(SchedulableTask):
             task_name=self.task_name,
         )
         already_desired: set = set()
+        pt_sources: dict = {}
         if self._streaming_stock_repo is not None:
             try:
                 already_desired = set(
                     self._streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)
                 )
+                pt_sources = self._streaming_stock_repo.get_pt_subscription_sources()
             except Exception as exc:
                 self._logger.warning(f"{self.task_name}: PT desired 조회 실패 — {exc}")
-        # 우리 카테고리가 이미 올린 desired는 제외 대상이 아니다 (재시작 재편입 케이스)
-        manual_desired = already_desired - set(self._synced_codes)
+        # 수동 UI 구독만 제외한다. program/legacy 출처까지 빼면 우리가 올린 desired가
+        # 후보에서 영구 제외돼 어떤 카테고리도 소유하지 않는 잔재로 굳는다.
+        manual_desired = {
+            code for code in already_desired
+            if pt_sources.get(code) == StreamingStockRepo.SOURCE_MANUAL
+        }
         return [
             code for code in codes
             if code not in manual_desired

--- a/tests/unit_test/repositories/test_streaming_stock_repo.py
+++ b/tests/unit_test/repositories/test_streaming_stock_repo.py
@@ -165,6 +165,48 @@ async def test_pt_persistence_tracks_subscription_source(tmp_path, mock_logger):
     }
 
 
+@pytest.mark.asyncio
+async def test_prune_orphan_pt_desired_removes_unowned_program_and_legacy(tmp_path, mock_logger):
+    """소유자가 없는 program/legacy PT desired만 제거하고 manual은 보존한다."""
+    db_path = str(tmp_path / "test_pt.db")
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path)
+
+    await repo.mark_desired("005930", StreamingType.PROGRAM_TRADING, source="manual")
+    await repo.mark_desired("000660", StreamingType.PROGRAM_TRADING, source="program")
+    await repo.mark_desired("035420", StreamingType.PROGRAM_TRADING, source="program")
+    await repo.mark_desired("080220", StreamingType.PROGRAM_TRADING, source="legacy")
+    repo.flush_pt_desired_sync()
+
+    pruned = await repo.prune_orphan_pt_desired(["000660"])
+
+    assert pruned == ["035420", "080220"]
+    assert repo.get_desired(StreamingType.PROGRAM_TRADING) == {"005930", "000660"}
+    assert repo.get_pt_subscription_sources() == {
+        "005930": "manual",
+        "000660": "program",
+    }
+
+    conn = sqlite3.connect(db_path)
+    rows = {row[0] for row in conn.execute("SELECT code FROM pt_subscriptions").fetchall()}
+    conn.close()
+    assert rows == {"005930", "000660"}
+
+
+@pytest.mark.asyncio
+async def test_prune_orphan_pt_desired_noop_when_nothing_to_remove(tmp_path, mock_logger):
+    """제거 대상이 없으면 빈 목록을 반환하고 상태를 바꾸지 않는다."""
+    db_path = str(tmp_path / "test_pt.db")
+    repo = StreamingStockRepo(logger=mock_logger)
+    repo.load_pt_desired_from_db(db_path)
+
+    await repo.mark_desired("005930", StreamingType.PROGRAM_TRADING, source="manual")
+    repo.flush_pt_desired_sync()
+
+    assert await repo.prune_orphan_pt_desired([]) == []
+    assert repo.get_desired(StreamingType.PROGRAM_TRADING) == {"005930"}
+
+
 def test_load_legacy_pt_subscription_table_migrates_source_to_legacy(tmp_path, mock_logger):
     """기존 code-only pt_subscriptions 테이블은 출처 미확인(legacy)으로 이관한다."""
     db_path = str(tmp_path / "test_pt.db")

--- a/tests/unit_test/task/background/intraday/test_program_capture_subscription_task.py
+++ b/tests/unit_test/task/background/intraday/test_program_capture_subscription_task.py
@@ -142,10 +142,42 @@ async def test_restart_leftover_is_adopted_then_cleared_when_closed():
 
 
 @pytest.mark.asyncio
+async def test_adopt_prunes_orphan_pt_desired_with_stored_batch():
+    # 재시작 시 store 에 남은 배치를 소유 목록으로 넘겨 나머지 PT desired 잔재를 정리한다.
+    store = _FakeStore()
+    store.save_keyed("program_capture_subscribed_codes", "005930,000660")
+    repo = MagicMock()
+    repo.get_desired.return_value = set()
+    repo.get_pt_subscription_sources.return_value = {}
+    repo.prune_orphan_pt_desired = AsyncMock(return_value=["035420"])
+    task, _policy = _make_task(scheduler_store=store, streaming_stock_repo=repo)
+
+    await task._tick()
+
+    repo.prune_orphan_pt_desired.assert_awaited_once_with(["005930", "000660"])
+
+
+@pytest.mark.asyncio
+async def test_adopt_prune_failure_does_not_break_tick():
+    # 잔재 정리 실패는 경고만 남기고 이후 동기화를 막지 않는다.
+    repo = MagicMock()
+    repo.get_desired.return_value = set()
+    repo.get_pt_subscription_sources.return_value = {}
+    repo.prune_orphan_pt_desired = AsyncMock(side_effect=Exception("db down"))
+    task, policy = _make_task(streaming_stock_repo=repo)
+
+    await task._tick()
+
+    assert policy.sync_subscriptions.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_excludes_manual_pt_desired_and_caps_max_codes():
     # 수동 UI 로 이미 PT desired 인 종목은 제외 (해지/영속 상태 간섭 방지), cap 적용
     repo = MagicMock()
     repo.get_desired.return_value = {"000660"}
+    repo.get_pt_subscription_sources.return_value = {"000660": "manual"}
+    repo.prune_orphan_pt_desired = AsyncMock(return_value=[])
     universe_service = MagicMock()
     universe_service.get_watchlist = AsyncMock(
         return_value={"000660": MagicMock(), "035420": MagicMock(), "084370": MagicMock()}
@@ -166,6 +198,29 @@ async def test_excludes_manual_pt_desired_and_caps_max_codes():
         ),
         call([], PRICE_CATEGORY, SubscriptionPriority.LOW, StreamingType.UNIFIED_PRICE),
     ]
+
+
+@pytest.mark.asyncio
+async def test_program_sourced_pt_desired_is_still_a_capture_candidate():
+    # program 출처(캡처 태스크가 남긴) desired 는 후보에서 빼지 않는다 —
+    # 빼면 어떤 카테고리도 소유하지 않는 잔재로 굳어 영구 누적된다.
+    repo = MagicMock()
+    repo.get_desired.return_value = {"000660"}
+    repo.get_pt_subscription_sources.return_value = {"000660": "program"}
+    repo.prune_orphan_pt_desired = AsyncMock(return_value=[])
+    universe_service = MagicMock()
+    universe_service.get_watchlist = AsyncMock(
+        return_value={"000660": MagicMock(), "035420": MagicMock()}
+    )
+    task, policy = _make_task(
+        streaming_stock_repo=repo,
+        universe_service=universe_service,
+    )
+
+    await task._tick()
+
+    pt_call = policy.sync_subscriptions.await_args_list[0]
+    assert sorted(pt_call.args[0]) == ["000660", "005930", "035420"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_system.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_system.py
@@ -1632,30 +1632,35 @@ def test_get_subscription_status_no_streaming_service(web_client, mock_web_ctx):
     assert data["pending_by_priority"]["HIGH"][0]["received_at"] is None
 
 
-def test_get_subscription_status_uses_program_trading_repo_as_critical_source(web_client, mock_web_ctx):
-    """CRITICAL은 PT 저장소의 현재 desired와 active 상태를 기준으로 노출된다."""
+def test_get_subscription_status_classifies_pt_desired_by_source(web_client, mock_web_ctx):
+    """CRITICAL은 수동(manual) PT 구독만, 정책이 모르는 PT 잔재는 LOW로 노출된다."""
     mock_svc = MagicMock()
     mock_svc.get_status.return_value = {
-        "active_count": 2,
+        "active_count": 1,
         "max_subscriptions": 40,
-        "active_codes_price": ["000660"],
+        "active_codes_price": [],
         "active_codes_pt": [],
-        "pending_count": 3,
+        "pending_count": 1,
         "pending_by_priority": {
-            "CRITICAL": ["000660"],  # 정책 refs에 남은 오래된 PT 종목
+            "CRITICAL": [],
             "HIGH": [],
             "MEDIUM": [],
-            "LOW": [],
+            "LOW": ["080220"],  # 캡처 태스크가 정책에 올린 종목
         },
     }
     mock_web_ctx.price_subscription_service = mock_svc
     mock_web_ctx.streaming_stock_repo = MagicMock()
     mock_web_ctx.streaming_stock_repo.get_desired.side_effect = lambda stream_type: (
-        {"005930", "080220"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+        {"005930", "080220", "000660"} if stream_type == StreamingType.PROGRAM_TRADING else set()
     )
     mock_web_ctx.streaming_stock_repo.get_active.side_effect = lambda stream_type: (
-        {"005930", "080220"} if stream_type == StreamingType.PROGRAM_TRADING else set()
+        {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
     )
+    mock_web_ctx.streaming_stock_repo.get_pt_subscription_sources.return_value = {
+        "005930": "manual",
+        "080220": "program",
+        "000660": "legacy",  # 어떤 카테고리도 소유하지 않는 잔재
+    }
     mock_web_ctx.streaming_service.get_cached_realtime_price.return_value = None
     mock_web_ctx.stock_code_repository.get_name_by_code.side_effect = lambda c: {
         "000660": "SK하이닉스",
@@ -1667,12 +1672,17 @@ def test_get_subscription_status_uses_program_trading_repo_as_critical_source(we
 
     assert response.status_code == 200
     data = response.json()["data"]
-    assert data["active_count"] == 3
-    assert data["active_codes_pt"] == ["005930", "080220"]
-    assert data["pending_count"] == 2
+    assert data["active_codes_pt"] == ["005930"]
+    assert data["pending_count"] == 3
+
     critical = data["pending_by_priority"]["CRITICAL"]
-    assert [row["code"] for row in critical] == ["005930", "080220"]
-    assert [row["active"] for row in critical] == [True, True]
+    assert [row["code"] for row in critical] == ["005930"]
+    assert critical[0]["pt_source"] == "manual"
+    assert critical[0]["active"] is True
+
+    low = data["pending_by_priority"]["LOW"]
+    assert [row["code"] for row in low] == ["000660", "080220"]
+    assert [row["pt_source"] for row in low] == ["legacy", "program"]
 
 
 def test_get_subscription_status_ignores_repo_error(web_client, mock_web_ctx):

--- a/view/web/routes/system.py
+++ b/view/web/routes/system.py
@@ -665,12 +665,21 @@ def get_subscription_status():
     active_codes_pt = set(status.get("active_codes_pt", []))
 
     repo = getattr(ctx, "streaming_stock_repo", None)
+    pt_sources: dict = {}
     if repo is not None:
         try:
             desired_pt = repo.get_desired(StreamingType.PROGRAM_TRADING)
             desired_pt_set = _code_set(desired_pt)
+            sources = repo.get_pt_subscription_sources()
+            pt_sources = sources if isinstance(sources, dict) else {}
             if desired_pt_set is not None:
-                pending_by_priority["CRITICAL"] = desired_pt_set
+                # 수동 UI 구독은 정책(_refs)을 거치지 않으므로 CRITICAL로 직접 보강한다.
+                pending_by_priority["CRITICAL"] |= {
+                    code for code in desired_pt_set if pt_sources.get(code) == "manual"
+                }
+                # 어떤 카테고리도 소유하지 않는 PT 잔재는 LOW로 노출한다.
+                tracked = set().union(*pending_by_priority.values())
+                pending_by_priority["LOW"] |= (desired_pt_set - tracked)
 
             active_pt_set = _code_set(repo.get_active(StreamingType.PROGRAM_TRADING))
             if active_pt_set is not None:
@@ -729,6 +738,7 @@ def get_subscription_status():
                 "snapshot_at": snapshot_at,
                 "price": price,
                 "price_source": price_source,
+                "pt_source": pt_sources.get(code),
             })
         return result
 

--- a/view/web/static/js/system.js
+++ b/view/web/static/js/system.js
@@ -722,7 +722,7 @@ function renderSubTable() {
 
     const rows = _subData.pending_by_priority ? _subData.pending_by_priority[_subTab] || [] : [];
     if (rows.length === 0) {
-        tbody.innerHTML = `<tr><td colspan="4" style="text-align:center; color:#888;">구독 종목 없음</td></tr>`;
+        tbody.innerHTML = `<tr><td colspan="5" style="text-align:center; color:#888;">구독 종목 없음</td></tr>`;
         const ctrl = document.getElementById('sub-table-pagination');
         if (ctrl) ctrl.innerHTML = '';
         return;
@@ -736,6 +736,10 @@ function renderSubTable() {
         const activeBadge = item.active
             ? `<span style="background:var(--success-color,#4CAF50); color:#fff; padding:2px 8px; border-radius:10px; font-size:0.82em; font-weight:bold;">구독 중</span>`
             : `<span style="background:#888; color:#fff; padding:2px 8px; border-radius:10px; font-size:0.82em;">대기</span>`;
+        const sourceLabel = { manual: '수동', program: '캡처', legacy: '잔재' }[item.pt_source];
+        const sourceHtml = sourceLabel
+            ? `<span style="color:${item.pt_source === 'manual' ? 'var(--accent)' : '#888'};">${sourceLabel}</span>`
+            : '<span style="color:#aaa;">-</span>';
         const priceHtml = item.price != null
             ? `<span style="font-weight:bold;">${Number(item.price).toLocaleString()}원</span>`
             : '<span style="color:#aaa;">-</span>';
@@ -750,6 +754,7 @@ function renderSubTable() {
                     <a href="/stock?code=${item.code}" target="_blank" class="stock-link">${displayName}</a>
                 </td>
                 <td>${activeBadge}</td>
+                <td style="font-size:0.9em;">${sourceHtml}</td>
                 <td style="font-size:0.9em;">${priceHtml}</td>
                 <td style="font-size:0.9em; color:#888;">${received}</td>
             </tr>

--- a/view/web/templates/system.html
+++ b/view/web/templates/system.html
@@ -53,12 +53,13 @@
                         <tr>
                             <th>종목명(코드)</th>
                             <th>구독 상태</th>
+                            <th>출처</th>
                             <th>현재가</th>
                             <th>마지막 수신</th>
                         </tr>
                     </thead>
                     <tbody id="sub-table-body">
-                        <tr><td colspan="4" style="text-align:center; color:#888;">로딩 중...</td></tr>
+                        <tr><td colspan="5" style="text-align:center; color:#888;">로딩 중...</td></tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
## 배경

시스템 페이지의 "실시간 현재가 구독 현황"에서 CRITICAL 탭이 63개로 표시되는데,
실제 수동 프로그램매매 구독은 4개뿐이었다.

`view/web/routes/system.py`가 정책이 계산한 CRITICAL 목록을
`streaming_stock_repo.get_desired(PROGRAM_TRADING)` 전량으로 **치환**하고 있어,
누가 어떤 우선순위로 요청했든 PT desired면 전부 CRITICAL로 보였다.

실측 (`data/program_subscribe/program_trading.db` / `pt_subscriptions`, 63행):

| source | 개수 | 정체 |
|---|---|---|
| `program` | 45 | `ProgramCaptureSubscriptionTask` 등록 — 정책상 **LOW** |
| `legacy` | 14 | source 컬럼 도입 전 잔재 (`updated_at` NULL) |
| `manual` | 4 | 실제 사용자 수동 구독 |

### 누적 원인

1. 캡처 태스크가 `sync_subscriptions`로 등록하면 `mark_desired(source="program")` → SQLite 영속화
2. 재시작 시 DB의 desired는 전부 복원되지만, 태스크는 `scheduler_store`의 마지막 배치(≤10개)만 재편입 → 나머지는 어떤 카테고리도 소유하지 않는 고아
3. `_resolve_target_codes`가 **이미 desired인 종목을 후보에서 전부 제외**해 고아가 재편입될 기회조차 없음

→ 단조 증가 (07-29 하루에만 18건 추가)

## 변경

**1. 표시 (`routes/system.py`, `system.js`, `system.html`)**
- CRITICAL 전량 override 제거
- 수동 UI 구독은 정책 `_refs`를 거치지 않으므로 `source == 'manual'`인 PT desired만 CRITICAL로 보강
- 어떤 정책 버킷에도 없는 PT 잔재는 LOW로 노출
- 응답 각 행에 `pt_source` 추가 → 테이블에 "출처"(수동/캡처/잔재) 컬럼

**2. 고아 정리 (`StreamingStockRepo.prune_orphan_pt_desired`)**
- 소유 목록에 없고 출처가 program/legacy인 PT desired 제거 후 flush
- manual은 보존

**3. 누적 차단 (`ProgramCaptureSubscriptionTask`)**
- 재시작 재편입 시 store 배치를 소유 목록으로 넘겨 잔재 정리
- 후보 제외 조건을 `source == 'manual'`로 한정

## 테스트

TDD로 진행 (테스트 선작성/수정 → 구현).

- `test_get_subscription_status_classifies_pt_desired_by_source` (기존 override 테스트 대체)
- `test_prune_orphan_pt_desired_removes_unowned_program_and_legacy` / `..._noop_when_nothing_to_remove`
- `test_adopt_prunes_orphan_pt_desired_with_stored_batch` / `test_adopt_prune_failure_does_not_break_tick`
- `test_program_sourced_pt_desired_is_still_a_capture_candidate`

```
pytest tests/unit_test        → 7330 passed
pytest tests/integration_test →  277 passed
```

## 부수 효과

`websocket_watchdog_task`의 재연결 복원이 `get_desired(PROGRAM_TRADING)` 전체를 돈다.
잔재 정리 후에는 63개가 아닌 실제 소유 종목만 40슬롯을 놓고 경쟁한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
