### PR TITLE
fix: thinking 토큰이 max_tokens를 먹어 AI 분석 본문이 잘리는 문제 해소

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -243,6 +243,10 @@ ai_analysis:
   # Gemini 2.5 계열은 thinking 토큰이 max_tokens를 소비하므로 넉넉히 (짧으면 요약이 잘림).
   # 2048은 종합 분석처럼 컨텍스트가 큰 요청에서 본문이 문장 중간에 잘리는 것이 실측됨(2026-07-21).
   max_tokens: 4096
+  # thinking 예산 제한(none/low/medium/high). 제한하지 않으면 사고 토큰이 max_tokens를
+  # 다 써서 본문이 비결정적으로 잘린다(2026-08-04 실측: 동일 프롬프트가 1495자/714자로 잘림,
+  # low 적용 시 3840자 완결 + 23.4초 -> 18.5초). 빈 값이면 파라미터 미전송(Ollama 등 미지원 provider용).
+  reasoning_effort: "low"
   disclosure_summary_enabled: true
   # Gemini 프로젝트 일일 한도보다 낮게 설정. 0이면 로컬 차단 비활성화.
   daily_request_limit: 100

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -332,6 +332,10 @@ class AiAnalysisConfig(BaseModel):
     # Gemini 2.5 계열은 thinking 토큰이 max_tokens 예산을 소비하므로, 짧게 잡으면
     # 실제 요약이 잘린다. 사고 후에도 2~3문장이 완성되도록 넉넉히 둔다.
     max_tokens: int = Field(2048, ge=1, le=8192)
+    # thinking 예산 제한. 제한하지 않으면 사고 토큰이 max_tokens 를 다 써서 본문이
+    # 비결정적으로 잘린다(2026-08-04 실측: 같은 프롬프트가 1495자/714자로 잘림).
+    # 빈 값이면 파라미터를 보내지 않는다 — 미지원 provider(Ollama 등)용.
+    reasoning_effort: Literal["", "none", "low", "medium", "high"] = "low"
     disclosure_summary_enabled: bool = True
     daily_request_limit: int = Field(100, ge=0)
     disclosure_reserve: int = Field(20, ge=0)

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -31,6 +31,7 @@ class AiClient:
         model: str,
         http_client: Optional[httpx.AsyncClient] = None,
         timeout_sec: float = 15.0,
+        reasoning_effort: str = "",
         usage_limiter=None,
         max_retries: int = 2,
         retry_backoff_sec: float = 0.5,
@@ -41,6 +42,7 @@ class AiClient:
         self._model = str(model or "")
         self._http_client = http_client
         self._timeout_sec = float(timeout_sec)
+        self._reasoning_effort = str(reasoning_effort or "").strip()
         self._usage_limiter = usage_limiter
         self._max_retries = max(0, int(max_retries))
         self._retry_backoff_sec = float(retry_backoff_sec)
@@ -92,6 +94,11 @@ class AiClient:
             "max_tokens": int(max_tokens),
             "temperature": float(temperature),
         }
+        # thinking 모델(Gemini 2.5 등)은 사고 토큰도 max_tokens 예산을 쓰므로,
+        # 제한하지 않으면 예산을 다 쓰고 본문이 잘린다. 미지원 provider 를 위해
+        # 빈 값이면 파라미터 자체를 보내지 않는다.
+        if self._reasoning_effort:
+            payload["reasoning_effort"] = self._reasoning_effort
         if self._usage_limiter is not None:
             await self._usage_limiter.reserve(usage_type)
         if self._http_client is not None:

--- a/tests/unit_test/config/test_ai_analysis_config.py
+++ b/tests/unit_test/config/test_ai_analysis_config.py
@@ -14,6 +14,8 @@ def test_defaults_are_disabled_and_gemini_flash():
     assert cfg.disclosure_reserve == 20
     # Gemini 2.5 thinking 토큰이 출력 예산을 갉아먹으므로 요약이 잘리지 않게 넉넉히
     assert cfg.max_tokens >= 1024
+    # thinking 예산을 제한하지 않으면 max_tokens 를 다 쓰고 본문이 잘린다(2026-08-04 실측)
+    assert cfg.reasoning_effort == "low"
 
 
 def test_accepts_ollama_local_overrides():
@@ -25,12 +27,15 @@ def test_accepts_ollama_local_overrides():
             "api_key": "",
             "model": "qwen2.5",
             "timeout_sec": 30,
+            "reasoning_effort": "",
         }
     )
 
     assert cfg.enabled is True
     assert cfg.base_url == "http://localhost:11434/v1"
     assert cfg.model == "qwen2.5"
+    # 빈 값은 파라미터 자체를 보내지 않는다는 뜻 (미지원 provider 보호)
+    assert cfg.reasoning_effort == ""
 
 
 def test_unknown_keys_are_tolerated():

--- a/tests/unit_test/services/test_ai_client.py
+++ b/tests/unit_test/services/test_ai_client.py
@@ -41,6 +41,40 @@ async def test_complete_posts_openai_compatible_chat_request():
     assert payload["messages"][1] == {"role": "user", "content": "이 공시를 요약해줘"}
 
 
+async def test_reasoning_effort_is_sent_when_configured():
+    """thinking 예산을 제한해 max_tokens 를 본문에 남긴다 (Gemini 2.5 계열)."""
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("요약입니다."))
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="gemini-2.5-flash",
+        http_client=http_client,
+        reasoning_effort="low",
+    )
+
+    await client.complete(system="s", user="u")
+
+    assert http_client.post.await_args.kwargs["json"]["reasoning_effort"] == "low"
+
+
+async def test_reasoning_effort_is_omitted_when_blank():
+    """미지원 provider(Ollama 등)에 알 수 없는 파라미터를 보내지 않는다."""
+    http_client = AsyncMock()
+    http_client.post.return_value = _response(_completion("요약입니다."))
+    client = AiClient(
+        base_url="https://example.com/v1",
+        api_key="secret",
+        model="llama3",
+        http_client=http_client,
+        reasoning_effort="",
+    )
+
+    await client.complete(system="s", user="u")
+
+    assert "reasoning_effort" not in http_client.post.await_args.kwargs["json"]
+
+
 async def test_trailing_slash_base_url_is_normalized():
     http_client = AsyncMock()
     http_client.post.return_value = _response(_completion("ok"))

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -190,6 +190,7 @@ def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_cont
             "model": "test-model",
             "timeout_sec": 8,
             "max_tokens": 1536,
+            "reasoning_effort": "low",
             "disclosure_summary_enabled": False,
             "daily_request_limit": 100,
             "disclosure_reserve": 20,
@@ -208,6 +209,7 @@ def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_cont
         api_key="test-key",
         model="test-model",
         timeout_sec=8.0,
+        reasoning_effort="low",
         usage_limiter=patched_service_container_deps["AiUsageLimiter"].return_value,
     )
     patched_service_container_deps["AiStockAnalyzer"].assert_called_once_with(

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -228,6 +228,7 @@ class ServiceContainer:
                 api_key=ai_config.api_key,
                 model=ai_config.model,
                 timeout_sec=float(ai_config.timeout_sec),
+                reasoning_effort=ai_config.reasoning_effort,
                 usage_limiter=ctx.ai_usage_limiter,
             )
             ctx.ai_stock_analyzer = AiStockAnalyzer(


### PR DESCRIPTION
gemini-2.5-flash 는 사고 토큰도 max_tokens 예산을 소비해, 제한하지 않으면 본문이 비결정적으로 잘렸다. 동일 프롬프트 실측(2026-08-04):

  현재 설정(4096)      finish=length  본문 1495자 / 714자  23.4s
  4096 + effort=low    finish=stop    본문 3840자          18.5s

max_tokens 상향은 사고가 더 쓰면 다시 잘리는 미봉책이라, 사고 예산 자체를
제한해 본문 몫을 돌려준다.

- AiClient: reasoning_effort 를 payload 에 실어 보낸다. 빈 값이면 파라미터를 보내지 않아 미지원 provider(Ollama 등)를 깨뜨리지 않는다.
- ai_analysis.reasoning_effort 설정 추가 (기본 low).
- 실경로 검증: 11.3초 / 1870자 / 잘림 경고 없음.