### PR TITLE
feat: 미국장 관심종목 5% 단위 등락 알림 추가

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -203,6 +203,12 @@ market_index_alert:
   enabled: true
   poll_interval_sec: 60
 
+# 미국장 관심종목 5% 단위 등락 알림. 해외는 실시간 스트림이 없어 정규장 중
+# 해외현재가 REST 를 poll_interval_sec 주기로 조회한다(관심종목 수 × 1회/주기).
+overseas_favorite_alert:
+  enabled: true
+  poll_interval_sec: 60
+
 # OpenDART 관심종목 공시 알림 (API 키 발급 후 enabled=true)
 dart_disclosure:
   enabled: false

--- a/repositories/overseas_stock_code_repository.py
+++ b/repositories/overseas_stock_code_repository.py
@@ -110,6 +110,10 @@ class OverseasStockCodeRepository:
         """심볼의 {name, exchange} 반환. 미등록이면 None."""
         return self.symbol_to_meta.get(str(symbol).upper())
 
+    def get_name_by_code(self, symbol: str) -> str | None:
+        """심볼의 종목명 반환. 미등록이면 None. (StockCodeRepository와 동일 시그니처)"""
+        return (self.get_meta(symbol) or {}).get("name")
+
     def all_symbols(self) -> list:
         """전 심볼 리스트 반환 (클라이언트 자동완성용)."""
         return [

--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Callable, Optional
 from zoneinfo import ZoneInfo
 
+from repositories.favorite_repository import MARKET_DOMESTIC, MARKET_OVERSEAS_US
 from services.notification_service import (
     NotificationCategory,
     NotificationLevel,
@@ -24,6 +25,7 @@ class FavoritePriceAlertService:
         notification_service: Optional[NotificationService],
         stock_code_repository=None,
         *,
+        market: str = MARKET_DOMESTIC,
         threshold_step_pct: float = 5.0,
         upper_limit_rate_pct: float = 29.5,
         favorite_cache_ttl_sec: float = 30.0,
@@ -34,6 +36,7 @@ class FavoritePriceAlertService:
         self._favorite_repository = favorite_repository
         self._notification_service = notification_service
         self._stock_code_repository = stock_code_repository
+        self._market = market
         self._threshold_step_pct = float(threshold_step_pct)
         self._upper_limit_rate_pct = float(upper_limit_rate_pct)
         self._favorite_cache_ttl_sec = float(favorite_cache_ttl_sec)
@@ -168,7 +171,7 @@ class FavoritePriceAlertService:
         ):
             return
         try:
-            codes = await self._favorite_repository.get_all()
+            codes = await self._favorite_repository.get_all(market=self._market)
         except Exception as exc:
             self._logger.warning(f"관심종목 알림용 목록 조회 실패: {exc}")
             return
@@ -236,6 +239,8 @@ class FavoritePriceAlertService:
         return bucket if rate > 0 else -bucket
 
     def _is_upper_limit(self, rate: float, *, sign=None, is_upper_limit: bool = False) -> bool:
+        if self._market == MARKET_OVERSEAS_US:
+            return False  # 미국장은 상한가 제도가 없다
         if is_upper_limit:
             return True
         if str(sign or "").strip() == "1":
@@ -276,11 +281,12 @@ class FavoritePriceAlertService:
         except (TypeError, ValueError):
             return None
 
-    @classmethod
-    def _format_price(cls, value) -> str:
-        number = cls._to_float(value)
+    def _format_price(self, value) -> str:
+        number = self._to_float(value)
         if number is None:
             return "-"
+        if self._market == MARKET_OVERSEAS_US:
+            return f"${number:,.2f}"
         if number.is_integer():
             return f"{int(number):,}원"
         return f"{number:,.2f}원"

--- a/task/background/intraday/overseas_favorite_price_alert_task.py
+++ b/task/background/intraday/overseas_favorite_price_alert_task.py
@@ -1,0 +1,117 @@
+"""미국장 관심종목 등락률 임계치 알림 태스크."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from common.types import ErrorCode
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+from repositories.favorite_repository import MARKET_OVERSEAS_US
+
+
+class OverseasFavoritePriceAlertTask(SchedulableTask):
+    """미국장은 실시간 스트림 경로가 없어 해외현재가 REST 조회로 등락률을 감시한다."""
+
+    CHECK_INTERVAL_SEC = 60
+    FETCH_TIMEOUT_SEC = 5.0
+    DEFAULT_EXCHANGE = "NASD"
+
+    def __init__(self, *, favorite_repository, broker, alert_service, market_clock,
+                 overseas_stock_code_repository=None, us_market_calendar_service=None,
+                 check_interval_sec: Optional[int] = None, logger=None) -> None:
+        self._favorite_repository = favorite_repository
+        self._broker = broker
+        self._alert_service = alert_service
+        self._market_clock = market_clock
+        self._overseas_stock_code_repository = overseas_stock_code_repository
+        self._us_mcs = us_market_calendar_service
+        self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def task_name(self) -> str:
+        return "overseas_favorite_price_alert"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.HIGH
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    def get_progress(self) -> dict:
+        return {"running": self._state == TaskState.RUNNING}
+
+    async def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+        self._task = None
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                if self._state != TaskState.SUSPENDED:
+                    self._state = TaskState.RUNNING
+                    await self._tick()
+                    if self._state == TaskState.RUNNING:
+                        self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error("%s: loop error — %s", self.task_name, exc, exc_info=True)
+            await asyncio.sleep(self._check_interval_sec)
+
+    async def _tick(self) -> None:
+        if not self._is_market_open_now():
+            return
+        symbols = await self._favorite_repository.get_all(market=MARKET_OVERSEAS_US)
+        for symbol in symbols:
+            price, rate = await self._fetch_price_rate(symbol)
+            if rate is None:
+                continue
+            await self._alert_service.handle_price_tick(symbol, price=price, rate=rate)
+
+    async def _fetch_price_rate(self, symbol: str):
+        try:
+            response = await asyncio.wait_for(
+                self._broker.get_overseas_price(symbol, exchange=self._exchange_of(symbol)),
+                timeout=self.FETCH_TIMEOUT_SEC,
+            )
+        except Exception as exc:
+            self._logger.warning("%s: %s 현재가 조회 예외 — %s", self.task_name, symbol, exc)
+            return None, None
+        if response.rt_cd != ErrorCode.SUCCESS.value:
+            self._logger.warning("%s: %s 현재가 조회 실패 — %s", self.task_name, symbol, response.msg1)
+            return None, None
+        return getattr(response.data, "price", None), getattr(response.data, "change_rate", None)
+
+    def _exchange_of(self, symbol: str) -> str:
+        if self._overseas_stock_code_repository is None:
+            return self.DEFAULT_EXCHANGE
+        meta = self._overseas_stock_code_repository.get_meta(symbol)
+        return (meta or {}).get("exchange") or self.DEFAULT_EXCHANGE
+
+    def _is_market_open_now(self) -> bool:
+        now = self._market_clock.get_current_kst_time()
+        if not self._market_clock.is_market_operating_hours(now):
+            return False
+        if self._us_mcs is None:
+            return True
+        return self._us_mcs.is_trading_day(self._market_clock.get_current_kst_date_str())

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from repositories.favorite_repository import MARKET_DOMESTIC, MARKET_OVERSEAS_US
 from services.favorite_price_alert_service import FavoritePriceAlertService
 from services.notification_service import NotificationCategory, NotificationLevel
 
@@ -196,6 +197,56 @@ async def test_ignores_non_favorite_and_invalid_rate():
     await svc.handle_price_tick("000660", price="150000", rate="bad")
 
     notifications.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reads_favorites_from_domestic_market_by_default():
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["005930"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("005930", price="75000", rate="5.12")
+
+    repo.get_all.assert_awaited_with(market=MARKET_DOMESTIC)
+
+
+@pytest.mark.asyncio
+async def test_alerts_overseas_favorite_with_usd_price():
+    """미국장 인스턴스는 overseas_us 관심종목을 읽고 달러 표기로 알린다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["AAPL"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications, market=MARKET_OVERSEAS_US)
+
+    await svc.handle_price_tick("AAPL", price="189.5", rate="5.30")
+
+    repo.get_all.assert_awaited_with(market=MARKET_OVERSEAS_US)
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert "AAPL" in args[2]
+    assert "+5%" in args[2]
+    assert "$189.50" in args[3]
+    assert kwargs["metadata"]["threshold_pct"] == 5
+
+
+@pytest.mark.asyncio
+async def test_overseas_market_never_emits_upper_limit_alert():
+    """미국장은 상한가 제도가 없으므로 30% 구간도 일반 임계치 알림으로 처리한다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["TSLA"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications, market=MARKET_OVERSEAS_US)
+
+    await svc.handle_price_tick("TSLA", price="300", rate="30.20")
+
+    notifications.emit.assert_awaited_once()
+    metadata = notifications.emit.call_args.kwargs["metadata"]
+    assert metadata["alert_type"] == "favorite_price_threshold"
+    assert metadata["threshold_pct"] == 30
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/task/background/intraday/test_overseas_favorite_price_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_overseas_favorite_price_alert_task.py
@@ -1,0 +1,129 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from repositories.favorite_repository import MARKET_OVERSEAS_US
+from task.background.intraday.overseas_favorite_price_alert_task import (
+    OverseasFavoritePriceAlertTask,
+)
+
+
+def _price_response(price, change_rate):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data=MagicMock(price=price, change_rate=change_rate),
+    )
+
+
+def _build_task(*, symbols, broker, market_open=True, trading_day=True, meta=None):
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=symbols)
+    alert_service = MagicMock()
+    alert_service.handle_price_tick = AsyncMock(return_value=True)
+    market_clock = MagicMock()
+    market_clock.is_market_operating_hours.return_value = market_open
+    market_clock.get_current_kst_date_str.return_value = "20260803"
+    calendar = MagicMock()
+    calendar.is_trading_day.return_value = trading_day
+    overseas_codes = MagicMock()
+    overseas_codes.get_meta.return_value = meta
+
+    task = OverseasFavoritePriceAlertTask(
+        favorite_repository=repo,
+        broker=broker,
+        alert_service=alert_service,
+        market_clock=market_clock,
+        overseas_stock_code_repository=overseas_codes,
+        us_market_calendar_service=calendar,
+    )
+    return task, repo, alert_service
+
+
+@pytest.mark.asyncio
+async def test_polls_overseas_favorites_and_forwards_price_to_alert_service():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(return_value=_price_response(189.5, 5.3))
+    task, repo, alert_service = _build_task(symbols=["AAPL"], broker=broker)
+
+    await task._tick()
+
+    repo.get_all.assert_awaited_once_with(market=MARKET_OVERSEAS_US)
+    broker.get_overseas_price.assert_awaited_once_with("AAPL", exchange="NASD")
+    alert_service.handle_price_tick.assert_awaited_once_with(
+        "AAPL", price=189.5, rate=5.3
+    )
+
+
+@pytest.mark.asyncio
+async def test_uses_exchange_from_overseas_stock_code_repository():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(return_value=_price_response(42.0, 5.1))
+    task, _, _ = _build_task(
+        symbols=["F"], broker=broker, meta={"exchange": "NYSE"}
+    )
+
+    await task._tick()
+
+    broker.get_overseas_price.assert_awaited_once_with("F", exchange="NYSE")
+
+
+@pytest.mark.asyncio
+async def test_skips_polling_outside_us_market_hours():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock()
+    task, repo, alert_service = _build_task(
+        symbols=["AAPL"], broker=broker, market_open=False
+    )
+
+    await task._tick()
+
+    broker.get_overseas_price.assert_not_awaited()
+    alert_service.handle_price_tick.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_polling_on_us_market_holiday():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock()
+    task, _, alert_service = _build_task(
+        symbols=["AAPL"], broker=broker, trading_day=False
+    )
+
+    await task._tick()
+
+    broker.get_overseas_price.assert_not_awaited()
+    alert_service.handle_price_tick.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_continues_remaining_symbols_when_one_lookup_fails():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(
+        side_effect=[
+            RuntimeError("timeout"),
+            ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None),
+            _price_response(300.0, -10.4),
+        ]
+    )
+    task, _, alert_service = _build_task(
+        symbols=["AAPL", "MSFT", "TSLA"], broker=broker
+    )
+
+    await task._tick()
+
+    alert_service.handle_price_tick.assert_awaited_once_with(
+        "TSLA", price=300.0, rate=-10.4
+    )
+
+
+@pytest.mark.asyncio
+async def test_skips_symbol_when_change_rate_is_missing():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(return_value=_price_response(189.5, None))
+    task, _, alert_service = _build_task(symbols=["AAPL"], broker=broker)
+
+    await task._tick()
+
+    alert_service.handle_price_tick.assert_not_awaited()

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -26,6 +26,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "ThemeClassificationCollectorService", "ThemeClassificationTask", "ThemeDailyLeaderReportTask",
     "ThemeIntradayLeaderAlertTask",
     "MarketIndexThresholdAlertTask",
+    "OverseasFavoritePriceAlertTask", "FavoritePriceAlertService",
     "USMarketCalendarService",
     "BacktestMicrostructureCaptureService", "MicrostructureCaptureTask",
     "PremiumWatchlistGeneratorTask", "CacheWarmupTask", "LogCleanupTask",
@@ -374,6 +375,7 @@ def test_service_container_batch_mode_skips_streaming_and_intraday_web_tasks(pat
     assert ctx.pre_market_health_check_task is None
     assert ctx.opening_position_reconcile_task is None
     assert ctx.notification_queue_task is None
+    assert ctx.overseas_favorite_price_alert_task is None
     assert ctx.after_market_reconcile_task is patched_service_container_deps["AfterMarketReconcileTask"].return_value
     assert ctx.post_market_replay_audit_task is patched_service_container_deps["PostMarketReplayAuditTask"].return_value
     assert ctx.newhigh_strategy_coverage_backtest_task is patched_service_container_deps[
@@ -415,6 +417,45 @@ def test_service_container_web_mode_keeps_realtime_and_skips_trading_batch_tasks
     assert ctx.after_market_reconcile_task is None
     assert ctx.theme_intraday_leader_alert_task is None
     assert ctx.order_execution_service is patched_service_container_deps["OrderExecutionService"].return_value
+
+
+def test_service_container_builds_overseas_favorite_price_alert_in_web_mode(patched_service_container_deps):
+    """미국장 관심종목 알림은 웹 모드에서 US 클럭 기반 서비스·폴링 태스크로 조립된다."""
+    from repositories.favorite_repository import MARKET_OVERSEAS_US
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.runtime_mode = RuntimeMode.WEB
+    ServiceContainer(ctx).run()
+
+    alert_cls = patched_service_container_deps["FavoritePriceAlertService"]
+    overseas_kwargs = next(
+        call.kwargs for call in alert_cls.call_args_list
+        if call.kwargs.get("market") == MARKET_OVERSEAS_US
+    )
+    assert overseas_kwargs["favorite_repository"] is ctx.favorite_repo
+    assert overseas_kwargs["state_file"] == "data/overseas_favorite_price_alert_state.json"
+    assert overseas_kwargs["today_provider"]() == overseas_kwargs["today_provider"]()
+
+    task_kwargs = patched_service_container_deps["OverseasFavoritePriceAlertTask"].call_args.kwargs
+    assert task_kwargs["broker"] is ctx.broker
+    assert task_kwargs["market_clock"].timezone_name == "America/New_York"
+    assert ctx.overseas_favorite_price_alert_task is (
+        patched_service_container_deps["OverseasFavoritePriceAlertTask"].return_value
+    )
+
+
+def test_service_container_disables_overseas_favorite_price_alert_via_config(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.runtime_mode = RuntimeMode.WEB
+    ctx.full_config = {"overseas_favorite_alert": {"enabled": False}}
+    ServiceContainer(ctx).run()
+
+    patched_service_container_deps["OverseasFavoritePriceAlertTask"].assert_not_called()
+    assert ctx.overseas_favorite_price_alert_task is None
+    assert ctx.overseas_favorite_price_alert_service is None
 
 
 def test_service_container_trading_mode_keeps_realtime_intraday_and_skips_web_batch_tasks(patched_service_container_deps):

--- a/tests/unit_test/view/web/routes/test_web_routes_favorite.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_favorite.py
@@ -201,13 +201,15 @@ async def test_get_favorite_list_overseas_passes_market(web_client, mock_web_ctx
         mock_web_ctx.price_subscription_service.sync_subscriptions.assert_not_awaited()
 
 
-async def test_add_favorite_overseas_skips_alert_and_subscription(web_client, mock_web_ctx):
-    """POST /api/favorite/{symbol}?market=overseas_us - 알림/구독 연동을 건너뛴다."""
+async def test_add_favorite_overseas_syncs_overseas_alert_service_only(web_client, mock_web_ctx):
+    """POST /api/favorite/{symbol}?market=overseas_us - 미국장 알림만 동기화하고 국내 구독은 건너뛴다."""
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.add = AsyncMock(return_value=True)
         mock_web_ctx.favorite_price_alert_service = MagicMock()
         mock_web_ctx.favorite_price_alert_service.add_favorite = AsyncMock()
+        mock_web_ctx.overseas_favorite_price_alert_service = MagicMock()
+        mock_web_ctx.overseas_favorite_price_alert_service.add_favorite = AsyncMock()
         mock_web_ctx.price_subscription_service = MagicMock()
         mock_web_ctx.price_subscription_service.add_subscription = AsyncMock()
 
@@ -217,23 +219,27 @@ async def test_add_favorite_overseas_skips_alert_and_subscription(web_client, mo
         assert data["added"] is True
         assert data["market"] == "overseas_us"
         mock_web_ctx.favorite_service.add.assert_called_once_with("AAPL", market="overseas_us")
+        mock_web_ctx.overseas_favorite_price_alert_service.add_favorite.assert_awaited_once_with("AAPL")
         mock_web_ctx.favorite_price_alert_service.add_favorite.assert_not_awaited()
         mock_web_ctx.price_subscription_service.add_subscription.assert_not_awaited()
 
 
-async def test_remove_favorite_overseas_skips_alert_and_subscription(web_client, mock_web_ctx):
-    """DELETE /api/favorite/{symbol}?market=overseas_us - 알림/구독 정리를 건너뛴다."""
+async def test_remove_favorite_overseas_syncs_overseas_alert_service_only(web_client, mock_web_ctx):
+    """DELETE /api/favorite/{symbol}?market=overseas_us - 미국장 알림 상태만 정리한다."""
     with patch("view.web.routes.favorite._get_ctx", return_value=mock_web_ctx):
         mock_web_ctx.favorite_service = MagicMock()
         mock_web_ctx.favorite_service.remove = AsyncMock(return_value=True)
         mock_web_ctx.favorite_price_alert_service = MagicMock()
         mock_web_ctx.favorite_price_alert_service.remove_favorite = AsyncMock()
+        mock_web_ctx.overseas_favorite_price_alert_service = MagicMock()
+        mock_web_ctx.overseas_favorite_price_alert_service.remove_favorite = AsyncMock()
         mock_web_ctx.price_subscription_service = MagicMock()
         mock_web_ctx.price_subscription_service.remove_subscription = AsyncMock()
 
         response = web_client.delete("/api/favorite/AAPL?market=overseas_us")
         assert response.status_code == 200
         mock_web_ctx.favorite_service.remove.assert_called_once_with("AAPL", market="overseas_us")
+        mock_web_ctx.overseas_favorite_price_alert_service.remove_favorite.assert_awaited_once_with("AAPL")
         mock_web_ctx.favorite_price_alert_service.remove_favorite.assert_not_awaited()
         mock_web_ctx.price_subscription_service.remove_subscription.assert_not_awaited()
 

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -106,6 +106,8 @@ class SchedulerBootstrap:
         # NotificationQueueTask 는 TimeDispatcher 등록 대상이 아님 (always-on)
         self._register(ctx.notification_queue_task)
         self._register(self._optional_task("dart_disclosure_monitor_task"))
+        # 미국장 시간대 판단은 태스크가 자체 US 클럭으로 수행하므로 TimeDispatcher 미등록
+        self._register(self._optional_task("overseas_favorite_price_alert_task"))
 
     def _register_trading_tasks(self) -> None:
         ctx = self._ctx

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -21,7 +21,9 @@ from config.config_loader import (
 )
 from core.account_snapshot import AccountSnapshotCache
 from core.market_clock import MarketClock
+from repositories.favorite_repository import MARKET_OVERSEAS_US
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
+from services.favorite_price_alert_service import FavoritePriceAlertService
 from services.backtest_microstructure_capture import BacktestMicrostructureCaptureService
 from services.execution_flow_service import ExecutionFlowService
 from services.event_shadow_journal_service import EventShadowJournalService
@@ -70,6 +72,7 @@ from task.background.intraday.pre_market_health_check_task import PreMarketHealt
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
 from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
+from task.background.intraday.overseas_favorite_price_alert_task import OverseasFavoritePriceAlertTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
@@ -701,6 +704,8 @@ class ServiceContainer:
                 and ctx.market_status_alert_service is not None
             ) else None
 
+            self._build_overseas_favorite_price_alert(config_dict, needs_web=needs_web)
+
             if needs_web:
                 ctx.notification_queue_task = NotificationQueueTask(
                     notification_service=ctx.notification_service,
@@ -757,6 +762,46 @@ class ServiceContainer:
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
+
+    def _build_overseas_favorite_price_alert(self, config_dict: dict, *, needs_web: bool) -> None:
+        """미국장 관심종목 5% 단위 등락 알림 조립.
+
+        해외는 실시간 스트림 경로가 없어 국내(웹소켓 틱)와 달리 REST 폴링 태스크가
+        틱을 공급한다. 알림 상태는 ET 날짜 기준으로 리셋해야 하므로 국내 인스턴스와
+        상태 파일·today_provider 를 분리한다.
+        """
+        ctx = self._ctx
+        ctx.overseas_favorite_price_alert_service = None
+        ctx.overseas_favorite_price_alert_task = None
+
+        alert_cfg = config_dict.get("overseas_favorite_alert", {})
+        if not isinstance(alert_cfg, dict):
+            alert_cfg = {}
+        if not needs_web or not alert_cfg.get("enabled", True):
+            return
+        if ctx.notification_service is None or getattr(ctx, "favorite_repo", None) is None:
+            return
+
+        us_clock = MarketClock.for_us_equities(logger=ctx.logger)
+        ctx.overseas_favorite_price_alert_service = FavoritePriceAlertService(
+            favorite_repository=ctx.favorite_repo,
+            notification_service=ctx.notification_service,
+            stock_code_repository=getattr(ctx, "overseas_stock_code_repository", None),
+            market=MARKET_OVERSEAS_US,
+            state_file="data/overseas_favorite_price_alert_state.json",
+            today_provider=us_clock.get_current_kst_date_str,
+            logger=ctx.logger,
+        )
+        ctx.overseas_favorite_price_alert_task = OverseasFavoritePriceAlertTask(
+            favorite_repository=ctx.favorite_repo,
+            broker=ctx.broker,
+            alert_service=ctx.overseas_favorite_price_alert_service,
+            market_clock=us_clock,
+            overseas_stock_code_repository=getattr(ctx, "overseas_stock_code_repository", None),
+            us_market_calendar_service=USMarketCalendarService(us_clock, logger=ctx.logger),
+            check_interval_sec=alert_cfg.get("poll_interval_sec", 60),
+            logger=ctx.logger,
+        )
 
     def _build_overseas_dryrun_pipeline(self) -> None:
         """해외 VBO dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).

--- a/view/web/routes/favorite.py
+++ b/view/web/routes/favorite.py
@@ -76,6 +76,10 @@ async def add_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
                 )
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 추가 실패: {e}")
+    elif added and market == MARKET_OVERSEAS_US:
+        overseas_alert_service = _ctx_attr(ctx, "overseas_favorite_price_alert_service")
+        if overseas_alert_service:
+            await overseas_alert_service.add_favorite(effective_code)
     return {"success": True, "added": added, "code": effective_code, "market": market}
 
 
@@ -98,6 +102,10 @@ async def remove_favorite(code: str, market: str = Query(MARKET_DOMESTIC)):
                     await price_subscription_service.remove_subscription(code, "favorite")
             except Exception as e:
                 ctx.logger.warning(f"관심종목 구독 제거 실패: {e}")
+    elif removed and market == MARKET_OVERSEAS_US:
+        overseas_alert_service = _ctx_attr(ctx, "overseas_favorite_price_alert_service")
+        if overseas_alert_service:
+            await overseas_alert_service.remove_favorite(effective_code)
     return {"success": True, "removed": removed, "code": effective_code, "market": market}
 
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -137,6 +137,8 @@ class WebAppContext:
             overseas_stock_code_repository=self.overseas_stock_code_repository,
         )
         self.favorite_price_alert_service: FavoritePriceAlertService = None
+        self.overseas_favorite_price_alert_service: FavoritePriceAlertService = None
+        self.overseas_favorite_price_alert_task = None
         self.account_snapshot_cache: AccountSnapshotCache = None
         self.api_budget_limiter = ApiBudgetLimiter()
         self.risk_gate_service: RiskGateService = None


### PR DESCRIPTION
## 배경

미국장 관심종목은 5% 단위 등락 알림이 **한 번도 발행될 수 없는 구조**였다. 버그가 아니라 미구현.

1. `FavoritePriceAlertService._refresh_favorites` 가 `get_all()` 을 market 인자 없이 호출 → `favorites` 테이블의 `market='overseas_us'` 행은 절대 로드되지 않음
2. `/api/favorite` POST·DELETE 가 `market == domestic` 일 때만 알림 서비스와 연동
3. 애초에 해외 실시간 틱 소스가 없음 — `handle_price_tick` 호출처는 국내 웹소켓(H0STCNT0/H0UNCNT0)과 국내 PT REST 보강 두 곳뿐

## 변경

- **`FavoritePriceAlertService`**: `market` 파라미터 추가. `get_all(market=...)` 로 조회하고, overseas_us 인스턴스는 USD 표기(`$189.50`)를 쓰며 상한가 판정을 하지 않는다(미국장은 상한가 제도 없음).
- **`OverseasFavoritePriceAlertTask` (신규)**: 해외 웹소켓을 새로 붙이는 대신 미국 정규장 중 해외현재가 REST 를 60초 주기로 조회해 틱을 공급한다. NYSE 휴장일은 `USMarketCalendarService.is_trading_day` 로 건너뛰고, 종목별 조회 실패는 남은 종목 진행을 막지 않는다.
- **ET 날짜 기준 상태 분리**: 미국장 세션(KST 23:30~06:00)이 KST 자정을 넘기 때문에 국내와 같은 상태 파일·날짜 기준을 쓰면 세션 중간에 버킷이 초기화된다. `state_file`/`today_provider` 를 US 클럭 기준으로 분리했다.
- **라우트**: overseas_us 추가·삭제 시 미국장 알림 캐시 동기화 (국내 실시간 구독 경로는 그대로 건너뜀).
- **`OverseasStockCodeRepository.get_name_by_code`**: 알림 본문 종목명 표기용 (`StockCodeRepository` 와 동일 시그니처).

## 설정

```yaml
overseas_favorite_alert:
  enabled: true
  poll_interval_sec: 60
```

API 비용은 `관심종목 수 × 1회/주기`. 미국 관심종목이 없으면 조회 자체가 발생하지 않는다.

## 알려진 한계

조기폐장일(13:00 ET)에는 16:00 까지 폴링이 계속되지만, 등락률이 고정돼 같은 버킷이므로 중복 알림은 발생하지 않는다.

## 테스트

TDD 로 진행 (실패 테스트 → 구현).

- 신규: 태스크 6건, 서비스 3건, 컨테이너 조립 2건 / 기존 해외 라우트 테스트 2건은 새 동작에 맞춰 갱신
- `pytest tests/unit_test` — 7345 passed
- `pytest tests/integration_test` — 277 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
