### PR TITLE
지수 카드 수급 표시 + x축 눈금 보강

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -156,6 +156,14 @@ class BrokerAPIWrapper:
         return await self._client.inquire_time_indexchartprice(index_code,
                                                                interval_seconds=interval_seconds)
 
+    async def inquire_index_price(self, index_code: str) -> ResCommonResponse:
+        """국내업종 현재지수(등락 종목수 포함)를 조회합니다 (KoreaInvestApiQuotations 위임)."""
+        return await self._client.inquire_index_price(index_code)
+
+    async def inquire_investor_daily_by_market(self, index_code: str, date: str = None) -> ResCommonResponse:
+        """시장별 투자자매매동향(일별)을 조회합니다 (KoreaInvestApiQuotations 위임)."""
+        return await self._client.inquire_investor_daily_by_market(index_code, date=date)
+
     async def inquire_time_itemchartprice(
         self, *, stock_code: str, input_hour_1: str,
         pw_data_incu_yn: str = "Y", etc_cls_code: str = "0"

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -184,6 +184,14 @@ class KoreaInvestApiClient:
         return await self._quotations.inquire_time_indexchartprice(index_code,
                                                                    interval_seconds=interval_seconds)
 
+    async def inquire_index_price(self, index_code: str) -> ResCommonResponse:
+        """국내업종(코스피/코스닥) 현재지수를 조회합니다. ResCommonResponse를 반환합니다."""
+        return await self._quotations.inquire_index_price(index_code)
+
+    async def inquire_investor_daily_by_market(self, index_code: str, date: str = None) -> ResCommonResponse:
+        """시장별(코스피/코스닥) 투자자매매동향(일별)을 조회합니다. ResCommonResponse를 반환합니다."""
+        return await self._quotations.inquire_investor_daily_by_market(index_code, date=date)
+
     async def inquire_time_itemchartprice(
         self,
         *,

--- a/brokers/korea_investment/korea_invest_params_provider.py
+++ b/brokers/korea_investment/korea_invest_params_provider.py
@@ -135,6 +135,49 @@ class TimeIndexChartPriceParams:
 
 
 @dataclass(frozen=True)
+class IndexPriceParams:
+    """국내업종 현재지수. 등락 종목수(ascn/stnr/down_issu_cnt)가 여기서만 나온다."""
+    fid_cond_mrkt_div_code: str  # 업종/지수는 "U"
+    fid_input_iscd: str  # 업종코드 (코스피 0001 / 코스닥 1001)
+
+    @classmethod
+    def index_price(cls, index_code: str):
+        return cls(fid_cond_mrkt_div_code="U", fid_input_iscd=index_code)
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InvestorDailyByMarketParams:
+    """시장별 투자자매매동향(일별). 업종코드(0001)와 업종구분(KSP)을 함께 요구한다."""
+    # KIS 는 같은 시장을 업종코드와 업종구분 두 축으로 받는다.
+    MARKET_DIVISIONS = {"0001": "KSP", "1001": "KSQ"}
+
+    fid_cond_mrkt_div_code: str  # 업종/지수는 "U"
+    fid_input_iscd: str  # 업종코드 (코스피 0001 / 코스닥 1001)
+    fid_input_date_1: str  # 조회 일자
+    fid_input_iscd_1: str  # 업종구분 (KSP 코스피 / KSQ 코스닥)
+    fid_input_date_2: str  # 조회 일자 (KIS 스펙상 date_1 과 동일)
+    fid_input_iscd_2: str  # 업종분류코드 (업종코드와 동일)
+
+    @classmethod
+    def of(cls, index_code: str, date: str):
+        day = tm.to_yyyymmdd(date)
+        return cls(
+            fid_cond_mrkt_div_code="U",
+            fid_input_iscd=index_code,
+            fid_input_date_1=day,
+            fid_input_iscd_1=cls.MARKET_DIVISIONS[index_code],
+            fid_input_date_2=day,
+            fid_input_iscd_2=index_code,
+        )
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class TimeItemChartPriceParams:
     fid_cond_mrkt_div_code: str  # 보통 "J"
     fid_input_iscd: str  # 종목코드
@@ -792,6 +835,14 @@ class Params:
     @staticmethod
     def time_indexchartprice(index_code: str, interval_seconds: int, include_past: str = "N") -> Dict[str, str]:
         return TimeIndexChartPriceParams.time_indexchartprice(index_code, interval_seconds, include_past).to_dict()
+
+    @staticmethod
+    def index_price(index_code: str) -> Dict[str, str]:
+        return IndexPriceParams.index_price(index_code).to_dict()
+
+    @staticmethod
+    def investor_daily_by_market(index_code: str, date: str) -> Dict[str, str]:
+        return InvestorDailyByMarketParams.of(index_code, date).to_dict()
 
     @staticmethod
     def time_itemchartprice(stock_code: str, input_hour: str,

--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Union, Optional
 from pydantic import ValidationError
 from brokers.korea_investment.korea_invest_api_base import KoreaInvestApiBase
 from brokers.korea_investment.korea_invest_env import KoreaInvestApiEnv
-from brokers.korea_investment.korea_invest_params_provider import Params
+from brokers.korea_investment.korea_invest_params_provider import Params, InvestorDailyByMarketParams
 from brokers.korea_investment.korea_invest_header_provider import KoreaInvestHeaderProvider
 from brokers.korea_investment.korea_invest_url_provider import KoreaInvestUrlProvider
 from brokers.korea_investment.korea_invest_url_keys import EndpointKey
@@ -555,6 +555,86 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
             rt_cd=ErrorCode.SUCCESS.value,
             msg1="지수 분봉 조회 성공",
             data={"summary": summary, "candles": candles},
+        )
+
+    async def inquire_index_price(self, index_code: str) -> ResCommonResponse:
+        """
+        국내업종(코스피 0001 / 코스닥 1001) 현재지수를 조회합니다.
+        TRID: FHPUP02100000 (실전 전용 가능성)
+        상승/보합/하락 종목수(ascn/stnr/down_issu_cnt)는 이 TR 에서만 나옵니다.
+        data 에 output 딕셔너리를 그대로 담아 반환합니다.
+        """
+        tr_id = self._trid_provider.quotations(TrIdLeaf.INDEX_PRICE)
+        params = Params.index_price(index_code)
+
+        with self._headers.temp(tr_id=tr_id):
+            response_data: ResCommonResponse = await self.call_api(
+                "GET", EndpointKey.INDEX_PRICE, params=params
+            )
+
+        if response_data.rt_cd != ErrorCode.SUCCESS.value:
+            error_msg = f"업종 현재지수 API 응답 비정상 (index_code: {index_code}), 응답: {response_data.data}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=error_msg, data=None)
+
+        raw = response_data.data if isinstance(response_data.data, dict) else {}
+        output = raw.get("output") or {}
+        if isinstance(output, list):
+            output = output[0] if output else {}
+
+        if not output:
+            warning_msg = f"업종 현재지수 데이터가 비어있음 (index_code: {index_code})"
+            self._logger.warning(warning_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.MISSING_KEY.value, msg1=warning_msg, data=None)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="업종 현재지수 조회 성공",
+            data=output,
+        )
+
+    async def inquire_investor_daily_by_market(self, index_code: str, date: str = None) -> ResCommonResponse:
+        """
+        시장별(코스피/코스닥) 투자자매매동향(일별)을 조회합니다.
+        TRID: FHPTJ04040000 (실전 전용 가능성)
+        data 에 output 행 리스트(최신순)를 담아 반환합니다.
+        순매수 거래대금(prsn/frgn/orgn_ntby_tr_pbmn) 단위는 백만원입니다.
+        """
+        if index_code not in InvestorDailyByMarketParams.MARKET_DIVISIONS:
+            error_msg = f"지원하지 않는 시장 코드: {index_code}"
+            self._logger.warning(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=error_msg, data=None)
+
+        if date is None:
+            date = datetime.now().strftime("%Y%m%d")
+
+        tr_id = self._trid_provider.quotations(TrIdLeaf.INVESTOR_DAILY_BY_MARKET)
+        params = Params.investor_daily_by_market(index_code, date)
+
+        with self._headers.temp(tr_id=tr_id):
+            response_data: ResCommonResponse = await self.call_api(
+                "GET", EndpointKey.INVESTOR_DAILY_BY_MARKET, params=params
+            )
+
+        if response_data.rt_cd != ErrorCode.SUCCESS.value:
+            error_msg = f"시장별 투자자매매동향 API 응답 비정상 (index_code: {index_code}), 응답: {response_data.data}"
+            self._logger.error(error_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=error_msg, data=None)
+
+        raw = response_data.data if isinstance(response_data.data, dict) else {}
+        rows = raw.get("output") or []
+        if not isinstance(rows, list):
+            rows = [rows]
+
+        if not rows:
+            warning_msg = f"시장별 투자자매매동향 데이터가 비어있음 (index_code: {index_code})"
+            self._logger.warning(warning_msg)
+            return ResCommonResponse(rt_cd=ErrorCode.MISSING_KEY.value, msg1=warning_msg, data=None)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="시장별 투자자매매동향 조회 성공",
+            data=rows,
         )
 
     async def inquire_time_itemchartprice(

--- a/brokers/korea_investment/korea_invest_trid_keys.py
+++ b/brokers/korea_investment/korea_invest_trid_keys.py
@@ -16,6 +16,8 @@ class TrIdLeaf(str, Enum):
     DAILY_ITEMCHARTPRICE =      "inquire_daily_itemchartprice"           # 기간별 시세 (일/주/월/년)
     DAILY_INDEXCHARTPRICE =     "inquire_daily_indexchartprice"          # 국내업종 기간별 지수 시세
     TIME_INDEXCHARTPRICE =      "inquire_time_indexchartprice"           # 국내업종 분봉 지수 시세
+    INDEX_PRICE =               "inquire_index_price"                    # 국내업종 현재지수 (등락 종목수, 실전 전용 가능성)
+    INVESTOR_DAILY_BY_MARKET =  "investor_daily_by_market"               # 시장별 투자자매매동향 일별 (실전 전용 가능성)
     TIME_ITEMCHARTPRICE =       "inquire_time_itemchartprice"             # 당일 분봉 조회
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice" # 일별 분봉 조회
     FINANCIAL_RATIO = "financial_ratio"  # 기업 재무비율

--- a/brokers/korea_investment/korea_invest_url_keys.py
+++ b/brokers/korea_investment/korea_invest_url_keys.py
@@ -15,6 +15,8 @@ class EndpointKey(str, Enum):
     DAILY_ITEMCHARTPRICE = "inquire_daily_itemchartprice"
     DAILY_INDEXCHARTPRICE = "inquire_daily_indexchartprice"
     TIME_INDEXCHARTPRICE = "inquire_time_indexchartprice"
+    INDEX_PRICE = "inquire_index_price"
+    INVESTOR_DAILY_BY_MARKET = "investor_daily_by_market"
     TIME_ITEMCHARTPRICE = "inquire_time_itemchartprice"
     TIME_DAILY_ITEMCHARTPRICE = "inquire_time_daily_itemchartprice"
     FINANCIAL_RATIO = "financial_ratio"

--- a/config/kis_config.yaml
+++ b/config/kis_config.yaml
@@ -16,6 +16,8 @@ paths:
   inquire_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice      # 기간별 시세 (일/주/월/년)
   inquire_daily_indexchartprice: /uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice    # 국내업종 기간별 지수 시세 (코스피/코스닥)
   inquire_time_indexchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-indexchartprice      # 국내업종 분봉 지수 시세 (코스피/코스닥)
+  inquire_index_price: /uapi/domestic-stock/v1/quotations/inquire-index-price                        # 국내업종 현재지수 (상승/보합/하락 종목수)
+  investor_daily_by_market: /uapi/domestic-stock/v1/quotations/inquire-investor-daily-by-market      # 시장별 투자자매매동향 일별 (개인/외국인/기관)
   inquire_time_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice        # 당일 분봉 조회
   inquire_time_daily_itemchartprice: /uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice # 일변 분봉 조회
   financial_ratio: /uapi/domestic-stock/v1/finance/financial-ratio  # 기업 재무비율 (영업이익 등)

--- a/config/tr_ids_config.yaml
+++ b/config/tr_ids_config.yaml
@@ -19,6 +19,8 @@ tr_ids:
     inquire_daily_itemchartprice:      FHKST03010100 # 기간별 시세 (일/주/월/년)
     inquire_daily_indexchartprice:     FHKUP03500100 # 국내업종 기간별 지수 시세 (코스피 0001 / 코스닥 1001)
     inquire_time_indexchartprice:      FHKUP03500200 # 국내업종 분봉 지수 시세 (FID_INPUT_HOUR_1 = 봉 간격(초))
+    inquire_index_price:               FHPUP02100000 # 국내업종 현재지수 (상승/보합/하락 종목수, 실전 전용 가능성)
+    investor_daily_by_market:          FHPTJ04040000 # 시장별 투자자매매동향 일별 (실전 전용 가능성)
     inquire_time_itemchartprice:       FHKST03010200 # 당일 분봉 조회
     inquire_time_daily_itemchartprice: FHKST03010230 # 일변 분봉 조회 (모의 미지원)
     financial_ratio: FHKST66430300  # 기업 재무비율 (KIS 문서 확인 필요, 실전 전용 가능성)

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -1,5 +1,6 @@
 # app/stock_query_service.py
 from __future__ import annotations
+import asyncio
 import time
 from datetime import datetime, timedelta
 from common.market_snapshot import ConclusionSnapshot, MarketSnapshot
@@ -1501,6 +1502,87 @@ class StockQueryService:
             "points": points,
         }
         return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="지수 조회 성공", data=data)
+
+    # 시장별 투자자매매동향은 백만원 단위로 온다. 카드에는 억원으로 표시한다.
+    _INVESTOR_FIELDS = {
+        "individual": "prsn_ntby_tr_pbmn",
+        "foreign": "frgn_ntby_tr_pbmn",
+        "institution": "orgn_ntby_tr_pbmn",
+    }
+    _BREADTH_FIELDS = {
+        "up": "ascn_issu_cnt",
+        "upper_limit": "uplm_issu_cnt",
+        "unchanged": "stnr_issu_cnt",
+        "down": "down_issu_cnt",
+        "lower_limit": "lslm_issu_cnt",
+    }
+
+    async def _index_investor_netbuy(self, index_code: str, date: str) -> Optional[dict]:
+        """개인/외국인/기관 순매수(억원). 조회 실패나 필드 누락이면 None."""
+        try:
+            resp = await self.broker.inquire_investor_daily_by_market(index_code, date=date)
+        except Exception as e:
+            self.logger.warning(f"지수 투자자 수급 조회 실패 ({index_code}): {e}")
+            return None
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
+            return None
+
+        rows = resp.data if isinstance(resp.data, list) else []
+        if not rows or not isinstance(rows[0], dict):
+            return None
+
+        netbuy = {}
+        for key, field in self._INVESTOR_FIELDS.items():
+            amount = _to_float(rows[0].get(field))
+            if amount is None:
+                return None
+            netbuy[key] = round(amount / 100)
+        return netbuy
+
+    async def _index_breadth(self, index_code: str) -> Optional[dict]:
+        """상승/보합/하락(및 상·하한) 종목수. 조회 실패나 필드 누락이면 None."""
+        try:
+            resp = await self.broker.inquire_index_price(index_code)
+        except Exception as e:
+            self.logger.warning(f"지수 등락 종목수 조회 실패 ({index_code}): {e}")
+            return None
+        if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not isinstance(resp.data, dict):
+            return None
+
+        breadth = {}
+        for key, field in self._BREADTH_FIELDS.items():
+            count = _to_float(resp.data.get(field))
+            if count is None:
+                return None
+            breadth[key] = int(count)
+        return breadth
+
+    async def get_index_flow(self, index_code: str) -> ResCommonResponse:
+        """코스피/코스닥의 당일 투자자 순매수와 등락 종목수를 조회한다.
+
+        기간 선택과 무관한 값이라 차트(get_index_chart)와 별도 호출로 둔다.
+        두 조회는 서로 다른 TR 이고 모의투자에서는 한쪽만 막힐 수 있어 각각 degrade 한다.
+        """
+        if index_code not in self.DOMESTIC_INDEX_NAMES:
+            msg = f"지원하지 않는 지수 코드: {index_code}"
+            self.logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=None)
+
+        date = self.market_clock.get_current_kst_time().strftime("%Y%m%d")
+        investors, breadth = await asyncio.gather(
+            self._index_investor_netbuy(index_code, date),
+            self._index_breadth(index_code),
+        )
+
+        if investors is None and breadth is None:
+            msg = f"지수 수급 조회 실패 ({index_code})"
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=msg, data=None)
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="지수 수급 조회 성공",
+            data={"code": index_code, "investors": investors, "breadth": breadth},
+        )
 
     async def get_recent_daily_index_ohlcv(
         self,

--- a/tests/frontend/run_market_indices_dom_tests.mjs
+++ b/tests/frontend/run_market_indices_dom_tests.mjs
@@ -43,6 +43,19 @@ const WIDGET_SRC =
 
 const SCAFFOLD = `<div id="market-indices"></div>`;
 
+function flowPayload(overrides) {
+  return Object.assign({
+    code: "0001",
+    investors: { individual: -31912, foreign: 28357, institution: 5277 },
+    breadth: { up: 380, upper_limit: 3, unchanged: 53, down: 477, lower_limit: 0 },
+  }, overrides || {});
+}
+
+// 차트와 수급은 서로 다른 엔드포인트라 기본 스텁은 URL 로 갈라준다.
+function defaultFetch(chartData) {
+  return async (url) => success(url.includes("/flow") ? flowPayload() : (chartData || indexPayload()));
+}
+
 async function makeWindow(fetchWithTimeout) {
   const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
     url: "http://localhost/",
@@ -55,7 +68,7 @@ async function makeWindow(fetchWithTimeout) {
     await new Promise(resolve => window.document.addEventListener("DOMContentLoaded", resolve));
   }
   applyCommonStubs(window);
-  window.fetchWithTimeout = fetchWithTimeout || (async () => success(indexPayload()));
+  window.fetchWithTimeout = fetchWithTimeout || defaultFetch();
   // Chart.js 는 CDN 로드라 jsdom 에서는 생성 호출만 기록한다.
   window.HTMLCanvasElement.prototype.getContext = () => ({});
   window.currentCharts = [];
@@ -212,20 +225,65 @@ test("국장 스파크라인은 x축에 날짜 눈금을 표시한다", async ()
   assert(config.options.scales.y.display === false, "y축은 계속 숨겨야 함");
 });
 
+// 눈금 콜백이 실제로 그리는 라벨만 추린다 (빈 문자열은 숨긴 눈금).
+function visibleTicks(chart) {
+  const { labels } = chart.config.data;
+  const { callback } = chart.config.options.scales.x.ticks;
+  return labels.map((_, i) => callback(i, i, labels)).filter(label => label !== "");
+}
+
 test("x축 눈금은 조밀해지지 않도록 개수를 제한한다", async () => {
   const points = Array.from({ length: 60 }, (_, i) => ({
     date: `202605${String((i % 28) + 1).padStart(2, "0")}`,
     close: 2600 + i,
   }));
-  const window = await makeWindow(async () => success(indexPayload({ points })));
+  const window = await makeWindow(defaultFetch(indexPayload({ points })));
 
   await window.renderMarketIndices();
 
-  const ticks = window.__charts[0].config.options.scales.x.ticks;
-  assert(ticks.autoSkip === true, "x축 눈금 autoSkip 이 꺼져 있음");
-  assert(ticks.maxTicksLimit > 1 && ticks.maxTicksLimit <= 6,
-    `x축 눈금 개수 제한이 비합리적임 (실제 ${ticks.maxTicksLimit})`);
+  const chart = window.__charts[0];
+  const ticks = chart.config.options.scales.x.ticks;
   assert(ticks.maxRotation === 0, "좁은 카드에서 라벨이 기울면 안 됨");
+  // 눈금 선택을 직접 하므로 Chart.js 의 autoSkip 이 겹쳐 잘라내면 안 된다.
+  assert(ticks.autoSkip === false, "직접 고른 눈금을 autoSkip 이 또 솎아냄");
+  const shown = visibleTicks(chart);
+  assert(shown.length > 3 && shown.length <= 7,
+    `x축 라벨 개수가 비합리적임 (실제 ${shown.length}개: ${shown})`);
+});
+
+test("x축 마지막 눈금은 항상 표시한다", async () => {
+  // 전일 기준점 + 09:00~15:30 10분봉 40개 = 41점 (정규장 하루치)
+  const points = [{ close: 6345.53, prev: true }];
+  for (let i = 0; i < 40; i++) {
+    const minutes = 9 * 60 + i * 10;
+    const hh = String(Math.floor(minutes / 60)).padStart(2, "0");
+    const mm = String(minutes % 60).padStart(2, "0");
+    points.push({ date: "20260812", time: `${hh}${mm}00`, close: 6400 + i });
+  }
+  const window = await makeWindow(defaultFetch(indexPayload({ period: "1D", points })));
+
+  await window.renderMarketIndices();
+
+  const chart = window.__charts[0];
+  const labels = chart.config.data.labels;
+  const { callback } = chart.config.options.scales.x.ticks;
+  assert(labels[labels.length - 1] === "15:30",
+    `마지막 라벨이 15:30 이어야 함 (실제 ${labels[labels.length - 1]})`);
+  // 기존에는 앞에서부터 솎아내느라 장 마감 시각이 잘려나갔다.
+  assert(callback(labels.length - 1, labels.length - 1, labels) === "15:30",
+    "장 마감 눈금이 표시되지 않음");
+  const shown = visibleTicks(chart);
+  assert(shown.length >= 5, `하루치 차트 눈금이 너무 적음 (실제 ${shown.length}개: ${shown})`);
+});
+
+test("점이 눈금 수보다 적으면 모든 라벨을 표시한다", async () => {
+  const window = await makeWindow(defaultFetch(minutePayload()));
+
+  await window.renderMarketIndices();
+
+  const shown = visibleTicks(window.__charts[0]);
+  assert(shown.join(",") === "09:00,09:10,09:20",
+    `점이 적으면 전부 표시해야 함 (실제 ${shown})`);
 });
 
 function minutePayload() {
@@ -253,7 +311,7 @@ test("국장 카드는 기간 선택 버튼을 갖고 기본은 1D 로 조회한
   assert(buttons.map(b => b.dataset.period).join(",") === "1D,1W,1M,1Y",
     `기간 버튼이 1D,1W,1M,1Y 여야 함 (실제 ${buttons.map(b => b.dataset.period)})`);
   assert(buttons[0].classList.contains("active"), "기본 기간 1D 가 선택 표시되어야 함");
-  assert(requested.every(u => u.includes("period=1D")),
+  assert(requested.filter(u => !u.includes("/flow")).every(u => u.includes("period=1D")),
     `기본 조회가 period=1D 여야 함 (실제 ${requested})`);
   // 미장 위젯 카드에는 기간 버튼을 붙이지 않는다(위젯이 자체 제공).
   const widget = window.document.querySelector('.market-index-card[data-kind="widget"]');
@@ -412,6 +470,98 @@ test("컨테이너가 없는 화면에서는 아무 일도 하지 않는다", as
   assert(!window.document.querySelector(".market-index-card"),
     "컨테이너가 없으면 카드를 만들면 안 됨");
   assert(!fetched, "컨테이너가 없으면 API 도 호출하면 안 됨");
+});
+
+// ── 수급 (투자자 순매수 + 등락 종목수) ──────────────────────────────────
+
+function flowOf(window, code = "0001") {
+  return window.document.querySelector(`.market-index-card[data-key="${code}"] .market-index-flow`);
+}
+
+test("국장 카드는 투자자 순매수와 등락 종목수를 함께 보여준다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    return success(url.includes("/flow") ? flowPayload() : minutePayload());
+  });
+
+  await window.renderMarketIndices();
+
+  assert(requested.some(u => u.includes("/api/market-index/0001/flow")), "코스피 수급 API 를 호출하지 않음");
+  assert(requested.some(u => u.includes("/api/market-index/1001/flow")), "코스닥 수급 API 를 호출하지 않음");
+
+  const flow = flowOf(window);
+  assert(flow, "수급 영역이 없음");
+  const text = flow.textContent;
+  ["개인", "외국인", "기관", "상승", "보합", "하락"].forEach(label => {
+    assert(text.includes(label), `수급에 '${label}' 이 없음: ${text}`);
+  });
+  assert(text.includes("-31,912"), `개인 순매수가 없음: ${text}`);
+  assert(text.includes("+28,357"), `외국인 순매수가 없음: ${text}`);
+  assert(text.includes("+5,277"), `기관 순매수가 없음: ${text}`);
+  // 상·하한 종목수는 네이버처럼 괄호로 덧붙인다.
+  assert(text.includes("380(3)"), `상승 종목수가 없음: ${text}`);
+  assert(text.includes("477(0)"), `하락 종목수가 없음: ${text}`);
+  assert(text.includes("53"), `보합 종목수가 없음: ${text}`);
+});
+
+test("순매수 부호와 등락은 상승/하락 색을 따른다", async () => {
+  const window = await makeWindow();
+
+  await window.renderMarketIndices();
+
+  const flow = flowOf(window);
+  const buy = Array.from(flow.querySelectorAll(".text-red")).map(el => el.textContent);
+  const sell = Array.from(flow.querySelectorAll(".text-blue")).map(el => el.textContent);
+  assert(buy.some(t => t.includes("28,357")), `순매수(+)는 상승색이어야 함 (실제 ${buy})`);
+  assert(sell.some(t => t.includes("31,912")), `순매도(-)는 하락색이어야 함 (실제 ${sell})`);
+  assert(buy.some(t => t.includes("380")), `상승 종목수는 상승색이어야 함 (실제 ${buy})`);
+  assert(sell.some(t => t.includes("477")), `하락 종목수는 하락색이어야 함 (실제 ${sell})`);
+});
+
+test("수급 조회가 실패하면 조용히 숨긴다", async () => {
+  const window = await makeWindow(async (url) => {
+    if (url.includes("/flow")) return { ok: false, status: 500, json: async () => ({}) };
+    return success(minutePayload());
+  });
+
+  await window.renderMarketIndices();
+
+  assert(!flowOf(window), "수급 조회 실패인데 영역이 남음");
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  assert(!kospi.querySelector(".market-index-error"), "수급 실패로 카드에 에러 문구가 뜸");
+  assert(kospi.querySelector("canvas"), "수급 실패가 차트까지 지움");
+});
+
+test("모의투자처럼 한쪽만 막히면 나오는 쪽만 보여준다", async () => {
+  const window = await makeWindow(async (url) => success(
+    url.includes("/flow") ? flowPayload({ investors: null }) : minutePayload()
+  ));
+
+  await window.renderMarketIndices();
+
+  const flow = flowOf(window);
+  assert(flow, "등락 종목수는 살아있는데 수급 영역이 없음");
+  assert(!flow.textContent.includes("개인"), `투자자 수급이 없는데 표시됨: ${flow.textContent}`);
+  assert(flow.textContent.includes("380(3)"), `등락 종목수가 없음: ${flow.textContent}`);
+});
+
+test("기간을 바꿔도 수급은 다시 조회하지 않는다", async () => {
+  const requested = [];
+  const window = await makeWindow(async (url) => {
+    requested.push(url);
+    return success(url.includes("/flow") ? flowPayload() : minutePayload());
+  });
+  await window.renderMarketIndices();
+  const kospi = window.document.querySelector('.market-index-card[data-key="0001"]');
+  const flowCallsBefore = requested.filter(u => u.includes("/flow")).length;
+
+  await window.selectMarketIndexPeriod(kospi, "0001", "1M");
+
+  assert(requested.filter(u => u.includes("/flow")).length === flowCallsBefore,
+    "기간 전환이 수급을 재조회함 (기간과 무관한 값)");
+  // 기간 전환이 body 를 비워도 수급 영역은 남아 있어야 한다.
+  assert(flowOf(window), "기간 전환이 수급 영역을 지움");
 });
 
 await run();

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_flow.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_index_flow.py
@@ -1,0 +1,180 @@
+"""국내업종 현재지수(등락 종목수)·시장별 투자자매매동향 조회 단위 테스트."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from brokers.korea_investment.korea_invest_quotations_api import KoreaInvestApiQuotations
+from brokers.korea_investment.korea_invest_url_keys import EndpointKey
+from common.types import ResCommonResponse, ErrorCode
+
+
+@pytest.fixture
+def quotations():
+    mock_env = MagicMock()
+    mock_env.active_config = {
+        "api_key": "dummy-key",
+        "api_secret_key": "dummy-secret",
+        "base_url": "https://mock-base",
+        "custtype": "P",
+        "paths": {},
+        "params": {},
+        "market_code": "J",
+    }
+
+    trid_provider = MagicMock()
+    trid_provider.quotations.return_value = "FHPUP02100000"
+
+    with patch("brokers.korea_investment.korea_invest_api_base.httpx.AsyncClient"):
+        api = KoreaInvestApiQuotations(
+            env=mock_env,
+            logger=MagicMock(),
+            market_clock=MagicMock(),
+            header_provider=MagicMock(),
+            url_provider=MagicMock(),
+            trid_provider=trid_provider,
+        )
+    return api
+
+
+def _ok(output):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data={"output": output})
+
+
+# ── 국내업종 현재지수 (상승/보합/하락 종목수) ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_index_price_sends_index_market_params(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok({"ascn_issu_cnt": "380"}))
+
+    await quotations.inquire_index_price("1001")
+
+    args, kwargs = quotations.call_api.call_args
+    assert args[0] == "GET"
+    assert args[1] == EndpointKey.INDEX_PRICE
+    params = kwargs["params"]
+    # 업종/지수는 시장분류 "U" 로 조회해야 한다 (주식 "J" 아님).
+    assert params["fid_cond_mrkt_div_code"] == "U"
+    assert params["fid_input_iscd"] == "1001"
+
+
+@pytest.mark.asyncio
+async def test_index_price_returns_issue_counts(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok({
+        "bstp_nmix_prpr": "6579.04",
+        "ascn_issu_cnt": "380",
+        "uplm_issu_cnt": "3",
+        "stnr_issu_cnt": "53",
+        "down_issu_cnt": "477",
+        "lslm_issu_cnt": "0",
+    }))
+
+    result = await quotations.inquire_index_price("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["ascn_issu_cnt"] == "380"
+    assert result.data["down_issu_cnt"] == "477"
+
+
+@pytest.mark.asyncio
+async def test_index_price_accepts_list_shaped_output(quotations):
+    # 일부 응답은 output 을 단일 원소 리스트로 준다.
+    quotations.call_api = AsyncMock(return_value=_ok([{"ascn_issu_cnt": "380"}]))
+
+    result = await quotations.inquire_index_price("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["ascn_issu_cnt"] == "380"
+
+
+@pytest.mark.asyncio
+async def test_index_price_reports_empty_output(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok({}))
+
+    result = await quotations.inquire_index_price("0001")
+
+    assert result.rt_cd == ErrorCode.MISSING_KEY.value
+
+
+@pytest.mark.asyncio
+async def test_index_price_propagates_api_error(quotations):
+    quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None,
+    ))
+
+    result = await quotations.inquire_index_price("0001")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+# ── 시장별 투자자매매동향(일별) ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_investor_by_market_sends_market_specific_params(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok([{"stck_bsop_date": "20260812"}]))
+
+    await quotations.inquire_investor_daily_by_market("1001", date="20260812")
+
+    args, kwargs = quotations.call_api.call_args
+    assert args[1] == EndpointKey.INVESTOR_DAILY_BY_MARKET
+    params = kwargs["params"]
+    assert params["fid_cond_mrkt_div_code"] == "U"
+    assert params["fid_input_iscd"] == "1001"
+    # 코스닥은 업종 구분이 KSQ (코스피는 KSP).
+    assert params["fid_input_iscd_1"] == "KSQ"
+    assert params["fid_input_iscd_2"] == "1001"
+    # 시작일과 종료일은 같은 날짜여야 한다 (KIS 스펙).
+    assert params["fid_input_date_1"] == "20260812"
+    assert params["fid_input_date_2"] == "20260812"
+
+
+@pytest.mark.asyncio
+async def test_investor_by_market_maps_kospi_to_ksp(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok([{"stck_bsop_date": "20260812"}]))
+
+    await quotations.inquire_investor_daily_by_market("0001", date="20260812")
+
+    assert quotations.call_api.call_args.kwargs["params"]["fid_input_iscd_1"] == "KSP"
+
+
+@pytest.mark.asyncio
+async def test_investor_by_market_rejects_unsupported_index(quotations):
+    quotations.call_api = AsyncMock()
+
+    result = await quotations.inquire_investor_daily_by_market("2001", date="20260812")
+
+    assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+    quotations.call_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_investor_by_market_returns_rows(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok([
+        {"stck_bsop_date": "20260812", "prsn_ntby_tr_pbmn": "-3191200",
+         "frgn_ntby_tr_pbmn": "2835700", "orgn_ntby_tr_pbmn": "527700"},
+        {"stck_bsop_date": "20260811", "prsn_ntby_tr_pbmn": "120000"},
+    ]))
+
+    result = await quotations.inquire_investor_daily_by_market("0001", date="20260812")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert len(result.data) == 2
+    assert result.data[0]["frgn_ntby_tr_pbmn"] == "2835700"
+
+
+@pytest.mark.asyncio
+async def test_investor_by_market_reports_empty_rows(quotations):
+    quotations.call_api = AsyncMock(return_value=_ok([]))
+
+    result = await quotations.inquire_investor_daily_by_market("0001", date="20260812")
+
+    assert result.rt_cd == ErrorCode.MISSING_KEY.value
+
+
+@pytest.mark.asyncio
+async def test_investor_by_market_propagates_api_error(quotations):
+    quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="모의투자 미지원", data=None,
+    ))
+
+    result = await quotations.inquire_investor_daily_by_market("0001", date="20260812")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value

--- a/tests/unit_test/services/test_stock_query_index_flow.py
+++ b/tests/unit_test/services/test_stock_query_index_flow.py
@@ -1,0 +1,143 @@
+"""홈 지수 패널용 지수 수급(투자자 순매수 + 등락 종목수) 서비스 단위 테스트."""
+from datetime import datetime
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.stock_query_service import StockQueryService
+from common.types import ResCommonResponse, ErrorCode
+
+
+def _service(broker):
+    clock = MagicMock()
+    clock.get_current_kst_time.return_value = datetime(2026, 8, 12, 15, 40)
+    return StockQueryService(
+        market_data_service=MagicMock(),
+        logger=MagicMock(),
+        market_clock=clock,
+        broker_api_wrapper=broker,
+    )
+
+
+def _ok(data):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=data)
+
+
+def _fail():
+    return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="모의투자 미지원", data=None)
+
+
+def _broker(investor=None, breadth=None):
+    broker = MagicMock()
+    broker.inquire_investor_daily_by_market = AsyncMock(
+        return_value=investor if investor is not None else _ok([{
+            "stck_bsop_date": "20260812",
+            # 단위: 백만원
+            "prsn_ntby_tr_pbmn": "-3191200",
+            "frgn_ntby_tr_pbmn": "2835700",
+            "orgn_ntby_tr_pbmn": "527700",
+        }])
+    )
+    broker.inquire_index_price = AsyncMock(
+        return_value=breadth if breadth is not None else _ok({
+            "ascn_issu_cnt": "380",
+            "uplm_issu_cnt": "3",
+            "stnr_issu_cnt": "53",
+            "down_issu_cnt": "477",
+            "lslm_issu_cnt": "0",
+        })
+    )
+    return broker
+
+
+@pytest.mark.asyncio
+async def test_index_flow_normalizes_investors_to_eok():
+    result = await _service(_broker()).get_index_flow("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    # KIS 는 백만원 단위로 준다. 네이버 카드와 같은 억원 표기로 맞춘다.
+    assert result.data["investors"] == {
+        "individual": -31912,
+        "foreign": 28357,
+        "institution": 5277,
+    }
+
+
+@pytest.mark.asyncio
+async def test_index_flow_normalizes_breadth_counts():
+    result = await _service(_broker()).get_index_flow("0001")
+
+    assert result.data["breadth"] == {
+        "up": 380,
+        "upper_limit": 3,
+        "unchanged": 53,
+        "down": 477,
+        "lower_limit": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_index_flow_queries_today_for_the_requested_index():
+    broker = _broker()
+
+    await _service(broker).get_index_flow("1001")
+
+    broker.inquire_investor_daily_by_market.assert_awaited_once_with("1001", date="20260812")
+    broker.inquire_index_price.assert_awaited_once_with("1001")
+
+
+@pytest.mark.asyncio
+async def test_index_flow_keeps_breadth_when_investor_query_fails():
+    # 모의투자에서는 한쪽만 막힐 수 있다. 살아있는 쪽은 그대로 보여준다.
+    result = await _service(_broker(investor=_fail())).get_index_flow("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["investors"] is None
+    assert result.data["breadth"]["up"] == 380
+
+
+@pytest.mark.asyncio
+async def test_index_flow_keeps_investors_when_breadth_query_fails():
+    result = await _service(_broker(breadth=_fail())).get_index_flow("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["breadth"] is None
+    assert result.data["investors"]["foreign"] == 28357
+
+
+@pytest.mark.asyncio
+async def test_index_flow_fails_when_both_queries_fail():
+    result = await _service(_broker(investor=_fail(), breadth=_fail())).get_index_flow("0001")
+
+    assert result.rt_cd != ErrorCode.SUCCESS.value
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_index_flow_rejects_unsupported_index_without_calling_broker():
+    broker = _broker()
+
+    result = await _service(broker).get_index_flow("2001")
+
+    assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+    broker.inquire_investor_daily_by_market.assert_not_awaited()
+    broker.inquire_index_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_index_flow_drops_investors_when_fields_are_unparsable():
+    result = await _service(_broker(investor=_ok([{"stck_bsop_date": "20260812"}]))).get_index_flow("0001")
+
+    assert result.data["investors"] is None
+
+
+@pytest.mark.asyncio
+async def test_index_flow_survives_broker_exception():
+    broker = _broker()
+    broker.inquire_index_price = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await _service(broker).get_index_flow("0001")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["breadth"] is None
+    assert result.data["investors"]["individual"] == -31912

--- a/tests/unit_test/view/web/test_market_indices_contracts.py
+++ b/tests/unit_test/view/web/test_market_indices_contracts.py
@@ -85,8 +85,47 @@ def test_market_indices_styles_are_defined():
         ".market-index-value",
         ".market-index-spark",
         ".market-index-period",
+        ".market-index-flow",
+        ".market-index-flow-value",
     ):
         assert selector in css, f"{selector} 스타일이 없음"
+
+
+def _css_rule_body(css: str, selector: str) -> str:
+    start = css.index(f"\n{selector} {{") + len(selector) + 3
+    return css[start:css.index("}", start)]
+
+
+def test_market_index_color_utilities_are_not_overridden():
+    """등락 색은 .text-red/.text-blue 가 잡는다.
+
+    두 유틸리티는 스타일시트 앞쪽(명시도 동일)에 있어서, 뒤에 오는 지수 카드 규칙이
+    color 를 직접 잡으면 색이 통째로 죽는다. 기본색은 컨테이너에만 둔다.
+    """
+    css = Path("view/web/static/css/style.css").read_text(encoding="utf-8")
+
+    for selector in (".market-index-change", ".market-index-flow-value"):
+        assert "color:" not in _css_rule_body(css, selector), (
+            f"{selector} 가 color 를 직접 잡으면 .text-red/.text-blue 가 무시된다"
+        )
+    for selector in (".market-index-body", ".market-index-flow"):
+        assert "color:" in _css_rule_body(css, selector), f"{selector} 에 기본 글자색이 없음"
+
+
+def test_domestic_index_flow_is_wired_to_its_own_endpoint():
+    script = _market_indices_js()
+
+    # 수급은 기간과 무관하므로 차트와 다른 엔드포인트를 쓴다.
+    assert "/flow`" in script, "수급 조회 엔드포인트가 없음"
+    for label in ("'개인'", "'외국인'", "'기관'", "'상승'", "'보합'", "'하락'"):
+        assert label in script, f"{label} 수급 항목이 없음"
+
+
+def test_market_index_flow_route_exists():
+    routes = Path("view/web/routes/stock.py").read_text(encoding="utf-8")
+
+    assert '"/market-index/{index_code}/flow"' in routes
+    assert "get_index_flow" in routes
 
 
 def test_domestic_index_period_selector_is_wired():

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -168,6 +168,17 @@ async def get_market_index(index_code: str, period: str = "1D"):
     return _serialize_response(resp)
 
 
+@router.get("/market-index/{index_code}/flow")
+async def get_market_index_flow(index_code: str):
+    """코스피(0001)/코스닥(1001)의 당일 투자자 순매수(억원)와 등락 종목수.
+
+    기간과 무관한 값이라 차트와 별도 엔드포인트로 둔다.
+    """
+    ctx = _get_ctx()
+    resp = await ctx.stock_query_service.get_index_flow(index_code)
+    return _serialize_response(resp)
+
+
 @router.get("/stock/{code}/stage")
 async def get_stock_stage(code: str):
     """종목의 Minervini Stage 조회 (1~4단계, 0=미계산)"""

--- a/view/web/static/css/style.css
+++ b/view/web/static/css/style.css
@@ -1281,6 +1281,9 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
     display: flex;
     flex-direction: column;
     justify-content: center;
+    /* 기본 글자색은 컨테이너가 정한다. 자식이 직접 color 를 잡으면 뒤에 정의된 탓에
+       .text-red/.text-blue 유틸리티(같은 명시도)를 덮어써 등락 색이 죽는다. */
+    color: var(--text-secondary);
 }
 .market-index-value {
     font-size: 1.35rem;
@@ -1290,13 +1293,36 @@ tr:hover { background: rgba(0, 0, 0, 0.03); }
 .market-index-change {
     font-size: 0.82rem;
     margin-top: 2px;
-    color: var(--text-secondary);
 }
 .market-index-spark {
     margin-top: 8px;
     width: 100%;
     /* x축 날짜 눈금이 들어가므로 선 영역(70px) + 라벨 높이만큼 잡는다. */
     max-height: 88px;
+}
+/* 투자자 순매수(좌) + 등락 종목수(우) 2열. 한쪽만 조회되면 그 열만 붙는다. */
+.market-index-flow {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+    gap: 4px 12px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+    font-size: 0.75rem;
+    /* 값 색은 .text-red/.text-blue 가 잡으므로 기본색은 컨테이너에 둔다. */
+    color: var(--text-primary);
+}
+.market-index-flow-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    line-height: 1.6;
+}
+.market-index-flow-label {
+    color: var(--text-secondary);
+}
+.market-index-flow-value {
+    font-weight: 600;
 }
 .market-index-error {
     margin: 0;

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -132,15 +132,27 @@ function _formatIndexPointLabel(point) {
     return date.length === 8 ? `${date.slice(4, 6)}/${date.slice(6, 8)}` : date;
 }
 
+// 좁은 카드라 눈금을 솎아내되, 뒤에서부터 세어 장 마감(마지막 봉) 라벨은 항상 남긴다.
+// (Chart.js autoSkip 은 앞에서부터 세기 때문에 하루치 차트의 끝이 잘려나갔다)
+const MARKET_INDEX_MAX_TICKS = 6;
+
+function _indexTickCallback(labels) {
+    const step = Math.max(1, Math.ceil((labels.length - 1) / (MARKET_INDEX_MAX_TICKS - 1)));
+    return function (_value, index) {
+        return (labels.length - 1 - index) % step === 0 ? labels[index] : '';
+    };
+}
+
 function _renderIndexSparkline(canvas, data) {
     if (typeof Chart === 'undefined' || !data.points.length) return;
 
     // 함께 표시하는 등락률과 색이 어긋나지 않도록 등락률 기준으로 칠한다.
     const color = Number.isFinite(data.changeRate) && data.changeRate < 0 ? '#3742fa' : '#ff4757';
+    const labels = data.points.map(_formatIndexPointLabel);
     const chart = new Chart(canvas.getContext('2d'), {
         type: 'line',
         data: {
-            labels: data.points.map(_formatIndexPointLabel),
+            labels,
             datasets: [{
                 data: data.points.map(p => p.close),
                 borderColor: color,
@@ -156,14 +168,14 @@ function _renderIndexSparkline(canvas, data) {
             animation: false,
             plugins: { legend: { display: false }, tooltip: { enabled: false } },
             scales: {
-                // 좁은 카드라 눈금을 몇 개로 제한하고 라벨은 눕힌 채로 둔다.
+                // 눈금은 _indexTickCallback 이 직접 고르므로 autoSkip 이 또 솎아내면 안 된다.
                 x: {
                     display: true,
                     grid: { display: false },
                     border: { display: false },
                     ticks: {
-                        autoSkip: true,
-                        maxTicksLimit: 5,
+                        autoSkip: false,
+                        callback: _indexTickCallback(labels),
                         maxRotation: 0,
                         minRotation: 0,
                         font: { size: 9 },
@@ -244,6 +256,87 @@ async function selectMarketIndexPeriod(card, code, period) {
     }
 }
 
+// 투자자 순매수(억원) 3주체 + 등락 종목수. 네이버 지수 카드와 같은 2열 배치다.
+const MARKET_INDEX_INVESTORS = [
+    { key: 'individual', label: '개인' },
+    { key: 'foreign', label: '외국인' },
+    { key: 'institution', label: '기관' },
+];
+
+function _formatIndexNetBuy(amount) {
+    if (!Number.isFinite(amount)) return { text: '-', className: '' };
+    const sign = amount > 0 ? '+' : (amount < 0 ? '-' : '');
+    const className = amount > 0 ? 'text-red' : (amount < 0 ? 'text-blue' : '');
+    return { text: `${sign}${Math.abs(amount).toLocaleString()}`, className };
+}
+
+function _marketIndexFlowRow(doc, label, text, className) {
+    const row = doc.createElement('div');
+    row.className = 'market-index-flow-row';
+
+    const name = doc.createElement('span');
+    name.className = 'market-index-flow-label';
+    name.textContent = label;
+    row.appendChild(name);
+
+    const value = doc.createElement('span');
+    value.className = `market-index-flow-value ${className}`.trim();
+    value.textContent = text;
+    row.appendChild(value);
+
+    return row;
+}
+
+function _marketIndexFlowColumn(doc, rows) {
+    const column = doc.createElement('div');
+    column.className = 'market-index-flow-col';
+    rows.forEach(row => column.appendChild(row));
+    return column;
+}
+
+// 상·하한 종목수는 네이버처럼 괄호로 덧붙인다: 380(3)
+function _formatIndexBreadthCount(count, limitCount) {
+    return Number.isFinite(limitCount) ? `${count.toLocaleString()}(${limitCount})` : count.toLocaleString();
+}
+
+function _buildMarketIndexFlow(doc, data) {
+    const investors = data.investors;
+    const breadth = data.breadth;
+    if (!investors && !breadth) return null;
+
+    const flow = doc.createElement('div');
+    flow.className = 'market-index-flow';
+
+    if (investors) {
+        flow.appendChild(_marketIndexFlowColumn(doc, MARKET_INDEX_INVESTORS.map(investor => {
+            const amount = _formatIndexNetBuy(investors[investor.key]);
+            return _marketIndexFlowRow(doc, investor.label, amount.text, amount.className);
+        })));
+    }
+
+    if (breadth) {
+        flow.appendChild(_marketIndexFlowColumn(doc, [
+            _marketIndexFlowRow(doc, '상승', _formatIndexBreadthCount(breadth.up, breadth.upper_limit), 'text-red'),
+            _marketIndexFlowRow(doc, '보합', _formatIndexBreadthCount(breadth.unchanged), ''),
+            _marketIndexFlowRow(doc, '하락', _formatIndexBreadthCount(breadth.down, breadth.lower_limit), 'text-blue'),
+        ]));
+    }
+
+    return flow;
+}
+
+// 수급은 기간과 무관하므로 카드를 만들 때 한 번만 조회한다.
+// 실전 전용 TR 이라 모의투자에서는 막힐 수 있고, 그때는 안내 없이 영역을 통째로 뺀다.
+async function appendMarketIndexFlow(doc, card, code) {
+    const res = await fetchWithTimeout(`/api/market-index/${code}/flow`);
+    const { json, error } = await readJsonResponse(res);
+    const data = json && json.rt_cd === '0' ? json.data : null;
+    if (error || !data) return;
+
+    const flow = _buildMarketIndexFlow(doc, data);
+    if (flow) card.appendChild(flow);
+}
+
 async function buildMarketIndexKisCard(doc, entry) {
     const card = _marketIndexCardShell(doc, 'kis', entry.code, entry.label);
     card.appendChild(_buildMarketIndexPeriodBar(doc, card, entry.code));
@@ -253,6 +346,7 @@ async function buildMarketIndexKisCard(doc, entry) {
     card.appendChild(body);
 
     await selectMarketIndexPeriod(card, entry.code, MARKET_INDEX_DEFAULT_PERIOD);
+    await appendMarketIndexFlow(doc, card, entry.code);
     return card;
 }
 


### PR DESCRIPTION
홈 화면 지수 카드가 네이버 지수 카드처럼 읽히도록 고쳤습니다.

## 1. x축 눈금 (`market_indices.js`)
Chart.js `autoSkip` 은 앞에서부터 세기 때문에 하루치 10분봉(전일 + 09:00~15:30 = 41점)에서
마지막 라벨이 **14:50 에서 잘렸습니다**. 뒤에서부터 세는 tick callback 으로 바꿔
장 마감(15:30)을 항상 남기고 라벨 수를 4개 → 6개로 늘렸습니다.

실제 브라우저(Chart.js 4.4.1) 렌더 확인:
- 이전: `전일, 10:20, 11:50, 13:20, 14:50`
- 이후: `전일, 10:10, 11:30, 12:50, 14:10, 15:30`

카드 폭 250px(그리드 최소폭 230px)에서도 6개 라벨이 유지되고 가로 스크롤은 생기지 않습니다.

## 2. 수급 (신규)
개인/외국인/기관 순매수(억원)와 상승/보합/하락 종목수를 카드에 붙입니다.
KIS TR 두 개를 신규 연동했습니다 (공식 샘플 + 실제 구현 2건 교차검증).

| API | path | tr_id | 필드 |
|---|---|---|---|
| 시장별 투자자매매동향(일별) | `inquire-investor-daily-by-market` | `FHPTJ04040000` | `prsn/frgn/orgn_ntby_tr_pbmn` (백만원 → 억원) |
| 국내업종 현재지수 | `inquire-index-price` | `FHPUP02100000` | `ascn/stnr/down/uplm/lslm_issu_cnt` |

- 둘 다 **실전 전용일 수 있어 각각 독립으로 degrade** 합니다. 한쪽만 막히면 살아있는 쪽만 표시하고, 둘 다 실패하면 안내 없이 수급 영역을 통째로 뺍니다(차트·에러 문구에 영향 없음).
- 기간과 무관한 값이라 `/api/market-index/{code}/flow` 로 분리해 **기간 전환 시 재조회하지 않습니다.**
- 상·하한은 네이버처럼 괄호로 덧붙입니다: `380(3)`, `477(0)`

## 3. 등락 색 (기존 버그)
`.market-index-change` 가 `color` 를 직접 잡아, 스타일시트 앞쪽에 정의된
`.text-red`/`.text-blue`(명시도 동일)를 덮어써 **등락률 색이 죽어 있었습니다**
(측정값 `rgb(89,98,117)` 회색). 기본색을 컨테이너로 옮겨 해결했고, 회귀 방지
계약 테스트를 추가했습니다.

## 검증
- 단위 7684 passed / 통합 279 passed
- 신규: 브로커 11개, 서비스 10개, jsdom DOM 8개(수급 5 + 눈금 3), CSS 계약 1개
- 실제 브라우저에서 Chart.js 눈금·수급 2열 배치·색상 computed style 확인

## ⚠️ 라이브 검증 필요
두 TR 은 자격증명이 필요해 로컬에서 실호출 검증을 못 했습니다. 모의투자 계정에서는
막힐 가능성이 있고, 그 경우 설계대로 조용히 숨겨집니다. **실전 계정에서 홈 화면을 한 번
확인해 주세요** — 수급이 안 보이면 API 차단이지 렌더 버그가 아닙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)