### PR TITLE
히트맵: 기간에 "올해"(YTD) 추가 + 마우스로 끌어서 이동

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -614,13 +614,16 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository YTD 수익률 랭킹 조회 실패: {e}")
             return []
 
-    async def get_period_base_closes(self, period_days: int) -> Dict[str, Any]:
+    async def get_period_base_closes(self, period_days: int = 0, ytd: bool = False) -> Dict[str, Any]:
         """최신 거래일에서 period_days 달력일 물러난 시점의 종목별 기준종가 (히트맵 기간 등락률용).
 
         목표일이 휴장일일 수 있으므로 '목표일 이하 가장 가까운 거래일'을 기준일로 삼는다.
         이력이 그만큼 축적돼 있지 않으면 기준일 없이 비운다 — 남아 있는 가장 오래된 날짜로
         대체하면 '1년 등락률' 이 실제로는 3개월 등락률인 수치가 되어 화면이 거짓말한다.
         daily_prices 는 수집 시작 시점이 늦어 기준가는 더 오래 축적된 ohlcv 에서 읽는다.
+
+        ytd=True 면 달력일 대신 '올해 첫 거래일' 을 기준일로 삼는다 (period_days 는 무시).
+        연초 첫 종가 기준은 get_ytd_return_ranking 과 같아 두 화면의 YTD 수치가 일치한다.
         """
         from datetime import datetime, timedelta
 
@@ -633,23 +636,32 @@ class StockOhlcvRepository:
                 if not latest_date:
                     return empty
 
-                target_date = (
-                    datetime.strptime(latest_date, "%Y%m%d") - timedelta(days=period_days)
-                ).strftime("%Y%m%d")
-
                 # 자릿수가 어긋난 레코드가 섞여도 8자리 날짜만 기준일 후보로 삼고,
                 # 최신 스냅샷 종목과 실제로 겹치는 코드가 있는 날짜만 채택한다(휴장일 배제).
-                async with conn.execute(
+                if ytd:
+                    base_sql = """
+                        SELECT MIN(base.date)
+                        FROM ohlcv AS base
+                        JOIN daily_prices AS latest
+                          ON latest.code = base.code AND latest.trade_date = ?
+                        WHERE base.date GLOB ?
                     """
-                    SELECT MAX(base.date)
-                    FROM ohlcv AS base
-                    JOIN daily_prices AS latest
-                      ON latest.code = base.code AND latest.trade_date = ?
-                    WHERE base.date <= ?
-                      AND base.date GLOB '[0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]'
-                    """,
-                    (latest_date, target_date),
-                ) as cursor:
+                    base_params = (latest_date, f"{latest_date[:4]}[0-1][0-9][0-3][0-9]")
+                else:
+                    target_date = (
+                        datetime.strptime(latest_date, "%Y%m%d") - timedelta(days=period_days)
+                    ).strftime("%Y%m%d")
+                    base_sql = """
+                        SELECT MAX(base.date)
+                        FROM ohlcv AS base
+                        JOIN daily_prices AS latest
+                          ON latest.code = base.code AND latest.trade_date = ?
+                        WHERE base.date <= ?
+                          AND base.date GLOB '[0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]'
+                    """
+                    base_params = (latest_date, target_date)
+
+                async with conn.execute(base_sql, base_params) as cursor:
                     base_row = await cursor.fetchone()
                 base_date = base_row[0] if base_row and base_row[0] else None
                 if not base_date:

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -110,9 +110,9 @@ class StockRepository:
         """최신 거래일 기준 시가총액 상위 스냅샷 조회 (국내 히트맵용)."""
         return await self._ohlcv_repo.get_market_cap_snapshot(limit=limit, market=market)
 
-    async def get_period_base_closes(self, period_days: int) -> Dict:
-        """최신 거래일에서 period_days 달력일 이전의 종목별 기준종가 조회 (히트맵 기간 등락률용)."""
-        return await self._ohlcv_repo.get_period_base_closes(period_days=period_days)
+    async def get_period_base_closes(self, period_days: int = 0, ytd: bool = False) -> Dict:
+        """최신 거래일에서 period_days 달력일 이전(ytd=True 면 올해 첫 거래일)의 종목별 기준종가 조회."""
+        return await self._ohlcv_repo.get_period_base_closes(period_days=period_days, ytd=ytd)
 
     async def update_newhigh_fields(self, trade_date: str, records: List[Dict]):
         """is_newhigh 및 is_historical_newhigh 컬럼 업데이트."""

--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -31,6 +31,7 @@ const SCAFFOLD = `
       <option value="1m">1개월</option>
       <option value="3m">3개월</option>
       <option value="6m">6개월</option>
+      <option value="ytd">올해</option>
       <option value="1y">1년</option>
     </select>
   </span>
@@ -467,6 +468,90 @@ test("휠 줌은 커서 아래 지점을 화면에 고정한다", async () => {
   assert(viewport.scrollTop === 0.35 * 2000 - 100, `세로 스크롤이 커서 기준으로 복원돼야 함 (실제 ${viewport.scrollTop})`);
 });
 
+function mouse(target, type, clientX, clientY, options = {}) {
+  const view = target.ownerDocument ? target.ownerDocument.defaultView : target.defaultView;
+  const event = new view.MouseEvent(type, {
+    clientX, clientY, button: 0, bubbles: true, cancelable: true, ...options,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+test("히트맵을 마우스로 끌면 휴대폰처럼 상하좌우로 움직인다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);  // scrollLeft 400 / scrollTop 300
+
+  const down = mouse(viewport, "mousedown", 400, 300);
+  assert(down.defaultPrevented, "끄는 동안 타일 라벨이 선택되지 않도록 기본 동작을 막아야 함");
+  assert(viewport.classList.contains("heatmap-panning"), "끄는 중임을 커서로 알 수 있어야 함");
+
+  // 왼쪽·위로 끌면 화면은 그 반대(오른쪽·아래)로 이동한다 — 종이를 밀듯이.
+  mouse(window.document, "mousemove", 350, 250);
+  assert(viewport.scrollLeft === 450, `왼쪽으로 끌면 오른쪽으로 이동해야 함 (실제 ${viewport.scrollLeft})`);
+  assert(viewport.scrollTop === 350, `위로 끌면 아래로 이동해야 함 (실제 ${viewport.scrollTop})`);
+
+  // 이동량은 누적이 아니라 시작점 기준이다(중간 이동을 두 번 세면 두 배로 튄다).
+  mouse(window.document, "mousemove", 300, 200);
+  assert(viewport.scrollLeft === 500 && viewport.scrollTop === 400,
+    `이동량은 시작점 기준이어야 함 (실제 ${viewport.scrollLeft}, ${viewport.scrollTop})`);
+
+  mouse(window.document, "mouseup", 300, 200);
+  assert(!viewport.classList.contains("heatmap-panning"), "손을 떼면 끌기 상태가 풀려야 함");
+
+  mouse(window.document, "mousemove", 100, 100);
+  assert(viewport.scrollLeft === 500 && viewport.scrollTop === 400, "손을 뗀 뒤 커서 이동은 화면을 움직이면 안 됨");
+});
+
+test("끌기는 경계를 넘어가지 않는다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+
+  mouse(viewport, "mousedown", 400, 300);
+  mouse(window.document, "mousemove", 5000, 5000);
+
+  assert(viewport.scrollLeft === 0 && viewport.scrollTop === 0,
+    `왼쪽 위 끝을 넘어가면 안 됨 (실제 ${viewport.scrollLeft}, ${viewport.scrollTop})`);
+});
+
+test("스크롤바를 잡은 드래그는 브라우저 기본 동작에 맡긴다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+
+  // clientWidth(785) 오른쪽 = 세로 스크롤바 영역
+  const down = mouse(viewport, "mousedown", 792, 300);
+  assert(!down.defaultPrevented, "스크롤바 드래그는 브라우저가 처리해야 함");
+  assert(!viewport.classList.contains("heatmap-panning"), "스크롤바에서는 끌기 상태로 들어가면 안 됨");
+
+  mouse(window.document, "mousemove", 792, 200);
+  assert(viewport.scrollTop === 300, "스크롤바 드래그를 이중으로 이동시키면 안 됨");
+});
+
+test("오른쪽 버튼 드래그는 화면을 움직이지 않는다", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  const viewport = giveViewportScrollbars(window);
+
+  mouse(viewport, "mousedown", 400, 300, { button: 2 });
+  mouse(window.document, "mousemove", 300, 200);
+
+  assert(viewport.scrollLeft === 400 && viewport.scrollTop === 300, "좌클릭 드래그만 이동이어야 함");
+});
+
 test("기간을 바꾸면 그 기간으로 다시 조회하고 캡션에 비교 구간을 밝힌다", async () => {
   const calls = [];
   const window = makeWindow(routed({
@@ -492,6 +577,30 @@ test("기간을 바꾸면 그 기간으로 다시 조회하고 캡션에 비교 
     `캡션에 비교 구간이 표시돼야 함 (실제 ${caption})`);
   assert(window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 0,
     "기간 변경 후에도 타일이 그려져야 함");
+});
+
+test("올해(ytd)도 같은 경로로 조회하고 캡션에 연초부터의 구간을 밝힌다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "ytd", base_date: "20260102", items: domesticSnapshot().items,
+    }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+  await window.setHeatmapPeriod("ytd");
+
+  const domesticCalls = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domesticCalls[domesticCalls.length - 1].includes("period=ytd"),
+    `조회 URL 에 기간이 실려야 함 (실제 ${domesticCalls[domesticCalls.length - 1]})`);
+
+  const caption = window.document.getElementById("heatmap-page-domestic-caption").textContent;
+  assert(caption.includes("올해"), `캡션에 기간이 표시돼야 함 (실제 ${caption})`);
+  assert(caption.includes("2026-01-02") && caption.includes("2026-08-07"),
+    `캡션에 비교 구간이 표시돼야 함 (실제 ${caption})`);
 });
 
 test("기간 비교 데이터가 없으면 캡션이 그 사실을 밝힌다", async () => {

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -624,6 +624,32 @@ class TestGetPeriodBaseCloses:
         assert result["closes"] == {"A001": 100}
 
     @pytest.mark.asyncio
+    async def test_ytd_uses_first_trading_day_of_year(self, repo):
+        """ytd 는 달력일이 아니라 '올해 첫 거래일' 종가를 기준으로 삼는다(YTD 랭킹과 같은 기준)."""
+        await repo.upsert_ohlcv([
+            _make_ohlcv("A001", "20251230", close=80),  # 전년 → 기준일 후보 아님
+            _make_ohlcv("A001", "20260105", close=100),
+            _make_ohlcv("A001", "20260302", close=120),
+        ])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_period_base_closes(ytd=True)
+
+        assert result["base_date"] == "20260105"
+        assert result["latest_date"] == "20260713"
+        assert result["closes"] == {"A001": 100}
+
+    @pytest.mark.asyncio
+    async def test_ytd_returns_empty_without_this_year_history(self, repo):
+        await repo.upsert_ohlcv([_make_ohlcv("A001", "20251230", close=80)])
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("A001", price=150)])
+
+        result = await repo.get_period_base_closes(ytd=True)
+
+        assert result["base_date"] is None
+        assert result["closes"] == {}
+
+    @pytest.mark.asyncio
     async def test_returns_empty_without_snapshots(self, repo):
         result = await repo.get_period_base_closes(period_days=30)
         assert result == {"base_date": None, "latest_date": None, "closes": {}}

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -597,6 +597,27 @@ async def test_get_domestic_heatmap_period_without_history(web_client, mock_web_
 
 
 @pytest.mark.asyncio
+async def test_get_domestic_heatmap_ytd_uses_first_close_of_year(web_client, mock_web_ctx):
+    """period=ytd 는 달력일이 아니라 올해 첫 거래일 종가를 기준으로 저장소에 요청한다."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "-0.72", "market_cap": 12101797,
+         "trade_date": "20260807", "market": "KOSPI", "current_price": 120000},
+    ])
+    mock_web_ctx.stock_repository.get_period_base_closes = AsyncMock(return_value={
+        "base_date": "20260102", "latest_date": "20260807", "closes": {"005930": 100000},
+    })
+
+    response = web_client.get("/api/heatmap/domestic?period=ytd")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["period"] == "ytd"
+    assert body["data"]["base_date"] == "20260102"
+    assert body["data"]["items"][0]["change_rate"] == 20.0
+    mock_web_ctx.stock_repository.get_period_base_closes.assert_awaited_once_with(ytd=True)
+
+
+@pytest.mark.asyncio
 async def test_get_domestic_heatmap_rejects_unknown_period(web_client, mock_web_ctx):
     """지원하지 않는 기간 문자열은 400 으로 거절한다."""
     mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[])

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -137,10 +137,21 @@ def test_heatmap_page_hosts_period_control():
     assert 'id="heatmap-page-period-wrap"' in template, "미국 탭에서 감출 대상 컨테이너가 필요함"
     assert "setHeatmapPeriod(this.value)" in template
 
-    for period in ("1d", "1w", "1m", "3m", "6m", "1y"):
+    for period in ("1d", "1w", "1m", "3m", "6m", "ytd", "1y"):
         assert f'value="{period}"' in template, f"{period} 기간 선택지가 없음"
         assert f"'{period}'" in page_script, f"{period} 가 스크립트 허용 목록에 없음"
     assert "period=${_heatmapPagePeriod}" in page_script, "조회 URL 에 기간이 실리지 않음"
+
+
+def test_heatmap_page_supports_drag_panning():
+    """확대한 화면은 마우스로 끌어 옮길 수 있어야 한다 — 배선(JS)과 커서 표시(CSS)가 함께 있어야 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert "'mousedown'" in page_script and "'mousemove'" in page_script and "'mouseup'" in page_script
+    assert "heatmap-panning" in page_script
+    assert "cursor: grab" in template, "끌 수 있다는 표시가 없음"
+    assert ".heatmap-page-viewport.heatmap-panning" in template, "끄는 중 커서 상태 스타일이 없음"
 
 
 def test_heatmap_page_reuses_home_render_script():

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -195,8 +195,11 @@ async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500), market: 
 
 # 히트맵 기간 등락률: 달력일로 물러난 뒤 그 이하 가장 가까운 거래일을 기준일로 삼는다.
 # "1d" 는 스냅샷에 이미 들어 있는 일간 등락률이라 추가 조회가 없다.
+# "ytd"(올해)만 달력일이 아니라 올해 첫 거래일이 기준이라 저장소에서 따로 계산한다.
 _HEATMAP_PERIOD_DAYS = {"1d": 0, "1w": 7, "1m": 30, "3m": 91, "6m": 182, "1y": 365}
-_HEATMAP_PERIOD_LABELS = {"1d": "1일", "1w": "1주", "1m": "1개월", "3m": "3개월", "6m": "6개월", "1y": "1년"}
+_HEATMAP_PERIOD_LABELS = {
+    "1d": "1일", "1w": "1주", "1m": "1개월", "3m": "3개월", "6m": "6개월", "ytd": "올해", "1y": "1년",
+}
 
 
 def _heatmap_period_change_rate(row: dict, closes: dict):
@@ -223,10 +226,10 @@ async def get_domestic_heatmap(
     기준일(trade_date)을 함께 반환해 화면이 장중에도 기준 시점을 표시할 수 있게 한다.
     period 를 주면 등락률을 그 기간 수익률로 바꿔 반환한다(면적=시가총액은 그대로).
     """
-    if period not in _HEATMAP_PERIOD_DAYS:
+    if period not in _HEATMAP_PERIOD_LABELS:
         raise HTTPException(
             status_code=400,
-            detail=f"period는 {', '.join(_HEATMAP_PERIOD_DAYS)} 중 하나여야 합니다.",
+            detail=f"period는 {', '.join(_HEATMAP_PERIOD_LABELS)} 중 하나여야 합니다.",
         )
 
     ctx = _get_ctx()
@@ -239,7 +242,10 @@ async def get_domestic_heatmap(
     base_date = None
     closes = {}
     if period != "1d" and rows:
-        base = await repository.get_period_base_closes(period_days=_HEATMAP_PERIOD_DAYS[period])
+        base = (
+            await repository.get_period_base_closes(ytd=True) if period == "ytd"
+            else await repository.get_period_base_closes(period_days=_HEATMAP_PERIOD_DAYS[period])
+        )
         base_date = (base or {}).get("base_date")
         closes = (base or {}).get("closes") or {}
 

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -10,6 +10,7 @@
  *   3) 기간 — 색(등락률)의 기준 구간. 서버가 ohlcv 기준종가로 계산하므로 재조회가 필요하다
  *      (면적=시가총액은 기간과 무관하게 최신 스냅샷 그대로). 미국 스냅샷에는 기간 이력이
  *      없어 국내 탭에서만 노출한다.
+ *   4) 끌어서 이동 — 확대한 화면을 휴대폰처럼 마우스로 잡아끌어 옮긴다.
  */
 
 // 홈 미리보기(200종목)보다 넓게 잡는다 — 작은 타일은 확대로 읽을 수 있다.
@@ -20,7 +21,7 @@ const HEATMAP_PAGE_ZOOM_STEPS = [1, 1.5, 2, 3, 4, 6, 8];
 // 작은 delta 를 여러 번 보내므로 누적해서 이 값을 넘을 때만 단계를 바꾼다.
 const HEATMAP_PAGE_WHEEL_STEP_DELTA = 100;
 // 서버(/api/heatmap/domestic?period=)가 받는 값과 같아야 한다.
-const HEATMAP_PAGE_PERIODS = ['1d', '1w', '1m', '3m', '6m', '1y'];
+const HEATMAP_PAGE_PERIODS = ['1d', '1w', '1m', '3m', '6m', 'ytd', '1y'];
 const HEATMAP_PAGE_DEFAULT_PERIOD = '1d';
 
 let _heatmapPageZoomIndex = 0;
@@ -227,6 +228,58 @@ function _bindHeatmapPageWheelZoom(viewport) {
     viewport.dataset.wheelZoomBound = '1';
 }
 
+// 휴대폰에서 화면을 밀듯 히트맵을 잡아끌어 옮긴다 — 확대해 놓으면 스크롤바를 찾아가는 것보다 빠르다.
+// (터치 기기는 브라우저 기본 스크롤이 이미 같은 동작이라 마우스만 다룬다.)
+const HEATMAP_PAGE_PANNING_CLASS = 'heatmap-panning';
+
+let _heatmapPagePan = null;
+
+function _onHeatmapPagePanStart(event) {
+    if (event.button !== 0) return;
+    const viewport = event.currentTarget;
+    // 스크롤바를 잡은 드래그는 브라우저 기본 동작이 이미 정확하다 — 손대면 두 배로 움직인다.
+    if (_heatmapPageOnScrollbar(viewport, event.clientX, event.clientY)) return;
+
+    _heatmapPagePan = {
+        viewport,
+        startX: event.clientX,
+        startY: event.clientY,
+        scrollLeft: viewport.scrollLeft,
+        scrollTop: viewport.scrollTop,
+    };
+    viewport.classList.add(HEATMAP_PAGE_PANNING_CLASS);
+    // 끄는 동안 타일 라벨이 텍스트로 선택되는 것을 막는다.
+    event.preventDefault();
+}
+
+// 이동량은 직전 위치가 아니라 시작점 기준이다 — 프레임을 누적하면 오차가 쌓인다.
+function _onHeatmapPagePanMove(event) {
+    const pan = _heatmapPagePan;
+    if (!pan) return;
+    pan.viewport.scrollLeft = Math.max(0, pan.scrollLeft - (event.clientX - pan.startX));
+    pan.viewport.scrollTop = Math.max(0, pan.scrollTop - (event.clientY - pan.startY));
+}
+
+function _onHeatmapPagePanEnd() {
+    if (!_heatmapPagePan) return;
+    _heatmapPagePan.viewport.classList.remove(HEATMAP_PAGE_PANNING_CLASS);
+    _heatmapPagePan = null;
+}
+
+// 이동·종료는 document 에 건다 — 커서가 히트맵 밖으로 나가도 끌기가 이어지고, 밖에서 손을 떼도 풀린다.
+let _heatmapPagePanDocumentBound = false;
+
+function _bindHeatmapPageDragPan(viewport) {
+    if (viewport.dataset.dragPanBound !== '1') {
+        viewport.addEventListener('mousedown', _onHeatmapPagePanStart);
+        viewport.dataset.dragPanBound = '1';
+    }
+    if (_heatmapPagePanDocumentBound) return;
+    document.addEventListener('mousemove', _onHeatmapPagePanMove);
+    document.addEventListener('mouseup', _onHeatmapPagePanEnd);
+    _heatmapPagePanDocumentBound = true;
+}
+
 function resetHeatmapPageZoom() {
     _heatmapPageZoomIndex = 0;
     _applyHeatmapPageZoom();
@@ -251,8 +304,10 @@ async function initHeatmapPage() {
     _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
     const periodSelect = document.getElementById('heatmap-page-period');
     if (periodSelect) periodSelect.value = HEATMAP_PAGE_DEFAULT_PERIOD;
+    _heatmapPagePan = null;
     _applyHeatmapPageZoom();
     _bindHeatmapPageWheelZoom(viewport);
+    _bindHeatmapPageDragPan(viewport);
 
     // 미국장이 꺼진 run 에서는 API 가 400 을 내므로 탭 자체를 감춘다.
     if (!await _heatmapOverseasEnabled()) {

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -38,6 +38,7 @@ const HEATMAP_PERIOD_LABELS = {
     '1m': '1개월',
     '3m': '3개월',
     '6m': '6개월',
+    'ytd': '올해',
     '1y': '1년',
 };
 

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -4,7 +4,9 @@
     <link rel="stylesheet" href="/static/css/heatmap.css?v=1">
     <style>
         /* 줌은 viewport(스크롤 영역) 안에서 sizer 를 키우는 방식이라 viewport 높이가 고정돼야 한다. */
-        .heatmap-page-viewport { position: relative; overflow: auto; height: calc(100vh - 300px); min-height: 420px; }
+        .heatmap-page-viewport { position: relative; overflow: auto; height: calc(100vh - 300px); min-height: 420px; cursor: grab; }
+        /* 끄는 동안 라벨이 선택되지 않도록 — mousedown 의 preventDefault 가 놓치는 경로 대비. */
+        .heatmap-page-viewport.heatmap-panning { cursor: grabbing; user-select: none; }
         .heatmap-page-sizer { position: relative; width: 100%; height: 100%; }
         .heatmap-page-panel { position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
         .heatmap-page-tabs { margin-bottom: 12px; }
@@ -47,6 +49,7 @@
                         <option value="1m">1개월</option>
                         <option value="3m">3개월</option>
                         <option value="6m">6개월</option>
+                        <option value="ytd">올해</option>
                         <option value="1y">1년</option>
                     </select>
                 </span>
@@ -76,6 +79,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_heatmap.js?v=4"></script>
-<script src="/static/js/heatmap_page.js?v=4"></script>
+<script src="/static/js/market_heatmap.js?v=5"></script>
+<script src="/static/js/heatmap_page.js?v=5"></script>
 {% endblock %}


### PR DESCRIPTION
@
## 무엇을

히트맵 기간 선택에 **올해(YTD)** 를 추가하고, 확대한 화면을 **마우스로 끌어서 이동**할 수 있게 했다.

### 올해(YTD)
- `get_period_base_closes(ytd=True)` — 달력일로 물러나는 대신 **올해 첫 거래일**을 기준일로 삼는다.
  기준을 `get_ytd_return_ranking` 과 맞춰 YTD 랭킹 화면과 수치가 어긋나지 않게 했다.
- `/api/heatmap/domestic?period=ytd` 지원. 올해 이력이 없으면 기준일 없이 비워 회색 타일 + 안내 문구.
- 기간 select 에서 6개월과 1년 사이에 위치(Finviz 순서). 캡션은 `올해 등락률: 2026-01-02 → 2026-08-07 종가`.
- 미국 탭은 기존대로 기간 선택 자체를 감춘다(Yahoo 스냅샷에 기간 이력 없음).

### 끌어서 이동
- viewport 좌클릭 드래그로 상하좌우 이동. 이동량은 직전 프레임이 아니라 **시작점 기준**이고 0 아래로 내려가지 않는다.
- 스크롤바를 잡은 드래그(브라우저 기본)와 우클릭은 그대로 둔다.
- 이동/종료는 `document` 에 걸어 커서가 히트맵 밖으로 나가도 끌기가 이어지고 밖에서 손을 떼도 풀린다.
- 커서 `grab` → 끄는 동안 `grabbing`, 라벨 텍스트 선택 방지.

## 확인
- 실데이터(`data/stocks.db`): ytd 기준일 `20260102`(6,782 종목 종가), 최신 스냅샷 `20260807` — 올해 첫 거래일이 실제로 존재해 "올해" 표기가 정직하다.
- 실제 브라우저에서 250/80px 끌어 스크롤이 정확히 같은 값만큼 이동, `grabbing` 커서 적용, 손 뗀 뒤 이동 없음 확인.
- 단위 7,487건 / 통합 277건 통과 (jsdom 히트맵 28건 포함).

## 알아둘 점
`ytd` 기준일은 "올해 첫 거래일"이라 만약 `ohlcv` 수집이 연중에 시작된 해라면 그 해의 첫 수집일이 기준이 된다 — 기존 YTD 랭킹과 동일한 성질이며, 위 실측대로 현재 데이터에는 해당하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@