### PR TITLE
Retry inactive program trading subscriptions

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_program.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_program.py
@@ -222,6 +222,7 @@ async def test_get_program_trading_status(web_client, mock_web_ctx):
     """GET /api/program-trading/status 테스트"""
     mock_web_ctx.streaming_stock_repo = MagicMock()
     mock_web_ctx.streaming_stock_repo.get_desired.return_value = {"005930", "000660"}
+    mock_web_ctx.streaming_stock_repo.get_active.return_value = {"005930"}
 
     response = web_client.get("/api/program-trading/status")
     
@@ -229,6 +230,7 @@ async def test_get_program_trading_status(web_client, mock_web_ctx):
     data = response.json()
     assert data["subscribed"] is True
     assert sorted(data["codes"]) == ["000660", "005930"]
+    assert data["active_codes"] == ["005930"]
 
 
 @pytest.mark.asyncio
@@ -255,7 +257,12 @@ async def test_get_program_trading_status_without_repo(web_client, mock_web_ctx)
     response = web_client.get("/api/program-trading/status")
 
     assert response.status_code == 200
-    assert response.json() == {"subscribed": False, "codes": [], "is_market_open": False}
+    assert response.json() == {
+        "subscribed": False,
+        "codes": [],
+        "active_codes": [],
+        "is_market_open": False,
+    }
 
 
 def test_websocket_echo_endpoint(web_client):

--- a/view/web/routes/program.py
+++ b/view/web/routes/program.py
@@ -66,10 +66,12 @@ async def get_program_trading_status():
     """프로그램매매 구독 상태 확인 (시장 개장 여부 포함)."""
     ctx = _get_ctx()
     codes = sorted(ctx.streaming_stock_repo.get_desired(StreamingType.PROGRAM_TRADING)) if ctx.streaming_stock_repo else []
+    active_codes = sorted(ctx.streaming_stock_repo.get_active(StreamingType.PROGRAM_TRADING)) if ctx.streaming_stock_repo else []
     is_market_open = await ctx.is_market_open_now()
     return {
         "subscribed": len(codes) > 0,
         "codes": codes,
+        "active_codes": active_codes,
         "is_market_open": is_market_open,
     }
 

--- a/view/web/static/js/program_trading.js
+++ b/view/web/static/js/program_trading.js
@@ -36,10 +36,10 @@ function connectPtEventSource() {
         try {
             const res = await fetch('/api/program-trading/status');
             const status = await res.json();
-            const serverCodes = new Set(status.codes || []);
+            const activeCodes = new Set(status.active_codes || status.codes || []);
 
-            // 서버에 없는 종목만 추려서 구독
-            const missingCodes = Array.from(ptSubscribedCodes).filter(c => !serverCodes.has(c));
+            // 실제 수신이 활성화되지 않은 종목만 다시 구독
+            const missingCodes = Array.from(ptSubscribedCodes).filter(c => !activeCodes.has(c));
 
             if (missingCodes.length === 0) {
                 // 서버에 이미 모든 구독이 살아있음 — 재구독 불필요

--- a/view/web/templates/program.html
+++ b/view/web/templates/program.html
@@ -44,7 +44,7 @@
 
 {% block scripts %}
 <script src="/static/js/program_chart.js?v=1"></script>
-<script src="/static/js/program_trading.js?v=1"></script>
+<script src="/static/js/program_trading.js?v=2"></script>
 <script>
     initProgramTrading();
 </script>


### PR DESCRIPTION
## What changed
- Expose active program-trading subscription codes in the status API.
- Retry only inactive restored subscriptions when the program page opens.
- Bump the program-trading JavaScript cache version.

## Root cause
The page compared its saved subscriptions only against desired server subscriptions. Codes that were desired but not active were skipped, leaving their tick stream empty.

## Validation
- `pytest tests/unit_test -v`
- `pytest tests/integration_test -v`