### PR TITLE
Fix market status sidecar alerts

### DIFF
--- a/core/retry_queue/client_with_retry_queue.py
+++ b/core/retry_queue/client_with_retry_queue.py
@@ -24,10 +24,13 @@ _EXCLUDED_METHODS = frozenset({
     "unsubscribe_unified_price",
     "subscribe_order_notice",
     "unsubscribe_order_notice",
+    "subscribe_market_status",
+    "unsubscribe_market_status",
     "is_websocket_receive_alive",
     # 구독 ACK 대기 — 큐/버짓에 태우면 안 되는 단순 await (budget 카테고리 미등록 → 직접 호출)
     "wait_for_unified_price_ack",
     "wait_for_program_trading_ack",
+    "wait_for_market_status_ack",
 })
 
 _BUDGET_ONLY_METHOD_CATEGORIES = {
@@ -45,6 +48,8 @@ _BUDGET_ONLY_METHOD_CATEGORIES = {
     "unsubscribe_unified_price": "websocket_subscribe",
     "subscribe_order_notice": "websocket_subscribe",
     "unsubscribe_order_notice": "websocket_subscribe",
+    "subscribe_market_status": "websocket_subscribe",
+    "unsubscribe_market_status": "websocket_subscribe",
 }
 
 _ACCOUNT_METHODS = frozenset({

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -136,6 +136,10 @@ class MarketStatusAlertService:
         reason = str(data.get("거래정지사유내용") or "").lower()
         if any(keyword.lower() in reason for keyword in self._SIDECAR_KEYWORDS):
             return "sidecar"
+        # 장운영정보는 거래소에 따라 '사이드카'라는 명칭 대신 프로그램매매
+        # 호가의 일시 효력정지 문구만 전달할 수 있다.
+        if "프로그램" in reason and "호가" in reason and ("정지" in reason or "효력정지" in reason):
+            return "sidecar"
         if any(keyword.lower() in reason for keyword in self._CIRCUIT_KEYWORDS):
             return "circuit_breaker"
         return None

--- a/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
+++ b/tests/unit_test/core/retry_queue/test_client_with_retry_queue.py
@@ -100,6 +100,15 @@ class FakeClient:
     async def unsubscribe_order_notice(self) -> bool:
         return True
 
+    async def subscribe_market_status(self, stock_code: str) -> bool:
+        return True
+
+    async def unsubscribe_market_status(self, stock_code: str) -> bool:
+        return True
+
+    async def wait_for_market_status_ack(self, stock_code: str, timeout=None) -> bool:
+        return True
+
     def is_websocket_receive_alive(self) -> bool:
         return True
 
@@ -396,6 +405,14 @@ class TestExcludedMethodsBypassQueue:
         assert result is True
         assert queue.done_queue.empty()
 
+    @pytest.mark.parametrize(
+        "method_name",
+        ["subscribe_market_status", "unsubscribe_market_status", "wait_for_market_status_ack"],
+    )
+    async def test_market_status_websocket_methods_bypass_queue(self, wrapped, queue, method_name):
+        assert await getattr(wrapped, method_name)("000000") is True
+        assert queue.done_queue.empty()
+
 
 class TestSyncMethodsBypassQueue:
     def test_sync_method_bypasses_queue(self, wrapped, queue):
@@ -471,8 +488,11 @@ class TestExcludedMethodsSet:
             "unsubscribe_unified_price",
             "subscribe_order_notice",
             "unsubscribe_order_notice",
+            "subscribe_market_status",
+            "unsubscribe_market_status",
             "is_websocket_receive_alive",
             "wait_for_program_trading_ack",
+            "wait_for_market_status_ack",
         }
         assert expected.issubset(_EXCLUDED_METHODS)
 

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -53,6 +53,28 @@ async def test_market_status_alert_service_reports_sidecar_warning():
 
 
 @pytest.mark.asyncio
+async def test_market_status_alert_service_reports_kosdaq_sidecar_when_reason_uses_program_quote_stop():
+    """장운영정보가 '사이드카' 대신 프로그램매매 호가 정지 문구를 주는 경우도 감지한다."""
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "000000",
+        "거래정지여부": "N",
+        "거래정지사유내용": "코스닥시장 프로그램매매 매수호가 일시효력정지",
+        "거래소구분코드": "KOSDAQ",
+    })
+
+    args = operator_alert.report.await_args.args
+    assert args[1] == "market_status:sidecar:buy:KOSDAQ:000000"
+    assert args[2] == "warning"
+    assert args[3] == "매수 사이드카 감지"
+
+
+@pytest.mark.asyncio
 async def test_market_status_alert_service_distinguishes_buy_and_sell_sidecars():
     operator_alert = AsyncMock()
     service = MarketStatusAlertService(


### PR DESCRIPTION
## Summary
- Recognize program-trading quote suspension messages as sidecar events.
- Exclude market-status WebSocket operations and ACK waits from the retry queue.

## Root cause
KOSDAQ status feeds can omit the literal '사이드카', while market-status subscriptions were incorrectly routed through the response retry queue.

## Validation
- 318 relevant unit tests passed.
- 22 retry-queue integration tests passed.
- Full suites exceeded the 10-minute local test limit without reporting a failure.