### PR TITLE
Start alert queue before price subscriptions

### DIFF
--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -414,6 +414,7 @@ class TestIndicatorsPaper:
 class TestEnvironmentPaper:
     def test_change_to_real_environment(self, paper_client, mock_paper_ctx):
         """모의 → 실전 환경 전환 성공."""
+        mock_paper_ctx.start_background_tasks_and_wait = AsyncMock()
         from view.web.routes import stock
         stock._status_cache = {"env_type": "모의투자", "current_time": "cached"}
         mock_paper_ctx.get_env_type.return_value = "실전투자"
@@ -426,7 +427,9 @@ class TestEnvironmentPaper:
         assert body["env_type"] == "실전투자"
         mock_paper_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
         mock_paper_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-        mock_paper_ctx.start_background_tasks.assert_called_once_with()
+        mock_paper_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+            schedule_price_subscriptions=False
+        )
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, paper_client, mock_paper_ctx):

--- a/tests/integration_test/test_it_web_api_real.py
+++ b/tests/integration_test/test_it_web_api_real.py
@@ -379,6 +379,7 @@ class TestIndicatorsReal:
 class TestEnvironmentReal:
     def test_change_to_paper_environment(self, real_client, mock_real_ctx):
         """실전 → 모의 환경 전환 성공."""
+        mock_real_ctx.start_background_tasks_and_wait = AsyncMock()
         from view.web.routes import stock
         stock._status_cache = {"env_type": "실전투자", "current_time": "cached"}
         mock_real_ctx.get_env_type.return_value = "모의투자"
@@ -391,7 +392,9 @@ class TestEnvironmentReal:
         assert body["env_type"] == "모의투자"
         mock_real_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
         mock_real_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-        mock_real_ctx.start_background_tasks.assert_called_once_with()
+        mock_real_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+            schedule_price_subscriptions=False
+        )
         assert stock._status_cache is None
 
     def test_environment_change_failure(self, real_client, mock_real_ctx):

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -86,6 +86,7 @@ def fake_web_ctx():
     ctx.ensure_strategy_states_loaded = AsyncMock()
     ctx._initialize_price_subscriptions = AsyncMock()
     ctx.start_background_tasks = MagicMock()
+    ctx.start_background_tasks_and_wait = AsyncMock()
     ctx.shutdown = AsyncMock()
 
     ctx.scheduler = MagicMock()
@@ -171,7 +172,9 @@ def test_web_main_lifespan_initializes_and_shutdowns_context(fake_web_ctx, mocke
         fake_web_ctx.order_execution_service.restore_state_from_broker.assert_awaited_once_with()
         fake_web_ctx.order_execution_service.reconcile_orders_with_broker.assert_awaited_once_with()
         fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-        fake_web_ctx.start_background_tasks.assert_called_once_with()
+        fake_web_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+            schedule_price_subscriptions=False
+        )
         assert api_common._ctx is fake_web_ctx
 
     fake_web_ctx.shutdown.assert_awaited_once_with()
@@ -371,7 +374,7 @@ def test_real_app_environment_switch_requires_real_confirmation_and_restarts_ser
 ):
     fake_web_ctx.initialize_services.reset_mock()
     fake_web_ctx._initialize_price_subscriptions.reset_mock()
-    fake_web_ctx.start_background_tasks.reset_mock()
+    fake_web_ctx.start_background_tasks_and_wait.reset_mock()
     fake_web_ctx.get_env_type.return_value = "실전투자"
 
     blocked = client_with_fake_lifespan.post(
@@ -390,4 +393,6 @@ def test_real_app_environment_switch_requires_real_confirmation_and_restarts_ser
     assert allowed.json() == {"success": True, "env_type": "실전투자"}
     fake_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
     fake_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-    fake_web_ctx.start_background_tasks.assert_called_once_with()
+    fake_web_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+        schedule_price_subscriptions=False
+    )

--- a/tests/unit_test/view/test_web_main.py
+++ b/tests/unit_test/view/test_web_main.py
@@ -41,6 +41,7 @@ def mock_web_app_context_cls():
         mock_instance.scheduler.stop = AsyncMock()
         mock_instance._initialize_price_subscriptions = AsyncMock()
         mock_instance.start_background_tasks = MagicMock()
+        mock_instance.start_background_tasks_and_wait = AsyncMock()
         mock_instance.shutdown = AsyncMock()
         oes = MagicMock()
         oes.restore_state_from_broker = AsyncMock(return_value=0)
@@ -73,7 +74,9 @@ async def test_lifespan_startup_shutdown(mock_web_app_context_cls, mock_web_api_
         # lifespan 에서 직접 await 하지 않는다.
         mock_ctx.scheduler.restore_state.assert_not_awaited()
         mock_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-        mock_ctx.start_background_tasks.assert_called_once_with()
+        mock_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+            schedule_price_subscriptions=False
+        )
     
     # Shutdown checks
     mock_ctx.shutdown.assert_awaited_once()

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -473,6 +473,7 @@ async def test_get_moving_average(web_client, mock_web_ctx):
 async def test_change_environment(web_client, mock_web_ctx):
     """POST /api/environment 엔드포인트 테스트"""
     mock_web_ctx.initialize_services = AsyncMock(return_value=True)
+    mock_web_ctx.start_background_tasks_and_wait = AsyncMock()
     mock_web_ctx.get_env_type.return_value = "실전투자"
 
     response = web_client.post(
@@ -484,7 +485,9 @@ async def test_change_environment(web_client, mock_web_ctx):
     assert response.json()["env_type"] == "실전투자"
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=False)
     mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-    mock_web_ctx.start_background_tasks.assert_called_once_with()
+    mock_web_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+        schedule_price_subscriptions=False
+    )
 
 
 @pytest.mark.asyncio
@@ -500,6 +503,7 @@ async def test_change_environment_to_real_requires_confirmation(web_client, mock
 @pytest.mark.asyncio
 async def test_change_environment_to_paper_does_not_require_confirmation(web_client, mock_web_ctx):
     mock_web_ctx.initialize_services = AsyncMock(return_value=True)
+    mock_web_ctx.start_background_tasks_and_wait = AsyncMock()
     mock_web_ctx.get_env_type.return_value = "paper"
 
     response = web_client.post("/api/environment", json={"is_paper": True})
@@ -507,7 +511,9 @@ async def test_change_environment_to_paper_does_not_require_confirmation(web_cli
     assert response.status_code == 200
     mock_web_ctx.initialize_services.assert_awaited_once_with(is_paper_trading=True)
     mock_web_ctx._initialize_price_subscriptions.assert_awaited_once_with(rebalance=False)
-    mock_web_ctx.start_background_tasks.assert_called_once_with()
+    mock_web_ctx.start_background_tasks_and_wait.assert_awaited_once_with(
+        schedule_price_subscriptions=False
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -617,6 +617,29 @@ async def test_start_background_tasks_with_restore(mock_deps):
 
 
 @pytest.mark.asyncio
+async def test_start_background_tasks_and_wait_starts_queue_before_price_subscriptions(mock_deps):
+    """초기 관심종목 가격 조회보다 외부 알림 큐가 먼저 준비되어야 한다."""
+    ctx = WebAppContext(None)
+    ctx.streaming_service = MagicMock()
+    ctx.background_scheduler = MagicMock()
+    ctx.price_subscription_service = MagicMock()
+    call_order = []
+
+    async def start_all():
+        call_order.append("background")
+
+    async def initialize_subscriptions(*, rebalance=True):
+        call_order.append("subscriptions")
+
+    ctx.background_scheduler.start_all = AsyncMock(side_effect=start_all)
+    ctx._initialize_price_subscriptions = AsyncMock(side_effect=initialize_subscriptions)
+
+    await ctx.start_background_tasks_and_wait()
+
+    assert call_order == ["background", "subscriptions"]
+
+
+@pytest.mark.asyncio
 async def test_start_background_tasks_manual_repeat_is_guarded(mock_deps):
     """웹 start hook/수동 start 연타가 들어와도 실제 task start는 한 번만 수행된다."""
     from scheduler.background_scheduler import BackgroundScheduler

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -622,6 +622,6 @@ async def change_environment(req: EnvironmentRequest):
     _status_cache_ts = 0.0
     if not success:
         raise HTTPException(status_code=500, detail="환경 전환 실패 (토큰 발급 오류)")
+    await ctx.start_background_tasks_and_wait(schedule_price_subscriptions=False)
     await ctx._initialize_price_subscriptions(rebalance=False)
-    ctx.start_background_tasks()
     return {"success": True, "env_type": ctx.get_env_type()}

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -467,6 +467,25 @@ class WebAppContext:
         if schedule_price_subscriptions:
             self._schedule_price_subscription_initialization()
 
+    async def start_background_tasks_and_wait(
+        self, *, schedule_price_subscriptions: bool = True
+    ) -> None:
+        """백그라운드 태스크를 기동 완료한 뒤 초기 가격 구독을 시작한다."""
+        from view.web.deployment_policy import is_demo_mode, is_public_mode
+
+        if is_public_mode(self) or is_demo_mode(self):
+            self.logger.info("공개/데모 모드: 백그라운드 태스크 시작을 건너뜁니다.")
+            return
+
+        if self.streaming_service:
+            self.streaming_service._callback = self._web_realtime_callback
+
+        if self.background_scheduler:
+            await self.background_scheduler.start_all()
+
+        if schedule_price_subscriptions:
+            await self._initialize_price_subscriptions()
+
     def _schedule_price_subscription_initialization(self):
         """초기 가격 구독 task를 background lifecycle에 맞춰 시작한다."""
         from view.web.bootstrap.runtime_mode import RuntimeMode

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -135,13 +135,13 @@ async def lifespan(app: FastAPI):
         await ctx.order_execution_service.restore_state_from_broker()
         await ctx.order_execution_service.reconcile_orders_with_broker()
 
+    # 외부 알림 큐를 먼저 기동해야 초기 관심종목 가격 평가가 텔레그램 전송 전에 유실되지 않는다.
+    await ctx.start_background_tasks_and_wait(schedule_price_subscriptions=False)
+
     # 관심종목 구독 의도는 기동 중 등록하고 실제 WebSocket 재조정은 백그라운드에서 수행한다.
     from view.web.deployment_policy import is_demo_mode, is_public_mode
     if not (is_public_mode(ctx) or is_demo_mode(ctx)):
         await ctx._initialize_price_subscriptions(rebalance=False)
-
-    # 백그라운드 태스크 시작 — StrategySchedulerTaskAdapter 가 restore_state() 호출
-    ctx.start_background_tasks()
 
     print("=== 웹 서비스 초기화 완료 ===")
     yield


### PR DESCRIPTION
## 변경 사항
- 웹 기동과 환경 전환에서 외부 알림 큐가 완전히 시작된 뒤 관심종목 초기 가격 구독을 시작하도록 순서를 보장합니다.
- 초기 가격 평가에서 감지된 관심종목 알림이 텔레그램 처리 전 유실되지 않도록 했습니다.

## 검증
- pytest tests/unit_test -v (7,367 passed)
- pytest tests/integration_test -v (277 passed)