### PR TITLE
Show market timing close targets

### DIFF
--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -48,8 +48,10 @@ class RegimeSnapshot:
     ma_values: List[float] = field(default_factory=list)
     fail_detail: str = ""
     data_date: str = ""       # 판정에 사용한 마지막 확정 일봉 날짜 (YYYYMMDD)
+    current_close: Optional[float] = None  # 판정 기준일 지수 종가
     recovery_earliest_days: Optional[int] = None  # 기존 급락 MA가 판정창에서 빠지는 최소 거래일
     recovery_target_ma: Optional[float] = None    # 해당 시점 3일 순변화 조건의 MA(20) 하한
+    recovery_target_close: Optional[float] = None  # 최초 전환일 종가 목표(그전 종가 현재 수준 유지 가정)
     next_close_floor: Optional[float] = None      # 다음 MA(20)의 hard decline 방지 종가 하한
 
 
@@ -205,6 +207,7 @@ class MarketRegimeService:
 
         recovery_earliest_days: Optional[int] = None
         recovery_target_ma: Optional[float] = None
+        recovery_target_close: Optional[float] = None
         next_close_floor: Optional[float] = None
         if not is_rising:
             # 다음 MA는 가장 오래된 20일 창 종가가 빠지고 다음 확정 종가가 들어온다.
@@ -225,6 +228,16 @@ class MarketRegimeService:
             # 시작한다. 마지막 MA가 이 값 이상이면 3일 순변화 조건을 충족한다.
             recovery_reference_ma = ma_values[recovery_earliest_days]
             recovery_target_ma = recovery_reference_ma * (1 + self._cfg.min_net_change_pct / 100)
+            # 최초 전환일까지 이전 종가가 현재 종가와 같다고 가정하고, 마지막 종가 하나로
+            # 목표 MA를 충족시키는 데 필요한 종가를 계산한다.
+            replacement_count = recovery_earliest_days
+            outgoing_closes = closes[-period:-period + replacement_count]
+            assumed_intermediate_closes = closes[-1] * (replacement_count - 1)
+            recovery_target_close = (
+                period * recovery_target_ma
+                - (sum(closes[-period:]) - sum(outgoing_closes))
+                - assumed_intermediate_closes
+            )
 
         snap = RegimeSnapshot(
             market=market,
@@ -237,8 +250,10 @@ class MarketRegimeService:
             ma_values=[round(v, 2) for v in ma_values],
             fail_detail=fail_detail,
             data_date=data_date,
+            current_close=round(closes[-1], 2),
             recovery_earliest_days=recovery_earliest_days,
             recovery_target_ma=round(recovery_target_ma, 2) if recovery_target_ma is not None else None,
+            recovery_target_close=round(recovery_target_close, 2) if recovery_target_close is not None else None,
             next_close_floor=round(next_close_floor, 2) if next_close_floor is not None else None,
         )
         logger.debug({

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1032,6 +1032,8 @@ class OneilUniverseService:
                 ma_str = " ➔ ".join([f"{v:.2f}" for v in snap.ma_values])
                 msg = f"• 지수: {market} ({code})\n• 상태: {status_text}\n"
                 msg += f"• 데이터 기준일: {snap.data_date or '확인 불가'}\n"
+                if snap.current_close is not None:
+                    msg += f"• 현재 지수(종가): {snap.current_close:,.2f}\n"
                 if not is_rising and snap.fail_detail:
                     msg += f"• 사유: {snap.fail_detail}\n"
                 msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"
@@ -1039,6 +1041,11 @@ class OneilUniverseService:
                     msg += f"\n• 최초 전환 가능: 최소 {snap.recovery_earliest_days}거래일 후 (이후 종가 조건 충족 시)"
                 if not is_rising and snap.recovery_target_ma is not None:
                     msg += f"\n• 전환 시 MA({self._cfg.market_ma_period}) 목표: ≥ {snap.recovery_target_ma:,.2f}"
+                if not is_rising and snap.recovery_target_close is not None:
+                    msg += (
+                        f"\n• 최초 전환일 종가 목표: ≥ {snap.recovery_target_close:,.2f} "
+                        f"(그전 종가 현재 수준 유지 가정)"
+                    )
                 if not is_rising and snap.next_close_floor is not None:
                     msg += (
                         f"\n• 다음 종가 하한: {snap.next_close_floor:,.2f} "

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -101,7 +101,7 @@ async def test_classify_hard_decline_returns_bear():
 
 @pytest.mark.asyncio
 async def test_classify_hard_decline_includes_recovery_price_guidance():
-    """급락 MA가 판정창에서 빠지는 최초 시점과 다음 종가 하한을 안내한다."""
+    """급락 MA가 판정창에서 빠지는 최초 시점과 전환 종가 목표를 안내한다."""
     closes = [200, 200, 200, 200, 200, 200, 200, 150]
     svc, _ = _make_service(closes)
 
@@ -110,6 +110,10 @@ async def test_classify_hard_decline_includes_recovery_price_guidance():
     # MA(5): 200 -> 200 -> 190. 마지막 hard decline(idx=2)은 2거래일 후 소멸한다.
     assert snap.recovery_earliest_days == 2
     assert snap.recovery_target_ma == 189.81  # 190 * (1 - 0.10%)
+    assert snap.current_close == 150
+    # 최초 전환일 전까지 현재 종가(150)를 유지한다고 가정하면,
+    # 전환일의 종가는 MA(5)를 189.81 이상으로 만들기 위해 249.05 이상이어야 한다.
+    assert snap.recovery_target_close == 249.05
     # 다음 MA가 -0.50%보다 더 급락하지 않는 종가 하한:
     # 200 + 5 * (190 * 0.995 - 190) = 195.25
     assert snap.next_close_floor == 195.25

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1781,6 +1781,8 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     failed_snap = _snap("KOSPI", False, [3.0, 2.0, 1.0], fail="MA decline")
     failed_snap.recovery_earliest_days = 2
     failed_snap.recovery_target_ma = 1.5
+    failed_snap.current_close = 1200.0
+    failed_snap.recovery_target_close = 1300.0
     failed_snap.next_close_floor = 1234.5
     service._regime_svc.classify = AsyncMock(side_effect=[
         _snap("KOSDAQ", True, [1.0, 2.0, 3.0]),
@@ -1803,6 +1805,8 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     assert call_kwargs["message"].count("데이터 기준일: 20260514") == 2
     assert "MA decline" in call_kwargs["message"]
     assert "최초 전환 가능: 최소 2거래일 후" in call_kwargs["message"]
+    assert "현재 지수(종가): 1,200.00" in call_kwargs["message"]
+    assert "최초 전환일 종가 목표: ≥ 1,300.00 (그전 종가 현재 수준 유지 가정)" in call_kwargs["message"]
     assert "다음 종가 하한: 1,234.50" in call_kwargs["message"]
 
 


### PR DESCRIPTION
## 변경 사항
- 마켓 타이밍 알림에 판정 기준일 지수 종가를 표시합니다.
- 최초 전환일의 종가 목표를 표시합니다.

## 이유
MA 목표만으로는 현재 지수와 전환에 필요한 종가를 바로 판단하기 어려웠습니다.

## 산출 기준
최초 전환일 종가 목표는 그 전 거래일 종가가 현재 기준일 종가와 같다고 가정한 계산값입니다.

## 검증
- pytest tests/unit_test/services -v -n0 (2323 passed)
- pytest tests/integration_test -v (277 passed)