### PR TITLE
Keep strategy scans active during risk-off regimes

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -76,6 +76,10 @@ class StrategySchedulerConfig:
     # P2 2-4: 활성 시 scan() 이후 매번 router 구독을 갱신하고 evaluate_single 결과를
     # EventShadowJournalService 에 기록 (실 주문 미발생). 기본 False — 안전한 dead code.
     event_driven_shadow: bool = False
+    # 시장 레짐은 신규 롱 진입만 차단한다. scan/check_exits 는 계속 수행하여
+    # 관찰 데이터와 청산 안전장치를 유지한다. 베어 레짐을 진입 조건으로 쓰는
+    # 인버스 전략은 False 로 명시적으로 우회한다.
+    market_timing_entry_gate: bool = True
 
 
 @dataclass(frozen=True)
@@ -843,6 +847,20 @@ class StrategyScheduler:
             holding_codes = {str(h.get('code')) for h in current_holdings if h.get('code')}
             valid_signals = [s for s in buy_signals if str(s.code) not in holding_codes]
 
+        # 시장 레짐은 탐색 단계가 아니라 실제 신규 롱 주문 직전에 적용한다.
+        # 전략이 scan() 중 position_state 를 선반영할 수 있으므로, 차단 신호는
+        # 아래에서 state 를 되돌려 실제 미보유 상태와 일치시킨다.
+        market_blocked_signals = await self._filter_market_timing_blocked_buys(cfg, valid_signals)
+        if market_blocked_signals:
+            self._rollback_rejected_buy_states(
+                cfg,
+                market_blocked_signals,
+                pre_existing_codes={str(h.get('code')).strip() for h in current_holdings if h.get('code')},
+                accepted_codes=set(),
+            )
+        blocked_codes = {id(signal) for signal in market_blocked_signals}
+        valid_signals = [signal for signal in valid_signals if id(signal) not in blocked_codes]
+
         remaining = max(cfg.max_positions - current_holds_count, 0)
         target_signals = valid_signals[:remaining]
         rejected_signals = valid_signals[remaining:]
@@ -897,8 +915,6 @@ class StrategyScheduler:
     ) -> None:
         """scan 중 선반영된 stateful 전략의 rejected BUY state를 되돌린다."""
         position_state = self._get_strategy_position_state(cfg.strategy)
-        if not position_state:
-            return
 
         removed_codes: List[str] = []
         for sig in signals:
@@ -907,6 +923,7 @@ class StrategyScheduler:
             code = str(sig.code).strip()
             if not code or code in pre_existing_codes or code in accepted_codes:
                 continue
+            cfg.strategy.discard_bought_today(code)
             if code in position_state:
                 position_state.pop(code, None)
                 removed_codes.append(code)
@@ -920,6 +937,51 @@ class StrategyScheduler:
             f"strategy={cfg.strategy.name}, codes={removed_codes}, "
             f"max_positions={cfg.max_positions}"
         )
+
+    async def _filter_market_timing_blocked_buys(
+        self,
+        cfg: StrategySchedulerConfig,
+        signals: List[TradeSignal],
+    ) -> List[TradeSignal]:
+        """시장 레짐이 🔴인 종목의 BUY만 주문 직전에 차단한다.
+
+        레짐 서비스가 주입되지 않은 기존/테스트 경로는 호환성을 위해 통과시킨다.
+        """
+        if not cfg.market_timing_entry_gate or self._market_regime_service is None:
+            return []
+
+        snapshots = {}
+        blocked: List[TradeSignal] = []
+        for signal in signals:
+            if signal.action != "BUY":
+                continue
+            try:
+                market = "KOSDAQ" if self.stock_code_repository.is_kosdaq(str(signal.code)) else "KOSPI"
+                if market not in snapshots:
+                    snapshots[market] = await self._market_regime_service.classify(
+                        market, logger=self._logger
+                    )
+                snapshot = snapshots[market]
+                if getattr(snapshot, "is_rising", False):
+                    continue
+                blocked.append(signal)
+                self._logger.info({
+                    "event": "signal_rejected",
+                    "reason": "market_timing_off",
+                    "strategy_name": signal.strategy_name or cfg.strategy.name,
+                    "code": signal.code,
+                    "name": signal.name,
+                    "action": signal.action,
+                    "market": market,
+                    "trend_status": getattr(snapshot, "trend_status", "unknown"),
+                    "message": "시장 레짐 🔴으로 신규 매수 주문 차단 (관찰 스캔은 유지)",
+                })
+            except Exception as exc:
+                self._logger.warning(
+                    f"[Scheduler] 시장 레짐 주문 게이트 조회 실패 — 매수 허용: {exc}",
+                    exc_info=True,
+                )
+        return blocked
 
     def _stamp_signals(self, signals: List[TradeSignal], strategy: LiveStrategy) -> None:
         """미stamp 신호에 created_at/signal_id/strategy_id/config_hash 부여 (scan/exit 공통)."""

--- a/strategies/first_pullback_strategy.py
+++ b/strategies/first_pullback_strategy.py
@@ -100,15 +100,10 @@ class FirstPullbackStrategy(LiveStrategy):
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger)
         }
-        if not any(market_timing.values()):
-            self._logger.info({"event": "scan_skipped", "reason": "Bad market timing for both markets"})
-            return signals
-
         today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
         candidates = [
             (code, item) for code, item in watchlist.items()
             if code not in self._position_state
-            and market_timing.get(item.market, False)
             and today_str >= self._cooldown.get(code, "")
         ]
         await self._sqs.prefetch_prices([code for code, _ in candidates])

--- a/strategies/high_tight_flag_strategy.py
+++ b/strategies/high_tight_flag_strategy.py
@@ -105,15 +105,10 @@ class HighTightFlagStrategy(LiveStrategy):
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger)
         }
-        if not any(market_timing.values()):
-            self._logger.info({"event": "scan_skipped", "reason": "Bad market timing for both markets"})
-            return signals
-
         today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
         candidates = [
             (code, item) for code, item in watchlist.items()
             if code not in self._position_state
-            and market_timing.get(item.market, False)
             and today_str >= self._cooldown.get(code, "")
         ]
         await self._sqs.prefetch_prices([code for code, _ in candidates])

--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -102,25 +102,12 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
         }
-        if not any(market_timing.values()):
-            self._logger.info({"event": "scan_skipped", "reason": "market_timing_off_both"})
-            return signals
-
         today_str = now.strftime("%Y%m%d")
         candidates = []
         for code, item in watchlist.items():
             if code in self._position_state:
                 continue
             if today_str < self._cooldown.get(code, ""):
-                continue
-            if not market_timing.get(item.market, False):
-                self._logger.info({
-                    "event": "entry_rejected",
-                    "code": code,
-                    "name": item.name,
-                    "reason": "market_timing_off",
-                    "market": item.market,
-                })
                 continue
             if item.rs_rating < self._cfg.rs_rating_min:
                 self._logger.info({

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -146,10 +146,6 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
                 "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
             }
-            if not any(market_timing.values()):
-                self._logger.info({"event": "scan_skipped", "reason": "market_timing_off_both"})
-                return signals
-
         candidate_codes = [c["code"] for c in candidates if c.get("code")]
         await self._sqs.prefetch_prices(candidate_codes)
 
@@ -169,13 +165,6 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                 continue
             if not self._cfg.allow_reentry and code in self._bought_today:
                 continue
-
-            # 시장 국면 게이트 (종목별) — bear regime 이면 state/주문 영향 없이 skip
-            if market_timing:
-                stock_market = stock.get("market", "")
-                if stock_market and not market_timing.get(stock_market, False):
-                    self._log_entry_rejected(log_data, "market_timing_off", f"{stock_market} 마켓 타이밍 차단")
-                    continue
 
             try:
                 # 4) 유동성·규모 필터 (OSBWatchlistItem 내장값 우선 사용)

--- a/strategies/oneil_pocket_pivot_strategy.py
+++ b/strategies/oneil_pocket_pivot_strategy.py
@@ -102,15 +102,10 @@ class OneilPocketPivotStrategy(LiveStrategy):
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger)
         }
-        if not any(market_timing.values()):
-            self._logger.info({"event": "scan_skipped", "reason": "Bad market timing for both markets"})
-            return signals
-
         today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
         candidates = [
             (code, item) for code, item in watchlist.items()
             if code not in self._position_state
-            and market_timing.get(item.market, False)
             and today_str >= self._cooldown.get(code, "")
         ]
         await self._sqs.prefetch_prices([code for code, _ in candidates])

--- a/strategies/oneil_squeeze_breakout_strategy.py
+++ b/strategies/oneil_squeeze_breakout_strategy.py
@@ -111,16 +111,11 @@ class OneilSqueezeBreakoutStrategy(LiveStrategy):
             "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
             "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger)
         }
-        if not any(market_timing.values()):
-            self._logger.info({"event": "scan_skipped", "reason": "Bad market timing for both markets"})
-            return signals
-
         # 4. 종목별 돌파 체크 (청크 기반 병렬 처리, TPS 제한 대응)
         today_str = self._tm.get_current_kst_time().strftime("%Y%m%d")
         candidates = [
             (code, item) for code, item in watchlist.items()
             if code not in self._position_state
-            and market_timing.get(item.market, False)
             and today_str >= self._cooldown.get(code, "")
         ]
         await self._sqs.prefetch_prices([code for code, _ in candidates])

--- a/tests/fixtures/backtest/oneil_pp_bgu_entry_cases.json
+++ b/tests/fixtures/backtest/oneil_pp_bgu_entry_cases.json
@@ -98,7 +98,7 @@
     },
     {
       "id": "20260504_reject_bad_market_timing",
-      "description": "Common fail: market timing blocks scan before price lookup",
+      "description": "Bear market timing keeps observation scan; live scheduler blocks the BUY order",
       "date": "20260504",
       "time": "12:00:00",
       "market_timing_ok": false,
@@ -115,9 +115,9 @@
       },
       "execution_strength": 150.0,
       "expected": {
-        "signal": false,
-        "entry_type": null,
-        "reason_contains": ""
+        "signal": true,
+        "entry_type": "PP",
+        "reason_contains": "PP진입"
       }
     },
     {

--- a/tests/unit_test/scheduler/test_strategy_scheduler.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler.py
@@ -56,7 +56,7 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             self._scheduler = None
         shutil.rmtree(self.test_dir)
 
-    def _make_scheduler(self, dry_run=True, live_expansion_gate_service=None):
+    def _make_scheduler(self, dry_run=True, live_expansion_gate_service=None, market_regime_service=None):
         vm = MagicMock()
         vm.get_holds_by_strategy.return_value = []
         vm.log_buy_async = AsyncMock(return_value=True)
@@ -110,9 +110,56 @@ class TestStrategyScheduler(unittest.IsolatedAsyncioTestCase):
             dry_run=dry_run,
             store=mock_store,
             live_expansion_gate_service=live_expansion_gate_service,
+            market_regime_service=market_regime_service,
         )
         self._scheduler = scheduler
         return scheduler, vm, oes, tm, mcs
+
+    async def test_run_strategy_scans_but_blocks_buy_in_bear_market_and_rolls_back_state(self):
+        """베어 국면에도 스캔은 유지하고 신규 BUY만 공통 게이트에서 차단한다."""
+        regime = MagicMock()
+        regime.classify = AsyncMock(return_value=SimpleNamespace(is_rising=False, trend_status="hard_decline"))
+        scheduler, vm, _, _, _ = self._make_scheduler(market_regime_service=regime)
+        scheduler.stock_code_repository.is_kosdaq.return_value = False
+
+        signal = TradeSignal(
+            code="005930", name="삼성전자", action="BUY", price=70000, qty=1,
+            reason="관찰 신호", strategy_name="테스트전략",
+        )
+        strategy = MockStrategy(scan_signals=[signal])
+        strategy.scan = AsyncMock(return_value=[signal])
+        strategy._position_state = {"005930": SimpleNamespace(entry_price=70000)}
+        strategy._save_state = MagicMock()
+
+        await scheduler._run_strategy(StrategySchedulerConfig(strategy=strategy, max_positions=3))
+
+        strategy.scan.assert_awaited_once()
+        vm.log_buy_async.assert_not_awaited()
+        self.assertEqual(strategy._position_state, {})
+        strategy._save_state.assert_called_once()
+        regime.classify.assert_awaited_once_with("KOSPI", logger=scheduler._logger)
+        rejection_logs = [
+            args[0] for args, _ in scheduler._logger.info.call_args_list
+            if args and isinstance(args[0], dict) and args[0].get("reason") == "market_timing_off"
+        ]
+        self.assertEqual(len(rejection_logs), 1)
+
+    async def test_run_strategy_bypasses_bear_buy_gate_when_disabled_for_inverse_strategy(self):
+        """베어 레짐을 진입 조건으로 쓰는 인버스 전략은 공통 롱 게이트를 우회한다."""
+        regime = MagicMock()
+        regime.classify = AsyncMock(return_value=SimpleNamespace(is_rising=False, trend_status="hard_decline"))
+        scheduler, vm, _, _, _ = self._make_scheduler(market_regime_service=regime)
+        signal = TradeSignal(code="114800", name="인버스", action="BUY", price=10000, qty=1,
+                             strategy_name="인버스 ETF 레짐")
+
+        await scheduler._run_strategy(StrategySchedulerConfig(
+            strategy=MockStrategy(name="인버스 ETF 레짐", scan_signals=[signal]),
+            max_positions=1,
+            market_timing_entry_gate=False,
+        ))
+
+        vm.log_buy_async.assert_awaited_once()
+        regime.classify.assert_not_awaited()
 
     def test_register_strategy(self):
         """전략 등록이 정상 동작하는지 테스트."""

--- a/tests/unit_test/strategies/test_first_pullback_strategy.py
+++ b/tests/unit_test/strategies/test_first_pullback_strategy.py
@@ -690,12 +690,12 @@ async def test_save_state_async_writes_file(mock_deps, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_scan_bad_market_timing(fp_scan_setup):
-    """마켓 타이밍 불량 시 스캔 제외."""
+async def test_scan_bad_market_timing_keeps_observation_scan(fp_scan_setup):
+    """마켓 타이밍 불량이어도 관찰 스캔은 유지한다."""
     strategy, sqs, universe, _, _ = fp_scan_setup
     universe.is_market_timing_ok.return_value = False
-    assert await strategy.scan() == []
-    sqs.get_recent_daily_ohlcv.assert_not_called()
+    assert await strategy.scan()
+    sqs.get_recent_daily_ohlcv.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_high_tight_flag_strategy.py
+++ b/tests/unit_test/strategies/test_high_tight_flag_strategy.py
@@ -515,14 +515,14 @@ async def test_scan_skip_existing_position(htf_scan_setup):
 
 
 @pytest.mark.asyncio
-async def test_scan_bad_market_timing(htf_scan_setup):
-    """scan: 마켓 타이밍 불량 → 스캔 제외."""
+async def test_scan_bad_market_timing_keeps_observation_scan(htf_scan_setup):
+    """scan: 마켓 타이밍 불량이어도 관찰 스캔은 유지한다."""
     strategy, sqs, universe, _, _ = htf_scan_setup
     universe.is_market_timing_ok.return_value = False
 
     signals = await strategy.scan()
     assert len(signals) == 0
-    sqs.get_recent_daily_ohlcv.assert_not_called()
+    sqs.get_recent_daily_ohlcv.assert_called()
 
 
 # ── check_exits() 테스트 ─────────────────────────────────────────────

--- a/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
@@ -70,8 +70,8 @@ def _make_strategy(universe, now_time=None, state_file=None):
 
 
 @pytest.mark.asyncio
-async def test_bear_regime_skips_stock_and_logs_market_timing_off(tmp_path):
-    """KOSDAQ 베어 → KOSDAQ 종목 skip, _check_entry 호출되지 않음."""
+async def test_bear_regime_keeps_observation_scan(tmp_path):
+    """KOSDAQ 베어여도 관찰용 진입 평가는 계속한다."""
     state_file = tmp_path / "lwcb_state.json"
     watchlist = {"035720": _make_watchlist_item("035720", "KOSDAQ", "카카오")}
     universe = _make_universe({"KOSPI": True, "KOSDAQ": False}, watchlist)
@@ -80,15 +80,14 @@ async def test_bear_regime_skips_stock_and_logs_market_timing_off(tmp_path):
     signals = await strategy.scan()
 
     assert signals == []
-    # OHLCV 조회조차 안 했어야 함 — 진입 평가 자체가 차단됨
-    sqs.get_ohlcv.assert_not_called()
+    sqs.get_ohlcv.assert_called_once()
     # state 변경 없음
     assert strategy._position_state == {}
 
 
 @pytest.mark.asyncio
-async def test_bear_regime_emits_market_timing_off_log(tmp_path):
-    """KOSDAQ 베어 → reason=market_timing_off 로그가 남는다."""
+async def test_bear_regime_does_not_emit_strategy_level_rejection(tmp_path):
+    """시장 레짐 차단 로그는 스케줄러 공통 주문 게이트가 남긴다."""
     state_file = tmp_path / "lwcb_state.json"
     watchlist = {"035720": _make_watchlist_item("035720", "KOSDAQ")}
     universe = _make_universe({"KOSPI": True, "KOSDAQ": False}, watchlist)
@@ -100,9 +99,7 @@ async def test_bear_regime_emits_market_timing_off_log(tmp_path):
         c.args[0] for c in logger.info.call_args_list
         if isinstance(c.args[0], dict) and c.args[0].get("event") == "entry_rejected"
     ]
-    assert any(r.get("reason") == "market_timing_off" for r in rejections), (
-        f"market_timing_off 로그 부재. rejects={rejections}"
-    )
+    assert not any(r.get("reason") == "market_timing_off" for r in rejections)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
@@ -68,22 +68,21 @@ def _make_strategy(universe, now_time=None):
 
 
 @pytest.mark.asyncio
-async def test_bear_regime_skips_stock_and_logs_market_timing_off():
-    """KOSDAQ 베어 → 카카오(KOSDAQ) skip 됨, 현재가 조회조차 호출되지 않음."""
+async def test_bear_regime_keeps_observation_scan():
+    """KOSDAQ 베어여도 관찰용 진입 평가는 계속한다."""
     universe = _make_universe({"KOSPI": True, "KOSDAQ": False})
     strategy, sqs = _make_strategy(universe)
 
     signals = await strategy.scan()
 
     assert signals == []
-    sqs.handle_get_current_stock_price.assert_not_called()  # 가격 조회 전에 차단
-    # 어떤 종목도 _bought_today 에 추가되지 않음 — state 변경 없음
+    sqs.handle_get_current_stock_price.assert_called()
     assert strategy._bought_today == set()
 
 
 @pytest.mark.asyncio
-async def test_bear_regime_emits_market_timing_off_log():
-    """KOSPI bull / KOSDAQ bear — KOSDAQ 종목 individual reject 로그 검증."""
+async def test_bear_regime_does_not_emit_strategy_level_rejection():
+    """시장 레짐 차단 로그는 스케줄러 공통 주문 게이트가 남긴다."""
     universe = _make_universe({"KOSPI": True, "KOSDAQ": False})
     strategy, _ = _make_strategy(universe)
     await strategy.scan()
@@ -93,9 +92,7 @@ async def test_bear_regime_emits_market_timing_off_log():
         c for c in logger.info.call_args_list
         if isinstance(c.args[0], dict) and c.args[0].get("event") == "entry_rejected"
     ]
-    assert any(c.args[0].get("reason") == "market_timing_off" for c in rejection_calls), (
-        f"market_timing_off 로그 부재. calls={[c.args[0] for c in rejection_calls]}"
-    )
+    assert not any(c.args[0].get("reason") == "market_timing_off" for c in rejection_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_fixture_cases.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_fixture_cases.py
@@ -150,4 +150,5 @@ async def test_oneil_pp_bgu_entry_fixture_cases(case, tmp_path, monkeypatch):
         assert "005930" not in strategy._position_state
 
     if not case["market_timing_ok"]:
-        sqs.get_current_price.assert_not_called()
+        # 시장 레짐 🔴에서도 관찰 스캔은 수행하며, 실주문은 scheduler 공통 게이트가 차단한다.
+        sqs.get_current_price.assert_called()

--- a/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_pocket_pivot_strategy.py
@@ -423,12 +423,12 @@ async def test_scan_skip_existing_position(pp_scan_setup):
 
 
 @pytest.mark.asyncio
-async def test_scan_bad_market_timing(pp_scan_setup):
-    """마켓 타이밍 불량 시 스캔 제외."""
+async def test_scan_bad_market_timing_keeps_observation_scan(pp_scan_setup):
+    """마켓 타이밍 불량이어도 관찰 스캔은 유지한다."""
     strategy, sqs, universe, _, _ = pp_scan_setup
     universe.is_market_timing_ok.return_value = False
     assert await strategy.scan() == []
-    sqs.get_current_price.assert_not_called()
+    sqs.get_current_price.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
+++ b/tests/unit_test/strategies/test_oneil_squeeze_breakout_strategy.py
@@ -456,15 +456,14 @@ async def test_scan_skip_existing_position(scan_setup):
     sqs.get_current_price.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_scan_bad_market_timing(scan_setup):
-    """scan: 마켓 타이밍이 좋지 않으면 스캔 제외."""
+async def test_scan_bad_market_timing_keeps_observation_scan(scan_setup):
+    """scan: 마켓 타이밍이 좋지 않아도 관찰 스캔은 유지한다."""
     strategy, sqs, universe, _, _ = scan_setup
     universe.is_market_timing_ok.return_value = False
     
     signals = await strategy.scan()
     assert len(signals) == 0
-    # 마켓 타이밍 체크 후 탈락하므로 가격 조회 API 호출 안함
-    sqs.get_current_price.assert_not_called()
+    sqs.get_current_price.assert_called()
 
 @pytest.mark.asyncio
 async def test_scan_exception_handling(scan_setup):

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -224,6 +224,7 @@ class StrategyFactory:
             force_exit_on_close=False,  # 멀티데이 베어 헤지 — 오버나잇 허용
             allow_pyramiding=False,     # 1포지션 invariant
             scan_when_position_full=True,
+            market_timing_entry_gate=False,  # 베어 레짐에서 진입하는 헤지 전략
         ))
 
         ctx.logger.info("웹 앱: 전략 스케줄러 초기화 완료 (수동 시작 대기)")


### PR DESCRIPTION
## What changed
- Keep long-strategy observation scans active when a market regime is risk-off.
- Apply the shared market-timing check immediately before submitting new BUY orders.
- Roll back strategy state created by a BUY signal that the market gate blocks.
- Exempt the inverse ETF regime strategy because bear regime is its entry condition.

## Why
The shared ETF-based regime signal can be imperfect. Continuing scans preserves candidate and diagnostic data without allowing automated long entries during a risk-off regime.

## Validation
- `pytest tests/unit_test -q` — 7,341 passed
- `pytest tests/integration_test -v` — 277 passed