### PR TITLE
Show stored trade trend history without monitor task

### DIFF
--- a/repositories/trade_trend_repository.py
+++ b/repositories/trade_trend_repository.py
@@ -46,10 +46,23 @@ class TradeTrendRepository:
             for item in rows
             if isinstance(item, dict) and item.get("dedup_key")
         }
+        known_periods = {
+            (str(item.get("phase") or ""), str(item.get("period_label") or ""))
+            for item in rows
+            if isinstance(item, dict) and item.get("phase") and item.get("period_label")
+        }
         for key in sorted(self._sent_keys):
             if not key.startswith("national_trade:") or key in known:
                 continue
-            rows.append(_legacy_national_release_from_key(key))
+            legacy = _legacy_national_release_from_key(key)
+            period_key = (
+                str(legacy.get("phase") or ""),
+                str(legacy.get("period_label") or ""),
+            )
+            if period_key in known_periods:
+                continue
+            rows.append(legacy)
+            known_periods.add(period_key)
         return sorted(
             rows,
             key=lambda item: (

--- a/tests/unit_test/repositories/test_trade_trend_repository.py
+++ b/tests/unit_test/repositories/test_trade_trend_repository.py
@@ -83,3 +83,30 @@ def test_trade_trend_repository_backfills_legacy_national_sent_keys(tmp_path):
             "dedup_key": "national_trade:customs_20d:2026년 7월 1~20일:https://customs.example/20d",
         }
     ]
+
+
+def test_trade_trend_repository_skips_legacy_key_when_period_history_exists(tmp_path):
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 8월 1~10일",
+        export_amount_100m_usd=213,
+        import_amount_100m_usd=195,
+        trade_balance_100m_usd=18,
+        trade_balance_label="흑자",
+        published_at="2026-08-11",
+    )
+    path = tmp_path / "trade_trend_state.json"
+    repo = TradeTrendRepository(path)
+    repo.mark_sent(
+        "national_trade:customs_10d:2026년 8월 1~10일:https://tradedata.example/10d"
+    )
+    repo.mark_national_release_sent(release, sent_at="2026-08-11T17:27:41+09:00")
+
+    history = TradeTrendRepository(path).get_national_release_history()
+
+    assert len(history) == 1
+    assert history[0]["dedup_key"] == release.dedup_key
+    assert history[0]["export_amount_100m_usd"] == 213

--- a/tests/unit_test/view/web/routes/test_trade_trend.py
+++ b/tests/unit_test/view/web/routes/test_trade_trend.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 import view.web.api_common as api_common
 import view.web.web_main as web_main
+from repositories.trade_trend_repository import TradeTrendRepository
 from services.trade_trend_service import NationalTradeTrendRelease
 
 
@@ -79,3 +80,52 @@ def test_national_trade_trend_history_merges_stored_and_recent_rows():
     assert payload["data"]["rows"][0]["period_label"] == "2026년 8월 1~10일"
     assert payload["data"]["rows"][0]["semiconductor_export_amount_100m_usd"] == 101
     assert payload["data"]["rows"][0]["working_days_current"] == 10.0
+
+
+def test_national_trade_trend_history_reads_state_file_when_task_is_missing(tmp_path):
+    state_file = tmp_path / "trade_trend_state.json"
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 8월 1~10일",
+        export_amount_100m_usd=213,
+        export_yoy_pct=45.3,
+        export_daily_avg_100m_usd=30.4,
+        semiconductor_export_amount_100m_usd=100,
+        semiconductor_daily_avg_100m_usd=14.3,
+        working_days_current=7.0,
+        import_amount_100m_usd=195,
+        import_yoy_pct=23.1,
+        trade_balance_100m_usd=18,
+        trade_balance_label="흑자",
+        published_at="2026-08-11",
+    )
+    TradeTrendRepository(state_file).mark_national_release_sent(
+        release,
+        sent_at="2026-08-11T17:27:41+09:00",
+    )
+    ctx = SimpleNamespace(
+        full_config={
+            "use_login": False,
+            "auth": {"secret_key": "test-token"},
+            "trade_trend_monitor": {"state_file_path": str(state_file)},
+        },
+        trade_trend_monitor_task=None,
+        national_trade_trend_client=None,
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).get(
+            "/api/trade-trends/national/history?include_recent=false"
+        )
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["data"]["stored_count"] == 1
+    assert payload["data"]["rows"][0]["period_label"] == "2026년 8월 1~10일"
+    assert payload["data"]["rows"][0]["semiconductor_export_amount_100m_usd"] == 100

--- a/view/web/routes/trade_trend.py
+++ b/view/web/routes/trade_trend.py
@@ -3,6 +3,7 @@
 """
 from fastapi import APIRouter, Query
 
+from repositories.trade_trend_repository import TradeTrendRepository
 from services.trade_trend_service import NationalTradeTrendRelease
 from view.web.api_common import _get_ctx
 
@@ -72,6 +73,33 @@ def _merge_rows(*groups: list[dict]) -> list[dict]:
     )
 
 
+def _config_section(ctx, section_name: str):
+    full_config = getattr(ctx, "full_config", {}) or {}
+    if isinstance(full_config, dict):
+        return full_config.get(section_name, {}) or {}
+    return getattr(full_config, section_name, None)
+
+
+def _config_value(section, key: str, default):
+    if isinstance(section, dict):
+        return section.get(key, default)
+    return getattr(section, key, default)
+
+
+def _load_stored_national_release_history(ctx) -> list[dict]:
+    task = getattr(ctx, "trade_trend_monitor_task", None)
+    if task is not None and hasattr(task, "get_national_release_history"):
+        return task.get_national_release_history()
+
+    trade_config = _config_section(ctx, "trade_trend_monitor")
+    repository_path = _config_value(
+        trade_config,
+        "state_file_path",
+        "data/trade_trend_state.json",
+    )
+    return TradeTrendRepository(repository_path).get_national_release_history()
+
+
 @router.get("/trade-trends/national/history")
 async def get_national_trade_trend_history(
     include_recent: bool = Query(True),
@@ -79,10 +107,7 @@ async def get_national_trade_trend_history(
 ):
     """저장된 알림 이력과 공식 페이지 최신 후보를 함께 반환한다."""
     ctx = _get_ctx()
-    task = getattr(ctx, "trade_trend_monitor_task", None)
-    stored_rows = []
-    if task is not None and hasattr(task, "get_national_release_history"):
-        stored_rows = task.get_national_release_history()
+    stored_rows = _load_stored_national_release_history(ctx)
 
     recent_rows = []
     client = getattr(ctx, "national_trade_trend_client", None)


### PR DESCRIPTION
## Summary
- Read stored national trade trend history from the JSON state file when the monitor task is not initialized
- Keep the history endpoint populated even when trade_trend_monitor is absent from config.yaml
- Skip duplicate legacy sent-key rows when a full history row already exists for the same phase and period

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\\unit_test -q
- python -m pytest tests\\integration_test -q