### PR TITLE
Add AI review to premium watchlist report

### DIFF
--- a/services/premium_watchlist_ai_analysis_service.py
+++ b/services/premium_watchlist_ai_analysis_service.py
@@ -1,0 +1,125 @@
+"""장 마감 우량주·국내 즐겨찾기 대상의 AI 보조 의견 생성."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from services.ai_signal import extract_signal
+
+
+class PremiumWatchlistAiAnalysisService:
+    """정량 선정 결과는 유지한 채, 제한된 종목에 AI 의견을 덧붙인다."""
+
+    def __init__(
+        self,
+        *,
+        ai_stock_analyzer,
+        favorite_service,
+        stock_code_repository,
+        stock_query_service=None,
+        minervini_stage_service=None,
+        rs_rating_service=None,
+        dart_disclosure_repository=None,
+        stock_news_collector=None,
+        logger=None,
+        max_stocks: int = 30,
+    ) -> None:
+        self._analyzer = ai_stock_analyzer
+        self._favorites = favorite_service
+        self._stock_codes = stock_code_repository
+        self._stock_query = stock_query_service
+        self._stage_service = minervini_stage_service
+        self._rs_rating_service = rs_rating_service
+        self._disclosures = dart_disclosure_repository
+        self._news = stock_news_collector
+        self._logger = logger or logging.getLogger(__name__)
+        self._max_stocks = max(1, int(max_stocks))
+
+    async def analyze(self, *, kospi: list[dict], kosdaq: list[dict], report_date: str) -> dict[str, dict]:
+        """우량주 우선으로 즐겨찾기를 합쳐 중복 없이 최대 N종목을 분석한다."""
+        candidates: list[tuple[str, str, str, dict]] = []
+        seen: set[str] = set()
+        for stock in [*kospi, *kosdaq]:
+            code = str(stock.get("code") or "").strip().zfill(6)
+            if not code or code in seen:
+                continue
+            seen.add(code)
+            candidates.append((code, str(stock.get("name") or code), "premium", stock))
+
+        favorite_codes = await self._favorites.get_all() if self._favorites else []
+        for raw_code in favorite_codes:
+            code = str(raw_code or "").strip().zfill(6)
+            if not code or code in seen:
+                continue
+            seen.add(code)
+            name = self._stock_codes.get_name_by_code(code) if self._stock_codes else None
+            candidates.append((code, str(name or code), "favorite", {}))
+
+        results: dict[str, dict] = {}
+        for code, name, source, stock in candidates[:self._max_stocks]:
+            context = await self._build_context(code, name, source, stock, report_date)
+            try:
+                analysis = await self._analyzer.analyze(context)
+                signal, signal_reason, _ = extract_signal(analysis)
+                results[code] = {
+                    "name": name, "source": source,
+                    "signal": signal, "signal_reason": signal_reason,
+                }
+            except Exception as exc:
+                self._logger.warning("장 마감 AI 분석 실패 (%s): %s", code, exc)
+        return results
+
+    async def _build_context(self, code: str, name: str, source: str, stock: dict, report_date: str) -> dict:
+        current, financial, stage, rs_rating, investor_flow, disclosures, news = await asyncio.gather(
+            self._optional_current_price(code),
+            self._optional_call(self._stock_query, "get_financial_ratio", code),
+            self._optional_call(self._stage_service, "get_stage_for_code", code),
+            self._optional_call(self._rs_rating_service, "get_rating", code),
+            self._optional_call(self._stock_query, "get_investor_trade_daily_multi", code, days=5),
+            self._optional_call(self._disclosures, "get_recent_by_stock_code", code, limit=5),
+            self._optional_call(self._news, "collect", code, limit=10),
+        )
+        return {
+            "code": code, "name": name, "report_date": report_date,
+            "candidate_source": "전일 우량주" if source == "premium" else "즐겨찾기",
+            "premium_metrics": stock or None,
+            "current": self._response_data(current),
+            "financial": self._response_data(financial),
+            "stage": self._response_data(stage),
+            "rs_rating": self._response_data(rs_rating),
+            "investor_flow": self._response_data(investor_flow),
+            "disclosures": self._response_data(disclosures),
+            "news": self._response_data(news),
+        }
+
+    async def _optional_current_price(self, code: str) -> Any:
+        if not self._stock_query:
+            return None
+        method = getattr(self._stock_query, "handle_get_current_stock_price", None)
+        if method is None:
+            return None
+        try:
+            return await method(code, caller="PremiumWatchlistAiAnalysisService", force_fresh=True)
+        except Exception:
+            return None
+
+    @staticmethod
+    async def _optional_call(target, method_name: str, *args, **kwargs) -> Any:
+        method = getattr(target, method_name, None) if target is not None else None
+        if method is None:
+            return None
+        try:
+            return await method(*args, **kwargs)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _response_data(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list, tuple)):
+            return value
+        if getattr(value, "rt_cd", None) == "0":
+            return getattr(value, "data", None)
+        return value

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -753,7 +753,7 @@ class TelegramReporter:
         return success
 
     @_serialized_report_send
-    async def send_premium_watchlist_report(self, kospi: List[Dict], kosdaq: List[Dict], report_date: str, limit: int = 30):
+    async def send_premium_watchlist_report(self, kospi: List[Dict], kosdaq: List[Dict], report_date: str, limit: int = 30, ai_analyses: Optional[Dict[str, Dict]] = None):
         """전일 기준 우량주 풀 리포트를 텔레그램으로 전송합니다."""
         title = (
             f"⭐ <b>전일 기준 우량주 리포트 ({report_date})</b>\n"
@@ -761,6 +761,8 @@ class TelegramReporter:
         )
         await self._send_message(title)
 
+        ai_analyses = ai_analyses or {}
+        premium_codes = {str(s.get("code") or "") for s in [*kospi, *kosdaq]}
         for market_label, stocks in [("KOSPI", kospi), ("KOSDAQ", kosdaq)]:
             if not stocks:
                 continue
@@ -801,6 +803,9 @@ class TelegramReporter:
                     f"점수:{score:.0f} RS:{rs_rating} "
                     f"시총:{mcap_str} 대금:{tv_str}"
                 )
+                ai = ai_analyses.get(str(code))
+                if ai:
+                    lines.append(f"   🤖 AI:{ai.get('signal', '중')} — {ai.get('signal_reason', '-')}")
 
             current = ""
             for line in lines:
@@ -812,6 +817,19 @@ class TelegramReporter:
                     current += chunk
             if current:
                 await self._send_message(current)
+
+        favorite_ai = [
+            (code, item) for code, item in ai_analyses.items()
+            if item.get("source") == "favorite" and code not in premium_codes
+        ]
+        if favorite_ai:
+            lines = ["<b>── 🤖 즐겨찾기 AI 분석 ──</b>"]
+            for code, item in favorite_ai:
+                lines.append(
+                    f"• <b>{item.get('name') or code}</b>({code}) AI:{item.get('signal', '중')} "
+                    f"— {item.get('signal_reason', '-')}"
+                )
+            await self._send_message("\n".join(lines))
 
     @_serialized_report_send
     async def send_minervini_report(self, items: List[Dict], report_date: str, limit: int = 30):

--- a/task/background/after_market/premium_watchlist_generator_task.py
+++ b/task/background/after_market/premium_watchlist_generator_task.py
@@ -31,6 +31,7 @@ class PremiumWatchlistGeneratorTask(AfterMarketTask):
         notification_service: Optional["NotificationService"] = None,
         worker_pool=None,
         telegram_reporter: Optional["TelegramReporter"] = None,
+        premium_watchlist_ai_service=None,
     ):
         super().__init__(
             mcs=market_calendar_service,
@@ -41,6 +42,7 @@ class PremiumWatchlistGeneratorTask(AfterMarketTask):
         self._universe_service = universe_service
         self._ns = notification_service
         self._telegram_reporter = telegram_reporter
+        self._premium_watchlist_ai_service = premium_watchlist_ai_service
 
         self._is_generating: bool = False
         self._last_generated_date: Optional[str] = None
@@ -133,11 +135,18 @@ class PremiumWatchlistGeneratorTask(AfterMarketTask):
                     f"KOSPI {result.get('kospi_count')}개, KOSDAQ {result.get('kosdaq_count')}개 종목 수집 완료 (소요: {elapsed:.1f}초)"
                 )
             if self._telegram_reporter:
-                await self._telegram_reporter.send_premium_watchlist_report(
-                    kospi=result.get("kospi_stocks", []),
-                    kosdaq=result.get("kosdaq_stocks", []),
-                    report_date=trading_date,
-                )
+                report_kwargs = {
+                    "kospi": result.get("kospi_stocks", []),
+                    "kosdaq": result.get("kosdaq_stocks", []),
+                    "report_date": trading_date,
+                }
+                if self._premium_watchlist_ai_service:
+                    report_kwargs["ai_analyses"] = await self._premium_watchlist_ai_service.analyze(
+                        kospi=result.get("kospi_stocks", []),
+                        kosdaq=result.get("kosdaq_stocks", []),
+                        report_date=trading_date,
+                    )
+                await self._telegram_reporter.send_premium_watchlist_report(**report_kwargs)
         except Exception as e:
             self._logger.error(f"전일 기준 우량주 생성 실패: {e}", exc_info=True)
             if self._ns:

--- a/tests/unit_test/services/test_premium_watchlist_ai_analysis_service.py
+++ b/tests/unit_test/services/test_premium_watchlist_ai_analysis_service.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.premium_watchlist_ai_analysis_service import PremiumWatchlistAiAnalysisService
+
+
+@pytest.mark.asyncio
+async def test_analyze_merges_premium_and_favorites_once_and_preserves_source():
+    favorites = MagicMock()
+    favorites.get_all = AsyncMock(return_value=["005930", "000660"])
+    analyzer = MagicMock()
+    analyzer.analyze = AsyncMock(return_value="신호: 상\n신호 근거: 수급이 개선되었습니다.\n상세")
+    service = PremiumWatchlistAiAnalysisService(
+        ai_stock_analyzer=analyzer,
+        favorite_service=favorites,
+        stock_code_repository=MagicMock(get_name_by_code=lambda code: {"005930": "삼성전자", "000660": "SK하이닉스"}[code]),
+    )
+
+    result = await service.analyze(
+        kospi=[{"code": "005930", "name": "삼성전자"}],
+        kosdaq=[],
+        report_date="20260320",
+    )
+
+    assert list(result) == ["005930", "000660"]
+    assert result["005930"]["source"] == "premium"
+    assert result["000660"]["source"] == "favorite"
+    assert result["005930"]["signal"] == "상"
+    assert result["005930"]["signal_reason"] == "수급이 개선되었습니다."
+    assert analyzer.analyze.await_count == 2
+    assert analyzer.analyze.await_args_list[0].args[0]["report_date"] == "20260320"

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -773,6 +773,19 @@ async def test_send_premium_watchlist_report_basic(telegram_reporter):
 
 
 @pytest.mark.asyncio
+async def test_send_premium_watchlist_report_includes_ai_signal_and_reason(telegram_reporter):
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+    await telegram_reporter.send_premium_watchlist_report(
+        [{"code": "005930", "name": "삼성전자", "total_score": 80.0}], [], "20260320",
+        ai_analyses={"005930": {"signal": "상", "signal_reason": "수급이 개선되었습니다."}},
+    )
+
+    full = "".join(c[0][0] for c in telegram_reporter._send_message.call_args_list)
+    assert "AI:상" in full
+    assert "수급이 개선되었습니다." in full
+
+
+@pytest.mark.asyncio
 async def test_send_premium_watchlist_report_empty_markets(telegram_reporter):
     """send_premium_watchlist_report: KOSPI/KOSDAQ 중 하나가 빈 경우"""
     telegram_reporter._send_message = AsyncMock(return_value=True)

--- a/tests/unit_test/task/background/after_market/test_premium_watchlist_generator_task.py
+++ b/tests/unit_test/task/background/after_market/test_premium_watchlist_generator_task.py
@@ -526,3 +526,28 @@ class TestTelegramReporterIntegration:
         await task_with_reporter._run_generation("20260320")
 
         mock_reporter.send_premium_watchlist_report.assert_not_awaited()
+
+    async def test_run_generation_includes_after_market_ai_analyses_in_report(
+        self, mock_universe_service, mock_mcs, mock_market_clock, mock_reporter
+    ):
+        ai_service = MagicMock()
+        ai_service.analyze = AsyncMock(return_value={
+            "000001": {"signal": "상", "signal_reason": "추세와 수급이 양호합니다."},
+        })
+        task = PremiumWatchlistGeneratorTask(
+            universe_service=mock_universe_service,
+            market_calendar_service=mock_mcs,
+            market_clock=mock_market_clock,
+            logger=MagicMock(),
+            telegram_reporter=mock_reporter,
+            premium_watchlist_ai_service=ai_service,
+        )
+
+        await task._run_generation("20260320")
+
+        ai_service.analyze.assert_awaited_once_with(
+            kospi=[_SAMPLE_KOSPI_STOCK] * 30,
+            kosdaq=[_SAMPLE_KOSDAQ_STOCK] * 20,
+            report_date="20260320",
+        )
+        assert mock_reporter.send_premium_watchlist_report.await_args.kwargs["ai_analyses"]["000001"]["signal"] == "상"

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -33,6 +33,7 @@ from services.ai_usage_limiter import AiUsageLimiter
 from services.ai_analysis_service import AIAnalysisService
 from services.ai_disclosure_analyzer import AiDisclosureAnalyzer
 from services.ai_stock_analyzer import AiStockAnalyzer
+from services.premium_watchlist_ai_analysis_service import PremiumWatchlistAiAnalysisService
 from services.ai_news_analyzer import AiNewsAnalyzer
 from services.stock_news_collector_service import StockNewsCollectorService
 from services.dart_disclosure_client import DartDisclosureClient
@@ -514,6 +515,19 @@ class ServiceContainer:
                 classification_repository=getattr(ctx, "theme_classification_repository", None),
             )
             if needs_batch:
+                premium_watchlist_ai_service = None
+                if ctx.ai_stock_analyzer:
+                    premium_watchlist_ai_service = PremiumWatchlistAiAnalysisService(
+                        ai_stock_analyzer=ctx.ai_stock_analyzer,
+                        favorite_service=ctx.favorite_service,
+                        stock_code_repository=ctx.stock_code_repository,
+                        stock_query_service=ctx.stock_query_service,
+                        minervini_stage_service=getattr(ctx, "minervini_stage_service", None),
+                        rs_rating_service=getattr(ctx, "rs_rating_service", None),
+                        dart_disclosure_repository=getattr(ctx, "dart_disclosure_repository", None),
+                        stock_news_collector=getattr(ctx, "stock_news_collector", None),
+                        logger=ctx.logger,
+                    )
                 ctx.premium_watchlist_generator_task = PremiumWatchlistGeneratorTask(
                     universe_service=ctx.oneil_universe_service,
                     market_calendar_service=ctx._mcs,
@@ -522,6 +536,7 @@ class ServiceContainer:
                     logger=ctx.logger,
                     worker_pool=ctx.worker_pool,
                     telegram_reporter=getattr(ctx, 'telegram_reporter', None),
+                    premium_watchlist_ai_service=premium_watchlist_ai_service,
                 )
             else:
                 ctx.premium_watchlist_generator_task = None


### PR DESCRIPTION
## What changed
- Analyze the after-market premium watchlist and domestic favorites with the configured AI analyzer.
- Keep premium candidates ahead of favorites, deduplicate codes, and cap the daily batch at 30 stocks.
- Add the AI signal and reason to premium report entries, with a separate favorites section.

## Why
AI analysis is now used as a supplementary risk/context signal without changing the existing quantitative selection score.

## Validation
- pytest tests/unit_test -v (7,445 passed)
- pytest tests/integration_test -v (277 passed)