### PR TITLE
Fix inactive program trading resubscription

### DIFF
--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -275,6 +275,7 @@ async def test_program_trading_subscription(mock_deps):
     ctx.streaming_stock_repo.get_desired.side_effect = (
         lambda stream_type: {"005930"} if stream_type == StreamingType.PROGRAM_TRADING else set()
     )
+    ctx.streaming_stock_repo.get_active.return_value = {"005930"}
     await ctx.start_program_trading("005930")
     assert ctx.streaming_service.subscribe_program_trading.call_count == 1
 

--- a/tests/unit_test/view/web/test_web_app_program_trading.py
+++ b/tests/unit_test/view/web/test_web_app_program_trading.py
@@ -112,6 +112,7 @@ async def test_start_program_trading_already_subscribed_alive(mock_ctx):
     """기존 desired를 UI에서 다시 선택하면 수동 출처로 승격한다."""
     code = "005930"
     mock_ctx.streaming_stock_repo.get_desired.return_value = {code}  # 이미 구독 중
+    mock_ctx.streaming_stock_repo.get_active.return_value = {code}
     mock_ctx.broker.is_websocket_receive_alive.return_value = True
 
     result = await mock_ctx.start_program_trading(code)
@@ -122,6 +123,24 @@ async def test_start_program_trading_already_subscribed_alive(mock_ctx):
         code,
         StreamingType.PROGRAM_TRADING,
         source="manual",
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_program_trading_retries_desired_but_inactive_subscription(mock_ctx):
+    """desired에만 남은 종목은 수신 태스크가 살아 있어도 실제 구독을 다시 시도한다."""
+    code = "005930"
+    mock_ctx.streaming_stock_repo.get_desired.return_value = {code}
+    mock_ctx.streaming_stock_repo.get_active.return_value = set()
+    mock_ctx.broker.is_websocket_receive_alive.return_value = True
+
+    result = await mock_ctx.start_program_trading(code)
+
+    assert result is True
+    mock_ctx.streaming_service.connect_websocket.assert_awaited_once()
+    mock_ctx.streaming_service.subscribe_program_trading.assert_awaited_once_with(code)
+    mock_ctx.streaming_stock_repo.mark_active.assert_awaited_once_with(
+        code, StreamingType.PROGRAM_TRADING
     )
 
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -652,6 +652,22 @@ class WebAppContext:
             if self.streaming_stock_repo else set()
         )
         if code in pt_desired:
+            pt_active = (
+                self.streaming_stock_repo.get_active(StreamingType.PROGRAM_TRADING)
+                if self.streaming_stock_repo else set()
+            )
+            if code in pt_active:
+                # 구버전/이관 구독을 사용자가 UI에서 다시 선택하면 수동 등록으로 확정한다.
+                if self.streaming_stock_repo:
+                    mark_result = self.streaming_stock_repo.mark_desired(
+                        code,
+                        StreamingType.PROGRAM_TRADING,
+                        source="manual",
+                    )
+                    if inspect.isawaitable(mark_result):
+                        await mark_result
+                return True
+
             # 구독 상태이지만 수신 태스크가 죽었으면 강제 재연결
             if (self.broker
                     and not self.broker.is_websocket_receive_alive()):
@@ -669,17 +685,6 @@ class WebAppContext:
                         await mark_result
                     return True
                 self.logger.info(f"[프로그램매매] {code} 재연결 실패로 구독 해제됨. 신규 구독 재시도.")
-            else:
-                # 구버전/이관 구독을 사용자가 UI에서 다시 선택하면 수동 등록으로 확정한다.
-                if self.streaming_stock_repo:
-                    mark_result = self.streaming_stock_repo.mark_desired(
-                        code,
-                        StreamingType.PROGRAM_TRADING,
-                        source="manual",
-                    )
-                    if inspect.isawaitable(mark_result):
-                        await mark_result
-                return True
 
         try:
             t_start = self.pm.start_timer()


### PR DESCRIPTION
## What changed
- Retry the program-trading WebSocket subscription when a code is desired but not active.
- Preserve the fast path for already-active subscriptions.
- Add regression coverage for inactive desired subscriptions.

## Root cause
The program page treated a desired subscription as active, so restored subscriptions with no active program-trading stream received no SSE data and the chart remained empty.

## Validation
- `pytest tests/unit_test -v`
- `pytest tests/integration_test -v`