### PR TITLE
Fix AI analysis request timeout

### DIFF
--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -142,7 +142,7 @@ class AiClient:
         content = message.get("content")
         return (
             isinstance(content, str)
-            and content.strip().casefold() == "signal is aborted without reason"
+            and "signal is aborted without reason" in content.casefold()
         )
 
     @staticmethod

--- a/tests/frontend/run_stock_dom_tests.mjs
+++ b/tests/frontend/run_stock_dom_tests.mjs
@@ -142,7 +142,7 @@ test("AI 종목 분석은 POST로 요청하고 결과를 텍스트로 안전하�
 
   assert(requested.url === "/api/stock/005930/ai-analysis", "AI 분석 URL이 잘못됨");
   assert(requested.options.method === "POST", "AI 분석이 POST 요청이 아님");
-  assert(requested.timeout === 45000, "AI 분석 타임아웃이 45초가 아님");
+  assert(requested.timeout === 60000, "AI 분석 타임아웃이 60초가 아님");
   const output = window.document.getElementById("ai-stock-analysis-output");
   assert(output.textContent.includes("<img src=x"), "AI 결과가 텍스트로 보존되지 않음");
   assert(!output.querySelector("img"), "AI 결과가 HTML로 실행됨");
@@ -215,7 +215,7 @@ test("AI 뉴스 검토는 POST로 요청하고 기사 제목을 텍스트로 안
 
   assert(requested.url === "/api/stock/005930/ai-news", "뉴스 검토 URL이 잘못됨");
   assert(requested.options.method === "POST", "뉴스 검토가 POST 요청이 아님");
-  assert(requested.timeout === 45000, "뉴스 검토 타임아웃이 45초가 아님");
+  assert(requested.timeout === 60000, "뉴스 검토 타임아웃이 60초가 아님");
 
   const list = window.document.getElementById("ai-news-list");
   assert(list.querySelectorAll("li").length === 2, "기사 목록이 2건으로 렌더되지 않음");

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -241,6 +241,25 @@ async def test_aborted_completion_is_retried_then_succeeds():
     assert http_client.post.await_count == 2
 
 
+async def test_aborted_completion_with_provider_metadata_is_retried():
+    """문구 앞뒤에 공급자 메타데이터가 붙어도 내부 중단으로 처리한다."""
+    http_client = AsyncMock()
+    http_client.post.side_effect = [
+        _response(_completion("[internal] signal is aborted without reason\n")),
+        _response(_completion("복구된 응답")),
+    ]
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="gemini-2.5-flash",
+        http_client=http_client,
+        retry_backoff_sec=0,
+    )
+
+    assert await client.complete(system="s", user="u") == "복구된 응답"
+    assert http_client.post.await_count == 2
+
+
 async def test_repeated_aborted_completion_raises_clear_error():
     http_client = AsyncMock()
     http_client.post.return_value = _response(

--- a/tests/unit_test/view/web/test_stock_js_contracts.py
+++ b/tests/unit_test/view/web/test_stock_js_contracts.py
@@ -28,3 +28,11 @@ def test_overseas_template_loads_dedicated_autocomplete():
     assert 'id="overseas-autocomplete-list"' in template
     assert "/static/js/autocomplete.js" in template
     assert "/static/js/overseas_autocomplete.js" in template
+
+
+def test_ai_analysis_requests_allow_server_retry_and_hide_abort_message():
+    stock_js = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
+
+    assert stock_js.count("60000,") >= 2
+    assert "isAiRequestAbort(error)" in stock_js
+    assert "AI 응답 시간이 초과되었습니다. 다시 시도해주세요." in stock_js

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -3,6 +3,11 @@
 let _currentExchange = 'KRX';
 let _currentStockCode = null;
 
+// stock.js 단독 로드 환경에서도 AI 요청 타임아웃을 안전하게 표시한다.
+function isAiRequestAbort(error) {
+    return error && error.name === 'AbortError';
+}
+
 // SSE 실시간 틱 수신 → 가격·전일대비·당일시세(고가·저가) UI 업데이트
 document.addEventListener('stock-price-tick', function (e) {
     const tick = e.detail;
@@ -534,7 +539,7 @@ async function requestAiStockAnalysis(code) {
         const response = await fetchWithTimeout(
             `/api/stock/${encodeURIComponent(targetCode)}/ai-analysis`,
             { method: 'POST' },
-            45000,
+            60000,
         );
         let json = {};
         try {
@@ -571,7 +576,9 @@ async function requestAiStockAnalysis(code) {
     } catch (error) {
         console.error('[stock-ai] 분석 실패:', error);
         status.textContent = '';
-        output.textContent = error.message || 'AI 분석 요청에 실패했습니다.';
+        output.textContent = isAiRequestAbort(error)
+            ? 'AI 응답 시간이 초과되었습니다. 다시 시도해주세요.'
+            : (error.message || 'AI 분석 요청에 실패했습니다.');
         output.classList.add('error');
         output.style.display = 'block';
     } finally {
@@ -602,7 +609,7 @@ async function requestAiNewsReview(code) {
         const response = await fetchWithTimeout(
             `/api/stock/${encodeURIComponent(targetCode)}/ai-news`,
             { method: 'POST' },
-            45000,
+            60000,
         );
         let json = {};
         try {
@@ -646,7 +653,9 @@ async function requestAiNewsReview(code) {
     } catch (error) {
         console.error('[stock-news] 검토 실패:', error);
         status.textContent = '';
-        output.textContent = error.message || 'AI 뉴스 검토 요청에 실패했습니다.';
+        output.textContent = isAiRequestAbort(error)
+            ? 'AI 응답 시간이 초과되었습니다. 다시 시도해주세요.'
+            : (error.message || 'AI 뉴스 검토 요청에 실패했습니다.');
         output.classList.add('error');
         output.style.display = 'block';
     } finally {


### PR DESCRIPTION
## What changed
- Extend AI analysis and news-review browser request timeouts from 45 to 60 seconds so backend retry attempts can finish.
- Replace raw AbortController messages with a clear Korean timeout message.
- Detect the Gemini aborted-signal text even when provider metadata surrounds it.

## Root cause
The browser aborted requests at 45 seconds, while the AI client can take about 46.5 seconds across its configured retries. Chrome exposed that AbortController error as \signal is aborted without reason\.

## Validation
- \pytest tests/unit_test -v\ (7,334 passed)
- \pytest tests/integration_test -v\ (277 passed)