### PR TITLE
Notify five-day period ranking

### DIFF
--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -402,6 +402,40 @@ class TelegramReporter:
             await self._send_message(current_message)
 
     @_serialized_report_send
+    async def send_period_investor_ranking_report(
+        self,
+        ranking_data: List[Dict],
+        report_date: str,
+        days: int = 5,
+        limit: int = 10,
+    ) -> bool:
+        """외국인·기관·프로그램 합산 기간수급 순매수 상위를 전송한다."""
+        if not ranking_data:
+            return False
+
+        ranked = sorted(
+            ranking_data,
+            key=lambda item: int(item.get("combined_period_ntby_tr_pbmn_won") or 0),
+            reverse=True,
+        )[:limit]
+        lines = [
+            f"💰 <b>{days}거래일 기간수급 순매수 ({report_date})</b>",
+            "<pre>",
+            "순 종목          외국인  기관  프로그램  합산(억)",
+        ]
+        for rank, item in enumerate(ranked, 1):
+            name = str(item.get("hts_kor_isnm") or "-")[:8]
+            foreign = int(item.get("frgn_period_ntby_tr_pbmn_won") or 0) / 100_000_000
+            institution = int(item.get("orgn_period_ntby_tr_pbmn_won") or 0) / 100_000_000
+            program = int(item.get("program_period_ntby_tr_pbmn_won") or 0) / 100_000_000
+            combined = int(item.get("combined_period_ntby_tr_pbmn_won") or 0) / 100_000_000
+            lines.append(
+                f"{rank:<2} {name:<8} {foreign:>6,.0f} {institution:>5,.0f} {program:>7,.0f} {combined:>8,.0f}"
+            )
+        lines.append("</pre>")
+        return await self._send_message("\n".join(lines))
+
+    @_serialized_report_send
     async def send_ytd_ranking_report(
         self,
         ranking_data: List[Dict],

--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -546,13 +546,15 @@ class RankingTask(AfterMarketTask):
             directory = os.path.dirname(self._ranking_report_state_path)
             if directory:
                 os.makedirs(directory, exist_ok=True)
+            state = {}
+            try:
+                with open(self._ranking_report_state_path, "r", encoding="utf-8") as f:
+                    state = json.load(f)
+            except FileNotFoundError:
+                pass
+            state["last_ranking_report_date"] = str(target_date)
             with open(self._ranking_report_state_path, "w", encoding="utf-8") as f:
-                json.dump(
-                    {"last_ranking_report_date": str(target_date)},
-                    f,
-                    ensure_ascii=False,
-                    indent=2,
-                )
+                json.dump(state, f, ensure_ascii=False, indent=2)
         except Exception as e:
             self._logger.warning(f"랭킹 리포트 발송 상태 저장 실패: {e}")
 
@@ -576,6 +578,53 @@ class RankingTask(AfterMarketTask):
             self._logger.info("텔레그램 랭킹 리포트 전송 완료")
         except Exception as e:
             self._logger.error(f"텔레그램 랭킹 리포트 전송 중 오류: {e}", exc_info=True)
+
+    def _load_last_period_ranking_report_date(self) -> Optional[str]:
+        try:
+            with open(self._ranking_report_state_path, "r", encoding="utf-8") as f:
+                value = json.load(f).get("last_period_ranking_report_date")
+            return str(value) if value else None
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            self._logger.warning(f"기간수급 리포트 발송 상태 로드 실패: {e}")
+            return None
+
+    def _save_last_period_ranking_report_date(self, target_date: str) -> None:
+        try:
+            directory = os.path.dirname(self._ranking_report_state_path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            state = {}
+            try:
+                with open(self._ranking_report_state_path, "r", encoding="utf-8") as f:
+                    state = json.load(f)
+            except FileNotFoundError:
+                pass
+            state["last_period_ranking_report_date"] = str(target_date)
+            with open(self._ranking_report_state_path, "w", encoding="utf-8") as f:
+                json.dump(state, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            self._logger.warning(f"기간수급 리포트 발송 상태 저장 실패: {e}")
+
+    async def _send_period_ranking_report_once(self, target_date: str, days: int) -> None:
+        if not self._telegram_reporter:
+            return
+        if self._load_last_period_ranking_report_date() == str(target_date):
+            self._logger.info(f"텔레그램 기간수급 리포트 이미 전송 완료 ({target_date}) — 스킵")
+            return
+        results = self._period_ranking_cache.get((str(target_date), days), [])
+        if not results:
+            self._logger.warning(f"기간수급 리포트 전송 보류: {target_date}, {days}일 결과 없음")
+            return
+        try:
+            result = await self._telegram_reporter.send_period_investor_ranking_report(
+                results, report_date=str(target_date), days=days,
+            )
+            if result is not False:
+                self._save_last_period_ranking_report_date(target_date)
+        except Exception as e:
+            self._logger.error(f"텔레그램 기간수급 리포트 전송 중 오류: {e}", exc_info=True)
 
     @staticmethod
     def _build_ranking(results: List[Dict], pbmn_field: str, top_n: int = 30):
@@ -717,6 +766,8 @@ class RankingTask(AfterMarketTask):
         ]
         if cache_key in self._period_ranking_cache:
             self._logger.info(f"기간수급 랭킹 캐시 예열 완료: {target_date}, {warmed}일")
+            if days == self.DEFAULT_PERIOD_RANKING_DAYS:
+                await self._send_period_ranking_report_once(str(target_date), days)
         else:
             self._logger.warning(f"기간수급 랭킹 캐시 예열 미완료: {target_date}, {days}일")
 

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -134,6 +134,25 @@ async def test_send_ranking_report_skips_same_trading_date_after_restart(tmp_pat
     restarted_reporter.send_ranking_report.assert_not_called()
 
 
+async def test_send_period_ranking_report_sends_five_day_ranking_once(tmp_path):
+    reporter = MagicMock()
+    reporter.send_period_investor_ranking_report = AsyncMock(return_value=True)
+    task = _make_task(
+        telegram_reporter=reporter,
+        ranking_report_state_path=str(tmp_path / "ranking_report_state.json"),
+    )
+    task._period_ranking_cache[("20260722", 5)] = [
+        {"hts_kor_isnm": "SK하이닉스", "combined_period_ntby_tr_pbmn_won": "3000000000"},
+    ]
+
+    await task._send_period_ranking_report_once("20260722", 5)
+    await task._send_period_ranking_report_once("20260722", 5)
+
+    reporter.send_period_investor_ranking_report.assert_awaited_once_with(
+        task._period_ranking_cache[("20260722", 5)], report_date="20260722", days=5,
+    )
+
+
 async def test_startup_self_heal_recovers_missed_investor_report_and_period_ranking():
     task = _make_task()
     mcs = MagicMock()

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -546,6 +546,28 @@ async def test_send_ytd_ranking_report(telegram_reporter):
     assert "+50.00%" in message
     assert "20260102" in message
 
+
+@pytest.mark.asyncio
+async def test_send_period_investor_ranking_report(telegram_reporter):
+    telegram_reporter._send_message = AsyncMock(return_value=True)
+
+    sent = await telegram_reporter.send_period_investor_ranking_report(
+        [{
+            "hts_kor_isnm": "SK하이닉스",
+            "frgn_period_ntby_tr_pbmn_won": "1000000000",
+            "orgn_period_ntby_tr_pbmn_won": "2000000000",
+            "program_period_ntby_tr_pbmn_won": "3000000000",
+            "combined_period_ntby_tr_pbmn_won": "6000000000",
+        }],
+        report_date="20260807",
+    )
+
+    assert sent is True
+    message = telegram_reporter._send_message.await_args.args[0]
+    assert "5거래일 기간수급 순매수" in message
+    assert "SK하이닉스" in message
+    assert "60" in message
+
 @pytest.mark.asyncio
 async def test_send_ranking_report_splits_message(telegram_reporter):
     """리포트가 너무 길 경우 메시지를 분할해서 전송하는지 검증"""


### PR DESCRIPTION
## What changed
- Send a Telegram report with the top 10 five-trading-day combined foreign, institutional, and program net-buy rankings after period data collection completes.
- Persist the send date to avoid duplicate reports after a restart.

## Validation
- 153 related unit tests passed.
- 11 web app integration smoke tests passed.