### PR TITLE
해외 모의 주문 TR 관련 stale 문서 4곳 정정

### DIFF
--- a/CODEBASE_SUMMARY.md
+++ b/CODEBASE_SUMMARY.md
@@ -99,9 +99,9 @@
 
 ### 4. 해외 주식 계층 (일봉 VBO, 자동 실주문 잠금)
 
-- 결론: 일봉 셋업형 전략만 적용 가능(해외 일봉 API만 존재), 장중/실시간 전략은 불가
+- 결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능. 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다
 - `brokers/korea_investment/korea_invest_overseas_stock_api.py`
-  - 해외 주문/조회 API (해외 주문 TR은 실전만 존재, 모의 주문 TR 없음)
+  - 해외 주문/조회 API. 주문·정정취소·잔고·체결 모두 **실전/모의 TR 쌍이 존재**(#606에서 주간거래 TTTS603x → 정규장 TTTT100xU 전환 시 VTTT... 모의 쌍 추가, `trid_provider`가 `is_paper_trading`으로 분기). 단 모의 서버가 해외 주문을 실제로 수락하는지는 미검증 — `scripts/probe_overseas_paper_order.py` 참고
 - `services/overseas_order_execution_service.py`, `services/overseas_position_sizing_service.py`, `services/overseas_reconcile_service.py`, `services/overseas_candidate_service.py`, `services/overseas_stock_sync_service.py`, `services/overseas_vbo_dryrun_service.py`
 - `services/us_market_calendar_service.py`
   - 규칙 기반 NYSE 휴장일/조기폐장 캘린더 (KIS에 해외 휴장일 TR 없어 로컬 계산)

--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -8,8 +8,14 @@ sized 신호(수량 산출 완료) → 지정가 매수/매도 주문 경로. �
 **핵심 안전 계약 — 구조적 실주문 잠금:**
 `live_enabled=False`(기본)에서는 broker 주문 메서드를 **절대 호출하지 않고** would-be
 주문 레코드만 반환한다(`signal_source="overseas_paper"`). `live_enabled=True` 일 때만
-실호출한다. 해외 주문 TR 은 실전(모의 없음)만 존재하므로, dry-run 검증 + Phase 5
-canary/kill-switch/reconcile 가 이 플래그를 켜는 유일한 주체다.
+실호출한다. 이 플래그를 켜는 유일한 주체는 dry-run 검증 + Phase 5
+canary/kill-switch/reconcile 다.
+
+주: 과거 이 자리에 있던 "해외 주문 TR 은 실전(모의 없음)만 존재" 기술은 stale 이다.
+#606 에서 모의 미지원인 주간거래(TTTS603x) → 정규장(TTTT100xU) 으로 전환하며
+`tr_ids_config.yaml` 에 VTTT... 모의 쌍이 추가됐고 `trid_provider` 가
+`is_paper_trading` 으로 분기한다. 다만 모의 서버가 해외 주문을 실제로 수락하는지는
+미검증 — `scripts/probe_overseas_paper_order.py` 참고.
 
 스케줄러/factory 배선(자동 발사)은 Phase 5 소관 — 본 서비스는 테스트된 게이팅
 컴포넌트로만 제공된다.

--- a/services/overseas_vbo_dryrun_service.py
+++ b/services/overseas_vbo_dryrun_service.py
@@ -5,11 +5,11 @@
  → VBO 일봉 진입 규칙(Phase 2) → shadow 저널 기록.
 
 **주문 경로 없음.** order_execution 의존을 갖지 않으며, "만약 진입했다면" 신호만
-shadow 저널에 남긴다. 해외 주문은 실전 TR(모의 없음)만 존재하므로, 라이브 검증
-전 단계에서 실주문이 절대 발생하지 않도록 구조적으로 차단한다.
+shadow 저널에 남긴다. 의존 자체가 없으므로 실주문이 구조적으로 발생할 수 없다.
 
-라이브 VBO(분봉/웹소켓 의존)는 해외에서 재생 불가하므로, 본 서비스는 EOD 성격의
-일봉 기반 dry-run 신호만 산출한다. 실제 스케줄러/factory 등록은 별도 단계.
+본 서비스는 EOD 성격의 일봉 기반 dry-run 신호만 산출한다(마감 후 사후 평가).
+장중 진입/청산 판정이 필요한 경로는 `OverseasIntradayVBOService`(REST 폴링, #776)가
+담당한다 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다.
 """
 import logging
 from typing import Any, Dict, List, Optional

--- a/todo_list.md
+++ b/todo_list.md
@@ -216,7 +216,9 @@
 
 ## 해외주식 전략 적용 (VBO 일봉)
 
-결론: 일봉 셋업형 전략만 적용 가능(해외 일봉 API 존재), 장중/실시간 전략은 불가. 첫 대상 = `LarryWilliamsVBOStrategy`. 제약: **해외 주문 TR은 실전(TTTS6036U 등)만, 모의 주문 TR 없음** → dry-run 검증 전 실주문 배선 금지. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
+결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다. 첫 대상 = `LarryWilliamsVBOStrategy`. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
+
+**정정 (2026-08-11)**: 종전 "해외 주문 TR은 실전(TTTS6036U 등)만, 모의 주문 TR 없음"은 stale이다. #606에서 모의 미지원인 주간거래 TTTS603x → 모의 검증 가능한 정규장 TTTT100xU로 전환하며 `tr_ids_config.yaml`에 real/paper 쌍이 모두 추가됐고(VTTT1002U 매수 / VTTT1006U 매도 / VTTT1004U 정정취소), `trid_provider.py`가 `is_paper_trading`으로 분기한다. 따라서 "모의가 없어 배선=실계좌 발사"라는 잠금 명분은 무효이고, 남은 유효 사유는 Phase 5 미완과 엣지 부재(아래 스윕 결과)뿐이다. 단 **모의 서버의 실제 주문 수락 여부는 아직 미검증** — `scripts/probe_overseas_paper_order.py --send`로 확인 후 이 문단을 갱신할 것.
 
 ### O-1. 미국 휴장일/조기폐장 캘린더 [완료 — #621, 2026-07-03]
 


### PR DESCRIPTION
## 배경

저장소 4곳이 **"해외 주문 TR은 실전만 존재, 모의 주문 TR 없음"** 이라고 기술하고 있었으나 stale하다.

`config/tr_ids_config.yaml:44-55` 에는 real/paper 쌍이 모두 있다:

| 항목 | 실전 | 모의 |
|---|---|---|
| 매수 | TTTT1002U | **VTTT1002U** |
| 매도 | TTTT1006U | **VTTT1006U** |
| 정정취소 | TTTT1004U | **VTTT1004U** |

`git log -S 'order_buy_paper: VTTT1002U'` → PR #606 「해외주식 미국 주문 정규장(모의) 전환」에서 추가됐다. 그 PR의 목적 자체가 모의 미지원인 주간거래(TTTS603x) → 모의 검증 가능한 정규장(TTTT100xU) 전환이었고, `trid_provider.py:132-145`가 `is_paper_trading`으로 분기한다. 문서만 따라가지 못했다.

`todo_list.md`는 아직 #606이 걷어낸 옛 TR(`TTTS6036U`)을 인용하고 있었다.

## 함께 정정한 것

같은 문장의 **"장중/실시간 전략은 불가"** 도 stale이다. #776이 `OverseasIntradayVBOService`/`Task`(REST 폴링)로 장중 진입·청산 판정 경로를 추가했고 `scheduler_bootstrap.py:158`에 등록돼 있다. 해외에 웹소켓/분봉이 없다는 제약은 여전하지만, 그래서 "불가"가 아니라 "폴링이 유일한 틱 소스"가 정확한 기술이다.

## 의미

잠금의 명분 중 **"모의가 없어 배선 = 실계좌 발사"는 무효**가 됐다. 남은 유효 사유는 Phase 5 미완(canary/kill-switch/reconcile)과 엣지 부재(08-05 스윕: 27조합 낙관 상한 전부 음수)뿐이다.

`live_enabled=False` 잠금 자체는 코드에 그대로 있고 이 PR은 건드리지 않는다.

## 미검증은 미검증으로

모의 서버가 해외 주문을 **실제로** 수락하는지는 아직 확인되지 않았다(코드 계약만 확인). 4곳 모두 이 점을 명시하고 `scripts/probe_overseas_paper_order.py`(#807)를 가리키게 했다.

## 변경 범위

| 파일 | 성격 |
|---|---|
| `CODEBASE_SUMMARY.md` | 문서 |
| `todo_list.md` | 문서 |
| `services/overseas_order_execution_service.py` | **docstring 전용** |
| `services/overseas_vbo_dryrun_service.py` | **docstring 전용** |

## 검증

- `pytest tests/unit_test -k overseas` — **331 passed**
- 편집한 두 모듈 import 정상 확인
- 통합 테스트는 생략했다. `.py` 변경이 docstring 전용이라 동작 변경이 없다(CLAUDE.md의 주석 전용 수정 예외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
