### PR TITLE
히트맵: 시장 선택(공통/코스피/코스닥) + 종목 검색

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -23,6 +23,18 @@ const SCAFFOLD = `
 <div class="heatmap-toolbar">
   <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
   <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+  <span class="heatmap-search" id="heatmap-page-search-wrap">
+    <input type="search" id="heatmap-page-search" placeholder="종목명·코드 검색">
+    <span id="heatmap-page-search-count"></span>
+  </span>
+  <span class="heatmap-period" id="heatmap-page-market-wrap">
+    <label for="heatmap-page-market">시장</label>
+    <select id="heatmap-page-market">
+      <option value="ALL" selected>공통</option>
+      <option value="KOSPI">코스피</option>
+      <option value="KOSDAQ">코스닥</option>
+    </select>
+  </span>
   <span class="heatmap-period" id="heatmap-page-period-wrap">
     <label for="heatmap-page-period">기간</label>
     <select id="heatmap-page-period">
@@ -603,6 +615,68 @@ test("올해(ytd)도 같은 경로로 조회하고 캡션에 연초부터의 구
     `캡션에 비교 구간이 표시돼야 함 (실제 ${caption})`);
 });
 
+test("시장을 고르면 그 시장만 다시 조회하고 기간 선택은 유지된다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success({
+      trade_date: "20260807", period: "3m", base_date: "20260508", items: domesticSnapshot().items,
+    }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+  const first = calls.filter(url => url.startsWith("/api/heatmap/domestic")).pop();
+  assert(first.includes("market=ALL"), `기본은 공통(ALL)이어야 함 (실제 ${first})`);
+
+  await window.setHeatmapPeriod("3m");
+  await window.setHeatmapMarket("KOSDAQ");
+
+  const domesticCalls = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domesticCalls.length === 3, `시장 변경도 재조회를 유발해야 함 (실제 ${domesticCalls.length}회)`);
+  const last = domesticCalls[domesticCalls.length - 1];
+  assert(last.includes("market=KOSDAQ"), `조회 URL 에 시장이 실려야 함 (실제 ${last})`);
+  assert(last.includes("period=3m"), `시장을 바꿔도 기간은 유지돼야 함 (실제 ${last})`);
+  assert(window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 0,
+    "시장 변경 후에도 타일이 그려져야 함");
+});
+
+test("같은 시장을 다시 고르면 재조회하지 않는다", async () => {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+
+  await window.initHeatmapPage();
+  await window.setHeatmapMarket("ALL");
+  await window.setHeatmapMarket("NASDAQ");  // 허용 목록 밖
+
+  assert(calls.filter(url => url.startsWith("/api/heatmap/domestic")).length === 1,
+    "같은 값·모르는 값은 재조회 대상이 아님");
+});
+
+test("미국 탭에서는 시장 선택도 감춘다 (S&P 500 고정)", async () => {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})], updated_at: 1767225600 }),
+  }));
+
+  await window.initHeatmapPage();
+  const wrap = window.document.getElementById("heatmap-page-market-wrap");
+  assert(wrap.style.display !== "none", "한국 탭에서는 시장 선택이 보여야 함");
+
+  await window.setHeatmapTab("overseas");
+  assert(wrap.style.display === "none", "미국 탭에서는 시장 선택을 감춰야 함");
+
+  await window.setHeatmapTab("domestic");
+  assert(wrap.style.display !== "none", "한국 탭으로 돌아오면 다시 보여야 함");
+});
+
 test("기간 비교 데이터가 없으면 캡션이 그 사실을 밝힌다", async () => {
   const window = makeWindow(routed({
     "/api/market-mode": () => marketMode(["domestic"]),
@@ -659,7 +733,83 @@ test("미국 탭에서는 기간 선택을 감춘다 (미국 스냅샷에 기간
   assert(wrap.style.display !== "none", "한국 탭으로 돌아오면 기간 선택이 다시 보여야 함");
 });
 
-test("pjax 재진입 시 기간은 1일로 돌아온다", async () => {
+// 검색은 재조회가 아니라 이미 그린 타일을 짚어 주는 기능이다 — 면적(시가총액)이 유지돼야
+// 히트맵으로서 읽히므로 일치하지 않는 타일을 지우지 않고 흐리게 둔다.
+function hitSymbols(window) {
+  return [...window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile.heatmap-tile-hit")]
+    .map(tile => tile.dataset.symbol);
+}
+
+async function searchablePage() {
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+  }));
+  await window.initHeatmapPage();
+  return window;
+}
+
+test("종목명으로 검색하면 일치 타일만 강조하고 개수를 알려준다", async () => {
+  const window = await searchablePage();
+  const panel = window.document.getElementById("heatmap-page-domestic");
+
+  window.searchHeatmapPage("대형1");
+
+  assert(panel.classList.contains("heatmap-searching"), "검색 중에는 나머지를 흐리게 할 표시가 필요함");
+  assert(JSON.stringify(hitSymbols(window)) === JSON.stringify(["B1"]),
+    `이름이 일치하는 타일만 강조돼야 함 (실제 ${hitSymbols(window)})`);
+  const count = window.document.getElementById("heatmap-page-search-count").textContent;
+  assert(count.includes("1"), `일치 개수를 알려야 함 (실제 ${count})`);
+  assert(window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 40,
+    "일치하지 않는 타일도 그대로 남아야 함(면적이 히트맵의 정보다)");
+});
+
+test("코드로도 찾고 대소문자는 가리지 않는다", async () => {
+  const window = await searchablePage();
+
+  window.searchHeatmapPage("  b3 ");
+
+  assert(JSON.stringify(hitSymbols(window)) === JSON.stringify(["B3"]),
+    `코드로도 찾아야 함 (실제 ${hitSymbols(window)})`);
+});
+
+test("검색어를 비우면 강조가 풀린다", async () => {
+  const window = await searchablePage();
+  const panel = window.document.getElementById("heatmap-page-domestic");
+
+  window.searchHeatmapPage("대형1");
+  window.searchHeatmapPage("");
+
+  assert(!panel.classList.contains("heatmap-searching"), "검색을 비우면 원래 화면으로 돌아와야 함");
+  assert(hitSymbols(window).length === 0, "강조가 남으면 안 됨");
+  assert(window.document.getElementById("heatmap-page-search-count").textContent === "",
+    "안내 문구도 지워져야 함");
+});
+
+test("일치하는 종목이 없으면 그 사실을 알린다", async () => {
+  const window = await searchablePage();
+
+  window.searchHeatmapPage("없는종목");
+
+  assert(hitSymbols(window).length === 0, "일치가 없어야 함");
+  const count = window.document.getElementById("heatmap-page-search-count").textContent;
+  assert(count.includes("없"), `일치 없음을 알려야 함 (실제 ${count})`);
+});
+
+test("확대하거나 다시 조회해도 검색 강조는 유지된다", async () => {
+  const window = await searchablePage();
+
+  window.searchHeatmapPage("대형1");
+  window.zoomHeatmapPage(2);  // 재렌더 → 타일 DOM 이 통째로 바뀐다
+  assert(JSON.stringify(hitSymbols(window)) === JSON.stringify(["B1"]),
+    `확대 후에도 강조가 남아야 함 (실제 ${hitSymbols(window)})`);
+
+  await window.setHeatmapMarket("KOSPI");
+  assert(JSON.stringify(hitSymbols(window)) === JSON.stringify(["B1"]),
+    `재조회 후에도 강조가 남아야 함 (실제 ${hitSymbols(window)})`);
+});
+
+test("pjax 재진입 시 기간·시장은 기본값으로 돌아온다", async () => {
   const calls = [];
   const window = makeWindow(routed({
     "/api/market-mode": () => marketMode(["domestic"]),
@@ -672,13 +822,19 @@ test("pjax 재진입 시 기간은 1일로 돌아온다", async () => {
 
   await window.initHeatmapPage();
   await window.setHeatmapPeriod("3m");
+  await window.setHeatmapMarket("KOSPI");
   calls.length = 0;
   await window.initHeatmapPage();
 
   const domesticCalls = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
   assert(domesticCalls[0].includes("period=1d"), `재진입은 1일로 시작해야 함 (실제 ${domesticCalls[0]})`);
+  assert(domesticCalls[0].includes("market=ALL"), `재진입은 공통으로 시작해야 함 (실제 ${domesticCalls[0]})`);
   assert(window.document.getElementById("heatmap-page-period").value === "1d",
     "기간 선택 UI 도 1일로 되돌아야 함");
+  assert(window.document.getElementById("heatmap-page-market").value === "ALL",
+    "시장 선택 UI 도 공통으로 되돌아야 함");
+  assert(window.document.getElementById("heatmap-page-search").value === "",
+    "검색어도 비워져야 함");
 });
 
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -1182,6 +1182,18 @@ class TestGetMarketCapSnapshot:
         assert [row["code"] for row in result] == ["A002"]
 
     @pytest.mark.asyncio
+    async def test_all_means_every_market(self, repo):
+        """히트맵의 '공통' 이 market="ALL" 로 내려오므로 필터 없이 전체가 나와야 한다."""
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300, market="KOSPI"),
+            _make_snapshot("A002", market_cap=200, market="KOSDAQ"),
+        ])
+
+        result = await repo.get_market_cap_snapshot(limit=10, market="ALL")
+
+        assert [row["code"] for row in result] == ["A001", "A002"]
+
+    @pytest.mark.asyncio
     async def test_returns_empty_without_snapshots(self, repo):
         assert await repo.get_market_cap_snapshot() == []
 

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -143,6 +143,37 @@ def test_heatmap_page_hosts_period_control():
     assert "period=${_heatmapPagePeriod}" in page_script, "조회 URL 에 기간이 실리지 않음"
 
 
+def test_heatmap_page_hosts_market_control():
+    """시장(공통/코스피/코스닥)은 조회 조건이라 화면·스크립트·API 값이 맞아야 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert 'id="heatmap-page-market"' in template
+    assert 'id="heatmap-page-market-wrap"' in template, "미국 탭에서 감출 대상 컨테이너가 필요함"
+    assert "setHeatmapMarket(this.value)" in template
+
+    # 저장소가 "ALL"/"KOSPI"/"KOSDAQ" 를 그대로 해석한다(ALL=필터 없음).
+    for market in ("ALL", "KOSPI", "KOSDAQ"):
+        assert f'value="{market}"' in template, f"{market} 선택지가 없음"
+        assert f"'{market}'" in page_script, f"{market} 가 스크립트 허용 목록에 없음"
+    assert "market=${_heatmapPageMarket}" in page_script, "조회 URL 에 시장이 실리지 않음"
+
+
+def test_heatmap_page_hosts_search_control():
+    """검색은 재조회가 아니라 그려진 타일을 짚는 기능이라, 이름 매칭 근거(data-name)와 강조 CSS 가 있어야 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+    css = _heatmap_css()
+
+    assert 'id="heatmap-page-search"' in template
+    assert "searchHeatmapPage(this.value)" in template
+    assert 'id="heatmap-page-search-count"' in template, "일치 개수를 알릴 자리가 필요함"
+
+    assert "data-name=" in _heatmap_js(), "종목명 검색 근거가 타일에 실려야 함"
+    assert "dataset.name" in page_script and "dataset.symbol" in page_script, "이름·코드 둘 다로 찾아야 함"
+    assert ".heatmap-tile-hit" in css and ".heatmap-searching" in css, "강조/흐림 스타일이 스타일시트에 없음"
+
+
 def test_heatmap_page_supports_drag_panning():
     """확대한 화면은 마우스로 끌어 옮길 수 있어야 한다 — 배선(JS)과 커서 표시(CSS)가 함께 있어야 한다."""
     template = _heatmap_page_template()

--- a/view/web/static/css/heatmap.css
+++ b/view/web/static/css/heatmap.css
@@ -24,3 +24,9 @@
 }
 .heatmap-tile-symbol { font-size: 0.72rem; font-weight: 700; line-height: 1.15; }
 .heatmap-tile-rate { font-size: 0.66rem; line-height: 1.15; }
+/* 검색 중: 일치하지 않는 타일은 지우지 않고 흐리게 둔다 — 면적(시가총액)이 히트맵의 정보다. */
+.heatmap-searching .heatmap-tile { opacity: 0.16; }
+.heatmap-searching .heatmap-tile-hit {
+    opacity: 1; z-index: 2;
+    outline: 2px solid #fff; outline-offset: -2px;
+}

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -7,10 +7,12 @@
  *      transform 으로 확대하면 작은 타일의 생략된 라벨이 그대로 없기 때문에,
  *      배율을 렌더에 넘겨 라벨 기준을 완화해야 확대의 의미가 있다.
  *      버튼(중앙 고정)과 마우스 휠(커서 고정) 두 경로가 같은 배율 단계를 공유한다.
- *   3) 기간 — 색(등락률)의 기준 구간. 서버가 ohlcv 기준종가로 계산하므로 재조회가 필요하다
- *      (면적=시가총액은 기간과 무관하게 최신 스냅샷 그대로). 미국 스냅샷에는 기간 이력이
+ *   3) 기간·시장 — 조회 조건. 기간은 색(등락률)의 기준 구간이라 서버가 ohlcv 기준종가로
+ *      계산하고(면적=시가총액은 기간과 무관하게 최신 스냅샷 그대로), 시장(공통/코스피/코스닥)은
+ *      담기는 종목 자체를 바꾼다 — 둘 다 재조회가 필요하다. 미국 탭은 기간 이력도 시장 구분도
  *      없어 국내 탭에서만 노출한다.
  *   4) 끌어서 이동 — 확대한 화면을 휴대폰처럼 마우스로 잡아끌어 옮긴다.
+ *   5) 검색 — 재조회 없이 그려진 타일에서 종목을 짚는다(일치 강조 + 나머지 흐림 + 스크롤).
  */
 
 // 홈 미리보기(200종목)보다 넓게 잡는다 — 작은 타일은 확대로 읽을 수 있다.
@@ -23,10 +25,14 @@ const HEATMAP_PAGE_WHEEL_STEP_DELTA = 100;
 // 서버(/api/heatmap/domestic?period=)가 받는 값과 같아야 한다.
 const HEATMAP_PAGE_PERIODS = ['1d', '1w', '1m', '3m', '6m', 'ytd', '1y'];
 const HEATMAP_PAGE_DEFAULT_PERIOD = '1d';
+// 저장소가 해석하는 시장 값 — 'ALL'(공통) 은 필터 없음이다.
+const HEATMAP_PAGE_MARKETS = ['ALL', 'KOSPI', 'KOSDAQ'];
+const HEATMAP_PAGE_DEFAULT_MARKET = 'ALL';
 
 let _heatmapPageZoomIndex = 0;
 let _heatmapPageWheelAccum = 0;
 let _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
+let _heatmapPageMarket = HEATMAP_PAGE_DEFAULT_MARKET;
 
 function _heatmapPageZoom() {
     return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
@@ -36,8 +42,9 @@ const HEATMAP_PAGE_SOURCES = {
     domestic: {
         targetId: 'heatmap-page-domestic',
         captionId: 'heatmap-page-domestic-caption',
-        // 기간이 바뀌면 URL 도 바뀌므로 함수로 둔다(_loadHeatmap 이 호출 시점에 평가한다).
-        url: () => `/api/heatmap/domestic?limit=${HEATMAP_PAGE_DOMESTIC_LIMIT}&period=${_heatmapPagePeriod}`,
+        // 조회 조건(기간·시장)이 바뀌면 URL 도 바뀌므로 함수로 둔다(_loadHeatmap 이 호출 시점에 평가한다).
+        url: () => `/api/heatmap/domestic?limit=${HEATMAP_PAGE_DOMESTIC_LIMIT}`
+            + `&period=${_heatmapPagePeriod}&market=${_heatmapPageMarket}`,
         loadingText: '국내 히트맵 조회 중...',
         toGroups: _domesticGroups,
         caption: _domesticCaption,
@@ -72,11 +79,14 @@ async function setHeatmapTab(market) {
         if (tab) tab.classList.toggle('active', active);
     });
 
-    // 미국 스냅샷(Yahoo)은 일간 등락률만 있어 기간 선택이 의미가 없다.
+    // 미국 스냅샷(Yahoo)은 일간 등락률만 있어 기간 선택이 의미가 없고, 시장도 S&P 500 고정이다.
     _heatmapPageShow(document.getElementById('heatmap-page-period-wrap'), market === 'domestic');
+    _heatmapPageShow(document.getElementById('heatmap-page-market-wrap'), market === 'domestic');
 
     // 실패한 탭은 lastData 가 없으므로 다시 열 때 재시도된다.
     if (!source.lastData) await _loadHeatmap(source);
+    // 탭을 바꾸면 일치 개수의 대상(보이는 패널)이 달라진다.
+    _applyHeatmapPageSearch();
 }
 
 async function setHeatmapPeriod(period) {
@@ -87,6 +97,85 @@ async function setHeatmapPeriod(period) {
     const source = HEATMAP_PAGE_SOURCES.domestic;
     source.lastData = null;
     await _loadHeatmap(source);
+    _applyHeatmapPageSearch();
+}
+
+async function setHeatmapMarket(market) {
+    if (!HEATMAP_PAGE_MARKETS.includes(market) || market === _heatmapPageMarket) return;
+    _heatmapPageMarket = market;
+
+    // 종목 구성 자체가 달라지므로 서버에서 다시 받아야 한다(면적 = 시가총액 상위 N).
+    const source = HEATMAP_PAGE_SOURCES.domestic;
+    source.lastData = null;
+    await _loadHeatmap(source);
+    _applyHeatmapPageSearch();
+}
+
+// 검색은 재조회가 아니라 이미 그려진 타일을 짚어 주는 기능이다. 일치하지 않는 종목을 지우면
+// 남은 타일이 화면을 다시 채워 면적(시가총액)이 뜻을 잃으므로, 흐리게 두고 일치만 도드라지게 한다.
+const HEATMAP_PAGE_SEARCHING_CLASS = 'heatmap-searching';
+const HEATMAP_PAGE_HIT_CLASS = 'heatmap-tile-hit';
+
+let _heatmapPageQuery = '';
+
+function _heatmapPageMatches(tile, query) {
+    const symbol = String(tile.dataset.symbol || '').toLowerCase();
+    const name = String(tile.dataset.name || '').toLowerCase();
+    return symbol.includes(query) || name.includes(query);
+}
+
+// 확대·재조회는 타일 DOM 을 통째로 새로 만든다 — 그릴 때마다 현재 검색어를 다시 입힌다.
+function _applyHeatmapPageSearch() {
+    const query = _heatmapPageQuery;
+    let hits = 0;
+
+    Object.values(HEATMAP_PAGE_SOURCES).forEach(source => {
+        const div = document.getElementById(source.targetId);
+        if (!div) return;
+        div.classList.toggle(HEATMAP_PAGE_SEARCHING_CLASS, Boolean(query));
+        div.querySelectorAll('.heatmap-tile').forEach(tile => {
+            const hit = Boolean(query) && _heatmapPageMatches(tile, query);
+            tile.classList.toggle(HEATMAP_PAGE_HIT_CLASS, hit);
+            if (hit && div.style.display !== 'none') hits += 1;
+        });
+    });
+
+    const countEl = document.getElementById('heatmap-page-search-count');
+    if (countEl) {
+        if (!query) countEl.textContent = '';
+        else countEl.textContent = hits ? `${hits}개 일치` : '일치하는 종목이 없습니다';
+    }
+    return hits;
+}
+
+// 찾은 종목이 확대된 화면 밖에 있으면 강조해도 보이지 않는다 — 첫(가장 큰) 일치로 스크롤한다.
+function _scrollHeatmapPageToFirstHit() {
+    const viewport = document.getElementById('heatmap-page-viewport');
+    if (!viewport || typeof viewport.getBoundingClientRect !== 'function') return;
+
+    const visible = Object.values(HEATMAP_PAGE_SOURCES)
+        .map(source => document.getElementById(source.targetId))
+        .find(div => div && div.style.display !== 'none');
+    const tile = visible && visible.querySelector(`.${HEATMAP_PAGE_HIT_CLASS}`);
+    if (!tile) return;
+
+    const tileRect = tile.getBoundingClientRect();
+    const viewRect = viewport.getBoundingClientRect();
+    if (!tileRect.width && !tileRect.height) return;  // 레이아웃이 없으면 스크롤할 곳도 없다
+
+    viewport.scrollLeft = Math.max(
+        0,
+        viewport.scrollLeft + (tileRect.left - viewRect.left) - (viewport.clientWidth - tileRect.width) / 2,
+    );
+    viewport.scrollTop = Math.max(
+        0,
+        viewport.scrollTop + (tileRect.top - viewRect.top) - (viewport.clientHeight - tileRect.height) / 2,
+    );
+}
+
+function searchHeatmapPage(query) {
+    _heatmapPageQuery = String(query || '').trim().toLowerCase();
+    if (_applyHeatmapPageSearch()) _scrollHeatmapPageToFirstHit();
 }
 
 // 확대/축소 후에도 보고 있던 지점이 화면 가운데에 남도록 스크롤 비율을 유지한다.
@@ -119,6 +208,7 @@ function _applyHeatmapPageZoom() {
         const div = document.getElementById(source.targetId);
         if (div && source.lastData) _renderHeatmap(div, source, source.lastData);
     });
+    _applyHeatmapPageSearch();
 }
 
 function _heatmapPageNextZoomIndex(step) {
@@ -304,6 +394,12 @@ async function initHeatmapPage() {
     _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
     const periodSelect = document.getElementById('heatmap-page-period');
     if (periodSelect) periodSelect.value = HEATMAP_PAGE_DEFAULT_PERIOD;
+    _heatmapPageMarket = HEATMAP_PAGE_DEFAULT_MARKET;
+    const marketSelect = document.getElementById('heatmap-page-market');
+    if (marketSelect) marketSelect.value = HEATMAP_PAGE_DEFAULT_MARKET;
+    _heatmapPageQuery = '';
+    const searchInput = document.getElementById('heatmap-page-search');
+    if (searchInput) searchInput.value = '';
     _heatmapPagePan = null;
     _applyHeatmapPageZoom();
     _bindHeatmapPageWheelZoom(viewport);

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -194,6 +194,7 @@ function _heatmapTileHtml(member, box, zoom) {
     return `
         <div class="heatmap-tile"
              data-symbol="${escapeHtml(member.symbol)}"
+             data-name="${escapeHtml(member.name)}"
              data-direction="${_heatmapDirection(member.rate)}"
              title="${escapeHtml(tooltip)}"
              style="left:${box.x.toFixed(4)}%; top:${box.y.toFixed(4)}%; width:${box.w.toFixed(4)}%; height:${box.h.toFixed(4)}%; background-color:${_heatmapColor(member.rate)};">

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <link rel="stylesheet" href="/static/css/heatmap.css?v=1">
+    <link rel="stylesheet" href="/static/css/heatmap.css?v=2">
     <style>
         /* 줌은 viewport(스크롤 영역) 안에서 sizer 를 키우는 방식이라 viewport 높이가 고정돼야 한다. */
         .heatmap-page-viewport { position: relative; overflow: auto; height: calc(100vh - 300px); min-height: 420px; cursor: grab; }
@@ -19,6 +19,14 @@
             border: 1px solid var(--border); border-radius: 5px;
         }
         .heatmap-period select:hover { border-color: var(--accent, #4a90e2); }
+        .heatmap-search { display: inline-flex; align-items: center; gap: 6px; }
+        .heatmap-search input {
+            width: 150px; padding: 3px 6px; font-size: 0.85rem;
+            background: var(--bg-secondary); color: var(--text-primary);
+            border: 1px solid var(--border); border-radius: 5px;
+        }
+        .heatmap-search input:focus { outline: none; border-color: var(--accent, #4a90e2); }
+        #heatmap-page-search-count { font-size: 0.78rem; color: var(--text-secondary); }
         .heatmap-zoom button {
             min-width: 30px; padding: 3px 8px; cursor: pointer;
             background: var(--bg-secondary); color: var(--text-primary);
@@ -40,6 +48,21 @@
             <div class="heatmap-toolbar">
                 <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
                 <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+                <span class="heatmap-search" id="heatmap-page-search-wrap"
+                      title="종목명·코드로 찾습니다 (일치 종목을 강조하고 나머지는 흐리게)">
+                    <input type="search" id="heatmap-page-search" placeholder="종목명·코드 검색"
+                           oninput="searchHeatmapPage(this.value)" aria-label="히트맵 종목 검색">
+                    <span id="heatmap-page-search-count"></span>
+                </span>
+                <span class="heatmap-period" id="heatmap-page-market-wrap"
+                      title="담을 종목의 시장 (공통 = 코스피+코스닥)">
+                    <label for="heatmap-page-market">시장</label>
+                    <select id="heatmap-page-market" onchange="setHeatmapMarket(this.value)">
+                        <option value="ALL" selected>공통</option>
+                        <option value="KOSPI">코스피</option>
+                        <option value="KOSDAQ">코스닥</option>
+                    </select>
+                </span>
                 <span class="heatmap-period" id="heatmap-page-period-wrap"
                       title="타일 색을 이 기간의 등락률로 계산합니다 (면적은 시가총액 그대로)">
                     <label for="heatmap-page-period">기간</label>
@@ -79,6 +102,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_heatmap.js?v=5"></script>
-<script src="/static/js/heatmap_page.js?v=5"></script>
+<script src="/static/js/market_heatmap.js?v=6"></script>
+<script src="/static/js/heatmap_page.js?v=6"></script>
 {% endblock %}


### PR DESCRIPTION
@
## 무엇을

히트맵에 **시장 선택**과 **종목 검색**을 추가했다. 둘 다 화면 쪽 작업이고, 시장 필터는 API(`/api/heatmap/domestic?market=`)가 이미 지원하던 것을 화면에 연결한 것이다.

### 시장 선택 (공통/코스피/코스닥)
- 툴바에 `시장` 선택 추가. `공통`=`ALL`(필터 없음), `코스피`=`KOSPI`, `코스닥`=`KOSDAQ`.
- 담기는 종목 구성 자체가 달라지므로 재조회한다(면적 = 각 시장의 시총 상위 500). 기간 선택은 유지된다.
- 미국 탭은 S&P 500 고정이라 기간과 함께 감춘다.

### 종목 검색
- 종목명·코드로 찾아 **일치 타일을 강조하고 나머지는 흐리게**(opacity 0.16) 둔다.
  일치하지 않는 종목을 지우는 방식은 쓰지 않았다 — 남은 타일이 화면을 다시 채우면 면적(시가총액)이 뜻을 잃는다.
- 첫(가장 큰) 일치로 스크롤해 확대 상태에서도 화면 안에 들어오게 하고, 일치 개수/없음을 알린다.
- 확대·재조회는 타일 DOM 을 통째로 새로 만들므로 렌더 뒤마다 검색어를 다시 입힌다.
- 이름 매칭 근거로 타일에 `data-name` 을 실었다(`market_heatmap.js`, 홈 미리보기와 공용).

## 확인
실행 중인 로컬 서버에서 직접 확인:
- `market=KOSDAQ` 조회 상위가 알테오젠·에코프로·에코프로비엠 등 코스닥 종목, 조회 URL `?limit=500&period=1d&market=KOSDAQ`.
- 검색 `레인보우` → `1개 일치`, 강조 타일 opacity 1 / 나머지 0.16, 해당 타일로 스크롤, 타일 500개 그대로 유지. 없는 이름 → "일치하는 종목이 없습니다", 지우면 원상복구.
- 단위 7,490건 / 통합 277건 통과 (jsdom 히트맵 36건 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@