### PR TITLE
fix: 개장 직후 지수 1D 차트가 비어 보이는 문제 — 전일 종가 기준점 추가

### DIFF
--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1484,12 +1484,19 @@ class StockQueryService:
         if limit and len(points) > limit:
             points = points[-limit:]
 
+        current = _to_float(summary.get("bstp_nmix_prpr"))
+        change = _to_float(summary.get("bstp_nmix_prdy_vrss"))
+        # 개장 직후에는 10분봉이 1개뿐이라 선이 그려지지 않는다. 전일 종가를 기준점으로 앞에 붙인다.
+        # (일/주봉은 이미 이전 봉을 담고 있어 필요 없고, 날짜 라벨과도 섞이면 안 된다)
+        if is_minute and current is not None and change is not None:
+            points.insert(0, {"close": current - change, "prev": True})
+
         data = {
             "code": index_code,
             "name": summary.get("hts_kor_isnm") or self.DOMESTIC_INDEX_NAMES[index_code],
             "period": period,
-            "current": _to_float(summary.get("bstp_nmix_prpr")),
-            "change": _to_float(summary.get("bstp_nmix_prdy_vrss")),
+            "current": current,
+            "change": change,
             "change_rate": _to_float(summary.get("bstp_nmix_prdy_ctrt")),
             "points": points,
         }

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -270,6 +270,26 @@ test("1D 는 x축에 분봉 시각을 표시한다", async () => {
     `1D x축 라벨이 HH:MM 이어야 함 (실제 ${labels.join(",")})`);
 });
 
+test("1D 첫 점이 전일 종가면 x축에 '전일' 로 표시한다", async () => {
+  // 개장 직후엔 분봉이 1개뿐이라 서버가 전일 종가를 기준점으로 앞에 붙인다.
+  const window = await makeWindow(async () => success(indexPayload({
+    period: "1D",
+    points: [
+      { close: 2637.85, prev: true },
+      { date: "20260729", time: "090000", close: 2650.15 },
+    ],
+  })));
+
+  await window.renderMarketIndices();
+
+  const labels = window.__charts[0].config.data.labels;
+  assert(labels.join(",") === "전일,09:00",
+    `전일 기준점 라벨이 '전일,09:00' 이어야 함 (실제 ${labels.join(",")})`);
+  // 점이 2개가 되므로 선이 실제로 그려져야 한다.
+  assert(window.__charts[0].config.data.datasets[0].data.length === 2,
+    "전일 기준점을 포함해 2개 점이 그려져야 함");
+});
+
 test("기간 버튼을 누르면 그 기간으로 다시 조회하고 차트를 교체한다", async () => {
   const requested = [];
   const window = await makeWindow(async (url) => {

--- a/tests/unit_test/services/test_stock_query_index_chart.py
+++ b/tests/unit_test/services/test_stock_query_index_chart.py
@@ -81,6 +81,45 @@ async def test_index_chart_1d_uses_minute_api_and_keeps_time():
 
 
 @pytest.mark.asyncio
+async def test_index_chart_1d_prepends_previous_close_point():
+    """개장 직후 분봉이 1개뿐이어도 선이 그려지도록 전일 종가를 첫 점으로 붙인다."""
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={
+            "bstp_nmix_prpr": "2650.15",
+            "bstp_nmix_prdy_vrss": "12.30",
+            "bstp_nmix_prdy_ctrt": "0.47",
+        },
+        candles=[
+            {"stck_bsop_date": "20260729", "stck_cntg_hour": "090000", "bstp_nmix_prpr": "2650.15"},
+        ],
+    ))
+
+    result = await _service(broker).get_index_chart("0001", period="1D")
+
+    points = result.data["points"]
+    assert len(points) == 2
+    # 전일 종가 = 현재값 - 전일대비. 별도 API 호출 없이 summary 로 계산한다.
+    assert points[0]["prev"] is True
+    assert points[0]["close"] == pytest.approx(2637.85)
+    assert points[1]["time"] == "090000"
+
+
+@pytest.mark.asyncio
+async def test_index_chart_daily_does_not_prepend_previous_close():
+    """일/주봉은 이미 이전 봉을 담고 있으므로 전일 종가를 덧붙이지 않는다."""
+    broker = MagicMock()
+    broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(
+        summary={"bstp_nmix_prpr": "2650.15", "bstp_nmix_prdy_vrss": "12.30"},
+        candles=[{"stck_bsop_date": "20260727", "bstp_nmix_prpr": "2650.15"}],
+    ))
+
+    result = await _service(broker).get_index_chart("0001", period="1M")
+
+    assert [p.get("prev") for p in result.data["points"]] == [None]
+
+
+@pytest.mark.asyncio
 async def test_index_chart_1y_uses_weekly_candles():
     broker = MagicMock()
     broker.inquire_daily_indexchartprice = AsyncMock(return_value=_broker_response(

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -124,6 +124,8 @@ function _formatIndexChange(change, rate) {
 
 // 분봉 응답에만 time 이 담기므로 라벨 형식은 요청한 기간이 아니라 받은 데이터를 보고 정한다.
 function _formatIndexPointLabel(point) {
+    // 서버가 1D 앞에 붙이는 전일 종가 기준점. 날짜가 없으므로 라벨을 따로 준다.
+    if (point.prev) return '전일';
     const time = String(point.time || '');
     if (time.length >= 4) return `${time.slice(0, 2)}:${time.slice(2, 4)}`;
     const date = String(point.date || '');

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -104,5 +104,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_indices.js?v=3"></script>
+<script src="/static/js/market_indices.js?v=4"></script>
 {% endblock %}


### PR DESCRIPTION
## 문제

홈 화면 지수 카드가 개장 직후 값·등락률만 보이고 차트 영역이 빈 채로 남는다.

원인은 데이터 누락이 아니라 **점 개수**다. 기본 기간 `1D`는 10분봉이라 09:00~09:10 사이엔 봉이 1개뿐이고, 스파크라인은 `pointRadius: 0`이라 점 1개면 그릴 선분이 없다. 캔버스와 x축 라벨(`09:00`)만 남아 빈 박스로 보인다.

실측 (09:12 KST):
```
/api/market-index/0001?period=1D → points=2
                       ?period=1W → points=5
                       ?period=1M → points=22
                       ?period=1Y → points=50
```

## 수정

- `StockQueryService.get_index_chart`가 **분봉 기간에 한해** `summary`의 현재값 − 전일대비로 계산한 전일 종가를 `points` 앞에 `{close, prev: true}`로 삽입한다.
  - 추가 API 호출 없음 (summary에 이미 있는 값).
  - 일/주봉(`1W`/`1M`/`1Y`)은 이미 이전 봉을 담고 있어 제외 — 날짜 라벨과 섞이지 않는다.
  - `current`/`change` 중 하나라도 없으면 삽입하지 않는다.
- `_formatIndexPointLabel`이 `prev` 점의 x축 라벨을 `전일`로 표시한다. 이 점엔 날짜가 없어 기존 `MM/DD`·`HH:MM` 포맷과 충돌하지 않는다.
- `index.html`의 `market_indices.js` 캐시 버스터 `v=3` → `v=4`.

부수 효과로 개장 직후 스파크라인이 전일 종가 대비 갭 방향을 보여주게 되어, 함께 표시되는 등락률과 시각적으로 일치한다.

## 테스트

TDD — 실패 확인 후 구현.

- `test_index_chart_1d_prepends_previous_close_point` — 분봉 1개일 때 전일 종가가 앞에 붙어 점이 2개가 되는지
- `test_index_chart_daily_does_not_prepend_previous_close` — 일봉엔 붙지 않는지
- `run_market_indices_dom_tests.mjs`: `1D 첫 점이 전일 종가면 x축에 '전일' 로 표시한다` — 라벨 `전일,09:00` + 데이터 포인트 2개

```
pytest tests/unit_test/services/test_stock_query_index_chart.py  → 11 passed
pytest tests/unit_test/view/web/ ...                             → 409 passed
pytest tests/integration_test                                    → 277 passed
```

## 배포 참고

`get_index_chart` 변경은 서버 코드라 **웹 서버 재시작 후에 적용**된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)