### PR TITLE
백테스트 마켓타이밍 게이트 복원 — 라이브 parity 갭

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -235,6 +235,28 @@ def _get_program_provider(stock_query_service: Any) -> Any | None:
     return getattr(market_data_service, "_broker_api_wrapper", None)
 
 
+def _build_market_resolver(logger: Any | None = None) -> Any | None:
+    """종목코드 → "KOSPI"/"KOSDAQ" resolver (마켓타이밍 게이트용).
+
+    라이브 StrategyScheduler 가 `stock_code_repository.is_kosdaq()` 로 판정하는 것과
+    동일하게 맞춘다. 저장소를 못 열면 None 을 반환해 게이트를 통과시킨다 —
+    게이트 배선 실패로 백테스트가 조용히 0거래가 되는 쪽이 더 위험하다.
+    """
+    try:
+        from repositories.stock_code_repository import StockCodeRepository
+
+        repo = StockCodeRepository()
+    except Exception as exc:
+        if logger:
+            logger.warning(f"마켓타이밍 게이트 비활성 — 종목코드 저장소 로드 실패: {exc}")
+        return None
+
+    def resolve(code: str) -> str:
+        return "KOSDAQ" if repo.is_kosdaq(str(code)) else "KOSPI"
+
+    return resolve
+
+
 def _load_pit_provider(path: str | None) -> Any | None:
     """full-records 스냅샷 JSON → PointInTimeUniverseProvider (R-1 생존편향)."""
     if not path:
@@ -1508,6 +1530,10 @@ async def _run(args: argparse.Namespace) -> None:
         microstructure_dir=args.microstructure_dir,
     )
     indicator_service = getattr(sqs, "indicator_service", None)
+    # 라이브 StrategyScheduler 의 마켓타이밍 진입 게이트를 백테스트에서도 적용한다.
+    # (#766 이 게이트를 전략 → 스케줄러로 옮겨 백테스트 경로에서 사라졌다.)
+    market_regime_service = getattr(universe_service, "_regime_svc", None)
+    market_resolver = _build_market_resolver(bootstrap_logger)
     with tempfile.TemporaryDirectory(prefix="period_backtest_") as tmp_dir:
         def make_runner(
             *,
@@ -1604,6 +1630,8 @@ async def _run(args: argparse.Namespace) -> None:
                 risk_gate_service=risk_sizing.risk_gate_service,
                 date_context_targets=[backtest_clock, replay_sqs],
                 mtm_bar_provider=mtm_bar_provider,
+                market_regime_service=market_regime_service,
+                market_resolver=market_resolver,
             )
 
         if args.walk_forward:

--- a/services/backtest_period_runner.py
+++ b/services/backtest_period_runner.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Protocol, Sequence
+from typing import Callable, Protocol, Sequence
 
 from common.types import Exchange, OrderSide as LiveOrderSide
 from common.trade_journal_schema import normalize_backtest_decision, normalize_backtest_execution
@@ -75,6 +75,9 @@ class BacktestPeriodRunnerConfig:
     warn_market_concentration_pct: float | None = 70.0
     warn_sector_concentration_pct: float | None = 50.0
     warn_theme_concentration_pct: float | None = 50.0
+    # 라이브 StrategyScheduler 와 동일한 진입 게이트. #766 이 이 게이트를 전략에서
+    # 스케줄러로 옮겼는데 백테스트는 스케줄러를 거치지 않아 게이트가 사라졌다.
+    market_timing_entry_gate: bool = True
 
 
 @dataclass
@@ -104,6 +107,8 @@ class BacktestPeriodRunner:
         risk_gate_service: BacktestRiskGate | None = None,
         date_context_targets: Sequence[object] | None = None,
         mtm_bar_provider: MarkToMarketBarProvider | None = None,
+        market_regime_service=None,
+        market_resolver: Callable[[str], str] | None = None,
     ) -> None:
         self._strategy = strategy
         self._bar_provider = bar_provider
@@ -117,6 +122,8 @@ class BacktestPeriodRunner:
         self._risk_gate_service = risk_gate_service
         self._date_context_targets = list(date_context_targets or [])
         self._mtm_bar_provider = mtm_bar_provider
+        self._market_regime_service = market_regime_service
+        self._market_resolver = market_resolver
         self._position_excursions: dict[str, dict[str, object]] = {}
 
     async def run(self, dates: Sequence[str]) -> BacktestPeriodRunResult:
@@ -161,6 +168,9 @@ class BacktestPeriodRunner:
             signal for signal in await self._strategy.scan()
             if signal.action == "BUY"
         ]
+        buy_signals = await self._filter_market_timing_blocked_buys(
+            buy_signals, date_ymd, result
+        )
         sized_signals: list[TradeSignal] = []
         for signal in buy_signals:
             sized_signal = await self._apply_position_sizing(signal, date_ymd, result)
@@ -219,6 +229,43 @@ class BacktestPeriodRunner:
                         portfolio_warnings=decision.warnings,
                     )
                 )
+
+    async def _filter_market_timing_blocked_buys(
+        self,
+        signals: list[TradeSignal],
+        date_ymd: str,
+        result: BacktestPeriodRunResult,
+    ) -> list[TradeSignal]:
+        """레짐이 🔴인 종목의 BUY 를 진입 전에 차단한다 (라이브 스케줄러와 동일 지점).
+
+        `classify_on_date` 로 **그 거래일 기준** 레짐을 쓴다 — 오늘 레짐으로 과거를
+        판정하면 look-ahead 가 된다. 레짐 서비스/resolver 미주입 경로와 조회 실패는
+        라이브와 동일하게 통과시킨다(fail-open) — 게이트 오류로 백테스트가 조용히
+        0거래가 되는 쪽이 더 위험하다.
+        """
+        if not self._config.market_timing_entry_gate:
+            return signals
+        if self._market_regime_service is None or self._market_resolver is None:
+            return signals
+
+        snapshots: dict[str, object] = {}
+        passed: list[TradeSignal] = []
+        for signal in signals:
+            try:
+                market = self._market_resolver(str(signal.code))
+                if market not in snapshots:
+                    snapshots[market] = await self._market_regime_service.classify_on_date(
+                        market, date_ymd
+                    )
+                if getattr(snapshots[market], "is_rising", False):
+                    passed.append(signal)
+                    continue
+                result.journal_records.append(
+                    self._rejected_signal_record(signal, date_ymd, "market_timing_off")
+                )
+            except Exception:
+                passed.append(signal)
+        return passed
 
     async def _execute_signal(
         self,

--- a/tests/unit_test/services/test_backtest_period_runner.py
+++ b/tests/unit_test/services/test_backtest_period_runner.py
@@ -662,3 +662,119 @@ async def test_period_runner_consecutive_day_buy_sell_invokes_mtm_provider_but_u
     assert mtm_provider.calls == [
         {"code": "005930", "start_ymd": "20260501", "end_ymd": "20260502"},
     ]
+
+
+# ── 마켓타이밍 게이트 parity (todo M-7) ────────────────────────────────────
+#
+# #766 이 게이트를 전략 → StrategyScheduler 로 옮기면서, 스케줄러를 거치지 않는
+# 백테스트 경로에서는 게이트가 통째로 사라졌다. 백테스트가 라이브보다 느슨하면
+# 성과가 과대평가된다.
+
+
+class _FakeRegimeSnapshot:
+    def __init__(self, is_rising: bool) -> None:
+        self.is_rising = is_rising
+        self.trend_status = "rising" if is_rising else "falling"
+
+
+class _FakeRegimeService:
+    def __init__(self, is_rising: bool = True, raises: bool = False) -> None:
+        self._is_rising = is_rising
+        self._raises = raises
+        self.calls: list[tuple[str, str]] = []
+
+    async def classify_on_date(self, market: str, date: str, logger=None):
+        self.calls.append((market, date))
+        if self._raises:
+            raise RuntimeError("index ohlcv unavailable")
+        return _FakeRegimeSnapshot(self._is_rising)
+
+
+def _gate_runner(*, regime_service, market="KOSPI", gate=True):
+    strategy = FakeStrategy()
+    provider = StaticBarProvider({
+        ("20260501", "005930", "BUY"): BacktestBar(
+            "20260501 091000", 70_000, 70_500, 69_500, 70_200, 1_000
+        ),
+    })
+    ledger = BacktestPortfolioLedger(initial_cash=1_000_000)
+    return BacktestPeriodRunner(
+        strategy=strategy,
+        bar_provider=provider,
+        ledger=ledger,
+        market_regime_service=regime_service,
+        market_resolver=lambda code: market,
+        config=BacktestPeriodRunnerConfig(market_timing_entry_gate=gate),
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_blocks_buy_when_regime_falling():
+    regime = _FakeRegimeService(is_rising=False)
+    runner = _gate_runner(regime_service=regime)
+
+    result = await runner.run(["20260501"])
+
+    assert result.execution_reports == []
+    assert [r["rejected_reason"] for r in result.journal_records] == ["market_timing_off"]
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_allows_buy_when_regime_rising():
+    runner = _gate_runner(regime_service=_FakeRegimeService(is_rising=True))
+
+    result = await runner.run(["20260501"])
+
+    assert [report.order.side.value for report in result.execution_reports] == ["BUY"]
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_classifies_on_backtest_date_not_today():
+    """PIT 보장 — 오늘 레짐이 아니라 그 거래일 레짐으로 판정해야 한다."""
+    regime = _FakeRegimeService(is_rising=True)
+    runner = _gate_runner(regime_service=regime)
+
+    await runner.run(["20260501"])
+
+    assert regime.calls == [("KOSPI", "20260501")]
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_resolves_market_per_code():
+    regime = _FakeRegimeService(is_rising=False)
+    runner = _gate_runner(regime_service=regime, market="KOSDAQ")
+
+    await runner.run(["20260501"])
+
+    assert regime.calls == [("KOSDAQ", "20260501")]
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_skipped_when_regime_service_absent():
+    """기존/테스트 경로 호환 — 레짐 서비스가 없으면 통과시킨다 (라이브와 동일)."""
+    runner = _gate_runner(regime_service=None)
+
+    result = await runner.run(["20260501"])
+
+    assert [report.order.side.value for report in result.execution_reports] == ["BUY"]
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_can_be_disabled_by_config():
+    regime = _FakeRegimeService(is_rising=False)
+    runner = _gate_runner(regime_service=regime, gate=False)
+
+    result = await runner.run(["20260501"])
+
+    assert [report.order.side.value for report in result.execution_reports] == ["BUY"]
+    assert regime.calls == []
+
+
+@pytest.mark.asyncio
+async def test_market_timing_gate_fails_open_on_lookup_error():
+    """레짐 조회 실패로 백테스트가 조용히 0거래가 되면 안 된다 (라이브와 동일)."""
+    runner = _gate_runner(regime_service=_FakeRegimeService(raises=True))
+
+    result = await runner.run(["20260501"])
+
+    assert [report.order.side.value for report in result.execution_reports] == ["BUY"]

--- a/todo_list.md
+++ b/todo_list.md
@@ -302,7 +302,11 @@
 
 ### M-7. 마켓 타이밍/레짐 변경 정합성 확인 [신규 — 2026-08-07]
 
-- [ ] 08-04~06 에 레짐·타이밍 판정이 세 번 바뀌었다: 레짐 판정을 지수 기반으로 전환(#770) · risk-off 구간에도 전략 scan 유지(#766) · recovery gate 완화(#780). 셋 다 **전략이 언제 도는지**를 바꾸므로, 1-8 백테스트의 마켓 타이밍 가정과 1-6 profitability gate 의 regime 태깅 기준이 이 변경과 어긋나지 않는지 확인이 필요하다. (1-8 은 "6월 하순 MA 하락 → `market_timing_off_both` 로 스캔 차단"을 전 구간 0거래의 원인 ②로 기록하고 있는데, 그 판정 로직이 바뀌었다.)
+- [x] **확인 결과: 실제 parity 갭이었고 복원 완료 (2026-08-07)**. #766 이 마켓타이밍 게이트를 전략에서 `StrategyScheduler._filter_market_timing_blocked_buys` 로 옮겼는데, **백테스트는 스케줄러를 거치지 않는다**(`scripts/run_backtest.py`·`backtest_walk_forward.py` 에 스케줄러 참조 0건). 그 결과 08-04 이후 백테스트에서 마켓타이밍 게이트가 통째로 사라져, 라이브보다 느슨한 조건으로 성과를 산출하고 있었다 — 1-5 의 원래 동기("백테스트가 검증하는 전략 ≠ 라이브가 거래하는 전략")가 마켓타이밍 축에서 재발한 것.
+  - 복원: `BacktestPeriodRunner._filter_market_timing_blocked_buys` 를 라이브와 동일 지점(진입 신호 → 사이징 직전)에 추가. `MarketRegimeService.classify_on_date`(#770 에서 만들어졌으나 **사용처가 0건이었다**)로 **그 거래일 기준** 레짐을 쓴다 — 오늘 레짐으로 과거를 판정하면 look-ahead. 시장 판정은 라이브와 같이 `stock_code_repository.is_kosdaq()`. 레짐 서비스/resolver 미주입과 조회 실패는 라이브와 동일하게 fail-open.
+  - **1-8 blocked 사유 ② 무효화**: "6월 하순 MA 하락 → `market_timing_off_both` 로 스캔 차단"은 #766 이후 백테스트에서 발생하지 않는다(전략의 스캔 스킵 코드가 삭제됨). 이제 게이트는 스캔이 아니라 **매수 신호**를 막으므로, 전 구간 0거래의 원인은 재확인이 필요하다.
+- [ ] **잔여: 전략에 남은 죽은 마켓타이밍 호출** — #766 이 차단 코드만 지우고 조회는 남겨, `larry_williams_vbo_strategy.py` 와 `larry_williams_channel_breakout_strategy.py` 는 `is_market_timing_ok` 를 scan 마다 2회(KOSPI/KOSDAQ) 호출하고 결과를 **전혀 쓰지 않는다**. 나머지 4개 전략은 로그 필드로만 소비한다(차단 없음). 제거하면 `_update_market_timing` 의 `market_timing_updated` 로그 이벤트가 함께 사라지므로 그 로그를 쓰는 소비처 확인 후 정리한다.
+- [ ] 1-6 profitability gate 의 regime 태깅이 #770 의 지수 기반 판정과 정합한지 확인 (별도).
 
 ---
 


### PR DESCRIPTION
@
## 발견

`#766` 이 마켓타이밍 게이트를 **전략 → `StrategyScheduler`** 로 옮겼습니다. 전략에서 `if not any(market_timing.values()): return signals`(스캔 스킵)과 종목별 `market_timing_off` 거절을 삭제하고, `_filter_market_timing_blocked_buys` 가 주문 직전 BUY 를 차단하도록 바꿨습니다.

그런데 **백테스트는 스케줄러를 거치지 않습니다** — `scripts/run_backtest.py`·`services/backtest_walk_forward.py` 어디에도 `StrategyScheduler` 참조가 없고, `BacktestPeriodRunner` 가 전략의 `scan()`/`check_exits()` 를 직접 호출합니다.

결과: **08-04 이후 백테스트에서 마켓타이밍 게이트가 통째로 사라졌습니다.** 라이브는 🔴 레짐 BUY 를 차단하는데(게이트 배선·`market_timing_entry_gate=True` 확인, 인버스 ETF 만 의도적 예외) 백테스트는 차단하지 않아, **백테스트가 라이브보다 느슨한 조건으로 성과를 산출**하고 있었습니다. `todo 1-5` 의 원래 동기였던 "백테스트가 검증하는 전략 ≠ 라이브가 거래하는 전략"이 마켓타이밍 축에서 재발한 것입니다.

## 변경

`BacktestPeriodRunner._filter_market_timing_blocked_buys` 를 라이브와 동일 지점(진입 신호 → 사이징 직전)에 추가했습니다.

| 항목 | 선택 | 이유 |
|---|---|---|
| 레짐 조회 | `classify_on_date(market, date_ymd)` | 그 거래일 기준. 오늘 레짐으로 과거를 판정하면 look-ahead. **이 메서드는 #770 에서 만들어졌으나 사용처가 0건이었습니다.** |
| 시장 판정 | `stock_code_repository.is_kosdaq()` | 라이브와 동일 |
| 미주입·조회 실패 | fail-open (통과) | 라이브와 동일. 게이트 오류로 백테스트가 조용히 0거래가 되는 쪽이 더 위험 |
| 차단 기록 | `rejected_reason="market_timing_off"` | 라이브 로그와 같은 사유 문자열 |
| 끄기 | `BacktestPeriodRunnerConfig.market_timing_entry_gate=False` | ablation 용 |

## 1-8 에 미치는 영향

`todo 1-8` 은 전 구간 0거래의 원인 ② 로 **"6월 하순 MA 하락 → 마켓 타이밍 게이트가 스캔 차단(`market_timing_off_both`)"** 을 기록하고 있습니다. #766 이후 그 스캔 스킵 코드는 삭제됐으므로 **이 사유는 더 이상 성립하지 않습니다.** 게이트가 스캔이 아니라 매수 신호를 막는 형태로 바뀌었으니, 0거래 원인은 재확인이 필요합니다(원인 ① PIT 후보 부재는 그대로).

## 남은 것 (이 PR 범위 밖)

`#766` 이 차단 코드만 지우고 조회는 남겨서, `larry_williams_vbo_strategy.py` 와 `larry_williams_channel_breakout_strategy.py` 는 `is_market_timing_ok` 를 scan 마다 2회 호출하고 **결과를 전혀 쓰지 않습니다**(나머지 4개 전략은 로그 필드로만 소비). 제거하면 `market_timing_updated` 로그 이벤트도 함께 사라지므로 소비처 확인이 필요해 분리했습니다 — todo 에 등재.

## 테스트

TDD — 신규 7건 red 확인 후 구현. 단위 7473 통과, 통합 277 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@