### PR TITLE
fix: 장중 paper 기록 유실 방지 — 틱마다 flush + 전용 저널 분리

### DIFF
--- a/task/background/intraday/overseas_intraday_vbo_task.py
+++ b/task/background/intraday/overseas_intraday_vbo_task.py
@@ -124,13 +124,16 @@ class OverseasIntradayVBOTask(SchedulableTask):
             if price is None:
                 continue
             await self._vbo.on_price(code, price)
+        # 폴링 패스마다 파일로 내린다 — EOD 까지 메모리에 들고 있으면 세션 중 재시작
+        # 한 번에 그날 기록이 통째로 사라진다(2026-08-05 실측 유실).
+        self._flush_journal(today)
 
     def _flush_journal(self, trade_date: str) -> None:
-        """세션 paper 기록을 자기 거래일 파일로 내린다.
+        """세션 paper 기록을 자기 거래일 파일로 내린다(버퍼가 비면 no-op).
 
-        저널 버퍼는 국내 shadow·해외 dry-run 과 공유되므로, 직접 flush 하지 않으면
-        다른 태스크의 flush 시점·파일명에 기록이 딸려가거나(날짜 오배치) 그 태스크가
-        실패하면 통째로 유실된다. flush 실패는 흡수한다 — 청산은 이미 끝났다.
+        저널은 이 경로 전용 인스턴스여야 한다 — 국내 shadow 와 버퍼를 공유하면
+        틱마다 flush 할 때 남의 기록이 US 거래일 파일로 딸려간다(배선에서 분리).
+        flush 실패는 흡수한다 — 다음 패스에서 다시 시도된다.
         """
         if self._journal is None:
             return

--- a/tests/unit_test/task/background/intraday/test_overseas_intraday_vbo_task.py
+++ b/tests/unit_test/task/background/intraday/test_overseas_intraday_vbo_task.py
@@ -127,6 +127,32 @@ async def test_tick_flushes_journal_with_session_date_at_eod():
 
 
 @pytest.mark.asyncio
+async def test_tick_flushes_journal_after_each_polling_pass():
+    """paper 기록을 EOD 까지 메모리에 들고 있으면 재시작 한 번에 하루치가 사라진다.
+
+    실측(2026-08-05): 진입 2건이 EOD flush 전 프로세스 종료로 통째로 유실됐다.
+    폴링 패스마다 파일로 내려 재시작에 견디게 한다(버퍼가 비면 no-op).
+    """
+    journal = MagicMock()
+    t = _task(now=_ny(10, 0), journal=journal)
+
+    await t.task._tick()
+
+    journal.flush_to_file.assert_called_once_with("20260512")
+
+
+@pytest.mark.asyncio
+async def test_tick_polling_flush_survives_journal_failure():
+    journal = MagicMock()
+    journal.flush_to_file = MagicMock(side_effect=RuntimeError("disk full"))
+    t = _task(now=_ny(10, 0), journal=journal)
+
+    await t.task._tick()  # flush 실패가 폴링 루프를 죽이지 않는다
+
+    t.vbo.on_price.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_tick_flushes_journal_only_once_per_day():
     journal = MagicMock()
     t = _task(now=_ny(15, 55), journal=journal)

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -711,6 +711,11 @@ def test_intraday_vbo_built_with_order_path_locked(patched_service_container_dep
     assert order_cls.call_args.kwargs["live_enabled"] is False
     assert svc_cls.call_args.kwargs["top_n"] == 7
     assert ctx.overseas_intraday_vbo_task is task_cls.return_value
+    # 장중 paper 저널은 국내 event_shadow 와 버퍼를 공유하면 안 된다 —
+    # 틱마다 flush 하므로 공유 시 남의 기록이 US 거래일 파일로 딸려간다.
+    paper_journal = order_cls.call_args.kwargs["journal"]
+    assert paper_journal is not ctx.event_shadow_journal_service
+    assert task_cls.call_args.kwargs["shadow_journal"] is paper_journal
 
 
 def test_domestic_active_without_overseas_enabled_skips_dryrun_task(patched_service_container_deps):

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -901,10 +901,14 @@ class ServiceContainer:
         if not getattr(cfg, "enabled", False):
             return
 
+        # 이 경로 전용 저널 — 국내 event_shadow 와 버퍼를 공유하면 틱마다 flush 할 때
+        # 남의 기록이 US 거래일 파일로 딸려간다. 파일은 같은 디렉토리에 append 되므로
+        # 소비 측(analyze/compare)은 signal_source 로 구분한다.
+        paper_journal = EventShadowJournalService(log_root="logs/strategies", logger=ctx.logger)
         order_execution_service = OverseasOrderExecutionService(
             broker=None,  # live_enabled=False 이므로 broker 미사용(구조적 잠금)
             live_enabled=False,
-            journal=ctx.event_shadow_journal_service,
+            journal=paper_journal,
             logger=ctx.logger,
         )
         ctx.overseas_intraday_vbo_service = OverseasIntradayVBOService(
@@ -926,7 +930,7 @@ class ServiceContainer:
             us_market_calendar_service=USMarketCalendarService(
                 market_clock=intraday_us_clock, logger=ctx.logger,
             ),
-            shadow_journal=ctx.event_shadow_journal_service,
+            shadow_journal=paper_journal,
             check_interval_sec=getattr(cfg, "poll_interval_sec", 60),
             session_prepare_delay_min=getattr(cfg, "session_prepare_delay_min", 5),
             eod_exit_before_min=getattr(cfg, "eod_exit_before_min", 10),


### PR DESCRIPTION
## 실측 유실

교차검증 데이터를 확인하다 발견했습니다. 08-05 세션의 진입이 **저널 파일에 한 건도 남지 않았습니다.**

```
08-05 23:44  NVDA buy 4주 @219.99   ← 로그에만 존재
08-05 23:48  MU   buy 1주 @912.055  ← overseas_paper 레코드 0건
```

원인은 프로세스 생명주기입니다:

```
08-05 23:39  기동 (PID 14964)
08-06 04~06  로그 0줄 — 프로세스 없음
08-06 08:53  재기동 (PID 17084)
```

EOD flush(15:50 ET = 05:50 KST) 전에 종료돼 in-memory 버퍼째 사라졌고, EOD 청산 로그도 없습니다. 교차검증은 1~2주 누적이 전제인데, 재시작 한 번에 하루치가 통째로 빠지면 표본이 계속 구멍납니다.

## 수정

**1. 폴링 패스마다 flush** — 주문이 기록되는 즉시 파일로 내립니다. 버퍼가 비면 `flush_to_file`이 no-op이라 비용이 없고, 실패해도 다음 패스에서 다시 시도됩니다.

**2. 전용 저널 인스턴스 분리** — 국내 `event_shadow`와 버퍼를 공유한 채 틱마다 flush하면 남의 기록이 US 거래일 파일로 딸려갑니다.

2번은 [#778](https://github.com/kyungsooNa/Investment/pull/778)에서 넣은 EOD flush도 갖고 있던 구조입니다. US 세션 시간대(22:30~06:00 KST)엔 국내 기록이 거의 없어 드러나지 않았을 뿐, 보장이 아니라 우연이었습니다. 틱마다 flush하면 상시 오염이 되므로 함께 고칩니다. 파일은 같은 디렉토리에 append되므로 소비 측(`analyze`/`compare`)은 `signal_source`로 구분합니다.

## 참고 — 전략 자체는 정상 작동 중

같은 조사에서 08-06 세션이 제대로 도는 것도 확인했습니다:

```
22:40  세션 준비 watch=10
22:51  MSFT buy 2주 @495.57
23:07  AMD  buy 2주 @484.82
23:21  SPCX buy 8주 @113.96
23:55  SPCX sell 8주 @110.50   ← 손절 정상 작동
```

진입 → 손절 청산 루프가 실장에서 검증됐습니다. 이 4건도 현재 메모리에만 있어, 이 PR이 배포돼야 안전하게 남습니다.

## 테스트

- 신규 3건 (폴링 flush · flush 실패 내성 · 전용 인스턴스 배선)
- `pytest tests/unit_test` 7447 passed
- `pytest tests/integration_test` 277 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
