### PR TITLE
Retain rate-limited favorite AI entries

### DIFF
--- a/services/premium_watchlist_ai_analysis_service.py
+++ b/services/premium_watchlist_ai_analysis_service.py
@@ -68,6 +68,12 @@ class PremiumWatchlistAiAnalysisService:
                 }
             except Exception as exc:
                 self._logger.warning("장 마감 AI 분석 실패 (%s): %s", code, exc)
+                results[code] = {
+                    "name": name,
+                    "source": source,
+                    "signal": "-",
+                    "signal_reason": "AI 분석 요청 제한으로 다음 리포트에서 재시도합니다.",
+                }
         return results
 
     async def _build_context(self, code: str, name: str, source: str, stock: dict, report_date: str) -> dict:

--- a/tests/unit_test/services/test_premium_watchlist_ai_analysis_service.py
+++ b/tests/unit_test/services/test_premium_watchlist_ai_analysis_service.py
@@ -30,3 +30,27 @@ async def test_analyze_merges_premium_and_favorites_once_and_preserves_source():
     assert result["005930"]["signal_reason"] == "수급이 개선되었습니다."
     assert analyzer.analyze.await_count == 2
     assert analyzer.analyze.await_args_list[0].args[0]["report_date"] == "20260320"
+
+
+@pytest.mark.asyncio
+async def test_analyze_keeps_favorite_in_report_when_ai_request_is_rate_limited():
+    favorites = MagicMock()
+    favorites.get_all = AsyncMock(return_value=["000660"])
+    analyzer = MagicMock()
+    analyzer.analyze = AsyncMock(side_effect=RuntimeError("429 Too Many Requests"))
+    service = PremiumWatchlistAiAnalysisService(
+        ai_stock_analyzer=analyzer,
+        favorite_service=favorites,
+        stock_code_repository=MagicMock(get_name_by_code=lambda _code: "SK하이닉스"),
+    )
+
+    result = await service.analyze(kospi=[], kosdaq=[], report_date="20260807")
+
+    assert result == {
+        "000660": {
+            "name": "SK하이닉스",
+            "source": "favorite",
+            "signal": "-",
+            "signal_reason": "AI 분석 요청 제한으로 다음 리포트에서 재시도합니다.",
+        }
+    }


### PR DESCRIPTION
## What changed
- Keep favorite stocks in the after-market AI report when the AI provider still returns a rate-limit error after its built-in retries.
- Display a clear pending-analysis state instead of silently omitting the stock.

## Why
SK hynix and Hana Micron were omitted when the AI provider returned HTTP 429.

## Validation
- Passed: C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test\services\test_premium_watchlist_ai_analysis_service.py tests\unit_test\services\test_telegram_notifier.py -v -n0 (54 passed)
- Passed: C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_test\test_it_web_app_e2e_smoke.py -v -n0 (11 passed)
- Full integration suite exceeded the local 64-second command limit before completion.