### PR TITLE
Add national trade trend monitor

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -243,6 +243,8 @@ dart_disclosure:
 # 제주(기본 sido_code=50) 반도체(기본 HS 8542) 월간 수출액을 텔레그램 리포트로 발송합니다.
 trade_trend_monitor:
   enabled: false
+  national_enabled: true
+  jeju_semiconductor_enabled: true
   customs_service_key: ""
   poll_interval_sec: 3600
   request_timeout_sec: 10
@@ -251,6 +253,10 @@ trade_trend_monitor:
   sido_param_name: "searchSidoCd"
   item_code: "8542"
   target_month:
+  national_list_urls:
+    - "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362&searchType=all&searchValue=%EC%88%98%EC%B6%9C%EC%9E%85%20%ED%98%84%ED%99%A9"
+    - "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchCondition=1&searchKeyword=%EC%88%98%EC%B6%9C%EC%9E%85%20%EB%8F%99%ED%96%A5"
+  national_max_detail_pages: 5
   state_file_path: "data/trade_trend_state.json"
 
 # AI 분석 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트 공통)

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -317,6 +317,8 @@ class DartDisclosureConfig(BaseModel):
 
 class TradeTrendMonitorConfig(BaseModel):
     enabled: bool = False
+    national_enabled: bool = True
+    jeju_semiconductor_enabled: bool = True
     customs_service_key: str = ""
     poll_interval_sec: int = Field(3600, ge=60)
     request_timeout_sec: float = Field(10.0, gt=0)
@@ -327,6 +329,11 @@ class TradeTrendMonitorConfig(BaseModel):
     sido_param_name: str = "searchSidoCd"
     item_code: str = "8542"
     target_month: Optional[str] = None
+    national_list_urls: List[str] = Field(default_factory=lambda: [
+        "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362&searchType=all&searchValue=%EC%88%98%EC%B6%9C%EC%9E%85%20%ED%98%84%ED%99%A9",
+        "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchCondition=1&searchKeyword=%EC%88%98%EC%B6%9C%EC%9E%85%20%EB%8F%99%ED%96%A5",
+    ])
+    national_max_detail_pages: int = Field(5, ge=1, le=20)
     state_file_path: str = "data/trade_trend_state.json"
 
     model_config = {"extra": "allow"}

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -10,7 +10,10 @@ import logging
 from typing import Optional, List, Dict
 from services.notification_service import NotificationEvent, NotificationCategory, NotificationLevel
 import unicodedata
-from services.trade_trend_service import format_jeju_semiconductor_report_html
+from services.trade_trend_service import (
+    format_jeju_semiconductor_report_html,
+    format_national_trade_trend_report_html,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +339,11 @@ class TelegramReporter:
     async def send_jeju_semiconductor_trade_report(self, report) -> bool:
         """제주 반도체 수출 월간 지표를 텔레그램 리포트 채널로 전송한다."""
         return await self._send_message(format_jeju_semiconductor_report_html(report))
+
+    @_serialized_report_send
+    async def send_national_trade_trend_report(self, release) -> bool:
+        """전국 수출입 잠정치/월간 동향을 텔레그램 리포트 채널로 전송한다."""
+        return await self._send_message(format_national_trade_trend_report_html(release))
 
     @_serialized_report_send
     async def send_ranking_report(self, rankings: Dict[str, List[Dict]], report_date: str):

--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
@@ -38,6 +39,27 @@ class JejuSemiconductorTradeReport:
     @property
     def dedup_key(self) -> str:
         return f"jeju_semiconductor:{self.period}:{self.export_amount_usd}"
+
+
+@dataclass(frozen=True)
+class NationalTradeTrendRelease:
+    source: str
+    phase: str
+    title: str
+    url: str
+    period_label: str
+    export_amount_100m_usd: Optional[float] = None
+    export_yoy_pct: Optional[float] = None
+    import_amount_100m_usd: Optional[float] = None
+    import_yoy_pct: Optional[float] = None
+    trade_balance_100m_usd: Optional[float] = None
+    trade_balance_label: str = ""
+    published_at: str = ""
+    highlights: list[str] = None
+
+    @property
+    def dedup_key(self) -> str:
+        return f"national_trade:{self.phase}:{self.period_label}:{self.url}"
 
 
 def _text(item: ET.Element, tag: str, default: str = "") -> str:
@@ -138,6 +160,64 @@ class CustomsTradeStatClient:
             return parse_customs_trade_xml(response.text)
 
 
+class NationalTradeTrendWebClient:
+    """관세청/산업부 보도자료 목록에서 전국 수출입 발표를 찾는다."""
+
+    DEFAULT_LIST_URLS = [
+        "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362&searchType=all&searchValue=%EC%88%98%EC%B6%9C%EC%9E%85%20%ED%98%84%ED%99%A9",
+        "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchCondition=1&searchKeyword=%EC%88%98%EC%B6%9C%EC%9E%85%20%EB%8F%99%ED%96%A5",
+    ]
+
+    def __init__(
+        self,
+        *,
+        http_client=None,
+        list_urls: Optional[list[str]] = None,
+        timeout_sec: float = 10.0,
+        max_detail_pages: int = 5,
+    ) -> None:
+        self._http_client = http_client
+        self._list_urls = list_urls or list(self.DEFAULT_LIST_URLS)
+        self._timeout_sec = timeout_sec
+        self._max_detail_pages = max_detail_pages
+
+    async def fetch_recent_releases(self) -> list[NationalTradeTrendRelease]:
+        releases: list[NationalTradeTrendRelease] = []
+        detail_url_groups: list[list[tuple[str, str]]] = []
+        for list_url in self._list_urls:
+            html_text = await self._fetch_text(list_url)
+            detail_url_groups.append(_extract_national_trade_links(html_text, list_url))
+
+        seen: set[str] = set()
+        for title, url in _interleave(detail_url_groups):
+            if url in seen:
+                continue
+            seen.add(url)
+            if len(releases) >= self._max_detail_pages:
+                break
+            detail_text = await self._fetch_text(url)
+            release = parse_national_trade_release(
+                title=title,
+                url=url,
+                source=_source_from_url(url),
+                text=detail_text,
+            )
+            if release.export_amount_100m_usd is None and release.import_amount_100m_usd is None:
+                continue
+            releases.append(release)
+        return releases
+
+    async def _fetch_text(self, url: str) -> str:
+        if self._http_client is not None:
+            response = await self._http_client.get(url, timeout=self._timeout_sec)
+            response.raise_for_status()
+            return response.text
+        async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.text
+
+
 def _pct(current: Optional[int], base: Optional[int]) -> Optional[float]:
     if current is None or base in (None, 0):
         return None
@@ -186,6 +266,212 @@ def select_export_row(rows: list[TradeStatItem]) -> Optional[TradeStatItem]:
     return _first_export(rows)
 
 
+def _clean_text(text: str) -> str:
+    text = html.unescape(re.sub(r"<[^>]+>", " ", str(text or "")))
+    text = re.sub(r"[\u00a0\r\n\t]+", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"(\d)\s+(년|월|일|억|달러|%)", r"\1\2", text)
+    return text.strip()
+
+
+def _source_from_url(url: str) -> str:
+    if "motir.go.kr" in url or "motie.go.kr" in url:
+        return "motie"
+    if "customs.go.kr" in url:
+        return "customs"
+    return "unknown"
+
+
+def _phase_from_title(title: str) -> str:
+    if re.search(r"1\s*일\s*[~∼-]\s*(?:\d{1,2}\s*월\s*)?10\s*일", title):
+        return "customs_10d"
+    if re.search(r"1\s*일\s*[~∼-]\s*(?:\d{1,2}\s*월\s*)?20\s*일", title):
+        return "customs_20d"
+    if "잠정치" in title:
+        return "customs_monthly"
+    return "motie_monthly"
+
+
+def _period_from_title(title: str, phase: str) -> str:
+    year_match = re.search(r"(\d{4})년", title)
+    month_match = re.search(r"(\d{1,2})월", title)
+    year = year_match.group(1) if year_match else ""
+    month = month_match.group(1) if month_match else ""
+    if not year or not month:
+        return title
+    if phase == "customs_10d":
+        return f"{year}년 {month}월 1~10일"
+    if phase == "customs_20d":
+        return f"{year}년 {month}월 1~20일"
+    return f"{year}년 {month}월"
+
+
+def _float(pattern: str, text: str) -> Optional[float]:
+    match = re.search(pattern, text)
+    if not match:
+        return None
+    try:
+        return float(match.group(1).replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _trade_label_pattern(label: str) -> str:
+    if label == "수출":
+        return r"수출(?!입)"
+    if label == "수입":
+        return r"(?<!수출)수입"
+    return re.escape(label)
+
+
+def _extract_amount_after(label: str, text: str) -> Optional[float]:
+    return _float(
+        rf"{_trade_label_pattern(label)}[^。]{{0,180}}?([0-9]+(?:\.[0-9]+)?)\s*억\s*달러",
+        text,
+    )
+
+
+def _signed_pct(value: Optional[float], text: str, start: int = 0) -> Optional[float]:
+    if value is None:
+        return None
+    window = text[start : start + 80]
+    if "감소" in window or "△" in window:
+        return -abs(value)
+    return value
+
+
+def _extract_yoy_after(label: str, text: str) -> Optional[float]:
+    label_pattern = _trade_label_pattern(label)
+    stop_pattern = r"(?<!수출)수입|무역수지" if label == "수출" else r"수출(?!입)|무역수지"
+    for label_match in re.finditer(label_pattern, text):
+        window = text[label_match.end() : label_match.end() + 180]
+        stop_match = re.search(stop_pattern, window)
+        if stop_match:
+            window = window[: stop_match.start()]
+        pct_match = re.search(r"([0-9]+(?:\.[0-9]+)?)\s*%", window)
+        if not pct_match:
+            continue
+        try:
+            value = float(pct_match.group(1))
+        except ValueError:
+            continue
+        return _signed_pct(value, window, pct_match.end())
+    return None
+
+
+def _extract_balance(text: str) -> tuple[Optional[float], str]:
+    match = re.search(r"무역수지(?:는)?\s*([0-9]+(?:\.[0-9]+)?)\s*억\s*달러\s*(흑자|적자)", text)
+    if not match:
+        return None, ""
+    amount = float(match.group(1).replace(",", ""))
+    label = match.group(2)
+    return (-amount if label == "적자" else amount), label
+
+
+def _extract_highlights(text: str) -> list[str]:
+    candidates = []
+    for sentence in re.split(r"[.。◇ㅇ]\s*", text):
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        if any(keyword in sentence for keyword in ("반도체", "승용차", "자동차", "선박", "석유제품", "주요 수출국")):
+            candidates.append(sentence[:180])
+        if len(candidates) >= 3:
+            break
+    return candidates
+
+
+def _attr(tag: str, name: str) -> str:
+    match = re.search(
+        rf"\b{name}\s*=\s*([\"'])(.*?)\1",
+        tag,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return ""
+    return html.unescape(match.group(2)).strip()
+
+
+def _interleave(groups: list[list[tuple[str, str]]]) -> list[tuple[str, str]]:
+    items: list[tuple[str, str]] = []
+    max_len = max((len(group) for group in groups), default=0)
+    for index in range(max_len):
+        for group in groups:
+            if index < len(group):
+                items.append(group[index])
+    return items
+
+
+def parse_national_trade_release(
+    *,
+    title: str,
+    url: str,
+    source: str,
+    text: str,
+) -> NationalTradeTrendRelease:
+    cleaned_title = _clean_text(title)
+    cleaned_text = _clean_text(text)
+    phase = _phase_from_title(cleaned_title)
+    export_amount = _extract_amount_after("수출", cleaned_text)
+    import_amount = _extract_amount_after("수입", cleaned_text)
+    balance_amount, balance_label = _extract_balance(cleaned_text)
+    published = ""
+    published_match = re.search(r"등록일\s*\|?\s*(\d{4}[.-]\d{2}[.-]\d{2})", cleaned_text)
+    if published_match:
+        published = published_match.group(1).replace(".", "-")
+    return NationalTradeTrendRelease(
+        source=source,
+        phase=phase,
+        title=cleaned_title,
+        url=url,
+        period_label=_period_from_title(cleaned_title, phase),
+        export_amount_100m_usd=export_amount,
+        export_yoy_pct=_extract_yoy_after("수출", cleaned_text),
+        import_amount_100m_usd=import_amount,
+        import_yoy_pct=_extract_yoy_after("수입", cleaned_text),
+        trade_balance_100m_usd=balance_amount,
+        trade_balance_label=balance_label,
+        published_at=published,
+        highlights=_extract_highlights(cleaned_text),
+    )
+
+
+def _extract_national_trade_links(html_text: str, base_url: str) -> list[tuple[str, str]]:
+    links: list[tuple[str, str]] = []
+    for match in re.finditer(
+        r"(<a\b[^>]*>)(.*?)</a>",
+        html_text,
+        flags=re.IGNORECASE | re.DOTALL,
+    ):
+        tag = match.group(1)
+        href = _attr(tag, "href")
+        title = _clean_text(match.group(2))
+        title_attr = _attr(tag, "title")
+        if title_attr:
+            title = title_attr
+        if not title:
+            continue
+        is_customs = "수출입 현황" in title and "잠정치" in title
+        is_motie = re.fullmatch(r"\d{4}년\s*\d{1,2}월\s*수출입\s*동향", title) is not None
+        if not (is_customs or is_motie):
+            continue
+        if is_customs and "nttInfoBtn" in tag:
+            ntt_sn = _attr(tag, "data-id")
+            ntt_sn_url = _attr(tag, "data-url")
+            if not ntt_sn:
+                continue
+            href = f"/kcs/na/ntt/selectNttInfo.do?bbsId=1362&mi=2891&nttSn={ntt_sn}"
+            if ntt_sn_url:
+                href = f"{href}&nttSnUrl={ntt_sn_url}"
+        elif is_motie and href.startswith("javascript:"):
+            article_match = re.search(r"article\.view\(['\"]?(\d+)", href)
+            if not article_match:
+                continue
+            href = f"/kor/article/ATCL3f49a5a8c/{article_match.group(1)}/view"
+        links.append((title, urljoin(base_url, href)))
+    return links
+
+
 def format_jeju_semiconductor_report_html(
     report: JejuSemiconductorTradeReport,
 ) -> str:
@@ -211,3 +497,34 @@ def format_jeju_semiconductor_report_html(
             "※ 지역 통관 통계이므로 제주반도체 매출과 1:1 대응하지 않습니다.",
         ]
     )
+
+
+def format_national_trade_trend_report_html(
+    release: NationalTradeTrendRelease,
+) -> str:
+    def money(value: Optional[float], include_label: bool = False) -> str:
+        if value is None:
+            return "-"
+        label = f" {release.trade_balance_label}" if include_label and release.trade_balance_label else ""
+        return f"{abs(value):,.1f}억 달러{label}"
+
+    def pct(value: Optional[float]) -> str:
+        if value is None:
+            return "-"
+        return f"{value:+.1f}%"
+
+    title = "전국 수출입 잠정치"
+    if release.phase == "motie_monthly":
+        title = "전국 월간 수출입동향"
+    elif release.phase == "customs_monthly":
+        title = "전국 월간 수출입 잠정치"
+    lines = [
+        f"🌐 <b>{title} ({html.escape(release.period_label, quote=False)})</b>",
+        f"수출: <b>{money(release.export_amount_100m_usd)}</b> ({pct(release.export_yoy_pct)})",
+        f"수입: <b>{money(release.import_amount_100m_usd)}</b> ({pct(release.import_yoy_pct)})",
+        f"무역수지: <b>{money(release.trade_balance_100m_usd, include_label=True)}</b>",
+    ]
+    if release.highlights:
+        lines += ["", *[f"• {html.escape(item, quote=False)}" for item in release.highlights[:3]]]
+    lines += ["", f'<a href="{html.escape(release.url, quote=False)}">원문 보기</a>']
+    return "\n".join(lines)

--- a/task/background/always_on/trade_trend_monitor_task.py
+++ b/task/background/always_on/trade_trend_monitor_task.py
@@ -36,6 +36,7 @@ class TradeTrendMonitorTask(SchedulableTask):
         self,
         *,
         customs_client,
+        national_client=None,
         repository_path: str = "data/trade_trend_state.json",
         telegram_reporter=None,
         config=None,
@@ -43,6 +44,7 @@ class TradeTrendMonitorTask(SchedulableTask):
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._client = customs_client
+        self._national_client = national_client
         self._repository = TradeTrendRepository(repository_path)
         self._reporter = telegram_reporter
         self._config = config
@@ -57,6 +59,7 @@ class TradeTrendMonitorTask(SchedulableTask):
             "last_success_at": None,
             "last_period": None,
             "sent_count": 0,
+            "national_sent_count": 0,
             "last_error": None,
         }
 
@@ -132,13 +135,21 @@ class TradeTrendMonitorTask(SchedulableTask):
             yyyymm = str(getattr(self._config, "target_month", "") or "")
             if not yyyymm:
                 yyyymm = _latest_available_month(now)
-            item_code = str(getattr(self._config, "item_code", "8542"))
-            previous_month = _month_delta(yyyymm, -1)
-            previous_year = _month_delta(yyyymm, -12)
-
             self._progress["last_checked_at"] = now.isoformat()
             self._progress["last_period"] = yyyymm
             self._progress["last_error"] = None
+
+            if bool(getattr(self._config, "national_enabled", True)):
+                await self._send_national_releases()
+
+            if not bool(getattr(self._config, "jeju_semiconductor_enabled", True)):
+                return
+            if self._client is None:
+                return
+
+            item_code = str(getattr(self._config, "item_code", "8542"))
+            previous_month = _month_delta(yyyymm, -1)
+            previous_year = _month_delta(yyyymm, -12)
 
             current = select_export_row(
                 await self._client.fetch_sido_item_month(yyyymm, item_code)
@@ -171,3 +182,15 @@ class TradeTrendMonitorTask(SchedulableTask):
                 self._repository.mark_sent(report.dedup_key)
                 self._progress["sent_count"] += 1
                 self._progress["last_success_at"] = now.isoformat()
+
+    async def _send_national_releases(self) -> None:
+        if self._national_client is None or self._reporter is None:
+            return
+        releases = await self._national_client.fetch_recent_releases()
+        for release in releases:
+            if self._repository.has_sent(release.dedup_key):
+                continue
+            sent = await self._reporter.send_national_trade_trend_report(release)
+            if sent:
+                self._repository.mark_sent(release.dedup_key)
+                self._progress["national_sent_count"] += 1

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -5,8 +5,12 @@ import pytest
 
 from services.trade_trend_service import (
     CustomsTradeStatClient,
+    NationalTradeTrendRelease,
+    NationalTradeTrendWebClient,
     TradeStatItem,
     build_jeju_semiconductor_report,
+    format_national_trade_trend_report_html,
+    parse_national_trade_release,
     parse_customs_trade_xml,
 )
 
@@ -125,3 +129,226 @@ def test_build_jeju_semiconductor_report_calculates_mom_yoy_and_share():
     assert report.yoy_pct == pytest.approx(365.85)
     assert report.jeju_export_share_pct == pytest.approx(73.2584)
     assert report.dedup_key == "jeju_semiconductor:2026.05:46585000"
+
+
+def test_parse_national_customs_20d_release_extracts_summary_numbers():
+    text = """
+    2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]
+    등록일 2026.07.21
+    관세청은 21 일, 7 월 1 일~20 일 기간의 수출입 현황 잠정치를 발표 했다.
+    동기간 수출은 549 억 달러 로 전년동기대비 52.3% 증가, 수입은 427 억 달러 로
+    20.0% 증가 했으며, 무역수지는 122 억 달러 흑자 를 기록했다고 밝혔다.
+    반도체(221 억 달러) 수출 7 월 기준 역대최대
+    """
+
+    release = parse_national_trade_release(
+        title="2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]",
+        url="https://customs.example/20d",
+        source="customs",
+        text=text,
+    )
+
+    assert release.phase == "customs_20d"
+    assert release.period_label == "2026년 7월 1~20일"
+    assert release.export_amount_100m_usd == pytest.approx(549)
+    assert release.export_yoy_pct == pytest.approx(52.3)
+    assert release.import_amount_100m_usd == pytest.approx(427)
+    assert release.import_yoy_pct == pytest.approx(20.0)
+    assert release.trade_balance_100m_usd == pytest.approx(122)
+    assert release.trade_balance_label == "흑자"
+    assert "반도체" in release.highlights[0]
+    assert release.dedup_key == "national_trade:customs_20d:2026년 7월 1~20일:https://customs.example/20d"
+
+
+def test_parse_national_motie_monthly_release_extracts_summary_numbers():
+    text = """
+    2026년 5월 수출입 동향
+    5월 수출은 전년 동월 대비 53.2% 증가한 877.5억 달러로 월 기준 역대 최대실적을 기록했다.
+    5월 수입은 전년 동월 대비 20.8% 증가한 608.0억 달러를 기록했다.
+    무역수지는 269.5억 달러 흑자로 전년 동월 대비 200.3억 달러 증가하였다.
+    반도체 수출이 169.4% 증가해 전체 수출 증가세를 주도했다.
+    """
+
+    release = parse_national_trade_release(
+        title="2026년 5월 수출입 동향",
+        url="https://motie.example/monthly",
+        source="motie",
+        text=text,
+    )
+
+    assert release.phase == "motie_monthly"
+    assert release.period_label == "2026년 5월"
+    assert release.export_amount_100m_usd == pytest.approx(877.5)
+    assert release.export_yoy_pct == pytest.approx(53.2)
+    assert release.import_amount_100m_usd == pytest.approx(608.0)
+    assert release.import_yoy_pct == pytest.approx(20.8)
+    assert release.trade_balance_100m_usd == pytest.approx(269.5)
+    assert release.trade_balance_label == "흑자"
+
+
+def test_format_national_trade_trend_report_html_includes_link_and_numbers():
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 7월 1일 ~ 7월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d?a=1&b=2",
+        period_label="2026년 7월 1~10일",
+        export_amount_100m_usd=298,
+        export_yoy_pct=53.9,
+        import_amount_100m_usd=235,
+        import_yoy_pct=17.4,
+        trade_balance_100m_usd=64,
+        trade_balance_label="흑자",
+        highlights=["반도체 수출 증가"],
+    )
+
+    message = format_national_trade_trend_report_html(release)
+
+    assert "전국 수출입 잠정치" in message
+    assert "수출: <b>298.0억 달러</b> (+53.9%)" in message
+    assert "수입: <b>235.0억 달러</b> (+17.4%)" in message
+    assert "무역수지: <b>64.0억 달러 흑자</b>" in message
+    assert "https://customs.example/10d?a=1&amp;b=2" in message
+
+
+class DummyTextResponse:
+    status_code = 200
+
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_national_web_client_discovers_matching_links_and_fetches_details():
+    list_html = """
+    <a href="javascript:" data-id="10170523" data-url="abc123" class="nttInfoBtn"
+       title="2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]">
+        2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]
+    </a>
+    <a href="/kcs/na/ntt/selectNttInfo.do?nttSn=2">다른 보도자료</a>
+    """
+    detail_html = """
+    <h3>2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]</h3>
+    동기간 수출은 549 억 달러 로 전년동기대비 52.3% 증가, 수입은 427 억 달러 로
+    20.0% 증가 했으며, 무역수지는 122 억 달러 흑자 를 기록했다고 밝혔다.
+    """
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(list_html),
+            DummyTextResponse(detail_html),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=["https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362"],
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert len(releases) == 1
+    assert releases[0].phase == "customs_20d"
+    assert releases[0].url == (
+        "https://www.customs.go.kr/kcs/na/ntt/selectNttInfo.do"
+        "?bbsId=1362&mi=2891&nttSn=10170523&nttSnUrl=abc123"
+    )
+    assert releases[0].export_amount_100m_usd == pytest.approx(549)
+
+
+@pytest.mark.asyncio
+async def test_national_web_client_discovers_motie_article_view_links():
+    list_html = """
+    <a href="javascript:article.view('172077');"><i>2026년 7월 수출입 동향</i></a>
+    """
+    detail_html = """
+    <h3>2026년 7월 수출입 동향</h3>
+    7월 수출은 전년 동월 대비 21.1% 증가한 620.0억 달러로 집계됐다.
+    수입은 전년 동월 대비 12.3% 증가한 530.0억 달러를 기록했다.
+    무역수지는 90.0억 달러 흑자였다.
+    """
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(list_html),
+            DummyTextResponse(detail_html),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=["https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchKeyword=x"],
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert len(releases) == 1
+    assert releases[0].phase == "motie_monthly"
+    assert releases[0].url == "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c/172077/view"
+    assert releases[0].export_amount_100m_usd == pytest.approx(620.0)
+
+
+@pytest.mark.asyncio
+async def test_national_web_client_interleaves_sources_before_detail_limit():
+    customs_list_html = """
+    <a href="javascript:" data-id="10170523" class="nttInfoBtn"
+       title="2026년 7월 1일 ~ 7월 20일 수출입 현황 [잠정치]">customs latest</a>
+    <a href="javascript:" data-id="10169503" class="nttInfoBtn"
+       title="2026년 7월 1일 ~ 7월 10일 수출입 현황 [잠정치]">customs previous</a>
+    """
+    motie_list_html = """
+    <a href="javascript:article.view('172077');"><i>2026년 7월 수출입 동향</i></a>
+    """
+    customs_detail_html = "수출은 549억 달러로 전년동기대비 52.3% 증가, 수입은 427억 달러로 20.0% 증가, 무역수지는 122억 달러 흑자"
+    motie_detail_html = "수출은 전년 동월 대비 21.1% 증가한 620억 달러, 수입은 전년 동월 대비 12.3% 증가한 530억 달러, 무역수지는 90억 달러 흑자"
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(customs_list_html),
+            DummyTextResponse(motie_list_html),
+            DummyTextResponse(customs_detail_html),
+            DummyTextResponse(motie_detail_html),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=[
+            "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362",
+            "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchKeyword=x",
+        ],
+        max_detail_pages=2,
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert [release.source for release in releases] == ["customs", "motie"]
+
+
+@pytest.mark.asyncio
+async def test_national_web_client_skips_unparseable_and_unrelated_motie_releases():
+    list_html = """
+    <a href="javascript:article.view('1');"><i>2026년 7월 수출입 동향</i></a>
+    <a href="javascript:article.view('2');"><i>2026년 상반기 및 6월 정보통신산업(ICT) 수출입 동향</i></a>
+    <a href="javascript:article.view('3');"><i>2026년 6월 수출입 동향</i></a>
+    """
+    empty_detail_html = "<h3>2026년 7월 수출입 동향</h3>보도자료입니다."
+    parseable_detail_html = "수출은 전년 동월 대비 53.2% 증가한 877.5억 달러, 수입은 전년 동월 대비 20.8% 증가한 608.0억 달러"
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(list_html),
+            DummyTextResponse(empty_detail_html),
+            DummyTextResponse(parseable_detail_html),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=["https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchKeyword=x"],
+        max_detail_pages=2,
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert len(releases) == 1
+    assert releases[0].period_label == "2026년 6월"

--- a/tests/unit_test/task/background/always_on/test_trade_trend_monitor_task.py
+++ b/tests/unit_test/task/background/always_on/test_trade_trend_monitor_task.py
@@ -6,6 +6,7 @@ import pytest
 
 from interfaces.schedulable_task import TaskState
 from services.trade_trend_service import TradeStatItem
+from services.trade_trend_service import NationalTradeTrendRelease
 from task.background.always_on.trade_trend_monitor_task import TradeTrendMonitorTask
 
 
@@ -49,6 +50,51 @@ async def test_tick_sends_jeju_semiconductor_report_once(tmp_path):
 
     reporter.send_jeju_semiconductor_trade_report.assert_awaited_once()
     assert task.get_progress()["sent_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_sends_national_trade_releases_once(tmp_path):
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 7월 1일 ~ 7월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 7월 1~10일",
+        export_amount_100m_usd=298,
+        export_yoy_pct=53.9,
+        import_amount_100m_usd=235,
+        import_yoy_pct=17.4,
+        trade_balance_100m_usd=64,
+        trade_balance_label="흑자",
+    )
+    client = SimpleNamespace(
+        fetch_sido_item_month=AsyncMock(return_value=[]),
+        fetch_sido_total_month=AsyncMock(return_value=[]),
+    )
+    national_client = SimpleNamespace(fetch_recent_releases=AsyncMock(return_value=[release]))
+    reporter = SimpleNamespace(
+        send_jeju_semiconductor_trade_report=AsyncMock(return_value=True),
+        send_national_trade_trend_report=AsyncMock(return_value=True),
+    )
+    task = TradeTrendMonitorTask(
+        customs_client=client,
+        national_client=national_client,
+        repository_path=str(tmp_path / "trade_trend_state.json"),
+        telegram_reporter=reporter,
+        config=SimpleNamespace(
+            item_code="8542",
+            jeju_semiconductor_enabled=False,
+            national_enabled=True,
+        ),
+        market_clock=DummyClock(datetime(2026, 7, 11, 9, 30)),
+        logger=MagicMock(),
+    )
+
+    await task._tick()
+    await task._tick()
+
+    reporter.send_national_trade_trend_report.assert_awaited_once_with(release)
+    assert task.get_progress()["national_sent_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -38,7 +38,7 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "AiNewsAnalyzer", "StockNewsCollectorService",
     "DartDisclosureClient", "DartDisclosureRepository",
     "DartDisclosureRuleService", "DartDisclosureMonitorTask",
-    "CustomsTradeStatClient", "TradeTrendMonitorTask",
+    "CustomsTradeStatClient", "NationalTradeTrendWebClient", "TradeTrendMonitorTask",
 ]
 
 REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
@@ -202,15 +202,18 @@ def test_service_container_builds_enabled_trade_trend_monitor(patched_service_co
     assert client_kwargs["service_key"] == "customs-key"
     assert client_kwargs["timeout_sec"] == 7.0
     assert client_kwargs["sido_code"] == "50"
+    national_cls = patched_service_container_deps["NationalTradeTrendWebClient"]
+    national_cls.assert_called_once()
     task_kwargs = patched_service_container_deps["TradeTrendMonitorTask"].call_args.kwargs
     assert task_kwargs["customs_client"] is client_cls.return_value
+    assert task_kwargs["national_client"] is national_cls.return_value
     assert task_kwargs["telegram_reporter"] is ctx.telegram_reporter
     assert ctx.trade_trend_monitor_task is patched_service_container_deps[
         "TradeTrendMonitorTask"
     ].return_value
 
 
-def test_service_container_skips_trade_trend_monitor_without_key(
+def test_service_container_builds_national_trade_trend_monitor_without_key(
     patched_service_container_deps,
 ):
     from view.web.bootstrap.service_container import ServiceContainer
@@ -221,8 +224,13 @@ def test_service_container_skips_trade_trend_monitor_without_key(
 
     ServiceContainer(ctx).run()
 
-    assert ctx.trade_trend_monitor_task is None
+    assert ctx.trade_trend_monitor_task is patched_service_container_deps[
+        "TradeTrendMonitorTask"
+    ].return_value
     patched_service_container_deps["CustomsTradeStatClient"].assert_not_called()
+    patched_service_container_deps["NationalTradeTrendWebClient"].assert_called_once()
+    task_kwargs = patched_service_container_deps["TradeTrendMonitorTask"].call_args.kwargs
+    assert task_kwargs["customs_client"] is None
 
 
 def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_container_deps):

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -39,7 +39,7 @@ from services.ai_news_analyzer import AiNewsAnalyzer
 from services.stock_news_collector_service import StockNewsCollectorService
 from services.dart_disclosure_client import DartDisclosureClient
 from services.dart_disclosure_rule_service import DartDisclosureRuleService
-from services.trade_trend_service import CustomsTradeStatClient
+from services.trade_trend_service import CustomsTradeStatClient, NationalTradeTrendWebClient
 from services.minervini_stage_service import MinerviniStageService
 from services.naver_finance_scraper_service import NaverFinanceScraperService
 from services.newhigh_service import NewHighService
@@ -299,20 +299,31 @@ class ServiceContainer:
         if trade_trend_config.enabled:
             if not needs_web:
                 ctx.logger.info("수출입동향 모니터는 WEB 런타임에서만 동작합니다.")
-            elif not trade_trend_config.customs_service_key:
-                ctx.logger.warning("수출입동향 모니터가 활성화됐지만 관세청 API 키가 없어 비활성화합니다.")
             elif getattr(ctx, "telegram_reporter", None) is None:
                 ctx.logger.warning("수출입동향 모니터가 활성화됐지만 텔레그램 리포터가 없어 비활성화합니다.")
             else:
-                ctx.trade_trend_customs_client = CustomsTradeStatClient(
-                    service_key=trade_trend_config.customs_service_key,
-                    base_url=trade_trend_config.customs_base_url,
+                ctx.trade_trend_customs_client = None
+                if trade_trend_config.jeju_semiconductor_enabled:
+                    if not trade_trend_config.customs_service_key:
+                        ctx.logger.warning(
+                            "제주 반도체 수출 모니터는 관세청 API 키가 없어 스킵합니다."
+                        )
+                    else:
+                        ctx.trade_trend_customs_client = CustomsTradeStatClient(
+                            service_key=trade_trend_config.customs_service_key,
+                            base_url=trade_trend_config.customs_base_url,
+                            timeout_sec=float(trade_trend_config.request_timeout_sec),
+                            sido_param_name=trade_trend_config.sido_param_name,
+                            sido_code=trade_trend_config.sido_code,
+                        )
+                ctx.national_trade_trend_client = NationalTradeTrendWebClient(
+                    list_urls=list(trade_trend_config.national_list_urls),
                     timeout_sec=float(trade_trend_config.request_timeout_sec),
-                    sido_param_name=trade_trend_config.sido_param_name,
-                    sido_code=trade_trend_config.sido_code,
+                    max_detail_pages=int(trade_trend_config.national_max_detail_pages),
                 )
                 ctx.trade_trend_monitor_task = TradeTrendMonitorTask(
                     customs_client=ctx.trade_trend_customs_client,
+                    national_client=ctx.national_trade_trend_client,
                     repository_path=trade_trend_config.state_file_path,
                     telegram_reporter=ctx.telegram_reporter,
                     config=trade_trend_config,


### PR DESCRIPTION
## Summary
- add national export/import release polling for customs and MOTIR bulletin pages
- send deduplicated Telegram reports for national trade trend releases
- allow national monitoring to run without the Jeju customs API key

## Validation
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v
- smoke-tested NationalTradeTrendWebClient against live customs/MOTIR pages