### PR TITLE
Use market indices for regime timing

### DIFF
--- a/common/oneil_common_types.py
+++ b/common/oneil_common_types.py
@@ -19,8 +19,8 @@ class OneilUniverseConfig(BaseStrategyConfig):
     squeeze_tolerance: float = 1.2  # BB 폭이 20일 최소폭의 1.2배 이내
 
     # 마켓 타이밍
-    kosdaq_etf_code: str = "229200"   # KODEX 코스닥150
-    kospi_etf_code: str = "069500"    # KODEX 200
+    kosdaq_index_code: str = "1001"   # KOSDAQ
+    kospi_index_code: str = "0001"    # KOSPI
     market_ma_period: int = 20
     market_ma_rising_days: int = 3
     market_ma_min_net_change_pct: float = -0.10

--- a/scripts/run_inverse_etf_regime_backtest.py
+++ b/scripts/run_inverse_etf_regime_backtest.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List
 
 from strategies.inverse_etf_regime_backtest import InverseEtfRegimeBacktest
 
-# KOSPI 레짐 판정용 지수 ETF (MarketRegimeService.kospi_etf_code 와 일치)
+# 이 독립 백테스트에서 사용하는 KOSPI 추종 ETF
 INDEX_ETF_CODE = "069500"   # KODEX 200
 INVERSE_ETF_CODE = "114800"  # KODEX 인버스 (-1x)
 

--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -1,6 +1,6 @@
 """시장 국면 판정 서비스.
 
-KOSPI / KOSDAQ 지수 프록시 ETF의 단기 MA 추세를 4-state로 분류하고
+KOSPI / KOSDAQ 실제 지수의 단기 MA 추세를 4-state로 분류하고
 전략 게이트 및 성과 리포트가 공통으로 참조할 bull / bear / sideways 라벨로 매핑한다.
 
 분류 로직은 OneilUniverseService._check_etf_ma_rising() 에서 이관되었다.
@@ -27,8 +27,8 @@ _TREND_STATUS_TO_LABEL = {
 
 @dataclass
 class MarketRegimeConfig:
-    kospi_etf_code: str = "069500"   # KODEX 200
-    kosdaq_etf_code: str = "229200"  # KODEX 코스닥150
+    kospi_index_code: str = "0001"   # KOSPI
+    kosdaq_index_code: str = "1001"  # KOSDAQ
     ma_period: int = 20
     rising_days: int = 3
     min_net_change_pct: float = -0.10
@@ -51,7 +51,7 @@ class RegimeSnapshot:
 
 
 class MarketRegimeService:
-    """시장(KOSPI/KOSDAQ) ETF MA 추세를 분류한다."""
+    """시장(KOSPI/KOSDAQ) 지수 MA 추세를 분류한다."""
 
     def __init__(
         self,
@@ -67,11 +67,11 @@ class MarketRegimeService:
         self._cache: Dict[str, RegimeSnapshot] = {}
         self._cache_date: str = ""
 
-    def _etf_code_for(self, market: str) -> str:
+    def _index_code_for(self, market: str) -> str:
         if market == "KOSPI":
-            return self._cfg.kospi_etf_code
+            return self._cfg.kospi_index_code
         if market == "KOSDAQ":
-            return self._cfg.kosdaq_etf_code
+            return self._cfg.kosdaq_index_code
         raise ValueError(f"Unknown market: {market}")
 
     async def classify(self, market: str, logger: Optional[logging.Logger] = None) -> RegimeSnapshot:
@@ -116,13 +116,12 @@ class MarketRegimeService:
         as_of_date: Optional[str],
         logger: logging.Logger,
     ) -> RegimeSnapshot:
-        etf_code = self._etf_code_for(market)
+        index_code = self._index_code_for(market)
         period = self._cfg.ma_period
         days = self._cfg.rising_days
 
-        force_refresh = as_of_date is None
         query_end_date = as_of_date
-        if force_refresh:
+        if as_of_date is None:
             now = self._tm.get_current_kst_time()
             query_end_date = (
                 previous_trading_day_str(now)
@@ -130,11 +129,10 @@ class MarketRegimeService:
                 else now.strftime("%Y%m%d")
             )
 
-        ohlcv_resp = await self._sqs.get_recent_daily_ohlcv(
-            etf_code,
+        ohlcv_resp = await self._sqs.get_recent_daily_index_ohlcv(
+            index_code,
             limit=period + days + 5,
             end_date=query_end_date,
-            force_refresh=force_refresh,
         )
         ohlcv = ohlcv_resp.data if ohlcv_resp and ohlcv_resp.rt_cd == ErrorCode.SUCCESS.value else []
         if as_of_date:
@@ -157,7 +155,7 @@ class MarketRegimeService:
             logger.debug({
                 "event": "market_regime_check",
                 "market": market,
-                "etf_code": etf_code,
+                "index_code": index_code,
                 "is_rising": False,
                 "trend_status": snap.trend_status,
                 "fail_detail": snap.fail_detail,
@@ -217,7 +215,7 @@ class MarketRegimeService:
         logger.debug({
             "event": "market_regime_check",
             "market": market,
-            "etf_code": etf_code,
+            "index_code": index_code,
             "is_rising": is_rising,
             "trend_status": trend_status,
             "regime_label": snap.regime_label,

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -84,8 +84,8 @@ class OneilUniverseService:
         # 시장 국면 분류기 — 외부 주입이 우선이고, 없으면 기존 OneilUniverseConfig 값 기준으로 자체 생성
         if market_regime_service is None:
             regime_cfg = MarketRegimeConfig(
-                kospi_etf_code=self._cfg.kospi_etf_code,
-                kosdaq_etf_code=self._cfg.kosdaq_etf_code,
+                kospi_index_code=self._cfg.kospi_index_code,
+                kosdaq_index_code=self._cfg.kosdaq_index_code,
                 ma_period=self._cfg.market_ma_period,
                 rising_days=self._cfg.market_ma_rising_days,
                 min_net_change_pct=self._cfg.market_ma_min_net_change_pct,
@@ -1011,7 +1011,7 @@ class OneilUniverseService:
         logger = logger or self._logger
         notification_rows = []
         overall_level = NotificationLevel.INFO
-        for market, code in [("KOSDAQ", self._cfg.kosdaq_etf_code), ("KOSPI", self._cfg.kospi_etf_code)]:
+        for market, code in [("KOSDAQ", self._cfg.kosdaq_index_code), ("KOSPI", self._cfg.kospi_index_code)]:
             snap = await self._regime_svc.classify(market, logger=logger)
             is_rising = snap.is_rising
             self._market_timing_cache[market] = is_rising

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1,7 +1,7 @@
 # app/stock_query_service.py
 from __future__ import annotations
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
 from common.overseas_types import OverseasExchange
 from common.types import ErrorCode, ResCommonResponse, ResTopMarketCapApiItem, ResBasicStockInfo, \
@@ -1494,3 +1494,47 @@ class StockQueryService:
             "points": points,
         }
         return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="지수 조회 성공", data=data)
+
+    async def get_recent_daily_index_ohlcv(
+        self,
+        index_code: str,
+        limit: int,
+        end_date: Optional[str] = None,
+    ) -> ResCommonResponse:
+        """국내 대표 지수의 최근 일봉 종가를 과거→현재 순으로 반환한다.
+
+        마켓 타이밍처럼 지수 자체의 이동평균이 필요한 소비자를 위한 경로다.
+        KIS 기간별 지수 API는 최대 50개 봉을 반환하므로, 이 메서드는 그 범위 내의
+        짧은 lookback만 지원한다.
+        """
+        if index_code not in self.DOMESTIC_INDEX_NAMES:
+            msg = f"지원하지 않는 지수 코드: {index_code}"
+            self.logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+        if limit < 1:
+            msg = f"limit은 1 이상이어야 합니다: {limit}"
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+
+        try:
+            end_dt = datetime.strptime(end_date, "%Y%m%d") if end_date else self.market_clock.get_current_kst_time()
+        except ValueError:
+            msg = f"잘못된 end_date 형식: {end_date}"
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+
+        resp = await self.broker.inquire_daily_indexchartprice(
+            index_code,
+            start_date=(end_dt - timedelta(days=max(limit * 2 + 1, 5))).strftime("%Y%m%d"),
+            end_date=end_dt.strftime("%Y%m%d"),
+            period="D",
+        )
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return resp or ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="지수 시세 조회 실패", data=[])
+
+        rows = []
+        for candle in (resp.data or {}).get("candles") or []:
+            date = str(candle.get("stck_bsop_date") or "")
+            close = _to_float(candle.get("bstp_nmix_prpr"))
+            if date and close is not None:
+                rows.append({"date": date, "close": close})
+        rows.sort(key=lambda row: row["date"])
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="지수 일봉 조회 성공", data=rows[-limit:])

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -22,15 +22,15 @@ def _build_ohlcv(closes):
 
 def _make_service(closes, *, today="20260514"):
     sqs = MagicMock()
-    sqs.get_recent_daily_ohlcv = AsyncMock(
+    sqs.get_recent_daily_index_ohlcv = AsyncMock(
         return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_build_ohlcv(closes))
     )
     tm = MagicMock()
     tm.get_current_kst_time = MagicMock(return_value=datetime.strptime(today, "%Y%m%d"))
     tm.is_market_operating_hours = MagicMock(return_value=False)
     cfg = MarketRegimeConfig(
-        kospi_etf_code="069500",
-        kosdaq_etf_code="229200",
+        kospi_index_code="0001",
+        kosdaq_index_code="1001",
         ma_period=5,
         rising_days=2,
         min_net_change_pct=-0.10,
@@ -39,6 +39,20 @@ def _make_service(closes, *, today="20260514"):
     )
     svc = MarketRegimeService(stock_query_service=sqs, market_clock=tm, config=cfg)
     return svc, sqs
+
+
+@pytest.mark.asyncio
+async def test_classify_uses_actual_market_index_ohlcv():
+    """마켓 타이밍은 ETF 프록시가 아닌 KOSPI 지수(0001) 일봉으로 계산한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes)
+
+    await svc.classify("KOSPI")
+
+    sqs.get_recent_daily_index_ohlcv.assert_awaited_once_with(
+        "0001", limit=12, end_date="20260514"
+    )
+    sqs.get_recent_daily_ohlcv.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -65,11 +79,10 @@ async def test_classify_live_forces_fresh_closed_ohlcv():
 
     snap = await svc.classify("KOSPI")
 
-    sqs.get_recent_daily_ohlcv.assert_awaited_once_with(
-        "069500",
+    sqs.get_recent_daily_index_ohlcv.assert_awaited_once_with(
+        "0001",
         limit=12,
         end_date="20260513",
-        force_refresh=True,
     )
     assert snap.data_date == "20260108"
 
@@ -132,7 +145,7 @@ async def test_classify_caches_until_date_changes():
     await svc.classify("KOSPI")
     await svc.classify("KOSPI")
     await svc.classify("KOSPI")
-    assert sqs.get_recent_daily_ohlcv.call_count == 1
+    assert sqs.get_recent_daily_index_ohlcv.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -144,7 +157,7 @@ async def test_classify_recomputes_after_date_change():
     # 날짜 변경
     svc._tm.get_current_kst_time = MagicMock(return_value=datetime.strptime("20260515", "%Y%m%d"))
     await svc.classify("KOSPI")
-    assert sqs.get_recent_daily_ohlcv.call_count == 2
+    assert sqs.get_recent_daily_index_ohlcv.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_stock_query_index_chart.py
+++ b/tests/unit_test/services/test_stock_query_index_chart.py
@@ -1,4 +1,6 @@
 """홈 지수 패널용 국내 지수 조회 서비스 단위 테스트."""
+from datetime import datetime
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -164,3 +166,28 @@ async def test_index_chart_skips_unparsable_candles():
 
     assert result.rt_cd == ErrorCode.SUCCESS.value
     assert [p["date"] for p in result.data["points"]] == ["20260727"]
+
+
+@pytest.mark.asyncio
+async def test_recent_daily_index_ohlcv_normalizes_and_limits_candles():
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        candles=[
+            {"stck_bsop_date": "20260729", "bstp_nmix_prpr": "2660.10"},
+            {"stck_bsop_date": "20260728", "bstp_nmix_prpr": "2650.20"},
+            {"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2640.30"},
+        ],
+    ))
+    service = _service(broker)
+    service.market_clock.get_current_kst_time.return_value = datetime(2026, 7, 30)
+
+    result = await service.get_recent_daily_index_ohlcv("0001", limit=2, end_date="20260729")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data == [
+        {"date": "20260728", "close": 2650.20},
+        {"date": "20260729", "close": 2660.10},
+    ]
+    assert broker.inquire_daily_indexchartprice.await_args.kwargs == {
+        "start_date": "20260724", "end_date": "20260729", "period": "D"
+    }


### PR DESCRIPTION
## What changed
- Switched market-regime MA calculations from KODEX 200/KODEX 코스닥150 ETF proxies to KOSPI (`0001`) and KOSDAQ (`1001`) index daily candles.
- Added a normalized recent-index-OHLCV query path and updated market-timing notification codes.
- Added regression tests for the index data source and candle normalization.

## Why
The notification labelled KOSPI/KOSDAQ while measuring ETF proxies, which can diverge from the actual index trend and produced misleading market-timing decisions.

## Validation
- `python -m pytest tests/unit_test -v` — 7,365 passed
- `python -m pytest tests/integration_test -v` — 277 passed