### PR TITLE
fix: 해외 VBO dry-run 청산 판정의 하향 편향 제거 (판정 불가 분리 + bracket)

### DIFF
--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -6,8 +6,9 @@
 신호 자체만으로 would-be 성과를 집계할 수 있다(국내 parity 분석과 다른 점).
 
 집계 지표:
-  - totals       : 신호수 / 승·패 / win_rate / 평균·중앙·합계 realized_pct
-  - by_exit_reason : stop vs eod 청산 분포
+  - decidability : same-day 청산 판정 가능/불가 분리 + 비관·낙관 bracket (게이팅 기준)
+  - totals       : 신호수 / 승·패 / win_rate / 평균·중앙·합계 realized_pct (비관 기준)
+  - by_exit_reason : undecided vs eod 청산 분포
   - by_exchange  : 거래소별 신호수·합계 realized_pct
   - by_date      : 거래일별 신호수·합계 realized_pct
   - sizing       : 사이징 주입 신호의 would-be USD 노출(notional) 합/평균
@@ -81,6 +82,18 @@ def load_dryrun_records(
                 realized = _to_float(signal.get("realized_pct"))
                 if not code or realized is None:
                     continue
+                exit_reason = signal.get("exit_reason") or ""
+                # 구모델 레코드(exit_reason="stop")는 진입 전 저가로 손절이 강제 판정된
+                # 하향 편향값이므로 판정 불가로 취급한다. 종가를 남기지 않아 낙관값은 없다.
+                decidable = signal.get("exit_decidable")
+                if decidable is None:
+                    decidable = exit_reason == "eod"
+                pessimistic = _to_float(signal.get("realized_pct_pessimistic"))
+                optimistic = _to_float(signal.get("realized_pct_optimistic"))
+                if pessimistic is None:
+                    pessimistic = realized
+                if optimistic is None and decidable:
+                    optimistic = realized
                 out.append({
                     "code": code,
                     "exchange": snapshot.get("exchange") or "",
@@ -88,8 +101,12 @@ def load_dryrun_records(
                     "entry_price": _to_float(signal.get("entry_price")),
                     "stop_price": _to_float(signal.get("stop_price")),
                     "exit_price": _to_float(signal.get("exit_price")),
-                    "exit_reason": signal.get("exit_reason") or "",
+                    "exit_reason": exit_reason,
+                    "exit_decidable": bool(decidable),
                     "realized_pct": realized,
+                    "realized_pct_pessimistic": pessimistic,
+                    "realized_pct_optimistic": optimistic,
+                    "bar": snapshot.get("bar") or {},
                     "qty": signal.get("qty"),
                     "notional_usd": _to_float(signal.get("notional_usd")),
                     "krw_exposure": _to_float(signal.get("krw_exposure")),
@@ -106,6 +123,33 @@ def _stats(values: List[float]) -> Dict[str, Optional[float]]:
         "sum": sum(values),
         "min": min(values),
         "max": max(values),
+    }
+
+
+def _compute_decidability(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """same-day 청산 판정 가능/불가를 분리해 게이팅용 bracket 을 산출한다.
+
+    일봉은 저가 발생 시각을 담지 않아 "저 <= 손절가" 건은 손절 여부를 확정할 수 없다.
+    비관(손절 체결 가정)만 집계하면 통계가 하향 편향되므로, 판정 가능 건만의 집계와
+    비관·낙관 양끝을 함께 낸다. canary go/no-go 는 이 bracket 으로 판단한다.
+    """
+    decided = [r for r in records if r.get("exit_decidable")]
+    pessimistic = [r["realized_pct_pessimistic"] for r in records
+                   if r.get("realized_pct_pessimistic") is not None]
+    optimistic = [r["realized_pct_optimistic"] for r in records
+                  if r.get("realized_pct_optimistic") is not None]
+    decided_returns = [r["realized_pct_pessimistic"] for r in decided
+                       if r.get("realized_pct_pessimistic") is not None]
+    decided_wins = sum(1 for v in decided_returns if v > 0)
+    return {
+        "decided": len(decided),
+        "undecided": len(records) - len(decided),
+        "undecided_ratio": ((len(records) - len(decided)) / len(records)) if records else None,
+        "decided_avg_realized_pct": (sum(decided_returns) / len(decided_returns)) if decided_returns else None,
+        "decided_win_rate": (decided_wins / len(decided_returns)) if decided_returns else None,
+        "pessimistic_avg_realized_pct": (sum(pessimistic) / len(pessimistic)) if pessimistic else None,
+        "optimistic_avg_realized_pct": (sum(optimistic) / len(optimistic)) if optimistic else None,
+        "optimistic_sample": len(optimistic),
     }
 
 
@@ -146,6 +190,7 @@ def compute_dryrun_report(records: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
     return {
+        "decidability": _compute_decidability(records),
         "totals": {
             "signals": len(records),
             "wins": wins,
@@ -387,6 +432,26 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
     lines.append(f"| median_realized_pct | {_fmt(t['median_realized_pct'], '%')} |")
     lines.append(f"| sum_realized_pct | {_fmt(t['sum_realized_pct'], '%')} |")
     lines.append("")
+
+    dec = report.get("decidability")
+    if dec:
+        lines.append("## 청산 판정 가능성 (bracket)")
+        lines.append("")
+        lines.append(
+            "일봉은 저가 발생 시각을 담지 않아 `저 <= 손절가` 건은 손절 체결 여부를 "
+            "확정할 수 없습니다(진입 전 저가로도 성립). 비관 평균만 보면 하향 편향되므로 "
+            "판정 가능 건 집계와 비관·낙관 양끝을 함께 봅니다."
+        )
+        lines.append("")
+        lines.append("| 항목 | 값 |")
+        lines.append("|---|---:|")
+        lines.append(f"| decided / undecided | {dec['decided']} / {dec['undecided']} |")
+        lines.append(f"| undecided_ratio | {_fmt(dec['undecided_ratio'])} |")
+        lines.append(f"| decided_avg_realized_pct | {_fmt(dec['decided_avg_realized_pct'], '%')} |")
+        lines.append(f"| decided_win_rate | {_fmt(dec['decided_win_rate'])} |")
+        lines.append(f"| pessimistic_avg_realized_pct | {_fmt(dec['pessimistic_avg_realized_pct'], '%')} |")
+        lines.append(f"| optimistic_avg_realized_pct | {_fmt(dec['optimistic_avg_realized_pct'], '%')} |")
+        lines.append("")
 
     lines.append("## 청산 사유")
     lines.append("")

--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -95,7 +95,12 @@ class OverseasVBODryRunService:
                     strategy_name=self.STRATEGY_NAME,
                     code=code,
                     signal=sig,
-                    snapshot={"exchange": ex.value, "avg_trading_value": cand.get("avg_trading_value")},
+                    snapshot={
+                        "exchange": ex.value,
+                        "avg_trading_value": cand.get("avg_trading_value"),
+                        # 청산 모델을 사후에 재계산할 수 있도록 판정 근거인 당일 봉을 남긴다.
+                        "bar": self._bar_ohlc(resp.data[-1]),
+                    },
                     signal_source=self.SIGNAL_SOURCE,
                 )
         self._logger.info({"event": "overseas_dryrun_scan", "exchange": ex.value,
@@ -142,15 +147,22 @@ class OverseasVBODryRunService:
             return None
         entry = target
         stop = entry * (1 + self._stop_loss_pct / 100.0)
-        # 당일 same-day exit(Phase 2 백테스트 모델과 동일): 당일저 <= 손절가면 손절가,
-        # 아니면 당일 종가(eod) 청산. 주문 경로 없는 would-be 청산 결과만 동봉한다.
+        # 당일 same-day exit(Phase 2 백테스트 모델과 동일). 단 일봉은 저가의 발생 시각을
+        # 담지 않으므로, 당일저 <= 손절가여도 그 저가가 돌파(진입) 전인지 후인지 알 수 없다.
+        # 특히 손절가 >= 시가인 돌파(0.5×prev_range 가 손절폭보다 큰 경우)는 진입 전
+        # 가격대만으로 조건이 성립해 손절이 강제 판정된다. 손절 확정으로 단정하지 않고
+        # 비관(손절)·낙관(종가) bracket 을 함께 남겨 집계 측이 편향을 분리하게 한다.
         low = self._f(cur.get("low"))
         close = self._f(cur.get("close"))
-        if low <= stop:
-            exit_price, exit_reason = stop, "stop"
-        else:
+        eod_pct = (close / entry - 1) * 100.0 if entry > 0 else 0.0
+        stop_pct = (stop / entry - 1) * 100.0 if entry > 0 else 0.0
+        decidable = low > stop
+        if decidable:
             exit_price, exit_reason = close, "eod"
-        realized_pct = (exit_price / entry - 1) * 100.0 if entry > 0 else 0.0
+            pessimistic = optimistic = eod_pct
+        else:
+            exit_price, exit_reason = stop, "undecided"
+            pessimistic, optimistic = stop_pct, eod_pct
         return {
             "code": code,
             "action": "BUY",
@@ -161,9 +173,17 @@ class OverseasVBODryRunService:
             "prev_range": prev_range,
             "exit_price": exit_price,
             "exit_reason": exit_reason,
-            "realized_pct": realized_pct,
+            "exit_decidable": decidable,
+            # realized_pct 는 하위호환용 비관값. 집계는 bracket 을 쓴다.
+            "realized_pct": pessimistic,
+            "realized_pct_pessimistic": pessimistic,
+            "realized_pct_optimistic": optimistic,
             "reason": "vbo_daily_breakout",
         }
+
+    @staticmethod
+    def _bar_ohlc(bar: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: bar.get(k) for k in ("date", "open", "high", "low", "close")}
 
     @staticmethod
     def _f(x) -> float:

--- a/strategies/overseas_daily_vbo_backtest.py
+++ b/strategies/overseas_daily_vbo_backtest.py
@@ -56,20 +56,26 @@ class OverseasDailyVBOBacktest:
 
             entry_price = target
             stop_price = entry_price * (1 + self._stop_loss_pct / 100.0)
-            if low <= stop_price:
-                exit_price, exit_reason = stop_price, "stop"
-            else:
-                exit_price, exit_reason = close, "eod"
+            # 일봉은 저가의 발생 시각을 담지 않아, 저 <= 손절가여도 그 저가가 진입(돌파)
+            # 전인지 후인지 판정할 수 없다. 손절가 >= 시가인 돌파는 진입 전 가격대만으로
+            # 조건이 성립해 손절이 강제 판정되므로, 확정 대신 비관·낙관 bracket 을 남긴다.
+            decidable = low > stop_price
+            exit_price = close if decidable else stop_price
+            exit_reason = "eod" if decidable else "undecided"
 
             gross = (exit_price / entry_price - 1) * 100
-            net = gross - self._cost_pct
+            gross_optimistic = (close / entry_price - 1) * 100
             trades.append({
                 "date": cur.get("date"),
                 "entry_price": entry_price,
                 "exit_price": exit_price,
                 "exit_reason": exit_reason,
+                "exit_decidable": decidable,
+                # gross/net 은 하위호환용 비관값. 낙관값은 판정 불가 건을 종가 청산으로 가정.
                 "gross_return_pct": gross,
-                "net_return_pct": net,
+                "net_return_pct": gross - self._cost_pct,
+                "gross_return_pct_optimistic": gross_optimistic,
+                "net_return_pct_optimistic": gross_optimistic - self._cost_pct,
             })
 
         return {"trades": trades, "summary": self._summarize(trades)}
@@ -108,15 +114,23 @@ class OverseasDailyVBOBacktest:
         n = len(trades)
         if n == 0:
             return {"total_trades": 0, "wins": 0, "win_rate": 0.0,
-                    "avg_net_return_pct": 0.0, "total_net_return_pct": 0.0}
+                    "avg_net_return_pct": 0.0, "total_net_return_pct": 0.0,
+                    "decided_trades": 0, "undecided_trades": 0,
+                    "avg_net_return_pct_optimistic": 0.0}
         nets = [t["net_return_pct"] for t in trades]
+        nets_optimistic = [t["net_return_pct_optimistic"] for t in trades]
         wins = sum(1 for x in nets if x > 0)
+        decided = sum(1 for t in trades if t["exit_decidable"])
         return {
             "total_trades": n,
             "wins": wins,
             "win_rate": wins / n,
             "avg_net_return_pct": sum(nets) / n,
             "total_net_return_pct": sum(nets),
+            # 판정 불가 비중이 크면 비관 평균은 하향 편향된 값이다.
+            "decided_trades": decided,
+            "undecided_trades": n - decided,
+            "avg_net_return_pct_optimistic": sum(nets_optimistic) / n,
         }
 
     @staticmethod

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -93,6 +93,68 @@ def test_load_returns_empty_when_dir_missing(tmp_path):
     assert load_dryrun_records(tmp_path / "nope", "20260601", "20260605") == []
 
 
+def test_load_extracts_exit_bracket_fields(tmp_path):
+    """판정 불가 신호의 비관·낙관 bracket 과 당일 봉을 그대로 실어 온다."""
+    shadow = tmp_path / "event_shadow"
+    rec = _rec(code="AAA", exchange="NASD", date="20260601",
+               realized_pct=-3.0, exit_reason="undecided")
+    rec["signal"].update({
+        "exit_decidable": False,
+        "realized_pct_pessimistic": -3.0,
+        "realized_pct_optimistic": 4.0,
+    })
+    rec["snapshot"]["bar"] = {"date": "20260601", "open": 100, "high": 120, "low": 95, "close": 104}
+    _write_jsonl(shadow, "20260601", [rec])
+
+    r = load_dryrun_records(shadow, "20260601", "20260601")[0]
+
+    assert r["exit_decidable"] is False
+    assert r["realized_pct_pessimistic"] == -3.0
+    assert r["realized_pct_optimistic"] == 4.0
+    assert r["bar"]["close"] == 104
+
+
+def test_load_treats_legacy_stop_records_as_undecided(tmp_path):
+    """구모델(exit_reason="stop") 레코드는 편향된 값이므로 판정 불가로 취급한다."""
+    shadow = tmp_path / "event_shadow"
+    _write_jsonl(shadow, "20260601", [
+        _rec(code="AAA", exchange="NASD", date="20260601", realized_pct=-3.0, exit_reason="stop"),
+        _rec(code="BBB", exchange="NASD", date="20260601", realized_pct=5.0, exit_reason="eod"),
+    ])
+
+    records = {r["code"]: r for r in load_dryrun_records(shadow, "20260601", "20260601")}
+
+    assert records["AAA"]["exit_decidable"] is False
+    assert records["AAA"]["realized_pct_pessimistic"] == -3.0
+    assert records["AAA"]["realized_pct_optimistic"] is None  # 종가 미기록 → 재계산 불가
+    assert records["BBB"]["exit_decidable"] is True
+    assert records["BBB"]["realized_pct_optimistic"] == 5.0
+
+
+def test_compute_reports_decidability_bracket():
+    """게이팅 근거: 판정 가능 건만의 집계와 비관·낙관 bracket 을 함께 낸다."""
+    records = [
+        {"code": "AAA", "exchange": "NASD", "trade_date": "20260601", "realized_pct": 5.0,
+         "exit_reason": "eod", "exit_decidable": True,
+         "realized_pct_pessimistic": 5.0, "realized_pct_optimistic": 5.0,
+         "qty": None, "notional_usd": None},
+        {"code": "BBB", "exchange": "NASD", "trade_date": "20260601", "realized_pct": -3.0,
+         "exit_reason": "undecided", "exit_decidable": False,
+         "realized_pct_pessimistic": -3.0, "realized_pct_optimistic": 9.0,
+         "qty": None, "notional_usd": None},
+    ]
+
+    d = compute_dryrun_report(records)["decidability"]
+
+    assert d["decided"] == 1
+    assert d["undecided"] == 1
+    assert d["undecided_ratio"] == pytest.approx(0.5)
+    assert d["decided_avg_realized_pct"] == pytest.approx(5.0)
+    assert d["decided_win_rate"] == pytest.approx(1.0)
+    assert d["pessimistic_avg_realized_pct"] == pytest.approx(1.0)
+    assert d["optimistic_avg_realized_pct"] == pytest.approx(7.0)
+
+
 # ── compute ──────────────────────────────────────────────────────────────
 
 def test_compute_totals_and_win_rate():

--- a/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_vbo_dryrun_service.py
@@ -58,30 +58,74 @@ async def test_scan_emits_buy_on_breakout(svc):
 
 @pytest.mark.asyncio
 async def test_scan_emits_same_day_eod_exit(svc):
-    """돌파 후 당일저가 손절가 미터치 → 당일 종가(eod) 청산을 동봉한다(Phase 2 모델 동일)."""
+    """돌파 후 당일저가 손절가 미터치 → 판정 가능(eod) 청산. bracket 양끝이 같다."""
     # target=105, stop=105*0.97=101.85, 당일저 104 > stop → eod 청산(종가 115)
     bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
     svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
 
     signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
 
+    expected = (115.0 / 105.0 - 1) * 100
     assert signals[0]["exit_reason"] == "eod"
+    assert signals[0]["exit_decidable"] is True
     assert signals[0]["exit_price"] == 115.0
-    assert signals[0]["realized_pct"] == pytest.approx((115.0 / 105.0 - 1) * 100)
+    assert signals[0]["realized_pct"] == pytest.approx(expected)
+    assert signals[0]["realized_pct_pessimistic"] == pytest.approx(expected)
+    assert signals[0]["realized_pct_optimistic"] == pytest.approx(expected)
 
 
 @pytest.mark.asyncio
-async def test_scan_emits_same_day_stop_exit(svc):
-    """돌파 후 당일저가 손절가 터치 → 손절가(stop) 청산을 동봉한다."""
-    # target=105, stop=101.85, 당일저 100 <= stop → stop 청산
+async def test_scan_marks_stop_touch_as_undecided(svc):
+    """당일저가가 손절가 이하 → 저가 시점이 진입 전/후인지 일봉만으론 판정 불가.
+
+    손절 확정으로 단정하지 않고 비관(손절)·낙관(종가) bracket 을 함께 동봉한다.
+    """
+    # target=105, stop=101.85, 당일저 100 <= stop → 판정 불가
     bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 100, 102)]
     svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
 
     signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
 
-    assert signals[0]["exit_reason"] == "stop"
-    assert signals[0]["exit_price"] == pytest.approx(101.85)
+    assert signals[0]["exit_reason"] == "undecided"
+    assert signals[0]["exit_decidable"] is False
+    assert signals[0]["realized_pct_pessimistic"] == pytest.approx(-3.0)
+    assert signals[0]["realized_pct_optimistic"] == pytest.approx((102.0 / 105.0 - 1) * 100)
+    # 하위호환: realized_pct/exit_price 는 비관(손절) 값을 유지한다.
     assert signals[0]["realized_pct"] == pytest.approx(-3.0)
+    assert signals[0]["exit_price"] == pytest.approx(101.85)
+
+
+@pytest.mark.asyncio
+async def test_scan_does_not_force_stop_when_target_far_above_open(svc):
+    """회귀: 손절가가 시가 이상이면 당일저가는 항상 손절가 이하 → 구모델은 무조건 손절.
+
+    0.5×prev_range 가 시가의 3%(손절폭) 를 넘는 돌파는 진입 전 가격대만으로 손절이
+    강제 판정돼 통계가 하향 편향됐다. 이런 건은 판정 불가로 분류돼야 한다.
+    """
+    # prev range 20 → target = 100+10 = 110, stop = 106.7 > 시가 100 → low<=stop 자동 성립
+    bars = [_bar("20260511", 100, 120, 100, 110), _bar("20260512", 100, 130, 99, 128)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["exit_reason"] == "undecided"
+    assert signals[0]["exit_decidable"] is False
+    # 종가 128 은 진입가 110 대비 +16% — 손절 확정으로 단정하면 통째로 버려지는 구간이다.
+    assert signals[0]["realized_pct_optimistic"] == pytest.approx((128.0 / 110.0 - 1) * 100)
+
+
+@pytest.mark.asyncio
+async def test_scan_records_bar_ohlc_in_snapshot(svc):
+    """저널 snapshot 에 당일 일봉 OHLC 를 동봉해 청산 모델을 사후 재계산 가능하게 한다."""
+    bars = [_bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 120, 104, 115)]
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(bars))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    snapshot = svc.journal.record.call_args.kwargs["snapshot"]
+    assert snapshot["bar"] == {
+        "date": "20260512", "open": 100, "high": 120, "low": 104, "close": 115,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_overseas_daily_vbo_backtest.py
+++ b/tests/unit_test/strategies/test_overseas_daily_vbo_backtest.py
@@ -47,16 +47,50 @@ def test_no_entry_when_high_below_target():
     assert res["trades"] == []
 
 
-def test_stop_loss_exit():
-    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
-    # target=105 진입, 저 100 <= 손절가 101.85 → 손절 청산 -3%
+def test_stop_touch_is_undecided_with_bracket():
+    """저 <= 손절가는 진입 전/후 순서를 일봉으로 판정할 수 없어 bracket 으로 남긴다."""
+    # target=105 진입, 저 100 <= 손절가 101.85 → 판정 불가(비관 -3% / 낙관 종가 110)
     bars = [_PREV, _bar("20260512", 100, 120, 100, 110)]
 
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
     res = bt.run_symbol(bars)
 
     t = res["trades"][0]
-    assert t["exit_reason"] == "stop"
-    assert round(t["net_return_pct"], 4) == -3.0
+    assert t["exit_reason"] == "undecided"
+    assert t["exit_decidable"] is False
+    assert round(t["net_return_pct"], 4) == -3.0  # 하위호환: 비관값 유지
+    assert round(t["net_return_pct_optimistic"], 3) == round((110 / 105 - 1) * 100, 3)
+
+
+def test_stop_not_forced_when_stop_price_above_open():
+    """회귀: 손절가 >= 시가면 당일저가는 자동으로 손절가 이하 → 구모델은 손절 강제."""
+    # 전일 range 20 → target 110, 손절가 106.7 > 시가 100
+    bars = [_bar("20260511", 100, 120, 100, 110), _bar("20260512", 100, 130, 99, 128)]
+
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    res = bt.run_symbol(bars)
+
+    t = res["trades"][0]
+    assert t["exit_reason"] == "undecided"
+    assert round(t["gross_return_pct_optimistic"], 3) == round((128 / 110 - 1) * 100, 3)
+
+
+def test_summary_separates_undecided_and_optimistic_average():
+    bars = [
+        _bar("20260511", 100, 110, 100, 105),  # prev(range10) for 0512
+        _bar("20260512", 100, 120, 104, 115),  # 판정 가능: target105, eod 115
+        _bar("20260513", 100, 101, 100, 100),  # 진입 없음
+        _bar("20260514", 100, 120, 95, 110),   # 판정 불가: target100.5, 저95<=97.485
+    ]
+
+    bt = OverseasDailyVBOBacktest(k_value=0.5, stop_loss_pct=-3.0, round_trip_cost_pct=0.0)
+    s = bt.run_symbol(bars)["summary"]
+
+    assert s["total_trades"] == 2
+    assert s["decided_trades"] == 1
+    assert s["undecided_trades"] == 1
+    # 낙관 평균은 판정 불가 건을 종가 청산으로 가정한 값 — 비관 평균보다 크다.
+    assert s["avg_net_return_pct_optimistic"] > s["avg_net_return_pct"]
 
 
 def test_round_trip_cost_reduces_net_return():
@@ -84,7 +118,7 @@ def test_summary_aggregates_win_rate_and_avg():
     assert s["total_trades"] == 2
     assert s["wins"] == 1
     assert s["win_rate"] == 0.5
-    assert res["trades"][1]["exit_reason"] == "stop"
+    assert res["trades"][1]["exit_reason"] == "undecided"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 배경

미국장 전략 미동작 원인 분석 중 발견한 계산 편향입니다. `overseas_vbo_dryrun` 태스크는 정상 동작 중이며(20 거래일·414 신호 누적), 문제는 그 신호에 동봉되는 **same-day 청산 판정**에 있었습니다.

## 문제

일봉은 저가의 발생 **시각**을 담지 않습니다. 따라서 `당일저 <= 손절가`만으로는 그 저가가 진입(돌파) 전인지 후인지 알 수 없는데, 기존 모델은 이를 손절 확정으로 처리했습니다.

특히 손절가가 시가 이상인 돌파(`0.5×prev_range`가 손절폭 3%보다 큰 경우)는 **진입 전 가격대만으로 조건이 자동 성립**합니다:

```
entry = open + 0.5×prevRange,  stop = entry×0.97
0.5×prevRange / open >= 3%  →  stop >= open >= 당일저가  →  무조건 손절 판정
```

누적 저널 414건 실측이 이를 그대로 보여줍니다.

| 시가→목표 괴리 | n | 평균 | 승률 |
|---|---|---|---|
| <1% | 35 | +0.01% | 51% |
| 1–2% | 160 | −0.16% | 42% |
| 2–3% | 103 | −1.44% | 26% |
| 3–5% | 85 | **−3.00%** | **0%** |
| >=5% | 31 | **−3.00%** | **0%** |

괴리 3% 이상 116건이 예외 없이 정확히 −3.00% — 통계가 아니라 산술적 강제입니다. 전체 손절 비중 54%, 평균 −1.26%로 Phase 5 게이팅 근거가 하향 편향돼 있었습니다.

## 변경

- **dry-run 서비스 · Phase 2 백테스트**: `저 <= 손절가`를 `undecided`로 분류하고 비관(손절)·낙관(종가) bracket을 함께 산출. `realized_pct`/`net_return_pct`는 하위호환을 위해 비관값 유지, 신규 필드로 양끝 제공.
- **저널 snapshot에 당일 봉 OHLC 동봉** — 청산 모델을 사후에 재계산할 수 있게 함(기존 손절 건은 종가 미기록이라 재계산 불가였음).
- **analyze 스크립트**: `decidability` 섹션 추가(판정 가능 건 집계 + 비관·낙관 양끝). 구모델 `"stop"` 레코드는 판정 불가로 취급.

## 재집계 결과 (기존 414건)

```
decided 190 / undecided 224 (54.1%)
판정 가능 건 평균 +0.79%, 승률 59.5%
비관 전체 평균 −1.26%
```

참값은 −1.26% ~ +0.79% 사이에 열려 있습니다(판정 가능 건만의 평균은 "하락이 얕았던 날"만 남은 선택 편향이라 상한도 아닙니다). **현 데이터로는 canary go/no-go 판단 불가**가 정확한 결론이며, 이후 누적분부터 양끝이 모두 기록돼 실제 bracket이 좁혀집니다.

## 테스트

- 신규/변경 테스트 11건 (편향 회귀 테스트 2건 포함) — TDD로 실패 확인 후 구현
- `pytest tests/unit_test` 7363 passed
- `pytest tests/integration_test` 277 passed

## 남은 작업 (별도)

실주문 경로는 여전히 없습니다 — `StrategyFactory`가 `overseas_us`에서 자동전략을 비활성화하고, dry-run은 마감 30분 후 완성 일봉을 보는 사후 평가라 발사 대상이 없습니다. 장중 REST 폴링 기반 라이브(paper) 경로는 후속 과제입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
