### PR TITLE
feat: add market timing recovery guidance

### DIFF
--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -48,6 +48,9 @@ class RegimeSnapshot:
     ma_values: List[float] = field(default_factory=list)
     fail_detail: str = ""
     data_date: str = ""       # 판정에 사용한 마지막 확정 일봉 날짜 (YYYYMMDD)
+    recovery_earliest_days: Optional[int] = None  # 기존 급락 MA가 판정창에서 빠지는 최소 거래일
+    recovery_target_ma: Optional[float] = None    # 해당 시점 3일 순변화 조건의 MA(20) 하한
+    next_close_floor: Optional[float] = None      # 다음 MA(20)의 hard decline 방지 종가 하한
 
 
 class MarketRegimeService:
@@ -200,6 +203,29 @@ class MarketRegimeService:
         elif max_daily_drop_pct < self._cfg.daily_dip_tolerance_pct:
             trend_status = "uptrend_under_pressure"
 
+        recovery_earliest_days: Optional[int] = None
+        recovery_target_ma: Optional[float] = None
+        next_close_floor: Optional[float] = None
+        if not is_rising:
+            # 다음 MA는 가장 오래된 20일 창 종가가 빠지고 다음 확정 종가가 들어온다.
+            # 하한은 새 hard decline을 만들지 않기 위한 값이며, 기존 급락은 판정창에서
+            # 자연스럽게 빠질 때까지 별도 거래일이 필요하다.
+            current_ma = ma_values[-1]
+            outgoing_close = closes[-period]
+            allowed_next_ma = current_ma * (1 + self._cfg.hard_decline_pct / 100)
+            next_close_floor = outgoing_close + period * (allowed_next_ma - current_ma)
+
+            hard_decline_indexes = [
+                index + 1
+                for index, change in enumerate(daily_changes_pct)
+                if change < self._cfg.hard_decline_pct
+            ]
+            recovery_earliest_days = max(hard_decline_indexes, default=1)
+            # recovery_earliest_days 뒤의 4개 MA 창은 기존 MA 중 해당 index부터
+            # 시작한다. 마지막 MA가 이 값 이상이면 3일 순변화 조건을 충족한다.
+            recovery_reference_ma = ma_values[recovery_earliest_days]
+            recovery_target_ma = recovery_reference_ma * (1 + self._cfg.min_net_change_pct / 100)
+
         snap = RegimeSnapshot(
             market=market,
             trend_status=trend_status,
@@ -211,6 +237,9 @@ class MarketRegimeService:
             ma_values=[round(v, 2) for v in ma_values],
             fail_detail=fail_detail,
             data_date=data_date,
+            recovery_earliest_days=recovery_earliest_days,
+            recovery_target_ma=round(recovery_target_ma, 2) if recovery_target_ma is not None else None,
+            next_close_floor=round(next_close_floor, 2) if next_close_floor is not None else None,
         )
         logger.debug({
             "event": "market_regime_check",

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1035,6 +1035,15 @@ class OneilUniverseService:
                 if not is_rising and snap.fail_detail:
                     msg += f"• 사유: {snap.fail_detail}\n"
                 msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"
+                if not is_rising and snap.recovery_earliest_days is not None:
+                    msg += f"\n• 최초 전환 가능: 최소 {snap.recovery_earliest_days}거래일 후 (이후 종가 조건 충족 시)"
+                if not is_rising and snap.recovery_target_ma is not None:
+                    msg += f"\n• 전환 시 MA({self._cfg.market_ma_period}) 목표: ≥ {snap.recovery_target_ma:,.2f}"
+                if not is_rising and snap.next_close_floor is not None:
+                    msg += (
+                        f"\n• 다음 종가 하한: {snap.next_close_floor:,.2f} "
+                        f"(새 MA 급락 -{abs(self._cfg.market_ma_hard_decline_pct):.2f}% 방지)"
+                    )
                 notification_rows.append(msg)
 
         if self._notification_service and notification_rows:

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -100,6 +100,22 @@ async def test_classify_hard_decline_returns_bear():
 
 
 @pytest.mark.asyncio
+async def test_classify_hard_decline_includes_recovery_price_guidance():
+    """급락 MA가 판정창에서 빠지는 최초 시점과 다음 종가 하한을 안내한다."""
+    closes = [200, 200, 200, 200, 200, 200, 200, 150]
+    svc, _ = _make_service(closes)
+
+    snap = await svc.classify("KOSPI")
+
+    # MA(5): 200 -> 200 -> 190. 마지막 hard decline(idx=2)은 2거래일 후 소멸한다.
+    assert snap.recovery_earliest_days == 2
+    assert snap.recovery_target_ma == 189.81  # 190 * (1 - 0.10%)
+    # 다음 MA가 -0.50%보다 더 급락하지 않는 종가 하한:
+    # 200 + 5 * (190 * 0.995 - 190) = 195.25
+    assert snap.next_close_floor == 195.25
+
+
+@pytest.mark.asyncio
 async def test_classify_weak_trend_returns_bear():
     """MA 순증감(net)이 min_net_change_pct(-0.10%) 미만이면 weak_trend → bear."""
     # 천천히 감소해 max_daily_drop_pct 은 hard_decline(-0.5%) 보다 크고

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1778,9 +1778,13 @@ async def test_update_market_timing_emits_notifications(mock_deps):
             ma_values=ma_values, fail_detail=fail, data_date="20260514",
         )
 
+    failed_snap = _snap("KOSPI", False, [3.0, 2.0, 1.0], fail="MA decline")
+    failed_snap.recovery_earliest_days = 2
+    failed_snap.recovery_target_ma = 1.5
+    failed_snap.next_close_floor = 1234.5
     service._regime_svc.classify = AsyncMock(side_effect=[
         _snap("KOSDAQ", True, [1.0, 2.0, 3.0]),
-        _snap("KOSPI", False, [3.0, 2.0, 1.0], fail="MA decline"),
+        failed_snap,
     ])
     await service._update_market_timing(caller="tester", logger=logger)
 
@@ -1798,6 +1802,8 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     assert "KOSPI" in call_kwargs["message"]
     assert call_kwargs["message"].count("데이터 기준일: 20260514") == 2
     assert "MA decline" in call_kwargs["message"]
+    assert "최초 전환 가능: 최소 2거래일 후" in call_kwargs["message"]
+    assert "다음 종가 하한: 1,234.50" in call_kwargs["message"]
 
 
 def test_compute_rs_scores_rating_mode(mock_deps):


### PR DESCRIPTION
## Summary\n- show the earliest possible recovery window for failed market timing\n- show the MA target and next-close floor in the alert\n- cover recovery calculations and alert rendering\n\n## Validation\n- pytest tests/unit_test -v\n- pytest tests/integration_test -v