### PR TITLE
feat: 유튜브 다이제스트 5~6단계 (저장소·07:30 스케줄·웹 UI)

### DIFF
--- a/repositories/youtube_digest_repository.py
+++ b/repositories/youtube_digest_repository.py
@@ -1,0 +1,195 @@
+"""
+유튜브 일일 다이제스트 저장소 - SQLite 기반 (data/youtube_digest.db).
+
+**자막 원문은 저장하지 않는다.** 영상 1편이 최대 34,000자(2026-08-10 실측)라
+원문까지 쌓으면 DB가 빠르게 비대해지는데, 리포트 조회에는 요약만 있으면 된다.
+
+같은 날 재실행은 덮어쓴다. 옛 언급이 남아 새 집계와 섞이면 순위가 오염된다.
+"""
+import aiosqlite
+from pathlib import Path
+
+_CREATE_DIGESTS = """
+CREATE TABLE IF NOT EXISTS youtube_digests (
+    report_date          TEXT PRIMARY KEY,
+    digest_text          TEXT NOT NULL DEFAULT '',
+    video_count          INTEGER NOT NULL DEFAULT 0,
+    failed_summary_count INTEGER NOT NULL DEFAULT 0,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
+)
+"""
+
+# rank 컬럼으로 언급 순위를 보존한다. count/video_count 로 다시 정렬하면
+# 동점 처리 규칙이 서비스와 어긋날 수 있다.
+_CREATE_MENTIONS = """
+CREATE TABLE IF NOT EXISTS youtube_digest_mentions (
+    report_date TEXT NOT NULL,
+    rank        INTEGER NOT NULL,
+    name        TEXT NOT NULL,
+    code        TEXT NOT NULL DEFAULT '',
+    count       INTEGER NOT NULL DEFAULT 0,
+    video_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (report_date, rank)
+)
+"""
+
+_CREATE_VIDEOS = """
+CREATE TABLE IF NOT EXISTS youtube_digest_videos (
+    report_date   TEXT NOT NULL,
+    ord           INTEGER NOT NULL,
+    video_id      TEXT NOT NULL DEFAULT '',
+    channel_title TEXT NOT NULL DEFAULT '',
+    title         TEXT NOT NULL DEFAULT '',
+    url           TEXT NOT NULL DEFAULT '',
+    published     TEXT NOT NULL DEFAULT '',
+    summary       TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (report_date, ord)
+)
+"""
+
+
+class YoutubeDigestRepository:
+    DB_PATH = Path("data/youtube_digest.db")
+
+    def __init__(self, db_path: Path | None = None):
+        self._db_path = db_path or self.DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _setup(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute(_CREATE_DIGESTS)
+        await conn.execute(_CREATE_MENTIONS)
+        await conn.execute(_CREATE_VIDEOS)
+        await conn.commit()
+
+    async def save(self, payload: dict) -> None:
+        """하루치 리포트를 저장한다. 같은 날짜가 있으면 통째로 교체한다."""
+        report_date = str(payload.get("report_date") or "")
+        if not report_date:
+            raise ValueError("report_date 가 필요합니다.")
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            await conn.execute(
+                "DELETE FROM youtube_digest_mentions WHERE report_date = ?", (report_date,)
+            )
+            await conn.execute(
+                "DELETE FROM youtube_digest_videos WHERE report_date = ?", (report_date,)
+            )
+            await conn.execute(
+                "INSERT OR REPLACE INTO youtube_digests"
+                " (report_date, digest_text, video_count, failed_summary_count)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    report_date,
+                    str(payload.get("digest_text") or ""),
+                    int(payload.get("video_count") or 0),
+                    int(payload.get("failed_summary_count") or 0),
+                ),
+            )
+            await conn.executemany(
+                "INSERT INTO youtube_digest_mentions"
+                " (report_date, rank, name, code, count, video_count)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        report_date,
+                        rank,
+                        str(mention.get("name") or ""),
+                        str(mention.get("code") or ""),
+                        int(mention.get("count") or 0),
+                        int(mention.get("video_count") or 0),
+                    )
+                    for rank, mention in enumerate(payload.get("mentions") or [])
+                ],
+            )
+            await conn.executemany(
+                "INSERT INTO youtube_digest_videos"
+                " (report_date, ord, video_id, channel_title, title, url, published, summary)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        report_date,
+                        order,
+                        str(video.get("video_id") or ""),
+                        str(video.get("channel_title") or ""),
+                        str(video.get("title") or ""),
+                        str(video.get("url") or ""),
+                        str(video.get("published") or ""),
+                        str(video.get("summary") or ""),
+                    )
+                    for order, video in enumerate(payload.get("videos") or [])
+                ],
+            )
+            await conn.commit()
+
+    async def get(self, report_date: str) -> dict | None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                "SELECT report_date, digest_text, video_count, failed_summary_count,"
+                " created_at FROM youtube_digests WHERE report_date = ?",
+                (report_date,),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is None:
+                return None
+            async with conn.execute(
+                "SELECT name, code, count, video_count FROM youtube_digest_mentions"
+                " WHERE report_date = ? ORDER BY rank ASC",
+                (report_date,),
+            ) as cur:
+                mention_rows = await cur.fetchall()
+            async with conn.execute(
+                "SELECT video_id, channel_title, title, url, published, summary"
+                " FROM youtube_digest_videos WHERE report_date = ? ORDER BY ord ASC",
+                (report_date,),
+            ) as cur:
+                video_rows = await cur.fetchall()
+        return {
+            "report_date": row[0],
+            "digest_text": row[1],
+            "video_count": row[2],
+            "failed_summary_count": row[3],
+            "created_at": row[4],
+            "mentions": [
+                {"name": m[0], "code": m[1], "count": m[2], "video_count": m[3]}
+                for m in mention_rows
+            ],
+            "videos": [
+                {
+                    "video_id": v[0],
+                    "channel_title": v[1],
+                    "title": v[2],
+                    "url": v[3],
+                    "published": v[4],
+                    "summary": v[5],
+                }
+                for v in video_rows
+            ],
+        }
+
+    async def list_recent(self, limit: int = 30) -> list[dict]:
+        """목록 화면용 요약. 본문·영상 요약은 담지 않는다 (응답 비대 방지)."""
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._setup(conn)
+            async with conn.execute(
+                "SELECT report_date, video_count, failed_summary_count, created_at"
+                " FROM youtube_digests ORDER BY report_date DESC LIMIT ?",
+                (max(1, int(limit)),),
+            ) as cur:
+                rows = await cur.fetchall()
+        return [
+            {
+                "report_date": row[0],
+                "video_count": row[1],
+                "failed_summary_count": row[2],
+                "created_at": row[3],
+            }
+            for row in rows
+        ]
+
+    async def latest(self) -> dict | None:
+        recent = await self.list_recent(limit=1)
+        if not recent:
+            return None
+        return await self.get(recent[0]["report_date"])

--- a/task/background/intraday/youtube_digest_task.py
+++ b/task/background/intraday/youtube_digest_task.py
@@ -1,0 +1,271 @@
+"""장 시작 전 유튜브 채널 일일 다이제스트를 생성·저장·발송하는 태스크.
+
+`TimeDispatcher` 를 쓰지 않는다. 그쪽은 `_is_after_market_close()` 로 장 마감
+이후에만 발행하도록 되어 있어 07:30 을 표현할 수 없다. 대신 장 시작 전 작업의
+선례인 `PreMarketHealthCheckTask` 처럼 자체 폴링 + 날짜 dedup 으로 게이팅한다.
+
+운영 규칙 두 가지:
+
+- **차단은 빈 리포트로 위장되면 안 된다.** IP 차단(IpBlocked)으로 자막을 못 받은
+  날과 새 영상이 없던 날은 전혀 다른 상황이다. 차단은 ERROR 알림을 내고 저장하지
+  않으며, 한 시간 뒤 한 번만 재시도한다(즉시 재시도는 차단을 악화시킨다).
+- **수집 구간은 마지막 실행 이후로 늘어난다.** 주말·휴일을 건너뛴 월요일 아침에
+  24시간만 보면 주말 업로드를 통째로 놓친다.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from typing import Dict, List, Optional
+
+from common.types import ErrorCode
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+from services.notification_service import NotificationCategory, NotificationLevel
+
+
+class YoutubeDigestTask(SchedulableTask):
+    """07:30 KST 에 하루치 유튜브 다이제스트를 만든다."""
+
+    POLL_INTERVAL_SEC = 60
+    RUN_AT_HOUR = 7
+    RUN_AT_MINUTE = 30
+    # 재시작·일시정지로 정각을 놓쳐도 당일 안에 따라잡는다. 이 창을 넘기면 포기한다
+    # (밤늦게 뒤늦게 발송되는 편이 더 나쁘다).
+    CATCHUP_WINDOW_HOURS = 6
+    # 차단 후 재시도까지 기다리는 시간. 즉시 재시도는 차단을 악화시킨다.
+    RETRY_AFTER_BLOCK_MIN = 60
+    MAX_BLOCK_RETRIES = 1
+    # 마지막 실행 이후가 아무리 길어도 이보다 더 거슬러 올라가지 않는다.
+    MAX_LOOKBACK_HOURS = 96
+    DEFAULT_LOOKBACK_HOURS = 24
+    MAX_VIDEOS_PER_CHANNEL = 3
+
+    def __init__(
+        self,
+        *,
+        channel_repository,
+        collector,
+        digest_service,
+        digest_repository,
+        notification_service=None,
+        market_clock=None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._channel_repo = channel_repository
+        self._collector = collector
+        self._digest_service = digest_service
+        self._digest_repo = digest_repository
+        self._ns = notification_service
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
+        self._state = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._last_run_date: Optional[str] = None
+        self._last_run_at = None
+        self._last_report_date: Optional[str] = None
+        self._last_error: Optional[str] = None
+        self._block_retries = 0
+        self._retry_after = None
+
+    @property
+    def task_name(self) -> str:
+        return "youtube_digest"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    # --- 라이프사이클 -------------------------------------------------------
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    def get_progress(self) -> Dict:
+        return {
+            "running": self._state == TaskState.RUNNING,
+            "last_report_date": self._last_report_date,
+            "last_run_date": self._last_run_date,
+            "last_error": self._last_error,
+            "block_retries": self._block_retries,
+        }
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self.POLL_INTERVAL_SEC)
+                if self._state == TaskState.SUSPENDED:
+                    continue
+                if await self._should_run_now():
+                    self._state = TaskState.RUNNING
+                    try:
+                        await self.run_once()
+                    finally:
+                        if self._state == TaskState.RUNNING:
+                            self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self._logger.error(f"[YoutubeDigest] 루프 오류: {e}", exc_info=True)
+
+    # --- 게이팅 -------------------------------------------------------------
+
+    async def _should_run_now(self) -> bool:
+        if self._market_clock is None:
+            return False
+        now = self._market_clock.get_current_kst_time()
+        if self._last_run_date == now.strftime("%Y%m%d"):
+            return False
+        if self._retry_after is not None and now < self._retry_after:
+            return False
+        start = now.replace(
+            hour=self.RUN_AT_HOUR, minute=self.RUN_AT_MINUTE, second=0, microsecond=0
+        )
+        return start <= now < start + timedelta(hours=self.CATCHUP_WINDOW_HOURS)
+
+    def _lookback_hours(self) -> float:
+        """마지막 실행 이후 경과 시간. 주말을 건너뛴 뒤에도 공백이 생기지 않게 한다."""
+        if self._last_run_at is None:
+            return self.DEFAULT_LOOKBACK_HOURS
+        now = self._market_clock.get_current_kst_time()
+        elapsed = (now - self._last_run_at).total_seconds() / 3600
+        return min(self.MAX_LOOKBACK_HOURS, max(self.DEFAULT_LOOKBACK_HOURS, elapsed))
+
+    # --- 실행 ---------------------------------------------------------------
+
+    async def run_once(self) -> None:
+        now = self._market_clock.get_current_kst_time()
+        report_date = now.strftime("%Y%m%d")
+        self._last_error = None
+        try:
+            channels = await self._channel_repo.get_all(enabled_only=True)
+            if not channels:
+                self._logger.info("[YoutubeDigest] 등록된 채널이 없어 건너뜁니다.")
+                self._mark_done(report_date, now)
+                return
+
+            items = await self._collector.collect(
+                channels,
+                since_hours=self._lookback_hours(),
+                max_videos_per_channel=self.MAX_VIDEOS_PER_CHANNEL,
+            )
+            if getattr(self._collector, "was_blocked", False):
+                await self._handle_block(report_date, now)
+                return
+
+            usable = [item for item in items if not item.get("skip_reason")]
+            if not usable:
+                self._logger.info("[YoutubeDigest] 자막을 확보한 새 영상이 없습니다.")
+                await self._emit(
+                    NotificationLevel.INFO,
+                    "유튜브 다이제스트 - 새 영상 없음",
+                    f"{report_date}: 자막을 확보한 영상이 없어 리포트를 건너뜁니다"
+                    f" (수집 시도 {len(items)}편).",
+                )
+                self._mark_done(report_date, now)
+                return
+
+            result = await self._digest_service.build_digest(
+                usable, report_date=report_date
+            )
+            if not result or result.rt_cd != ErrorCode.SUCCESS.value:
+                message = getattr(result, "msg1", "응답 없음") if result else "응답 없음"
+                self._last_error = message
+                self._logger.warning(f"[YoutubeDigest] 리포트 생성 실패: {message}")
+                await self._emit(
+                    NotificationLevel.ERROR,
+                    "유튜브 다이제스트 생성 실패",
+                    f"{report_date}: {message}",
+                )
+                self._mark_done(report_date, now)
+                return
+
+            await self._digest_repo.save(result.data)
+            self._last_report_date = report_date
+            await self._emit(
+                NotificationLevel.INFO,
+                "유튜브 다이제스트",
+                self._format_message(result.data),
+            )
+            self._logger.info(
+                f"[YoutubeDigest] 리포트 완료: {report_date} "
+                f"영상 {result.data.get('video_count')}편"
+            )
+            self._mark_done(report_date, now)
+        except Exception as e:
+            self._last_error = str(e)
+            self._logger.error(f"[YoutubeDigest] 실행 실패: {e}", exc_info=True)
+            self._mark_done(report_date, now)
+
+    async def _handle_block(self, report_date: str, now) -> None:
+        self._last_error = "blocked"
+        if self._block_retries < self.MAX_BLOCK_RETRIES:
+            self._block_retries += 1
+            self._retry_after = now + timedelta(minutes=self.RETRY_AFTER_BLOCK_MIN)
+            self._logger.warning(
+                f"[YoutubeDigest] YouTube 차단 — {self.RETRY_AFTER_BLOCK_MIN}분 뒤 재시도합니다."
+            )
+            return
+        self._logger.error("[YoutubeDigest] YouTube 차단이 계속돼 오늘 리포트를 포기합니다.")
+        await self._emit(
+            NotificationLevel.ERROR,
+            "유튜브 다이제스트 - YouTube 차단",
+            f"{report_date}: YouTube 가 IP를 차단해 자막을 받지 못했습니다."
+            " 오늘 리포트는 생성되지 않습니다.",
+        )
+        self._mark_done(report_date, now)
+
+    def _mark_done(self, report_date: str, now) -> None:
+        self._last_run_date = report_date
+        self._last_run_at = now
+        self._block_retries = 0
+        self._retry_after = None
+
+    async def _emit(self, level: NotificationLevel, title: str, message: str) -> None:
+        if self._ns is None:
+            return
+        await self._ns.emit(
+            NotificationCategory.BACKGROUND,
+            level,
+            title,
+            message,
+            # 웹 알림함에만 쌓이면 아침에 못 본다. 텔레그램까지 확실히 보낸다.
+            metadata={"force_external": True},
+        )
+
+    @staticmethod
+    def _format_message(data: dict) -> str:
+        mentions = data.get("mentions") or []
+        top = ", ".join(
+            f"{m['name']}({m['video_count']}편)" for m in mentions[:5]
+        ) or "언급 종목 없음"
+        return (
+            f"{data.get('report_date')} · 영상 {data.get('video_count')}편\n"
+            f"많이 언급: {top}\n\n"
+            f"{data.get('digest_text') or ''}"
+        )

--- a/tests/frontend/run_youtube_dom_tests.mjs
+++ b/tests/frontend/run_youtube_dom_tests.mjs
@@ -1,0 +1,376 @@
+/*
+ * jsdom 기반 유튜브 다이제스트 화면 회귀 테스트.
+ *
+ * 이 화면은 (1) 채널 CRUD 후 목록 재조회, (2) AI 가 만든 자유 텍스트 렌더링이
+ * 핵심이라 문자열 검사로는 회귀를 못 잡는다. 특히 리포트 본문·영상 제목은 외부
+ * (유튜브 제목, LLM 출력)에서 오므로 escape 누락이 곧 XSS 다.
+ *
+ * 실행: node run_youtube_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { applyCommonStubs, test, assert, run } from "./harness.mjs";
+
+const YOUTUBE_JS = process.env.YOUTUBE_JS_PATH
+  ? resolve(process.env.YOUTUBE_JS_PATH)
+  : resolve(import.meta.dirname, "../../view/web/static/js/youtube.js");
+
+const SCAFFOLD = `
+  <div id="youtube-page">
+    <span id="youtube-run-status"></span>
+    <div id="youtube-status"></div>
+    <input type="text" id="youtube-channel-url">
+    <span id="youtube-channel-status"></span>
+    <table><tbody id="youtube-channel-body"></tbody></table>
+    <select id="youtube-report-date"></select>
+    <div id="youtube-report-body"></div>
+  </div>`;
+
+function ok(payload) {
+  return { ok: true, status: 200, json: async () => payload };
+}
+
+function httpError(status) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+/** 라우트별 응답을 지정하고 호출 기록을 남기는 fetch 대역. */
+function makeFetch(routes) {
+  const calls = [];
+  const fetchWithTimeout = async (url, options = {}, timeoutMs) => {
+    calls.push({ url, method: (options.method || "GET").toUpperCase(), body: options.body, timeoutMs });
+    for (const [prefix, handler] of routes) {
+      if (url.startsWith(prefix)) {
+        return typeof handler === "function" ? handler(url, options) : handler;
+      }
+    }
+    return ok(null);
+  };
+  return { fetchWithTimeout, calls };
+}
+
+/**
+ * `calls` 를 넘기면 페이지 자동 초기화가 낸 요청을 비우고 돌려준다.
+ * 그래야 각 테스트가 자기 동작이 낸 요청만 센다.
+ */
+async function makeWindow(fetchWithTimeout, calls) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url: "http://localhost/youtube",
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+  if (window.document.readyState === "loading") {
+    await new Promise((r) => window.document.addEventListener("DOMContentLoaded", r));
+  }
+  applyCommonStubs(window);
+  window.fetchWithTimeout = fetchWithTimeout;
+  window.eval(readFileSync(YOUTUBE_JS, "utf8"));
+  await settle();
+  if (calls) calls.length = 0;
+  return window;
+}
+
+/** 자동 초기화의 fetch 체인이 끝날 때까지 이벤트 루프를 돌린다. */
+async function settle() {
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+const CHANNELS = [
+  { channel_id: "UC1", handle: "chesleytv", title: "체슬리TV", enabled: true },
+  { channel_id: "UC2", handle: "rsangmoo", title: "상무니tv", enabled: false },
+];
+
+const REPORT = {
+  report_date: "20260810",
+  video_count: 2,
+  failed_summary_count: 0,
+  digest_text: "오늘의 공통 화두는 반도체다.",
+  mentions: [
+    { name: "삼성전자", code: "005930", count: 16, video_count: 4 },
+    { name: "SK하이닉스", code: "000660", count: 8, video_count: 3 },
+  ],
+  videos: [
+    {
+      video_id: "v1",
+      title: "영상 제목",
+      channel_title: "체슬리TV",
+      url: "https://www.youtube.com/watch?v=v1",
+      summary: "v1 요약",
+    },
+  ],
+};
+
+function defaultRoutes(overrides = []) {
+  return [
+    ...overrides,
+    ["/api/youtube/channels", ok(CHANNELS)],
+    ["/api/youtube/reports/latest", ok({ report: REPORT })],
+    ["/api/youtube/reports/", ok(REPORT)],
+    ["/api/youtube/reports", ok([{ report_date: "20260810", video_count: 2 }])],
+    ["/api/youtube/status", ok({ enabled: true, progress: { last_report_date: "20260810" } })],
+  ];
+}
+
+// ── 채널 관리 ────────────────────────────────────────────────
+
+test("채널 목록이 행으로 렌더된다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeChannels();
+
+  const rows = window.document.querySelectorAll("#youtube-channel-body tr");
+  assert(rows.length === 2, `행 2개여야 하는데 ${rows.length}`);
+  assert(rows[0].textContent.includes("체슬리TV"), "채널명이 보여야 한다");
+  assert(rows[0].textContent.includes("@chesleytv"), "핸들이 보여야 한다");
+});
+
+test("수집 on/off 상태가 버튼 라벨로 구분된다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeChannels();
+
+  const buttons = window.document.querySelectorAll(".yt-toggle");
+  assert(buttons[0].textContent === "수집 중", `on 라벨 불일치: ${buttons[0].textContent}`);
+  assert(buttons[1].textContent === "중지", `off 라벨 불일치: ${buttons[1].textContent}`);
+});
+
+test("빈 채널 목록이면 안내 문구가 뜬다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes([["/api/youtube/channels", ok([])]]));
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeChannels();
+
+  assert(
+    window.document.getElementById("youtube-channel-body").textContent.includes("등록된 채널이 없습니다"),
+    "빈 목록 안내가 있어야 한다",
+  );
+});
+
+test("페이지가 로드되면 채널·상태·리포트를 자동으로 읽는다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+
+  await makeWindow(fetchWithTimeout);  // 초기화 호출을 비우지 않는다
+
+  const urls = calls.map((c) => c.url);
+  assert(urls.includes("/api/youtube/status"), "상태를 읽어야 한다");
+  assert(urls.includes("/api/youtube/channels"), "채널을 읽어야 한다");
+  assert(urls.includes("/api/youtube/reports/latest"), "최신 리포트를 읽어야 한다");
+});
+
+test("채널 추가는 URL 을 POST 하고 목록을 다시 읽는다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/channels", (url, options) =>
+      (options.method === "POST"
+        ? ok({ added: true, channel_id: "UC3", title: "새채널" })
+        : ok(CHANNELS))]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+  window.document.getElementById("youtube-channel-url").value = "@newone";
+
+  await window.addYoutubeChannel();
+
+  const post = calls.find((c) => c.method === "POST");
+  assert(post, "POST 요청이 있어야 한다");
+  assert(JSON.parse(post.body).url === "@newone", "입력한 URL 을 보내야 한다");
+  assert(
+    calls.filter((c) => c.method === "GET" && c.url === "/api/youtube/channels").length === 1,
+    "추가 후 목록을 다시 읽어야 한다",
+  );
+  assert(window.document.getElementById("youtube-channel-url").value === "", "입력칸이 비워져야 한다");
+});
+
+test("빈 입력으로 추가하면 요청을 보내지 않는다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+  window.document.getElementById("youtube-channel-url").value = "   ";
+
+  await window.addYoutubeChannel();
+
+  assert(calls.length === 0, "요청이 없어야 한다");
+  assert(
+    window.document.getElementById("youtube-channel-status").textContent.includes("입력"),
+    "안내가 떠야 한다",
+  );
+});
+
+test("해석 실패한 채널은 오류 문구로 알린다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/channels", (url, options) =>
+      (options.method === "POST" ? httpError(400) : ok(CHANNELS))]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+  window.document.getElementById("youtube-channel-url").value = "@nope";
+
+  await window.addYoutubeChannel();
+
+  assert(
+    window.document.getElementById("youtube-channel-status").textContent.includes("실패"),
+    "실패 안내가 떠야 한다",
+  );
+});
+
+test("채널 삭제는 DELETE 를 보낸다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.removeYoutubeChannel("UC1");
+
+  const del = calls.find((c) => c.method === "DELETE");
+  assert(del && del.url.endsWith("/UC1"), "DELETE 대상이 맞아야 한다");
+});
+
+test("수집 토글은 PATCH 로 반대값을 보낸다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.toggleYoutubeChannel("UC1", false);
+
+  const patch = calls.find((c) => c.method === "PATCH");
+  assert(patch, "PATCH 요청이 있어야 한다");
+  assert(JSON.parse(patch.body).enabled === false, "enabled=false 여야 한다");
+});
+
+// ── 리포트 ───────────────────────────────────────────────────
+
+test("리포트 본문·언급표·영상목록이 렌더된다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReport("");
+
+  const doc = window.document;
+  assert(doc.getElementById("youtube-digest-text").textContent.includes("반도체"), "본문이 있어야 한다");
+  assert(doc.querySelectorAll("#youtube-mention-body tr").length === 2, "언급 2행이어야 한다");
+  assert(doc.querySelectorAll("#youtube-video-list li").length === 1, "영상 1건이어야 한다");
+});
+
+test("리포트가 없으면 빈 화면 대신 안내가 뜬다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/reports/latest", ok({ report: null })]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReport("");
+
+  assert(
+    window.document.getElementById("youtube-report-body").textContent.includes("아직 생성된 리포트가 없습니다"),
+    "첫 실행 전 안내가 떠야 한다",
+  );
+});
+
+test("AI 출력과 유튜브 제목은 HTML 로 해석되지 않는다", async () => {
+  const evil = JSON.parse(JSON.stringify(REPORT));
+  evil.digest_text = '<img src=x onerror="window.__pwned=1">';
+  evil.videos[0].title = '<script>window.__pwned2=1</script>';
+  evil.mentions[0].name = '<b>삼성전자</b>';
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes([["/api/youtube/reports/latest", ok(evil)]]));
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReport("");
+
+  const body = window.document.getElementById("youtube-report-body");
+  assert(body.querySelector("img") === null, "img 태그가 생성되면 안 된다");
+  assert(body.querySelector("script") === null, "script 태그가 생성되면 안 된다");
+  assert(body.querySelector("#youtube-mention-body b") === null, "종목명이 마크업으로 해석되면 안 된다");
+  assert(window.__pwned === undefined && window.__pwned2 === undefined, "스크립트가 실행되면 안 된다");
+});
+
+test("요약 실패 편수가 있으면 경고를 표시한다", async () => {
+  const partial = Object.assign({}, REPORT, { failed_summary_count: 2 });
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/reports/latest", ok({ report: partial })]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReport("");
+
+  assert(
+    window.document.querySelector("#youtube-report-body .warn").textContent.includes("2편"),
+    "실패 편수를 알려야 한다",
+  );
+});
+
+test("날짜를 고르면 해당 날짜를 조회한다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReport("20260809");
+
+  assert(
+    calls.some((c) => c.url === "/api/youtube/reports/20260809"),
+    "선택한 날짜로 조회해야 한다",
+  );
+});
+
+test("날짜 목록이 select 옵션으로 채워진다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes());
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeReportDates();
+
+  const options = window.document.querySelectorAll("#youtube-report-date option");
+  assert(options.length === 1, `옵션 1개여야 하는데 ${options.length}`);
+  assert(options[0].value === "20260810", "날짜 값이 맞아야 한다");
+});
+
+// ── 수동 실행 ────────────────────────────────────────────────
+
+test("지금 생성은 기본 타임아웃보다 긴 예산을 준다", async () => {
+  // 자막 수집 + 영상별 AI 요약이라 15초 기본값으로는 항상 끊긴다.
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes([["/api/youtube/run", ok({ ok: true })]]));
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.runYoutubeDigestNow();
+
+  const runCall = calls.find((c) => c.url === "/api/youtube/run");
+  assert(runCall.method === "POST", "POST 여야 한다");
+  assert(runCall.timeoutMs > 60000, `타임아웃이 너무 짧다: ${runCall.timeoutMs}`);
+});
+
+test("생성 실패는 조용히 넘어가지 않는다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(defaultRoutes([["/api/youtube/run", httpError(503)]]));
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.runYoutubeDigestNow();
+
+  assert(
+    window.document.getElementById("youtube-run-status").textContent.includes("실패"),
+    "실패를 화면에 알려야 한다",
+  );
+});
+
+test("AI 비활성 상태를 상태줄에 알린다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/status", ok({ enabled: false, progress: null })]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeStatus();
+
+  assert(
+    window.document.getElementById("youtube-status").textContent.includes("비활성"),
+    "비활성 안내가 떠야 한다",
+  );
+});
+
+test("마지막 오류가 있으면 상태줄에 보인다", async () => {
+  const { fetchWithTimeout, calls } = makeFetch(
+    defaultRoutes([["/api/youtube/status",
+      ok({ enabled: true, progress: { last_report_date: "20260809", last_error: "blocked" } })]]),
+  );
+  const window = await makeWindow(fetchWithTimeout, calls);
+
+  await window.loadYoutubeStatus();
+
+  assert(
+    window.document.getElementById("youtube-status").textContent.includes("blocked"),
+    "마지막 오류가 보여야 한다",
+  );
+});
+
+run();

--- a/tests/unit_test/repositories/test_youtube_digest_repository.py
+++ b/tests/unit_test/repositories/test_youtube_digest_repository.py
@@ -1,0 +1,133 @@
+"""유튜브 일일 다이제스트 저장소 단위 테스트."""
+from pathlib import Path
+
+import pytest
+
+from repositories.youtube_digest_repository import YoutubeDigestRepository
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> YoutubeDigestRepository:
+    return YoutubeDigestRepository(db_path=tmp_path / "youtube_digest.db")
+
+
+def _payload(report_date: str = "20260810", **kwargs) -> dict:
+    base = {
+        "report_date": report_date,
+        "video_count": 2,
+        "failed_summary_count": 0,
+        "digest_text": "오늘의 공통 화두는 반도체다.",
+        "mentions": [
+            {"name": "삼성전자", "code": "005930", "count": 16, "video_count": 4},
+            {"name": "SK하이닉스", "code": "000660", "count": 8, "video_count": 3},
+        ],
+        "videos": [
+            {
+                "video_id": "v1",
+                "title": "영상1",
+                "channel_title": "체슬리TV",
+                "url": "https://www.youtube.com/watch?v=v1",
+                "published": "2026-08-10T07:00:00+00:00",
+                "summary": "v1 요약",
+            }
+        ],
+    }
+    base.update(kwargs)
+    return base
+
+
+async def test_save_then_get_roundtrip(repo):
+    await repo.save(_payload())
+
+    stored = await repo.get("20260810")
+
+    assert stored["report_date"] == "20260810"
+    assert stored["digest_text"] == "오늘의 공통 화두는 반도체다."
+    assert stored["video_count"] == 2
+    assert stored["failed_summary_count"] == 0
+    assert [m["name"] for m in stored["mentions"]] == ["삼성전자", "SK하이닉스"]
+    assert stored["mentions"][0]["code"] == "005930"
+    assert stored["videos"][0]["summary"] == "v1 요약"
+
+
+async def test_get_returns_none_for_missing_date(repo):
+    assert await repo.get("20991231") is None
+
+
+async def test_mentions_keep_ranking_order(repo):
+    """언급 순위는 리포트의 핵심이라 저장·조회를 거쳐도 순서가 보존돼야 한다."""
+    mentions = [
+        {"name": f"종목{i}", "code": f"{i:06d}", "count": 10 - i, "video_count": 5 - i}
+        for i in range(5)
+    ]
+    await repo.save(_payload(mentions=mentions))
+
+    stored = await repo.get("20260810")
+
+    assert [m["name"] for m in stored["mentions"]] == [m["name"] for m in mentions]
+
+
+async def test_save_is_idempotent_and_replaces_previous_run(repo):
+    """같은 날 재실행하면 덮어써야 한다 — 옛 언급이 남아 섞이면 안 된다."""
+    await repo.save(_payload(digest_text="1차", mentions=[
+        {"name": "옛종목", "code": "000001", "count": 3, "video_count": 1}
+    ]))
+
+    await repo.save(_payload(digest_text="2차"))
+
+    stored = await repo.get("20260810")
+    assert stored["digest_text"] == "2차"
+    assert [m["name"] for m in stored["mentions"]] == ["삼성전자", "SK하이닉스"]
+
+
+async def test_save_replaces_previous_videos(repo):
+    await repo.save(_payload(videos=[
+        {
+            "video_id": "old",
+            "title": "옛영상",
+            "channel_title": "채널",
+            "url": "u",
+            "published": "p",
+            "summary": "옛 요약",
+        }
+    ]))
+
+    await repo.save(_payload())
+
+    stored = await repo.get("20260810")
+    assert [v["video_id"] for v in stored["videos"]] == ["v1"]
+
+
+async def test_list_recent_returns_newest_first(repo):
+    for date in ["20260808", "20260810", "20260809"]:
+        await repo.save(_payload(date))
+
+    recent = await repo.list_recent(limit=2)
+
+    assert [row["report_date"] for row in recent] == ["20260810", "20260809"]
+
+
+async def test_list_recent_is_a_summary_without_heavy_fields(repo):
+    """목록 화면이 리포트 본문·영상 요약까지 끌어오면 응답이 무거워진다."""
+    await repo.save(_payload())
+
+    row = (await repo.list_recent())[0]
+
+    assert row["video_count"] == 2
+    assert "videos" not in row
+    assert "digest_text" not in row
+
+
+async def test_list_recent_on_empty_db(repo):
+    assert await repo.list_recent() == []
+
+
+async def test_latest_returns_most_recent_report(repo):
+    await repo.save(_payload("20260809", digest_text="어제"))
+    await repo.save(_payload("20260810", digest_text="오늘"))
+
+    assert (await repo.latest())["digest_text"] == "오늘"
+
+
+async def test_latest_returns_none_on_empty_db(repo):
+    assert await repo.latest() is None

--- a/tests/unit_test/task/background/intraday/test_youtube_digest_task.py
+++ b/tests/unit_test/task/background/intraday/test_youtube_digest_task.py
@@ -1,0 +1,293 @@
+"""유튜브 일일 다이제스트 스케줄 태스크 단위 테스트."""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytz
+
+from common.types import ErrorCode, ResCommonResponse
+from task.background.intraday.youtube_digest_task import YoutubeDigestTask
+
+_KST = pytz.timezone("Asia/Seoul")
+
+
+def _clock(hour: int, minute: int = 0, day: int = 10) -> MagicMock:
+    clock = MagicMock()
+    clock.get_current_kst_time.return_value = _KST.localize(
+        datetime(2026, 8, day, hour, minute)
+    )
+    return clock
+
+
+def _ok_digest(**kwargs) -> ResCommonResponse:
+    data = {
+        "report_date": "20260810",
+        "video_count": 2,
+        "failed_summary_count": 0,
+        "mentions": [{"name": "삼성전자", "code": "005930", "count": 4, "video_count": 2}],
+        "videos": [],
+        "digest_text": "오늘의 화두",
+    }
+    data.update(kwargs)
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=data)
+
+
+def _task(
+    *,
+    clock=None,
+    collect_result=None,
+    was_blocked=False,
+    digest_result=None,
+    channels=None,
+):
+    channel_repo = MagicMock()
+    channel_repo.get_all = AsyncMock(
+        return_value=channels if channels is not None else [{"channel_id": "UC1", "title": "채널"}]
+    )
+    collector = MagicMock()
+    collector.collect = AsyncMock(
+        return_value=collect_result
+        if collect_result is not None
+        else [{"video_id": "v1", "skip_reason": None, "transcript": "본문"}]
+    )
+    collector.was_blocked = was_blocked
+    digest_service = MagicMock()
+    digest_service.build_digest = AsyncMock(
+        return_value=digest_result if digest_result is not None else _ok_digest()
+    )
+    digest_repo = MagicMock()
+    digest_repo.save = AsyncMock()
+    notifier = MagicMock()
+    notifier.emit = AsyncMock()
+
+    task = YoutubeDigestTask(
+        channel_repository=channel_repo,
+        collector=collector,
+        digest_service=digest_service,
+        digest_repository=digest_repo,
+        notification_service=notifier,
+        market_clock=clock or _clock(7, 30),
+    )
+    return task, {
+        "channel_repo": channel_repo,
+        "collector": collector,
+        "digest_service": digest_service,
+        "digest_repo": digest_repo,
+        "notifier": notifier,
+    }
+
+
+# --- 실행 시각 게이팅 -------------------------------------------------------
+
+
+@pytest.mark.parametrize("hour,minute,expected", [
+    (7, 29, False),
+    (7, 30, True),
+    (9, 0, True),     # 재시작 늦어도 당일 안에 따라잡는다
+    (13, 29, True),
+    (13, 30, False),  # 캐치업 창을 지나면 그날은 포기
+    (23, 0, False),
+])
+async def test_run_window(hour, minute, expected):
+    task, _ = _task(clock=_clock(hour, minute))
+
+    assert await task._should_run_now() is expected
+
+
+async def test_does_not_run_twice_on_the_same_day():
+    task, deps = _task(clock=_clock(7, 30))
+
+    assert await task._should_run_now() is True
+    await task.run_once()
+
+    assert await task._should_run_now() is False
+
+
+async def test_runs_again_on_the_next_day():
+    clock = _clock(7, 30, day=10)
+    task, _ = _task(clock=clock)
+    await task.run_once()
+
+    clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 11, 7, 30))
+
+    assert await task._should_run_now() is True
+
+
+# --- 정상 경로 --------------------------------------------------------------
+
+
+async def test_run_once_saves_and_notifies():
+    task, deps = _task()
+
+    await task.run_once()
+
+    deps["digest_repo"].save.assert_awaited_once()
+    saved = deps["digest_repo"].save.await_args.args[0]
+    assert saved["report_date"] == "20260810"
+    deps["notifier"].emit.assert_awaited_once()
+
+
+async def test_report_is_pushed_to_telegram():
+    """웹 알림함에만 남으면 안 된다 — 외부 발송을 강제해야 한다."""
+    task, deps = _task()
+
+    await task.run_once()
+
+    metadata = deps["notifier"].emit.await_args.kwargs["metadata"]
+    assert metadata["force_external"] is True
+
+
+async def test_only_enabled_channels_are_collected():
+    task, deps = _task()
+
+    await task.run_once()
+
+    deps["channel_repo"].get_all.assert_awaited_once_with(enabled_only=True)
+
+
+async def test_skipped_videos_are_not_sent_to_the_digest():
+    collected = [
+        {"video_id": "v1", "skip_reason": None, "transcript": "본문"},
+        {"video_id": "live", "skip_reason": "transcript_unavailable", "transcript": ""},
+    ]
+    task, deps = _task(collect_result=collected)
+
+    await task.run_once()
+
+    passed = deps["digest_service"].build_digest.await_args.args[0]
+    assert [item["video_id"] for item in passed] == ["v1"]
+
+
+# --- 주말 건너뛴 뒤 수집 구간 -------------------------------------------------
+
+
+async def test_first_run_looks_back_one_day():
+    task, deps = _task()
+
+    await task.run_once()
+
+    assert deps["collector"].collect.await_args.kwargs["since_hours"] == 24
+
+
+async def test_lookback_covers_the_gap_since_the_last_run():
+    """월요일 07:30 실행이 주말 영상을 놓치면 안 된다."""
+    clock = _clock(7, 30, day=7)  # 금요일
+    task, deps = _task(clock=clock)
+    await task.run_once()
+
+    clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 10, 7, 30))
+    await task.run_once()
+
+    assert deps["collector"].collect.await_args.kwargs["since_hours"] == 72
+
+
+# --- 차단·빈 결과 -----------------------------------------------------------
+
+
+async def test_ip_block_never_produces_an_empty_report():
+    """차단은 '오늘 영상 없음'이 아니다 — 빈 리포트를 저장·발송하면 안 된다."""
+    task, deps = _task(collect_result=[], was_blocked=True)
+
+    await task.run_once()
+
+    deps["digest_service"].build_digest.assert_not_awaited()
+    deps["digest_repo"].save.assert_not_awaited()
+
+
+async def test_first_block_stays_quiet_because_it_will_be_retried():
+    """일시적 차단마다 알림을 쏘면 경보 피로만 생긴다."""
+    task, deps = _task(collect_result=[], was_blocked=True)
+
+    await task.run_once()
+
+    deps["notifier"].emit.assert_not_awaited()
+
+
+async def test_persistent_block_notifies_error():
+    clock = _clock(7, 30)
+    task, deps = _task(clock=clock, collect_result=[], was_blocked=True)
+
+    await task.run_once()
+    clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 10, 8, 31))
+    await task.run_once()
+
+    deps["digest_repo"].save.assert_not_awaited()
+    assert "차단" in deps["notifier"].emit.await_args.args[2]
+    assert deps["notifier"].emit.await_args.args[1].value == "error"
+
+
+async def test_ip_block_is_retried_once_before_giving_up():
+    """한 번 막혔다고 그날 리포트를 버리기엔 아깝다 — 뒤로 미뤄 1회만 재시도한다."""
+    clock = _clock(7, 30)
+    task, deps = _task(clock=clock, collect_result=[], was_blocked=True)
+
+    await task.run_once()
+    assert await task._should_run_now() is False  # 재시도 대기 중
+
+    clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 10, 8, 31))
+    assert await task._should_run_now() is True
+
+    await task.run_once()  # 두 번째도 차단
+    clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 10, 10, 0))
+    assert await task._should_run_now() is False  # 포기
+
+
+async def test_no_usable_video_notifies_without_calling_ai():
+    task, deps = _task(collect_result=[
+        {"video_id": "v1", "skip_reason": "transcript_unavailable", "transcript": ""}
+    ])
+
+    await task.run_once()
+
+    deps["digest_service"].build_digest.assert_not_awaited()
+    deps["digest_repo"].save.assert_not_awaited()
+    deps["notifier"].emit.assert_awaited_once()
+
+
+async def test_no_registered_channel_is_a_noop():
+    task, deps = _task(channels=[])
+
+    await task.run_once()
+
+    deps["collector"].collect.assert_not_awaited()
+
+
+async def test_digest_failure_notifies_error_and_does_not_save():
+    failed = ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="AI 실패", data=None)
+    task, deps = _task(digest_result=failed)
+
+    await task.run_once()
+
+    deps["digest_repo"].save.assert_not_awaited()
+    assert deps["notifier"].emit.await_args.args[1].value == "error"
+
+
+async def test_unexpected_error_does_not_escape_the_loop():
+    task, deps = _task()
+    deps["collector"].collect = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await task.run_once()
+
+    assert task.get_progress()["last_error"] == "boom"
+
+
+# --- 라이프사이클 -----------------------------------------------------------
+
+
+async def test_start_and_stop_clean_up_the_loop():
+    task, _ = _task()
+
+    await task.start()
+    assert task.get_progress()["running"] is False
+    await task.stop()
+
+    assert task.state.name == "STOPPED"
+
+
+def test_progress_exposes_required_keys():
+    task, _ = _task()
+
+    progress = task.get_progress()
+
+    assert "running" in progress
+    assert "last_report_date" in progress

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -39,6 +39,8 @@ SERVICE_CONTAINER_PATCH_NAMES = [
     "DartDisclosureClient", "DartDisclosureRepository",
     "DartDisclosureRuleService", "DartDisclosureMonitorTask",
     "CustomsTradeStatClient", "NationalTradeTrendWebClient", "TradeTrendMonitorTask",
+    "YoutubeChannelRepository", "YoutubeDigestRepository",
+    "YoutubeTranscriptCollectorService", "YoutubeDigestService", "YoutubeDigestTask",
 ]
 
 REPOSITORY_BOOTSTRAP_PATCH_NAMES = [
@@ -317,6 +319,64 @@ def test_service_container_skips_ai_news_analyzer_when_disabled(
     assert ctx.stock_news_collector is patched_service_container_deps[
         "StockNewsCollectorService"
     ].return_value
+
+
+def test_service_container_builds_youtube_digest_pipeline(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {
+        "ai_analysis": {
+            "enabled": True,
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen2.5",
+        }
+    }
+
+    ServiceContainer(ctx).run()
+
+    assert ctx.youtube_digest_task is patched_service_container_deps[
+        "YoutubeDigestTask"
+    ].return_value
+    assert ctx.youtube_channel_repository is not None
+    assert ctx.youtube_digest_repository is not None
+
+
+def test_service_container_skips_youtube_digest_when_ai_disabled(
+    patched_service_container_deps,
+):
+    """다이제스트의 본체가 AI 요약이라 AI 없이는 태스크를 만들지 않는다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {"ai_analysis": {"enabled": False}}
+
+    ServiceContainer(ctx).run()
+
+    assert ctx.youtube_digest_task is None
+    patched_service_container_deps["YoutubeDigestTask"].assert_not_called()
+
+
+def test_youtube_digest_chunk_stays_under_ai_input_budget(
+    patched_service_container_deps,
+):
+    """청크가 max_input_chars 를 넘으면 AiClient 가 뒤를 잘라 요약이 깨진다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.full_config = {
+        "ai_analysis": {
+            "enabled": True,
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen2.5",
+            "max_input_chars": 24000,
+        }
+    }
+
+    ServiceContainer(ctx).run()
+
+    kwargs = patched_service_container_deps["YoutubeDigestService"].call_args.kwargs
+    assert kwargs["chunk_chars"] < 24000
 
 
 def test_service_container_creates_query_and_order_services(patched_service_container_deps):

--- a/tests/unit_test/view/web/routes/test_web_routes_youtube.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_youtube.py
@@ -1,0 +1,238 @@
+"""유튜브 다이제스트 API 엔드포인트 테스트 (youtube.html)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _patch_ctx(mock_web_ctx):
+    return patch("view.web.routes.youtube._get_ctx", return_value=mock_web_ctx)
+
+
+def _channel_repo(mock_web_ctx, **overrides):
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=[
+        {"channel_id": "UC1", "handle": "chesleytv", "title": "체슬리TV", "enabled": True},
+    ])
+    repo.add = AsyncMock(return_value=True)
+    repo.remove = AsyncMock(return_value=True)
+    repo.set_enabled = AsyncMock(return_value=True)
+    for key, value in overrides.items():
+        setattr(repo, key, value)
+    mock_web_ctx.youtube_channel_repository = repo
+    return repo
+
+
+def _digest_repo(mock_web_ctx, **overrides):
+    repo = MagicMock()
+    repo.list_recent = AsyncMock(return_value=[{"report_date": "20260810", "video_count": 6}])
+    repo.get = AsyncMock(return_value={"report_date": "20260810", "digest_text": "본문"})
+    repo.latest = AsyncMock(return_value={"report_date": "20260810", "digest_text": "본문"})
+    for key, value in overrides.items():
+        setattr(repo, key, value)
+    mock_web_ctx.youtube_digest_repository = repo
+    return repo
+
+
+# --- 채널 관리 ---------------------------------------------------------------
+
+
+async def test_list_channels(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _channel_repo(mock_web_ctx)
+
+        response = web_client.get("/api/youtube/channels")
+
+        assert response.status_code == 200
+        assert response.json()[0]["handle"] == "chesleytv"
+
+
+async def test_add_channel_resolves_handle_to_channel_id(web_client, mock_web_ctx):
+    """사용자는 URL/핸들만 안다 — 서버가 channel_id 로 해석해야 한다."""
+    with _patch_ctx(mock_web_ctx):
+        repo = _channel_repo(mock_web_ctx)
+        collector = MagicMock()
+        collector.resolve_channel = AsyncMock(return_value={
+            "channel_id": "UC" + "a" * 22, "handle": "rsangmoo", "title": "상무니tv",
+        })
+        mock_web_ctx.youtube_transcript_collector = collector
+
+        response = web_client.post(
+            "/api/youtube/channels", json={"url": "https://www.youtube.com/@rsangmoo"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["added"] is True
+        repo.add.assert_awaited_once_with(
+            "UC" + "a" * 22, handle="rsangmoo", title="상무니tv"
+        )
+
+
+async def test_add_channel_reports_unresolvable_handle(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _channel_repo(mock_web_ctx)
+        collector = MagicMock()
+        collector.resolve_channel = AsyncMock(return_value=None)
+        mock_web_ctx.youtube_transcript_collector = collector
+
+        response = web_client.post("/api/youtube/channels", json={"url": "@없는채널"})
+
+        assert response.status_code == 400
+
+
+async def test_add_channel_rejects_blank_url(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _channel_repo(mock_web_ctx)
+        mock_web_ctx.youtube_transcript_collector = MagicMock()
+
+        response = web_client.post("/api/youtube/channels", json={"url": "   "})
+
+        assert response.status_code == 400
+
+
+async def test_add_channel_reports_duplicate(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        repo = _channel_repo(mock_web_ctx, add=AsyncMock(return_value=False))
+        collector = MagicMock()
+        collector.resolve_channel = AsyncMock(return_value={
+            "channel_id": "UC1", "handle": "chesleytv", "title": "체슬리TV",
+        })
+        mock_web_ctx.youtube_transcript_collector = collector
+
+        response = web_client.post("/api/youtube/channels", json={"url": "@chesleytv"})
+
+        assert response.status_code == 200
+        assert response.json()["added"] is False
+
+
+async def test_delete_channel(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        repo = _channel_repo(mock_web_ctx)
+
+        response = web_client.delete("/api/youtube/channels/UC1")
+
+        assert response.status_code == 200
+        repo.remove.assert_awaited_once_with("UC1")
+
+
+async def test_delete_unknown_channel_returns_404(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _channel_repo(mock_web_ctx, remove=AsyncMock(return_value=False))
+
+        response = web_client.delete("/api/youtube/channels/UC9")
+
+        assert response.status_code == 404
+
+
+async def test_toggle_channel(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        repo = _channel_repo(mock_web_ctx)
+
+        response = web_client.patch(
+            "/api/youtube/channels/UC1", json={"enabled": False}
+        )
+
+        assert response.status_code == 200
+        repo.set_enabled.assert_awaited_once_with("UC1", False)
+
+
+# --- 리포트 조회 -------------------------------------------------------------
+
+
+async def test_list_reports(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _digest_repo(mock_web_ctx)
+
+        response = web_client.get("/api/youtube/reports")
+
+        assert response.status_code == 200
+        assert response.json()[0]["report_date"] == "20260810"
+
+
+async def test_get_report_by_date(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        repo = _digest_repo(mock_web_ctx)
+
+        response = web_client.get("/api/youtube/reports/20260810")
+
+        assert response.status_code == 200
+        repo.get.assert_awaited_once_with("20260810")
+
+
+async def test_get_missing_report_returns_404(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _digest_repo(mock_web_ctx, get=AsyncMock(return_value=None))
+
+        response = web_client.get("/api/youtube/reports/20991231")
+
+        assert response.status_code == 404
+
+
+async def test_latest_report(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        _digest_repo(mock_web_ctx)
+
+        response = web_client.get("/api/youtube/reports/latest")
+
+        assert response.status_code == 200
+        assert response.json()["report"]["report_date"] == "20260810"
+
+
+async def test_latest_report_is_wrapped_in_an_object(web_client, mock_web_ctx):
+    """bare null 은 프런트 공용 readJsonResponse 가 오류로 처리한다 — 객체로 감싸야 한다."""
+    with _patch_ctx(mock_web_ctx):
+        _digest_repo(mock_web_ctx, latest=AsyncMock(return_value=None))
+
+        response = web_client.get("/api/youtube/reports/latest")
+
+        assert response.status_code == 200
+        assert response.json() == {"report": None}
+
+
+# --- 수동 실행 ---------------------------------------------------------------
+
+
+async def test_run_now_triggers_the_task(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        task = MagicMock()
+        task.run_once = AsyncMock()
+        task.get_progress.return_value = {"running": False, "last_report_date": "20260810"}
+        mock_web_ctx.youtube_digest_task = task
+
+        response = web_client.post("/api/youtube/run")
+
+        assert response.status_code == 200
+        task.run_once.assert_awaited_once()
+
+
+async def test_run_now_returns_503_without_task(web_client, mock_web_ctx):
+    """AI 비활성이면 태스크가 없다 — 조용히 성공한 척하면 안 된다."""
+    with _patch_ctx(mock_web_ctx):
+        mock_web_ctx.youtube_digest_task = None
+
+        response = web_client.post("/api/youtube/run")
+
+        assert response.status_code == 503
+
+
+async def test_status_reports_task_progress(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        task = MagicMock()
+        task.get_progress.return_value = {"running": False, "last_error": "blocked"}
+        mock_web_ctx.youtube_digest_task = task
+
+        response = web_client.get("/api/youtube/status")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["progress"]["last_error"] == "blocked"
+
+
+async def test_status_without_task_says_disabled(web_client, mock_web_ctx):
+    with _patch_ctx(mock_web_ctx):
+        mock_web_ctx.youtube_digest_task = None
+
+        response = web_client.get("/api/youtube/status")
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -107,6 +107,8 @@ class SchedulerBootstrap:
         self._register(ctx.notification_queue_task)
         self._register(self._optional_task("dart_disclosure_monitor_task"))
         self._register(self._optional_task("trade_trend_monitor_task"))
+        # 07:30 발행 시각은 태스크가 자체 폴링으로 판정하므로 TimeDispatcher 미등록
+        self._register(self._optional_task("youtube_digest_task"))
         # 미국장 시간대 판단은 태스크가 자체 US 클럭으로 수행하므로 TimeDispatcher 미등록
         self._register(self._optional_task("overseas_favorite_price_alert_task"))
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -88,6 +88,11 @@ from view.web.bootstrap.query_bootstrap import QueryBootstrap
 from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
 from view.web.market_mode_utils import is_market_enabled
 from repositories.dart_disclosure_repository import DartDisclosureRepository
+from repositories.youtube_channel_repository import YoutubeChannelRepository
+from repositories.youtube_digest_repository import YoutubeDigestRepository
+from services.youtube_transcript_collector_service import YoutubeTranscriptCollectorService
+from services.youtube_digest_service import YoutubeDigestService
+from task.background.intraday.youtube_digest_task import YoutubeDigestTask
 
 if TYPE_CHECKING:  # pragma: no cover
     from view.web.web_app_initializer import WebAppContext
@@ -425,6 +430,33 @@ class ServiceContainer:
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Streaming] 초기화 실패: {e}", exc_info=True)
             raise
+
+        # 유튜브 일일 다이제스트. 채널 저장소는 UI 관리용이라 항상 만들고, 요약 태스크는
+        # 본체가 AI 라서 AI 비활성 시 만들지 않는다.
+        ctx.youtube_channel_repository = YoutubeChannelRepository()
+        ctx.youtube_digest_repository = YoutubeDigestRepository()
+        ctx.youtube_transcript_collector = YoutubeTranscriptCollectorService(logger=ctx.logger)
+        ctx.youtube_digest_service = None
+        ctx.youtube_digest_task = None
+        if ctx.ai_client is not None:
+            # 청크는 입력 예산보다 작아야 AiClient 가 뒤를 잘라내지 않는다.
+            _yt_budget = int(ai_config.max_input_chars) or 24000
+            ctx.youtube_digest_service = YoutubeDigestService(
+                ctx.ai_client,
+                stock_code_repository=ctx.stock_code_repository,
+                max_tokens=int(ai_config.max_tokens),
+                chunk_chars=max(2000, _yt_budget - 2000),
+                logger=ctx.logger,
+            )
+            ctx.youtube_digest_task = YoutubeDigestTask(
+                channel_repository=ctx.youtube_channel_repository,
+                collector=ctx.youtube_transcript_collector,
+                digest_service=ctx.youtube_digest_service,
+                digest_repository=ctx.youtube_digest_repository,
+                notification_service=ctx.notification_service,
+                market_clock=ctx.market_clock,
+                logger=ctx.logger,
+            )
 
         try:
             _ps_cfg = getattr(ctx.full_config, "position_sizing", None) or PositionSizingConfig()

--- a/view/web/routes/__init__.py
+++ b/view/web/routes/__init__.py
@@ -28,6 +28,7 @@ from view.web.routes.kill_switch import router as kill_switch_router
 from view.web.routes.strategy_report import router as strategy_report_router
 from view.web.routes.operator_dashboard import router as operator_dashboard_router
 from view.web.routes.ai import router as ai_router
+from view.web.routes.youtube import router as youtube_router
 
 router = APIRouter(prefix="/api")
 protected_router = APIRouter(
@@ -57,4 +58,5 @@ protected_router.include_router(kill_switch_router)
 protected_router.include_router(strategy_report_router)
 protected_router.include_router(operator_dashboard_router)
 protected_router.include_router(ai_router)
+protected_router.include_router(youtube_router)
 router.include_router(protected_router)

--- a/view/web/routes/youtube.py
+++ b/view/web/routes/youtube.py
@@ -1,0 +1,133 @@
+"""
+유튜브 일일 다이제스트 API 엔드포인트 (youtube.html).
+
+채널은 사용자가 URL/핸들로 등록한다. channel_id 해석은 서버가 맡는다 —
+사용자가 `UC...` 24자를 직접 알아낼 방법이 없다.
+"""
+import logging
+
+from fastapi import APIRouter, Body, HTTPException
+
+from view.web.api_common import _get_ctx
+
+router = APIRouter(prefix="/youtube", tags=["youtube"])
+logger = logging.getLogger(__name__)
+
+
+def _ctx_attr(ctx, name: str, default=None):
+    """MagicMock 테스트 컨텍스트에서 미정의 속성이 truthy Mock으로 생기는 것을 피한다."""
+    if hasattr(ctx, "__dict__"):
+        return ctx.__dict__.get(name, default)
+    return getattr(ctx, name, default)
+
+
+# --- 채널 관리 ---------------------------------------------------------------
+
+
+@router.get("/channels")
+async def list_channels():
+    """등록된 채널 목록 (비활성 포함)."""
+    ctx = _get_ctx()
+    return await ctx.youtube_channel_repository.get_all()
+
+
+@router.post("/channels")
+async def add_channel(payload: dict = Body(...)):
+    """채널 URL/핸들을 channel_id 로 해석해 등록한다."""
+    url = str((payload or {}).get("url") or "").strip()
+    if not url:
+        raise HTTPException(status_code=400, detail="채널 URL 또는 핸들을 입력하세요.")
+
+    ctx = _get_ctx()
+    resolved = await ctx.youtube_transcript_collector.resolve_channel(url)
+    if not resolved:
+        raise HTTPException(
+            status_code=400,
+            detail=f"채널을 찾을 수 없습니다: {url}",
+        )
+
+    added = await ctx.youtube_channel_repository.add(
+        resolved["channel_id"],
+        handle=resolved.get("handle", ""),
+        title=resolved.get("title", ""),
+    )
+    return {
+        "added": added,
+        "channel_id": resolved["channel_id"],
+        "handle": resolved.get("handle", ""),
+        "title": resolved.get("title", ""),
+    }
+
+
+@router.delete("/channels/{channel_id}")
+async def delete_channel(channel_id: str):
+    ctx = _get_ctx()
+    if not await ctx.youtube_channel_repository.remove(channel_id):
+        raise HTTPException(status_code=404, detail=f"등록되지 않은 채널: {channel_id}")
+    return {"removed": True, "channel_id": channel_id}
+
+
+@router.patch("/channels/{channel_id}")
+async def toggle_channel(channel_id: str, payload: dict = Body(...)):
+    """수집 on/off 전환."""
+    enabled = bool((payload or {}).get("enabled", True))
+    ctx = _get_ctx()
+    if not await ctx.youtube_channel_repository.set_enabled(channel_id, enabled):
+        raise HTTPException(status_code=404, detail=f"등록되지 않은 채널: {channel_id}")
+    return {"channel_id": channel_id, "enabled": enabled}
+
+
+# --- 리포트 조회 -------------------------------------------------------------
+
+
+@router.get("/reports")
+async def list_reports(limit: int = 30):
+    """리포트 날짜 목록 (본문 제외)."""
+    ctx = _get_ctx()
+    return await ctx.youtube_digest_repository.list_recent(limit=limit)
+
+
+@router.get("/reports/latest")
+async def get_latest_report():
+    """가장 최근 리포트. 아직 없으면 report=null.
+
+    bare null 로 돌려주면 프런트 공용 readJsonResponse 가 비객체를 오류로 처리해
+    첫 실행 전 화면에 "불러오지 못했습니다"가 뜬다. 그래서 객체로 감싼다.
+    """
+    ctx = _get_ctx()
+    return {"report": await ctx.youtube_digest_repository.latest()}
+
+
+@router.get("/reports/{report_date}")
+async def get_report(report_date: str):
+    ctx = _get_ctx()
+    report = await ctx.youtube_digest_repository.get(report_date)
+    if report is None:
+        raise HTTPException(status_code=404, detail=f"리포트 없음: {report_date}")
+    return report
+
+
+# --- 수동 실행 / 상태 ---------------------------------------------------------
+
+
+@router.post("/run")
+async def run_now():
+    """스케줄을 기다리지 않고 즉시 1회 생성한다 (AI 한도를 소비한다)."""
+    ctx = _get_ctx()
+    task = _ctx_attr(ctx, "youtube_digest_task")
+    if task is None:
+        raise HTTPException(
+            status_code=503,
+            detail="AI 분석이 비활성화되어 다이제스트를 생성할 수 없습니다.",
+        )
+    await task.run_once()
+    return {"ok": True, "progress": task.get_progress()}
+
+
+@router.get("/status")
+async def get_status():
+    ctx = _get_ctx()
+    task = _ctx_attr(ctx, "youtube_digest_task")
+    if task is None:
+        return {"enabled": False, "progress": None}
+    return {"enabled": True, "progress": task.get_progress()}

--- a/view/web/static/js/youtube.js
+++ b/view/web/static/js/youtube.js
@@ -1,0 +1,218 @@
+/*
+ * 유튜브 일일 다이제스트 화면 (youtube.html).
+ *
+ * 채널 관리 + 리포트 조회. 리포트 본문은 AI 가 만든 마크다운성 텍스트라
+ * 그대로 escape 해서 <pre> 로 보여준다 (HTML 로 해석하지 않는다).
+ */
+
+let youtubeChannels = [];
+
+async function loadYoutubeChannels() {
+    const tbody = document.getElementById('youtube-channel-body');
+    if (!tbody) return;
+    try {
+        const res = await fetchWithTimeout('/api/youtube/channels');
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        youtubeChannels = Array.isArray(json) ? json : [];
+    } catch (e) {
+        tbody.innerHTML = `<tr><td colspan="4">채널 목록을 불러오지 못했습니다: ${escapeHtml(e.message)}</td></tr>`;
+        return;
+    }
+    renderYoutubeChannels();
+}
+
+function renderYoutubeChannels() {
+    const tbody = document.getElementById('youtube-channel-body');
+    if (!tbody) return;
+    if (!youtubeChannels.length) {
+        tbody.innerHTML = '<tr><td colspan="4">등록된 채널이 없습니다.</td></tr>';
+        return;
+    }
+    tbody.innerHTML = youtubeChannels.map((ch) => {
+        const id = escapeHtml(ch.channel_id);
+        const label = ch.enabled ? '수집 중' : '중지';
+        return `<tr data-channel-id="${id}">
+            <td>${escapeHtml(ch.title || '(제목 없음)')}</td>
+            <td>@${escapeHtml(ch.handle || '')}</td>
+            <td><button type="button" class="yt-toggle" onclick="toggleYoutubeChannel('${id}', ${ch.enabled ? 'false' : 'true'})">${label}</button></td>
+            <td><button type="button" class="yt-remove" onclick="removeYoutubeChannel('${id}')">삭제</button></td>
+        </tr>`;
+    }).join('');
+}
+
+async function addYoutubeChannel() {
+    const input = document.getElementById('youtube-channel-url');
+    const status = document.getElementById('youtube-channel-status');
+    if (!input) return;
+    const url = (input.value || '').trim();
+    if (!url) {
+        if (status) status.textContent = '채널 URL 또는 핸들을 입력하세요.';
+        return;
+    }
+    if (status) status.textContent = '채널을 확인하는 중...';
+    try {
+        const res = await fetchWithTimeout('/api/youtube/channels', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url }),
+        });
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        if (status) {
+            status.textContent = json.added
+                ? `추가됨: ${json.title || json.channel_id}`
+                : `이미 등록된 채널입니다: ${json.title || json.channel_id}`;
+        }
+        input.value = '';
+        await loadYoutubeChannels();
+    } catch (e) {
+        if (status) status.textContent = `추가 실패: ${e.message}`;
+    }
+}
+
+async function removeYoutubeChannel(channelId) {
+    try {
+        const res = await fetchWithTimeout(`/api/youtube/channels/${encodeURIComponent(channelId)}`, {
+            method: 'DELETE',
+        });
+        const { error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        await loadYoutubeChannels();
+    } catch (e) {
+        const status = document.getElementById('youtube-channel-status');
+        if (status) status.textContent = `삭제 실패: ${e.message}`;
+    }
+}
+
+async function toggleYoutubeChannel(channelId, enabled) {
+    try {
+        const res = await fetchWithTimeout(`/api/youtube/channels/${encodeURIComponent(channelId)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled }),
+        });
+        const { error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        await loadYoutubeChannels();
+    } catch (e) {
+        const status = document.getElementById('youtube-channel-status');
+        if (status) status.textContent = `변경 실패: ${e.message}`;
+    }
+}
+
+async function loadYoutubeReportDates() {
+    const select = document.getElementById('youtube-report-date');
+    if (!select) return;
+    try {
+        const res = await fetchWithTimeout('/api/youtube/reports');
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        const rows = Array.isArray(json) ? json : [];
+        select.innerHTML = rows.map((row) => {
+            const date = escapeHtml(row.report_date);
+            return `<option value="${date}">${date} (${row.video_count}편)</option>`;
+        }).join('');
+    } catch (e) {
+        select.innerHTML = '';
+    }
+}
+
+async function loadYoutubeReport(reportDate) {
+    const body = document.getElementById('youtube-report-body');
+    if (!body) return;
+    const url = reportDate
+        ? `/api/youtube/reports/${encodeURIComponent(reportDate)}`
+        : '/api/youtube/reports/latest';
+    body.textContent = '불러오는 중...';
+    try {
+        const res = await fetchWithTimeout(url);
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        // latest 는 { report: ... } 로 감싸져 오고, 날짜 지정 조회는 리포트 자체가 온다.
+        renderYoutubeReport(reportDate ? json : json.report);
+    } catch (e) {
+        body.innerHTML = `<p class="error">리포트를 불러오지 못했습니다: ${escapeHtml(e.message)}</p>`;
+    }
+}
+
+function renderYoutubeReport(report) {
+    const body = document.getElementById('youtube-report-body');
+    if (!body) return;
+    if (!report) {
+        body.innerHTML = '<p>아직 생성된 리포트가 없습니다. 매일 07:30에 자동 생성됩니다.</p>';
+        return;
+    }
+    const mentions = (report.mentions || []).map((m, i) => `<tr>
+        <td>${i + 1}</td>
+        <td>${escapeHtml(m.name)}</td>
+        <td>${escapeHtml(m.code || '')}</td>
+        <td>${m.count}</td>
+        <td>${m.video_count}</td>
+    </tr>`).join('');
+    const videos = (report.videos || []).map((v) => `<li>
+        <a href="${escapeHtml(v.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(v.title)}</a>
+        <span class="yt-channel">${escapeHtml(v.channel_title)}</span>
+        <pre class="yt-video-summary">${escapeHtml(v.summary || '')}</pre>
+    </li>`).join('');
+    const failedNote = report.failed_summary_count
+        ? `<p class="warn">요약 실패 ${report.failed_summary_count}편</p>`
+        : '';
+
+    body.innerHTML = `
+        <h3>${escapeHtml(report.report_date)} · 영상 ${report.video_count}편</h3>
+        ${failedNote}
+        <pre id="youtube-digest-text" class="yt-digest">${escapeHtml(report.digest_text || '')}</pre>
+        <h4>많이 언급된 종목</h4>
+        <table class="yt-mentions"><thead><tr>
+            <th>#</th><th>종목</th><th>코드</th><th>언급</th><th>영상 수</th>
+        </tr></thead><tbody id="youtube-mention-body">${mentions}</tbody></table>
+        <h4>영상별 요약</h4>
+        <ul id="youtube-video-list">${videos}</ul>`;
+}
+
+async function runYoutubeDigestNow() {
+    const status = document.getElementById('youtube-run-status');
+    if (status) status.textContent = '생성 중... (수 분 걸릴 수 있습니다)';
+    try {
+        // 자막 수집 + 영상별 AI 요약이라 기본 타임아웃(15초)으로는 끊긴다.
+        const res = await fetchWithTimeout('/api/youtube/run', { method: 'POST' }, 600000);
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        if (status) status.textContent = '생성 완료';
+        await loadYoutubeReportDates();
+        await loadYoutubeReport('');
+    } catch (e) {
+        if (status) status.textContent = `생성 실패: ${e.message}`;
+    }
+}
+
+async function loadYoutubeStatus() {
+    const el = document.getElementById('youtube-status');
+    if (!el) return;
+    try {
+        const res = await fetchWithTimeout('/api/youtube/status');
+        const { json, error } = await readJsonResponse(res);
+        if (error) throw new Error(error);
+        if (!json.enabled) {
+            el.textContent = 'AI 분석이 비활성화되어 자동 생성이 꺼져 있습니다.';
+            return;
+        }
+        const progress = json.progress || {};
+        const parts = [`마지막 리포트: ${progress.last_report_date || '없음'}`];
+        if (progress.last_error) parts.push(`마지막 오류: ${progress.last_error}`);
+        el.textContent = parts.join(' · ');
+    } catch (e) {
+        el.textContent = '';
+    }
+}
+
+function initYoutubePage() {
+    loadYoutubeStatus();
+    loadYoutubeChannels();
+    loadYoutubeReportDates().then(() => loadYoutubeReport(''));
+}
+
+if (typeof document !== 'undefined' && document.getElementById('youtube-page')) {
+    initYoutubePage();
+}

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -103,6 +103,7 @@
         {% if can_operate %}<a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>{% endif %}
         {% if can_operate %}<a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>{% endif %}
         <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>
+        <a href="/youtube" class="{% if active_page == 'youtube' %}active{% endif %}">유튜브 다이제스트</a>
         {% if can_operate %}<a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>{% endif %}
     {% endif %}
 </nav>

--- a/view/web/templates/youtube.html
+++ b/view/web/templates/youtube.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <style>
+        .yt-form { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
+        .yt-form input[type="search"], .yt-form input[type="text"] {
+            width: 320px; padding: 5px 8px; font-size: 0.9rem;
+            background: var(--bg-secondary); color: var(--text-primary);
+            border: 1px solid var(--border); border-radius: 5px;
+        }
+        .yt-hint { font-size: 0.78rem; color: var(--text-secondary); }
+        .yt-digest, .yt-video-summary {
+            white-space: pre-wrap; word-break: break-word;
+            background: var(--bg-secondary); border: 1px solid var(--border);
+            border-radius: 6px; padding: 10px; font-size: 0.88rem; line-height: 1.55;
+        }
+        .yt-video-summary { font-size: 0.82rem; margin: 6px 0 12px; }
+        .yt-mentions { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+        .yt-mentions th, .yt-mentions td { padding: 5px 8px; border-bottom: 1px solid var(--border); text-align: left; }
+        .yt-channel { font-size: 0.78rem; color: var(--text-secondary); margin-left: 6px; }
+        #youtube-video-list { list-style: none; padding-left: 0; }
+        .warn { color: var(--warning, #d68910); font-size: 0.85rem; }
+    </style>
+
+    <div class="section" id="youtube-page">
+        <div class="card">
+            <h2>유튜브 일일 다이제스트</h2>
+            <p class="yt-hint">
+                등록한 채널의 최근 영상 자막을 모아 매일 07:30에 AI가 정리합니다.
+                <strong>출연자의 발언 집계</strong>이며 사실 확인이나 투자 판단이 아닙니다.
+            </p>
+            <div class="yt-form">
+                <button type="button" onclick="runYoutubeDigestNow()">지금 생성</button>
+                <span id="youtube-run-status" class="yt-hint"></span>
+            </div>
+            <div id="youtube-status" class="yt-hint"></div>
+        </div>
+
+        <div class="card">
+            <h3>대상 채널</h3>
+            <div class="yt-form">
+                <input type="text" id="youtube-channel-url"
+                       placeholder="https://www.youtube.com/@channel 또는 @channel"
+                       aria-label="유튜브 채널 URL 또는 핸들">
+                <button type="button" onclick="addYoutubeChannel()">추가</button>
+                <span id="youtube-channel-status" class="yt-hint"></span>
+            </div>
+            <table class="yt-mentions">
+                <thead><tr><th>채널</th><th>핸들</th><th>수집</th><th></th></tr></thead>
+                <tbody id="youtube-channel-body"><tr><td colspan="4">불러오는 중...</td></tr></tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <h3>리포트</h3>
+            <div class="yt-form">
+                <label for="youtube-report-date" class="yt-hint">날짜</label>
+                <select id="youtube-report-date" onchange="loadYoutubeReport(this.value)"></select>
+            </div>
+            <div id="youtube-report-body">불러오는 중...</div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/youtube.js?v=1"></script>
+{% endblock %}

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -603,6 +603,10 @@ async def strategy_reports(request: Request):
 async def heatmap(request: Request):
     return await render_page(request, "heatmap.html", "heatmap")
 
+@page_router.get("/youtube")
+async def youtube(request: Request):
+    return await render_page(request, "youtube.html", "youtube")
+
 # 5. 로그아웃
 @page_router.get("/logout")
 async def logout(request: Request):


### PR DESCRIPTION
[#801](https://github.com/kyungsooNa/Investment/pull/801)에서 만든 수집·요약 파이프라인을 **매일 자동으로 돌리고 화면에서 보게** 합니다.

## A. 리포트 저장소

`YoutubeDigestRepository` — 일자별 저장/조회. 두 가지 판단을 코드에 박았습니다.

- **같은 날 재실행은 통째로 교체**합니다. 옛 언급이 남아 새 집계와 섞이면 순위가 오염됩니다.
- **자막 원문은 저장하지 않습니다.** 영상당 최대 34,000자(실측)라 DB만 비대해지고 리포트 조회에는 쓰이지 않습니다.

## B. 07:30 스케줄 태스크

`TimeDispatcher` 는 `_is_after_market_close()` 로 **장 마감 이후에만** 발행하도록 되어 있어 07:30 을 표현할 수 없습니다. 공용 컴포넌트를 고치는 대신, 장 시작 전 작업의 선례인 `PreMarketHealthCheckTask` 처럼 자체 폴링 + 날짜 dedup 으로 게이팅합니다.

| 상황 | 동작 |
|---|---|
| 재시작으로 07:30 을 놓침 | 6시간 안에 따라잡고, 그 뒤엔 포기 (밤늦은 발송이 더 나쁨) |
| 주말·휴일 건너뜀 | 수집 구간이 마지막 실행 이후로 늘어남 (최대 96h) — 월요일에 24h만 보면 주말 업로드를 통째로 놓침 |
| IP 차단 1회 | 조용히 1시간 뒤 재시도 (일시적 차단마다 경보 = 피로) |
| IP 차단 지속 | ERROR 알림 + **그날은 생성하지 않음** — 빈 리포트로 위장되면 안 됨 |

알림은 `force_external` 로 텔레그램까지 보냅니다. 웹 알림함에만 쌓이면 아침에 못 봅니다.

## C. 웹

- `/api/youtube/*` — 채널 CRUD, 리포트 조회, 수동 실행, 상태
- `/youtube` 페이지 + 공통 네비 링크
- 채널은 **URL/핸들로 등록**합니다. 사용자가 `UC...` 24자를 알아낼 방법이 없어 서버가 해석합니다.

작업 중 발견한 계약 결함 하나를 고쳤습니다: `reports/latest` 가 bare `null` 을 반환하면 프런트 공용 `readJsonResponse` 가 비객체를 오류로 처리해, **첫 실행 전 화면에 "불러오지 못했습니다"가 뜹니다.** `{ report: ... }` 로 감쌌습니다.

## 검증

- 단위 **7615 passed** / 통합 **278 passed** (jsdom 러너가 게이트에 자동 편입)
- jsdom 회귀 **19건** — 리포트 본문·영상 제목은 LLM/유튜브에서 오는 외부 문자열이라 escape 누락이 곧 XSS 입니다. 렌더 경로에 XSS 테스트를 포함했습니다.
- 템플릿 Jinja 렌더 직접 확인 (네비 활성 표시 포함)

브라우저 실물 확인은 하지 않았습니다 — 앱을 띄우면 실제 브로커 연결과 백그라운드 스케줄러가 함께 기동되어, 확인 목적으로 감수할 부작용이 아니라고 판단했습니다. 대신 JS 동작은 jsdom, 라우트는 단위 테스트, 템플릿은 렌더로 각각 덮었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
