### PR TITLE
Fix favorite price alert deduplication

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -17,7 +17,7 @@ from utils.strategy_state_io import StrategyStateIO
 
 
 class FavoritePriceAlertService:
-    """관심종목이 전일대비율 5% 단위 구간을 새로 밟을 때 알림을 발행한다."""
+    """관심종목의 당일 등락률 최고 상승·최저 하락 임계치를 알린다."""
 
     def __init__(
         self,
@@ -46,7 +46,8 @@ class FavoritePriceAlertService:
         self._logger = logger or logging.getLogger(__name__)
         self._favorite_codes: set[str] = set()
         self._favorite_cache_ts: float = 0.0
-        self._last_alert_bucket: dict[str, int] = {}
+        self._highest_positive_alert_bucket: dict[str, int] = {}
+        self._lowest_negative_alert_bucket: dict[str, int] = {}
         self._upper_limit_alerted_codes: set[str] = set()
 
     async def add_favorite(self, code: str) -> None:
@@ -62,7 +63,8 @@ class FavoritePriceAlertService:
             return
         await self._load_alert_state_for_today()
         self._favorite_codes.discard(normalized)
-        self._last_alert_bucket.pop(normalized, None)
+        self._highest_positive_alert_bucket.pop(normalized, None)
+        self._lowest_negative_alert_bucket.pop(normalized, None)
         self._upper_limit_alerted_codes.discard(normalized)
         await self._save_alert_state()
 
@@ -105,10 +107,16 @@ class FavoritePriceAlertService:
         bucket = self._rate_bucket(rate_value)
         if bucket == 0:
             return False
-        if self._last_alert_bucket.get(normalized) == bucket:
-            return False
-
-        self._last_alert_bucket[normalized] = bucket
+        if bucket > 0:
+            highest_bucket = self._highest_positive_alert_bucket.get(normalized, 0)
+            if bucket <= highest_bucket:
+                return False
+            self._highest_positive_alert_bucket[normalized] = bucket
+        else:
+            lowest_bucket = self._lowest_negative_alert_bucket.get(normalized, 0)
+            if bucket >= lowest_bucket:
+                return False
+            self._lowest_negative_alert_bucket[normalized] = bucket
         await self._save_alert_state()
 
         threshold_pct = int(bucket * self._threshold_step_pct)
@@ -181,12 +189,13 @@ class FavoritePriceAlertService:
         self._favorite_cache_ts = now
 
     async def _load_alert_state_for_today(self) -> None:
-        """당일 마지막 알림 임계치를 복원한다. 날짜가 바뀌면 이전 상태는 버린다."""
+        """당일 알림 임계치를 복원한다. 날짜가 바뀌면 이전 상태는 버린다."""
         today = self._today_provider()
         if self._state_date == today:
             return
 
-        self._last_alert_bucket.clear()
+        self._highest_positive_alert_bucket.clear()
+        self._lowest_negative_alert_bucket.clear()
         self._upper_limit_alerted_codes.clear()
         self._state_date = today
         if not self._state_file:
@@ -200,13 +209,25 @@ class FavoritePriceAlertService:
         if not isinstance(data, dict) or data.get("date") != today:
             return
 
-        buckets = data.get("last_alert_bucket", {})
-        if isinstance(buckets, dict):
+        for field_name, target in (
+            ("highest_positive_alert_bucket", self._highest_positive_alert_bucket),
+            ("lowest_negative_alert_bucket", self._lowest_negative_alert_bucket),
+            ("last_alert_bucket", None),
+        ):
+            buckets = data.get(field_name, {})
+            if not isinstance(buckets, dict):
+                continue
             for code, bucket in buckets.items():
                 normalized = self._normalize_code(code)
                 try:
                     if normalized:
-                        self._last_alert_bucket[normalized] = int(bucket)
+                        bucket_value = int(bucket)
+                        if target is not None:
+                            target[normalized] = bucket_value
+                        elif bucket_value > 0:
+                            self._highest_positive_alert_bucket.setdefault(normalized, bucket_value)
+                        elif bucket_value < 0:
+                            self._lowest_negative_alert_bucket.setdefault(normalized, bucket_value)
                 except (TypeError, ValueError):
                     continue
         codes = data.get("upper_limit_alerted_codes", [])
@@ -220,7 +241,8 @@ class FavoritePriceAlertService:
             return
         payload = {
             "date": self._state_date,
-            "last_alert_bucket": self._last_alert_bucket,
+            "highest_positive_alert_bucket": self._highest_positive_alert_bucket,
+            "lowest_negative_alert_bucket": self._lowest_negative_alert_bucket,
             "upper_limit_alerted_codes": sorted(self._upper_limit_alerted_codes),
         }
         try:

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -94,8 +94,8 @@ async def test_does_not_repeat_five_percent_after_retracing_without_another_aler
 
 
 @pytest.mark.asyncio
-async def test_realerts_five_percent_after_ten_percent_alert():
-    """+10% 알림이 끼어들면 +5% 재진입은 새 등락 단계로 한 번 알린다."""
+async def test_does_not_alert_lower_positive_threshold_after_ten_percent_alert():
+    """+10% 도달 뒤 +5% 구간으로 내려와도 상승 알림을 재발행하지 않는다."""
     repo = MagicMock()
     repo.get_all = AsyncMock(return_value=["005930"])
     notifications = MagicMock()
@@ -109,7 +109,26 @@ async def test_realerts_five_percent_after_ten_percent_alert():
     assert [
         call.kwargs["metadata"]["threshold_pct"]
         for call in notifications.emit.await_args_list
-    ] == [5, 10, 5]
+    ] == [5, 10]
+
+
+@pytest.mark.asyncio
+async def test_does_not_chatter_between_ten_and_five_percent_thresholds():
+    """+10% 경계 부근의 틱 변동은 +5% 또는 +10% 알림을 반복하지 않는다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["009150"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("009150", price="1304000", rate="10.04")
+    await svc.handle_price_tick("009150", price="1303000", rate="9.96")
+    await svc.handle_price_tick("009150", price="1304000", rate="10.04")
+
+    assert [
+        call.kwargs["metadata"]["threshold_pct"]
+        for call in notifications.emit.await_args_list
+    ] == [10]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 변경 사항
- 관심종목 등락률 알림이 당일 최고 상승·최저 하락 임계치를 기준으로 한 번만 발송되도록 수정했습니다.
- +10% 부근의 작은 변동으로 +5%와 +10% 알림이 반복되는 사례를 막는 회귀 테스트를 추가했습니다.
- 기존 상태 파일의 last_alert_bucket 값도 읽어 이전 실행 상태와 호환됩니다.

## 원인 및 영향
기존에는 직전 알림 구간과 값이 달라지기만 하면 알림을 보냈습니다. 따라서 +10.04% → +9.96% → +10.04%가 각각 +10%, +5%, +10% 알림을 만들었습니다. 이제 하락으로 낮은 상승 구간에 진입해도 상승 알림을 보내지 않습니다.

## 검증
- pytest tests/unit_test -v (7,366 passed)
- pytest tests/integration_test -v (277 passed)