### PR TITLE
fix: prevent index threshold alert flapping

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -10,6 +10,8 @@ from common.operator_alert_types import AlertSource
 class MarketStatusAlertService:
     """KIS 장운영정보(H0* MKO0)에서 시장 안전장치 발동을 감지한다."""
 
+    _MOVE_5_THRESHOLD_PCT = 5.0
+    _MOVE_5_RESOLVE_PCT = 4.5
     _CIRCUIT_KEYWORDS = ("서킷", "circuit", "매매거래중단", "거래중단")
     _SIDECAR_KEYWORDS = ("사이드카", "sidecar")
 
@@ -85,15 +87,19 @@ class MarketStatusAlertService:
         active_keys = self._active_index_keys_by_code.setdefault(index_code, set())
         expected_keys: set[str] = set()
 
-        if abs(change_rate) >= 5.0:
-            key = f"market_index:move_5:{direction}:{index_code}"
-            expected_keys.add(key)
+        move_5_key = f"market_index:move_5:{direction}:{index_code}"
+        if abs(change_rate) >= self._MOVE_5_THRESHOLD_PCT:
+            expected_keys.add(move_5_key)
             await self._report_index_alert(
-                key=key, severity="error",
+                key=move_5_key, severity="error",
                 title=f"{index_name} {self._direction_label(direction)} 5% 이상 등락",
                 index_code=index_code, index_name=index_name, change_rate=change_rate,
-                threshold_pct=5.0, event_type="move_5",
+                threshold_pct=self._MOVE_5_THRESHOLD_PCT, event_type="move_5",
             )
+        elif abs(change_rate) > self._MOVE_5_RESOLVE_PCT and move_5_key in active_keys:
+            # 경계값 부근의 1분 단위 등락으로 경보/해제가 반복되지 않도록,
+            # 발동 후에는 충분히 회복할 때까지 같은 방향의 경보를 유지한다.
+            expected_keys.add(move_5_key)
         if change_rate <= -8.0:
             key = f"market_index:fall_8:{index_code}"
             expected_keys.add(key)

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -168,3 +168,27 @@ async def test_market_status_alert_service_reports_index_thresholds_and_resolves
         "market_index:move_5:down:0001",
         "market_index:fall_8:0001",
     }
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_keeps_move_5_alert_active_until_recovery_buffer():
+    """-5% 경보는 -4.5% 이상 회복 전까지 유지해 경계값 반복 알림을 막는다."""
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_index_change("0001", "코스피", -5.03)
+    await service.on_index_change("0001", "코스피", -4.90)
+
+    operator_alert.report.assert_awaited_once()
+    operator_alert.resolve.assert_not_awaited()
+
+    await service.on_index_change("0001", "코스피", -4.50)
+
+    operator_alert.resolve.assert_awaited_once_with(
+        AlertSource.MARKET_STATUS,
+        "market_index:move_5:down:0001",
+        "지수 등락률 정상화",
+    )


### PR DESCRIPTION
## What changed
- Add a 4.5% recovery threshold for active 5% index-move alerts.
- Keep the existing alert active while the index remains in the 4.5%–5.0% boundary band.
- Add regression coverage for -5.03% -> -4.90% -> -4.50%.

## Why
One-minute index values around -5% repeatedly triggered and immediately resolved the same alert.

## Validation
- pytest tests/unit_test -v (7,430 passed)
- pytest tests/integration_test -v (277 passed)