### PR TITLE
Retry aborted AI responses

### DIFF
--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -111,16 +111,39 @@ class AiClient:
                     url, headers=headers, json=payload, timeout=self._timeout_sec
                 )
                 response.raise_for_status()
-                return response.json()
+                response_payload = response.json()
+                if self._is_aborted_completion(response_payload):
+                    raise AiClientError(
+                        "UPSTREAM_ABORTED",
+                        "AI 공급자 응답이 일시적으로 중단되었습니다. 잠시 후 다시 시도하세요.",
+                    )
+                return response_payload
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code not in _RETRYABLE_STATUS:
                     raise
                 last_exc = exc
             except httpx.TransportError as exc:
                 last_exc = exc
+            except AiClientError as exc:
+                if exc.status != "UPSTREAM_ABORTED":
+                    raise
+                last_exc = exc
             if attempt < self._max_retries:
                 await asyncio.sleep(self._retry_backoff_sec * (2**attempt))
         raise last_exc
+
+    @staticmethod
+    def _is_aborted_completion(payload: dict) -> bool:
+        """Gemini OpenAI 호환 API의 HTTP 200 내부 중단 응답을 감지한다."""
+        choices = payload.get("choices") or []
+        if not choices:
+            return False
+        message = choices[0].get("message") or {}
+        content = message.get("content")
+        return (
+            isinstance(content, str)
+            and content.strip().casefold() == "signal is aborted without reason"
+        )
 
     @staticmethod
     def _parse(payload: dict) -> str:

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -222,6 +222,46 @@ async def test_transient_network_error_is_retried_then_succeeds():
     assert http_client.post.await_count == 2
 
 
+async def test_aborted_completion_is_retried_then_succeeds():
+    """Gemini가 HTTP 200으로 돌려주는 내부 중단 문구도 일시 오류로 재시도한다."""
+    http_client = AsyncMock()
+    http_client.post.side_effect = [
+        _response(_completion("signal is aborted without reason")),
+        _response(_completion("복구된 응답")),
+    ]
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="gemini-2.5-flash",
+        http_client=http_client,
+        retry_backoff_sec=0,
+    )
+
+    assert await client.complete(system="s", user="u") == "복구된 응답"
+    assert http_client.post.await_count == 2
+
+
+async def test_repeated_aborted_completion_raises_clear_error():
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(
+        _completion("signal is aborted without reason")
+    )
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="gemini-2.5-flash",
+        http_client=http_client,
+        max_retries=1,
+        retry_backoff_sec=0,
+    )
+
+    with pytest.raises(AiClientError, match="일시적으로 중단") as exc_info:
+        await client.complete(system="s", user="u")
+
+    assert exc_info.value.status == "UPSTREAM_ABORTED"
+    assert http_client.post.await_count == 2
+
+
 async def test_client_error_4xx_is_not_retried():
     http_client = AsyncMock()
     http_client.post.return_value = _status_response(401)


### PR DESCRIPTION
## What changed
- Retry Gemini/OpenAI-compatible HTTP 200 responses containing the known aborted-signal sentinel.
- Return a clear Korean upstream-interruption error if all retries are exhausted.
- Cover recovery and exhaustion paths with unit tests.

## Why
Gemini can return \signal is aborted without reason\ as completion content rather than an HTTP failure, so it previously bypassed retry handling and appeared directly in the AI news review UI.

## Validation
- \pytest tests/unit_test -v\ (7,332 passed; 4 existing warnings)
- \pytest tests/integration_test -v\ (277 passed)