### PR TITLE
fix: deliver KRX sidecar alerts

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -785,16 +785,29 @@ class KoreaInvestWebSocketAPI:
         return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
 
     async def subscribe_market_status(self, stock_code: str):
-        """국내주식 장운영정보(H0UNMKO0)를 구독합니다."""
-        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
-        self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 요청 ({tr_id})...")
-        return await self.send_realtime_request(tr_id, stock_code, tr_type="1")
+        """KRX 및 통합 장운영정보 채널을 함께 구독합니다."""
+        results = []
+        for tr_id in self._get_market_status_subscription_tr_ids():
+            self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 요청 ({tr_id})...")
+            results.append(await self.send_realtime_request(tr_id, stock_code, tr_type="1"))
+        return all(results)
 
     async def unsubscribe_market_status(self, stock_code: str):
-        """국내주식 장운영정보(H0UNMKO0) 구독을 해지합니다."""
-        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
-        self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 해지 요청 ({tr_id})...")
-        return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
+        """KRX 및 통합 장운영정보 채널 구독을 해지합니다."""
+        results = []
+        for tr_id in self._get_market_status_subscription_tr_ids():
+            self._logger.info(f"[장운영정보] 종목 {stock_code} 구독 해지 요청 ({tr_id})...")
+            results.append(await self.send_realtime_request(tr_id, stock_code, tr_type="2"))
+        return all(results)
+
+    def _get_market_status_subscription_tr_ids(self) -> tuple[str, ...]:
+        """KRX 우선 채널과 통합 채널을 중복 없이 반환한다."""
+        websocket_config = self._env.active_config['tr_ids']['websocket']
+        tr_ids = (
+            websocket_config.get('market_status', 'H0STMKO0'),
+            websocket_config.get('unified_market_status', 'H0UNMKO0'),
+        )
+        return tuple(dict.fromkeys(tr_ids))
 
     async def _resubscribe_all(self):
         """재연결 시 기존 구독 항목들을 다시 구독 요청합니다."""
@@ -986,9 +999,11 @@ class KoreaInvestWebSocketAPI:
         return await self.wait_for_subscription_ack(tr_id, stock_code, timeout)
 
     async def wait_for_market_status_ack(self, stock_code, timeout: float = None) -> bool:
-        """장운영정보(H0UNMKO0) 구독 ACK 확정을 기다린다."""
-        tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_market_status', 'H0UNMKO0')
-        return await self.wait_for_subscription_ack(tr_id, stock_code, timeout)
+        """KRX 및 통합 장운영정보 채널의 구독 ACK 확정을 기다린다."""
+        results = []
+        for tr_id in self._get_market_status_subscription_tr_ids():
+            results.append(await self.wait_for_subscription_ack(tr_id, stock_code, timeout))
+        return all(results)
 
     async def subscribe_realtime_price(self, stock_code):
         """실시간 주식체결 데이터(현재가)를 구독합니다."""

--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -38,7 +38,7 @@ class MarketStatusAlertService:
         direction = self._classify_direction(reason)
         direction_key = f":{direction}" if direction else ""
         dedup_key = f"market_status:{event_type}{direction_key}:{exchange}:{code}"
-        severity = "critical" if event_type == "circuit_breaker" else "warning"
+        severity = "critical" if event_type == "circuit_breaker" else "error"
         event_name = "서킷브레이커" if event_type == "circuit_breaker" else "사이드카"
         title = f"{self._direction_label(direction)} {event_name} 감지".strip()
         message = f"{exchange} {code}: {reason or '장운영정보 특수 상태 감지'}"
@@ -67,7 +67,10 @@ class MarketStatusAlertService:
         if self._notification_service is not None:
             from services.notification_service import NotificationCategory, NotificationLevel
 
-            level = NotificationLevel.CRITICAL if severity == "critical" else NotificationLevel.WARNING
+            level = {
+                "critical": NotificationLevel.CRITICAL,
+                "error": NotificationLevel.ERROR,
+            }.get(severity, NotificationLevel.WARNING)
             await self._notification_service.emit(
                 NotificationCategory.SYSTEM,
                 level,
@@ -86,7 +89,7 @@ class MarketStatusAlertService:
             key = f"market_index:move_5:{direction}:{index_code}"
             expected_keys.add(key)
             await self._report_index_alert(
-                key=key, severity="warning",
+                key=key, severity="error",
                 title=f"{index_name} {self._direction_label(direction)} 5% 이상 등락",
                 index_code=index_code, index_name=index_name, change_rate=change_rate,
                 threshold_pct=5.0, event_type="move_5",
@@ -127,7 +130,10 @@ class MarketStatusAlertService:
         if self._notification_service is not None:
             from services.notification_service import NotificationCategory, NotificationLevel
 
-            level = NotificationLevel.CRITICAL if severity == "critical" else NotificationLevel.WARNING
+            level = {
+                "critical": NotificationLevel.CRITICAL,
+                "error": NotificationLevel.ERROR,
+            }.get(severity, NotificationLevel.WARNING)
             await self._notification_service.emit(
                 NotificationCategory.SYSTEM, level, title, message, metadata=metadata,
             )

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -2792,6 +2792,20 @@ def test_handle_websocket_message_market_status_success(websocket_api_instance):
     assert result["data"]["거래정지사유내용"] == "사이드카 발동"
 
 
+def test_handle_websocket_message_krx_market_status_success(websocket_api_instance):
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+    data_str = "000000^N^매수 사이드카 발동^2^0^0^0^00^0^0^KOSPI"
+
+    api._handle_websocket_message(f"0|H0STMKO0|000000|{data_str}")
+
+    result = api.on_realtime_message_callback.call_args.args[0]
+    assert result["type"] == "market_status"
+    assert result["tr_id"] == "H0STMKO0"
+    assert result["data"]["유가증권단축종목코드"] == "000000"
+    assert result["data"]["거래정지사유내용"] == "매수 사이드카 발동"
+
+
 def test_is_receive_alive_true_and_false(websocket_api_instance):
     api = websocket_api_instance
     done_task = MagicMock()
@@ -2865,10 +2879,14 @@ async def test_subscribe_unsubscribe_wrappers(websocket_api_instance):
     assert mock_send.await_args_list[2].kwargs == {"tr_type": "1"}
     assert mock_send.await_args_list[3].args == ("H0UNCNT0", "005930")
     assert mock_send.await_args_list[3].kwargs == {"tr_type": "2"}
-    assert mock_send.await_args_list[4].args == ("H0UNMKO0", "005930")
+    assert mock_send.await_args_list[4].args == ("H0STMKO0", "005930")
     assert mock_send.await_args_list[4].kwargs == {"tr_type": "1"}
     assert mock_send.await_args_list[5].args == ("H0UNMKO0", "005930")
-    assert mock_send.await_args_list[5].kwargs == {"tr_type": "2"}
+    assert mock_send.await_args_list[5].kwargs == {"tr_type": "1"}
+    assert mock_send.await_args_list[6].args == ("H0STMKO0", "005930")
+    assert mock_send.await_args_list[6].kwargs == {"tr_type": "2"}
+    assert mock_send.await_args_list[7].args == ("H0UNMKO0", "005930")
+    assert mock_send.await_args_list[7].kwargs == {"tr_type": "2"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -31,7 +31,7 @@ async def test_market_status_alert_service_reports_circuit_breaker():
 
 
 @pytest.mark.asyncio
-async def test_market_status_alert_service_reports_sidecar_warning():
+async def test_market_status_alert_service_reports_sidecar_as_error_for_immediate_delivery():
     operator_alert = AsyncMock()
     service = MarketStatusAlertService(
         operator_alert_service=operator_alert,
@@ -48,7 +48,7 @@ async def test_market_status_alert_service_reports_sidecar_warning():
     args = operator_alert.report.await_args.args
     kwargs = operator_alert.report.await_args.kwargs
     assert args[1] == "market_status:sidecar:sell:KRX:005930"
-    assert args[2] == "warning"
+    assert args[2] == "error"
     assert kwargs["metadata"]["telegram_channel"] == "report"
 
 
@@ -70,7 +70,7 @@ async def test_market_status_alert_service_reports_kosdaq_sidecar_when_reason_us
 
     args = operator_alert.report.await_args.args
     assert args[1] == "market_status:sidecar:buy:KOSDAQ:000000"
-    assert args[2] == "warning"
+    assert args[2] == "error"
     assert args[3] == "매수 사이드카 감지"
 
 
@@ -158,7 +158,7 @@ async def test_market_status_alert_service_reports_index_thresholds_and_resolves
 
     assert operator_alert.report.await_count == 2
     assert operator_alert.report.await_args_list[0].args[1] == "market_index:move_5:down:0001"
-    assert operator_alert.report.await_args_list[0].args[2] == "warning"
+    assert operator_alert.report.await_args_list[0].args[2] == "error"
     assert operator_alert.report.await_args_list[1].args[1] == "market_index:fall_8:0001"
     assert operator_alert.report.await_args_list[1].args[2] == "critical"
 


### PR DESCRIPTION
## 변경 사항
- KRX 장운영정보(H0STMKO0)와 통합 채널(H0UNMKO0)을 함께 구독하고 ACK를 확인합니다.
- 사이드카와 코스피·코스닥 ±5% 시장 경고를 Telegram 전송 정책에 맞는 error 등급으로 올립니다.
- KRX 장운영정보 프레임과 양 채널 구독을 테스트로 보장합니다.

## 원인
기존에는 통합 장운영정보 채널만 구독했고, 사이드카/±5% 경고가 warning 등급이라 기본 SYSTEM Telegram 정책(error, critical)에서 필터링됐습니다.

## 검증
- pytest tests/unit_test -v (7,368 passed)
- pytest tests/integration_test -v (277 passed)