### PR TITLE
Suppress intraday ranking refresh notifications

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -219,8 +219,8 @@ class RankingTask(AfterMarketTask):
 
     # ── 기본 랭킹 캐시 (상승/하락/거래량/거래대금) ───────────────
 
-    async def refresh_basic_ranking(self) -> None:
-        """상승률/하락률/거래량/거래대금 랭킹을 1회 조회하여 캐시."""
+    async def refresh_basic_ranking(self, *, notify: bool = True) -> None:
+        """상승률/하락률/거래량/거래대금 랭킹을 1회 조회하여 캐시한다."""
         if not self._market_data_service:
             self._logger.warning("MarketDataService 미설정 — 기본 랭킹 캐시 스킵")
             return
@@ -246,7 +246,7 @@ class RankingTask(AfterMarketTask):
                 self._basic_ranking_updated_at = datetime.now()
                 self._logger.info(f"기본 랭킹 캐시 갱신 완료: {list(self._basic_ranking_cache.keys())}")
                 self.pm.log_timer("RankingTask.refresh_basic_ranking", t_start, threshold=1.0)
-                if self._notification_service:
+                if notify and self._notification_service:
                     await self._notification_service.emit(
                         NotificationCategory.BACKGROUND, NotificationLevel.INFO, "기본 랭킹 갱신 완료",
                         f"상승/하락/거래량/거래대금 캐시 갱신 완료",

--- a/task/background/intraday/theme_intraday_leader_alert_task.py
+++ b/task/background/intraday/theme_intraday_leader_alert_task.py
@@ -211,7 +211,7 @@ class ThemeIntradayLeaderAlertTask(SchedulableTask):
     async def _build_intraday_rankings(self, slot_label: str) -> Dict[str, Any]:
         refresh = getattr(self._ranking_task, "refresh_basic_ranking", None)
         if callable(refresh):
-            result = refresh()
+            result = refresh(notify=False)
             if inspect.isawaitable(result):
                 await result
 

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -1075,6 +1075,25 @@ async def test_refresh_basic_ranking_success_notification(bg_service, mock_deps)
 
 
 @pytest.mark.asyncio
+async def test_refresh_basic_ranking_suppresses_success_notification_when_requested(bg_service):
+    """장중 캐시 갱신은 성공 알림 없이 수행할 수 있다."""
+    bg_service._notification_service = AsyncMock()
+    bg_service._market_data_service.get_top_rise_fall_stocks.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data=[]
+    )
+    bg_service._market_data_service.get_top_volume_stocks.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data=[]
+    )
+    bg_service._market_data_service.get_top_trading_value_stocks.return_value = ResCommonResponse(
+        rt_cd="0", msg1="OK", data=[]
+    )
+
+    await bg_service.refresh_basic_ranking(notify=False)
+
+    bg_service._notification_service.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_refresh_investor_ranking_notification(bg_service, mock_deps):
     """투자자 랭킹 갱신 성공/실패 알림 테스트."""
     broker, mapper, _, _, _, _ = mock_deps

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -99,7 +99,7 @@ async def test_open_tick_sends_intraday_theme_report_for_current_hourly_slot():
 
     await deps.task._tick()
 
-    deps.ranking_task.refresh_basic_ranking.assert_awaited_once()
+    deps.ranking_task.refresh_basic_ranking.assert_awaited_once_with(notify=False)
     rankings = deps.theme_service.build_intraday_theme_report.await_args.args[0]
     assert rankings["report_date"] == "20260706"
     assert rankings["program_all_stocks"] == []


### PR DESCRIPTION
## What changed

- Refresh intraday ranking caches without emitting a completion notification.
- Preserve completion notifications for non-intraday ranking refreshes.
- Add regression coverage for the silent refresh path.

## Why

The intraday theme task refreshes ranking data every minute. Each successful refresh previously produced a background notification, creating unnecessary alert noise.

## Validation

- `pytest tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py tests/unit_test/task/background/after_market/test_ranking_task.py -v -n0` (98 passed)
- `pytest tests/integration_test -v -n0` (277 passed)