### PR TITLE
feat: relax market regime recovery gate

### DIFF
--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -21,6 +21,7 @@ _TREND_STATUS_TO_LABEL = {
     "rising": "bull",
     "hard_decline": "bear",
     "weak_trend": "bear",
+    "recovery": "bull",
     "uptrend_under_pressure": "sideways",
 }
 
@@ -39,7 +40,7 @@ class MarketRegimeConfig:
 @dataclass
 class RegimeSnapshot:
     market: str               # "KOSPI" | "KOSDAQ"
-    trend_status: str         # rising / hard_decline / weak_trend / uptrend_under_pressure
+    trend_status: str         # rising / hard_decline / weak_trend / recovery / uptrend_under_pressure
     regime_label: str         # bull / bear / sideways
     snapshot_date: str        # YYYYMMDD
     is_rising: bool
@@ -50,8 +51,6 @@ class RegimeSnapshot:
     data_date: str = ""       # 판정에 사용한 마지막 확정 일봉 날짜 (YYYYMMDD)
     current_close: Optional[float] = None  # 판정 기준일 지수 종가
     recovery_earliest_days: Optional[int] = None  # 기존 급락 MA가 판정창에서 빠지는 최소 거래일
-    recovery_target_ma: Optional[float] = None    # 해당 시점 3일 순변화 조건의 MA(20) 하한
-    recovery_target_close: Optional[float] = None  # 최초 전환일 종가 목표(그전 종가 현재 수준 유지 가정)
     next_close_floor: Optional[float] = None      # 다음 MA(20)의 hard decline 방지 종가 하한
 
 
@@ -78,6 +77,14 @@ class MarketRegimeService:
         if market == "KOSDAQ":
             return self._cfg.kosdaq_index_code
         raise ValueError(f"Unknown market: {market}")
+
+    @staticmethod
+    def _is_recovery_ready(closes: List[float], ma_values: List[float]) -> bool:
+        """급락 해소 뒤의 회복 진입 조건을 판정한다."""
+        ma_is_not_falling = ma_values[-1] >= ma_values[-2]
+        close_is_above_ma = closes[-1] >= ma_values[-1]
+        recent_price_rise = closes[-1] > closes[-2] or closes[-2] > closes[-3]
+        return ma_is_not_falling and close_is_above_ma and recent_price_rise
 
     async def classify(self, market: str, logger: Optional[logging.Logger] = None) -> RegimeSnapshot:
         """오늘 기준 캐시된 분류를 반환. 캐시가 비어 있으면 SQS로 재계산."""
@@ -196,18 +203,19 @@ class MarketRegimeService:
             )
             trend_status = "hard_decline"
         elif net_change_pct < self._cfg.min_net_change_pct:
-            is_rising = False
-            fail_detail = (
-                f"MA trend weak: net {net_change_pct:.2f}% < {self._cfg.min_net_change_pct:.2f}% "
-                f"({first_ma:.2f} -> {last_ma:.2f})"
-            )
-            trend_status = "weak_trend"
+            if self._is_recovery_ready(closes, ma_values):
+                trend_status = "recovery"
+            else:
+                is_rising = False
+                fail_detail = (
+                    f"MA trend weak: net {net_change_pct:.2f}% < {self._cfg.min_net_change_pct:.2f}% "
+                    f"({first_ma:.2f} -> {last_ma:.2f})"
+                )
+                trend_status = "weak_trend"
         elif max_daily_drop_pct < self._cfg.daily_dip_tolerance_pct:
             trend_status = "uptrend_under_pressure"
 
         recovery_earliest_days: Optional[int] = None
-        recovery_target_ma: Optional[float] = None
-        recovery_target_close: Optional[float] = None
         next_close_floor: Optional[float] = None
         if not is_rising:
             # 다음 MA는 가장 오래된 20일 창 종가가 빠지고 다음 확정 종가가 들어온다.
@@ -224,21 +232,6 @@ class MarketRegimeService:
                 if change < self._cfg.hard_decline_pct
             ]
             recovery_earliest_days = max(hard_decline_indexes, default=1)
-            # recovery_earliest_days 뒤의 4개 MA 창은 기존 MA 중 해당 index부터
-            # 시작한다. 마지막 MA가 이 값 이상이면 3일 순변화 조건을 충족한다.
-            recovery_reference_ma = ma_values[recovery_earliest_days]
-            recovery_target_ma = recovery_reference_ma * (1 + self._cfg.min_net_change_pct / 100)
-            # 최초 전환일까지 이전 종가가 현재 종가와 같다고 가정하고, 마지막 종가 하나로
-            # 목표 MA를 충족시키는 데 필요한 종가를 계산한다.
-            replacement_count = recovery_earliest_days
-            outgoing_closes = closes[-period:-period + replacement_count]
-            assumed_intermediate_closes = closes[-1] * (replacement_count - 1)
-            recovery_target_close = (
-                period * recovery_target_ma
-                - (sum(closes[-period:]) - sum(outgoing_closes))
-                - assumed_intermediate_closes
-            )
-
         snap = RegimeSnapshot(
             market=market,
             trend_status=trend_status,
@@ -252,8 +245,6 @@ class MarketRegimeService:
             data_date=data_date,
             current_close=round(closes[-1], 2),
             recovery_earliest_days=recovery_earliest_days,
-            recovery_target_ma=round(recovery_target_ma, 2) if recovery_target_ma is not None else None,
-            recovery_target_close=round(recovery_target_close, 2) if recovery_target_close is not None else None,
             next_close_floor=round(next_close_floor, 2) if next_close_floor is not None else None,
         )
         logger.debug({

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -1039,12 +1039,10 @@ class OneilUniverseService:
                 msg += f"• 최근 MA({self._cfg.market_ma_period}) 추이: {ma_str}"
                 if not is_rising and snap.recovery_earliest_days is not None:
                     msg += f"\n• 최초 전환 가능: 최소 {snap.recovery_earliest_days}거래일 후 (이후 종가 조건 충족 시)"
-                if not is_rising and snap.recovery_target_ma is not None:
-                    msg += f"\n• 전환 시 MA({self._cfg.market_ma_period}) 목표: ≥ {snap.recovery_target_ma:,.2f}"
-                if not is_rising and snap.recovery_target_close is not None:
+                if not is_rising and snap.recovery_earliest_days is not None:
                     msg += (
-                        f"\n• 최초 전환일 종가 목표: ≥ {snap.recovery_target_close:,.2f} "
-                        f"(그전 종가 현재 수준 유지 가정)"
+                        f"\n• 회복 전환 조건: 급락 구간 해소 후 MA({self._cfg.market_ma_period}) 비하락, "
+                        f"종가가 MA 위, 최근 2거래일 중 1일 이상 상승"
                     )
                 if not is_rising and snap.next_close_floor is not None:
                     msg += (

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -100,8 +100,8 @@ async def test_classify_hard_decline_returns_bear():
 
 
 @pytest.mark.asyncio
-async def test_classify_hard_decline_includes_recovery_price_guidance():
-    """급락 MA가 판정창에서 빠지는 최초 시점과 전환 종가 목표를 안내한다."""
+async def test_classify_hard_decline_includes_recovery_guidance():
+    """급락 MA가 판정창에서 빠지는 최초 시점과 다음 종가 하한을 안내한다."""
     closes = [200, 200, 200, 200, 200, 200, 200, 150]
     svc, _ = _make_service(closes)
 
@@ -109,11 +109,7 @@ async def test_classify_hard_decline_includes_recovery_price_guidance():
 
     # MA(5): 200 -> 200 -> 190. 마지막 hard decline(idx=2)은 2거래일 후 소멸한다.
     assert snap.recovery_earliest_days == 2
-    assert snap.recovery_target_ma == 189.81  # 190 * (1 - 0.10%)
     assert snap.current_close == 150
-    # 최초 전환일 전까지 현재 종가(150)를 유지한다고 가정하면,
-    # 전환일의 종가는 MA(5)를 189.81 이상으로 만들기 위해 249.05 이상이어야 한다.
-    assert snap.recovery_target_close == 249.05
     # 다음 MA가 -0.50%보다 더 급락하지 않는 종가 하한:
     # 200 + 5 * (190 * 0.995 - 190) = 195.25
     assert snap.next_close_floor == 195.25
@@ -130,6 +126,25 @@ async def test_classify_weak_trend_returns_bear():
     assert snap.trend_status == "weak_trend"
     assert snap.regime_label == "bear"
     assert snap.is_rising is False
+
+
+@pytest.mark.asyncio
+async def test_classify_recovers_after_hard_decline_window_clears():
+    """급락이 해소된 뒤 MA 비하락·종가 MA 상회·최근 상승이면 회복을 허용한다."""
+    # 마지막 세 MA(5)는 108.50 -> 108.20 -> 108.20이다.
+    # 기존 순변화 기준만 쓰면 약세지만, MA가 더 내려가지 않고 종가가 MA 위이며
+    # 최근 2일에 상승이 있으므로 회복 국면으로 판정해야 한다.
+    closes = [110, 109.5, 109, 108.5, 108, 107.5, 108, 109]
+    svc, _ = _make_service(closes)
+
+    snap = await svc.classify("KOSPI")
+
+    assert snap.net_change_pct < -0.10
+    assert snap.max_daily_drop_pct >= -0.50
+    assert snap.current_close > snap.ma_values[-1]
+    assert snap.trend_status == "recovery"
+    assert snap.regime_label == "bull"
+    assert snap.is_rising is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_oneil_universe_service.py
+++ b/tests/unit_test/services/test_oneil_universe_service.py
@@ -1780,9 +1780,7 @@ async def test_update_market_timing_emits_notifications(mock_deps):
 
     failed_snap = _snap("KOSPI", False, [3.0, 2.0, 1.0], fail="MA decline")
     failed_snap.recovery_earliest_days = 2
-    failed_snap.recovery_target_ma = 1.5
     failed_snap.current_close = 1200.0
-    failed_snap.recovery_target_close = 1300.0
     failed_snap.next_close_floor = 1234.5
     service._regime_svc.classify = AsyncMock(side_effect=[
         _snap("KOSDAQ", True, [1.0, 2.0, 3.0]),
@@ -1806,7 +1804,7 @@ async def test_update_market_timing_emits_notifications(mock_deps):
     assert "MA decline" in call_kwargs["message"]
     assert "최초 전환 가능: 최소 2거래일 후" in call_kwargs["message"]
     assert "현재 지수(종가): 1,200.00" in call_kwargs["message"]
-    assert "최초 전환일 종가 목표: ≥ 1,300.00 (그전 종가 현재 수준 유지 가정)" in call_kwargs["message"]
+    assert "회복 전환 조건: 급락 구간 해소 후 MA(20) 비하락" in call_kwargs["message"]
     assert "다음 종가 하한: 1,234.50" in call_kwargs["message"]
 
 


### PR DESCRIPTION
## What changed
- Keep the MA(20) hard-decline buy block.
- Allow recovery after the decline window clears when MA is non-falling, the close is at or above MA, and recent price action rises.
- Replace the misleading single-close recovery target with the actual recovery criteria.

## Why
The previous recovery calculation could require unrealistic one-day index moves.

## Validation
- pytest tests/unit_test -v (7,429 passed)
- pytest tests/integration_test -v (277 passed)