### PR TITLE
Add national trade trend year backfill

### DIFF
--- a/repositories/trade_trend_repository.py
+++ b/repositories/trade_trend_repository.py
@@ -28,16 +28,42 @@ class TradeTrendRepository:
         *,
         sent_at: str = "",
     ) -> None:
+        self.save_national_release(
+            release,
+            source_type="sent",
+            sent_at=sent_at,
+        )
+
+    def save_national_release(
+        self,
+        release: NationalTradeTrendRelease,
+        *,
+        source_type: str = "backfill",
+        sent_at: str = "",
+    ) -> bool:
         self._sent_keys.add(release.dedup_key)
-        row = _national_release_to_dict(release, sent_at=sent_at)
+        row = _national_release_to_dict(
+            release,
+            source_type=source_type,
+            sent_at=sent_at,
+        )
         existing = {
             str(item.get("dedup_key")): item
             for item in self._national_release_history
             if isinstance(item, dict)
         }
+        previous = existing.get(release.dedup_key)
+        if (
+            isinstance(previous, dict)
+            and previous.get("source_type") == "sent"
+            and source_type != "sent"
+        ):
+            row["source_type"] = "sent"
+            row["sent_at"] = previous.get("sent_at", "")
         existing[release.dedup_key] = row
         self._national_release_history = list(existing.values())
         self._save()
+        return previous != row
 
     def get_national_release_history(self) -> list[dict]:
         rows = list(self._national_release_history)
@@ -101,11 +127,12 @@ class TradeTrendRepository:
 def _national_release_to_dict(
     release: NationalTradeTrendRelease,
     *,
+    source_type: str = "sent",
     sent_at: str = "",
 ) -> dict:
     return {
         "source": release.source,
-        "source_type": "sent",
+        "source_type": source_type,
         "phase": release.phase,
         "title": release.title,
         "url": release.url,

--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -7,7 +7,7 @@ import zipfile
 from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Optional
-from urllib.parse import urljoin
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 from xml.etree import ElementTree as ET
 
 import httpx
@@ -200,18 +200,35 @@ class NationalTradeTrendWebClient:
         self._max_detail_pages = max_detail_pages
 
     async def fetch_recent_releases(self) -> list[NationalTradeTrendRelease]:
+        return await self.fetch_releases()
+
+    async def fetch_releases(
+        self,
+        *,
+        year: Optional[int] = None,
+        max_detail_pages: Optional[int] = None,
+        list_page_count: int = 1,
+    ) -> list[NationalTradeTrendRelease]:
         releases: list[NationalTradeTrendRelease] = []
         detail_url_groups: list[list[tuple[str, str]]] = []
-        for list_url in self._list_urls:
+        for list_url in _expand_list_page_urls(self._list_urls, list_page_count):
             html_text = await self._fetch_text(list_url)
-            detail_url_groups.append(_extract_national_trade_links(html_text, list_url))
+            links = _extract_national_trade_links(html_text, list_url)
+            if year is not None:
+                links = [
+                    (title, url)
+                    for title, url in links
+                    if _period_year_from_title(title) == year
+                ]
+            detail_url_groups.append(links)
 
         seen: set[str] = set()
+        detail_limit = max_detail_pages or self._max_detail_pages
         for title, url in _interleave(detail_url_groups):
             if url in seen:
                 continue
             seen.add(url)
-            if len(releases) >= self._max_detail_pages:
+            if len(releases) >= detail_limit:
                 break
             detail_text = await self._fetch_text(url)
             detail_text = await self._append_tradedata_attachment_text(detail_text, url)
@@ -375,6 +392,13 @@ def _period_year_month(period_label: str) -> Optional[tuple[int, int]]:
     if not match:
         return None
     return int(match.group(1)), int(match.group(2))
+
+
+def _period_year_from_title(title: str) -> Optional[int]:
+    match = re.search(r"(\d{4})년", title)
+    if not match:
+        return None
+    return int(match.group(1))
 
 
 def _previous_month_key(period_label: str, phase: str) -> Optional[tuple[str, int, int]]:
@@ -583,6 +607,31 @@ def _interleave(groups: list[list[tuple[str, str]]]) -> list[tuple[str, str]]:
             if index < len(group):
                 items.append(group[index])
     return items
+
+
+def _expand_list_page_urls(list_urls: list[str], list_page_count: int) -> list[str]:
+    page_count = max(1, int(list_page_count or 1))
+    urls = []
+    for url in list_urls:
+        urls.append(url)
+        for page_index in range(2, page_count + 1):
+            urls.append(_with_query_param(url, "pageIndex", str(page_index)))
+    return urls
+
+
+def _with_query_param(url: str, key: str, value: str) -> str:
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query[key] = value
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query),
+            parts.fragment,
+        )
+    )
 
 
 def parse_national_trade_release(

--- a/tests/unit_test/repositories/test_trade_trend_repository.py
+++ b/tests/unit_test/repositories/test_trade_trend_repository.py
@@ -110,3 +110,53 @@ def test_trade_trend_repository_skips_legacy_key_when_period_history_exists(tmp_
     assert len(history) == 1
     assert history[0]["dedup_key"] == release.dedup_key
     assert history[0]["export_amount_100m_usd"] == 213
+
+
+def test_trade_trend_repository_backfill_saves_release_without_sent_at(tmp_path):
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 6월 1일 ~ 6월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/20260610",
+        period_label="2026년 6월 1~10일",
+        export_amount_100m_usd=250,
+        import_amount_100m_usd=210,
+        trade_balance_100m_usd=40,
+        trade_balance_label="흑자",
+        published_at="2026-06-11",
+    )
+    path = tmp_path / "trade_trend_state.json"
+    repo = TradeTrendRepository(path)
+
+    repo.save_national_release(release, source_type="backfill")
+    loaded = TradeTrendRepository(path)
+    history = loaded.get_national_release_history()
+
+    assert loaded.has_sent(release.dedup_key)
+    assert history[0]["source_type"] == "backfill"
+    assert history[0]["sent_at"] == ""
+    assert history[0]["period_label"] == "2026년 6월 1~10일"
+
+
+def test_trade_trend_repository_backfill_preserves_existing_sent_marker(tmp_path):
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/10d",
+        period_label="2026년 8월 1~10일",
+        export_amount_100m_usd=213,
+        import_amount_100m_usd=195,
+        trade_balance_100m_usd=18,
+        trade_balance_label="흑자",
+        published_at="2026-08-11",
+    )
+    path = tmp_path / "trade_trend_state.json"
+    repo = TradeTrendRepository(path)
+    repo.mark_national_release_sent(release, sent_at="2026-08-11T17:27:41+09:00")
+
+    repo.save_national_release(release, source_type="backfill")
+    history = TradeTrendRepository(path).get_national_release_history()
+
+    assert history[0]["source_type"] == "sent"
+    assert history[0]["sent_at"] == "2026-08-11T17:27:41+09:00"

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -523,6 +523,43 @@ async def test_national_web_client_interleaves_sources_before_detail_limit():
 
 
 @pytest.mark.asyncio
+async def test_national_web_client_fetches_year_releases_from_paginated_lists():
+    first_page = """
+    <a href="/aug">2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]</a>
+    """
+    second_page = """
+    <a href="/dec">2025년 12월 1일 ~ 12월 20일 수출입 현황 [잠정치]</a>
+    <a href="/jan">2026년 1월 1일 ~ 1월 10일 수출입 현황 [잠정치]</a>
+    """
+    aug_detail = "수출은 213억 달러로 전년동기대비 45.3% 증가, 수입은 195억 달러로 23.1% 증가, 무역수지는 18억 달러 흑자"
+    jan_detail = "수출은 180억 달러로 전년동기대비 12.0% 증가, 수입은 170억 달러로 10.0% 증가, 무역수지는 10억 달러 흑자"
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(first_page),
+            DummyTextResponse(second_page),
+            DummyTextResponse(aug_detail),
+            DummyTextResponse(jan_detail),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=["https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362"],
+        max_detail_pages=10,
+    )
+
+    releases = await client.fetch_releases(year=2026, list_page_count=2)
+
+    assert [release.period_label for release in releases] == [
+        "2026년 8월 1~10일",
+        "2026년 1월 1~10일",
+    ]
+    requested_urls = [call.args[0] for call in http_client.get.await_args_list[:2]]
+    assert requested_urls[0].endswith("bbsId=1362")
+    assert "pageIndex=2" in requested_urls[1]
+
+
+@pytest.mark.asyncio
 async def test_national_web_client_skips_unparseable_and_unrelated_motie_releases():
     list_html = """
     <a href="javascript:article.view('1');"><i>2026년 7월 수출입 동향</i></a>

--- a/tests/unit_test/view/web/routes/test_trade_trend.py
+++ b/tests/unit_test/view/web/routes/test_trade_trend.py
@@ -129,3 +129,50 @@ def test_national_trade_trend_history_reads_state_file_when_task_is_missing(tmp_
     assert payload["data"]["stored_count"] == 1
     assert payload["data"]["rows"][0]["period_label"] == "2026년 8월 1~10일"
     assert payload["data"]["rows"][0]["semiconductor_export_amount_100m_usd"] == 100
+
+
+def test_national_trade_trend_backfill_saves_year_releases(tmp_path):
+    state_file = tmp_path / "trade_trend_state.json"
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 1월 1일 ~ 1월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/jan10",
+        period_label="2026년 1월 1~10일",
+        export_amount_100m_usd=180,
+        import_amount_100m_usd=170,
+        trade_balance_100m_usd=10,
+        trade_balance_label="흑자",
+        published_at="2026-01-11",
+    )
+    client = SimpleNamespace(
+        fetch_releases=AsyncMock(return_value=[release]),
+    )
+    ctx = SimpleNamespace(
+        full_config={
+            "use_login": False,
+            "auth": {"secret_key": "test-token"},
+            "trade_trend_monitor": {"state_file_path": str(state_file)},
+        },
+        trade_trend_monitor_task=None,
+        national_trade_trend_client=client,
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).post(
+            "/api/trade-trends/national/backfill?year=2026&max_detail_pages=20&list_page_count=2"
+        )
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["data"]["saved_count"] == 1
+    assert payload["data"]["stored_count"] == 1
+    assert TradeTrendRepository(state_file).get_national_release_history()[0]["source_type"] == "backfill"
+    client.fetch_releases.assert_awaited_once_with(
+        year=2026,
+        max_detail_pages=20,
+        list_page_count=2,
+    )

--- a/view/web/routes/trade_trend.py
+++ b/view/web/routes/trade_trend.py
@@ -1,7 +1,9 @@
 """
 수출입동향 조회 API.
 """
-from fastapi import APIRouter, Query
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
 
 from repositories.trade_trend_repository import TradeTrendRepository
 from services.trade_trend_service import NationalTradeTrendRelease
@@ -100,6 +102,16 @@ def _load_stored_national_release_history(ctx) -> list[dict]:
     return TradeTrendRepository(repository_path).get_national_release_history()
 
 
+def _repository_from_config(ctx) -> TradeTrendRepository:
+    trade_config = _config_section(ctx, "trade_trend_monitor")
+    repository_path = _config_value(
+        trade_config,
+        "state_file_path",
+        "data/trade_trend_state.json",
+    )
+    return TradeTrendRepository(repository_path)
+
+
 @router.get("/trade-trends/national/history")
 async def get_national_trade_trend_history(
     include_recent: bool = Query(True),
@@ -123,5 +135,41 @@ async def get_national_trade_trend_history(
             "latest": rows[0] if rows else None,
             "stored_count": len(stored_rows),
             "recent_count": len(recent_rows),
+        },
+    }
+
+
+@router.post("/trade-trends/national/backfill")
+async def backfill_national_trade_trend_history(
+    year: int | None = Query(None, ge=2000, le=2100),
+    max_detail_pages: int = Query(40, ge=1, le=200),
+    list_page_count: int = Query(4, ge=1, le=20),
+):
+    """공식 페이지에서 지정 연도 수출입 발표를 가져와 저장 이력에 누적한다."""
+    target_year = year or datetime.now().year
+    ctx = _get_ctx()
+    client = getattr(ctx, "national_trade_trend_client", None)
+    if client is None or not hasattr(client, "fetch_releases"):
+        raise HTTPException(status_code=503, detail="수출입동향 공식 페이지 클라이언트가 없습니다.")
+
+    releases = await client.fetch_releases(
+        year=target_year,
+        max_detail_pages=max_detail_pages,
+        list_page_count=list_page_count,
+    )
+    repository = _repository_from_config(ctx)
+    saved_count = 0
+    for release in releases:
+        if repository.save_national_release(release, source_type="backfill"):
+            saved_count += 1
+    stored_rows = repository.get_national_release_history()
+    return {
+        "success": True,
+        "data": {
+            "year": target_year,
+            "fetched_count": len(releases),
+            "saved_count": saved_count,
+            "stored_count": len(stored_rows),
+            "rows": stored_rows,
         },
     }


### PR DESCRIPTION
## Summary
- Add a national trade trend backfill endpoint for a target year
- Let the official-page client collect releases from multiple list pages with a year filter
- Store backfilled releases in trade_trend_state.json without losing existing sent markers

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\\unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\\integration_test -q