### PR TITLE
feat: 히트맵 기간 선택 (1일/1주/1개월/3개월/6개월/1년)

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -614,6 +614,61 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository YTD 수익률 랭킹 조회 실패: {e}")
             return []
 
+    async def get_period_base_closes(self, period_days: int) -> Dict[str, Any]:
+        """최신 거래일에서 period_days 달력일 물러난 시점의 종목별 기준종가 (히트맵 기간 등락률용).
+
+        목표일이 휴장일일 수 있으므로 '목표일 이하 가장 가까운 거래일'을 기준일로 삼는다.
+        이력이 그만큼 축적돼 있지 않으면 기준일 없이 비운다 — 남아 있는 가장 오래된 날짜로
+        대체하면 '1년 등락률' 이 실제로는 3개월 등락률인 수치가 되어 화면이 거짓말한다.
+        daily_prices 는 수집 시작 시점이 늦어 기준가는 더 오래 축적된 ohlcv 에서 읽는다.
+        """
+        from datetime import datetime, timedelta
+
+        empty = {"base_date": None, "latest_date": None, "closes": {}}
+        try:
+            async with self._get_read_connection() as conn:
+                async with conn.execute("SELECT MAX(trade_date) FROM daily_prices") as cursor:
+                    latest_row = await cursor.fetchone()
+                latest_date = latest_row[0] if latest_row and latest_row[0] else None
+                if not latest_date:
+                    return empty
+
+                target_date = (
+                    datetime.strptime(latest_date, "%Y%m%d") - timedelta(days=period_days)
+                ).strftime("%Y%m%d")
+
+                # 자릿수가 어긋난 레코드가 섞여도 8자리 날짜만 기준일 후보로 삼고,
+                # 최신 스냅샷 종목과 실제로 겹치는 코드가 있는 날짜만 채택한다(휴장일 배제).
+                async with conn.execute(
+                    """
+                    SELECT MAX(base.date)
+                    FROM ohlcv AS base
+                    JOIN daily_prices AS latest
+                      ON latest.code = base.code AND latest.trade_date = ?
+                    WHERE base.date <= ?
+                      AND base.date GLOB '[0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]'
+                    """,
+                    (latest_date, target_date),
+                ) as cursor:
+                    base_row = await cursor.fetchone()
+                base_date = base_row[0] if base_row and base_row[0] else None
+                if not base_date:
+                    return {"base_date": None, "latest_date": latest_date, "closes": {}}
+
+                async with conn.execute(
+                    "SELECT code, close FROM ohlcv WHERE date = ? AND close > 0",
+                    (base_date,),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                return {
+                    "base_date": base_date,
+                    "latest_date": latest_date,
+                    "closes": {row[0]: row[1] for row in rows},
+                }
+        except Exception as e:
+            self._logger.error(f"StockOhlcvRepository 기간 기준종가 조회 실패: {e}")
+            return empty
+
     async def get_newhigh_stocks(self, trade_date: str) -> List[Dict]:
         """특정 거래일의 신고가(is_newhigh=1) 종목을 시가총액 내림차순으로 조회."""
         try:

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -110,6 +110,10 @@ class StockRepository:
         """최신 거래일 기준 시가총액 상위 스냅샷 조회 (국내 히트맵용)."""
         return await self._ohlcv_repo.get_market_cap_snapshot(limit=limit, market=market)
 
+    async def get_period_base_closes(self, period_days: int) -> Dict:
+        """최신 거래일에서 period_days 달력일 이전의 종목별 기준종가 조회 (히트맵 기간 등락률용)."""
+        return await self._ohlcv_repo.get_period_base_closes(period_days=period_days)
+
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
         """is_newhigh 및 is_historical_newhigh 컬럼 업데이트."""
         await self._ohlcv_repo.update_newhigh_fields(trade_date, records)

--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -23,6 +23,17 @@ const SCAFFOLD = `
 <div class="heatmap-toolbar">
   <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
   <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+  <span class="heatmap-period" id="heatmap-page-period-wrap">
+    <label for="heatmap-page-period">기간</label>
+    <select id="heatmap-page-period">
+      <option value="1d" selected>1일</option>
+      <option value="1w">1주</option>
+      <option value="1m">1개월</option>
+      <option value="3m">3개월</option>
+      <option value="6m">6개월</option>
+      <option value="1y">1년</option>
+    </select>
+  </span>
   <span class="heatmap-zoom">
     <button type="button" id="heatmap-page-zoom-out">−</button>
     <span id="heatmap-page-zoom-level">100%</span>
@@ -345,6 +356,111 @@ test("휠 줌은 커서 아래 지점을 화면에 고정한다", async () => {
   window._restoreHeatmapPagePoint(viewport, anchor);
   assert(viewport.scrollLeft === 0.4 * 4000 - 300, `가로 스크롤이 커서 기준으로 복원돼야 함 (실제 ${viewport.scrollLeft})`);
   assert(viewport.scrollTop === 0.35 * 2000 - 100, `세로 스크롤이 커서 기준으로 복원돼야 함 (실제 ${viewport.scrollTop})`);
+});
+
+test("기간을 바꾸면 그 기간으로 다시 조회하고 캡션에 비교 구간을 밝힌다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "3m", base_date: "20260508", items: domesticSnapshot().items,
+    }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+  await window.setHeatmapPeriod("3m");
+
+  const domesticCalls = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domesticCalls.length === 2, `기간 변경은 재조회를 유발해야 함 (실제 ${domesticCalls.length}회)`);
+  assert(domesticCalls[domesticCalls.length - 1].includes("period=3m"),
+    `조회 URL 에 기간이 실려야 함 (실제 ${domesticCalls[domesticCalls.length - 1]})`);
+
+  const caption = window.document.getElementById("heatmap-page-domestic-caption").textContent;
+  assert(caption.includes("3개월"), `캡션에 기간이 표시돼야 함 (실제 ${caption})`);
+  assert(caption.includes("2026-05-08") && caption.includes("2026-08-07"),
+    `캡션에 비교 구간이 표시돼야 함 (실제 ${caption})`);
+  assert(window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 0,
+    "기간 변경 후에도 타일이 그려져야 함");
+});
+
+test("기간 비교 데이터가 없으면 캡션이 그 사실을 밝힌다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "1y", base_date: null,
+      items: domesticSnapshot().items.map(item => ({ ...item, change_rate: null })),
+    }),
+  }));
+
+  await window.initHeatmapPage();
+  await window.setHeatmapPeriod("1y");
+
+  const caption = window.document.getElementById("heatmap-page-domestic-caption").textContent;
+  assert(caption.includes("1년") && caption.includes("없"), `비교 불가를 알려야 함 (실제 ${caption})`);
+  assert(window.document.querySelector('#heatmap-page-domestic .heatmap-tile[data-direction="unknown"]'),
+    "등락률을 못 낸 종목은 unknown 타일이어야 함");
+});
+
+test("기간을 바꿔도 보고 있던 배율은 유지된다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "1m", base_date: "20260707", items: domesticSnapshot().items,
+    }),
+  }));
+
+  await window.initHeatmapPage();
+  window.zoomHeatmapPage(2);
+  const zoomed = window.document.getElementById("heatmap-page-sizer").style.width;
+
+  await window.setHeatmapPeriod("1m");
+
+  assert(window.document.getElementById("heatmap-page-sizer").style.width === zoomed,
+    `기간 변경이 배율을 되돌리면 안 됨 (실제 ${window.document.getElementById("heatmap-page-sizer").style.width})`);
+  assert(window.document.getElementById("heatmap-page-zoom-level").textContent === `${Math.round(Number.parseFloat(zoomed))}%`,
+    "배율 표시도 유지돼야 함");
+});
+
+test("미국 탭에서는 기간 선택을 감춘다 (미국 스냅샷에 기간 데이터가 없음)", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})], updated_at: 1767225600 }),
+  }));
+
+  await window.initHeatmapPage();
+  const wrap = window.document.getElementById("heatmap-page-period-wrap");
+  assert(wrap.style.display !== "none", "한국 탭에서는 기간 선택이 보여야 함");
+
+  await window.setHeatmapTab("overseas");
+  assert(wrap.style.display === "none", "미국 탭에서는 기간 선택을 감춰야 함");
+
+  await window.setHeatmapTab("domestic");
+  assert(wrap.style.display !== "none", "한국 탭으로 돌아오면 기간 선택이 다시 보여야 함");
+});
+
+test("pjax 재진입 시 기간은 1일로 돌아온다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "3m", base_date: "20260508", items: domesticSnapshot().items,
+    }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+  await window.setHeatmapPeriod("3m");
+  calls.length = 0;
+  await window.initHeatmapPage();
+
+  const domesticCalls = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domesticCalls[0].includes("period=1d"), `재진입은 1일로 시작해야 함 (실제 ${domesticCalls[0]})`);
+  assert(window.document.getElementById("heatmap-page-period").value === "1d",
+    "기간 선택 UI 도 1일로 되돌아야 함");
 });
 
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -558,6 +558,83 @@ class TestGetYtdReturnRanking:
         assert result[0]["market_cap"] == 999_000_000
 
 
+# ── get_period_base_closes ───────────────────────────────────────────────────
+
+class TestGetPeriodBaseCloses:
+    """get_period_base_closes: 히트맵 기간 등락률의 기준일·기준종가 조회.
+
+    달력일로 물러난 목표일 '이하' 가장 가까운 거래일을 기준일로 삼는다(휴장일 대응).
+    데이터가 그만큼 축적돼 있지 않으면 기준일 없이 비운다 — 있는 것 중 가장 오래된
+    날짜로 대체하면 '1년 등락률' 이 실제로는 3개월 등락률인 수치가 되어 화면이 거짓말한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_picks_nearest_trading_day_at_or_before_target(self, repo):
+        # 최신 20260713 - 30일 = 20260613 → 그 이하 가장 가까운 거래일 20260612
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260612", close=100),
+            _make_ohlcv("A001", "20260615", close=140),  # 목표일 이후 → 기준일 후보 아님
+        ])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_period_base_closes(period_days=30)
+
+        assert result["base_date"] == "20260612"
+        assert result["latest_date"] == "20260713"
+        assert result["closes"] == {"A001": 100}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_history_does_not_reach_back(self, repo):
+        await repo.upsert_ohlcv([_make_ohlcv("A001", "20260710", close=100)])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_period_base_closes(period_days=365)
+
+        assert result["base_date"] is None
+        assert result["closes"] == {}
+
+    @pytest.mark.asyncio
+    async def test_skips_date_with_no_overlapping_codes(self, repo):
+        """기준일 후보가 휴장일(채권 등 추적 종목과 겹치지 않는 코드만 존재)이면 건너뛴다."""
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260610", close=100),
+            _make_ohlcv("BOND1", "20260612", close=999),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_period_base_closes(period_days=30)
+
+        assert result["base_date"] == "20260610"
+        assert result["closes"] == {"A001": 100}
+
+    @pytest.mark.asyncio
+    async def test_excludes_non_positive_close(self, repo):
+        """정지주 등 0원 종가는 등락률 분모가 될 수 없어 제외한다."""
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20260612", close=100),
+            _make_ohlcv("HALT", "20260612", close=0),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [
+            _make_snapshot("A001", price=150),
+            _make_snapshot("HALT", price=0),
+        ])
+
+        result = await repo.get_period_base_closes(period_days=30)
+
+        assert result["closes"] == {"A001": 100}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_snapshots(self, repo):
+        result = await repo.get_period_base_closes(period_days=30)
+        assert result == {"base_date": None, "latest_date": None, "closes": {}}
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_empty(self, repo, monkeypatch):
+        _broken_read_ctx(repo, monkeypatch)
+        result = await repo.get_period_base_closes(period_days=30)
+        assert result == {"base_date": None, "latest_date": None, "closes": {}}
+
+
 # ── get_price_history ────────────────────────────────────────────────────────
 
 class TestGetPriceHistory:

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -542,7 +542,69 @@ async def test_get_domestic_heatmap(web_client, mock_web_ctx):
         "market_cap": 12101797,
         "market": "KOSPI",
     }]
+    # 기본은 일간 등락률이므로 기간 기준가를 조회하지 않는다.
+    assert body["data"]["period"] == "1d"
+    assert body["data"]["base_date"] is None
     mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_awaited_once_with(limit=300, market=None)
+    assert not mock_web_ctx.stock_repository.get_period_base_closes.called
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_period_uses_base_close(web_client, mock_web_ctx):
+    """period 지정 시 등락률이 해당 기간 기준종가 대비 수익률로 바뀐다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "-0.72", "market_cap": 12101797,
+         "trade_date": "20260807", "market": "KOSPI", "current_price": 120000},
+        {"code": "000660", "name": "SK하이닉스", "change_rate": "1.10", "market_cap": 9000000,
+         "trade_date": "20260807", "market": "KOSPI", "current_price": 90000},
+    ])
+    mock_web_ctx.stock_repository.get_period_base_closes = AsyncMock(return_value={
+        "base_date": "20260508", "latest_date": "20260807", "closes": {"005930": 100000},
+    })
+
+    response = web_client.get("/api/heatmap/domestic?limit=300&period=3m")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["period"] == "3m"
+    assert body["data"]["base_date"] == "20260508"
+    assert body["data"]["items"][0]["change_rate"] == 20.0
+    # 기준종가가 없는 종목은 회색(unknown) 타일이 되도록 None 으로 비운다.
+    assert body["data"]["items"][1]["change_rate"] is None
+    mock_web_ctx.stock_repository.get_period_base_closes.assert_awaited_once_with(period_days=91)
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_period_without_history(web_client, mock_web_ctx):
+    """기간만큼 이력이 없으면 기준일 없이 안내 메시지를 낸다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "-0.72", "market_cap": 12101797,
+         "trade_date": "20260807", "market": "KOSPI", "current_price": 120000},
+    ])
+    mock_web_ctx.stock_repository.get_period_base_closes = AsyncMock(return_value={
+        "base_date": None, "latest_date": "20260807", "closes": {},
+    })
+
+    response = web_client.get("/api/heatmap/domestic?period=1y")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["base_date"] is None
+    assert body["data"]["items"][0]["change_rate"] is None
+    assert "1년" in body["msg1"]
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_rejects_unknown_period(web_client, mock_web_ctx):
+    """지원하지 않는 기간 문자열은 400 으로 거절한다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[])
+
+    response = web_client.get("/api/heatmap/domestic?period=7y")
+
+    assert response.status_code == 400
+    mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -555,7 +617,7 @@ async def test_get_domestic_heatmap_with_market_filter(web_client, mock_web_ctx)
     assert response.status_code == 200
     body = response.json()
     assert body["rt_cd"] == "0"
-    assert body["data"] == {"trade_date": None, "items": []}
+    assert body["data"] == {"trade_date": None, "items": [], "period": "1d", "base_date": None}
     mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_awaited_once_with(limit=100, market="KOSDAQ")
 
 

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -128,6 +128,21 @@ def test_heatmap_page_hosts_zoom_controls():
     assert "resetHeatmapPageZoom()" in template
 
 
+def test_heatmap_page_hosts_period_control():
+    """기간은 색(등락률)의 기준 구간이라 서버 재조회가 필요하다 — 화면·스크립트·API 값이 맞아야 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert 'id="heatmap-page-period"' in template
+    assert 'id="heatmap-page-period-wrap"' in template, "미국 탭에서 감출 대상 컨테이너가 필요함"
+    assert "setHeatmapPeriod(this.value)" in template
+
+    for period in ("1d", "1w", "1m", "3m", "6m", "1y"):
+        assert f'value="{period}"' in template, f"{period} 기간 선택지가 없음"
+        assert f"'{period}'" in page_script, f"{period} 가 스크립트 허용 목록에 없음"
+    assert "period=${_heatmapPagePeriod}" in page_script, "조회 URL 에 기간이 실리지 않음"
+
+
 def test_heatmap_page_reuses_home_render_script():
     """트리맵 계산/색상은 market_heatmap.js 한 곳에만 두고 페이지 스크립트는 배선만 한다."""
     template = _heatmap_page_template()

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -193,35 +193,85 @@ async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500), market: 
     }
 
 
+# 히트맵 기간 등락률: 달력일로 물러난 뒤 그 이하 가장 가까운 거래일을 기준일로 삼는다.
+# "1d" 는 스냅샷에 이미 들어 있는 일간 등락률이라 추가 조회가 없다.
+_HEATMAP_PERIOD_DAYS = {"1d": 0, "1w": 7, "1m": 30, "3m": 91, "6m": 182, "1y": 365}
+_HEATMAP_PERIOD_LABELS = {"1d": "1일", "1w": "1주", "1m": "1개월", "3m": "3개월", "6m": "6개월", "1y": "1년"}
+
+
+def _heatmap_period_change_rate(row: dict, closes: dict):
+    """기간 등락률(%). 기준종가가 없는 종목은 None (화면에서 회색 타일)."""
+    base_close = closes.get(row.get("code"))
+    current_price = row.get("current_price")
+    if not base_close or not current_price:
+        return None
+    try:
+        return round((float(current_price) / float(base_close) - 1.0) * 100, 2)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+
+
 @router.get("/heatmap/domestic")
-async def get_domestic_heatmap(limit: int = Query(300, ge=1, le=1000), market: Optional[str] = Query(None)):
+async def get_domestic_heatmap(
+    limit: int = Query(300, ge=1, le=1000),
+    market: Optional[str] = Query(None),
+    period: str = Query("1d"),
+):
     """국내 히트맵용 시가총액 스냅샷.
 
     실시간 전종목 시세 소스가 없어 장마감 후 수집된 daily_prices 스냅샷을 쓴다.
     기준일(trade_date)을 함께 반환해 화면이 장중에도 기준 시점을 표시할 수 있게 한다.
+    period 를 주면 등락률을 그 기간 수익률로 바꿔 반환한다(면적=시가총액은 그대로).
     """
+    if period not in _HEATMAP_PERIOD_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"period는 {', '.join(_HEATMAP_PERIOD_DAYS)} 중 하나여야 합니다.",
+        )
+
     ctx = _get_ctx()
     repository = getattr(ctx, "stock_repository", None)
     if not repository:
         return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "StockRepository 미설정", "data": None}
 
     rows = await repository.get_market_cap_snapshot(limit=limit, market=market)
+
+    base_date = None
+    closes = {}
+    if period != "1d" and rows:
+        base = await repository.get_period_base_closes(period_days=_HEATMAP_PERIOD_DAYS[period])
+        base_date = (base or {}).get("base_date")
+        closes = (base or {}).get("closes") or {}
+
     items = [
         {
             "code": row.get("code") or "",
             "name": row.get("name") or "",
-            "change_rate": row.get("change_rate"),
+            "change_rate": (
+                row.get("change_rate") if period == "1d"
+                else _heatmap_period_change_rate(row, closes)
+            ),
             "market_cap": row.get("market_cap"),
             "market": row.get("market") or "",
         }
         for row in rows
     ]
+
+    if not items:
+        msg1 = "저장된 시가총액 스냅샷이 없습니다."
+    elif period != "1d" and not base_date:
+        msg1 = f"{_HEATMAP_PERIOD_LABELS[period]} 비교 데이터가 없습니다."
+    else:
+        msg1 = "국내 히트맵 조회 성공"
+
     return {
         "rt_cd": ErrorCode.SUCCESS.value,
-        "msg1": "국내 히트맵 조회 성공" if items else "저장된 시가총액 스냅샷이 없습니다.",
+        "msg1": msg1,
         "data": {
             "trade_date": rows[0].get("trade_date") if rows else None,
             "items": items,
+            "period": period,
+            "base_date": base_date,
         },
     }
 

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -1,12 +1,15 @@
 /* view/web/static/js/heatmap_page.js — 히트맵 전용 페이지(/heatmap)
  *
  * 트리맵 계산·색상·조회는 market_heatmap.js 를 그대로 재사용하고(먼저 로드돼야 한다),
- * 이 파일은 전용 페이지가 추가로 가지는 두 가지만 소유한다.
+ * 이 파일은 전용 페이지가 추가로 가지는 세 가지만 소유한다.
  *   1) 한국/미국 탭 전환 — 탭을 열 때 처음 한 번만 조회한다.
  *   2) 줌 — CSS transform 이 아니라 캔버스(sizer) 자체를 키우고 다시 그린다.
  *      transform 으로 확대하면 작은 타일의 생략된 라벨이 그대로 없기 때문에,
  *      배율을 렌더에 넘겨 라벨 기준을 완화해야 확대의 의미가 있다.
  *      버튼(중앙 고정)과 마우스 휠(커서 고정) 두 경로가 같은 배율 단계를 공유한다.
+ *   3) 기간 — 색(등락률)의 기준 구간. 서버가 ohlcv 기준종가로 계산하므로 재조회가 필요하다
+ *      (면적=시가총액은 기간과 무관하게 최신 스냅샷 그대로). 미국 스냅샷에는 기간 이력이
+ *      없어 국내 탭에서만 노출한다.
  */
 
 // 홈 미리보기(200종목)보다 넓게 잡는다 — 작은 타일은 확대로 읽을 수 있다.
@@ -16,9 +19,13 @@ const HEATMAP_PAGE_ZOOM_STEPS = [1, 1.5, 2, 3, 4, 6, 8];
 // 휠 한 칸(Chrome deltaMode=0 기준 deltaY 100) 이 배율 한 단계다. 트랙패드는 한 번 굴려도
 // 작은 delta 를 여러 번 보내므로 누적해서 이 값을 넘을 때만 단계를 바꾼다.
 const HEATMAP_PAGE_WHEEL_STEP_DELTA = 100;
+// 서버(/api/heatmap/domestic?period=)가 받는 값과 같아야 한다.
+const HEATMAP_PAGE_PERIODS = ['1d', '1w', '1m', '3m', '6m', '1y'];
+const HEATMAP_PAGE_DEFAULT_PERIOD = '1d';
 
 let _heatmapPageZoomIndex = 0;
 let _heatmapPageWheelAccum = 0;
+let _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
 
 function _heatmapPageZoom() {
     return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
@@ -28,7 +35,8 @@ const HEATMAP_PAGE_SOURCES = {
     domestic: {
         targetId: 'heatmap-page-domestic',
         captionId: 'heatmap-page-domestic-caption',
-        url: `/api/heatmap/domestic?limit=${HEATMAP_PAGE_DOMESTIC_LIMIT}`,
+        // 기간이 바뀌면 URL 도 바뀌므로 함수로 둔다(_loadHeatmap 이 호출 시점에 평가한다).
+        url: () => `/api/heatmap/domestic?limit=${HEATMAP_PAGE_DOMESTIC_LIMIT}&period=${_heatmapPagePeriod}`,
         loadingText: '국내 히트맵 조회 중...',
         toGroups: _domesticGroups,
         caption: _domesticCaption,
@@ -63,8 +71,21 @@ async function setHeatmapTab(market) {
         if (tab) tab.classList.toggle('active', active);
     });
 
+    // 미국 스냅샷(Yahoo)은 일간 등락률만 있어 기간 선택이 의미가 없다.
+    _heatmapPageShow(document.getElementById('heatmap-page-period-wrap'), market === 'domestic');
+
     // 실패한 탭은 lastData 가 없으므로 다시 열 때 재시도된다.
     if (!source.lastData) await _loadHeatmap(source);
+}
+
+async function setHeatmapPeriod(period) {
+    if (!HEATMAP_PAGE_PERIODS.includes(period) || period === _heatmapPagePeriod) return;
+    _heatmapPagePeriod = period;
+
+    // 색 기준이 바뀌었으므로 이전 응답은 못 쓴다. 배율은 렌더 때 다시 반영되어 유지된다.
+    const source = HEATMAP_PAGE_SOURCES.domestic;
+    source.lastData = null;
+    await _loadHeatmap(source);
 }
 
 // 확대/축소 후에도 보고 있던 지점이 화면 가운데에 남도록 스크롤 비율을 유지한다.
@@ -199,6 +220,9 @@ async function initHeatmapPage() {
     });
     _heatmapPageZoomIndex = 0;
     _heatmapPageWheelAccum = 0;
+    _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
+    const periodSelect = document.getElementById('heatmap-page-period');
+    if (periodSelect) periodSelect.value = HEATMAP_PAGE_DEFAULT_PERIOD;
     _applyHeatmapPageZoom();
     _bindHeatmapPageWheelZoom(viewport);
 

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -32,6 +32,14 @@ const HEATMAP_DOWN_COLORS = [
 ];
 const HEATMAP_FLAT_COLOR = '#6b7280';
 const HEATMAP_UNKNOWN_COLOR = '#3f4650';
+// 기간 등락률 응답의 캡션 표기. '1d' 는 스냅샷 일간 등락률이라 기간 표기를 붙이지 않는다.
+const HEATMAP_PERIOD_LABELS = {
+    '1w': '1주',
+    '1m': '1개월',
+    '3m': '3개월',
+    '6m': '6개월',
+    '1y': '1년',
+};
 
 let _heatmapRequestSequence = 0;
 
@@ -226,11 +234,21 @@ function _overseasCaption(data) {
         : `최신 업데이트: ${date.toLocaleString('ko-KR')}`;
 }
 
+function _heatmapDateText(value) {
+    const raw = String(value || '');
+    return /^\d{8}$/.test(raw) ? `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}` : null;
+}
+
 // 장중에도 전일 종가가 보일 수 있으므로 기준일을 감추지 않는다.
+// 기간(period)을 받은 응답은 색이 그 구간 등락률이므로 비교 구간을 함께 밝힌다.
 function _domesticCaption(data) {
-    const raw = String(data.trade_date || '');
-    if (!/^\d{8}$/.test(raw)) return '기준일: --';
-    return `기준일: ${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)} 종가`;
+    const latest = _heatmapDateText(data.trade_date);
+    const periodLabel = HEATMAP_PERIOD_LABELS[String(data.period || '')];
+    if (!periodLabel) return latest ? `기준일: ${latest} 종가` : '기준일: --';
+
+    const base = _heatmapDateText(data.base_date);
+    if (!base) return `${periodLabel} 비교 데이터가 없습니다`;
+    return `${periodLabel} 등락률: ${base} → ${latest || '--'} 종가`;
 }
 
 function _renderHeatmapCaption(elementId, text) {
@@ -267,8 +285,10 @@ async function _loadHeatmap(source, options = {}) {
     if (!div) return;
     if (options.showLoading !== false) showLoading(div, source.loadingText);
 
+    // 조회 조건(기간 등)이 바뀌는 소스는 url 을 함수로 준다 — 호출 시점에 평가한다.
+    const url = typeof source.url === 'function' ? source.url() : source.url;
     try {
-        const res = await fetchWithTimeout(source.url, {}, 30000);
+        const res = await fetchWithTimeout(url, {}, 30000);
         const { json, error } = await readJsonResponse(res);
         if (!isLatestRequest()) return;
 

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -9,6 +9,14 @@
         .heatmap-page-panel { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
         .heatmap-page-tabs { margin-bottom: 12px; }
         .heatmap-zoom { display: inline-flex; align-items: center; gap: 6px; }
+        .heatmap-period { display: inline-flex; align-items: center; gap: 6px; }
+        .heatmap-period label { font-size: 0.78rem; color: var(--text-secondary); }
+        .heatmap-period select {
+            padding: 3px 6px; cursor: pointer; font-size: 0.85rem;
+            background: var(--bg-secondary); color: var(--text-primary);
+            border: 1px solid var(--border); border-radius: 5px;
+        }
+        .heatmap-period select:hover { border-color: var(--accent, #4a90e2); }
         .heatmap-zoom button {
             min-width: 30px; padding: 3px 8px; cursor: pointer;
             background: var(--bg-secondary); color: var(--text-primary);
@@ -30,6 +38,18 @@
             <div class="heatmap-toolbar">
                 <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
                 <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+                <span class="heatmap-period" id="heatmap-page-period-wrap"
+                      title="타일 색을 이 기간의 등락률로 계산합니다 (면적은 시가총액 그대로)">
+                    <label for="heatmap-page-period">기간</label>
+                    <select id="heatmap-page-period" onchange="setHeatmapPeriod(this.value)">
+                        <option value="1d" selected>1일</option>
+                        <option value="1w">1주</option>
+                        <option value="1m">1개월</option>
+                        <option value="3m">3개월</option>
+                        <option value="6m">6개월</option>
+                        <option value="1y">1년</option>
+                    </select>
+                </span>
                 <span class="heatmap-zoom" title="히트맵 위에서 마우스 휠로도 확대·축소할 수 있습니다">
                     <button type="button" onclick="zoomHeatmapPage(-1)" title="축소" aria-label="축소">−</button>
                     <span id="heatmap-page-zoom-level">100%</span>
@@ -55,6 +75,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_heatmap.js?v=3"></script>
-<script src="/static/js/heatmap_page.js?v=2"></script>
+<script src="/static/js/market_heatmap.js?v=4"></script>
+<script src="/static/js/heatmap_page.js?v=3"></script>
 {% endblock %}


### PR DESCRIPTION
## 무엇을

`/heatmap` 국내 히트맵의 **타일 색 기준 기간**을 고를 수 있게 한다. 1일(기존 동작) / 1주 / 1개월 / 3개월 / 6개월 / 1년.
면적(시가총액)은 기간과 무관하게 최신 스냅샷 그대로다 — 바뀌는 것은 색뿐이다.

## 왜

색이 최신 종가의 일간 등락률로만 고정돼 있어 "최근 한 달 동안 어느 대형주가 올랐나" 같은 질문에 답할 수 없었다.

## 어떻게

**저장소** `StockOhlcvRepository.get_period_base_closes(period_days)`
- 최신 거래일에서 달력일로 물러난 목표일을 잡고, **그 이하 가장 가까운 거래일**을 기준일로 채택한다(휴장일 대응).
- 최신 스냅샷 종목과 실제로 겹치는 코드가 있는 날짜만 후보로 삼아 휴장일·이형 레코드를 배제한다(YTD 랭킹과 같은 방식).
- 이력이 그만큼 축적돼 있지 않으면 **기준일 없이 비운다.** 남아 있는 가장 오래된 날짜로 대체하면 "1년 등락률"이 실제로는 3개월치인 수치가 되어 화면이 거짓말한다.
- 기준가는 `daily_prices`(수집 시작이 늦음)가 아니라 더 오래 축적된 `ohlcv` 에서 읽는다.

**API** `GET /api/heatmap/domestic?period=1d|1w|1m|3m|6m|1y`
- `period != 1d` 이면 `change_rate` 를 그 기간 수익률(`current_price / base_close - 1`)로 대체하고 `base_date` 를 함께 반환한다.
- 기준종가가 없는 종목(신규상장·정지주 등)은 `change_rate: null` → 기존 회색(unknown) 타일 경로로 흘러간다.
- 지원하지 않는 문자열은 400. 기본값 `1d` 는 추가 조회 없이 기존과 동일하게 동작한다.

**화면**
- 툴바에 기간 `select`. 변경 시 재조회하되 **보고 있던 배율은 유지**된다.
- 캡션이 비교 구간을 밝힌다: `3개월 등락률: 2026-05-08 → 2026-08-07 종가`, 데이터가 없으면 `1년 비교 데이터가 없습니다`.
- 조회 조건이 바뀌는 소스는 `source.url` 을 함수로 두고 `_loadHeatmap` 이 호출 시점에 평가한다.
- `market_heatmap.js?v=4`, `heatmap_page.js?v=3` 로 캐시 버스팅.

## 미국 탭은 제외

미국 히트맵은 Yahoo batch quote 스냅샷(`OverseasMarketStatsService`)이 소스이고 여기엔 **일간 등락률만 있다.** 500종목의 과거 시세를 새로 끌어와야 하므로(심볼별 호출) 이 PR 범위에서 제외하고, 미국 탭에서는 기간 선택을 감춘다. 필요하면 별도 과제로 다루는 게 맞다.

## 테스트

- 저장소 6건 — 기준일 채택(목표일 이하 최근접), 이력 부족 시 비움, 휴장일 스킵, 0원 종가 제외, 스냅샷 없음, 읽기 오류
- 라우트 3건 신설 + 기존 2건 계약 갱신(`period`/`base_date` 키 추가)
- 소스계약 1건 — 템플릿 선택지 ↔ 스크립트 허용 목록 ↔ URL 파라미터 일치
- jsdom 5건 — 기간 변경 재조회·캡션 구간 표기·비교불가 표기·배율 유지·미국 탭 감춤·pjax 재진입 시 1일 복귀
- `pytest tests/unit_test` 7483 passed / `pytest tests/integration_test` 277 passed
- 실 DB(`data/stocks.db`) 대조: 1주 base=20260731, 1개월 20260708, 3개월 20260508, 6개월 20260206, 1년 20250807 — 상위 5종목 기준종가 100% 확보, `ohlcv.close` 와 `daily_prices.current_price` 단위 일치 확인

실제 서버 기동 확인은 하지 않았다(브로커 자격증명/토큰 발급 필요). DOM 행위는 jsdom 회귀로, 계산은 실 DB 대조로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)