### PR TITLE
진단 스크립트 AI 소비 한도 집계 누락 수정 + X-4 실측 종결

### DIFF
--- a/scripts/check_ai_key.py
+++ b/scripts/check_ai_key.py
@@ -22,6 +22,7 @@ except Exception:
     pass
 
 from services.ai_client import AiClient  # noqa: E402
+from services.ai_usage_limiter import AiUsageLimitExceeded, AiUsageLimiter  # noqa: E402
 
 _ROOT = Path(__file__).resolve().parents[1]
 _DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
@@ -37,6 +38,24 @@ def _load_ai_config() -> dict:
     with open(config_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     return data.get("ai_analysis") or {}
+
+
+def _build_client(cfg: dict) -> AiClient:
+    """진단용 AiClient 를 만든다.
+
+    앱과 같은 usage_limiter 를 붙여 이 스크립트의 소비도 일일 한도에 집계된다.
+    """
+    limiter = AiUsageLimiter(
+        daily_request_limit=int(cfg.get("daily_request_limit", 100)),
+        disclosure_reserve=int(cfg.get("disclosure_reserve", 20)),
+    )
+    return AiClient(
+        base_url=str(cfg.get("base_url") or _DEFAULT_BASE_URL),
+        api_key=str(cfg.get("api_key") or ""),
+        model=str(cfg.get("model") or _DEFAULT_MODEL),
+        timeout_sec=20,
+        usage_limiter=limiter,
+    )
 
 
 def _mask(api_key: str) -> str:
@@ -67,12 +86,17 @@ async def _main() -> None:
     print(f"모델={model}  base_url={base_url}  키={_mask(api_key)}")
     print("AI 호출 중...")
 
-    client = AiClient(base_url=base_url, api_key=api_key, model=model, timeout_sec=20)
+    client = _build_client(cfg)
     try:
         result = await client.complete(
             system="너는 한국 주식 애널리스트다.",
             user="삼성전자 유상증자 공시를 투자자 관점에서 한 문장으로 요약해줘.",
         )
+    except AiUsageLimitExceeded as exc:
+        # 한도 소진은 키·모델·네트워크 문제가 아니므로 안내를 분리한다.
+        print(f"[중단] 일일 AI 호출 한도에 걸려 요청을 보내지 않았습니다: {exc}")
+        print("→ 한도 초기화를 기다리거나 ai_analysis.daily_request_limit 을 조정하세요.")
+        sys.exit(1)
     except Exception as exc:
         print(f"[실패] {type(exc).__name__}: {exc}")
         print("→ 키 형식(AIza)·모델명·네트워크/프록시를 확인하세요.")

--- a/scripts/check_disclosure_ai.py
+++ b/scripts/check_disclosure_ai.py
@@ -29,6 +29,7 @@ except Exception:
 from repositories.favorite_repository import FavoriteRepository  # noqa: E402
 from services.ai_client import AiClient  # noqa: E402
 from services.ai_disclosure_analyzer import AiDisclosureAnalyzer  # noqa: E402
+from services.ai_usage_limiter import AiUsageLimiter  # noqa: E402
 from services.dart_disclosure_client import DartDisclosureClient  # noqa: E402
 from services.dart_disclosure_rule_service import DartDisclosureRuleService  # noqa: E402
 
@@ -57,15 +58,23 @@ async def _fetch(client, date, max_pages):
 
 
 def _build_ai(ai_cfg: dict):
-    """(AiClient, AiDisclosureAnalyzer) 또는 (None, None) 반환."""
+    """(AiClient, AiDisclosureAnalyzer) 또는 (None, None) 반환.
+
+    앱과 같은 usage_limiter 를 붙여 이 스크립트의 소비도 일일 한도에 집계된다.
+    """
     ai_key = str(ai_cfg.get("api_key") or "")
     if not ai_cfg.get("enabled"):
         return None, None
+    limiter = AiUsageLimiter(
+        daily_request_limit=int(ai_cfg.get("daily_request_limit", 100)),
+        disclosure_reserve=int(ai_cfg.get("disclosure_reserve", 20)),
+    )
     ai_client = AiClient(
         base_url=str(ai_cfg.get("base_url") or _DEFAULT_BASE_URL),
         api_key=ai_key,
         model=str(ai_cfg.get("model") or _DEFAULT_MODEL),
         timeout_sec=float(ai_cfg.get("timeout_sec", 15)),
+        usage_limiter=limiter,
     )
     analyzer = AiDisclosureAnalyzer(ai_client, max_tokens=int(ai_cfg.get("max_tokens", 2048)))
     return ai_client, analyzer

--- a/tests/unit_test/scripts/test_check_ai_scripts.py
+++ b/tests/unit_test/scripts/test_check_ai_scripts.py
@@ -1,4 +1,8 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
+
+import pytest
+
+from services.ai_usage_limiter import AiUsageLimitExceeded
 
 from scripts import check_ai_key, check_disclosure_ai, check_news_ai
 
@@ -26,8 +30,71 @@ async def test_check_ai_key_allows_empty_api_key_for_ollama(monkeypatch):
         api_key="",
         model="qwen2.5",
         timeout_sec=20,
+        usage_limiter=ANY,
     )
     ai_client.complete.assert_awaited_once()
+
+
+def test_check_ai_key_attaches_usage_limiter_so_script_usage_is_counted():
+    """스크립트가 쓴 요청도 앱과 같은 일일 한도에 집계되어야 한다."""
+    client = check_ai_key._build_client(
+        {
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+            "daily_request_limit": 100,
+            "disclosure_reserve": 20,
+        }
+    )
+
+    assert client._usage_limiter is not None
+
+
+async def test_check_ai_key_distinguishes_usage_limit_from_key_failure(
+    monkeypatch, capsys
+):
+    """한도 소진은 키·모델·네트워크 문제가 아니므로 안내가 달라야 한다."""
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(
+        side_effect=AiUsageLimitExceeded(
+            limit_kind="interactive",
+            daily_limit=100,
+            used=80,
+            reset_at="2026-08-08T00:00:00-07:00",
+            interactive_limit=80,
+            disclosure_reserve=20,
+        )
+    )
+    monkeypatch.setattr(
+        check_ai_key,
+        "_load_ai_config",
+        lambda: {"api_key": "AIzaXXXX", "model": "gemini-2.5-flash"},
+    )
+    monkeypatch.setattr(check_ai_key, "AiClient", MagicMock(return_value=ai_client))
+
+    with pytest.raises(SystemExit):
+        await check_ai_key._main()
+
+    out = capsys.readouterr().out
+    assert "한도" in out
+    assert "키 형식" not in out
+
+
+def test_disclosure_dry_run_attaches_usage_limiter_so_script_usage_is_counted():
+    """공시 진단 소비도 /api/ai/usage 집계에 포함돼야 한다."""
+    ai_client, analyzer = check_disclosure_ai._build_ai(
+        {
+            "enabled": True,
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+            "daily_request_limit": 100,
+            "disclosure_reserve": 20,
+        }
+    )
+
+    assert analyzer is not None
+    assert ai_client._usage_limiter is not None
 
 
 def test_disclosure_dry_run_builds_ollama_analyzer_without_api_key():

--- a/todo_list.md
+++ b/todo_list.md
@@ -77,10 +77,9 @@
 **개선포인트 (미착수 — 우선순위 순)**
 
 - [x] **프론트엔드 결과 보존 완료 (2026-08-07)**: 종목별 직전 검토 결과를 메모리에 두고(`_aiNewsCache`), 검토 이력이 있는 종목 상세를 다시 열면 본문·기사목록·신호 배지를 복원한다(상태줄에 `이전 검토 결과` 표기, 버튼은 `다시 검토`). 재요청은 버튼 클릭으로만 발생하며 캐시를 무시하고 새로 호출한다 — 서버·한도 로직 무변경. 새로고침 시 사라지는 세션 캐시로 충분(뉴스 목록이 몇 시간 단위로 정체되므로).
-- [ ] **수집 결과 해시 비교로 AI 스킵** — 스크래핑은 매번 수행(무료)하되 기사 제목 집합이 직전과 같으면 AI를 건너뛰고 이전 결과 재사용. 인메모리 dict로 충분. `by_type` 실측으로 뉴스 소비가 실제로 많다고 확인된 뒤 착수.
-- [ ] **news 전용 하위 한도(`news_daily_limit`)** — 지금은 정할 근거가 없어 넣지 않았다. `GET /api/ai/usage`의 `by_type`을 며칠 실측해 stock/ranking 대비 news 비중을 본 뒤 판단한다(선구현 금지).
+- [x] ~~**수집 결과 해시 비교로 AI 스킵**~~ / ~~**news 전용 하위 한도(`news_daily_limit`)**~~ — **둘 다 드롭 (2026-08-07, `by_type` 실측 근거)**: `data/ai_usage.db` 07-19~08-07 실측에서 `news` 는 전 기간 통틀어 **5건(3일)** 에 불과했다(`stock` 최대 12/일, `disclosure` 5~15/일 — 07-20·21 만 96/100 으로 한도 근접). 두 항목 모두 "뉴스 소비가 많다고 확인되면 착수" 를 조건으로 걸어둔 것이고 그 전제가 실측으로 부정됐다. 프론트 캐시(위 항목)까지 들어간 뒤라 재클릭 낭비도 이미 막혀 있다. 뉴스 소비가 유의미해지면 재검토한다(선구현 금지).
 - [ ] **(조건부·큰 작업) 주기적 백그라운드 수집** — 관심종목 뉴스 폴링. 한도 소비가 관심종목 수 × 주기로 폭증하므로 **중요도 필터가 선행 조건**이며, 사실상 공시 파이프라인(dedup DB·재시도·다이제스트) 규모의 작업이다. 위 3개 항목 이후에 재검토.
-- [ ] **기존 진단 스크립트 리미터 미부착** — `check_ai_key.py`·`check_disclosure_ai.py`는 `AiClient`에 `usage_limiter`를 붙이지 않아 소비가 `/api/ai/usage` 집계에서 빠진다(`check_news_ai.py`는 부착됨). 저위험 정리 과제.
+- [x] **기존 진단 스크립트 리미터 부착 완료 (2026-08-07)** — `check_ai_key.py`·`check_disclosure_ai.py`가 `AiClient` 에 `usage_limiter` 를 붙이지 않아 소비가 `/api/ai/usage` 집계에서 빠지던 것을 해소(`check_news_ai.py` 패턴 준용). `check_ai_key.py` 는 클라이언트 생성을 `_build_client()` 로 분리했고, 한도 소진(`AiUsageLimitExceeded`)은 키·모델·네트워크 실패와 안내를 분리해 오진을 막는다.
 
 주요 파일: `services/stock_news_collector_service.py`, `services/ai_news_analyzer.py`, `services/ai_usage_limiter.py`, `view/web/routes/stock.py`, `view/web/routes/ai.py`, `view/web/static/js/stock.js`, `scripts/check_news_ai.py`, `tests/frontend/run_stock_dom_tests.mjs`
 


### PR DESCRIPTION
@
## 문제

`check_ai_key.py`·`check_disclosure_ai.py` 가 `AiClient` 에 `usage_limiter` 를 붙이지 않아, 이 스크립트들이 쓴 요청이 `/api/ai/usage` 집계에서 빠졌다. 한도가 남았다고 표시되는데 실제로는 소비된 상태가 될 수 있다. `check_news_ai.py` 는 이미 부착돼 있어 세 스크립트의 동작이 갈려 있었다.

부수로, 기존 `except Exception` 경로는 한도 초과를 **"키 형식(AIza)·모델명·네트워크/프록시를 확인하세요"** 로 오진한다 — 키 진단 스크립트에서 가장 나쁜 오답이다.

## 변경

- 두 스크립트에 `AiUsageLimiter` 부착 (`check_news_ai.py` 패턴 준용)
- `check_ai_key.py` 의 클라이언트 생성을 `_build_client()` 로 분리 — 테스트 가능하게
- `AiUsageLimitExceeded` 를 별도 분기로 안내 분리

## X-4 개선포인트 2건 드롭

`data/ai_usage.db` 07-19~08-07 실측:

| usage_type | 실측 |
|---|---|
| `news` | **전 기간 5건 (3일)** |
| `stock` | 최대 12/일 |
| `disclosure` | 5~15/일 (07-20·21 만 96/100 으로 한도 근접) |

**수집 결과 해시 비교로 AI 스킵**과 **`news_daily_limit`** 은 둘 다 "`by_type` 실측으로 뉴스 소비가 많다고 확인된 뒤 착수" 를 조건으로 걸어둔 항목인데, 그 전제가 실측으로 부정됐다. 프론트 캐시(#791 계열)까지 들어간 뒤라 재클릭 낭비도 이미 막혀 있다. 선구현 금지 원칙대로 드롭하고, 소비가 유의미해지면 재검토한다.

## 테스트

TDD — 신규 3건 + 기존 계약 1건 red 확인 후 구현. 단위 7460 통과, 통합 277 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@