### PR TITLE
Fallback national trade trend backfill client

### DIFF
--- a/tests/unit_test/view/web/routes/test_trade_trend.py
+++ b/tests/unit_test/view/web/routes/test_trade_trend.py
@@ -176,3 +176,51 @@ def test_national_trade_trend_backfill_saves_year_releases(tmp_path):
         max_detail_pages=20,
         list_page_count=2,
     )
+
+
+def test_national_trade_trend_backfill_builds_client_when_missing(tmp_path, monkeypatch):
+    state_file = tmp_path / "trade_trend_state.json"
+    release = NationalTradeTrendRelease(
+        source="customs",
+        phase="customs_10d",
+        title="2026년 1월 1일 ~ 1월 10일 수출입 현황 [잠정치]",
+        url="https://customs.example/jan10",
+        period_label="2026년 1월 1~10일",
+        export_amount_100m_usd=180,
+        import_amount_100m_usd=170,
+        trade_balance_100m_usd=10,
+        trade_balance_label="흑자",
+        published_at="2026-01-11",
+    )
+    fallback_client = SimpleNamespace(
+        fetch_releases=AsyncMock(return_value=[release]),
+    )
+    monkeypatch.setattr(
+        "view.web.routes.trade_trend.NationalTradeTrendWebClient",
+        lambda: fallback_client,
+    )
+    ctx = SimpleNamespace(
+        full_config={
+            "use_login": False,
+            "auth": {"secret_key": "test-token"},
+            "trade_trend_monitor": {"state_file_path": str(state_file)},
+        },
+        trade_trend_monitor_task=None,
+        national_trade_trend_client=None,
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).post(
+            "/api/trade-trends/national/backfill?year=2026&max_detail_pages=20&list_page_count=2"
+        )
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    assert response.json()["data"]["stored_count"] == 1
+    fallback_client.fetch_releases.assert_awaited_once_with(
+        year=2026,
+        max_detail_pages=20,
+        list_page_count=2,
+    )

--- a/view/web/routes/trade_trend.py
+++ b/view/web/routes/trade_trend.py
@@ -3,10 +3,13 @@
 """
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Query
 
 from repositories.trade_trend_repository import TradeTrendRepository
-from services.trade_trend_service import NationalTradeTrendRelease
+from services.trade_trend_service import (
+    NationalTradeTrendRelease,
+    NationalTradeTrendWebClient,
+)
 from view.web.api_common import _get_ctx
 
 router = APIRouter()
@@ -112,6 +115,13 @@ def _repository_from_config(ctx) -> TradeTrendRepository:
     return TradeTrendRepository(repository_path)
 
 
+def _national_trade_trend_client(ctx):
+    client = getattr(ctx, "national_trade_trend_client", None)
+    if client is not None and hasattr(client, "fetch_releases"):
+        return client
+    return NationalTradeTrendWebClient()
+
+
 @router.get("/trade-trends/national/history")
 async def get_national_trade_trend_history(
     include_recent: bool = Query(True),
@@ -148,9 +158,7 @@ async def backfill_national_trade_trend_history(
     """공식 페이지에서 지정 연도 수출입 발표를 가져와 저장 이력에 누적한다."""
     target_year = year or datetime.now().year
     ctx = _get_ctx()
-    client = getattr(ctx, "national_trade_trend_client", None)
-    if client is None or not hasattr(client, "fetch_releases"):
-        raise HTTPException(status_code=503, detail="수출입동향 공식 페이지 클라이언트가 없습니다.")
+    client = _national_trade_trend_client(ctx)
 
     releases = await client.fetch_releases(
         year=target_year,


### PR DESCRIPTION
## Summary
- Allow the national trade trend backfill endpoint to run even when the web context did not initialize a national trade trend client
- Add route coverage for the missing-client fallback path

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\\unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\\integration_test -q