### PR TITLE
feat: 유튜브 채널 일일 다이제스트 1~4단계 (저장소·수집·요약·진단)

### DIFF
--- a/repositories/youtube_channel_repository.py
+++ b/repositories/youtube_channel_repository.py
@@ -1,0 +1,133 @@
+"""
+유튜브 일일 다이제스트 대상 채널 저장소 - SQLite 기반 (data/youtube_channels.db).
+
+채널은 웹 UI에서 추가/삭제/on-off 하므로, 시드는 "최초 1회"만 넣는다.
+사용자가 지운 채널이 재시작 때 되살아나지 않도록 seeded 플래그를 meta 테이블에 남긴다.
+"""
+import re
+from pathlib import Path
+
+import aiosqlite
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS youtube_channels (
+    channel_id TEXT PRIMARY KEY,
+    handle     TEXT NOT NULL DEFAULT '',
+    title      TEXT NOT NULL DEFAULT '',
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
+)
+"""
+
+_CREATE_META = """
+CREATE TABLE IF NOT EXISTS youtube_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"""
+
+_SEEDED_KEY = "seeded"
+
+# 2026-08-10 실측으로 channelId·한국어 자막(ASR) 존재를 확인한 채널.
+SEED_CHANNELS = [
+    {"channel_id": "UCXST0Hq6CAmG0dmo3jgrlEw", "handle": "chesleytv", "title": "체슬리TV"},
+    {"channel_id": "UCdOjVxkj5JA0iDu3_xcsTyQ", "handle": "koreanstockrider", "title": "증시각도기TV"},
+    {"channel_id": "UCiDmfbYvuMEVbRxPmFP4sng", "handle": "rsangmoo", "title": "상무니tv"},
+    {"channel_id": "UCrPcpr8lzO1GTSSZjm2lV2w", "handle": "Power_bus2", "title": "세력버스"},
+    {"channel_id": "UC9Cilvlvu_7YWYQGhSCrFOg", "handle": "10min_stock", "title": "10분 주식"},
+]
+
+_RE_CHANNEL_ID = re.compile(r"^UC[\w-]{22}$")
+
+
+class YoutubeChannelRepository:
+    DB_PATH = Path("data/youtube_channels.db")
+
+    def __init__(self, db_path: Path | None = None):
+        self._db_path = db_path or self.DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _setup(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute(_CREATE_TABLE)
+        await conn.execute(_CREATE_META)
+        await conn.commit()
+
+    async def get_all(self, enabled_only: bool = False) -> list[dict]:
+        query = "SELECT channel_id, handle, title, enabled FROM youtube_channels"
+        if enabled_only:
+            query += " WHERE enabled = 1"
+        query += " ORDER BY created_at ASC, rowid ASC"
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(query) as cur:
+                rows = await cur.fetchall()
+        return [
+            {
+                "channel_id": row[0],
+                "handle": row[1],
+                "title": row[2],
+                "enabled": bool(row[3]),
+            }
+            for row in rows
+        ]
+
+    async def add(self, channel_id: str, handle: str = "", title: str = "") -> bool:
+        """채널 추가. 이미 있으면 False (멱등성 보장)."""
+        channel_id = str(channel_id or "").strip()
+        if not _RE_CHANNEL_ID.match(channel_id):
+            raise ValueError(f"유효한 채널 ID가 아닙니다 (UC + 22자): {channel_id!r}")
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            cur = await conn.execute(
+                "INSERT OR IGNORE INTO youtube_channels (channel_id, handle, title)"
+                " VALUES (?, ?, ?)",
+                (channel_id, str(handle or ""), str(title or "")),
+            )
+            await conn.commit()
+            return cur.rowcount > 0
+
+    async def remove(self, channel_id: str) -> bool:
+        """채널 제거. 없으면 False."""
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            cur = await conn.execute(
+                "DELETE FROM youtube_channels WHERE channel_id = ?", (channel_id,)
+            )
+            await conn.commit()
+            return cur.rowcount > 0
+
+    async def set_enabled(self, channel_id: str, enabled: bool) -> bool:
+        """수집 on/off 전환. 없는 채널이면 False."""
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            cur = await conn.execute(
+                "UPDATE youtube_channels SET enabled = ? WHERE channel_id = ?",
+                (1 if enabled else 0, channel_id),
+            )
+            await conn.commit()
+            return cur.rowcount > 0
+
+    async def seed_defaults(self) -> int:
+        """최초 1회만 기본 채널을 넣고, 넣은 개수를 반환한다."""
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                "SELECT 1 FROM youtube_meta WHERE key = ?", (_SEEDED_KEY,)
+            ) as cur:
+                if await cur.fetchone():
+                    return 0
+            inserted = 0
+            for channel in SEED_CHANNELS:
+                cur = await conn.execute(
+                    "INSERT OR IGNORE INTO youtube_channels (channel_id, handle, title)"
+                    " VALUES (?, ?, ?)",
+                    (channel["channel_id"], channel["handle"], channel["title"]),
+                )
+                inserted += cur.rowcount > 0
+            await conn.execute(
+                "INSERT OR REPLACE INTO youtube_meta (key, value) VALUES (?, '1')",
+                (_SEEDED_KEY,),
+            )
+            await conn.commit()
+        return inserted

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ aiosqlite>=0.19.0
 orjson
 pytest-timeout>=2.1.0
 apscheduler>=3.10.0
+# 유튜브 자막 취득. watch 페이지의 timedtext baseUrl 은 빈 응답을 주고
+# innertube 직접 호출도 막혀 있어(2026-08-10 실측) 이 라이브러리가 유일한 동작 경로다.
+youtube-transcript-api>=1.0.0

--- a/scripts/check_youtube_ai.py
+++ b/scripts/check_youtube_ai.py
@@ -52,10 +52,12 @@ def _load_config() -> dict:
         return yaml.safe_load(f) or {}
 
 
-def _build_ai(ai_cfg: dict):
+def _build_ai(ai_cfg: dict, stock_code_repository=None):
     """(AiClient, YoutubeDigestService) 또는 (None, None) 반환.
 
     앱과 같은 usage_limiter 를 붙여 이 스크립트의 소비도 일일 한도에 집계된다.
+    종목코드 저장소는 호출자가 넘긴다 — 여기서 직접 만들면 DB가 없는 환경에서
+    pykrx 로 KRX 를 호출해 버려 이 함수가 네트워크에 묶인다.
     """
     if not ai_cfg.get("enabled"):
         return None, None
@@ -78,7 +80,7 @@ def _build_ai(ai_cfg: dict):
     budget = int(ai_cfg.get("max_input_chars", 0)) or 24000
     digest = YoutubeDigestService(
         ai_client,
-        stock_code_repository=StockCodeRepository(),
+        stock_code_repository=stock_code_repository,
         max_tokens=int(ai_cfg.get("max_tokens", 2048)),
         chunk_chars=max(2000, budget - 2000),
     )
@@ -114,7 +116,8 @@ async def _main() -> None:
         print("[안내] 등록된 채널이 없습니다.")
         return
 
-    ai_client, digest = _build_ai(ai_cfg) if args.ai else (None, None)
+    code_repo = StockCodeRepository()
+    ai_client, digest = _build_ai(ai_cfg, code_repo) if args.ai else (None, None)
     if args.ai and digest is None:
         print("[안내] config.yaml 의 ai_analysis.enabled 가 false 라 AI 요약을 건너뜁니다.")
 
@@ -146,9 +149,7 @@ async def _main() -> None:
             f"{item.get('title', '')[:50]} ({len(item.get('transcript', ''))}자)"
         )
 
-    counter = digest or YoutubeDigestService(
-        None, stock_code_repository=StockCodeRepository()
-    )
+    counter = digest or YoutubeDigestService(None, stock_code_repository=code_repo)
     print("\n[종목 언급 집계] (AI 미사용, 최장일치 스캔)")
     _print_mentions(counter.count_stock_mentions(usable))
 

--- a/scripts/check_youtube_ai.py
+++ b/scripts/check_youtube_ai.py
@@ -1,0 +1,177 @@
+"""유튜브 채널 자막 수집 → 종목 언급 집계 → AI 다이제스트 dry-run 진단.
+
+config.yaml 의 ai_analysis 설정으로 등록 채널의 최근 영상 자막을 실제로 받아
+언급 집계와 AI 요약까지 한 번에 확인한다. 웹 서버·브로커 인증 없이 검증 가능.
+
+**--ai 를 주면 실제 AI 요청을 보내 일일 한도를 소비한다.** 소비량은
+(영상 수 + 긴 영상의 추가 청크 수 + 종합 1건) 이다. 기본은 수집·집계만 한다.
+
+사용:
+    python scripts/check_youtube_ai.py                       # 수집+언급집계만 (한도 0건)
+    python scripts/check_youtube_ai.py --ai --max-videos 2   # AI 요약까지 (한도 소비)
+    python scripts/check_youtube_ai.py --hours 48            # 최근 48시간 영상
+    python scripts/check_youtube_ai.py --debug               # 실패 시 traceback
+"""
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Windows 콘솔(cp949)이 처리 못 하는 문자에서 출력이 잘리지 않도록 UTF-8 고정.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+from repositories.stock_code_repository import StockCodeRepository  # noqa: E402
+from repositories.youtube_channel_repository import (  # noqa: E402
+    YoutubeChannelRepository,
+)
+from services.ai_client import AiClient  # noqa: E402
+from services.ai_usage_limiter import AiUsageLimiter  # noqa: E402
+from services.youtube_digest_service import YoutubeDigestService  # noqa: E402
+from services.youtube_transcript_collector_service import (  # noqa: E402
+    YoutubeTranscriptCollectorService,
+)
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+_DEFAULT_MODEL = "gemini-2.5-flash"
+
+
+def _load_config() -> dict:
+    config_path = _ROOT / "config" / "config.yaml"
+    if not config_path.exists():
+        print(f"[오류] {config_path} 가 없습니다.")
+        sys.exit(1)
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _build_ai(ai_cfg: dict):
+    """(AiClient, YoutubeDigestService) 또는 (None, None) 반환.
+
+    앱과 같은 usage_limiter 를 붙여 이 스크립트의 소비도 일일 한도에 집계된다.
+    """
+    if not ai_cfg.get("enabled"):
+        return None, None
+    limiter = AiUsageLimiter(
+        daily_request_limit=int(ai_cfg.get("daily_request_limit", 100)),
+        disclosure_reserve=int(ai_cfg.get("disclosure_reserve", 20)),
+    )
+    ai_client = AiClient(
+        base_url=str(ai_cfg.get("base_url") or _DEFAULT_BASE_URL),
+        api_key=str(ai_cfg.get("api_key") or ""),
+        model=str(ai_cfg.get("model") or _DEFAULT_MODEL),
+        timeout_sec=float(ai_cfg.get("timeout_sec", 45)),
+        reasoning_effort=str(ai_cfg.get("reasoning_effort") or ""),
+        usage_limiter=limiter,
+        max_concurrent_requests=int(ai_cfg.get("max_concurrent_requests", 0)),
+        min_request_interval_sec=float(ai_cfg.get("min_request_interval_sec", 0.0)),
+        max_input_chars=int(ai_cfg.get("max_input_chars", 0)),
+    )
+    # 입력 예산보다 청크를 작게 잡아야 AiClient 가 뒤를 잘라내지 않는다.
+    budget = int(ai_cfg.get("max_input_chars", 0)) or 24000
+    digest = YoutubeDigestService(
+        ai_client,
+        stock_code_repository=StockCodeRepository(),
+        max_tokens=int(ai_cfg.get("max_tokens", 2048)),
+        chunk_chars=max(2000, budget - 2000),
+    )
+    return ai_client, digest
+
+
+def _print_mentions(mentions: list) -> None:
+    if not mentions:
+        print("  (언급된 종목 없음)")
+        return
+    for rank, mention in enumerate(mentions[:20], start=1):
+        print(
+            f"  {rank:2d}. {mention['name']:<14s} "
+            f"언급 {mention['count']:3d}회 / {mention['video_count']}개 영상"
+        )
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hours", type=float, default=24.0, help="최근 N시간 영상 (기본 24)")
+    parser.add_argument("--max-videos", type=int, default=3, help="채널당 영상 수 상한")
+    parser.add_argument("--ai", action="store_true", help="AI 요약까지 실행(한도 소비)")
+    parser.add_argument("--debug", action="store_true", help="실패 시 전체 traceback 출력")
+    args = parser.parse_args()
+
+    config = _load_config()
+    ai_cfg = config.get("ai_analysis") or {}
+
+    repo = YoutubeChannelRepository()
+    await repo.seed_defaults()
+    channels = await repo.get_all(enabled_only=True)
+    if not channels:
+        print("[안내] 등록된 채널이 없습니다.")
+        return
+
+    ai_client, digest = _build_ai(ai_cfg) if args.ai else (None, None)
+    if args.ai and digest is None:
+        print("[안내] config.yaml 의 ai_analysis.enabled 가 false 라 AI 요약을 건너뜁니다.")
+
+    print(f"채널={len(channels)}개  최근={args.hours}시간  채널당 상한={args.max_videos}편")
+    print(f"AI 요약={'ON' if digest else 'OFF'}\n")
+
+    collector = YoutubeTranscriptCollectorService()
+    try:
+        items = await collector.collect(
+            channels, since_hours=args.hours, max_videos_per_channel=args.max_videos
+        )
+    except Exception as e:
+        if args.debug:
+            raise
+        print(f"[오류] 수집 실패: {type(e).__name__}: {e}")
+        return
+
+    usable = [item for item in items if not item.get("skip_reason")]
+    print(f"[수집] 영상 {len(items)}편 중 자막 확보 {len(usable)}편")
+    if collector.was_blocked:
+        print(
+            "\n[중단] YouTube 가 이 IP를 차단했습니다(IpBlocked). 짧은 시간에 반복 실행하면"
+            " 걸립니다 — 몇 분~몇 시간 뒤 다시 시도하세요.\n"
+        )
+    for item in items:
+        mark = "OK  " if not item.get("skip_reason") else f"SKIP({item['skip_reason']})"
+        print(
+            f"  {mark} [{item.get('channel_title', '')}] "
+            f"{item.get('title', '')[:50]} ({len(item.get('transcript', ''))}자)"
+        )
+
+    counter = digest or YoutubeDigestService(
+        None, stock_code_repository=StockCodeRepository()
+    )
+    print("\n[종목 언급 집계] (AI 미사용, 최장일치 스캔)")
+    _print_mentions(counter.count_stock_mentions(usable))
+
+    if digest is None:
+        print("\n[안내] AI 요약을 보려면 --ai 를 붙이세요.")
+        return
+
+    print("\n[AI 다이제스트] 생성 중...")
+    try:
+        result = await digest.build_digest(usable, report_date="dryrun")
+    except Exception as e:
+        if args.debug:
+            raise
+        print(f"[오류] AI 실패: {type(e).__name__}: {e}")
+        return
+
+    if result.rt_cd != "0":
+        print(f"[실패] {result.msg1}")
+        return
+    print(result.data["digest_text"])
+    if result.data["failed_summary_count"]:
+        print(f"\n[주의] 요약 실패 {result.data['failed_summary_count']}편")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/services/youtube_digest_service.py
+++ b/services/youtube_digest_service.py
@@ -1,0 +1,280 @@
+"""유튜브 방송 자막을 종목 언급 집계 + AI 요약으로 묶어 일일 리포트를 만드는 서비스.
+
+설계 의도 두 가지:
+
+1. **종목 언급 집계는 AI를 쓰지 않는다.** 자막에서 종목명을 직접 세면 검증 가능하고
+   환각이 없다. AI는 "무슨 맥락으로 말했는지"만 담당한다.
+2. **집계는 최장일치 + 좌측 경계 스캔이다.** 2026-08-10 실데이터에서 확인한 오검출을
+   막기 위한 3중 규칙이다.
+   - 최장일치: `SK하이닉스` 안의 `SK` 를 따로 세지 않는다.
+   - 좌측 경계: 매칭 직전 글자가 낱말 글자면 버린다. 공백을 지우고 매칭하면
+     `하이닉스`→`이닉스`, `그레이드`→`레이`, `에서 한`→`서한` 처럼 어절 내부가
+     걸린다(실측: 레이 59회·이닉스 13회 전량 오검출).
+   - 최소 길이 3: 2글자 종목명(레이·서한·고영·테스…)은 음성인식 자막에서
+     오검출이 압도적이라 아예 후보에서 뺀다.
+
+리포트는 유튜버의 **발언 집계**이지 사실 확인이나 매매 판단이 아니다. 프롬프트도
+그 선을 넘지 않도록 제약한다.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import Counter
+from typing import Any, Mapping, Optional, Sequence
+
+from common.types import ErrorCode, ResCommonResponse
+
+# 상장 종목명이지만 일반명사로 훨씬 자주 쓰여 카운트가 무의미해지는 이름.
+# 최장일치·좌측경계로도 걸러지지 않으므로 명시적으로 제외한다.
+_AMBIGUOUS_NAMES = frozenset(
+    {"이번주", "이스트", "네이처", "코리아", "하이라이트", "포인트", "제이스"}
+)
+
+# 최장일치 스캔에서 볼 최대 이름 길이. 실제 종목명은 이보다 짧다.
+_MAX_NAME_LEN = 20
+
+# 2글자 이름은 자막에서 어절 파편과 충돌해 오검출이 압도적이라 후보에서 뺀다.
+_MIN_NAME_LEN = 3
+
+_RE_SPACE = re.compile(r"\s+")
+
+_VIDEO_SYSTEM_PROMPT = (
+    "너는 한국 주식 유튜브 방송의 자동생성 자막을 정리하는 보조자다. "
+    "자막은 음성인식 결과라 종목명·숫자에 오탈자가 섞여 있다. "
+    "확실하지 않은 고유명사는 단정하지 말고 '불확실'로 표시한다. "
+    "자막에 없는 내용을 채워 넣지 않는다. "
+    "이것은 출연자의 발언 정리이지 사실 확인이나 투자 판단이 아니다. "
+    "매수·매도 지시나 목표가 제시를 하지 않고, 출연자가 그런 말을 했다면 "
+    "'출연자 발언'임을 명시해 인용만 한다. "
+    "한국어로 '핵심 주장', '언급 종목과 이유', '시장 전망', '리스크 언급' "
+    "순서의 짧은 불릿으로 답한다."
+)
+
+_DIGEST_SYSTEM_PROMPT = (
+    "너는 여러 주식 유튜브 방송의 하루치 요약을 묶어 일일 다이제스트를 만드는 보조자다. "
+    "여러 채널이 공통으로 말한 주제를 위로 올리고, 한 채널만 말한 내용은 "
+    "'단독 언급'으로 따로 묶는다. "
+    "채널마다 의견이 엇갈리면 어느 쪽이 맞다고 판정하지 말고 양쪽을 나란히 적는다. "
+    "입력으로 주어진 종목 언급 횟수는 자막에서 기계적으로 센 값이다. "
+    "횟수가 많다고 유망하다는 뜻이 아니므로 그렇게 해석하지 않는다. "
+    "이것은 발언 집계이지 투자 권유가 아니다. 매수·매도 지시를 하지 않는다. "
+    "한국어로 '오늘의 공통 화두', '많이 언급된 종목', '엇갈리는 시각', "
+    "'단독 언급', '확인이 필요한 주장' 순서의 짧은 섹션으로 답한다."
+)
+
+
+class YoutubeDigestService:
+    """자막 묶음 → 종목 언급 집계 + AI 다이제스트."""
+
+    def __init__(
+        self,
+        ai_client,
+        stock_code_repository=None,
+        *,
+        max_tokens: int = 2048,
+        chunk_chars: int = 18000,
+        max_mentions: int = 30,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._client = ai_client
+        self._code_repo = stock_code_repository
+        self._max_tokens = int(max_tokens)
+        self._chunk_chars = max(1, int(chunk_chars))
+        self._max_mentions = max(1, int(max_mentions))
+        self._logger = logger or logging.getLogger(__name__)
+        self._name_index: Optional[dict] = None
+
+    # --- 종목 언급 집계 (AI 미사용) --------------------------------------------
+
+    def _build_name_index(self) -> dict:
+        """공백 제거한 종목명 → 종목코드. 최초 1회만 만든다."""
+        if self._name_index is not None:
+            return self._name_index
+        index: dict = {}
+        raw = getattr(self._code_repo, "name_to_code", None) or {}
+        for name, code in raw.items():
+            key = _RE_SPACE.sub("", str(name or ""))
+            if len(key) < _MIN_NAME_LEN or len(key) > _MAX_NAME_LEN:
+                continue
+            if key in _AMBIGUOUS_NAMES or key.isdigit():
+                continue
+            index[key] = str(code)
+        self._name_index = index
+        return index
+
+    @staticmethod
+    def _compact(text: str) -> tuple[str, list[int]]:
+        """공백을 지운 문자열과, 각 글자가 원문 어디서 왔는지의 위치표를 만든다.
+
+        공백을 지워야 'SK 하이닉스'가 종목명 'SK하이닉스'와 붙지만, 좌측 경계를
+        판정하려면 원문 위치가 필요하다.
+        """
+        chars: list[str] = []
+        origins: list[int] = []
+        for position, char in enumerate(text or ""):
+            if char.isspace():
+                continue
+            chars.append(char)
+            origins.append(position)
+        return "".join(chars), origins
+
+    def _scan_longest_match(self, text: str, index: Mapping[str, str]) -> Counter:
+        """좌→우 최장일치 스캔 + 좌측 경계 검사."""
+        counts: Counter = Counter()
+        source = text or ""
+        compacted, origins = self._compact(source)
+        length = len(compacted)
+        position = 0
+        while position < length:
+            window = min(_MAX_NAME_LEN, length - position)
+            matched = 0
+            for size in range(window, _MIN_NAME_LEN - 1, -1):
+                candidate = compacted[position : position + size]
+                if candidate in index and self._has_left_boundary(source, origins[position]):
+                    counts[candidate] += 1
+                    matched = size
+                    break
+            position += matched or 1
+        return counts
+
+    @staticmethod
+    def _has_left_boundary(source: str, origin: int) -> bool:
+        """직전 글자가 낱말 글자면 어절 내부이므로 종목 언급으로 보지 않는다."""
+        if origin == 0:
+            return True
+        return not source[origin - 1].isalnum()
+
+    def count_stock_mentions(self, items: Sequence[Mapping[str, Any]]) -> list[dict]:
+        """자막에서 종목 언급 횟수와 언급 영상 수를 집계한다."""
+        index = self._build_name_index()
+        if not index:
+            return []
+        totals: Counter = Counter()
+        video_spread: Counter = Counter()
+        for item in items or []:
+            if item.get("skip_reason"):
+                continue
+            counts = self._scan_longest_match(item.get("transcript", ""), index)
+            totals.update(counts)
+            video_spread.update(counts.keys())
+        mentions = [
+            {
+                "name": name,
+                "code": index[name],
+                "count": count,
+                "video_count": video_spread[name],
+            }
+            for name, count in totals.items()
+        ]
+        # 여러 방송이 공통으로 말한 종목이 한 방송의 반복보다 위에 오게 한다.
+        mentions.sort(key=lambda m: (-m["video_count"], -m["count"], m["name"]))
+        return mentions[: self._max_mentions]
+
+    # --- AI 요약 --------------------------------------------------------------
+
+    def _chunks(self, text: str) -> list[str]:
+        return [
+            text[i : i + self._chunk_chars]
+            for i in range(0, len(text), self._chunk_chars)
+        ] or [""]
+
+    async def summarize_video(self, item: Mapping[str, Any]) -> str:
+        """영상 1편을 요약한다. 자막이 길면 청크별로 나눠 부르고 이어붙인다."""
+        chunks = self._chunks(str(item.get("transcript") or ""))
+        parts: list[str] = []
+        for order, chunk in enumerate(chunks, start=1):
+            header = (
+                f"[채널] {item.get('channel_title', '')}\n"
+                f"[제목] {item.get('title', '')}\n"
+            )
+            if len(chunks) > 1:
+                header += f"[구간] {order}/{len(chunks)}\n"
+            output = await self._client.complete(
+                system=_VIDEO_SYSTEM_PROMPT,
+                user=f"{header}[자막]\n{chunk}",
+                max_tokens=self._max_tokens,
+                temperature=0.2,
+                usage_type="youtube",
+            )
+            parts.append(str(output or "").strip())
+        return "\n".join(part for part in parts if part)
+
+    async def build_digest(
+        self, items: Sequence[Mapping[str, Any]], *, report_date: str
+    ) -> ResCommonResponse:
+        usable = [item for item in (items or []) if not item.get("skip_reason")]
+        if not usable:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.EMPTY_VALUES.value,
+                msg1="자막을 읽을 수 있는 영상이 없습니다.",
+                data=None,
+            )
+
+        mentions = self.count_stock_mentions(usable)
+        videos: list[dict] = []
+        failed = 0
+        for item in usable:
+            try:
+                summary = await self.summarize_video(item)
+            except Exception as e:
+                # 한 편의 업스트림 실패로 하루치 리포트를 통째로 버리지 않는다.
+                self._logger.warning(f"영상 요약 실패 ({item.get('video_id')}): {e}")
+                summary = ""
+                failed += 1
+            videos.append(
+                {
+                    "video_id": item.get("video_id", ""),
+                    "title": item.get("title", ""),
+                    "channel_title": item.get("channel_title", ""),
+                    "url": item.get("url", ""),
+                    "published": item.get("published", ""),
+                    "summary": summary,
+                }
+            )
+
+        payload = {
+            "report_date": report_date,
+            "mentions": [
+                {"name": m["name"], "count": m["count"], "video_count": m["video_count"]}
+                for m in mentions
+            ],
+            "videos": [
+                {
+                    "channel": v["channel_title"],
+                    "title": v["title"],
+                    "summary": v["summary"],
+                }
+                for v in videos
+                if v["summary"]
+            ],
+        }
+        try:
+            digest_text = await self._client.complete(
+                system=_DIGEST_SYSTEM_PROMPT,
+                user=json.dumps(payload, ensure_ascii=False, default=str, indent=2),
+                max_tokens=self._max_tokens,
+                temperature=0.2,
+                usage_type="youtube",
+            )
+        except Exception as e:
+            self._logger.error(f"유튜브 다이제스트 종합 요약 실패: {e}")
+            return ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1=f"AI 종합 요약 실패: {e}",
+                data=None,
+            )
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상처리 되었습니다.",
+            data={
+                "report_date": report_date,
+                "video_count": len(videos),
+                "failed_summary_count": failed,
+                "mentions": mentions,
+                "videos": videos,
+                "digest_text": str(digest_text or "").strip(),
+            },
+        )

--- a/services/youtube_transcript_collector_service.py
+++ b/services/youtube_transcript_collector_service.py
@@ -1,0 +1,273 @@
+"""유튜브 채널의 최근 영상 자막을 수집하는 서비스.
+
+2026-08-10 실측으로 확인한 제약 — 코드를 바꾸기 전에 반드시 읽을 것:
+
+- 채널 페이지 HTML에는 `"channelId"` 가 아니라 **`"externalId"`** 키에 UC... 가 들어 있다.
+- 영상 목록은 RSS(`feeds/videos.xml?channel_id=`)로 받는다. API 키·쿼터가 필요 없고
+  최근 15개를 준다. 하루 1회 배치에는 이걸로 충분하다.
+- watch 페이지의 `captionTracks[].baseUrl` 은 **HTTP 200 + 빈 본문**을 돌려준다.
+  innertube WEB 은 UNPLAYABLE, ANDROID/IOS 는 HTTP 400. 즉 직접 스크래핑은 죽은 경로다.
+  실제로 동작하는 유일한 방법이 `youtube-transcript-api` 라서 의존성으로 넣었다.
+- 라이브 방송은 `VideoUnplayable` 로 실패한다. 실패가 아니라 **스킵**으로 처리한다.
+- 짧은 시간에 반복 호출하면 `IpBlocked` 로 IP가 막힌다(실측: 연속 실행 후 15편 전량 실패).
+  그래서 (1) 영상 사이에 간격을 두고, (2) 차단은 영상별 스킵이 아니라 **배치 중단**으로
+  다룬다. 차단을 스킵으로 흘리면 "오늘은 볼 영상이 없었다"는 정상 리포트처럼 보인다.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional, Sequence
+
+import httpx
+
+_CHANNEL_URL = "https://www.youtube.com/@{handle}"
+_FEED_URL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+_WATCH_URL = "https://www.youtube.com/watch?v={video_id}"
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/122.0 Safari/537.36"
+    ),
+    "Accept-Language": "ko-KR,ko;q=0.9",
+}
+
+_NS = {
+    "a": "http://www.w3.org/2005/Atom",
+    "yt": "http://www.youtube.com/xml/schemas/2015",
+}
+
+_RE_EXTERNAL_ID = re.compile(r'"externalId":"(UC[\w-]{22})"')
+_RE_OG_TITLE = re.compile(r'<meta property="og:title" content="([^"]*)"')
+_RE_HANDLE = re.compile(r"(?:youtube\.com/)?@?([\w.-]+)/?$")
+
+# 라이브·자막 없는 영상을 지나쳐 목표 편수를 채우기 위해 더 보는 후보 수.
+_SKIP_ALLOWANCE = 3
+
+# youtube-transcript-api 가 IP 차단 시 올리는 예외 이름. 내부 클래스를 import 하면
+# 라이브러리 버전에 묶이므로 이름으로 판별한다.
+_BLOCKED_EXCEPTIONS = frozenset({"IpBlocked", "RequestBlocked"})
+
+
+class TranscriptUnavailable(RuntimeError):
+    """자막을 가져올 수 없는 영상 (라이브/자막 비활성)."""
+
+
+class TranscriptBlocked(TranscriptUnavailable):
+    """YouTube 가 IP를 차단했다. 영상 문제가 아니라 배치 전체가 진행 불가인 상태."""
+
+
+class YoutubeTranscriptCollectorService:
+    """채널 해석 → 최근 영상 목록 → 자막 취득까지 담당한다."""
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        timeout_sec: float = 20.0,
+        http_client=None,
+        transcript_fetcher: Optional[Callable[[str, Sequence[str]], str]] = None,
+        languages: Sequence[str] = ("ko",),
+        request_interval_sec: float = 2.0,
+        sleeper: Optional[Callable[[float], Any]] = None,
+    ):
+        self._logger = logger or logging.getLogger(__name__)
+        self._timeout_sec = float(timeout_sec)
+        self._http_client = http_client
+        self._transcript_fetcher = transcript_fetcher
+        self._languages = tuple(languages)
+        self._request_interval_sec = max(0.0, float(request_interval_sec))
+        self._sleeper = sleeper or asyncio.sleep
+        self.was_blocked = False
+
+    # --- HTTP ---------------------------------------------------------------
+
+    async def _get(self, url: str) -> str:
+        if self._http_client is not None:
+            response = await self._http_client.get(url, headers=_HEADERS)
+            response.raise_for_status()
+            return response.text
+        async with httpx.AsyncClient(
+            follow_redirects=True, timeout=self._timeout_sec
+        ) as client:
+            response = await client.get(url, headers=_HEADERS)
+            response.raise_for_status()
+            return response.text
+
+    # --- 채널 -----------------------------------------------------------------
+
+    async def resolve_channel(self, handle_or_url: str) -> Optional[dict]:
+        """핸들/URL 을 channel_id 로 해석한다. 실패 시 None."""
+        raw = str(handle_or_url or "").strip()
+        matched = _RE_HANDLE.search(raw)
+        if not matched:
+            return None
+        handle = matched.group(1)
+        try:
+            html = await self._get(_CHANNEL_URL.format(handle=handle))
+        except Exception as e:
+            self._logger.warning(f"유튜브 채널 페이지 조회 실패 (@{handle}): {e}")
+            return None
+        found = _RE_EXTERNAL_ID.search(html)
+        if not found:
+            self._logger.warning(f"채널 ID 추출 실패 (@{handle}) — 페이지 구조 변경 의심")
+            return None
+        title = _RE_OG_TITLE.search(html)
+        return {
+            "channel_id": found.group(1),
+            "handle": handle,
+            "title": title.group(1) if title else "",
+        }
+
+    async def list_recent_videos(
+        self, channel_id: str, *, since_hours: float = 24.0, limit: int = 10
+    ) -> list[dict]:
+        """RSS 에서 since_hours 이내 업로드분만 최신순으로 돌려준다."""
+        xml_text = await self._get(_FEED_URL.format(channel_id=channel_id))
+        root = ET.fromstring(xml_text)
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=float(since_hours))
+        videos: list[dict] = []
+        for entry in root.findall("a:entry", _NS):
+            video_id = entry.findtext("yt:videoId", "", _NS)
+            published = entry.findtext("a:published", "", _NS)
+            if not video_id or not self._is_recent(published, cutoff):
+                continue
+            videos.append(
+                {
+                    "video_id": video_id,
+                    "title": entry.findtext("a:title", "", _NS),
+                    "published": published,
+                    "url": _WATCH_URL.format(video_id=video_id),
+                }
+            )
+            if len(videos) >= max(1, int(limit)):
+                break
+        return videos
+
+    @staticmethod
+    def _is_recent(published: str, cutoff: datetime) -> bool:
+        try:
+            return datetime.fromisoformat(published) >= cutoff
+        except ValueError:
+            return False
+
+    # --- 자막 -----------------------------------------------------------------
+
+    def _load_default_fetcher(self) -> Optional[Callable[[str, Sequence[str]], str]]:
+        """youtube-transcript-api 를 지연 import 한다 (미설치 시 None)."""
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+        except ImportError:
+            return None
+
+        api = YouTubeTranscriptApi()
+
+        def fetch(video_id: str, languages: Sequence[str]) -> str:
+            fetched = api.fetch(video_id, languages=list(languages))
+            return " ".join(snippet.text for snippet in fetched)
+
+        return fetch
+
+    async def fetch_transcript(self, video_id: str) -> str:
+        """자막 텍스트를 반환한다. 취득 불가면 TranscriptUnavailable."""
+        fetcher = self._transcript_fetcher or self._load_default_fetcher()
+        if fetcher is None:
+            raise TranscriptUnavailable(
+                "youtube-transcript-api 가 설치되어 있지 않습니다 "
+                "(pip install youtube-transcript-api)"
+            )
+        try:
+            # 라이브러리가 동기 API 라 이벤트 루프를 막지 않도록 스레드로 넘긴다.
+            return await asyncio.to_thread(fetcher, video_id, self._languages)
+        except TranscriptUnavailable:
+            raise
+        except Exception as e:
+            name = type(e).__name__
+            if name in _BLOCKED_EXCEPTIONS:
+                raise TranscriptBlocked(f"{name}: {e}") from e
+            raise TranscriptUnavailable(f"{name}: {e}") from e
+
+    # --- 수집 -----------------------------------------------------------------
+
+    async def collect(
+        self,
+        channels: Sequence[dict],
+        *,
+        since_hours: float = 24.0,
+        max_videos_per_channel: int = 5,
+    ) -> list[dict]:
+        """채널 목록의 최근 영상 자막을 모은다.
+
+        `max_videos_per_channel` 은 후보 수가 아니라 **자막을 확보한 편수** 상한이다.
+        채널의 최신 영상이 라이브인 경우가 흔해(실측: 5채널 중 4채널) 후보를 상한만큼만
+        보면 그 채널이 통째로 빈손이 된다. 아래로 몇 편 더 내려가며 채운다.
+
+        한 채널·한 영상의 실패가 배치 전체를 멈추지 않는다. 실패는 skip_reason 으로
+        남겨 리포트에서 "몇 편을 못 읽었는지"가 보이게 한다.
+        """
+        quota = max(1, int(max_videos_per_channel))
+        self.was_blocked = False
+        items: list[dict] = []
+        requested = 0
+        for channel in channels or []:
+            channel_id = channel.get("channel_id")
+            if not channel_id:
+                continue
+            try:
+                videos = await self.list_recent_videos(
+                    channel_id,
+                    since_hours=since_hours,
+                    limit=quota + _SKIP_ALLOWANCE,
+                )
+            except Exception as e:
+                self._logger.warning(f"유튜브 RSS 조회 실패 ({channel_id}): {e}")
+                continue
+            collected = 0
+            for video in videos:
+                if requested:
+                    await self._pace()
+                requested += 1
+                item = await self._collect_one(channel, video)
+                items.append(item)
+                if item["skip_reason"] == "blocked":
+                    self.was_blocked = True
+                    self._logger.error(
+                        "YouTube 가 IP를 차단해 자막 수집을 중단합니다 — 잠시 후 재시도하세요."
+                    )
+                    return items
+                if item["skip_reason"] is None:
+                    collected += 1
+                    if collected >= quota:
+                        break
+        return items
+
+    async def _pace(self) -> None:
+        if self._request_interval_sec > 0:
+            await self._sleeper(self._request_interval_sec)
+
+    async def _collect_one(self, channel: dict, video: dict) -> dict:
+        item = {
+            "channel_id": channel.get("channel_id", ""),
+            "channel_title": channel.get("title", ""),
+            "transcript": "",
+            "skip_reason": None,
+            **video,
+        }
+        try:
+            transcript = await self.fetch_transcript(video["video_id"])
+        except TranscriptBlocked as e:
+            self._logger.warning(f"자막 차단 ({video['video_id']}): {e}")
+            item["skip_reason"] = "blocked"
+            return item
+        except TranscriptUnavailable as e:
+            self._logger.info(f"자막 스킵 ({video['video_id']}): {e}")
+            item["skip_reason"] = "transcript_unavailable"
+            return item
+        if not str(transcript or "").strip():
+            item["skip_reason"] = "empty_transcript"
+            return item
+        item["transcript"] = transcript
+        return item

--- a/tests/unit_test/repositories/test_youtube_channel_repository.py
+++ b/tests/unit_test/repositories/test_youtube_channel_repository.py
@@ -1,0 +1,94 @@
+"""유튜브 리포트 대상 채널 저장소 단위 테스트."""
+from pathlib import Path
+
+import pytest
+
+from repositories.youtube_channel_repository import (
+    SEED_CHANNELS,
+    YoutubeChannelRepository,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> YoutubeChannelRepository:
+    return YoutubeChannelRepository(db_path=tmp_path / "youtube_channels.db")
+
+
+async def test_add_and_get_all(repo):
+    assert await repo.add("UC" + "a" * 22, handle="foo", title="푸TV") is True
+
+    rows = await repo.get_all()
+
+    assert len(rows) == 1
+    assert rows[0]["channel_id"] == "UC" + "a" * 22
+    assert rows[0]["handle"] == "foo"
+    assert rows[0]["title"] == "푸TV"
+    assert rows[0]["enabled"] is True
+
+
+async def test_add_is_idempotent(repo):
+    cid = "UC" + "b" * 22
+    assert await repo.add(cid, handle="bar") is True
+    assert await repo.add(cid, handle="bar") is False
+
+    assert len(await repo.get_all()) == 1
+
+
+async def test_add_rejects_invalid_channel_id(repo):
+    """UC 로 시작하는 24자만 허용 — 핸들이 잘못 저장되면 수집 전체가 조용히 빈다."""
+    for bad in ["", "foo", "UCshort", "AB" + "c" * 22]:
+        with pytest.raises(ValueError):
+            await repo.add(bad)
+
+    assert await repo.get_all() == []
+
+
+async def test_remove(repo):
+    cid = "UC" + "c" * 22
+    await repo.add(cid)
+
+    assert await repo.remove(cid) is True
+    assert await repo.remove(cid) is False
+    assert await repo.get_all() == []
+
+
+async def test_set_enabled_and_enabled_only_filter(repo):
+    on, off = "UC" + "d" * 22, "UC" + "e" * 22
+    await repo.add(on)
+    await repo.add(off)
+
+    assert await repo.set_enabled(off, False) is True
+
+    assert len(await repo.get_all()) == 2
+    enabled = await repo.get_all(enabled_only=True)
+    assert [row["channel_id"] for row in enabled] == [on]
+
+
+async def test_set_enabled_returns_false_for_unknown_channel(repo):
+    assert await repo.set_enabled("UC" + "f" * 22, False) is False
+
+
+async def test_seed_defaults_inserts_once(repo):
+    assert await repo.seed_defaults() == len(SEED_CHANNELS)
+    assert await repo.seed_defaults() == 0
+
+    rows = await repo.get_all()
+    assert len(rows) == len(SEED_CHANNELS)
+    assert {row["handle"] for row in rows} == {c["handle"] for c in SEED_CHANNELS}
+
+
+async def test_seed_defaults_does_not_resurrect_removed_channel(repo):
+    """사용자가 UI에서 지운 채널이 재시작 때 되살아나면 안 된다."""
+    await repo.seed_defaults()
+    removed = SEED_CHANNELS[0]["channel_id"]
+    await repo.remove(removed)
+
+    assert await repo.seed_defaults() == 0
+    assert removed not in {row["channel_id"] for row in await repo.get_all()}
+
+
+def test_seed_channels_are_wellformed():
+    for channel in SEED_CHANNELS:
+        assert channel["channel_id"].startswith("UC")
+        assert len(channel["channel_id"]) == 24
+        assert channel["handle"]

--- a/tests/unit_test/scripts/test_check_ai_scripts.py
+++ b/tests/unit_test/scripts/test_check_ai_scripts.py
@@ -186,11 +186,23 @@ def test_youtube_dry_run_attaches_usage_limiter_so_script_usage_is_counted():
             "model": "qwen2.5",
             "daily_request_limit": 100,
             "disclosure_reserve": 20,
-        }
+        },
+        MagicMock(),
     )
 
     assert digest is not None
     assert ai_client._usage_limiter is not None
+
+
+def test_youtube_dry_run_does_not_touch_the_stock_code_db():
+    """_build_ai 가 저장소를 직접 만들면 DB 없는 환경에서 KRX 네트워크에 묶인다."""
+    repo = MagicMock()
+
+    _, digest = check_youtube_ai._build_ai(
+        {"enabled": True, "base_url": "http://x/v1", "api_key": "", "model": "m"}, repo
+    )
+
+    assert digest._code_repo is repo
 
 
 def test_youtube_dry_run_chunk_stays_under_input_budget():
@@ -202,7 +214,8 @@ def test_youtube_dry_run_chunk_stays_under_input_budget():
             "api_key": "",
             "model": "qwen2.5",
             "max_input_chars": 24000,
-        }
+        },
+        MagicMock(),
     )
 
     assert digest._chunk_chars < 24000

--- a/tests/unit_test/scripts/test_check_ai_scripts.py
+++ b/tests/unit_test/scripts/test_check_ai_scripts.py
@@ -4,7 +4,7 @@ import pytest
 
 from services.ai_usage_limiter import AiUsageLimitExceeded
 
-from scripts import check_ai_key, check_disclosure_ai, check_news_ai
+from scripts import check_ai_key, check_disclosure_ai, check_news_ai, check_youtube_ai
 
 
 async def test_check_ai_key_allows_empty_api_key_for_ollama(monkeypatch):
@@ -170,3 +170,89 @@ async def test_news_dry_run_no_ai_flag_skips_analyzer(monkeypatch):
 
     build_ai.assert_not_called()
     collector.collect.assert_awaited_once_with("005930", limit=15)
+
+
+def test_youtube_dry_run_returns_no_digest_when_ai_disabled():
+    assert check_youtube_ai._build_ai({"enabled": False}) == (None, None)
+
+
+def test_youtube_dry_run_attaches_usage_limiter_so_script_usage_is_counted():
+    """스크립트가 쓴 요청도 앱과 같은 일일 한도에 집계되어야 한다."""
+    ai_client, digest = check_youtube_ai._build_ai(
+        {
+            "enabled": True,
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+            "daily_request_limit": 100,
+            "disclosure_reserve": 20,
+        }
+    )
+
+    assert digest is not None
+    assert ai_client._usage_limiter is not None
+
+
+def test_youtube_dry_run_chunk_stays_under_input_budget():
+    """청크가 max_input_chars 를 넘으면 AiClient 가 뒤를 잘라 요약이 깨진다."""
+    _, digest = check_youtube_ai._build_ai(
+        {
+            "enabled": True,
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+            "model": "qwen2.5",
+            "max_input_chars": 24000,
+        }
+    )
+
+    assert digest._chunk_chars < 24000
+
+
+async def test_youtube_dry_run_skips_ai_without_flag(monkeypatch, capsys):
+    """기본 실행은 수집·집계만 하고 일일 한도를 소비하지 않는다."""
+    monkeypatch.setattr(
+        check_youtube_ai, "_load_config", lambda: {"ai_analysis": {"enabled": True}}
+    )
+    monkeypatch.setattr(check_youtube_ai.sys, "argv", ["check_youtube_ai.py"])
+    build_ai = MagicMock(return_value=(None, None))
+    monkeypatch.setattr(check_youtube_ai, "_build_ai", build_ai)
+
+    repo = MagicMock()
+    repo.seed_defaults = AsyncMock(return_value=0)
+    repo.get_all = AsyncMock(return_value=[{"channel_id": "UC" + "a" * 22, "title": "채널"}])
+    monkeypatch.setattr(check_youtube_ai, "YoutubeChannelRepository", lambda: repo)
+
+    collector = MagicMock()
+    collector.collect = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        check_youtube_ai, "YoutubeTranscriptCollectorService", lambda: collector
+    )
+    monkeypatch.setattr(check_youtube_ai, "StockCodeRepository", MagicMock())
+
+    await check_youtube_ai._main()
+
+    build_ai.assert_not_called()
+    assert "AI 요약=OFF" in capsys.readouterr().out
+
+
+async def test_youtube_dry_run_stops_early_without_channels(monkeypatch, capsys):
+    monkeypatch.setattr(
+        check_youtube_ai, "_load_config", lambda: {"ai_analysis": {"enabled": True}}
+    )
+    monkeypatch.setattr(check_youtube_ai.sys, "argv", ["check_youtube_ai.py"])
+
+    repo = MagicMock()
+    repo.seed_defaults = AsyncMock(return_value=0)
+    repo.get_all = AsyncMock(return_value=[])
+    monkeypatch.setattr(check_youtube_ai, "YoutubeChannelRepository", lambda: repo)
+
+    collector = MagicMock()
+    collector.collect = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        check_youtube_ai, "YoutubeTranscriptCollectorService", lambda: collector
+    )
+
+    await check_youtube_ai._main()
+
+    collector.collect.assert_not_awaited()
+    assert "등록된 채널이 없습니다" in capsys.readouterr().out

--- a/tests/unit_test/services/test_youtube_digest_service.py
+++ b/tests/unit_test/services/test_youtube_digest_service.py
@@ -1,0 +1,260 @@
+"""유튜브 다이제스트 서비스 단위 테스트."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.types import ErrorCode
+from services.youtube_digest_service import YoutubeDigestService
+
+
+class _FakeCodeRepo:
+    def __init__(self, name_to_code: dict):
+        self.name_to_code = dict(name_to_code)
+
+
+_NAMES = {
+    "삼성전자": "005930",
+    "SK하이닉스": "000660",
+    "SK": "034730",
+    "LG전자": "066570",
+    "네이버": "035420",
+    "대상": "001680",
+    "이닉스": "452400",
+    "코리아": "999999",
+}
+
+
+def _item(video_id: str, transcript: str, **kwargs) -> dict:
+    base = {
+        "video_id": video_id,
+        "title": f"{video_id} 제목",
+        "channel_title": "테스트채널",
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+        "published": "2026-08-10T07:00:00+00:00",
+        "transcript": transcript,
+        "skip_reason": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _service(ai_client=None, **kwargs) -> YoutubeDigestService:
+    return YoutubeDigestService(
+        ai_client or MagicMock(),
+        stock_code_repository=_FakeCodeRepo(_NAMES),
+        **kwargs,
+    )
+
+
+def test_longest_match_prevents_substring_false_positive():
+    """'SK 하이닉스'는 SK하이닉스 1건이어야 한다 — 안쪽의 '이닉스'를 따로 세면 안 된다."""
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "오늘은 SK 하이닉스 얘기입니다.")])
+
+    assert [(m["name"], m["count"]) for m in mentions] == [("SK하이닉스", 1)]
+
+
+def test_two_char_names_are_excluded_as_asr_noise():
+    """2글자 이름은 자막 어절 파편과 충돌해 오검출이 압도적이다 (실측: 레이 59회 전량 오검출)."""
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "SK 주가가 올랐습니다.")])
+
+    assert mentions == []
+
+
+def test_left_boundary_blocks_match_inside_a_word():
+    """'하이닉스'의 뒷부분이 '이닉스' 언급으로 잡히면 안 된다 (실측 13회 오검출)."""
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "하이닉스가 크게 올랐습니다.")])
+
+    assert mentions == []
+
+
+def test_left_boundary_allows_match_after_punctuation():
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "(네이버)와 '삼성전자'를 봅니다.")])
+
+    assert {m["name"] for m in mentions} == {"네이버", "삼성전자"}
+
+
+def test_korean_particles_do_not_block_match():
+    """'삼성전자가/를/는' 처럼 조사가 붙어도 언급으로 세야 한다."""
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "삼성전자가 오르고 삼성전자를 봅니다")])
+
+    assert mentions[0]["count"] == 2
+
+
+def test_ambiguous_common_word_names_are_excluded():
+    """'코리아'는 일반명사처럼 쓰여 카운트가 무의미해진다."""
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "코리아 디스카운트 얘기와 네이버입니다.")])
+
+    assert {m["name"] for m in mentions} == {"네이버"}
+
+
+def test_mentions_aggregate_count_and_video_spread():
+    svc = _service()
+    items = [
+        _item("v1", "삼성전자 삼성전자 네이버"),
+        _item("v2", "삼성전자 LG전자"),
+    ]
+
+    mentions = svc.count_stock_mentions(items)
+
+    by_name = {m["name"]: m for m in mentions}
+    assert by_name["삼성전자"]["count"] == 3
+    assert by_name["삼성전자"]["video_count"] == 2
+    assert by_name["네이버"]["video_count"] == 1
+
+
+def test_mentions_sorted_by_video_count_then_count():
+    """여러 방송이 공통으로 말한 종목이 한 방송의 반복보다 위여야 한다."""
+    svc = _service()
+    items = [
+        _item("v1", "삼성전자 " * 10),
+        _item("v2", "네이버 LG전자"),
+        _item("v3", "네이버 LG전자"),
+    ]
+
+    mentions = svc.count_stock_mentions(items)
+
+    assert [m["name"] for m in mentions[:2]] == ["LG전자", "네이버"]
+    assert mentions[2]["name"] == "삼성전자"
+
+
+def test_mentions_include_code_for_downstream_linking():
+    svc = _service()
+
+    mentions = svc.count_stock_mentions([_item("v1", "네이버 좋습니다")])
+
+    assert mentions[0]["code"] == "035420"
+
+
+def test_skipped_items_are_not_counted():
+    svc = _service()
+
+    mentions = svc.count_stock_mentions(
+        [_item("v1", "", skip_reason="transcript_unavailable")]
+    )
+
+    assert mentions == []
+
+
+def test_count_without_code_repository_returns_empty():
+    svc = YoutubeDigestService(MagicMock(), stock_code_repository=None)
+
+    assert svc.count_stock_mentions([_item("v1", "삼성전자")]) == []
+
+
+async def test_summarize_video_single_call_for_short_transcript():
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value="요약")
+    svc = _service(ai, chunk_chars=100)
+
+    summary = await svc.summarize_video(_item("v1", "짧은 자막"))
+
+    assert summary == "요약"
+    assert ai.complete.await_count == 1
+
+
+async def test_summarize_video_chunks_long_transcript():
+    """실측상 자막이 34,000자까지 나온다 — 입력 예산 안으로 쪼개 호출해야 한다."""
+    ai = MagicMock()
+    ai.complete = AsyncMock(side_effect=["앞부분", "뒷부분"])
+    svc = _service(ai, chunk_chars=100)
+
+    summary = await svc.summarize_video(_item("v1", "가" * 200))
+
+    assert ai.complete.await_count == 2
+    assert "앞부분" in summary and "뒷부분" in summary
+    for call in ai.complete.await_args_list:
+        assert len(call.kwargs["user"]) <= 100 + 500  # 청크 + 프롬프트 여유
+
+
+async def test_build_digest_returns_error_when_no_usable_video():
+    ai = MagicMock()
+    ai.complete = AsyncMock()
+    svc = _service(ai)
+
+    result = await svc.build_digest(
+        [_item("v1", "", skip_reason="empty_transcript")], report_date="20260810"
+    )
+
+    assert result.rt_cd == ErrorCode.EMPTY_VALUES.value
+    ai.complete.assert_not_awaited()
+
+
+async def test_build_digest_produces_report_payload():
+    ai = MagicMock()
+    ai.complete = AsyncMock(side_effect=["v1 요약", "v2 요약", "종합 리포트"])
+    svc = _service(ai)
+
+    result = await svc.build_digest(
+        [_item("v1", "삼성전자 이야기"), _item("v2", "삼성전자 네이버 이야기")],
+        report_date="20260810",
+    )
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    data = result.data
+    assert data["report_date"] == "20260810"
+    assert data["video_count"] == 2
+    assert data["digest_text"] == "종합 리포트"
+    assert data["mentions"][0]["name"] == "삼성전자"
+    assert len(data["videos"]) == 2
+    assert data["videos"][0]["summary"] == "v1 요약"
+
+
+async def test_build_digest_keeps_going_when_one_video_summary_fails():
+    ai = MagicMock()
+    ai.complete = AsyncMock(side_effect=[RuntimeError("upstream 503"), "v2 요약", "종합"])
+    svc = _service(ai)
+
+    result = await svc.build_digest(
+        [_item("v1", "삼성전자"), _item("v2", "네이버")], report_date="20260810"
+    )
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    summaries = [v["summary"] for v in result.data["videos"]]
+    assert summaries[0] == ""
+    assert summaries[1] == "v2 요약"
+    assert result.data["failed_summary_count"] == 1
+
+
+async def test_build_digest_reports_error_when_final_call_fails():
+    ai = MagicMock()
+    ai.complete = AsyncMock(side_effect=["v1 요약", RuntimeError("upstream 503")])
+    svc = _service(ai)
+
+    result = await svc.build_digest([_item("v1", "삼성전자")], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+async def test_digest_prompt_forbids_trading_instructions():
+    """유튜버 발언 집계일 뿐 매매 지시가 아니라는 제약이 프롬프트에 있어야 한다."""
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value="요약")
+    svc = _service(ai)
+
+    await svc.summarize_video(_item("v1", "삼성전자"))
+
+    system = ai.complete.await_args.kwargs["system"]
+    assert "매수" in system and "지시" in system
+
+
+async def test_ai_calls_are_tagged_with_usage_type():
+    """/api/ai/usage 집계에 유튜브 소비가 잡혀야 한다."""
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value="요약")
+    svc = _service(ai)
+
+    await svc.summarize_video(_item("v1", "삼성전자"))
+
+    assert ai.complete.await_args.kwargs["usage_type"] == "youtube"

--- a/tests/unit_test/services/test_youtube_transcript_collector_service.py
+++ b/tests/unit_test/services/test_youtube_transcript_collector_service.py
@@ -1,0 +1,272 @@
+"""유튜브 자막 수집 서비스 단위 테스트 (네트워크·라이브러리 미설치와 무관하게 통과해야 함)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.youtube_transcript_collector_service import (
+    TranscriptBlocked,
+    TranscriptUnavailable,
+    YoutubeTranscriptCollectorService,
+)
+
+
+def _rss(entries: list[tuple[str, str, str]]) -> str:
+    items = "".join(
+        f"<entry><yt:videoId>{vid}</yt:videoId><title>{title}</title>"
+        f"<published>{published}</published></entry>"
+        for vid, title, published in entries
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"'
+        ' xmlns="http://www.w3.org/2005/Atom">'
+        f"{items}</feed>"
+    )
+
+
+def _iso(hours_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+class _FakeResponse:
+    def __init__(self, text: str, status_code: int = 200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeHttp:
+    """httpx.AsyncClient 대역 — URL 접두사별 응답을 돌려준다."""
+
+    def __init__(self, routes: dict):
+        self._routes = routes
+        self.calls: list[str] = []
+
+    async def get(self, url, **kwargs):
+        self.calls.append(url)
+        for prefix, response in self._routes.items():
+            if url.startswith(prefix):
+                return response
+        return _FakeResponse("", status_code=404)
+
+
+def _service(routes: dict, fetcher=None) -> YoutubeTranscriptCollectorService:
+    return YoutubeTranscriptCollectorService(
+        http_client=_FakeHttp(routes),
+        transcript_fetcher=fetcher,
+        request_interval_sec=0,
+    )
+
+
+async def test_resolve_channel_extracts_external_id():
+    """watch/채널 페이지는 channelId 가 아니라 externalId 키를 쓴다 (2026-08 실측)."""
+    html = '<html>..."externalId":"UCXST0Hq6CAmG0dmo3jgrlEw"...' \
+           '<meta property="og:title" content="체슬리TV"></html>'
+    svc = _service({"https://www.youtube.com/@": _FakeResponse(html)})
+
+    result = await svc.resolve_channel("https://www.youtube.com/@chesleytv")
+
+    assert result["channel_id"] == "UCXST0Hq6CAmG0dmo3jgrlEw"
+    assert result["handle"] == "chesleytv"
+    assert result["title"] == "체슬리TV"
+
+
+async def test_resolve_channel_accepts_bare_handle():
+    html = '"externalId":"UC' + "a" * 22 + '"'
+    svc = _service({"https://www.youtube.com/@": _FakeResponse(html)})
+
+    result = await svc.resolve_channel("@rsangmoo")
+
+    assert result["handle"] == "rsangmoo"
+
+
+async def test_resolve_channel_returns_none_when_not_found():
+    svc = _service({"https://www.youtube.com/@": _FakeResponse("<html>없음</html>")})
+
+    assert await svc.resolve_channel("nope") is None
+
+
+async def test_list_recent_videos_filters_by_age():
+    feed = _rss(
+        [
+            ("new1", "최근 영상", _iso(3)),
+            ("old1", "지난주 영상", _iso(72)),
+        ]
+    )
+    svc = _service({"https://www.youtube.com/feeds": _FakeResponse(feed)})
+
+    videos = await svc.list_recent_videos("UC" + "a" * 22, since_hours=24)
+
+    assert [v["video_id"] for v in videos] == ["new1"]
+    assert videos[0]["url"] == "https://www.youtube.com/watch?v=new1"
+
+
+async def test_list_recent_videos_applies_limit():
+    feed = _rss([(f"v{i}", f"영상{i}", _iso(1)) for i in range(5)])
+    svc = _service({"https://www.youtube.com/feeds": _FakeResponse(feed)})
+
+    videos = await svc.list_recent_videos("UC" + "a" * 22, since_hours=24, limit=2)
+
+    assert len(videos) == 2
+
+
+async def test_collect_skips_live_video_without_failing_the_batch():
+    """라이브는 VideoUnplayable 로 실패한다 — 스킵하고 나머지는 계속 수집해야 한다."""
+    feed = _rss([("live1", "모닝브리프 라이브", _iso(1)), ("ok1", "정규 영상", _iso(2))])
+
+    def fetcher(video_id, languages):
+        if video_id == "live1":
+            raise TranscriptUnavailable("live")
+        return "오늘 삼성전자 얘기를 하겠습니다."
+
+    svc = _service({"https://www.youtube.com/feeds": _FakeResponse(feed)}, fetcher)
+
+    items = await svc.collect([{"channel_id": "UC" + "a" * 22, "title": "체슬리TV"}])
+
+    assert len(items) == 2
+    by_id = {item["video_id"]: item for item in items}
+    assert by_id["live1"]["skip_reason"] == "transcript_unavailable"
+    assert by_id["live1"]["transcript"] == ""
+    assert by_id["ok1"]["skip_reason"] is None
+    assert "삼성전자" in by_id["ok1"]["transcript"]
+
+
+async def test_collect_continues_when_one_channel_feed_fails():
+    """한 채널의 RSS 실패가 다른 채널 수집을 막으면 안 된다."""
+    feed = _rss([("ok1", "정규 영상", _iso(1))])
+    good = "UC" + "a" * 22
+    bad = "UC" + "b" * 22
+    routes = {
+        f"https://www.youtube.com/feeds/videos.xml?channel_id={good}": _FakeResponse(feed),
+        f"https://www.youtube.com/feeds/videos.xml?channel_id={bad}": _FakeResponse("", 500),
+    }
+    svc = YoutubeTranscriptCollectorService(
+        http_client=_FakeHttp(routes),
+        transcript_fetcher=lambda video_id, languages: "본문",
+    )
+
+    items = await svc.collect(
+        [{"channel_id": bad, "title": "깨진채널"}, {"channel_id": good, "title": "정상채널"}]
+    )
+
+    assert [item["video_id"] for item in items] == ["ok1"]
+
+
+async def test_collect_marks_empty_transcript_as_skipped():
+    feed = _rss([("v1", "자막없음", _iso(1))])
+    svc = _service(
+        {"https://www.youtube.com/feeds": _FakeResponse(feed)},
+        lambda video_id, languages: "   ",
+    )
+
+    items = await svc.collect([{"channel_id": "UC" + "a" * 22, "title": "채널"}])
+
+    assert items[0]["skip_reason"] == "empty_transcript"
+
+
+async def test_collect_looks_past_live_videos_to_reach_the_quota():
+    """채널 최신 영상이 라이브면 그 아래까지 내려가야 한다 (실측: 5채널 중 4채널이 빈손)."""
+    feed = _rss(
+        [
+            ("live1", "LIVE 장전", _iso(1)),
+            ("live2", "당일전략 라이브", _iso(2)),
+            ("ok1", "정규 영상", _iso(3)),
+            ("ok2", "그 전 영상", _iso(4)),
+        ]
+    )
+
+    def fetcher(video_id, languages):
+        if video_id.startswith("live"):
+            raise TranscriptUnavailable("live")
+        return "자막 본문"
+
+    svc = _service({"https://www.youtube.com/feeds": _FakeResponse(feed)}, fetcher)
+
+    items = await svc.collect(
+        [{"channel_id": "UC" + "a" * 22, "title": "채널"}], max_videos_per_channel=1
+    )
+
+    usable = [item for item in items if not item["skip_reason"]]
+    assert [item["video_id"] for item in usable] == ["ok1"]
+    # 스킵한 라이브도 기록에 남아 "왜 적게 걷혔는지"가 리포트에서 보여야 한다.
+    assert [item["video_id"] for item in items] == ["live1", "live2", "ok1"]
+
+
+async def test_collect_respects_max_videos_per_channel():
+    feed = _rss([(f"v{i}", f"영상{i}", _iso(1)) for i in range(6)])
+    svc = _service(
+        {"https://www.youtube.com/feeds": _FakeResponse(feed)},
+        lambda video_id, languages: "본문",
+    )
+
+    items = await svc.collect(
+        [{"channel_id": "UC" + "a" * 22, "title": "채널"}], max_videos_per_channel=3
+    )
+
+    assert len(items) == 3
+
+
+async def test_ip_block_aborts_the_batch_instead_of_looking_like_normal_skips():
+    """IP 차단(실측 IpBlocked)은 영상별 스킵이 아니라 배치 전체의 실패다.
+
+    그냥 스킵으로 흘리면 '오늘은 볼 영상이 없었다'는 정상 리포트처럼 보인다.
+    """
+    feed = _rss([(f"v{i}", f"영상{i}", _iso(1)) for i in range(3)])
+
+    def fetcher(video_id, languages):
+        raise TranscriptBlocked("IpBlocked")
+
+    good = "UC" + "a" * 22
+    other = "UC" + "b" * 22
+    svc = _service({"https://www.youtube.com/feeds": _FakeResponse(feed)}, fetcher)
+
+    items = await svc.collect(
+        [{"channel_id": good, "title": "채널1"}, {"channel_id": other, "title": "채널2"}]
+    )
+
+    assert [item["skip_reason"] for item in items] == ["blocked"]
+    assert svc.was_blocked is True
+
+
+async def test_blocked_flag_is_false_on_a_clean_run():
+    feed = _rss([("v1", "영상", _iso(1))])
+    svc = _service(
+        {"https://www.youtube.com/feeds": _FakeResponse(feed)},
+        lambda video_id, languages: "본문",
+    )
+
+    await svc.collect([{"channel_id": "UC" + "a" * 22, "title": "채널"}])
+
+    assert svc.was_blocked is False
+
+
+async def test_transcript_fetches_are_spaced_out():
+    """연속 호출이 YouTube 차단을 부른다 — 영상 사이에 간격을 둬야 한다."""
+    feed = _rss([(f"v{i}", f"영상{i}", _iso(1)) for i in range(3)])
+    slept: list[float] = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    svc = YoutubeTranscriptCollectorService(
+        http_client=_FakeHttp({"https://www.youtube.com/feeds": _FakeResponse(feed)}),
+        transcript_fetcher=lambda video_id, languages: "본문",
+        request_interval_sec=1.5,
+        sleeper=fake_sleep,
+    )
+
+    await svc.collect([{"channel_id": "UC" + "a" * 22, "title": "채널"}], max_videos_per_channel=3)
+
+    assert slept == [1.5, 1.5]  # 첫 요청 앞에는 대기하지 않는다
+
+
+async def test_fetch_transcript_raises_when_library_missing():
+    """라이브러리 미설치는 조용한 빈 리포트가 아니라 명시적 실패여야 한다."""
+    svc = YoutubeTranscriptCollectorService(http_client=_FakeHttp({}), transcript_fetcher=None)
+    svc._load_default_fetcher = lambda: None  # 설치 안 된 상황 재현
+
+    with pytest.raises(TranscriptUnavailable):
+        await svc.fetch_transcript("v1")


### PR DESCRIPTION
선정한 유튜브 채널의 최근 영상 자막을 모아 **종목 언급을 집계**하고 **AI로 요약**하는 파이프라인의 기반입니다. 웹 UI 채널 관리 + 자동 스케줄(07:30) + 텔레그램 발송은 후속 PR(5~6단계)로 갑니다.

## 무엇이 들어있나

| 파일 | 역할 |
|---|---|
| `repositories/youtube_channel_repository.py` | 채널 CRUD + enabled 토글. 시드는 최초 1회만 |
| `services/youtube_transcript_collector_service.py` | RSS 영상 목록 + 자막 취득 |
| `services/youtube_digest_service.py` | 종목 언급 집계(AI 미사용) + map-reduce AI 요약 |
| `scripts/check_youtube_ai.py` | dry-run 진단 (기본은 AI 한도 0건) |

집계는 **AI를 쓰지 않습니다.** 자막에서 종목명을 직접 세므로 검증 가능하고 환각이 없습니다. AI는 "무슨 맥락으로 말했는지"만 담당합니다. 리포트는 유튜버의 **발언 집계**이지 매매 판단이 아니며, 프롬프트도 그 선을 넘지 않도록 제약했습니다.

## 2026-08-10 실측으로 확정한 제약

코드를 "단순화"하려다 되살리기 쉬운 함정들이라 주석에 근거를 남겼습니다.

1. **자막 취득 경로는 `youtube-transcript-api` 하나뿐.** watch 페이지의 `captionTracks[].baseUrl` 은 HTTP 200 + **본문 길이 0** 을 반환하고(fmt=json3/srv3/vtt 모두), innertube 는 WEB `UNPLAYABLE` / ANDROID·IOS HTTP 400. 직접 스크래핑은 죽은 경로입니다. 채널 ID 키도 `channelId` 가 아니라 **`externalId`** 입니다.
2. **`IpBlocked` 를 영상별 스킵으로 흘리면 안 됩니다.** 반복 실행 시 IP가 막혀 방금 되던 영상까지 15편 전량 실패했는데, 스킵으로 처리하면 *"오늘은 볼 영상이 없었다"* 는 정상 리포트처럼 위장됩니다. → 별도 예외 + `skip_reason="blocked"` + 배치 즉시 중단 + `was_blocked` 플래그, 영상 사이 2초 간격.
3. **채널 최신 영상이 라이브인 경우가 흔합니다** (5채널 중 4채널). 편수 상한을 "후보 수"로 잡으면 그 채널이 통째로 빈손이 되어, **자막 확보 편수** 기준으로 바꾸고 아래로 더 내려가게 했습니다.
4. **종목 집계는 최장일치 + 좌측경계 + 최소길이 3.** 공백 제거 후 부분문자열 매칭은 `그레이드`→레이(59회), `하이닉스`→이닉스(13회), `에서 한`→서한 을 만듭니다. 조사(가/를/는)는 뒤에 붙으므로 우측 경계는 보지 않습니다.

수정 전후 실측 비교 (동일 영상 6편):

```
전: 삼성전자 16 / 레이 59 / SK하이닉스 8 / 서한 8 / 이닉스 13 / 캐리 5 ...
후: 삼성전자 16 / SK하이닉스 8 / 카카오 6 / 알테오젠 4 / LG전자 16 ...
```

## 검증

- `pytest tests/unit_test` — **7537 passed**
- `pytest tests/integration_test` — **277 passed**
- 실제 dry-run 1회 실행으로 수집·집계·AI 리포트 육안 확인 (AI 다이제스트가 채널 간 공통 화두/단독 언급/불확실 종목명을 의도대로 분리)

## 의존성

`youtube-transcript-api>=1.0.0` 추가 — 위 1번 사유로 대안이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
