### PR TITLE
feat: 히트맵 마우스 휠 확대·축소

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -241,6 +241,112 @@ test("줌은 상·하한을 벗어나지 않고 초기화로 100% 로 돌아온�
     "초기화 후 배율 표시도 100% 여야 함");
 });
 
+// jsdom 은 레이아웃이 없어 scrollWidth/clientWidth 가 모두 0 이다.
+// 커서 고정 계산은 아래 전용 테스트에서 크기를 가진 가짜 viewport 로 검증한다.
+function wheel(window, deltaY, options = {}) {
+  const viewport = window.document.getElementById("heatmap-page-viewport");
+  const event = new window.WheelEvent("wheel", {
+    deltaY, deltaMode: 0, clientX: 0, clientY: 0, bubbles: true, cancelable: true, ...options,
+  });
+  viewport.dispatchEvent(event);
+  return event;
+}
+
+test("마우스 휠을 위로 굴리면 확대되고 아래로 굴리면 축소된다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+
+  await window.initHeatmapPage();
+  const sizer = window.document.getElementById("heatmap-page-sizer");
+  const before = labeledSymbols(window, "heatmap-page-domestic");
+
+  // 라벨 생략 기준이 완화되는지는 버튼 줌과 같은 배율(2칸=2배)에서 비교한다.
+  wheel(window, -100);
+  wheel(window, -100);
+  const zoomedIn = Number.parseFloat(sizer.style.width);
+  assert(zoomedIn > 100, `휠 업이 확대여야 함 (실제 ${sizer.style.width})`);
+  assert(sizer.style.height === sizer.style.width, "휠 확대도 가로/세로 배율이 같아야 함");
+  assert(window.document.getElementById("heatmap-page-zoom-level").textContent === `${Math.round(zoomedIn)}%`,
+    "휠 확대 후 배율 표시가 캔버스 배율과 일치해야 함");
+  assert(labeledSymbols(window, "heatmap-page-domestic").length > before.length,
+    "휠 확대도 버튼 확대처럼 라벨을 살려야 함");
+
+  wheel(window, 100);
+  wheel(window, 100);
+  assert(sizer.style.width === "100%", `휠 다운이 축소여야 함 (실제 ${sizer.style.width})`);
+});
+
+test("휠 확대는 재조회 없이 다시 그리고 페이지 스크롤을 막는다", async () => {
+  let domesticCalls = 0;
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => { domesticCalls += 1; return success(domesticSnapshot()); },
+  }));
+
+  await window.initHeatmapPage();
+  const event = wheel(window, -100);
+
+  assert(event.defaultPrevented, "휠 줌 중에는 페이지가 같이 스크롤되지 않도록 기본 동작을 막아야 함");
+  assert(domesticCalls === 1, `휠 줌은 재조회하지 않아야 함 (실제 ${domesticCalls})`);
+});
+
+test("트랙패드의 작은 휠 delta 는 한 칸 분량이 모일 때만 배율을 바꾼다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+
+  await window.initHeatmapPage();
+  const sizer = window.document.getElementById("heatmap-page-sizer");
+
+  for (let i = 0; i < 4; i += 1) wheel(window, -10);
+  assert(sizer.style.width === "100%", `누적이 한 칸에 못 미치면 배율이 그대로여야 함 (실제 ${sizer.style.width})`);
+
+  for (let i = 0; i < 6; i += 1) wheel(window, -10);
+  assert(Number.parseFloat(sizer.style.width) > 100, "누적이 한 칸을 채우면 확대돼야 함");
+});
+
+test("휠 축소는 기본 배율 아래로 내려가지 않는다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+
+  await window.initHeatmapPage();
+  const sizer = window.document.getElementById("heatmap-page-sizer");
+
+  for (let i = 0; i < 5; i += 1) wheel(window, 100);
+  assert(sizer.style.width === "100%", `기본 배율 아래로 축소되면 안 됨 (실제 ${sizer.style.width})`);
+});
+
+test("휠 줌은 커서 아래 지점을 화면에 고정한다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+
+  // 커서는 viewport 좌상단에서 (300, 100) → 콘텐츠 기준 (800, 350) = 비율 (0.4, 0.35)
+  const viewport = {
+    scrollWidth: 2000, scrollHeight: 1000,
+    clientWidth: 1000, clientHeight: 500,
+    scrollLeft: 500, scrollTop: 250,
+    getBoundingClientRect: () => ({ left: 0, top: 0 }),
+  };
+  const anchor = window._heatmapPagePointRatio(viewport, 300, 100);
+  assert(Math.abs(anchor.x - 0.4) < 1e-9 && Math.abs(anchor.y - 0.35) < 1e-9,
+    `커서 지점 비율이 어긋남 (실제 ${anchor.x}, ${anchor.y})`);
+
+  // 2배로 커진 캔버스에서도 같은 지점이 커서 위치에 남아야 한다.
+  viewport.scrollWidth = 4000;
+  viewport.scrollHeight = 2000;
+  window._restoreHeatmapPagePoint(viewport, anchor);
+  assert(viewport.scrollLeft === 0.4 * 4000 - 300, `가로 스크롤이 커서 기준으로 복원돼야 함 (실제 ${viewport.scrollLeft})`);
+  assert(viewport.scrollTop === 0.35 * 2000 - 100, `세로 스크롤이 커서 기준으로 복원돼야 함 (실제 ${viewport.scrollTop})`);
+});
+
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {
   const calls = [];
   makeWindow(routed({

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -6,14 +6,19 @@
  *   2) 줌 — CSS transform 이 아니라 캔버스(sizer) 자체를 키우고 다시 그린다.
  *      transform 으로 확대하면 작은 타일의 생략된 라벨이 그대로 없기 때문에,
  *      배율을 렌더에 넘겨 라벨 기준을 완화해야 확대의 의미가 있다.
+ *      버튼(중앙 고정)과 마우스 휠(커서 고정) 두 경로가 같은 배율 단계를 공유한다.
  */
 
 // 홈 미리보기(200종목)보다 넓게 잡는다 — 작은 타일은 확대로 읽을 수 있다.
 const HEATMAP_PAGE_DOMESTIC_LIMIT = 500;
 const HEATMAP_PAGE_OVERSEAS_LIMIT = 500;
 const HEATMAP_PAGE_ZOOM_STEPS = [1, 1.5, 2, 3, 4, 6, 8];
+// 휠 한 칸(Chrome deltaMode=0 기준 deltaY 100) 이 배율 한 단계다. 트랙패드는 한 번 굴려도
+// 작은 delta 를 여러 번 보내므로 누적해서 이 값을 넘을 때만 단계를 바꾼다.
+const HEATMAP_PAGE_WHEEL_STEP_DELTA = 100;
 
 let _heatmapPageZoomIndex = 0;
+let _heatmapPageWheelAccum = 0;
 
 function _heatmapPageZoom() {
     return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
@@ -94,11 +99,15 @@ function _applyHeatmapPageZoom() {
     });
 }
 
-function zoomHeatmapPage(step) {
-    const next = Math.min(
+function _heatmapPageNextZoomIndex(step) {
+    return Math.min(
         HEATMAP_PAGE_ZOOM_STEPS.length - 1,
         Math.max(0, _heatmapPageZoomIndex + step),
     );
+}
+
+function zoomHeatmapPage(step) {
+    const next = _heatmapPageNextZoomIndex(step);
     if (next === _heatmapPageZoomIndex) return;
 
     const viewport = document.getElementById('heatmap-page-viewport');
@@ -106,6 +115,67 @@ function zoomHeatmapPage(step) {
     _heatmapPageZoomIndex = next;
     _applyHeatmapPageZoom();
     _restoreHeatmapPageCenter(viewport, anchor);
+}
+
+// 휠 줌은 커서 아래 지점을 고정한다 — 중앙 기준으로 되돌리면 방금 겨눈 타일이 화면에서 벗어난다.
+function _heatmapPagePointRatio(viewport, clientX, clientY) {
+    if (!viewport || !viewport.scrollWidth || !viewport.scrollHeight) return null;
+    const rect = viewport.getBoundingClientRect();
+    const offsetX = clientX - rect.left;
+    const offsetY = clientY - rect.top;
+    return {
+        x: (viewport.scrollLeft + offsetX) / viewport.scrollWidth,
+        y: (viewport.scrollTop + offsetY) / viewport.scrollHeight,
+        offsetX,
+        offsetY,
+    };
+}
+
+function _restoreHeatmapPagePoint(viewport, anchor) {
+    if (!viewport || !anchor) return;
+    viewport.scrollLeft = Math.max(0, anchor.x * viewport.scrollWidth - anchor.offsetX);
+    viewport.scrollTop = Math.max(0, anchor.y * viewport.scrollHeight - anchor.offsetY);
+}
+
+function zoomHeatmapPageAt(step, clientX, clientY) {
+    const next = _heatmapPageNextZoomIndex(step);
+    if (next === _heatmapPageZoomIndex) return;
+
+    const viewport = document.getElementById('heatmap-page-viewport');
+    const anchor = _heatmapPagePointRatio(viewport, clientX, clientY);
+    _heatmapPageZoomIndex = next;
+    _applyHeatmapPageZoom();
+    _restoreHeatmapPagePoint(viewport, anchor);
+}
+
+// 브라우저별 스크롤 단위(0=픽셀, 1=줄, 2=페이지)를 픽셀 기준으로 맞춘다.
+function _heatmapPageWheelDelta(event) {
+    if (event.deltaMode === 1) return event.deltaY * 40;
+    if (event.deltaMode === 2) return event.deltaY * HEATMAP_PAGE_WHEEL_STEP_DELTA;
+    return event.deltaY;
+}
+
+function _onHeatmapPageWheel(event) {
+    // 히트맵 위에서 휠은 배율 조작이다 — 페이지까지 같이 스크롤되면 보던 지점이 튄다.
+    event.preventDefault();
+
+    const delta = _heatmapPageWheelDelta(event);
+    if (!delta) return;
+    // 방향을 바꾸면 반대 방향 누적은 버린다(직전 잔량 때문에 한 칸이 씹히는 것을 막는다).
+    if ((delta > 0) !== (_heatmapPageWheelAccum > 0)) _heatmapPageWheelAccum = 0;
+    _heatmapPageWheelAccum += delta;
+
+    const notches = Math.trunc(_heatmapPageWheelAccum / HEATMAP_PAGE_WHEEL_STEP_DELTA);
+    if (!notches) return;
+    _heatmapPageWheelAccum -= notches * HEATMAP_PAGE_WHEEL_STEP_DELTA;
+    zoomHeatmapPageAt(-notches, event.clientX, event.clientY);  // 휠 업(delta < 0) = 확대
+}
+
+// pjax 재진입 시 viewport 는 새 노드지만, 같은 노드에 두 번 걸리는 것도 막는다.
+function _bindHeatmapPageWheelZoom(viewport) {
+    if (viewport.dataset.wheelZoomBound === '1') return;
+    viewport.addEventListener('wheel', _onHeatmapPageWheel, { passive: false });
+    viewport.dataset.wheelZoomBound = '1';
 }
 
 function resetHeatmapPageZoom() {
@@ -119,7 +189,8 @@ function resetHeatmapPageZoom() {
 }
 
 async function initHeatmapPage() {
-    if (!document.getElementById('heatmap-page-viewport')) return;
+    const viewport = document.getElementById('heatmap-page-viewport');
+    if (!viewport) return;
 
     // pjax 재진입 시 이전 화면의 응답/배율이 남지 않도록 초기화한다.
     Object.values(HEATMAP_PAGE_SOURCES).forEach(source => {
@@ -127,7 +198,9 @@ async function initHeatmapPage() {
         source.sequence = 0;
     });
     _heatmapPageZoomIndex = 0;
+    _heatmapPageWheelAccum = 0;
     _applyHeatmapPageZoom();
+    _bindHeatmapPageWheelZoom(viewport);
 
     // 미국장이 꺼진 run 에서는 API 가 400 을 내므로 탭 자체를 감춘다.
     if (!await _heatmapOverseasEnabled()) {

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -30,7 +30,7 @@
             <div class="heatmap-toolbar">
                 <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
                 <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
-                <span class="heatmap-zoom">
+                <span class="heatmap-zoom" title="히트맵 위에서 마우스 휠로도 확대·축소할 수 있습니다">
                     <button type="button" onclick="zoomHeatmapPage(-1)" title="축소" aria-label="축소">−</button>
                     <span id="heatmap-page-zoom-level">100%</span>
                     <button type="button" onclick="zoomHeatmapPage(1)" title="확대" aria-label="확대">+</button>
@@ -56,5 +56,5 @@
 
 {% block scripts %}
 <script src="/static/js/market_heatmap.js?v=3"></script>
-<script src="/static/js/heatmap_page.js?v=1"></script>
+<script src="/static/js/heatmap_page.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## 무엇을

`/heatmap` 전용 페이지에서 **마우스 휠로 확대·축소**할 수 있게 한다. 기존 +/− 버튼은 그대로 동작한다.

## 왜

원하는 타일까지 배율을 올리는 데 버튼 클릭이 여러 번 필요했고, 버튼 줌은 항상 화면 중앙을 고정하므로 겨눈 종목이 확대 후 화면에서 벗어났다.

## 어떻게

- `heatmap-page-viewport` 에 `wheel` 리스너(`passive: false`)를 걸어 기존 배율 단계(`HEATMAP_PAGE_ZOOM_STEPS`)를 공유한다 — 재조회 없이 마지막 응답으로 다시 그리는 경로도 그대로 재사용.
- **커서 고정**: 휠 줌은 커서 아래 콘텐츠 지점의 비율을 저장해 확대 후 같은 화면 좌표로 되돌린다(버튼 줌은 기존 중앙 고정 유지).
- **트랙패드 대응**: 작은 delta 를 누적해 한 칸(deltaY 100) 분량이 모일 때만 배율을 바꾸고, 방향이 바뀌면 누적을 버린다. `deltaMode`(줄/페이지)는 픽셀 기준으로 정규화.
- 휠 처리 중 `preventDefault()` 로 페이지 동시 스크롤을 막고, pjax 재진입 시 누적값·중복 바인딩을 초기화한다.
- 툴바 줌 컨트롤에 휠 사용 가능 안내 `title` 추가, `heatmap_page.js?v=2` 로 캐시 버스팅.

## 테스트

jsdom 회귀 6건 추가 (`tests/frontend/run_heatmap_page_dom_tests.mjs`) — 휠 방향·재조회 없음·기본 동작 차단·누적 임계·기본 배율 하한·커서 고정 스크롤 복원 계산.

- `run_heatmap_page_dom_tests.mjs` 13/13, `run_market_heatmap_dom_tests.mjs` 13/13
- `pytest tests/unit_test` 7473 passed
- `pytest tests/integration_test` 277 passed

실제 서버 기동 확인은 하지 않았다(브로커 자격증명/토큰 발급이 필요해 임의로 띄우지 않음). DOM 행위는 jsdom 회귀로 검증했고, jsdom 은 레이아웃이 없어 스크롤 복원은 크기를 가진 가짜 viewport 로 계산만 잠갔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)