### PR TITLE
Add trade trend monitor

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -238,6 +238,21 @@ dart_disclosure:
   daily_digest_time: "19:40"
   max_pages_per_poll: 5
 
+# 수출입동향/제주 반도체 수출 모니터.
+# 관세청_시도별 품목별 수출입실적(GW) 활용신청 후 service key를 넣으면
+# 제주(기본 sido_code=50) 반도체(기본 HS 8542) 월간 수출액을 텔레그램 리포트로 발송합니다.
+trade_trend_monitor:
+  enabled: false
+  customs_service_key: ""
+  poll_interval_sec: 3600
+  request_timeout_sec: 10
+  customs_base_url: "https://openapi.customs.go.kr/openapi/service/newTradestatistics/"
+  sido_code: "50"
+  sido_param_name: "searchSidoCd"
+  item_code: "8542"
+  target_month:
+  state_file_path: "data/trade_trend_state.json"
+
 # AI 분석 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트 공통)
 #   관심종목 신규 공시의 실제 DART 본문을 읽어 최종 중요도와 요약을 산출
 #   본문/AI 조회 실패 시 제목 규칙 판정으로 자동 폴백

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -315,6 +315,23 @@ class DartDisclosureConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class TradeTrendMonitorConfig(BaseModel):
+    enabled: bool = False
+    customs_service_key: str = ""
+    poll_interval_sec: int = Field(3600, ge=60)
+    request_timeout_sec: float = Field(10.0, gt=0)
+    customs_base_url: str = (
+        "https://openapi.customs.go.kr/openapi/service/newTradestatistics/"
+    )
+    sido_code: str = "50"
+    sido_param_name: str = "searchSidoCd"
+    item_code: str = "8542"
+    target_month: Optional[str] = None
+    state_file_path: str = "data/trade_trend_state.json"
+
+    model_config = {"extra": "allow"}
+
+
 class AiAnalysisConfig(BaseModel):
     """AI 분석 공통 설정 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트).
 
@@ -534,6 +551,7 @@ class AppConfig(BaseModel):
     data_quality: DataQualityConfig = Field(default_factory=DataQualityConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     dart_disclosure: DartDisclosureConfig = Field(default_factory=DartDisclosureConfig)
+    trade_trend_monitor: TradeTrendMonitorConfig = Field(default_factory=TradeTrendMonitorConfig)
     ai_analysis: AiAnalysisConfig = Field(default_factory=AiAnalysisConfig)
     position_sizing: PositionSizingConfig = Field(default_factory=PositionSizingConfig)
     execution_quality_report: ExecutionQualityReportConfig = Field(default_factory=ExecutionQualityReportConfig)

--- a/repositories/trade_trend_repository.py
+++ b/repositories/trade_trend_repository.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Union
+
+
+class TradeTrendRepository:
+    def __init__(self, path: Union[str, Path] = "data/trade_trend_state.json") -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._sent_keys: set[str] = set()
+        self._load()
+
+    def has_sent(self, key: str) -> bool:
+        return key in self._sent_keys
+
+    def mark_sent(self, key: str) -> None:
+        self._sent_keys.add(key)
+        self._save()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        self._sent_keys = set(str(key) for key in payload.get("sent_keys", []))
+
+    def _save(self) -> None:
+        payload = {"sent_keys": sorted(self._sent_keys)}
+        self._path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -10,6 +10,7 @@ import logging
 from typing import Optional, List, Dict
 from services.notification_service import NotificationEvent, NotificationCategory, NotificationLevel
 import unicodedata
+from services.trade_trend_service import format_jeju_semiconductor_report_html
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +331,11 @@ class TelegramReporter:
 
         table += "</pre>"
         return header + table
+
+    @_serialized_report_send
+    async def send_jeju_semiconductor_trade_report(self, report) -> bool:
+        """제주 반도체 수출 월간 지표를 텔레그램 리포트 채널로 전송한다."""
+        return await self._send_message(format_jeju_semiconductor_report_html(report))
 
     @_serialized_report_send
     async def send_ranking_report(self, rankings: Dict[str, List[Dict]], report_date: str):

--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import html
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from urllib.parse import urljoin
+from xml.etree import ElementTree as ET
+
+import httpx
+
+
+@dataclass(frozen=True)
+class TradeStatItem:
+    period: str
+    item_name: str
+    item_code: str
+    export_amount_usd: int
+    import_amount_usd: int
+    trade_balance_usd: int
+    export_weight: int = 0
+    import_weight: int = 0
+
+
+@dataclass(frozen=True)
+class JejuSemiconductorTradeReport:
+    period: str
+    export_amount_usd: int
+    previous_month_export_amount_usd: Optional[int]
+    previous_year_export_amount_usd: Optional[int]
+    mom_pct: Optional[float]
+    yoy_pct: Optional[float]
+    jeju_total_export_amount_usd: Optional[int]
+    jeju_export_share_pct: Optional[float]
+    fetched_at: str
+    item_name: str = "제주 반도체"
+
+    @property
+    def dedup_key(self) -> str:
+        return f"jeju_semiconductor:{self.period}:{self.export_amount_usd}"
+
+
+def _text(item: ET.Element, tag: str, default: str = "") -> str:
+    node = item.find(tag)
+    if node is None or node.text is None:
+        return default
+    return node.text.strip()
+
+
+def _int_text(item: ET.Element, tag: str) -> int:
+    raw = _text(item, tag, "0").replace(",", "")
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def parse_customs_trade_xml(xml_text: str) -> list[TradeStatItem]:
+    root = ET.fromstring(xml_text)
+    result_code = root.findtext("./header/resultCode", default="")
+    if result_code and result_code != "00":
+        result_msg = root.findtext("./header/resultMsg", default="UNKNOWN ERROR")
+        raise ValueError(f"관세청 수출입통계 API 오류: {result_code} {result_msg}")
+
+    rows: list[TradeStatItem] = []
+    for item in root.findall(".//item"):
+        period = _text(item, "year")
+        if not period or period == "총계":
+            continue
+        rows.append(
+            TradeStatItem(
+                period=period,
+                item_name=_text(item, "statKor"),
+                item_code=_text(item, "hsCode"),
+                export_amount_usd=_int_text(item, "expDlr"),
+                import_amount_usd=_int_text(item, "impDlr"),
+                trade_balance_usd=_int_text(item, "balPayments"),
+                export_weight=_int_text(item, "expWgt"),
+                import_weight=_int_text(item, "impWgt"),
+            )
+        )
+    return rows
+
+
+class CustomsTradeStatClient:
+    """관세청 GW 수출입통계 API 클라이언트."""
+
+    DEFAULT_BASE_URL = "https://openapi.customs.go.kr/openapi/service/newTradestatistics/"
+
+    def __init__(
+        self,
+        *,
+        service_key: str,
+        http_client=None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_sec: float = 10.0,
+        sido_param_name: str = "searchSidoCd",
+        sido_code: str = "50",
+    ) -> None:
+        self._service_key = service_key
+        self._base_url = base_url if base_url.endswith("/") else f"{base_url}/"
+        self._timeout_sec = timeout_sec
+        self._http_client = http_client
+        self._sido_param_name = sido_param_name
+        self._sido_code = sido_code
+
+    async def fetch_sido_item_month(
+        self, yyyymm: str, item_code: str
+    ) -> list[TradeStatItem]:
+        params = {
+            "searchBgnDe": yyyymm,
+            "searchEndDe": yyyymm,
+            "searchItemCd": item_code,
+            self._sido_param_name: self._sido_code,
+            "serviceKey": self._service_key,
+        }
+        return await self._get("getsidoitemtradeList", params)
+
+    async def fetch_sido_total_month(self, yyyymm: str) -> list[TradeStatItem]:
+        params = {
+            "searchBgnDe": yyyymm,
+            "searchEndDe": yyyymm,
+            self._sido_param_name: self._sido_code,
+            "serviceKey": self._service_key,
+        }
+        return await self._get("getsidotradeList", params)
+
+    async def _get(self, operation: str, params: dict) -> list[TradeStatItem]:
+        url = urljoin(self._base_url, operation)
+        if self._http_client is not None:
+            response = await self._http_client.get(url, params=params, timeout=self._timeout_sec)
+            response.raise_for_status()
+            return parse_customs_trade_xml(response.text)
+
+        async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            return parse_customs_trade_xml(response.text)
+
+
+def _pct(current: Optional[int], base: Optional[int]) -> Optional[float]:
+    if current is None or base in (None, 0):
+        return None
+    return (current - base) / base * 100
+
+
+def _first_export(rows: list[TradeStatItem]) -> Optional[TradeStatItem]:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: row.export_amount_usd)
+
+
+def build_jeju_semiconductor_report(
+    *,
+    current: TradeStatItem,
+    previous_month: Optional[TradeStatItem],
+    previous_year: Optional[TradeStatItem],
+    jeju_total: Optional[TradeStatItem],
+    fetched_at: datetime,
+) -> JejuSemiconductorTradeReport:
+    previous_month_amount = (
+        previous_month.export_amount_usd if previous_month is not None else None
+    )
+    previous_year_amount = (
+        previous_year.export_amount_usd if previous_year is not None else None
+    )
+    total_amount = jeju_total.export_amount_usd if jeju_total is not None else None
+    share = None
+    if total_amount:
+        share = current.export_amount_usd / total_amount * 100
+    return JejuSemiconductorTradeReport(
+        period=current.period,
+        export_amount_usd=current.export_amount_usd,
+        previous_month_export_amount_usd=previous_month_amount,
+        previous_year_export_amount_usd=previous_year_amount,
+        mom_pct=_pct(current.export_amount_usd, previous_month_amount),
+        yoy_pct=_pct(current.export_amount_usd, previous_year_amount),
+        jeju_total_export_amount_usd=total_amount,
+        jeju_export_share_pct=share,
+        fetched_at=fetched_at.isoformat(),
+        item_name=current.item_name or "제주 반도체",
+    )
+
+
+def select_export_row(rows: list[TradeStatItem]) -> Optional[TradeStatItem]:
+    return _first_export(rows)
+
+
+def format_jeju_semiconductor_report_html(
+    report: JejuSemiconductorTradeReport,
+) -> str:
+    def money(value: Optional[int]) -> str:
+        if value is None:
+            return "-"
+        return f"{value / 1_000_000:,.1f}백만 달러"
+
+    def pct(value: Optional[float]) -> str:
+        if value is None:
+            return "-"
+        return f"{value:+.1f}%"
+
+    return "\n".join(
+        [
+            f"📦 <b>제주 반도체 수출 ({html.escape(report.period, quote=False)})</b>",
+            f"수출액: <b>{money(report.export_amount_usd)}</b>",
+            f"전월비: {pct(report.mom_pct)} / 전년비: {pct(report.yoy_pct)}",
+            f"제주 전체 수출 내 비중: {pct(report.jeju_export_share_pct)}",
+            f"전월: {money(report.previous_month_export_amount_usd)}",
+            f"전년동월: {money(report.previous_year_export_amount_usd)}",
+            "",
+            "※ 지역 통관 통계이므로 제주반도체 매출과 1:1 대응하지 않습니다.",
+        ]
+    )

--- a/task/background/always_on/trade_trend_monitor_task.py
+++ b/task/background/always_on/trade_trend_monitor_task.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Optional
+
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+from repositories.trade_trend_repository import TradeTrendRepository
+from services.trade_trend_service import (
+    build_jeju_semiconductor_report,
+    select_export_row,
+)
+
+
+def _month_delta(yyyymm: str, delta_months: int) -> str:
+    year = int(yyyymm[:4])
+    month = int(yyyymm[4:6]) + delta_months
+    while month <= 0:
+        year -= 1
+        month += 12
+    while month > 12:
+        year += 1
+        month -= 12
+    return f"{year:04d}{month:02d}"
+
+
+def _latest_available_month(now: datetime) -> str:
+    # 지역별 품목 월간 통계는 익월 중순 이후 확인하는 보수적 기준으로 본다.
+    first_day_this_month = now.replace(day=1)
+    return _month_delta(first_day_this_month.strftime("%Y%m"), -1)
+
+
+class TradeTrendMonitorTask(SchedulableTask):
+    def __init__(
+        self,
+        *,
+        customs_client,
+        repository_path: str = "data/trade_trend_state.json",
+        telegram_reporter=None,
+        config=None,
+        market_clock=None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._client = customs_client
+        self._repository = TradeTrendRepository(repository_path)
+        self._reporter = telegram_reporter
+        self._config = config
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._tasks: list[asyncio.Task] = []
+        self._tick_lock: Optional[asyncio.Lock] = None
+        self._progress = {
+            "running": False,
+            "last_checked_at": None,
+            "last_success_at": None,
+            "last_period": None,
+            "sent_count": 0,
+            "last_error": None,
+        }
+
+    @property
+    def task_name(self) -> str:
+        return "trade_trend_monitor"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    def get_progress(self) -> dict:
+        return dict(self._progress)
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        self._state = TaskState.RUNNING
+        self._progress["running"] = True
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+        self._progress["running"] = False
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.RUNNING
+
+    def _get_tick_lock(self) -> asyncio.Lock:
+        if self._tick_lock is None:
+            self._tick_lock = asyncio.Lock()
+        return self._tick_lock
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                if self._state == TaskState.RUNNING:
+                    try:
+                        await self._tick()
+                    except Exception as exc:
+                        self._progress["last_error"] = f"{type(exc).__name__}: {exc}"
+                        self._logger.error(
+                            "%s: 수출입동향 조회 실패 — %s",
+                            self.task_name,
+                            exc,
+                            exc_info=True,
+                        )
+                await asyncio.sleep(int(getattr(self._config, "poll_interval_sec", 3600)))
+        except asyncio.CancelledError:
+            pass
+
+    async def _tick(self) -> None:
+        lock = self._get_tick_lock()
+        if lock.locked():
+            return
+        async with lock:
+            now = self._market_clock.get_current_kst_time()
+            yyyymm = str(getattr(self._config, "target_month", "") or "")
+            if not yyyymm:
+                yyyymm = _latest_available_month(now)
+            item_code = str(getattr(self._config, "item_code", "8542"))
+            previous_month = _month_delta(yyyymm, -1)
+            previous_year = _month_delta(yyyymm, -12)
+
+            self._progress["last_checked_at"] = now.isoformat()
+            self._progress["last_period"] = yyyymm
+            self._progress["last_error"] = None
+
+            current = select_export_row(
+                await self._client.fetch_sido_item_month(yyyymm, item_code)
+            )
+            if current is None:
+                return
+            prev = select_export_row(
+                await self._client.fetch_sido_item_month(previous_month, item_code)
+            )
+            prev_year = select_export_row(
+                await self._client.fetch_sido_item_month(previous_year, item_code)
+            )
+            total = select_export_row(await self._client.fetch_sido_total_month(yyyymm))
+
+            report = build_jeju_semiconductor_report(
+                current=current,
+                previous_month=prev,
+                previous_year=prev_year,
+                jeju_total=total,
+                fetched_at=now,
+            )
+            if self._repository.has_sent(report.dedup_key):
+                self._progress["last_success_at"] = now.isoformat()
+                return
+            if self._reporter is None:
+                return
+
+            sent = await self._reporter.send_jeju_semiconductor_trade_report(report)
+            if sent:
+                self._repository.mark_sent(report.dedup_key)
+                self._progress["sent_count"] += 1
+                self._progress["last_success_at"] = now.isoformat()

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.trade_trend_service import (
+    CustomsTradeStatClient,
+    TradeStatItem,
+    build_jeju_semiconductor_report,
+    parse_customs_trade_xml,
+)
+
+
+CUSTOMS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>00</resultCode>
+    <resultMsg>NORMAL SERVICE.</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <year>2026.05</year>
+        <statKor>집적회로 반도체</statKor>
+        <hsCode>8542</hsCode>
+        <expDlr>46585000</expDlr>
+        <expWgt>1200</expWgt>
+        <impDlr>1000</impDlr>
+        <impWgt>10</impWgt>
+        <balPayments>46584000</balPayments>
+      </item>
+      <item>
+        <year>총계</year>
+        <statKor>-</statKor>
+        <hsCode>-</hsCode>
+        <expDlr>46585000</expDlr>
+        <impDlr>1000</impDlr>
+        <balPayments>46584000</balPayments>
+      </item>
+    </items>
+  </body>
+</response>
+"""
+
+
+def test_parse_customs_trade_xml_skips_total_row_and_parses_amounts():
+    rows = parse_customs_trade_xml(CUSTOMS_XML)
+
+    assert rows == [
+        TradeStatItem(
+            period="2026.05",
+            item_name="집적회로 반도체",
+            item_code="8542",
+            export_amount_usd=46585000,
+            import_amount_usd=1000,
+            trade_balance_usd=46584000,
+            export_weight=1200,
+            import_weight=10,
+        )
+    ]
+
+
+def test_parse_customs_trade_xml_raises_on_api_error():
+    xml = "<response><header><resultCode>99</resultCode><resultMsg>bad key</resultMsg></header></response>"
+
+    with pytest.raises(ValueError, match="bad key"):
+        parse_customs_trade_xml(xml)
+
+
+class DummyResponse:
+    status_code = 200
+    text = CUSTOMS_XML
+
+    def raise_for_status(self):
+        return None
+
+
+class DummyHttpClient:
+    def __init__(self):
+        self.get = AsyncMock(return_value=DummyResponse())
+
+
+@pytest.mark.asyncio
+async def test_customs_client_calls_sido_item_endpoint_with_configured_params():
+    http_client = DummyHttpClient()
+    client = CustomsTradeStatClient(
+        service_key="test-key",
+        http_client=http_client,
+        base_url="https://example.test/openapi/service/newTradestatistics",
+        sido_param_name="searchSidoCd",
+        sido_code="50",
+    )
+
+    rows = await client.fetch_sido_item_month("202605", "8542")
+
+    assert rows[0].export_amount_usd == 46585000
+    http_client.get.assert_awaited_once()
+    url = http_client.get.await_args.args[0]
+    params = http_client.get.await_args.kwargs["params"]
+    assert url.endswith("/getsidoitemtradeList")
+    assert params["searchBgnDe"] == "202605"
+    assert params["searchEndDe"] == "202605"
+    assert params["searchItemCd"] == "8542"
+    assert params["searchSidoCd"] == "50"
+    assert params["serviceKey"] == "test-key"
+
+
+def test_build_jeju_semiconductor_report_calculates_mom_yoy_and_share():
+    current = TradeStatItem("2026.05", "집적회로 반도체", "8542", 46585000, 0, 0)
+    prev = TradeStatItem("2026.04", "집적회로 반도체", "8542", 30000000, 0, 0)
+    prev_year = TradeStatItem("2025.05", "집적회로 반도체", "8542", 10000000, 0, 0)
+    total = TradeStatItem("2026.05", "제주 전체", "-", 63590000, 0, 0)
+
+    report = build_jeju_semiconductor_report(
+        current=current,
+        previous_month=prev,
+        previous_year=prev_year,
+        jeju_total=total,
+        fetched_at=datetime(2026, 6, 16, 9, 30),
+    )
+
+    assert report.period == "2026.05"
+    assert report.export_amount_usd == 46585000
+    assert report.mom_pct == pytest.approx(55.2833)
+    assert report.yoy_pct == pytest.approx(365.85)
+    assert report.jeju_export_share_pct == pytest.approx(73.2584)
+    assert report.dedup_key == "jeju_semiconductor:2026.05:46585000"

--- a/tests/unit_test/task/background/always_on/test_trade_trend_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_trade_trend_monitor_task.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from interfaces.schedulable_task import TaskState
+from services.trade_trend_service import TradeStatItem
+from task.background.always_on.trade_trend_monitor_task import TradeTrendMonitorTask
+
+
+class DummyClock:
+    def __init__(self, now: datetime):
+        self._now = now
+
+    def get_current_kst_time(self):
+        return self._now
+
+
+@pytest.mark.asyncio
+async def test_tick_sends_jeju_semiconductor_report_once(tmp_path):
+    current = TradeStatItem("2026.05", "집적회로 반도체", "8542", 46585000, 0, 0)
+    previous_month = TradeStatItem("2026.04", "집적회로 반도체", "8542", 30000000, 0, 0)
+    previous_year = TradeStatItem("2025.05", "집적회로 반도체", "8542", 10000000, 0, 0)
+    total = TradeStatItem("2026.05", "제주 전체", "-", 63590000, 0, 0)
+    async def fetch_sido_item_month(yyyymm, item_code):
+        return {
+            "202605": [current],
+            "202604": [previous_month],
+            "202505": [previous_year],
+        }[yyyymm]
+
+    client = SimpleNamespace(
+        fetch_sido_item_month=AsyncMock(side_effect=fetch_sido_item_month),
+        fetch_sido_total_month=AsyncMock(return_value=[total]),
+    )
+    reporter = SimpleNamespace(send_jeju_semiconductor_trade_report=AsyncMock(return_value=True))
+    task = TradeTrendMonitorTask(
+        customs_client=client,
+        repository_path=str(tmp_path / "trade_trend_state.json"),
+        telegram_reporter=reporter,
+        config=SimpleNamespace(item_code="8542"),
+        market_clock=DummyClock(datetime(2026, 6, 16, 9, 30)),
+        logger=MagicMock(),
+    )
+
+    await task._tick()
+    await task._tick()
+
+    reporter.send_jeju_semiconductor_trade_report.assert_awaited_once()
+    assert task.get_progress()["sent_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_start_stop_cancels_background_loop(tmp_path):
+    client = SimpleNamespace(
+        fetch_sido_item_month=AsyncMock(return_value=[]),
+        fetch_sido_total_month=AsyncMock(return_value=[]),
+    )
+    task = TradeTrendMonitorTask(
+        customs_client=client,
+        repository_path=str(tmp_path / "trade_trend_state.json"),
+        telegram_reporter=None,
+        config=SimpleNamespace(poll_interval_sec=3600),
+        market_clock=DummyClock(datetime(2026, 6, 16, 9, 30)),
+        logger=MagicMock(),
+    )
+
+    await task.start()
+    assert task.state == TaskState.RUNNING
+    await task.stop()
+
+    assert task.state == TaskState.STOPPED

--- a/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
+++ b/tests/unit_test/view/web/bootstrap/test_scheduler_bootstrap.py
@@ -131,6 +131,16 @@ def test_web_registers_optional_dart_disclosure_monitor(patched_scheduler_deps):
     assert "dart_disclosure_monitor" in names
 
 
+def test_web_registers_optional_trade_trend_monitor(patched_scheduler_deps):
+    ctx = _make_fake_context(RuntimeMode.WEB)
+    ctx.trade_trend_monitor_task = MagicMock(task_name="trade_trend_monitor")
+
+    _run(ctx)
+
+    names = _registered_bg_task_names(patched_scheduler_deps)
+    assert "trade_trend_monitor" in names
+
+
 def test_overseas_us_registers_dryrun_task(patched_scheduler_deps):
     ctx = _make_fake_context(RuntimeMode.WEB)
     ctx.market_mode = "overseas_us"

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -38,6 +38,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "AiNewsAnalyzer", "StockNewsCollectorService",
     "DartDisclosureClient", "DartDisclosureRepository",
     "DartDisclosureRuleService", "DartDisclosureMonitorTask",
+    "CustomsTradeStatClient", "TradeTrendMonitorTask",
 ]
 
 REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
@@ -176,6 +177,52 @@ def test_service_container_skips_dart_pipeline_without_key(patched_service_conta
 
     assert ctx.dart_disclosure_monitor_task is None
     patched_service_container_deps["DartDisclosureClient"].assert_not_called()
+
+
+def test_service_container_builds_enabled_trade_trend_monitor(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.runtime_mode = RuntimeMode.WEB
+    ctx.full_config = {
+        "trade_trend_monitor": {
+            "enabled": True,
+            "customs_service_key": "customs-key",
+            "request_timeout_sec": 7,
+            "sido_code": "50",
+            "sido_param_name": "searchSidoCd",
+        }
+    }
+
+    ServiceContainer(ctx).run()
+
+    client_cls = patched_service_container_deps["CustomsTradeStatClient"]
+    client_cls.assert_called_once()
+    client_kwargs = client_cls.call_args.kwargs
+    assert client_kwargs["service_key"] == "customs-key"
+    assert client_kwargs["timeout_sec"] == 7.0
+    assert client_kwargs["sido_code"] == "50"
+    task_kwargs = patched_service_container_deps["TradeTrendMonitorTask"].call_args.kwargs
+    assert task_kwargs["customs_client"] is client_cls.return_value
+    assert task_kwargs["telegram_reporter"] is ctx.telegram_reporter
+    assert ctx.trade_trend_monitor_task is patched_service_container_deps[
+        "TradeTrendMonitorTask"
+    ].return_value
+
+
+def test_service_container_skips_trade_trend_monitor_without_key(
+    patched_service_container_deps,
+):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.runtime_mode = RuntimeMode.WEB
+    ctx.full_config = {"trade_trend_monitor": {"enabled": True, "customs_service_key": ""}}
+
+    ServiceContainer(ctx).run()
+
+    assert ctx.trade_trend_monitor_task is None
+    patched_service_container_deps["CustomsTradeStatClient"].assert_not_called()
 
 
 def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_container_deps):

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -106,6 +106,7 @@ class SchedulerBootstrap:
         # NotificationQueueTask 는 TimeDispatcher 등록 대상이 아님 (always-on)
         self._register(ctx.notification_queue_task)
         self._register(self._optional_task("dart_disclosure_monitor_task"))
+        self._register(self._optional_task("trade_trend_monitor_task"))
         # 미국장 시간대 판단은 태스크가 자체 US 클럭으로 수행하므로 TimeDispatcher 미등록
         self._register(self._optional_task("overseas_favorite_price_alert_task"))
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -18,6 +18,7 @@ from config.config_loader import (
     OrderPolicyConfig,
     PositionSizingConfig,
     RiskGateConfig,
+    TradeTrendMonitorConfig,
 )
 from core.account_snapshot import AccountSnapshotCache
 from core.market_clock import MarketClock
@@ -38,6 +39,7 @@ from services.ai_news_analyzer import AiNewsAnalyzer
 from services.stock_news_collector_service import StockNewsCollectorService
 from services.dart_disclosure_client import DartDisclosureClient
 from services.dart_disclosure_rule_service import DartDisclosureRuleService
+from services.trade_trend_service import CustomsTradeStatClient
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
@@ -70,6 +72,7 @@ from task.background.after_market.theme_daily_leader_report_task import ThemeDai
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
 from task.background.always_on.notification_queue_task import NotificationQueueTask
 from task.background.always_on.dart_disclosure_monitor_task import DartDisclosureMonitorTask
+from task.background.always_on.trade_trend_monitor_task import TradeTrendMonitorTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
@@ -288,6 +291,33 @@ class ServiceContainer:
                     logger=ctx.logger,
                     ai_analyzer=ctx.ai_disclosure_analyzer,
                     notification_service=ctx.notification_service,
+                )
+
+        ctx.trade_trend_monitor_task = None
+        raw_trade_trend_config = config_dict.get("trade_trend_monitor") or {}
+        trade_trend_config = TradeTrendMonitorConfig.model_validate(raw_trade_trend_config)
+        if trade_trend_config.enabled:
+            if not needs_web:
+                ctx.logger.info("수출입동향 모니터는 WEB 런타임에서만 동작합니다.")
+            elif not trade_trend_config.customs_service_key:
+                ctx.logger.warning("수출입동향 모니터가 활성화됐지만 관세청 API 키가 없어 비활성화합니다.")
+            elif getattr(ctx, "telegram_reporter", None) is None:
+                ctx.logger.warning("수출입동향 모니터가 활성화됐지만 텔레그램 리포터가 없어 비활성화합니다.")
+            else:
+                ctx.trade_trend_customs_client = CustomsTradeStatClient(
+                    service_key=trade_trend_config.customs_service_key,
+                    base_url=trade_trend_config.customs_base_url,
+                    timeout_sec=float(trade_trend_config.request_timeout_sec),
+                    sido_param_name=trade_trend_config.sido_param_name,
+                    sido_code=trade_trend_config.sido_code,
+                )
+                ctx.trade_trend_monitor_task = TradeTrendMonitorTask(
+                    customs_client=ctx.trade_trend_customs_client,
+                    repository_path=trade_trend_config.state_file_path,
+                    telegram_reporter=ctx.telegram_reporter,
+                    config=trade_trend_config,
+                    market_clock=ctx.market_clock,
+                    logger=ctx.logger,
                 )
 
         try:


### PR DESCRIPTION
﻿## What changed
- Added a trade trend monitor for Jeju semiconductor export statistics using the Korea Customs GW trade-stat API.
- Added stateful duplicate-send protection and a Telegram report formatter/sender.
- Wired the monitor into WEB-mode service bootstrap and always-on scheduler registration behind a disabled-by-default config section.

## Why
Jeju regional semiconductor export data is a useful leading indicator for estimating Jeju Semiconductor revenue direction, while remaining separate from the national export trend polling flow.

## Validation
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v`
