### PR TITLE
fix: 운영 요약 경보 사각지대 해소 — 상시 오탐 제거 + 당일청산 미이행 검출

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,14 @@ jobs:
         git commit -m "chore: safe update badge [skip ci]" || echo "No changes"
         git push
 
-    # 🚀 2. GitHub Pages 상세 리포트 배포 (유지)
+    # 🚀 2. GitHub Pages 상세 리포트 배포 (main 전용 — PR CI가 Pages 배포 지연에 묶이지 않도록)
     - name: Upload Pages artifact
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v3
       with:
         path: htmlcov/
 
     - name: Deploy to GitHub Pages
+      if: github.ref == 'refs/heads/main'
       id: deployment
       uses: actions/deploy-pages@v4

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -308,6 +308,7 @@ _MA_PROXIMITY_LOWER_PCT = -2.0
 _MA_PROXIMITY_UPPER_PCT = 4.0
 _MA_NEAR_MISS_MAX_EXCESS_PCT = 4.0
 _MAX_EXECUTION_QUALITY_ROWS = 5
+_MAX_SAME_DAY_EXIT_VIOLATIONS_SHOWN = 5
 
 
 def _to_float(value: Any) -> Optional[float]:
@@ -491,6 +492,7 @@ class StrategyLogReportService:
         self._profitability_gate_config = profitability_gate_config
         self._last_execution_quality_candidates: List[dict] = []
         self._last_strategy_degradation_candidates: List[dict] = []
+        self._last_same_day_exit_violations: List[dict] = []
         self._last_operational_decision_report: str = ""
 
     def get_last_execution_quality_candidates(self) -> List[dict]:
@@ -500,6 +502,10 @@ class StrategyLogReportService:
     def get_last_strategy_degradation_candidates(self) -> List[dict]:
         """최근 generate_report 실행에서 산출된 전략 성과 저하 후보 목록."""
         return list(self._last_strategy_degradation_candidates)
+
+    def get_last_same_day_exit_violations(self) -> List[dict]:
+        """최근 generate_report 기준 '당일청산 규칙인데 마감 후 보유 중'인 포지션."""
+        return list(self._last_same_day_exit_violations)
 
     def get_last_operational_decision_report(self) -> str:
         """최근 generate_report 실행에서 산출된 운영 의사결정 요약."""
@@ -1429,6 +1435,83 @@ class StrategyLogReportService:
         match = re.search(r"'([^']+)'", regime_decomposition_section)
         return match.group(1) if match else "단일"
 
+    @staticmethod
+    def _format_same_day_exit_violation_lines(violations: List[dict]) -> List[str]:
+        if not violations:
+            return []
+        lines = [f"• 🚨 당일청산 미이행 {len(violations)}건 — 강제청산 실행/잔량 즉시 확인"]
+        for item in violations[:_MAX_SAME_DAY_EXIT_VIOLATIONS_SHOWN]:
+            code = str(item.get("code") or "").strip()
+            name = _esc(item.get("name") or code or "종목 미상")
+            details = [_esc(_strategy_display_label(item.get("strategy")))]
+            details.append(f"{name}({_esc(code)})" if code else name)
+            qty = _to_int(item.get("qty"), default=0)
+            if qty > 0:
+                details.append(f"잔량 {qty}주")
+            holding_days = item.get("holding_days")
+            if isinstance(holding_days, int):
+                details.append(f"보유 {holding_days}일")
+            lines.append(f"  - {' · '.join(details)}")
+        rest = len(violations) - _MAX_SAME_DAY_EXIT_VIOLATIONS_SHOWN
+        if rest > 0:
+            lines.append(f"  - 외 {rest}건")
+        return lines
+
+    def _detect_same_day_exit_violations(self, target_date: str) -> List[dict]:
+        """당일청산 규칙(`trailing_rule=same_day_*`)인데 마감 후에도 HOLD 인 포지션.
+
+        강제청산이 실행되지 않으면 장부는 정상으로 보이고(HOLD 는 유효한 상태) 아무
+        경보도 울리지 않는다. 실제로 절반 유출 결함은 3주간 "고아가 이상하게 는다"는
+        간접 신호로만 드러났다. 규칙과 상태의 모순을 직접 본다.
+
+        판정 근거는 거래 레코드에 저장된 `trailing_rule` 이다 — 스케줄러 설정
+        (`force_exit_on_close`)을 참조하지 않으므로 리포트가 전략 구성에 결합되지 않고,
+        규칙이 바뀐 뒤 진입한 건과 이전 건이 각자의 규칙으로 판정된다.
+        """
+        if self._virtual_trade_service is None:
+            return []
+        try:
+            holds = self._virtual_trade_service.get_holds() or []
+        except Exception:
+            return []
+
+        violations: List[dict] = []
+        for hold in holds:
+            rule = str(hold.get("trailing_rule") or "")
+            if not rule.startswith("same_day"):
+                continue
+            code = str(hold.get("code") or "").strip()
+            violations.append({
+                "strategy": hold.get("strategy") or "전략 미상",
+                "code": code,
+                "name": hold.get("name") or code,
+                "qty": _to_int(hold.get("qty"), default=0),
+                "buy_date": hold.get("buy_date"),
+                "trailing_rule": rule,
+                "holding_days": self._holding_days(hold.get("buy_date"), target_date),
+            })
+        return violations
+
+    @staticmethod
+    def _holding_days(buy_date: Any, target_date: str) -> Optional[int]:
+        """진입일 ~ 리포트 기준일 경과일수. 파싱 실패 시 None."""
+        raw = str(buy_date or "").strip()[:10]
+        if not raw:
+            return None
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y%m%d"):
+            try:
+                bought = datetime.strptime(raw, fmt).date()
+                break
+            except ValueError:
+                continue
+        else:
+            return None
+        try:
+            target = datetime.strptime(_fmt_date(target_date), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+        return max((target - bought).days, 0)
+
     def _same_day_closed_codes(self, target_date: str) -> Set[str]:
         """target_date 에 청산된 종목코드. 진입분이 관리 대상인지 판정하는 데 쓴다."""
         if self._virtual_trade_service is None:
@@ -1459,6 +1542,7 @@ class StrategyLogReportService:
         execution_quality_candidates: List[dict],
         warnings_section: Optional[str],
         same_day_closed_codes: Optional[Set[str]] = None,
+        same_day_exit_violations: Optional[List[dict]] = None,
     ) -> str:
         lines = [f"<b>🧭 [{_fmt_date(target_date)}] 운영 의사결정 요약</b>"]
 
@@ -1511,6 +1595,10 @@ class StrategyLogReportService:
             lines.append("• 전략 확대 후보: 없음 — 표본/수익성 게이트 기준 미충족")
             if multiple_weak:
                 lines.append("• 검증 리스크: Deflated Sharpe 약함")
+
+        # 규칙과 상태의 모순 — 강제청산 미이행은 장부상 정상이라 다른 경보에 안 걸린다.
+        for line in self._format_same_day_exit_violation_lines(same_day_exit_violations or []):
+            lines.append(line)
 
         broker_count = self._extract_broker_reconciled_count(overnight_exposure_section)
         if broker_count is not None:
@@ -1981,6 +2069,8 @@ class StrategyLogReportService:
         date_prefix = f"{target_date[:4]}-{target_date[4:6]}-{target_date[6:8]}"
         self._last_execution_quality_candidates = []
         self._last_strategy_degradation_candidates = []
+        # 전략 로그가 없는 날에도 미청산 잔량은 남아 있을 수 있다 — 두 경로 모두에서 본다.
+        self._last_same_day_exit_violations = self._detect_same_day_exit_violations(target_date)
         strategy_files = self._find_strategy_files()
 
         if not strategy_files:
@@ -1995,6 +2085,7 @@ class StrategyLogReportService:
                 degradation_section=None,
                 execution_quality_candidates=[],
                 warnings_section=None,
+                same_day_exit_violations=self._last_same_day_exit_violations,
             )
             return (
                 f"<b>📊 [{_fmt_date(target_date)}] 전략 실행 요약</b>\n\n"
@@ -2296,6 +2387,7 @@ class StrategyLogReportService:
             execution_quality_candidates=self.get_last_execution_quality_candidates(),
             warnings_section=warnings_section,
             same_day_closed_codes=self._same_day_closed_codes(target_date),
+            same_day_exit_violations=self._last_same_day_exit_violations,
         )
 
         if not active_sections:

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple
 
 from common.strategy_identity import STRATEGY_IDENTITY_RESOLVER, StrategyStatus
 from common.trade_journal_comparison import compare_trade_journals
@@ -1429,6 +1429,22 @@ class StrategyLogReportService:
         match = re.search(r"'([^']+)'", regime_decomposition_section)
         return match.group(1) if match else "단일"
 
+    def _same_day_closed_codes(self, target_date: str) -> Set[str]:
+        """target_date 에 청산된 종목코드. 진입분이 관리 대상인지 판정하는 데 쓴다."""
+        if self._virtual_trade_service is None:
+            return set()
+        try:
+            solds = self._virtual_trade_service.get_solds() or []
+        except Exception:
+            return set()
+        date_prefix = _fmt_date(target_date)
+        return {
+            str(trade.get("code") or "").strip()
+            for trade in solds
+            if str(trade.get("sell_date", "")).startswith(date_prefix)
+            and str(trade.get("code") or "").strip()
+        }
+
     def _build_operational_decision_report(
         self,
         target_date: str,
@@ -1440,14 +1456,32 @@ class StrategyLogReportService:
         overnight_exposure_section: Optional[str],
         regime_decomposition_section: Optional[str],
         degradation_section: Optional[str],
-        execution_quality_section: Optional[str],
+        execution_quality_candidates: List[dict],
         warnings_section: Optional[str],
+        same_day_closed_codes: Optional[Set[str]] = None,
     ) -> str:
         lines = [f"<b>🧭 [{_fmt_date(target_date)}] 운영 의사결정 요약</b>"]
 
-        if buy_count > 0:
-            lines.append(f"• 신규 진입 {buy_count}건 — 체결/포지션 관리 확인")
-            for entry in buy_entries:
+        # 당일 청산분은 마감 후 관리 대상이 아니다 — 진입 건수만 세면 이미 닫힌
+        # 포지션까지 "체결/포지션 관리 확인" 대상으로 표시된다.
+        closed_codes = same_day_closed_codes or set()
+        open_entries = [
+            entry for entry in buy_entries
+            if str(entry.get("code") or "").strip() not in closed_codes
+        ]
+        closed_count = buy_count - len(open_entries)
+
+        if buy_count > 0 and not open_entries:
+            lines.append(f"• 신규 진입 {buy_count}건 — 전량 당일청산, 관리 대상 없음")
+        elif buy_count > 0:
+            if closed_count > 0:
+                lines.append(
+                    f"• 신규 진입 {buy_count}건 (당일청산 {closed_count}건) — "
+                    f"잔여 {len(open_entries)}건 체결/포지션 관리 확인"
+                )
+            else:
+                lines.append(f"• 신규 진입 {buy_count}건 — 체결/포지션 관리 확인")
+            for entry in open_entries:
                 strategy = _esc(entry.get("strategy") or "전략 미상")
                 code = str(entry.get("code") or "").strip()
                 name = _esc(entry.get("name") or code or "종목 미상")
@@ -1494,7 +1528,10 @@ class StrategyLogReportService:
 
         if degradation_section:
             lines.append("• 성과 저하 후보: 별도 경고 확인")
-        if execution_quality_section:
+        # 체결 품질 섹션은 기록이 하나라도 있으면 항상 렌더된다(슬리피지 0% 포함).
+        # 섹션 존재가 아니라 임계를 넘긴 비활성화 후보 유무로 판정해야 상시 경고를
+        # 띄우지 않는다 — 상시 경고는 진짜 경고를 가린다.
+        if execution_quality_candidates:
             lines.append("• 체결 품질 후보: 별도 경고 확인")
         if warnings_section:
             lines.append("• 시스템 경고: 데이터 수신/파싱 상태 확인")
@@ -1956,7 +1993,7 @@ class StrategyLogReportService:
                 overnight_exposure_section=None,
                 regime_decomposition_section=None,
                 degradation_section=None,
-                execution_quality_section=None,
+                execution_quality_candidates=[],
                 warnings_section=None,
             )
             return (
@@ -2256,8 +2293,9 @@ class StrategyLogReportService:
             overnight_exposure_section=overnight_exposure_section,
             regime_decomposition_section=regime_decomposition_section,
             degradation_section=degradation_section,
-            execution_quality_section=execution_quality_section,
+            execution_quality_candidates=self.get_last_execution_quality_candidates(),
             warnings_section=warnings_section,
+            same_day_closed_codes=self._same_day_closed_codes(target_date),
         )
 
         if not active_sections:

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1807,6 +1807,92 @@ async def test_new_entry_line_reports_no_target_when_all_closed_same_day(tmp_pat
     assert "신규 진입 1건 — 전량 당일청산, 관리 대상 없음" in decision
 
 
+# ── 미검출 보완: 당일청산 미이행 직접 검출 ──────────────────────────────
+
+def _hold(code, name, strategy="래리윌리엄스VBO", buy_date="2026-07-16 09:10:00",
+          trailing_rule="same_day_eod_or_stop", qty=15):
+    return {"strategy": strategy, "code": code, "name": name, "qty": qty,
+            "buy_price": 75000, "buy_date": buy_date, "status": "HOLD",
+            "trailing_rule": trailing_rule}
+
+
+@pytest.mark.asyncio
+async def test_same_day_exit_violation_detected_when_position_survives_close(tmp_path):
+    """당일청산 규칙 포지션이 마감 후에도 HOLD 면 강제청산 미이행이다.
+
+    강제청산 절반 유출은 장부상 정상이라 무경보였고, 발견 경로가 "고아가 이상하게
+    는다"는 간접 신호뿐이었다 — 직접 검출을 세운다.
+    """
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [_buy_trade("475150", "아이엠비디엑스", strategy="래리윌리엄스VBO")],
+            holds=[_hold("475150", "아이엠비디엑스")],
+        ),
+    )
+
+    assert "당일청산 미이행" in decision
+    assert "아이엠비디엑스(475150)" in decision
+
+
+@pytest.mark.asyncio
+async def test_same_day_exit_violation_absent_for_multiday_strategy(tmp_path):
+    """멀티데이 보유 전략의 오버나이트는 정상 — 경고 대상이 아니다."""
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [_buy_trade("005930", "삼성전자", strategy="오닐포켓피벗")],
+            holds=[_hold("005930", "삼성전자", strategy="오닐포켓피벗", trailing_rule=None)],
+        ),
+    )
+
+    assert "당일청산 미이행" not in decision
+
+
+@pytest.mark.asyncio
+async def test_same_day_exit_violation_reports_holding_days(tmp_path):
+    """전일 이전 진입분이 남아 있으면 더 심각하다 — 보유일수를 함께 낸다."""
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [], holds=[_hold("475150", "아이엠비디엑스", buy_date="2026-07-14 09:10:00")],
+        ),
+    )
+
+    assert "당일청산 미이행" in decision
+    assert "2일" in decision
+
+
+@pytest.mark.asyncio
+async def test_same_day_exit_violations_exposed_via_accessor(tmp_path):
+    log_dir = tmp_path / "strategies"
+    log_dir.mkdir(exist_ok=True)
+    _write_log(
+        str(log_dir / "20260716_091000_FirstPullback.log.json"),
+        [{"timestamp": "2026-07-16 09:10:00,000", "level": "INFO",
+          "data": {"event": "scan_with_watchlist", "count": 1}}],
+    )
+    svc = StrategyLogReportService(
+        log_dir=str(log_dir),
+        virtual_trade_service=_vts([], holds=[_hold("475150", "아이엠비디엑스")]),
+    )
+    await svc.generate_report("20260716")
+
+    violations = svc.get_last_same_day_exit_violations()
+    assert len(violations) == 1
+    assert violations[0]["code"] == "475150"
+    assert violations[0]["qty"] == 15
+
+
+@pytest.mark.asyncio
+async def test_no_violation_line_when_no_same_day_holds(tmp_path):
+    decision = await _decision_for(
+        tmp_path, virtual_trade_service=_vts([_buy_trade("005930", "삼성전자")]),
+    )
+
+    assert "당일청산 미이행" not in decision
+
+
 @pytest.mark.asyncio
 async def test_new_entry_line_ignores_other_day_sells(tmp_path):
     """전일 청산 기록은 당일 진입 판정에 영향을 주지 않는다."""

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1698,3 +1698,125 @@ async def test_operational_decision_report_includes_new_entry_details(tmp_path):
     decision = svc.get_last_operational_decision_report()
     assert "신규 진입 1건 — 체결/포지션 관리 확인" in decision
     assert "FirstPullback · 삼성전자(005930) · 2주 · ₩75,000 · 09:10" in decision
+
+
+def _vts(all_trades, solds=(), holds=()):
+    class DummyVirtualTradeService:
+        def get_all_trades(self):
+            return list(all_trades)
+
+        def get_solds(self):
+            return list(solds)
+
+        def get_holds(self):
+            return list(holds)
+
+    return DummyVirtualTradeService()
+
+
+def _buy_trade(code, name, strategy="first_pullback", date="2026-07-16 09:10:00", status="HOLD"):
+    return {"strategy": strategy, "code": code, "name": name, "buy_price": 75000,
+            "qty": 2, "buy_date": date, "status": status, "reason": "원장 체결"}
+
+
+async def _decision_for(tmp_path, *, virtual_trade_service, patch_svc=None):
+    log_dir = tmp_path / "strategies"
+    log_dir.mkdir(exist_ok=True)
+    _write_log(
+        str(log_dir / "20260716_091000_FirstPullback.log.json"),
+        [{"timestamp": "2026-07-16 09:10:00,000", "level": "INFO",
+          "data": {"event": "scan_with_watchlist", "count": 1}}],
+    )
+    svc = StrategyLogReportService(
+        log_dir=str(log_dir), virtual_trade_service=virtual_trade_service,
+    )
+    if patch_svc:
+        patch_svc(svc)
+    await svc.generate_report("20260716")
+    return svc.get_last_operational_decision_report()
+
+
+# ── 오탐 1: 체결 품질 "별도 경고 확인" ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_execution_quality_warning_absent_when_no_threshold_candidate(tmp_path):
+    """섹션이 렌더돼도 임계 통과 후보가 없으면 경고를 띄우지 않는다.
+
+    체결 품질 섹션은 기록이 하나라도 있으면 항상 생성되므로(슬리피지 0% 포함),
+    섹션 존재만 검사하면 상시 경고가 떠 진짜 경고를 가린다.
+    """
+    def _patch(svc):
+        svc._build_execution_quality_section = lambda _records: "<b>📈 체결 품질 요약</b>\n• 정상"
+
+    decision = await _decision_for(
+        tmp_path, virtual_trade_service=_vts([_buy_trade("005930", "삼성전자")]),
+        patch_svc=_patch,
+    )
+
+    assert "체결 품질 후보" not in decision
+
+
+@pytest.mark.asyncio
+async def test_execution_quality_warning_present_when_candidate_exists(tmp_path):
+    def _patch(svc):
+        def _build(_records):
+            svc._last_execution_quality_candidates = [
+                {"strategy": "first_pullback", "reason": "슬리피지 과다"}
+            ]
+            return "<b>📈 체결 품질 요약</b>\n• ⚠️ 비활성화 후보 1개"
+        svc._build_execution_quality_section = _build
+
+    decision = await _decision_for(
+        tmp_path, virtual_trade_service=_vts([_buy_trade("005930", "삼성전자")]),
+        patch_svc=_patch,
+    )
+
+    assert "체결 품질 후보: 별도 경고 확인" in decision
+
+
+# ── 오탐 2: 신규 진입 N건이 당일 청산 미반영 ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_new_entry_line_excludes_same_day_closed_positions(tmp_path):
+    """당일 청산된 진입분은 마감 후 '관리 대상'이 아니다."""
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [_buy_trade("005930", "삼성전자"), _buy_trade("000660", "SK하이닉스")],
+            solds=[{"code": "005930", "name": "삼성전자",
+                    "sell_date": "2026-07-16 15:20:00", "status": "SOLD"}],
+        ),
+    )
+
+    assert "신규 진입 2건 (당일청산 1건) — 잔여 1건 체결/포지션 관리 확인" in decision
+    assert "SK하이닉스(000660)" in decision
+    assert "삼성전자(005930)" not in decision
+
+
+@pytest.mark.asyncio
+async def test_new_entry_line_reports_no_target_when_all_closed_same_day(tmp_path):
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [_buy_trade("005930", "삼성전자")],
+            solds=[{"code": "005930", "name": "삼성전자",
+                    "sell_date": "2026-07-16 15:20:00", "status": "SOLD"}],
+        ),
+    )
+
+    assert "신규 진입 1건 — 전량 당일청산, 관리 대상 없음" in decision
+
+
+@pytest.mark.asyncio
+async def test_new_entry_line_ignores_other_day_sells(tmp_path):
+    """전일 청산 기록은 당일 진입 판정에 영향을 주지 않는다."""
+    decision = await _decision_for(
+        tmp_path,
+        virtual_trade_service=_vts(
+            [_buy_trade("005930", "삼성전자")],
+            solds=[{"code": "005930", "name": "삼성전자",
+                    "sell_date": "2026-07-15 15:20:00", "status": "SOLD"}],
+        ),
+    )
+
+    assert "신규 진입 1건 — 체결/포지션 관리 확인" in decision

--- a/todo_list.md
+++ b/todo_list.md
@@ -200,7 +200,7 @@
 - [x] **익일 대사 완료 (2026-07-23)**: DB 조회로 `broker_reconciled` 고아 10종목이 07-22 이전과 동일하게 유지(증가 없음)됨을 확인 — 유출 종료.
 - [ ] 기존 고아 10종목 처리 방침 결정. 7월 4건(031980·086790·001450 ×2)은 `scripts/repair_partial_sell_ledger.py` 로 복구 가능하나 원 전략이 전부 당일청산 VBO 라 **복구 = 익일 강제청산 지시**임 — 청산 의사 결정 후 실행. 5~6월 6건은 절반 패턴이 아니라 원인 미상, 별도 조사.
 - [ ] 오염된 성과 기록 5건(trade id 251·261·263·265·269) 의심 플래그. 나머지 절반이 미청산이라 소급 재구성 불가 — 재작성하지 말 것.
-- [ ] 운영 요약 오탐 2건 수정: `_build_decision_summary` 가 `if execution_quality_section:` / `if degradation_section:` 로 **섹션 존재 여부만** 검사해 슬리피지 0%에도 "별도 경고 확인"이 뜬다. 임계 필터링된 `get_last_execution_quality_candidates()` 를 써야 한다. 같은 함수의 "신규 진입 N건" 도 당일 청산을 반영하지 않아 이미 닫힌 포지션을 관리 대상으로 표시한다. ※ 이 오탐이 이번 결함을 3주간 가렸다.
+- [x] **운영 요약 오탐 수정 완료 (2026-08-06)**: `_build_operational_decision_report`(todo 원문의 `_build_decision_summary` 는 오기)가 `if execution_quality_section:` 으로 **섹션 존재 여부만** 검사해 슬리피지 0%에도 "체결 품질 후보: 별도 경고 확인"이 상시 노출됐다 → 임계 필터링된 `get_last_execution_quality_candidates()` 로 판정하도록 교체. "신규 진입 N건" 은 당일 청산분을 제외해 잔여 관리 대상만 표시(`신규 진입 2건 (당일청산 1건) — 잔여 1건 …` / 전량 청산 시 `관리 대상 없음`). ※ `degradation_section` 은 후보 0건이면 `None` 을 반환하므로 원래부터 오탐이 아니었다 — todo 원문의 "오탐 2건" 중 성과저하 쪽은 사실과 달랐다.
 - [ ] (제안) "당일청산 전략인데 마감 후 보유 중" 직접 검출 점검 추가. 이번 결함은 장부상 정상이라 무경보였고, 발견 경로가 "고아가 이상하게 는다"는 간접 신호뿐이었다.
 
 주요 파일: `scheduler/strategy_scheduler.py`(FORCE_EXIT_TIERS/ORDER_CUTOFF), `repositories/virtual_trade_repository.py`(`_settle_hold_sale`), `services/strategy_log_report_service.py`, `scripts/repair_partial_sell_ledger.py`

--- a/todo_list.md
+++ b/todo_list.md
@@ -201,7 +201,7 @@
 - [ ] 기존 고아 10종목 처리 방침 결정. 7월 4건(031980·086790·001450 ×2)은 `scripts/repair_partial_sell_ledger.py` 로 복구 가능하나 원 전략이 전부 당일청산 VBO 라 **복구 = 익일 강제청산 지시**임 — 청산 의사 결정 후 실행. 5~6월 6건은 절반 패턴이 아니라 원인 미상, 별도 조사.
 - [ ] 오염된 성과 기록 5건(trade id 251·261·263·265·269) 의심 플래그. 나머지 절반이 미청산이라 소급 재구성 불가 — 재작성하지 말 것.
 - [x] **운영 요약 오탐 수정 완료 (2026-08-06)**: `_build_operational_decision_report`(todo 원문의 `_build_decision_summary` 는 오기)가 `if execution_quality_section:` 으로 **섹션 존재 여부만** 검사해 슬리피지 0%에도 "체결 품질 후보: 별도 경고 확인"이 상시 노출됐다 → 임계 필터링된 `get_last_execution_quality_candidates()` 로 판정하도록 교체. "신규 진입 N건" 은 당일 청산분을 제외해 잔여 관리 대상만 표시(`신규 진입 2건 (당일청산 1건) — 잔여 1건 …` / 전량 청산 시 `관리 대상 없음`). ※ `degradation_section` 은 후보 0건이면 `None` 을 반환하므로 원래부터 오탐이 아니었다 — todo 원문의 "오탐 2건" 중 성과저하 쪽은 사실과 달랐다.
-- [ ] (제안) "당일청산 전략인데 마감 후 보유 중" 직접 검출 점검 추가. 이번 결함은 장부상 정상이라 무경보였고, 발견 경로가 "고아가 이상하게 는다"는 간접 신호뿐이었다.
+- [x] **"당일청산 전략인데 마감 후 보유 중" 직접 검출 추가 (2026-08-06)**: 거래 레코드의 `trailing_rule`(`same_day_*`)과 HOLD 상태의 모순을 운영 요약에서 직접 검출한다(`🚨 당일청산 미이행 N건` + 전략/종목/잔량/보유일수, `get_last_same_day_exit_violations()` 노출). 판정을 스케줄러 설정(`force_exit_on_close`)이 아니라 진입 시점에 기록된 규칙으로 하므로 리포트가 전략 구성에 결합되지 않고, 규칙 변경 전후 진입분이 각자 기준으로 판정된다. 전략 로그가 없는 날에도 검출한다(미청산 잔량은 남아 있을 수 있음).
 
 주요 파일: `scheduler/strategy_scheduler.py`(FORCE_EXIT_TIERS/ORDER_CUTOFF), `repositories/virtual_trade_repository.py`(`_settle_hold_sale`), `services/strategy_log_report_service.py`, `scripts/repair_partial_sell_ledger.py`
 


### PR DESCRIPTION
## 배경

todo P0 [0-2](todo_list.md:203-204). 강제청산 절반 유출 결함이 **3주간 발견되지 않은** 배경에 운영 요약의 두 가지 문제가 있었습니다. 방향이 반대인 한 쌍이라 함께 고칩니다.

| | 문제 | 결과 |
|---|---|---|
| 오탐 | 정상인데 경고가 뜸 | 진짜 경고가 묻힘 |
| 미검출 | 이상인데 경고가 없음 | 간접 신호로만 발견 |

## 1. 오탐 — 체결 품질 "별도 경고 확인"이 상시 노출

`_build_execution_quality_section`은 기록이 하나라도 있으면 **항상** 섹션을 렌더합니다(슬리피지 0%인 정상 상태 포함). 임계를 넘긴 비활성화 후보는 별도로 `_last_execution_quality_candidates`에 담기는데, 요약은 이걸 보지 않고 섹션 존재만 검사했습니다.

```python
if execution_quality_section:            # 정상이어도 항상 참
    lines.append("• 체결 품질 후보: 별도 경고 확인")
```

→ `get_last_execution_quality_candidates()`(임계 필터링됨)로 판정하도록 교체.

## 2. 오탐 — "신규 진입 N건"이 당일 청산 미반영

당일 청산된 포지션까지 마감 후 "체결/포지션 관리 확인" 대상으로 표시했습니다. 당일청산 전략(VBO 등)은 대부분이 이미 닫힌 상태라 목록이 통째로 무의미해집니다.

```
신규 진입 2건 (당일청산 1건) — 잔여 1건 체결/포지션 관리 확인
신규 진입 1건 — 전량 당일청산, 관리 대상 없음
```

청산 0건이면 기존 문구 그대로라 하위호환됩니다.

## 3. 미검출 — 당일청산 미이행 직접 검출 (신규)

강제청산이 실행되지 않아도 **장부상 HOLD는 유효한 상태**라 어떤 경보에도 걸리지 않았습니다. 규칙과 상태의 모순을 직접 봅니다.

```
• 🚨 당일청산 미이행 1건 — 강제청산 실행/잔량 즉시 확인
  - 래리윌리엄스VBO · 아이엠비디엑스(475150) · 잔량 15주 · 보유 2일
```

설계 선택 두 가지:

- **판정 근거를 진입 시점에 기록된 `trailing_rule`로 둡니다** — 스케줄러 설정(`force_exit_on_close`)을 참조하지 않아 리포트가 전략 구성에 결합되지 않고, 규칙 변경 전후 진입분이 각자의 기준으로 판정됩니다.
- **전략 로그가 없는 날에도 검출합니다** — 미청산 잔량은 그날 매매와 무관하게 남아 있습니다.

`get_last_same_day_exit_violations()`로 노출해 후속 알림/태스크가 소비할 수 있습니다.

## todo 원문과 다른 점 2가지

작업하며 확인한 사실을 todo에 정정 기록했습니다:

1. **`degradation_section`은 오탐이 아니었습니다.** todo는 "오탐 2건"으로 이 조건도 지목했지만, `_build_strategy_degradation_section`은 후보 0건이면 `None`을 반환하므로 `if degradation_section:`은 원래부터 "후보 있음"과 동치입니다. 깨지지 않은 것이라 건드리지 않았습니다.
2. **함수명이 달랐습니다.** todo의 `_build_decision_summary`는 실제로 `_build_operational_decision_report`입니다.

## 테스트

- 신규 10건 (오탐 5 · 검출 5)
- `pytest tests/unit_test` 7438 passed
- `pytest tests/integration_test` 277 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
