### PR TITLE
Add universe coverage diagnostics

### DIFF
--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -34,6 +34,14 @@ def _chunked(lst, size):
         yield lst[i:i + size]
 
 
+def _market_counts(items):
+    counts = {}
+    for item in items:
+        market = getattr(item, "market", "") or "UNKNOWN"
+        counts[market] = counts.get(market, 0) + 1
+    return counts
+
+
 _ETF_NAME_PREFIXES = (
     "KODEX", "TIGER", "KBSTAR", "ARIRANG", "SOL", "ACE",
     "HANARO", "KOSEF", "PLUS", "TIMEFOLIO", "WON", "FOCUS",
@@ -241,11 +249,15 @@ class OneilUniverseService:
         self._watchlist = {
             item.code: item for item in sorted_items[:self._cfg.max_watchlist]
         }
+        final_items = list(self._watchlist.values())
         logger.info({
             "event": "build_watchlist_finished",
             "premium_stocks": len(self._pool_a_items),
             "daily_surge_stocks": len(pool_b_items),
-            "final_count": len(self._watchlist)
+            "final_count": len(self._watchlist),
+            "pool_a_market_counts": _market_counts(self._pool_a_items.values()),
+            "pool_b_market_counts": _market_counts(pool_b_items.values()),
+            "market_counts": _market_counts(final_items),
         })
         self.pm.log_timer("OneilUniverseService._build_watchlist", t_start, threshold=5.0)
 

--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -5,6 +5,7 @@ from collections import Counter
 import glob
 import gzip
 import html
+import json
 import os
 import re
 import time
@@ -309,6 +310,7 @@ _MA_PROXIMITY_UPPER_PCT = 4.0
 _MA_NEAR_MISS_MAX_EXCESS_PCT = 4.0
 _MAX_EXECUTION_QUALITY_ROWS = 5
 _MAX_SAME_DAY_EXIT_VIOLATIONS_SHOWN = 5
+_KOSDAQ_CANDIDATE_WARNING_MIN = 5
 
 
 def _to_float(value: Any) -> Optional[float]:
@@ -481,6 +483,7 @@ class StrategyLogReportService:
         enabled_strategy_provider: Optional[Callable[[], Optional[List[str]]]] = None,
         strategy_degradation_config: Optional[Any] = None,
         profitability_gate_config: Optional[Any] = None,
+        premium_stocks_file: str = os.path.join("data", "premium_stocks.json"),
     ):
         self._log_dir = log_dir
         self._stock_code_repo = stock_code_repo
@@ -490,6 +493,7 @@ class StrategyLogReportService:
         self._enabled_strategy_provider = enabled_strategy_provider
         self._strategy_degradation_config = strategy_degradation_config
         self._profitability_gate_config = profitability_gate_config
+        self._premium_stocks_file = premium_stocks_file
         self._last_execution_quality_candidates: List[dict] = []
         self._last_strategy_degradation_candidates: List[dict] = []
         self._last_same_day_exit_violations: List[dict] = []
@@ -570,6 +574,87 @@ class StrategyLogReportService:
                         yield entry.get('level', 'INFO'), ts, data
         except Exception:
             pass
+
+    def _load_premium_stock_counts(self, target_date: str) -> Optional[dict]:
+        if not self._premium_stocks_file or not os.path.exists(self._premium_stocks_file):
+            return None
+        try:
+            with open(self._premium_stocks_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            return None
+
+        generated_date = str(data.get("generated_date") or "")
+        if generated_date and generated_date != target_date:
+            return None
+
+        kospi = data.get("kospi") if isinstance(data.get("kospi"), list) else []
+        kosdaq = data.get("kosdaq") if isinstance(data.get("kosdaq"), list) else []
+        return {
+            "generated_date": generated_date,
+            "generated_at": data.get("generated_at"),
+            "kospi_count": len(kospi),
+            "kosdaq_count": len(kosdaq),
+            "total_count": len(kospi) + len(kosdaq),
+        }
+
+    def _load_premium_generation_summary(self, target_date: str) -> dict:
+        date_prefix = _fmt_date(target_date)
+        pattern = os.path.join(self._log_dir, "**", f"{target_date}*generate_premium_watchlist*.log.json*")
+        summary = {
+            "evaluated_total": None,
+            "selected": None,
+        }
+        for fpath in glob.glob(pattern, recursive=True):
+            for _level, _ts, data in self._iter_events(fpath, date_prefix):
+                event = data.get("event")
+                if event == "2nd_filter_progress":
+                    total = _to_int(data.get("total"), default=0)
+                    if total:
+                        summary["evaluated_total"] = max(summary["evaluated_total"] or 0, total)
+                elif event == "2nd_filter_done":
+                    summary["selected"] = _to_int(data.get("selected"), default=0)
+                elif event == "save_done":
+                    summary["saved_kospi_count"] = _to_int(data.get("kospi_count"), default=0)
+                    summary["saved_kosdaq_count"] = _to_int(data.get("kosdaq_count"), default=0)
+        return summary
+
+    def _build_universe_coverage_section(
+        self,
+        target_date: str,
+        market_timing: Mapping[str, Tuple[str, bool]],
+    ) -> Tuple[Optional[str], List[str]]:
+        counts = self._load_premium_stock_counts(target_date)
+        if not counts:
+            return None, []
+
+        generation = self._load_premium_generation_summary(target_date)
+        lines = ["<b>🧺 유니버스 커버리지</b>"]
+        evaluated_total = generation.get("evaluated_total")
+        selected = generation.get("selected")
+        if evaluated_total is not None and selected is not None:
+            lines.append(
+                f"• Pool A funnel: 필터 평가 {evaluated_total:,}종목 → "
+                f"통과 {selected:,}종목 → 저장 {counts['total_count']:,}종목"
+            )
+        else:
+            lines.append(f"• Pool A 저장 후보: {counts['total_count']:,}종목")
+        lines.append(
+            f"• 저장 후보: KOSPI {counts['kospi_count']:,}개 / "
+            f"KOSDAQ {counts['kosdaq_count']:,}개"
+        )
+
+        warnings: List[str] = []
+        kosdaq_bull = bool(market_timing.get("KOSDAQ", ("", False))[1])
+        if kosdaq_bull and counts["kosdaq_count"] < _KOSDAQ_CANDIDATE_WARNING_MIN:
+            warning = (
+                f"KOSDAQ 상승인데 최종 KOSDAQ 후보 {counts['kosdaq_count']}종목 "
+                f"(경고 기준 {_KOSDAQ_CANDIDATE_WARNING_MIN}종목 미만)"
+            )
+            lines.append(f"• ⚠️ {warning}")
+            warnings.append(f"• {warning}")
+
+        return "\n".join(lines), warnings
 
     def _db_resolve(self, code: str, current_name: str) -> str:
         """종목명이 코드와 같으면 StockCodeRepository에서 이름을 조회한다."""
@@ -2361,6 +2446,11 @@ class StrategyLogReportService:
                 f"• 시가/현재가 0 수신 오류 — 총 {total}건 ({details})"
             )
 
+        universe_coverage_section, universe_warnings = self._build_universe_coverage_section(
+            target_date, market_timing
+        )
+        system_warnings.extend(universe_warnings)
+
         warnings_section = ""
         if system_warnings:
             warnings_section = "<b>⚠️ 시스템 경고</b>\n" + "\n".join(system_warnings)
@@ -2396,6 +2486,7 @@ class StrategyLogReportService:
                 section
                 for section in (
                     warnings_section,
+                    universe_coverage_section,
                     portfolio_summary,
                     divergence_section,
                     degradation_section,
@@ -2418,6 +2509,8 @@ class StrategyLogReportService:
         sections: List[str] = []
         if warnings_section:
             sections.append(warnings_section)
+        if universe_coverage_section:
+            sections.append(universe_coverage_section)
         sections.extend(active_sections)
         body = "\n\n".join(sections)
         portfolio_summary = self._build_portfolio_summary(target_date, fallback_buys)

--- a/tests/unit_test/services/test_oneil_universe_service_logs.py
+++ b/tests/unit_test/services/test_oneil_universe_service_logs.py
@@ -135,6 +135,12 @@ async def test_build_watchlist_sorted_logs(service, mock_components):
     assert sorted_log["items"][0]["code"] == "A1"
     assert sorted_log["items"][1]["code"] == "B1"
 
+    finished_log = next((c[0][0] for c in logger.info.call_args_list if isinstance(c[0][0], dict) and c[0][0].get("event") == "build_watchlist_finished"), None)
+    assert finished_log is not None
+    assert finished_log["market_counts"] == {"KOSPI": 1, "KOSDAQ": 1}
+    assert finished_log["pool_a_market_counts"] == {"KOSPI": 1}
+    assert finished_log["pool_b_market_counts"] == {"KOSDAQ": 1}
+
 @pytest.mark.asyncio
 async def test_build_daily_surge_pool_parallel_execution(mock_components):
     """_build_daily_surge_pool 메서드가 후보 종목들을 병렬로 처리하여 수집하는지 검증"""

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -479,6 +479,51 @@ async def test_report_buy_signal(log_dir):
 
 
 @pytest.mark.asyncio
+async def test_report_includes_universe_coverage_warning_when_kosdaq_bull_has_few_candidates(log_dir, tmp_path):
+    """KOSDAQ 상승장인데 저장된 코스닥 후보가 적으면 리포트에 커버리지 경고를 노출한다."""
+    premium_file = tmp_path / "premium_stocks.json"
+    premium_file.write_text(json.dumps({
+        "generated_date": "20260418",
+        "generated_at": "2026-04-18T16:40:00",
+        "kospi": [{"code": "005930", "name": "삼성전자"}],
+        "kosdaq": [{"code": "144960", "name": "뉴파워프라즈마"}],
+    }, ensure_ascii=False), encoding="utf-8")
+
+    oneil_dir = os.path.join(log_dir, "oneil_pool")
+    os.makedirs(oneil_dir, exist_ok=True)
+    _write_log(os.path.join(oneil_dir, "20260418_generate_premium_watchlist_1.log.json"), [
+        {
+            "timestamp": "2026-04-18 16:30:00,000",
+            "level": "INFO",
+            "name": "strategy.generate_premium_watchlist.oneil_pool",
+            "data": {"event": "2nd_filter_progress", "processed": 829, "total": 829, "selected": 5},
+        },
+        {
+            "timestamp": "2026-04-18 16:40:00,000",
+            "level": "INFO",
+            "name": "strategy.generate_premium_watchlist.oneil_pool",
+            "data": {"event": "2nd_filter_done", "selected": 5},
+        },
+    ])
+    _write_log(os.path.join(log_dir, "20260418_090000_TestStrategy.log.json"), [
+        {
+            "timestamp": "2026-04-18 09:00:00,000",
+            "level": "INFO",
+            "name": "strategy.TestStrategy",
+            "data": {"event": "market_timing_updated", "market": "KOSDAQ", "ok": True},
+        },
+        _make_entry("scan_with_watchlist", "", "", date="2026-04-18"),
+    ])
+
+    svc = StrategyLogReportService(log_dir=log_dir, premium_stocks_file=str(premium_file))
+    report = await svc.generate_report("20260418")
+
+    assert "유니버스 커버리지" in report
+    assert "필터 평가 829종목 → 통과 5종목 → 저장 2종목" in report
+    assert "KOSDAQ 상승인데 최종 KOSDAQ 후보 1종목" in report
+
+
+@pytest.mark.asyncio
 async def test_report_rejected_event(log_dir):
     """breakout_rejected 이벤트가 '매수 실패' 섹션에 포함된다."""
     log_path = os.path.join(log_dir, "20260418_093000_TestStrategy.log.json")


### PR DESCRIPTION
## Summary
- Add universe coverage section to daily strategy reports from premium_stocks.json and generation logs.
- Warn when KOSDAQ market timing is bullish but final KOSDAQ candidates are below the minimum threshold.
- Add market-count fields to OneilUniverseService build_watchlist_finished logs.

## Validation
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v