### PR TITLE
Prevent duplicate market cap gap reports

### DIFF
--- a/scheduler/strategy_scheduler_store.py
+++ b/scheduler/strategy_scheduler_store.py
@@ -201,6 +201,28 @@ class StrategySchedulerStore:
             row = cur.fetchone()
         return row[0] if row else None
 
+    def claim_daily_task(self, task_name: str, date_str: str) -> bool:
+        """task_name/date 조합을 원자적으로 선점한다.
+
+        여러 프로세스가 같은 SQLite DB를 공유해도 INSERT OR IGNORE의 UNIQUE
+        제약으로 최초 1개 프로세스만 True를 받는다.
+        """
+        key = f"daily_task_claim::{task_name}::{date_str}"
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT OR IGNORE INTO scheduler_state (key, value) VALUES (?, ?)",
+                (key, "claimed"),
+            )
+            self._conn.commit()
+            return cur.rowcount == 1
+
+    def release_daily_task(self, task_name: str, date_str: str) -> None:
+        """실패한 daily task claim을 해제해 다음 실행에서 재시도 가능하게 한다."""
+        key = f"daily_task_claim::{task_name}::{date_str}"
+        with self._lock:
+            self._conn.execute("DELETE FROM scheduler_state WHERE key = ?", (key,))
+            self._conn.commit()
+
     # ── 레거시 파일 마이그레이션 ──
 
     def _migrate_legacy_files(self) -> None:

--- a/task/background/after_market/market_cap_gap_report_task.py
+++ b/task/background/after_market/market_cap_gap_report_task.py
@@ -94,9 +94,37 @@ class MarketCapGapReportTask(AfterMarketTask):
         except Exception as exc:
             self._logger.warning(f"{self.task_name}: 마지막 전송 날짜 저장 실패 — {exc}")
 
+    def _claim_report_date(self, date_str: str) -> bool:
+        if self._scheduler_store is None:
+            return True
+        claim = getattr(self._scheduler_store, "claim_daily_task", None)
+        if claim is None:
+            return True
+        try:
+            return bool(claim(self.task_name, date_str))
+        except Exception as exc:
+            self._logger.warning(f"{self.task_name}: 일일 실행 claim 실패 — {exc}")
+            return True
+
+    def _release_report_date_claim(self, date_str: str) -> None:
+        if self._scheduler_store is None:
+            return
+        release = getattr(self._scheduler_store, "release_daily_task", None)
+        if release is None:
+            return
+        try:
+            release(self.task_name, date_str)
+        except Exception as exc:
+            self._logger.warning(f"{self.task_name}: 일일 실행 claim 해제 실패 — {exc}")
+
     async def _on_market_closed(self, latest_trading_date: str) -> None:
         if self._last_reported_date == latest_trading_date:
             self._logger.info(f"{self.task_name}: {latest_trading_date} 이미 전송 완료 — 스킵")
+            return
+        if not self._claim_report_date(latest_trading_date):
+            self._logger.info(
+                f"{self.task_name}: {latest_trading_date} 다른 프로세스가 이미 실행 중/완료 — 스킵"
+            )
             return
 
         self._progress["running"] = True
@@ -135,5 +163,7 @@ class MarketCapGapReportTask(AfterMarketTask):
                     "시총갭 리포트 전송 실패",
                     str(exc),
                 )
+            if self._last_reported_date != latest_trading_date:
+                self._release_report_date_claim(latest_trading_date)
         finally:
             self._progress["running"] = False

--- a/tests/unit_test/scheduler/test_strategy_scheduler_store.py
+++ b/tests/unit_test/scheduler/test_strategy_scheduler_store.py
@@ -121,6 +121,29 @@ def test_save_and_load_keyed_value(store):
     assert store.load_keyed("last_run") == "2026-04-22 09:00:00"
 
 
+def test_claim_daily_task_allows_only_first_store(db_path, mock_logger):
+    """여러 store 인스턴스가 같은 DB를 써도 같은 태스크/날짜 claim은 1회만 성공한다."""
+    store1 = StrategySchedulerStore(db_path=db_path, logger=mock_logger)
+    store2 = StrategySchedulerStore(db_path=db_path, logger=mock_logger)
+    try:
+        assert store1.claim_daily_task("market_cap_gap_report_us", "20260811") is True
+        assert store2.claim_daily_task("market_cap_gap_report_us", "20260811") is False
+        assert store2.claim_daily_task("market_cap_gap_report_us", "20260812") is True
+    finally:
+        store1.close()
+        store2.close()
+
+
+def test_release_daily_task_allows_retry(store):
+    """실패한 daily task는 claim 해제 후 재시도할 수 있다."""
+    assert store.claim_daily_task("market_cap_gap_report_us", "20260811") is True
+    assert store.claim_daily_task("market_cap_gap_report_us", "20260811") is False
+
+    store.release_daily_task("market_cap_gap_report_us", "20260811")
+
+    assert store.claim_daily_task("market_cap_gap_report_us", "20260811") is True
+
+
 def test_migrate_csv_success(tmp_path, mock_logger, monkeypatch):
     """CSV 레거시 파일 마이그레이션 성공 테스트"""
     csv_path = tmp_path / "signal_history.csv"

--- a/tests/unit_test/task/background/after_market/test_market_cap_gap_report_task.py
+++ b/tests/unit_test/task/background/after_market/test_market_cap_gap_report_task.py
@@ -32,12 +32,23 @@ class _FakeStore:
 
     def __init__(self):
         self._data = {}
+        self._claims = set()
 
     def save_keyed(self, key, value):
         self._data[key] = value
 
     def load_keyed(self, key):
         return self._data.get(key)
+
+    def claim_daily_task(self, task_name, date_str):
+        key = (task_name, date_str)
+        if key in self._claims:
+            return False
+        self._claims.add(key)
+        return True
+
+    def release_daily_task(self, task_name, date_str):
+        self._claims.discard((task_name, date_str))
 
 
 @pytest.mark.asyncio
@@ -85,6 +96,54 @@ async def test_persisted_date_skips_resend_after_restart(service, reporter):
     # build_report/전송은 최초 1회뿐이어야 한다 (catch-up 재전송 방지)
     service.build_report.assert_awaited_once()
     reporter.send_market_cap_gap_report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_claimed_date_skips_without_build_or_send(service, reporter):
+    """다른 프로세스가 같은 날짜를 선점했으면 리포트 생성 전 스킵한다."""
+    store = _FakeStore()
+    assert store.claim_daily_task("market_cap_gap_report_us", "20260625") is True
+
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="us_close",
+        scheduler_store=store,
+        logger=MagicMock(),
+    )
+
+    await task._on_market_closed("20260625")
+
+    service.build_report.assert_not_called()
+    reporter.send_market_cap_gap_report.assert_not_called()
+    assert task.get_progress()["last_reported_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_failed_report_releases_claim_for_retry(service, reporter):
+    service.build_report.side_effect = [RuntimeError("boom"), {
+        "report_date": "20260625",
+        "trigger": "us_close",
+        "fx_rate": 1400.0,
+        "korean": [],
+        "us": [],
+        "comparisons": [],
+    }]
+    store = _FakeStore()
+    task = MarketCapGapReportTask(
+        market_cap_gap_service=service,
+        telegram_reporter=reporter,
+        session="us_close",
+        scheduler_store=store,
+        logger=MagicMock(),
+    )
+
+    await task._on_market_closed("20260625")
+    await task._on_market_closed("20260625")
+
+    assert service.build_report.await_count == 2
+    reporter.send_market_cap_gap_report.assert_awaited_once()
+    assert task.get_progress()["last_reported_date"] == "20260625"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add an atomic SQLite daily-task claim to StrategySchedulerStore
- Use the claim before building/sending market cap gap reports so concurrent app processes skip duplicates
- Release the claim on failed report generation so a later retry can run

## Tests
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test/scheduler/test_strategy_scheduler_store.py tests/unit_test/task/background/after_market/test_market_cap_gap_report_task.py -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v (7146 passed, 2 warnings)
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v (279 passed)