### PR TITLE
feat: 해외 장중 VBO 폴링 경로(paper) — 미국장에서 전략이 실제로 돌게

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -86,6 +86,21 @@ overseas_stock:
   # 해외 VBO dry-run would-be 수량 계산용 고정 USD 슬롯. 실주문 경로 없음.
   dryrun_slot_usd: 1000.0
   dryrun_max_qty:
+  # 미국 정규장 REST 폴링 VBO(장중 경로). dry-run 은 마감 후 사후 평가라 발사 대상이
+  # 없어, 장중에 실제로 도는 전략 경로를 별도로 둔다. 주문은 항상 would-be 기록만
+  # 남는다(allow_live_trading 과 무관하게 자동 경로의 실주문은 Phase 5 까지 잠금).
+  # 비용 주의: top_n × (정규장 390분 ÷ poll_interval) 만큼 해외현재가 API 를 호출한다.
+  intraday_vbo:
+    enabled: false
+    poll_interval_sec: 60
+    top_n: 20
+    k_value: 0.5
+    stop_loss_pct: -3.0
+    max_positions: 5
+    # 개장 직후엔 당일 봉(시가)이 없을 수 있어 세션 준비를 늦춘다.
+    session_prepare_delay_min: 5
+    # 마감 N분 전부터는 신규 진입 없이 EOD 청산만 수행(조기폐장일 13:00 ET 반영).
+    eod_exit_before_min: 10
 
 # 선택
 htsid: ""

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -463,6 +463,20 @@ class OpeningPositionReconcileConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class OverseasIntradayVBOConfig(BaseModel):
+    """미국 정규장 REST 폴링 VBO 경로. 주문은 항상 would-be(실주문 잠금 유지)."""
+    enabled: bool = False
+    poll_interval_sec: int = Field(60, gt=0)
+    top_n: int = Field(20, gt=0)
+    k_value: float = Field(0.5, gt=0)
+    stop_loss_pct: float = -3.0
+    max_positions: int = Field(5, gt=0)
+    session_prepare_delay_min: int = Field(5, ge=0)
+    eod_exit_before_min: int = Field(10, ge=0)
+
+    model_config = {"extra": "allow"}
+
+
 class OverseasStockConfig(BaseModel):
     enabled_exchanges: List[Literal["NASD", "NYSE", "AMEX"]] = Field(
         default_factory=lambda: ["NASD", "NYSE", "AMEX"]
@@ -473,6 +487,7 @@ class OverseasStockConfig(BaseModel):
     allow_live_trading: bool = False
     dryrun_slot_usd: float = Field(1000.0, gt=0)
     dryrun_max_qty: Optional[int] = Field(default=None, gt=0)
+    intraday_vbo: OverseasIntradayVBOConfig = Field(default_factory=OverseasIntradayVBOConfig)
 
     model_config = {"extra": "allow"}
 

--- a/services/overseas_intraday_vbo_service.py
+++ b/services/overseas_intraday_vbo_service.py
@@ -1,0 +1,252 @@
+# services/overseas_intraday_vbo_service.py
+"""해외 장중 VBO 라이브(paper) 신호·주문 경로.
+
+dry-run(`OverseasVBODryRunService`)은 미국장 마감 후 *완성된* 일봉을 평가하는 사후
+백테스트라, 신호 시점엔 이미 진입 기회가 지나 있어 발사 대상이 없다. 본 서비스는
+장중 REST 폴링가로 진입/청산을 판정해 "전략이 실제로 도는" 최소 경로를 만든다.
+(해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스 — `OverseasFavoritePriceAlertTask`
+가 쓰는 것과 동일한 패턴.)
+
+  세션 준비 : 후보(거래대금 상위) × 전일Range·당일시가 → target = 당일시가 + K×전일Range
+  틱 판정   : 폴링가 >= target → 진입, 폴링가 <= 손절가 → 손절, 마감 전 → EOD 청산
+
+**실주문 잠금은 `OverseasOrderExecutionService` 가 단독으로 관장한다.** 본 서비스는
+broker 의존을 갖지 않으며, live_enabled=False 인 주문 서비스를 주입받으면 would-be
+주문만 저널에 남는다(Phase 5 이전 기본값).
+
+한계: 포지션 상태는 in-memory 다. 장중 재시작 시 보유가 소실돼 EOD 청산 기록이
+누락될 수 있다(paper 경로라 실포지션 영향은 없음).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+class OverseasIntradayVBOService:
+    STRATEGY_NAME = "LarryWilliamsVBO_overseas_intraday"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        order_execution_service,
+        position_sizing_service=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        k_value: float = 0.5,
+        stop_loss_pct: float = -3.0,
+        top_n: int = 20,
+        max_positions: int = 5,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+    ) -> None:
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._orders = order_execution_service
+        self._sizing_service = position_sizing_service
+        self._logger = logger or logging.getLogger(__name__)
+        self._k = k_value
+        self._stop_loss_pct = stop_loss_pct
+        self._top_n = top_n
+        self._max_positions = max_positions
+        self._default_exchange = exchange
+
+        self._session_date: Optional[str] = None
+        self._watch: Dict[str, Dict[str, Any]] = {}
+        self._positions: Dict[str, Dict[str, Any]] = {}
+        self._entered_today: set[str] = set()
+
+    # ── 세션 ────────────────────────────────────────────────────────────
+
+    async def prepare_session(
+        self,
+        trade_date: str,
+        exchange: Optional[OverseasExchange] = None,
+    ) -> int:
+        """당일 감시 목록(종목별 target)을 만든다. 반환: 감시 종목 수.
+
+        당일 봉이 아직 없는 종목은 시가를 알 수 없으므로 감시에서 제외한다
+        (fail-closed — 추정 시가로 진입하지 않는다). 같은 거래일에 두 번 호출되면
+        두 번째부터는 no-op 이다.
+        """
+        if self._session_date == trade_date:
+            return len(self._watch)
+
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(ex, top_n=self._top_n)
+
+        watch: Dict[str, Dict[str, Any]] = {}
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            setup = await self._build_setup(code, trade_date, ex)
+            if setup:
+                watch[code] = setup
+
+        self._session_date = trade_date
+        self._watch = watch
+        self._positions = {}
+        self._entered_today = set()
+        self._logger.info({
+            "event": "overseas_intraday_vbo_session", "trade_date": trade_date,
+            "exchange": ex.value, "candidates": len(candidates or []), "watch": len(watch),
+        })
+        return len(watch)
+
+    async def _build_setup(
+        self, code: str, trade_date: str, exchange: OverseasExchange,
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            resp = await self._sqs.get_recent_daily_ohlcv(code, limit=2, exchange=exchange)
+        except Exception as e:
+            self._logger.warning({"event": "overseas_intraday_vbo_ohlcv_error",
+                                  "code": code, "error": str(e)})
+            return None
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+            return None
+        rows = resp.data
+        if len(rows) < 2:
+            return None
+        prev, cur = rows[-2], rows[-1]
+        if str(cur.get("date") or "") != str(trade_date):
+            return None  # 당일 봉 미생성 → 시가 미확정
+        prev_range = self._f(prev.get("high")) - self._f(prev.get("low"))
+        open_ = self._f(cur.get("open"))
+        if prev_range <= 0 or open_ <= 0:
+            return None
+        return {
+            "open": open_,
+            "prev_range": prev_range,
+            "target": open_ + self._k * prev_range,
+            "exchange": exchange,
+        }
+
+    def watch_codes(self) -> List[str]:
+        return list(self._watch.keys())
+
+    def get_state(self) -> Dict[str, Any]:
+        return {
+            "session_date": self._session_date,
+            "watch": self._watch,
+            "positions": self._positions,
+            "entered_today": sorted(self._entered_today),
+        }
+
+    # ── 틱 판정 ─────────────────────────────────────────────────────────
+
+    async def on_price(self, code: str, price: float) -> Optional[Dict[str, Any]]:
+        """폴링가 1건을 판정해 주문까지 수행한다. 주문이 없으면 None."""
+        px = self._f(price)
+        if px <= 0:
+            return None
+
+        held = self._positions.get(code)
+        if held is not None:
+            held["last_price"] = px
+            if px <= held["stop_price"]:
+                return await self._exit(code, px, reason="stop")
+            return None
+
+        setup = self._watch.get(code)
+        if setup is None or code in self._entered_today:
+            return None
+        if px < setup["target"]:
+            return None
+        if len(self._positions) >= self._max_positions:
+            self._logger.info({"event": "overseas_intraday_vbo_entry_blocked", "code": code,
+                               "reason": "max_positions", "max_positions": self._max_positions})
+            return None
+        return await self._enter(code, px, setup)
+
+    async def _enter(self, code: str, price: float, setup: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        qty = self._resolve_qty(price)
+        if qty <= 0:
+            return None
+        stop_price = price * (1 + self._stop_loss_pct / 100.0)
+        signal = {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "action": "BUY",
+            "date": self._session_date,
+            "entry_price": price,
+            "target": setup["target"],
+            "stop_price": stop_price,
+            "prev_range": setup["prev_range"],
+            "reason": "vbo_intraday_breakout",
+        }
+        resp = await self._orders.place_entry(
+            code=code, qty=qty, limit_price=price,
+            exchange=setup["exchange"], signal=signal,
+        )
+        if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            self._logger.warning({"event": "overseas_intraday_vbo_entry_rejected", "code": code,
+                                  "msg": getattr(resp, "msg1", "")})
+            return None
+        self._positions[code] = {
+            "qty": qty, "entry_price": price, "stop_price": stop_price,
+            "last_price": price, "exchange": setup["exchange"],
+        }
+        self._entered_today.add(code)
+        return signal
+
+    async def _exit(self, code: str, price: float, *, reason: str) -> Optional[Dict[str, Any]]:
+        held = self._positions.get(code)
+        if held is None:
+            return None
+        signal = {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "action": "SELL",
+            "date": self._session_date,
+            "entry_price": held["entry_price"],
+            "exit_price": price,
+            "exit_reason": reason,
+            "realized_pct": (price / held["entry_price"] - 1) * 100.0 if held["entry_price"] > 0 else 0.0,
+        }
+        resp = await self._orders.place_exit(
+            code=code, qty=held["qty"], limit_price=price, reason=reason,
+            exchange=held["exchange"], signal=signal,
+        )
+        if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            self._logger.warning({"event": "overseas_intraday_vbo_exit_rejected", "code": code,
+                                  "reason": reason, "msg": getattr(resp, "msg1", "")})
+            return None
+        self._positions.pop(code, None)
+        return signal
+
+    async def close_all(self, *, reason: str = "eod") -> List[Dict[str, Any]]:
+        """보유 전량을 마지막 폴링가로 청산한다(마감 전 EOD 청산용)."""
+        actions: List[Dict[str, Any]] = []
+        for code in list(self._positions.keys()):
+            held = self._positions[code]
+            action = await self._exit(code, held.get("last_price") or held["entry_price"], reason=reason)
+            if action:
+                actions.append(action)
+        return actions
+
+    # ── 보조 ────────────────────────────────────────────────────────────
+
+    def _resolve_qty(self, price: float) -> int:
+        """사이징 미주입 시 1주(최소 단위)로 진입한다."""
+        if self._sizing_service is None:
+            return 1
+        try:
+            sized = self._sizing_service.size(limit_price_usd=price)
+        except Exception as e:
+            self._logger.warning({"event": "overseas_intraday_vbo_sizing_error", "error": str(e)})
+            return 0
+        try:
+            return int(sized.get("qty") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/task/background/intraday/overseas_intraday_vbo_task.py
+++ b/task/background/intraday/overseas_intraday_vbo_task.py
@@ -1,0 +1,164 @@
+# task/background/intraday/overseas_intraday_vbo_task.py
+"""해외 장중 VBO 폴링 태스크 (라이브 paper 경로).
+
+미국은 웹소켓/분봉 경로가 없어 해외현재가 REST 폴링이 유일한 장중 틱 소스다
+(`OverseasFavoritePriceAlertTask` 와 동일 패턴). 정규장 동안 감시 종목을 폴링해
+`OverseasIntradayVBOService` 에 틱을 흘리고, 마감 직전에는 EOD 청산만 수행한다.
+
+TimeDispatcher 미등록 — 마감 이벤트가 아니라 장중 연속 루프이므로 자체 폴링한다.
+
+**주문 경로**: 서비스가 `OverseasOrderExecutionService` 를 통해서만 주문하며,
+live_enabled=False(기본)에서는 would-be 만 기록된다 — 실주문 없음.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from common.types import ErrorCode
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+
+
+class OverseasIntradayVBOTask(SchedulableTask):
+    CHECK_INTERVAL_SEC = 60
+    FETCH_TIMEOUT_SEC = 5.0
+    DEFAULT_CLOSE_TIME = "16:00"
+
+    def __init__(
+        self,
+        *,
+        vbo_service,
+        broker,
+        market_clock,
+        us_market_calendar_service=None,
+        check_interval_sec: Optional[int] = None,
+        session_prepare_delay_min: int = 5,
+        eod_exit_before_min: int = 10,
+        logger=None,
+    ) -> None:
+        self._vbo = vbo_service
+        self._broker = broker
+        self._market_clock = market_clock
+        self._us_mcs = us_market_calendar_service
+        self._check_interval_sec = check_interval_sec or self.CHECK_INTERVAL_SEC
+        self._prepare_delay_min = session_prepare_delay_min
+        self._eod_exit_before_min = eod_exit_before_min
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._task: Optional[asyncio.Task] = None
+        self._last_eod_date: Optional[str] = None
+
+    @property
+    def task_name(self) -> str:
+        return "overseas_intraday_vbo"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.NORMAL
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    def get_progress(self) -> dict:
+        return {"running": self._state == TaskState.RUNNING}
+
+    async def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+        self._task = None
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                if self._state != TaskState.SUSPENDED:
+                    self._state = TaskState.RUNNING
+                    await self._tick()
+                    if self._state == TaskState.RUNNING:
+                        self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error("%s: loop error — %s", self.task_name, exc, exc_info=True)
+            await asyncio.sleep(self._check_interval_sec)
+
+    async def _tick(self) -> None:
+        now = self._market_clock.get_current_kst_time()
+        today = self._market_clock.get_current_kst_date_str()
+        if not self._market_clock.is_market_operating_hours(now):
+            return
+        if self._us_mcs is not None and not self._us_mcs.is_trading_day(today):
+            return
+        if self._minutes_of_day(now) < self._prepare_ready_minute(now):
+            # 개장 직후에는 당일 봉(시가)이 아직 없을 수 있어 세션 준비를 미룬다.
+            return
+
+        if self._is_eod_window(now, today):
+            if self._last_eod_date != today:
+                actions = await self._vbo.close_all(reason="eod")
+                self._last_eod_date = today
+                self._logger.info({"event": "overseas_intraday_vbo_eod_exit",
+                                   "trade_date": today, "exits": len(actions or [])})
+            return
+
+        await self._vbo.prepare_session(today)
+        for code in self._vbo.watch_codes():
+            price = await self._fetch_price(code)
+            if price is None:
+                continue
+            await self._vbo.on_price(code, price)
+
+    async def _fetch_price(self, code: str) -> Optional[float]:
+        try:
+            resp = await asyncio.wait_for(
+                self._broker.get_overseas_price(code), timeout=self.FETCH_TIMEOUT_SEC,
+            )
+        except Exception as exc:
+            self._logger.warning("%s: %s 현재가 조회 예외 — %s", self.task_name, code, exc)
+            return None
+        if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            return None
+        price = getattr(getattr(resp, "data", None), "price", None)
+        try:
+            price = float(price)
+        except (TypeError, ValueError):
+            return None
+        return price if price > 0 else None
+
+    # ── 시각 판정 ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _minutes_of_day(dt) -> int:
+        return dt.hour * 60 + dt.minute
+
+    def _prepare_ready_minute(self, now) -> int:
+        open_dt = self._market_clock.get_market_open_time(now)
+        return self._minutes_of_day(open_dt) + self._prepare_delay_min
+
+    def _close_minute(self, today: str) -> int:
+        """조기폐장(13:00 ET)을 반영한 당일 마감 분. 캘린더 미주입 시 16:00."""
+        close_str = self.DEFAULT_CLOSE_TIME
+        if self._us_mcs is not None:
+            close_str = self._us_mcs.get_close_time_str(today) or self.DEFAULT_CLOSE_TIME
+        try:
+            hh, mm = str(close_str).split(":")
+            return int(hh) * 60 + int(mm)
+        except (ValueError, AttributeError):
+            return 16 * 60
+
+    def _is_eod_window(self, now, today: str) -> bool:
+        return self._minutes_of_day(now) >= self._close_minute(today) - self._eod_exit_before_min

--- a/tests/unit_test/services/test_overseas_intraday_vbo_service.py
+++ b/tests/unit_test/services/test_overseas_intraday_vbo_service.py
@@ -1,0 +1,206 @@
+"""해외 장중 VBO 라이브(paper) 경로 서비스 테스트.
+
+dry-run(마감 후 완성 일봉 사후 평가)과 달리 장중 폴링가로 진입/청산을 판정한다.
+주문은 OverseasOrderExecutionService 위임 — live_enabled=False 이면 would-be 만
+기록되므로 실주문은 발생하지 않는다.
+"""
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from services.overseas_intraday_vbo_service import OverseasIntradayVBOService
+from common.types import ErrorCode, ResCommonResponse
+from common.overseas_types import OverseasExchange
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ok(data=None):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=data)
+
+
+def _fail():
+    return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="rejected", data=None)
+
+
+def _svc(*, candidates=None, bars=None, max_positions=5, sizing=None):
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=candidates if candidates is not None else [
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    # 기본: 전일 range 10(100~110), 당일 시가 100 → target = 105
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ok(bars if bars is not None else [
+        _bar("20260511", 100, 110, 100, 105), _bar("20260512", 100, 101, 99, 100),
+    ]))
+    orders = MagicMock()
+    orders.place_entry = AsyncMock(return_value=_ok({"would_be": True}))
+    orders.place_exit = AsyncMock(return_value=_ok({"would_be": True}))
+
+    service = OverseasIntradayVBOService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        order_execution_service=orders,
+        position_sizing_service=sizing,
+        logger=MagicMock(),
+        k_value=0.5,
+        stop_loss_pct=-3.0,
+        max_positions=max_positions,
+    )
+    return SimpleNamespace(service=service, candidate_service=candidate_service, sqs=sqs, orders=orders)
+
+
+# ── 세션 준비 ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_prepare_session_computes_target_from_prev_range_and_open():
+    s = _svc()
+
+    watched = await s.service.prepare_session("20260512", exchange=OverseasExchange.NASD)
+
+    assert watched == 1
+    assert s.service.get_state()["watch"]["AAA"]["target"] == pytest.approx(105.0)
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_skips_symbol_without_today_bar():
+    """당일 봉이 아직 없으면 시가를 알 수 없다 → 감시 제외(fail-closed)."""
+    s = _svc(bars=[_bar("20260508", 100, 110, 100, 105), _bar("20260511", 100, 110, 100, 105)])
+
+    watched = await s.service.prepare_session("20260512", exchange=OverseasExchange.NASD)
+
+    assert watched == 0
+    assert s.service.get_state()["watch"] == {}
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_is_idempotent_for_same_date():
+    s = _svc()
+
+    await s.service.prepare_session("20260512", exchange=OverseasExchange.NASD)
+    await s.service.prepare_session("20260512", exchange=OverseasExchange.NASD)
+
+    assert s.candidate_service.get_candidates.await_count == 1
+
+
+# ── 진입 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_on_price_below_target_does_not_order():
+    s = _svc()
+    await s.service.prepare_session("20260512")
+
+    assert await s.service.on_price("AAA", 104.9) is None
+    s.orders.place_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_price_breakout_places_entry_at_polled_price():
+    """라이브 경로의 진입가는 목표가가 아니라 실제 폴링가다(체결 가정 정직화)."""
+    s = _svc()
+    await s.service.prepare_session("20260512")
+
+    action = await s.service.on_price("AAA", 106.0)
+
+    assert action["action"] == "BUY"
+    _, kwargs = s.orders.place_entry.call_args
+    assert kwargs["code"] == "AAA"
+    assert kwargs["limit_price"] == 106.0
+    assert kwargs["qty"] == 1  # 사이징 미주입 시 1주
+    assert s.service.get_state()["positions"]["AAA"]["stop_price"] == pytest.approx(106.0 * 0.97)
+
+
+@pytest.mark.asyncio
+async def test_on_price_does_not_reenter_same_day():
+    s = _svc()
+    await s.service.prepare_session("20260512")
+    await s.service.on_price("AAA", 106.0)
+    await s.service.on_price("AAA", 107.0)
+
+    assert s.orders.place_entry.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_entry_uses_position_sizing_when_injected():
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 9, "notional_usd": 954.0})
+    s = _svc(sizing=sizing)
+    await s.service.prepare_session("20260512")
+
+    await s.service.on_price("AAA", 106.0)
+
+    assert s.orders.place_entry.call_args.kwargs["qty"] == 9
+    assert sizing.size.call_args.kwargs["limit_price_usd"] == 106.0
+
+
+@pytest.mark.asyncio
+async def test_entry_not_registered_when_order_rejected():
+    s = _svc()
+    s.orders.place_entry = AsyncMock(return_value=_fail())
+    await s.service.prepare_session("20260512")
+
+    action = await s.service.on_price("AAA", 106.0)
+
+    assert action is None
+    assert s.service.get_state()["positions"] == {}
+
+
+@pytest.mark.asyncio
+async def test_max_positions_blocks_new_entry():
+    s = _svc(candidates=[
+        {"code": "AAA", "exchange": "NASD"}, {"code": "BBB", "exchange": "NASD"},
+    ], max_positions=1)
+    await s.service.prepare_session("20260512")
+
+    await s.service.on_price("AAA", 106.0)
+    action = await s.service.on_price("BBB", 106.0)
+
+    assert action is None
+    assert s.orders.place_entry.await_count == 1
+
+
+# ── 청산 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_stop_loss_exit_when_price_breaks_stop():
+    s = _svc()
+    await s.service.prepare_session("20260512")
+    await s.service.on_price("AAA", 100.0 + 6.0)  # 진입 106 → stop 102.82
+
+    action = await s.service.on_price("AAA", 102.0)
+
+    assert action["action"] == "SELL"
+    assert s.orders.place_exit.call_args.kwargs["reason"] == "stop"
+    assert s.service.get_state()["positions"] == {}
+
+
+@pytest.mark.asyncio
+async def test_close_all_exits_open_positions_with_reason():
+    s = _svc()
+    await s.service.prepare_session("20260512")
+    await s.service.on_price("AAA", 106.0)
+
+    actions = await s.service.close_all(reason="eod")
+
+    assert len(actions) == 1
+    assert s.orders.place_exit.call_args.kwargs["reason"] == "eod"
+    assert s.service.get_state()["positions"] == {}
+
+
+@pytest.mark.asyncio
+async def test_close_all_is_noop_without_positions():
+    s = _svc()
+
+    assert await s.service.close_all(reason="eod") == []
+    s.orders.place_exit.assert_not_awaited()
+
+
+# ── 안전 계약 ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_service_has_no_direct_broker_dependency():
+    """실주문 잠금은 OverseasOrderExecutionService 가 단독으로 관장한다."""
+    s = _svc()
+    assert not hasattr(s.service, "_broker")

--- a/tests/unit_test/task/background/intraday/test_overseas_intraday_vbo_task.py
+++ b/tests/unit_test/task/background/intraday/test_overseas_intraday_vbo_task.py
@@ -1,0 +1,139 @@
+"""해외 장중 VBO 폴링 태스크 테스트.
+
+미국 정규장에서만 동작하며(휴장/장외 no-op), 개장 후 준비 지연이 지나면 세션을
+준비하고 감시 종목을 폴링한다. 마감 임박에는 진입 대신 EOD 청산만 수행한다.
+"""
+import pytest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytz
+
+from task.background.intraday.overseas_intraday_vbo_task import OverseasIntradayVBOTask
+from common.types import ErrorCode, ResCommonResponse
+
+_NY = pytz.timezone("America/New_York")
+
+
+def _ny(h, m, day=12):
+    return _NY.localize(datetime(2026, 5, day, h, m))
+
+
+def _price(value):
+    return ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="ok",
+        data=SimpleNamespace(price=value),
+    )
+
+
+def _task(*, now=None, operating=True, trading_day=True, early_close=False, watch=("AAA",)):
+    clock = MagicMock()
+    clock.get_current_kst_time = MagicMock(return_value=now or _ny(10, 0))
+    clock.get_current_kst_date_str = MagicMock(return_value="20260512")
+    clock.is_market_operating_hours = MagicMock(return_value=operating)
+    clock.get_market_open_time = MagicMock(return_value=_ny(9, 30))
+
+    us_mcs = MagicMock()
+    us_mcs.is_trading_day = MagicMock(return_value=trading_day)
+    us_mcs.get_close_time_str = MagicMock(return_value="13:00" if early_close else "16:00")
+
+    vbo = MagicMock()
+    vbo.prepare_session = AsyncMock(return_value=len(watch))
+    vbo.watch_codes = MagicMock(return_value=list(watch))
+    vbo.on_price = AsyncMock(return_value=None)
+    vbo.close_all = AsyncMock(return_value=[])
+
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(return_value=_price(106.0))
+
+    task = OverseasIntradayVBOTask(
+        vbo_service=vbo,
+        broker=broker,
+        market_clock=clock,
+        us_market_calendar_service=us_mcs,
+        logger=MagicMock(),
+        session_prepare_delay_min=5,
+        eod_exit_before_min=10,
+    )
+    return SimpleNamespace(task=task, vbo=vbo, broker=broker, clock=clock, us_mcs=us_mcs)
+
+
+@pytest.mark.asyncio
+async def test_tick_noop_on_us_holiday():
+    t = _task(trading_day=False)
+
+    await t.task._tick()
+
+    t.vbo.prepare_session.assert_not_awaited()
+    t.broker.get_overseas_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_noop_outside_market_hours():
+    t = _task(operating=False)
+
+    await t.task._tick()
+
+    t.vbo.prepare_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_waits_for_session_prepare_delay():
+    """개장 직후엔 당일 봉(시가)이 아직 없을 수 있어 준비를 미룬다."""
+    t = _task(now=_ny(9, 32))
+
+    await t.task._tick()
+
+    t.vbo.prepare_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_prepares_session_and_polls_watch_codes():
+    t = _task(now=_ny(10, 0))
+
+    await t.task._tick()
+
+    t.vbo.prepare_session.assert_awaited_once()
+    assert t.vbo.prepare_session.await_args.args[0] == "20260512"
+    t.broker.get_overseas_price.assert_awaited_once()
+    t.vbo.on_price.assert_awaited_once_with("AAA", 106.0)
+
+
+@pytest.mark.asyncio
+async def test_tick_closes_positions_near_close_and_stops_polling():
+    t = _task(now=_ny(15, 55))
+
+    await t.task._tick()
+
+    t.vbo.close_all.assert_awaited_once()
+    assert t.vbo.close_all.await_args.kwargs["reason"] == "eod"
+    t.vbo.on_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_uses_early_close_time_for_eod_exit():
+    """조기폐장일(13:00 ET)에는 12:50 부터 EOD 청산 구간이다."""
+    t = _task(now=_ny(12, 55), early_close=True)
+
+    await t.task._tick()
+
+    t.vbo.close_all.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_symbol_when_price_fetch_fails():
+    t = _task()
+    t.broker.get_overseas_price = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await t.task._tick()  # 예외가 루프로 전파되지 않는다
+
+    t.vbo.on_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_name_and_progress():
+    t = _task()
+
+    assert t.task.task_name == "overseas_intraday_vbo"
+    assert t.task.get_progress()["running"] is False

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -667,6 +667,52 @@ def test_domestic_active_with_overseas_enabled_builds_dryrun_task(patched_servic
     assert ctx.overseas_dryrun_task is task_cls.return_value
 
 
+def test_intraday_vbo_not_built_when_disabled(patched_service_container_deps):
+    """장중 VBO 폴링 경로는 config opt-in — 기본값(enabled=false)에선 미조립."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True):
+        ServiceContainer(ctx).run()
+
+    assert ctx.overseas_intraday_vbo_task is None
+    assert ctx.overseas_intraday_vbo_service is None
+
+
+def test_intraday_vbo_built_with_order_path_locked(patched_service_container_deps):
+    """enabled=true 면 조립하되 주문 서비스는 live_enabled=False 로 고정한다(자동 실주문 잠금)."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        # allow_live_trading=True 여도 자동 경로는 열리지 않아야 한다.
+        overseas_stock={"allow_live_trading": True, "intraday_vbo": {"enabled": True, "top_n": 7}},
+    )
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasOrderExecutionService", autospec=True) as order_cls, \
+         patch("view.web.bootstrap.service_container.OverseasIntradayVBOService", autospec=True) as svc_cls, \
+         patch("view.web.bootstrap.service_container.OverseasIntradayVBOTask", autospec=True) as task_cls:
+        ServiceContainer(ctx).run()
+
+    assert order_cls.call_args.kwargs["live_enabled"] is False
+    assert svc_cls.call_args.kwargs["top_n"] == 7
+    assert ctx.overseas_intraday_vbo_task is task_cls.return_value
+
+
 def test_domestic_active_without_overseas_enabled_skips_dryrun_task(patched_service_container_deps):
     """overseas_us 가 enabled 에 없으면 dry-run 태스크는 조립되지 않는다(None)."""
     from view.web.bootstrap.service_container import ServiceContainer

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -151,6 +151,8 @@ class SchedulerBootstrap:
             TaskPriority.LOW,
             market="overseas_us",
         )
+        # 장중 VBO 폴링(연속 루프) — 마감 이벤트가 아니므로 TimeDispatcher 미등록.
+        self._register(self._optional_task("overseas_intraday_vbo_task"))
 
     def _register_websocket_watchdog(self) -> None:
         # WebSocket watchdog 은 TimeDispatcher 등록 대상이 아님 (continuous monitor).

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -50,6 +50,8 @@ from services.order_policy_service import OrderPolicyService
 from services.position_sizing_service import PositionSizingService
 from services.risk_gate_service import RiskGateService
 from services.overseas_candidate_service import OverseasCandidateService
+from services.overseas_intraday_vbo_service import OverseasIntradayVBOService
+from services.overseas_order_execution_service import OverseasOrderExecutionService
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.strategy_log_report_service import StrategyLogReportService
@@ -73,6 +75,7 @@ from task.background.intraday.program_capture_subscription_task import ProgramCa
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
 from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
 from task.background.intraday.overseas_favorite_price_alert_task import OverseasFavoritePriceAlertTask
+from task.background.intraday.overseas_intraday_vbo_task import OverseasIntradayVBOTask
 from view.web.bootstrap.runtime_mode import RuntimeMode
 from view.web.bootstrap.backtest_task_bootstrap import BacktestTaskBootstrap
 from view.web.bootstrap.repository_bootstrap import RepositoryBootstrap
@@ -864,4 +867,52 @@ class ServiceContainer:
             # Ticket-driven: 미국장 TimeDispatcher(time_dispatcher_us)가 NY 마감 후
             # 티켓을 발행하면 WorkerPool 이 execute() 를 호출한다(자체 AfterMarketLoop 미사용).
             worker_pool=ctx.worker_pool,
+        )
+        self._build_overseas_intraday_vbo(overseas_stock_cfg, overseas_position_sizing_service)
+
+    def _build_overseas_intraday_vbo(self, overseas_stock_cfg, position_sizing_service) -> None:
+        """해외 장중 VBO 폴링 경로 조립 (config 로 opt-in, 기본 off).
+
+        dry-run 은 마감 후 사후 평가라 발사 대상이 없다. 본 경로는 정규장 중 폴링가로
+        진입/청산을 판정해 전략이 실제로 돌게 한다. 다만 **주문 서비스는
+        `live_enabled=False` 로 고정**한다 — 해외 주문 TR 은 실전만 존재하고 Phase 5
+        (canary/kill-switch/reconcile) 가 미완이라, 자동 발사는 여전히 잠근다.
+        `allow_live_trading` 은 수동 주문 경로용이며 이 자동 경로를 열지 않는다.
+        """
+        ctx = self._ctx
+        ctx.overseas_intraday_vbo_service = None
+        ctx.overseas_intraday_vbo_task = None
+        cfg = getattr(overseas_stock_cfg, "intraday_vbo", None)
+        if not getattr(cfg, "enabled", False):
+            return
+
+        order_execution_service = OverseasOrderExecutionService(
+            broker=None,  # live_enabled=False 이므로 broker 미사용(구조적 잠금)
+            live_enabled=False,
+            journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+        )
+        ctx.overseas_intraday_vbo_service = OverseasIntradayVBOService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            order_execution_service=order_execution_service,
+            position_sizing_service=position_sizing_service,
+            logger=ctx.logger,
+            k_value=getattr(cfg, "k_value", 0.5),
+            stop_loss_pct=getattr(cfg, "stop_loss_pct", -3.0),
+            top_n=getattr(cfg, "top_n", 20),
+            max_positions=getattr(cfg, "max_positions", 5),
+        )
+        intraday_us_clock = MarketClock.for_us_equities(logger=ctx.logger)
+        ctx.overseas_intraday_vbo_task = OverseasIntradayVBOTask(
+            vbo_service=ctx.overseas_intraday_vbo_service,
+            broker=ctx.broker,
+            market_clock=intraday_us_clock,
+            us_market_calendar_service=USMarketCalendarService(
+                market_clock=intraday_us_clock, logger=ctx.logger,
+            ),
+            check_interval_sec=getattr(cfg, "poll_interval_sec", 60),
+            session_prepare_delay_min=getattr(cfg, "session_prepare_delay_min", 5),
+            eod_exit_before_min=getattr(cfg, "eod_exit_before_min", 10),
+            logger=ctx.logger,
         )


### PR DESCRIPTION
## 배경

미국장 전략 미동작 분석([PR #769](https://github.com/kyungsooNa/Investment/pull/769))의 후속입니다. 기존 `overseas_vbo_dryrun`은 마감 30분 후 **완성된** 일봉을 평가하는 사후 백테스트라, 신호가 나올 때는 이미 진입 시점이 지나 있습니다. `live_enabled=True`로 바꿔도 발사할 대상이 없습니다.

해외는 웹소켓/분봉 경로가 없어 REST 폴링이 유일한 장중 틱 소스이므로, 이미 운영 중인 `OverseasFavoritePriceAlertTask`와 동일한 폴링 패턴으로 장중 경로를 만들었습니다.

## 변경

**`OverseasIntradayVBOService`** — 순수 상태기계 (broker 의존 없음)
- 세션 준비: 후보(거래대금 상위 N) × 전일Range·당일시가 → `target = 당일시가 + K×전일Range`
- 틱 판정: 폴링가 ≥ target → 진입 / ≤ 손절가 → 손절 / `close_all` → EOD 청산
- 진입가는 목표가가 아니라 **실제 폴링가** — 체결 가정을 낙관적으로 만들지 않기 위함
- 당일 봉이 아직 없으면 시가 미확정이므로 감시 제외 (fail-closed, 추정 시가로 진입하지 않음)
- 종목당 1일 1회 진입, `max_positions` 제한

**`OverseasIntradayVBOTask`** — 정규장 폴링 루프
- 휴장일/장외 no-op, 개장 후 `session_prepare_delay_min` 경과 후 세션 준비
- 마감 `eod_exit_before_min` 전부터는 신규 진입 없이 EOD 청산만 (조기폐장 13:00 ET 반영)
- 마감 이벤트가 아닌 연속 루프이므로 TimeDispatcher 미등록

**config** — `overseas_stock.intraday_vbo`로 opt-in, 기본 `enabled: false`
- 비용: `top_n × (390분 ÷ poll_interval)` 만큼 해외현재가 API 호출 (기본값 기준 약 7,800회/일)

## 실주문 잠금은 그대로

주문 서비스는 **`live_enabled=False`로 고정 배선**했습니다. `allow_live_trading`(수동 주문용 플래그)이 true여도 이 자동 경로는 열리지 않습니다. 해외 주문 TR은 실전만 존재하고 Phase 5(canary·kill-switch·reconcile)가 미완이므로, 자동 발사는 그 게이팅 통과가 유일한 해제 조건입니다.

따라서 이 PR이 만드는 것은 **would-be 주문이 장중 실제 타이밍에 기록되는 경로**입니다. 사후 평가(dry-run)와 달리 실행 가능성까지 포함된 데이터가 쌓입니다.

## 한계

- 포지션 상태가 in-memory라 장중 재시작 시 보유가 소실돼 EOD 청산 기록이 누락될 수 있습니다(paper 경로라 실포지션 영향 없음). 상태 영속화는 Phase 5에서 reconcile과 함께 다루는 게 맞다고 봅니다.
- 당일 봉이 장중에 시가를 담아 반환되는지는 실장에서만 검증 가능합니다. 미반환 시 해당 종목은 조용히 감시 제외되며 `watch=0` 로그로 드러납니다.

## 테스트

- 신규 23건 (서비스 13 · 태스크 8 · 배선 2)
- `pytest tests/unit_test` 7392 passed
- `pytest tests/integration_test` 277 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
