### PR TITLE
Limit period ranking reports to week end

### DIFF
--- a/task/background/after_market/ranking_task.py
+++ b/task/background/after_market/ranking_task.py
@@ -610,6 +610,9 @@ class RankingTask(AfterMarketTask):
     async def _send_period_ranking_report_once(self, target_date: str, days: int) -> None:
         if not self._telegram_reporter:
             return
+        if not await self._is_week_last_trading_day(target_date):
+            self._logger.info(f"기간수급 리포트 전송 스킵: {target_date}은 주 마지막 거래일이 아님")
+            return
         if self._load_last_period_ranking_report_date() == str(target_date):
             self._logger.info(f"텔레그램 기간수급 리포트 이미 전송 완료 ({target_date}) — 스킵")
             return
@@ -625,6 +628,21 @@ class RankingTask(AfterMarketTask):
                 self._save_last_period_ranking_report_date(target_date)
         except Exception as e:
             self._logger.error(f"텔레그램 기간수급 리포트 전송 중 오류: {e}", exc_info=True)
+
+    async def _is_week_last_trading_day(self, target_date: str) -> bool:
+        target = datetime.strptime(str(target_date), "%Y%m%d")
+        if self._mcs is None:
+            return target.weekday() == 4
+
+        try:
+            next_open_day = await self._mcs.get_next_open_day(str(target_date))
+            if not next_open_day or next_open_day == str(target_date):
+                return target.weekday() == 4
+            next_open = datetime.strptime(str(next_open_day), "%Y%m%d")
+            return next_open.isocalendar()[:2] != target.isocalendar()[:2]
+        except Exception as e:
+            self._logger.warning(f"주 마지막 거래일 판정 실패: {target_date}, {e}")
+            return target.weekday() == 4
 
     @staticmethod
     def _build_ranking(results: List[Dict], pbmn_field: str, top_n: int = 30):

--- a/tests/unit_test/scheduler/test_ranking_task_execute.py
+++ b/tests/unit_test/scheduler/test_ranking_task_execute.py
@@ -153,15 +153,52 @@ async def test_send_period_ranking_report_sends_five_day_ranking_once(tmp_path):
         telegram_reporter=reporter,
         ranking_report_state_path=str(tmp_path / "ranking_report_state.json"),
     )
-    task._period_ranking_cache[("20260722", 5)] = [
+    task._period_ranking_cache[("20260724", 5)] = [
         {"hts_kor_isnm": "SK하이닉스", "combined_period_ntby_tr_pbmn_won": "3000000000"},
     ]
 
-    await task._send_period_ranking_report_once("20260722", 5)
-    await task._send_period_ranking_report_once("20260722", 5)
+    await task._send_period_ranking_report_once("20260724", 5)
+    await task._send_period_ranking_report_once("20260724", 5)
 
     reporter.send_period_investor_ranking_report.assert_awaited_once_with(
-        task._period_ranking_cache[("20260722", 5)], report_date="20260722", days=5,
+        task._period_ranking_cache[("20260724", 5)], report_date="20260724", days=5,
+    )
+
+
+async def test_send_period_ranking_report_skips_before_week_last_trading_day(tmp_path):
+    reporter = MagicMock()
+    reporter.send_period_investor_ranking_report = AsyncMock(return_value=True)
+    task = _make_task(
+        telegram_reporter=reporter,
+        ranking_report_state_path=str(tmp_path / "ranking_report_state.json"),
+    )
+    task._period_ranking_cache[("20260810", 5)] = [
+        {"hts_kor_isnm": "셀트리온", "combined_period_ntby_tr_pbmn_won": "289400000000"},
+    ]
+
+    await task._send_period_ranking_report_once("20260810", 5)
+
+    reporter.send_period_investor_ranking_report.assert_not_called()
+
+
+async def test_send_period_ranking_report_sends_on_holiday_shortened_week_last_day(tmp_path):
+    reporter = MagicMock()
+    reporter.send_period_investor_ranking_report = AsyncMock(return_value=True)
+    mcs = MagicMock()
+    mcs.get_next_open_day = AsyncMock(return_value="20260727")
+    task = _make_task(
+        telegram_reporter=reporter,
+        market_calendar_service=mcs,
+        ranking_report_state_path=str(tmp_path / "ranking_report_state.json"),
+    )
+    task._period_ranking_cache[("20260723", 5)] = [
+        {"hts_kor_isnm": "SK하이닉스", "combined_period_ntby_tr_pbmn_won": "3000000000"},
+    ]
+
+    await task._send_period_ranking_report_once("20260723", 5)
+
+    reporter.send_period_investor_ranking_report.assert_awaited_once_with(
+        task._period_ranking_cache[("20260723", 5)], report_date="20260723", days=5,
     )
 
 


### PR DESCRIPTION
﻿## What changed

- Gate the 5-trading-day period investor ranking Telegram report so it only sends on the week's last trading day.
- Use `MarketCalendarService.get_next_open_day()` when available so holiday-shortened weeks can send before Friday.
- Keep a Friday-only fallback when the market calendar is unavailable or cannot determine the next open day.

## Why

The period ranking report was sent whenever the rolling 5-trading-day cache was warmed after market close. That allowed Monday reports like `20260810`, even though the intended behavior is a weekly end-of-week report.

## Validation

- `pytest tests/unit_test/scheduler/test_ranking_task_execute.py -v`
- `pytest tests/unit_test -v`
- `pytest tests/integration_test -v`
