### PR TITLE
Add trade trend history page

### DIFF
--- a/repositories/trade_trend_repository.py
+++ b/repositories/trade_trend_repository.py
@@ -4,12 +4,15 @@ import json
 from pathlib import Path
 from typing import Union
 
+from services.trade_trend_service import NationalTradeTrendRelease
+
 
 class TradeTrendRepository:
     def __init__(self, path: Union[str, Path] = "data/trade_trend_state.json") -> None:
         self._path = Path(path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._sent_keys: set[str] = set()
+        self._national_release_history: list[dict] = []
         self._load()
 
     def has_sent(self, key: str) -> bool:
@@ -19,6 +22,44 @@ class TradeTrendRepository:
         self._sent_keys.add(key)
         self._save()
 
+    def mark_national_release_sent(
+        self,
+        release: NationalTradeTrendRelease,
+        *,
+        sent_at: str = "",
+    ) -> None:
+        self._sent_keys.add(release.dedup_key)
+        row = _national_release_to_dict(release, sent_at=sent_at)
+        existing = {
+            str(item.get("dedup_key")): item
+            for item in self._national_release_history
+            if isinstance(item, dict)
+        }
+        existing[release.dedup_key] = row
+        self._national_release_history = list(existing.values())
+        self._save()
+
+    def get_national_release_history(self) -> list[dict]:
+        rows = list(self._national_release_history)
+        known = {
+            str(item.get("dedup_key"))
+            for item in rows
+            if isinstance(item, dict) and item.get("dedup_key")
+        }
+        for key in sorted(self._sent_keys):
+            if not key.startswith("national_trade:") or key in known:
+                continue
+            rows.append(_legacy_national_release_from_key(key))
+        return sorted(
+            rows,
+            key=lambda item: (
+                str(item.get("published_at") or ""),
+                str(item.get("period_label") or ""),
+                str(item.get("sent_at") or ""),
+            ),
+            reverse=True,
+        )
+
     def _load(self) -> None:
         if not self._path.exists():
             return
@@ -27,10 +68,65 @@ class TradeTrendRepository:
         except (OSError, json.JSONDecodeError):
             return
         self._sent_keys = set(str(key) for key in payload.get("sent_keys", []))
+        raw_history = payload.get("national_release_history", [])
+        if isinstance(raw_history, list):
+            self._national_release_history = [
+                item for item in raw_history if isinstance(item, dict)
+            ]
 
     def _save(self) -> None:
-        payload = {"sent_keys": sorted(self._sent_keys)}
+        payload = {
+            "sent_keys": sorted(self._sent_keys),
+            "national_release_history": self.get_national_release_history(),
+        }
         self._path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+
+
+def _national_release_to_dict(
+    release: NationalTradeTrendRelease,
+    *,
+    sent_at: str = "",
+) -> dict:
+    return {
+        "source": release.source,
+        "source_type": "sent",
+        "phase": release.phase,
+        "title": release.title,
+        "url": release.url,
+        "period_label": release.period_label,
+        "export_amount_100m_usd": release.export_amount_100m_usd,
+        "export_yoy_pct": release.export_yoy_pct,
+        "import_amount_100m_usd": release.import_amount_100m_usd,
+        "import_yoy_pct": release.import_yoy_pct,
+        "trade_balance_100m_usd": release.trade_balance_100m_usd,
+        "trade_balance_label": release.trade_balance_label,
+        "published_at": release.published_at,
+        "highlights": list(release.highlights or []),
+        "sent_at": sent_at,
+        "dedup_key": release.dedup_key,
+    }
+
+
+def _legacy_national_release_from_key(key: str) -> dict:
+    _, phase, period_label, url = key.split(":", 3)
+    return {
+        "source": "",
+        "source_type": "sent",
+        "phase": phase,
+        "title": "",
+        "url": url,
+        "period_label": period_label,
+        "export_amount_100m_usd": None,
+        "export_yoy_pct": None,
+        "import_amount_100m_usd": None,
+        "import_yoy_pct": None,
+        "trade_balance_100m_usd": None,
+        "trade_balance_label": "",
+        "published_at": "",
+        "highlights": [],
+        "sent_at": "",
+        "dedup_key": key,
+    }

--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -287,6 +287,8 @@ def _phase_from_title(title: str) -> str:
         return "customs_10d"
     if re.search(r"1\s*일\s*[~∼-]\s*(?:\d{1,2}\s*월\s*)?20\s*일", title):
         return "customs_20d"
+    if "확정치" in title:
+        return "customs_monthly_final"
     if "잠정치" in title:
         return "customs_monthly"
     return "motie_monthly"
@@ -518,6 +520,8 @@ def format_national_trade_trend_report_html(
         title = "전국 월간 수출입동향"
     elif release.phase == "customs_monthly":
         title = "전국 월간 수출입 잠정치"
+    elif release.phase == "customs_monthly_final":
+        title = "전국 월간 수출입 확정치"
     lines = [
         f"🌐 <b>{title} ({html.escape(release.period_label, quote=False)})</b>",
         f"수출: <b>{money(release.export_amount_100m_usd)}</b> ({pct(release.export_yoy_pct)})",

--- a/task/background/always_on/trade_trend_monitor_task.py
+++ b/task/background/always_on/trade_trend_monitor_task.py
@@ -78,6 +78,9 @@ class TradeTrendMonitorTask(SchedulableTask):
     def get_progress(self) -> dict:
         return dict(self._progress)
 
+    def get_national_release_history(self) -> list[dict]:
+        return self._repository.get_national_release_history()
+
     async def start(self) -> None:
         if any(not task.done() for task in self._tasks):
             return
@@ -192,5 +195,9 @@ class TradeTrendMonitorTask(SchedulableTask):
                 continue
             sent = await self._reporter.send_national_trade_trend_report(release)
             if sent:
-                self._repository.mark_sent(release.dedup_key)
+                now = self._market_clock.get_current_kst_time()
+                self._repository.mark_national_release_sent(
+                    release,
+                    sent_at=now.isoformat(),
+                )
                 self._progress["national_sent_count"] += 1

--- a/tests/integration_test/view/web/templates/test_it_template_static_assets.py
+++ b/tests/integration_test/view/web/templates/test_it_template_static_assets.py
@@ -27,6 +27,7 @@ PAGE_PATHS = [
     "/virtual",
     "/scheduler",
     "/strategy-reports",
+    "/trade-trends",
     "/program",
     "/system",
 ]
@@ -102,6 +103,7 @@ def test_rendered_pages_reference_served_static_assets(web_client_with_fake_ctx)
         ("/overseas-marketcap", "overseas_us"),
         ("/overseas-ranking", "overseas_us"),
         ("/virtual", "common"),
+        ("/trade-trends", "common"),
         ("/system", "common"),
     ],
 )

--- a/tests/unit_test/repositories/test_trade_trend_repository.py
+++ b/tests/unit_test/repositories/test_trade_trend_repository.py
@@ -1,0 +1,63 @@
+from services.trade_trend_service import NationalTradeTrendRelease
+from repositories.trade_trend_repository import TradeTrendRepository
+
+
+def test_trade_trend_repository_saves_national_release_history(tmp_path):
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 8월 1~10일",
+        export_amount_100m_usd=301.2,
+        export_yoy_pct=12.3,
+        import_amount_100m_usd=250.1,
+        import_yoy_pct=4.5,
+        trade_balance_100m_usd=51.1,
+        trade_balance_label="흑자",
+        published_at="2026-08-11",
+        highlights=["반도체 수출 증가"],
+    )
+    path = tmp_path / "trade_trend_state.json"
+    repo = TradeTrendRepository(path)
+
+    repo.mark_national_release_sent(release, sent_at="2026-08-11T09:30:00")
+    loaded = TradeTrendRepository(path)
+
+    assert loaded.has_sent(release.dedup_key)
+    assert loaded.get_national_release_history()[0]["period_label"] == "2026년 8월 1~10일"
+    assert loaded.get_national_release_history()[0]["source_type"] == "sent"
+    assert loaded.get_national_release_history()[0]["export_amount_100m_usd"] == 301.2
+    assert loaded.get_national_release_history()[0]["sent_at"] == "2026-08-11T09:30:00"
+
+
+def test_trade_trend_repository_backfills_legacy_national_sent_keys(tmp_path):
+    path = tmp_path / "trade_trend_state.json"
+    path.write_text(
+        '{"sent_keys":["national_trade:customs_20d:2026년 7월 1~20일:https://customs.example/20d"]}',
+        encoding="utf-8",
+    )
+    repo = TradeTrendRepository(path)
+
+    history = repo.get_national_release_history()
+
+    assert history == [
+        {
+            "source": "",
+            "source_type": "sent",
+            "phase": "customs_20d",
+            "title": "",
+            "url": "https://customs.example/20d",
+            "period_label": "2026년 7월 1~20일",
+            "export_amount_100m_usd": None,
+            "export_yoy_pct": None,
+            "import_amount_100m_usd": None,
+            "import_yoy_pct": None,
+            "trade_balance_100m_usd": None,
+            "trade_balance_label": "",
+            "published_at": "",
+            "highlights": [],
+            "sent_at": "",
+            "dedup_key": "national_trade:customs_20d:2026년 7월 1~20일:https://customs.example/20d",
+        }
+    ]

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -259,6 +259,25 @@ async def test_national_web_client_discovers_matching_links_and_fetches_details(
 
 
 @pytest.mark.asyncio
+async def test_national_web_client_skips_customs_final_releases():
+    list_html = """
+    <a href="javascript:" data-id="10170123" class="nttInfoBtn"
+       title="2026년 6월 월간 수출입 현황 [확정치]">final</a>
+    """
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(return_value=DummyTextResponse(list_html))
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=["https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362"],
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert releases == []
+    http_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_national_web_client_discovers_motie_article_view_links():
     list_html = """
     <a href="javascript:article.view('172077');"><i>2026년 7월 수출입 동향</i></a>

--- a/tests/unit_test/view/web/routes/test_trade_trend.py
+++ b/tests/unit_test/view/web/routes/test_trade_trend.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+import view.web.api_common as api_common
+import view.web.web_main as web_main
+from services.trade_trend_service import NationalTradeTrendRelease
+
+
+def test_national_trade_trend_history_merges_stored_and_recent_rows():
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 8월 1~10일",
+        export_amount_100m_usd=301,
+        export_yoy_pct=12.0,
+        import_amount_100m_usd=250,
+        import_yoy_pct=4.0,
+        trade_balance_100m_usd=51,
+        trade_balance_label="흑자",
+        published_at="2026-08-11",
+    )
+    stored = {
+        "source": "customs",
+        "source_type": "sent",
+        "phase": release.phase,
+        "title": release.title,
+        "url": release.url,
+        "period_label": release.period_label,
+        "export_amount_100m_usd": release.export_amount_100m_usd,
+        "export_yoy_pct": release.export_yoy_pct,
+        "import_amount_100m_usd": release.import_amount_100m_usd,
+        "import_yoy_pct": release.import_yoy_pct,
+        "trade_balance_100m_usd": release.trade_balance_100m_usd,
+        "trade_balance_label": release.trade_balance_label,
+        "published_at": release.published_at,
+        "highlights": [],
+        "sent_at": "2026-08-11T09:30:00",
+        "dedup_key": release.dedup_key,
+    }
+    ctx = SimpleNamespace(
+        full_config={"use_login": False, "auth": {"secret_key": "test-token"}},
+        trade_trend_monitor_task=SimpleNamespace(
+            get_national_release_history=lambda: [stored],
+        ),
+        national_trade_trend_client=SimpleNamespace(
+            fetch_recent_releases=AsyncMock(return_value=[release]),
+        ),
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).get("/api/trade-trends/national/history")
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["rows"]) == 1
+    assert payload["data"]["rows"][0]["source_type"] == "sent"
+    assert payload["data"]["rows"][0]["period_label"] == "2026년 8월 1~10일"

--- a/view/web/routes/__init__.py
+++ b/view/web/routes/__init__.py
@@ -29,6 +29,7 @@ from view.web.routes.strategy_report import router as strategy_report_router
 from view.web.routes.operator_dashboard import router as operator_dashboard_router
 from view.web.routes.ai import router as ai_router
 from view.web.routes.youtube import router as youtube_router
+from view.web.routes.trade_trend import router as trade_trend_router
 
 router = APIRouter(prefix="/api")
 protected_router = APIRouter(
@@ -59,4 +60,5 @@ protected_router.include_router(strategy_report_router)
 protected_router.include_router(operator_dashboard_router)
 protected_router.include_router(ai_router)
 protected_router.include_router(youtube_router)
+protected_router.include_router(trade_trend_router)
 router.include_router(protected_router)

--- a/view/web/routes/trade_trend.py
+++ b/view/web/routes/trade_trend.py
@@ -1,0 +1,87 @@
+"""
+수출입동향 조회 API.
+"""
+from fastapi import APIRouter, Query
+
+from services.trade_trend_service import NationalTradeTrendRelease
+from view.web.api_common import _get_ctx
+
+router = APIRouter()
+
+
+def _release_to_dict(release: NationalTradeTrendRelease, source_type: str) -> dict:
+    return {
+        "source": release.source,
+        "source_type": source_type,
+        "phase": release.phase,
+        "title": release.title,
+        "url": release.url,
+        "period_label": release.period_label,
+        "export_amount_100m_usd": release.export_amount_100m_usd,
+        "export_yoy_pct": release.export_yoy_pct,
+        "import_amount_100m_usd": release.import_amount_100m_usd,
+        "import_yoy_pct": release.import_yoy_pct,
+        "trade_balance_100m_usd": release.trade_balance_100m_usd,
+        "trade_balance_label": release.trade_balance_label,
+        "published_at": release.published_at,
+        "highlights": list(release.highlights or []),
+        "sent_at": "",
+        "dedup_key": release.dedup_key,
+    }
+
+
+def _merge_rows(*groups: list[dict]) -> list[dict]:
+    rows_by_key: dict[str, dict] = {}
+    for rows in groups:
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            key = str(row.get("dedup_key") or row.get("url") or "")
+            if not key:
+                continue
+            current = rows_by_key.get(key, {})
+            merged = dict(row)
+            if current:
+                merged = {**row, **{k: v for k, v in current.items() if v not in (None, "", [])}}
+                if current.get("source_type") == "sent":
+                    merged["source_type"] = "sent"
+            rows_by_key[key] = merged
+    return sorted(
+        rows_by_key.values(),
+        key=lambda item: (
+            str(item.get("published_at") or ""),
+            str(item.get("period_label") or ""),
+            str(item.get("sent_at") or ""),
+        ),
+        reverse=True,
+    )
+
+
+@router.get("/trade-trends/national/history")
+async def get_national_trade_trend_history(
+    include_recent: bool = Query(True),
+    limit: int = Query(60, ge=1, le=300),
+):
+    """저장된 알림 이력과 공식 페이지 최신 후보를 함께 반환한다."""
+    ctx = _get_ctx()
+    task = getattr(ctx, "trade_trend_monitor_task", None)
+    stored_rows = []
+    if task is not None and hasattr(task, "get_national_release_history"):
+        stored_rows = task.get_national_release_history()
+
+    recent_rows = []
+    client = getattr(ctx, "national_trade_trend_client", None)
+    if include_recent and client is not None:
+        releases = await client.fetch_recent_releases()
+        recent_rows = [_release_to_dict(release, "official") for release in releases]
+
+    rows = _merge_rows(stored_rows, recent_rows)[:limit]
+    return {
+        "success": True,
+        "data": {
+            "rows": rows,
+            "latest": rows[0] if rows else None,
+            "stored_count": len(stored_rows),
+            "recent_count": len(recent_rows),
+        },
+    }

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -512,6 +512,109 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 .summary-item .label { font-size: 0.75rem; color: var(--text-secondary); }
 .summary-item .value { font-size: 1.2rem; font-weight: 700; margin-top: 4px; }
 
+.trade-trend-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.trade-trend-summary {
+    margin-top: 12px;
+}
+
+.trade-trend-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+    gap: 12px;
+    margin: 12px 0;
+}
+
+.trade-trend-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+    height: 260px;
+    padding: 12px 4px 4px;
+    overflow-x: auto;
+}
+
+.trade-trend-chart-group {
+    display: grid;
+    grid-template-rows: 1fr auto;
+    gap: 8px;
+    min-width: 72px;
+    height: 100%;
+}
+
+.trade-trend-bars {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 4px;
+    min-height: 0;
+}
+
+.trade-trend-bar {
+    width: 18px;
+    border-radius: 4px 4px 0 0;
+    display: inline-block;
+}
+
+.trade-trend-bar.export {
+    background: #e94560;
+}
+
+.trade-trend-bar.import {
+    background: #2f80ed;
+}
+
+.trade-trend-chart-label {
+    min-height: 34px;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    text-align: center;
+    line-height: 1.25;
+}
+
+.trade-trend-highlights {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.trade-trend-highlight {
+    padding: 8px 10px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.86rem;
+    line-height: 1.45;
+}
+
+.trade-trend-muted {
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+}
+
+.trade-trend-empty {
+    width: 100%;
+    align-self: center;
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.trade-trend-table td {
+    vertical-align: middle;
+}
+
+@media (max-width: 760px) {
+    .trade-trend-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 .stats-box {
     background-color: #f8f9fa;
     padding: 15px;

--- a/view/web/static/js/trade_trends.js
+++ b/view/web/static/js/trade_trends.js
@@ -1,0 +1,174 @@
+let tradeTrendRows = [];
+let tradeTrendFilter = 'all';
+
+function tradeMoney(value) {
+    if (value === null || value === undefined || value === '') return '-';
+    return `${Number(value).toLocaleString(undefined, { maximumFractionDigits: 1 })}억 달러`;
+}
+
+function tradePct(value) {
+    if (value === null || value === undefined || value === '') return '-';
+    const number = Number(value);
+    return `${number > 0 ? '+' : ''}${number.toFixed(1)}%`;
+}
+
+function tradeBalance(row) {
+    if (row.trade_balance_100m_usd === null || row.trade_balance_100m_usd === undefined) return '-';
+    const label = row.trade_balance_label ? ` ${row.trade_balance_label}` : '';
+    return `${Math.abs(Number(row.trade_balance_100m_usd)).toLocaleString(undefined, { maximumFractionDigits: 1 })}억 달러${label}`;
+}
+
+function phaseLabel(phase) {
+    if (phase === 'customs_10d') return '1~10일';
+    if (phase === 'customs_20d') return '1~20일';
+    if (phase === 'customs_monthly_final') return '월간 확정';
+    if (phase === 'customs_monthly') return '월간 잠정';
+    if (phase === 'motie_monthly') return '산업부 월간';
+    return phase || '-';
+}
+
+function sourceLabel(row) {
+    if (row.source_type === 'sent') return '발송됨';
+    return '공식 최신';
+}
+
+async function loadTradeTrendHistory() {
+    const status = document.getElementById('trade-trend-status');
+    if (status) status.textContent = '조회 중';
+    try {
+        const res = await fetch('/api/trade-trends/national/history?include_recent=true&limit=120');
+        const payload = await res.json();
+        if (!res.ok || !payload.success) {
+            throw new Error(payload.detail || '수출입동향 조회 실패');
+        }
+        tradeTrendRows = payload.data.rows || [];
+        renderTradeTrendSummary(payload.data.latest);
+        renderTradeTrendChart(tradeTrendRows);
+        renderTradeTrendHighlights(tradeTrendRows);
+        renderTradeTrendTable();
+        if (status) {
+            const recentCount = payload.data.recent_count || 0;
+            const storedCount = payload.data.stored_count || 0;
+            status.textContent = `공식 후보 ${recentCount}건, 발송 이력 ${storedCount}건`;
+        }
+    } catch (error) {
+        if (status) status.textContent = `조회 실패: ${error.message}`;
+        tradeTrendRows = [];
+        renderTradeTrendSummary(null);
+        renderTradeTrendChart([]);
+        renderTradeTrendHighlights([]);
+        renderTradeTrendTable();
+    }
+}
+
+function renderTradeTrendSummary(latest) {
+    document.getElementById('trade-latest-period').textContent = latest ? latest.period_label : '-';
+    document.getElementById('trade-latest-export').textContent = latest ? tradeMoney(latest.export_amount_100m_usd) : '-';
+    document.getElementById('trade-latest-import').textContent = latest ? tradeMoney(latest.import_amount_100m_usd) : '-';
+    document.getElementById('trade-latest-balance').textContent = latest ? tradeBalance(latest) : '-';
+}
+
+function filterTradeTrendRows(filter, button) {
+    tradeTrendFilter = filter;
+    const parent = button && button.closest('.sub-nav-container');
+    if (parent) {
+        parent.querySelectorAll('.sub-tab-btn').forEach((el) => el.classList.remove('active'));
+        button.classList.add('active');
+    }
+    renderTradeTrendTable();
+}
+
+function filteredTradeTrendRows() {
+    if (tradeTrendFilter === 'all') return tradeTrendRows;
+    if (tradeTrendFilter === 'monthly') {
+        return tradeTrendRows.filter((row) => String(row.phase || '').includes('monthly') || row.phase === 'motie_monthly');
+    }
+    return tradeTrendRows.filter((row) => row.phase === tradeTrendFilter);
+}
+
+function renderTradeTrendTable() {
+    const tbody = document.getElementById('trade-trend-history-body');
+    if (!tbody) return;
+    const rows = filteredTradeTrendRows();
+    if (!rows.length) {
+        tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;padding:18px;">표시할 수출입동향이 없습니다.</td></tr>';
+        return;
+    }
+    tbody.innerHTML = rows.map((row) => `
+        <tr>
+            <td>
+                <strong>${escapeHtml(row.period_label || '-')}</strong>
+                <div class="trade-trend-muted">${escapeHtml(phaseLabel(row.phase))}</div>
+            </td>
+            <td>${escapeHtml(row.published_at || '-')}</td>
+            <td>${tradeMoney(row.export_amount_100m_usd)}</td>
+            <td class="${Number(row.export_yoy_pct || 0) >= 0 ? 'text-red' : 'text-blue'}">${tradePct(row.export_yoy_pct)}</td>
+            <td>${tradeMoney(row.import_amount_100m_usd)}</td>
+            <td class="${Number(row.import_yoy_pct || 0) >= 0 ? 'text-red' : 'text-blue'}">${tradePct(row.import_yoy_pct)}</td>
+            <td><strong>${tradeBalance(row)}</strong></td>
+            <td><span class="badge ${row.source_type === 'sent' ? 'open' : 'paper'}">${sourceLabel(row)}</span></td>
+            <td>${row.url ? `<a class="stock-link" target="_blank" rel="noopener" href="${escapeAttribute(row.url)}">보기</a>` : '-'}</td>
+        </tr>
+    `).join('');
+}
+
+function renderTradeTrendChart(rows) {
+    const chart = document.getElementById('trade-trend-chart');
+    if (!chart) return;
+    const points = rows
+        .filter((row) => row.export_amount_100m_usd !== null && row.export_amount_100m_usd !== undefined)
+        .slice(0, 12)
+        .reverse();
+    if (!points.length) {
+        chart.innerHTML = '<div class="trade-trend-empty">차트로 볼 숫자 데이터가 없습니다.</div>';
+        return;
+    }
+    const maxValue = Math.max(...points.map((row) => Math.max(
+        Number(row.export_amount_100m_usd || 0),
+        Number(row.import_amount_100m_usd || 0),
+    )), 1);
+    chart.innerHTML = points.map((row) => {
+        const exportHeight = Math.max(6, Number(row.export_amount_100m_usd || 0) / maxValue * 100);
+        const importHeight = Math.max(6, Number(row.import_amount_100m_usd || 0) / maxValue * 100);
+        return `
+            <div class="trade-trend-chart-group" title="${escapeAttribute(row.period_label || '')}">
+                <div class="trade-trend-bars">
+                    <span class="trade-trend-bar export" style="height:${exportHeight}%"></span>
+                    <span class="trade-trend-bar import" style="height:${importHeight}%"></span>
+                </div>
+                <div class="trade-trend-chart-label">${escapeHtml(row.period_label || '-')}</div>
+            </div>
+        `;
+    }).join('');
+}
+
+function renderTradeTrendHighlights(rows) {
+    const target = document.getElementById('trade-trend-highlights');
+    if (!target) return;
+    const highlights = [];
+    rows.forEach((row) => {
+        (row.highlights || []).forEach((item) => {
+            if (item && !highlights.includes(item)) highlights.push(item);
+        });
+    });
+    if (!highlights.length) {
+        target.innerHTML = '<div class="trade-trend-muted">핵심 품목 메모가 없습니다.</div>';
+        return;
+    }
+    target.innerHTML = highlights.slice(0, 6).map((item) =>
+        `<div class="trade-trend-highlight">${escapeHtml(item)}</div>`
+    ).join('');
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+    return escapeHtml(value);
+}

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investment - Web View</title>
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/static/css/style.css?v=15">
+    <link rel="stylesheet" href="/static/css/style.css?v=16">
     <style>
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spinning { display: inline-block; animation: spin 1s linear infinite; opacity: 1 !important; }
@@ -103,6 +103,7 @@
         {% if can_operate %}<a href="/virtual" class="{% if active_page == 'virtual' %}active{% endif %}">모의투자 기록</a>{% endif %}
         {% if can_operate %}<a href="/scheduler" class="{% if active_page == 'scheduler' %}active{% endif %}">전략 스케줄러</a>{% endif %}
         <a href="/strategy-reports" class="{% if active_page == 'strategy_reports' %}active{% endif %}">상세 리포트</a>
+        <a href="/trade-trends" class="{% if active_page == 'trade_trends' %}active{% endif %}">수출입동향</a>
         <a href="/youtube" class="{% if active_page == 'youtube' %}active{% endif %}">유튜브 다이제스트</a>
         {% if can_operate %}<a href="/system" class="{% if active_page == 'system' %}active{% endif %}">시스템 상태</a>{% endif %}
     {% endif %}

--- a/view/web/templates/trade_trends.html
+++ b/view/web/templates/trade_trends.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div id="section-trade-trends" class="section">
+    <div class="card">
+        <div class="trade-trend-toolbar">
+            <div>
+                <h2>수출입동향</h2>
+                <div id="trade-trend-status" class="trade-trend-muted">조회 대기 중</div>
+            </div>
+            <button class="btn btn-secondary" onclick="loadTradeTrendHistory()">새로고침</button>
+        </div>
+        <div class="summary-bar trade-trend-summary">
+            <div class="summary-item">
+                <div class="label">최신 구간</div>
+                <div class="value" id="trade-latest-period">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">수출</div>
+                <div class="value" id="trade-latest-export">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">수입</div>
+                <div class="value" id="trade-latest-import">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">무역수지</div>
+                <div class="value" id="trade-latest-balance">-</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="trade-trend-grid">
+        <div class="card trade-trend-chart-card">
+            <h2>최근 흐름</h2>
+            <div id="trade-trend-chart" class="trade-trend-chart"></div>
+        </div>
+        <div class="card trade-trend-notes-card">
+            <h2>핵심 품목 메모</h2>
+            <div id="trade-trend-highlights" class="trade-trend-highlights">-</div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="trade-trend-toolbar">
+            <h2>히스토리</h2>
+            <div class="sub-nav-container">
+                <button class="sub-tab-btn active" onclick="filterTradeTrendRows('all', this)">전체</button>
+                <button class="sub-tab-btn" onclick="filterTradeTrendRows('customs_10d', this)">1~10일</button>
+                <button class="sub-tab-btn" onclick="filterTradeTrendRows('customs_20d', this)">1~20일</button>
+                <button class="sub-tab-btn" onclick="filterTradeTrendRows('monthly', this)">월간</button>
+            </div>
+        </div>
+        <div class="table-container">
+            <table class="data-table trade-trend-table">
+                <thead>
+                    <tr>
+                        <th>구간</th>
+                        <th>발표</th>
+                        <th>수출</th>
+                        <th>수출 YoY</th>
+                        <th>수입</th>
+                        <th>수입 YoY</th>
+                        <th>무역수지</th>
+                        <th>상태</th>
+                        <th>원문</th>
+                    </tr>
+                </thead>
+                <tbody id="trade-trend-history-body"></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/trade_trends.js?v=1"></script>
+<script>
+    loadTradeTrendHistory();
+</script>
+{% endblock %}

--- a/view/web/web_main.py
+++ b/view/web/web_main.py
@@ -599,6 +599,10 @@ async def operator_dashboard(request: Request):
 async def strategy_reports(request: Request):
     return await render_page(request, "strategy_reports.html", "strategy_reports")
 
+@page_router.get("/trade-trends")
+async def trade_trends(request: Request):
+    return await render_page(request, "trade_trends.html", "trade_trends")
+
 @page_router.get("/heatmap")
 async def heatmap(request: Request):
     return await render_page(request, "heatmap.html", "heatmap")


### PR DESCRIPTION
## Summary
- store national trade trend alert details in trade_trend_state.json
- add /api/trade-trends/national/history merging sent history with current official candidates
- add /trade-trends page with summary, bar chart, highlights, and filterable table
- keep customs final releases out of current parser because their body format can produce bad numeric extraction

## Official status checked
- Customs official search currently shows latest 2026-07-01~20 release; 2026-08-01~10 is not posted yet as of 2026-08-11 KST.

## Validation
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v
- smoke-tested NationalTradeTrendWebClient against live customs/MOTIR pages