### PR TITLE
fix: 유튜브 자막 요청 기본 간격 2초 → 5초 (429 마진 확보)

### DIFF
--- a/services/youtube_transcript_collector_service.py
+++ b/services/youtube_transcript_collector_service.py
@@ -12,6 +12,9 @@
 - 짧은 시간에 반복 호출하면 `IpBlocked` 로 IP가 막힌다(실측: 연속 실행 후 15편 전량 실패).
   그래서 (1) 영상 사이에 간격을 두고, (2) 차단은 영상별 스킵이 아니라 **배치 중단**으로
   다룬다. 차단을 스킵으로 흘리면 "오늘은 볼 영상이 없었다"는 정상 리포트처럼 보인다.
+  차단의 실체는 timedtext 엔드포인트의 **HTTP 429 + 구글 "Sorry..." 페이지**
+  ("your computer or network may be sending automated queries") 다. 영구 밴이 아니라
+  속도 제한이고, `Retry-After` 를 주지 않아 해제 시각을 알 수 없다.
 """
 from __future__ import annotations
 
@@ -71,7 +74,10 @@ class YoutubeTranscriptCollectorService:
         http_client=None,
         transcript_fetcher: Optional[Callable[[str, Sequence[str]], str]] = None,
         languages: Sequence[str] = ("ko",),
-        request_interval_sec: float = 2.0,
+        # 하루 1회 배치라 간격을 늘려도 총 소요가 문제되지 않는다. 최악(5채널 × 후보 6편)
+        # 이어도 30건 × 5초 = 2분 30초. 429 를 한 번 맞으면 그날 리포트가 통째로 날아가므로
+        # 속도보다 마진을 택한다.
+        request_interval_sec: float = 5.0,
         sleeper: Optional[Callable[[float], Any]] = None,
     ):
         self._logger = logger or logging.getLogger(__name__)

--- a/tests/unit_test/services/test_youtube_transcript_collector_service.py
+++ b/tests/unit_test/services/test_youtube_transcript_collector_service.py
@@ -243,6 +243,16 @@ async def test_blocked_flag_is_false_on_a_clean_run():
     assert svc.was_blocked is False
 
 
+def test_default_request_interval_keeps_margin_against_rate_limiting():
+    """기본 간격이 좁아지면 429(구글 "Sorry...")를 맞아 그날 리포트가 통째로 날아간다.
+
+    다른 테스트는 전부 간격을 명시로 넘겨 기본값을 덮으므로 여기서만 잠긴다.
+    """
+    svc = YoutubeTranscriptCollectorService()
+
+    assert svc._request_interval_sec >= 5.0
+
+
 async def test_transcript_fetches_are_spaced_out():
     """연속 호출이 YouTube 차단을 부른다 — 영상 사이에 간격을 둬야 한다."""
     feed = _rss([(f"v{i}", f"영상{i}", _iso(1)) for i in range(3)])


### PR DESCRIPTION
## 차단의 실체를 특정했습니다

`IpBlocked` 라는 라이브러리 예외 이름만 보고 있었는데, 실제 HTTP 계층을 확인하니 이렇습니다.

| 경로 | 결과 |
|---|---|
| RSS(영상 목록) | HTTP 200 정상 |
| watch 페이지 | HTTP 200 정상, `captionTracks` 존재 |
| **timedtext(자막 본문)** | **HTTP 429** + 구글 "Sorry..." 페이지 |

응답 본문: *"your computer or network may be sending automated queries."*

즉 **영구 밴이 아니라 자동화 요청 속도 제한**입니다. 계정과 무관하고 IP 단위입니다. 다만 `Retry-After` 헤더를 주지 않아 해제 시각을 알 수 없습니다.

## 왜 2초로는 부족한가

최악의 경우 5채널 × 후보 6편(영상 상한 3 + 스킵 여유 3) = **30건이 1분 안에** 나갑니다.

하루 1회 배치라 5초로 늘려도 총 소요는 **2분 30초**입니다. 반면 429 를 한 번 맞으면 **그날 리포트가 통째로 날아갑니다.** 속도보다 마진이 명백히 유리합니다.

## 테스트

기존 테스트는 전부 `request_interval_sec` 을 명시로 넘겨 기본값을 덮으므로, 기본값이 조용히 낮아지는 걸 못 잡습니다. 기본값만 잠그는 테스트를 따로 추가했습니다.

검증: 단위 **7616 passed** / 통합 **278 passed**

## 남은 제약 (이 PR로 해결되지 않음)

진단 과정에서 걸린 429 가 **아직 풀리지 않았습니다.** 최근 영상 10편 시도 시 성공 0 / 차단 10 입니다. 해제 전까지는 파이프라인 실측 완주 검증을 할 수 없습니다.

해제 확인용:

```
python -c "from youtube_transcript_api import YouTubeTranscriptApi as A; print(len(A().fetch('pP-klrXkvhQ', languages=['ko']).snippets))"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
