### PR TITLE
Fix favorite alerts from program price snapshots

### DIFF
--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -1214,6 +1214,54 @@ def test_web_realtime_callback_injects_scalar_price_and_skips_without_streaming(
     ctx._web_realtime_callback({"type": "realtime_program_trading", "data": {}})
 
 
+def test_web_realtime_callback_evaluates_favorite_alert_from_program_trading_price(mock_deps):
+    """프로그램매매 프레임에 주입된 가격도 관심종목 등락률 알림을 평가한다."""
+    ctx = WebAppContext(None)
+    ctx.streaming_service = MagicMock()
+    ctx.streaming_service.get_cached_realtime_price.return_value = {
+        "price": "85300",
+        "change": "-5100",
+        "rate": "-5.64",
+        "sign": "5",
+    }
+    data = {"type": "realtime_program_trading", "data": {"유가증권단축종목코드": "080220"}}
+
+    with patch.object(ctx, "_schedule_favorite_alert_from_program_price") as mock_schedule:
+        ctx._web_realtime_callback(data)
+
+    mock_schedule.assert_called_once_with(
+        "080220",
+        price="85300",
+        rate="-5.64",
+        sign="5",
+    )
+    ctx.streaming_service.dispatch_realtime_message.assert_called_once_with(data)
+
+
+def test_schedule_favorite_alert_from_program_price_creates_task(mock_deps):
+    """프로그램매매 가격 기반 관심종목 알림 평가는 백그라운드 태스크로 예약한다."""
+    ctx = WebAppContext(None)
+    ctx.favorite_price_alert_service = MagicMock()
+    ctx.favorite_price_alert_service.handle_price_tick = MagicMock(return_value="alert-coro")
+    loop = MagicMock()
+
+    with patch("view.web.web_app_initializer.asyncio.get_running_loop", return_value=loop):
+        ctx._schedule_favorite_alert_from_program_price(
+            "080220",
+            price="85300",
+            rate="-5.64",
+            sign="5",
+        )
+
+    ctx.favorite_price_alert_service.handle_price_tick.assert_called_once_with(
+        "080220",
+        price="85300",
+        rate="-5.64",
+        sign="5",
+    )
+    loop.create_task.assert_called_once_with("alert-coro")
+
+
 def test_emit_and_log_missing_reason_no_logger_or_price_service(mock_deps):
     """streaming logger/service 누락 및 price stream service 누락 분기를 확인한다."""
     ctx = WebAppContext(None)

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -540,6 +540,12 @@ class WebAppContext:
                         item['change'] = price_data.get('change')
                         item['rate'] = price_data.get('rate')
                         item['sign'] = price_data.get('sign')
+                        self._schedule_favorite_alert_from_program_price(
+                            code,
+                            price=item.get('price'),
+                            rate=item.get('rate'),
+                            sign=item.get('sign'),
+                        )
                     else:
                         item['price'] = price_data
                 elif code:
@@ -548,6 +554,25 @@ class WebAppContext:
 
         if self.streaming_service:
             self.streaming_service.dispatch_realtime_message(data)
+
+    def _schedule_favorite_alert_from_program_price(self, code: str, *, price, rate, sign) -> None:
+        """프로그램매매 프레임에 보강된 가격으로 관심종목 등락률 알림을 평가한다."""
+        if not code or price is None or rate is None or not self.favorite_price_alert_service:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(
+                self.favorite_price_alert_service.handle_price_tick(
+                    code,
+                    price=price,
+                    rate=rate,
+                    sign=sign,
+                )
+            )
+        except RuntimeError:
+            pass
+        except Exception as e:
+            self.logger.warning(f"프로그램매매 가격 기반 관심종목 알림 평가 실패 ({code}): {e}")
 
     def _emit_missing_reason(self, code: str, reason: str) -> None:
         """동일 종목/원인 로그를 저빈도로 남긴다."""


### PR DESCRIPTION
﻿## Summary
- evaluate favorite price threshold alerts when program-trading frames include cached price/rate data
- add regression coverage for program-trading price alert scheduling

## Tests
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v`
- `C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v`
