### PR TITLE
feat: 히트맵 스크롤바 위 휠은 이동 (휠=위아래, Ctrl+휠=좌우)

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -332,6 +332,115 @@ test("휠 축소는 기본 배율 아래로 내려가지 않는다", async () =>
   assert(sizer.style.width === "100%", `기본 배율 아래로 축소되면 안 됨 (실제 ${sizer.style.width})`);
 });
 
+// jsdom 은 레이아웃이 없어 스크롤바 두께(offsetWidth - clientWidth)도 0 이다.
+// 스크롤바 위 판정은 실제 픽셀에 걸려 있으므로 viewport 에 크기를 심어 재현한다.
+function giveViewportScrollbars(window, { width = 800, height = 600, bar = 15 } = {}) {
+  const viewport = window.document.getElementById("heatmap-page-viewport");
+  const metrics = {
+    offsetWidth: width, offsetHeight: height,
+    clientWidth: width - bar, clientHeight: height - bar,
+    scrollWidth: width * 2, scrollHeight: height * 2,
+  };
+  Object.entries(metrics).forEach(([key, value]) => {
+    Object.defineProperty(viewport, key, { value, configurable: true });
+  });
+  // scrollTop/scrollLeft 는 jsdom 이 레이아웃 없이 항상 0 으로 두므로 쓰기 가능하게 바꾼다.
+  Object.defineProperty(viewport, "scrollTop", { value: 300, writable: true, configurable: true });
+  Object.defineProperty(viewport, "scrollLeft", { value: 400, writable: true, configurable: true });
+  viewport.getBoundingClientRect = () => ({ left: 0, top: 0, width, height });
+  return viewport;
+}
+
+test("세로 스크롤바 위에서는 확대가 아니라 위아래로 이동한다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+  const zoomBefore = window.document.getElementById("heatmap-page-sizer").style.width;
+
+  // clientWidth(785) 오른쪽 = 세로 스크롤바 영역
+  const event = wheel(window, 100, { clientX: 792, clientY: 300 });
+
+  assert(window.document.getElementById("heatmap-page-sizer").style.width === zoomBefore,
+    "스크롤바 위 휠은 배율을 바꾸면 안 됨");
+  assert(viewport.scrollTop === 400, `아래로 굴리면 아래로 이동해야 함 (실제 ${viewport.scrollTop})`);
+  assert(viewport.scrollLeft === 400, "세로 이동이 가로 스크롤을 건드리면 안 됨");
+  assert(event.defaultPrevented, "직접 이동시키므로 기본 스크롤은 막아야 함");
+
+  wheel(window, -100, { clientX: 792, clientY: 300 });
+  assert(viewport.scrollTop === 300, `위로 굴리면 위로 돌아와야 함 (실제 ${viewport.scrollTop})`);
+});
+
+test("가로 스크롤바 위에서도 휠은 이동이다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+  const zoomBefore = window.document.getElementById("heatmap-page-sizer").style.width;
+
+  // clientHeight(585) 아래 = 가로 스크롤바 영역
+  wheel(window, 100, { clientX: 400, clientY: 592 });
+
+  assert(window.document.getElementById("heatmap-page-sizer").style.width === zoomBefore,
+    "스크롤바 위 휠은 배율을 바꾸면 안 됨");
+  assert(viewport.scrollTop === 400, `아래로 굴리면 아래로 이동해야 함 (실제 ${viewport.scrollTop})`);
+});
+
+test("스크롤바 위에서 Ctrl+휠은 좌우로 이동한다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+  const zoomBefore = window.document.getElementById("heatmap-page-sizer").style.width;
+
+  const event = wheel(window, 100, { clientX: 792, clientY: 300, ctrlKey: true });
+
+  assert(viewport.scrollLeft === 500, `Ctrl+휠 다운은 오른쪽으로 이동해야 함 (실제 ${viewport.scrollLeft})`);
+  assert(viewport.scrollTop === 300, "가로 이동이 세로 스크롤을 건드리면 안 됨");
+  assert(window.document.getElementById("heatmap-page-sizer").style.width === zoomBefore,
+    "Ctrl+휠도 배율을 바꾸면 안 됨");
+  assert(event.defaultPrevented, "브라우저 페이지 확대(Ctrl+휠 기본동작)를 막아야 함");
+
+  wheel(window, -100, { clientX: 792, clientY: 300, ctrlKey: true });
+  assert(viewport.scrollLeft === 400, `Ctrl+휠 업은 왼쪽으로 이동해야 함 (실제 ${viewport.scrollLeft})`);
+});
+
+test("스크롤바 이동은 0 아래로 내려가지 않는다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+
+  for (let i = 0; i < 10; i += 1) wheel(window, -100, { clientX: 792, clientY: 300 });
+  assert(viewport.scrollTop === 0, `세로 이동 하한이 0 이어야 함 (실제 ${viewport.scrollTop})`);
+
+  for (let i = 0; i < 10; i += 1) wheel(window, -100, { clientX: 792, clientY: 300, ctrlKey: true });
+  assert(viewport.scrollLeft === 0, `가로 이동 하한이 0 이어야 함 (실제 ${viewport.scrollLeft})`);
+});
+
+test("스크롤바가 아닌 히트맵 본문 위에서는 그대로 확대·축소한다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+
+  wheel(window, -100, { clientX: 400, clientY: 300 });
+
+  assert(Number.parseFloat(window.document.getElementById("heatmap-page-sizer").style.width) > 100,
+    "본문 위 휠은 확대여야 함 (스크롤바 판정이 본문까지 삼키면 안 됨)");
+  assert(viewport.scrollTop !== 200, "본문 확대는 이동이 아니라 커서 고정 재계산이어야 함");
+});
+
 test("휠 줌은 커서 아래 지점을 화면에 고정한다", async () => {
   const window = makeWindow(routed({
     "/api/market-mode": () => marketMode(["domestic"]),

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -176,12 +176,40 @@ function _heatmapPageWheelDelta(event) {
     return event.deltaY;
 }
 
+// 스크롤바(오른쪽·아래 여백) 위인지. clientWidth/Height 는 스크롤바를 뺀 안쪽 크기라
+// 그 밖의 좁은 띠가 스크롤바 영역이다. 스크롤바가 없으면 두께가 0 이라 판정되지 않는다.
+function _heatmapPageOnScrollbar(viewport, clientX, clientY) {
+    if (!viewport || typeof viewport.getBoundingClientRect !== 'function') return false;
+    const rect = viewport.getBoundingClientRect();
+    const onVertical = viewport.offsetWidth - viewport.clientWidth > 0
+        && clientX - rect.left >= viewport.clientWidth;
+    const onHorizontal = viewport.offsetHeight - viewport.clientHeight > 0
+        && clientY - rect.top >= viewport.clientHeight;
+    return onVertical || onHorizontal;
+}
+
+// 스크롤바 위에서는 배율이 아니라 이동이 자연스럽다. Ctrl 을 누르면 좌우로 움직인다
+// (가로 스크롤바까지 커서를 내려가지 않고도 옆으로 밀 수 있게).
+function _heatmapPageWheelPan(viewport, delta, horizontal) {
+    if (horizontal) viewport.scrollLeft = Math.max(0, viewport.scrollLeft + delta);
+    else viewport.scrollTop = Math.max(0, viewport.scrollTop + delta);
+}
+
 function _onHeatmapPageWheel(event) {
     // 히트맵 위에서 휠은 배율 조작이다 — 페이지까지 같이 스크롤되면 보던 지점이 튄다.
+    // Ctrl+휠 의 브라우저 페이지 확대도 여기서 막는다.
     event.preventDefault();
 
     const delta = _heatmapPageWheelDelta(event);
     if (!delta) return;
+
+    const viewport = event.currentTarget;
+    if (_heatmapPageOnScrollbar(viewport, event.clientX, event.clientY)) {
+        // 이동은 배율 단계와 무관하므로 휠 누적에 섞지 않는다.
+        _heatmapPageWheelPan(viewport, delta, event.ctrlKey);
+        return;
+    }
+
     // 방향을 바꾸면 반대 방향 누적은 버린다(직전 잔량 때문에 한 칸이 씹히는 것을 막는다).
     if ((delta > 0) !== (_heatmapPageWheelAccum > 0)) _heatmapPageWheelAccum = 0;
     _heatmapPageWheelAccum += delta;

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -50,7 +50,8 @@
                         <option value="1y">1년</option>
                     </select>
                 </span>
-                <span class="heatmap-zoom" title="히트맵 위에서 마우스 휠로도 확대·축소할 수 있습니다">
+                <span class="heatmap-zoom"
+                      title="히트맵 위에서 마우스 휠로도 확대·축소할 수 있습니다 (스크롤바 위에서는 휠=위아래 이동, Ctrl+휠=좌우 이동)">
                     <button type="button" onclick="zoomHeatmapPage(-1)" title="축소" aria-label="축소">−</button>
                     <span id="heatmap-page-zoom-level">100%</span>
                     <button type="button" onclick="zoomHeatmapPage(1)" title="확대" aria-label="확대">+</button>
@@ -76,5 +77,5 @@
 
 {% block scripts %}
 <script src="/static/js/market_heatmap.js?v=4"></script>
-<script src="/static/js/heatmap_page.js?v=3"></script>
+<script src="/static/js/heatmap_page.js?v=4"></script>
 {% endblock %}


### PR DESCRIPTION
## 무엇을

확대 상태에서 **스크롤바 위에 커서가 있을 때는** 휠이 배율을 바꾸지 않고 화면을 **이동**시킨다.

| 커서 위치 | 휠 | Ctrl+휠 |
|---|---|---|
| 히트맵 본문 | 확대·축소 (커서 고정) | 확대·축소 |
| 오른쪽/아래 스크롤바 | **위아래 이동** | **좌우 이동** |

## 왜

휠 줌이 viewport 전체를 먹고 있어서, 확대 후 화면을 밀어 보려고 스크롤바로 커서를 옮기면 그것마저 확대가 됐다.

## 어떻게

- 스크롤바 위 판정: `offsetWidth - clientWidth` 로 스크롤바 두께를 구해, 커서가 `clientWidth`/`clientHeight` 밖의 띠에 있으면 이동으로 처리한다. **스크롤바가 없으면 두께가 0** 이라 판정되지 않아 100% 배율에서는 기존 동작 그대로다.
- 이동은 `Math.max(0, …)` 로 하한을 잘라 음수 스크롤을 막는다.
- 이동은 배율 단계와 무관하므로 **휠 누적값(트랙패드 임계)에 섞지 않는다** — 스크롤바에서 굴린 양이 나중 줌 한 칸을 앞당기지 않는다.
- Ctrl+휠 의 브라우저 페이지 확대는 기존 `preventDefault()` 로 계속 막힌다.
- 툴바 줌 컨트롤 `title` 에 이 조작을 적어두고, `heatmap_page.js?v=4` 로 캐시 버스팅.

## 테스트

jsdom 5건 추가 — 세로바 위 위아래 이동 / 가로바 위 이동 / 스크롤바 위 Ctrl+휠 좌우 이동 / 하한 0 / **본문 위에서는 여전히 확대**(판정이 본문을 삼키지 않는지).
jsdom 은 레이아웃이 없어 스크롤바 두께·scrollTop 이 항상 0 이므로, viewport 에 크기를 심어(`Object.defineProperty`) 재현했다.

- `run_heatmap_page_dom_tests.mjs` 23/23, `run_market_heatmap_dom_tests.mjs` 13/13
- `pytest tests/unit_test` 7483 passed / `pytest tests/integration_test` 277 passed

실제 서버 기동 확인은 하지 않았다(브로커 자격증명/토큰 발급 필요) — 스크롤바 두께 판정은 브라우저 실측값에 걸려 있어, 화면에서 한 번 확인해주시면 좋다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)