### PR TITLE
Stabilize index threshold alert recovery

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -12,6 +12,7 @@ class MarketStatusAlertService:
 
     _MOVE_5_THRESHOLD_PCT = 5.0
     _MOVE_5_RESOLVE_PCT = 4.5
+    _MOVE_5_RESOLVE_CONSECUTIVE_SAMPLES = 3
     _CIRCUIT_KEYWORDS = ("서킷", "circuit", "매매거래중단", "거래중단")
     _SIDECAR_KEYWORDS = ("사이드카", "sidecar")
 
@@ -26,6 +27,7 @@ class MarketStatusAlertService:
         self._logger = logger or logging.getLogger(__name__)
         self._active_keys_by_code: dict[str, set[str]] = {}
         self._active_index_keys_by_code: dict[str, set[str]] = {}
+        self._move_5_recovery_samples_by_code: dict[str, int] = {}
 
     async def on_market_status(self, data: dict[str, Any]) -> None:
         """StreamingService handler entrypoint."""
@@ -86,9 +88,13 @@ class MarketStatusAlertService:
         direction = "up" if change_rate >= 0 else "down"
         active_keys = self._active_index_keys_by_code.setdefault(index_code, set())
         expected_keys: set[str] = set()
+        active_move_5_keys = {
+            key for key in active_keys if key.startswith("market_index:move_5:")
+        }
 
         move_5_key = f"market_index:move_5:{direction}:{index_code}"
         if abs(change_rate) >= self._MOVE_5_THRESHOLD_PCT:
+            self._move_5_recovery_samples_by_code.pop(index_code, None)
             expected_keys.add(move_5_key)
             await self._report_index_alert(
                 key=move_5_key, severity="error",
@@ -96,10 +102,19 @@ class MarketStatusAlertService:
                 index_code=index_code, index_name=index_name, change_rate=change_rate,
                 threshold_pct=self._MOVE_5_THRESHOLD_PCT, event_type="move_5",
             )
-        elif abs(change_rate) > self._MOVE_5_RESOLVE_PCT and move_5_key in active_keys:
-            # 경계값 부근의 1분 단위 등락으로 경보/해제가 반복되지 않도록,
-            # 발동 후에는 충분히 회복할 때까지 같은 방향의 경보를 유지한다.
-            expected_keys.add(move_5_key)
+        elif active_move_5_keys:
+            if abs(change_rate) > self._MOVE_5_RESOLVE_PCT:
+                # 경계값 부근의 1분 단위 등락으로 경보/해제가 반복되지 않도록,
+                # 발동 후에는 충분히 회복할 때까지 같은 방향의 경보를 유지한다.
+                self._move_5_recovery_samples_by_code.pop(index_code, None)
+                expected_keys.update(active_move_5_keys)
+            else:
+                recovery_samples = self._move_5_recovery_samples_by_code.get(index_code, 0) + 1
+                if recovery_samples < self._MOVE_5_RESOLVE_CONSECUTIVE_SAMPLES:
+                    self._move_5_recovery_samples_by_code[index_code] = recovery_samples
+                    expected_keys.update(active_move_5_keys)
+                else:
+                    self._move_5_recovery_samples_by_code.pop(index_code, None)
         if change_rate <= -8.0:
             key = f"market_index:fall_8:{index_code}"
             expected_keys.add(key)

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -165,14 +165,21 @@ async def test_market_status_alert_service_reports_index_thresholds_and_resolves
     await service.on_index_change("0001", "코스피", -1.0)
 
     assert {call.args[1] for call in operator_alert.resolve.await_args_list} == {
+        "market_index:fall_8:0001",
+    }
+
+    await service.on_index_change("0001", "코스피", -1.0)
+    await service.on_index_change("0001", "코스피", -1.0)
+
+    assert {call.args[1] for call in operator_alert.resolve.await_args_list} == {
         "market_index:move_5:down:0001",
         "market_index:fall_8:0001",
     }
 
 
 @pytest.mark.asyncio
-async def test_market_status_alert_service_keeps_move_5_alert_active_until_recovery_buffer():
-    """-5% 경보는 -4.5% 이상 회복 전까지 유지해 경계값 반복 알림을 막는다."""
+async def test_market_status_alert_service_resolves_move_5_after_three_recovery_samples():
+    """-5% 경보는 정상 범위가 3회 연속 관측되어야 해제한다."""
     operator_alert = AsyncMock()
     service = MarketStatusAlertService(
         operator_alert_service=operator_alert,
@@ -186,6 +193,37 @@ async def test_market_status_alert_service_keeps_move_5_alert_active_until_recov
     operator_alert.resolve.assert_not_awaited()
 
     await service.on_index_change("0001", "코스피", -4.50)
+    await service.on_index_change("0001", "코스피", -4.40)
+
+    operator_alert.resolve.assert_not_awaited()
+
+    await service.on_index_change("0001", "코스피", -4.30)
+
+    operator_alert.resolve.assert_awaited_once_with(
+        AlertSource.MARKET_STATUS,
+        "market_index:move_5:down:0001",
+        "지수 등락률 정상화",
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_resets_move_5_recovery_count_on_relapse():
+    """회복 확인 중 다시 -5%에 닿으면 해제 확인 횟수를 처음부터 센다."""
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_index_change("0001", "코스피", -5.03)
+    await service.on_index_change("0001", "코스피", -4.40)
+    await service.on_index_change("0001", "코스피", -5.01)
+    await service.on_index_change("0001", "코스피", -4.40)
+    await service.on_index_change("0001", "코스피", -4.30)
+
+    operator_alert.resolve.assert_not_awaited()
+
+    await service.on_index_change("0001", "코스피", -4.20)
 
     operator_alert.resolve.assert_awaited_once_with(
         AlertSource.MARKET_STATUS,


### PR DESCRIPTION
## What changed

- Require three consecutive one-minute readings inside the recovery buffer before resolving a ±5% index-move alert.
- Reset the recovery count if the index returns to the ±5% alert threshold.

## Why

A single brief move just inside the recovery buffer could resolve the alert, followed by another alert when the index moved back near -5%. The confirmation window prevents this alert/resolve churn.

## Validation

- `pytest tests/unit_test/services/test_market_status_alert_service.py tests/unit_test/task/background/intraday/test_market_index_threshold_alert_task.py -v -n0` (10 passed)
- `pytest tests/integration_test -v -n0` (277 passed)

Note: the complete unit suite contains 7,432 tests and was manually stopped near 90% completion without failures; it was not recorded as a full pass.