### PR TITLE
Prioritize period ranking refresh

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -180,11 +180,11 @@ class RankingTask(AfterMarketTask):
             if needs_basic:
                 await self.refresh_basic_ranking()
                 self._basic_last_collected_date = date
+            if needs_period:
+                await self.prewarm_period_ranking(date)
             if needs_investor:
                 await self.refresh_investor_ranking()
                 self._last_collected_date = date
-            if needs_period:
-                await self.prewarm_period_ranking(date)
 
     # ── 장마감 후 자동 갱신 스케줄러 ────────────────────────────
 
@@ -211,11 +211,11 @@ class RankingTask(AfterMarketTask):
         if needs_basic:
             await self.refresh_basic_ranking()
             self._basic_last_collected_date = latest_trading_date
+        if needs_period:
+            await self.prewarm_period_ranking(latest_trading_date)
         if needs_investor:
             await self.refresh_investor_ranking()
             self._last_collected_date = latest_trading_date
-        if needs_period:
-            await self.prewarm_period_ranking(latest_trading_date)
 
     # ── 기본 랭킹 캐시 (상승/하락/거래량/거래대금) ───────────────
 

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -41,9 +41,20 @@ async def test_execute_runs_both_when_not_done():
     task._basic_last_collected_date = None
     task._last_collected_date = None
 
-    task.refresh_basic_ranking = AsyncMock()
-    task.refresh_investor_ranking = AsyncMock()
-    task.prewarm_period_ranking = AsyncMock()
+    execution_order = []
+
+    async def refresh_basic():
+        execution_order.append("basic")
+
+    async def refresh_investor():
+        execution_order.append("investor")
+
+    async def prewarm_period(_date):
+        execution_order.append("period")
+
+    task.refresh_basic_ranking = AsyncMock(side_effect=refresh_basic)
+    task.refresh_investor_ranking = AsyncMock(side_effect=refresh_investor)
+    task.prewarm_period_ranking = AsyncMock(side_effect=prewarm_period)
 
     await task.execute({"date": "20250417"})
 
@@ -52,6 +63,7 @@ async def test_execute_runs_both_when_not_done():
     task.prewarm_period_ranking.assert_awaited_once_with("20250417")
     assert task._basic_last_collected_date == "20250417"
     assert task._last_collected_date == "20250417"
+    assert execution_order == ["basic", "period", "investor"]
 
 
 async def test_execute_runs_only_investor_if_basic_done():

--- a/tests/unit_test/task/background/after_market/test_ranking_task.py
+++ b/tests/unit_test/task/background/after_market/test_ranking_task.py
@@ -1698,14 +1698,28 @@ async def test_scheduler_refreshes_when_no_prior_update(bg_service, mock_deps):
     
     bg_service._basic_last_collected_date = None
     bg_service._last_collected_date = None
-    bg_service.refresh_basic_ranking = AsyncMock()
-    bg_service.refresh_investor_ranking = AsyncMock()
+    execution_order = []
+
+    async def refresh_basic():
+        execution_order.append("basic")
+
+    async def prewarm_period(_date):
+        execution_order.append("period")
+
+    async def refresh_investor():
+        execution_order.append("investor")
+
+    bg_service.refresh_basic_ranking = AsyncMock(side_effect=refresh_basic)
+    bg_service.prewarm_period_ranking = AsyncMock(side_effect=prewarm_period)
+    bg_service.refresh_investor_ranking = AsyncMock(side_effect=refresh_investor)
 
     date = await market_calendar_service.get_latest_trading_date()
     await bg_service._on_market_closed(date)
 
     bg_service.refresh_basic_ranking.assert_awaited_once()
     bg_service.refresh_investor_ranking.assert_awaited_once()
+    bg_service.prewarm_period_ranking.assert_awaited_once_with(date)
+    assert execution_order == ["basic", "period", "investor"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Run period investor-flow prewarming before the daily investor ranking sweep.
- Cover the execution order for both ticket-driven and fallback scheduling paths.

## Why
The daily investor sweep delayed the 5-day period ranking until after the weekly YTD report. Prioritizing the period sweep makes the cache available earlier.

## Validation
- Passed: C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test\scheduler\test_ranking_task_execute.py tests\unit_test\task\background\after_market\test_ranking_task.py -v -n0 (99 passed)
- Full unit and integration suites exceeded the local 64-second command limit before completion.