### PR TITLE
Mark partial quarters in trade trend chart

### DIFF
--- a/tests/unit_test/view/web/static/test_trade_trends_js.py
+++ b/tests/unit_test/view/web/static/test_trade_trends_js.py
@@ -83,7 +83,7 @@ return {
     }
 
 
-def test_quarter_model_sums_monthly_rows_and_derives_working_day_average():
+def test_quarter_model_marks_partial_quarter_with_month_count():
     result = run_trade_trends_js(
         """
 const { buildTradeTrendChartModel } = sandbox.module.exports;
@@ -112,6 +112,9 @@ const item = model.items[0];
 return {
   selectedPhase: model.selectedPhase,
   label: item.label,
+  periodLabel: item.period_label,
+  monthCount: item.month_count,
+  isPartial: item.is_partial,
   exportAmount: item.export_amount_100m_usd,
   importAmount: item.import_amount_100m_usd,
   chipAmount: item.semiconductor_export_amount_100m_usd,
@@ -124,13 +127,52 @@ return {
 
     assert result == {
         "selectedPhase": "quarter",
-        "label": "2026 Q3",
+        "label": "2026 Q3 (2/3개월)",
+        "periodLabel": "2026 Q3 월간 확정치 누적 (3개월 중 2개월)",
+        "monthCount": 2,
+        "isPartial": True,
         "exportAmount": 1200,
         "importAmount": 1072,
         "chipAmount": 480,
         "workingDays": 40,
         "exportDaily": 30,
         "chipDaily": 12,
+    }
+
+
+def test_quarter_model_keeps_plain_label_when_all_three_months_present():
+    result = run_trade_trends_js(
+        """
+const { buildTradeTrendChartModel } = sandbox.module.exports;
+const rows = ['7', '8', '9'].map((month, index) => ({
+  period_label: `2026년 ${month}월`,
+  phase: 'customs_monthly',
+  published_at: `2026-1${index}-01`,
+  export_amount_100m_usd: 600,
+  import_amount_100m_usd: 500,
+  semiconductor_export_amount_100m_usd: 240,
+  working_days_current: 20
+}));
+const model = buildTradeTrendChartModel(rows, 'quarter');
+const item = model.items[0];
+return {
+  label: item.label,
+  periodLabel: item.period_label,
+  monthCount: item.month_count,
+  isPartial: item.is_partial,
+  exportAmount: item.export_amount_100m_usd,
+  workingDays: item.working_days_current
+};
+"""
+    )
+
+    assert result == {
+        "label": "2026 Q3",
+        "periodLabel": "2026 Q3 월간 확정치 누적",
+        "monthCount": 3,
+        "isPartial": False,
+        "exportAmount": 1800,
+        "workingDays": 60,
     }
 
 

--- a/view/web/static/js/trade_trends.js
+++ b/view/web/static/js/trade_trends.js
@@ -290,9 +290,15 @@ function tradeTrendQuarterItem(label, rows) {
     const importAmount = tradeSum(rows, 'import_amount_100m_usd');
     const semiconductorAmount = tradeSum(rows, 'semiconductor_export_amount_100m_usd');
     const workingDays = tradeSum(rows, 'working_days_current');
+    const monthCount = rows.length;
+    const isPartial = monthCount < 3;
     return {
-        label,
-        period_label: `${label} 월간 확정치 누적`,
+        label: isPartial ? `${label} (${monthCount}/3개월)` : label,
+        period_label: isPartial
+            ? `${label} 월간 확정치 누적 (3개월 중 ${monthCount}개월)`
+            : `${label} 월간 확정치 누적`,
+        month_count: monthCount,
+        is_partial: isPartial,
         export_amount_100m_usd: exportAmount,
         import_amount_100m_usd: importAmount,
         semiconductor_export_amount_100m_usd: semiconductorAmount,


### PR DESCRIPTION
## 배경

수출입동향 `최근 흐름` 분기 탭에서 `2026 Q2` 카드 하나만 보이는 것을 확인하다 발견한 표시 문제입니다.

분기 카드는 저장된 `monthly` 단계 행만 합산합니다. 현재 이력에는 월간 행이 `2026-05`, `2026-06` 두 건뿐이라 4월이 빠진 2개월 합계가 `2026 Q2 월간 확정치 누적`으로 표시됩니다. 조업일수 43.0일(정상 분기 ~62일)이 그 신호인데, 라벨만 봐서는 온전한 분기와 구분되지 않습니다.

(Q1이 아예 없는 것은 별개 사안 — 해당 월의 월간 행이 수집되지 않았기 때문이며 `POST /api/trade-trends/national/backfill` 로 채워야 합니다. 이 PR 범위 아님.)

## 변경

`tradeTrendQuarterItem`이 `month_count` / `is_partial`을 함께 실어 보내고, 3개월 미만이면 카드 제목과 툴팁에 개월 수를 노출합니다.

- 제목: `2026 Q2` → `2026 Q2 (2/3개월)`
- 툴팁: `2026 Q2 월간 확정치 누적 (3개월 중 2개월)`
- 3개월이 모두 있으면 기존 문구 그대로

막대 높이는 일평균 기준이라 부분 분기여도 왜곡되지 않습니다. 합계 수치만 오해 소지가 있어 라벨로 해소했습니다.

## 검증

- 기존 분기 테스트를 부분 분기 기대값으로 먼저 수정 → 실패 확인 → 구현
- 3개월 완전 분기 테스트 신규 추가
- `pytest tests/unit_test` 7685 passed
- `pytest tests/integration_test` 279 passed
- 실제 `data/trade_trend_state.json` 로 모델을 돌려 카드 제목이 `2026 Q2 (2/3개월)`로 나오는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
