### PR TITLE
Fix customs board paging and export amount parsing

### DIFF
--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -491,17 +491,34 @@ def _float(pattern: str, text: str) -> Optional[float]:
 
 def _trade_label_pattern(label: str) -> str:
     if label == "수출":
-        return r"수출(?!입)"
+        # 제목의 "반도체 수출 400억 달러"가 본문 총수출액보다 먼저 잡히는 것을 막는다.
+        return r"(?<!반도체)(?<!반도체 )수출(?!입)"
     if label == "수입":
         return r"(?<!수출)수입"
     return re.escape(label)
 
 
 def _extract_amount_after(label: str, text: str) -> Optional[float]:
-    return _float(
-        rf"{_trade_label_pattern(label)}[^。]{{0,180}}?([0-9]+(?:\.[0-9]+)?)\s*억\s*달러",
-        text,
+    label_pattern = _trade_label_pattern(label)
+    # 다음 지표 언급 전까지만 금액을 찾는다. 같은 라벨의 다른 언급도 경계로 둔다.
+    stop_pattern = (
+        r"(?<!수출)수입|무역수지|수출"
+        if label == "수출"
+        else r"수출(?!입)|무역수지|(?<!수출)수입"
     )
+    for label_match in re.finditer(label_pattern, text):
+        window = text[label_match.end() : label_match.end() + 180]
+        stop_match = re.search(stop_pattern, window)
+        if stop_match:
+            window = window[: stop_match.start()]
+        amount_match = re.search(r"([0-9][0-9,]*(?:\.[0-9]+)?)\s*억\s*달러", window)
+        if not amount_match:
+            continue
+        try:
+            return float(amount_match.group(1).replace(",", ""))
+        except ValueError:
+            continue
+    return None
 
 
 def _signed_pct(value: Optional[float], text: str, start: int = 0) -> Optional[float]:
@@ -609,13 +626,24 @@ def _interleave(groups: list[list[tuple[str, str]]]) -> list[tuple[str, str]]:
     return items
 
 
+_LIST_PAGE_PARAM_BY_HOST = {"www.customs.go.kr": "currPage"}
+_DEFAULT_LIST_PAGE_PARAM = "pageIndex"
+
+
+def _list_page_param(url: str) -> str:
+    """게시판마다 페이지 번호 쿼리 키가 다르다. 관세청은 pageIndex를 무시한다."""
+    host = urlsplit(url).netloc.lower()
+    return _LIST_PAGE_PARAM_BY_HOST.get(host, _DEFAULT_LIST_PAGE_PARAM)
+
+
 def _expand_list_page_urls(list_urls: list[str], list_page_count: int) -> list[str]:
     page_count = max(1, int(list_page_count or 1))
     urls = []
     for url in list_urls:
         urls.append(url)
+        page_param = _list_page_param(url)
         for page_index in range(2, page_count + 1):
-            urls.append(_with_query_param(url, "pageIndex", str(page_index)))
+            urls.append(_with_query_param(url, page_param, str(page_index)))
     return urls
 
 

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -162,6 +162,29 @@ def test_parse_national_customs_20d_release_extracts_summary_numbers():
     assert release.dedup_key == "national_trade:customs_20d:2026년 7월 1~20일:https://customs.example/20d"
 
 
+def test_parse_national_release_ignores_semiconductor_headline_for_export_amount():
+    """제목의 '반도체 수출 400억 달러'가 본문 총수출액보다 먼저 나온다."""
+    text = """
+    2026년 6월 수출입 현황 [잠정치]
+    - 수출 및 무역수지 역대 최대 / 월수출 1천억 달러, 반도체 수출 400억 달러 최초 돌파
+    등록일 2026.07.02
+    ◇ 관세청은 1 일, 6 월 1 일~30 일 기간의 수출입 현황 잠정치를 발표 했다.
+    ◇ 수출은 1,023 억 달러 로 전년동기대비 70.9% 증가, 수입은 661 억 달러 로
+    30.1% 증가 했고, 무역수지는 361 억 달러 흑자 를 기록했다고 밝혔다.
+    """
+
+    release = parse_national_trade_release(
+        title="2026년 6월 수출입 현황 [잠정치]",
+        url="https://customs.example/monthly",
+        source="customs",
+        text=text,
+    )
+
+    assert release.export_amount_100m_usd == pytest.approx(1023)
+    assert release.import_amount_100m_usd == pytest.approx(661)
+    assert release.export_yoy_pct == pytest.approx(70.9)
+
+
 def test_parse_national_customs_release_extracts_semiconductor_and_working_days():
     text = """
     ◇ 동기간 수출은 213억 달러로 전년동기대비 45.3% 증가, 수입은 195억 달러로
@@ -556,7 +579,30 @@ async def test_national_web_client_fetches_year_releases_from_paginated_lists():
     ]
     requested_urls = [call.args[0] for call in http_client.get.await_args_list[:2]]
     assert requested_urls[0].endswith("bbsId=1362")
-    assert "pageIndex=2" in requested_urls[1]
+    assert "currPage=2" in requested_urls[1]
+
+
+@pytest.mark.asyncio
+async def test_national_web_client_uses_page_param_matching_each_list_host():
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(return_value=DummyTextResponse(""))
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=[
+            "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362",
+            "https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?searchCondition=1",
+        ],
+    )
+
+    await client.fetch_releases(year=2026, list_page_count=2)
+
+    requested_urls = [call.args[0] for call in http_client.get.await_args_list]
+    customs_urls = [url for url in requested_urls if "customs.go.kr" in url]
+    motie_urls = [url for url in requested_urls if "motir.go.kr" in url]
+    assert any("currPage=2" in url for url in customs_urls)
+    assert not any("pageIndex" in url for url in customs_urls)
+    assert any("pageIndex=2" in url for url in motie_urls)
+    assert not any("currPage" in url for url in motie_urls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 배경

분기 탭에 `2026 Q1`이 없는 원인을 쫓다가 백필이 과거 월을 전혀 못 가져오는 것을 확인했습니다. 백필을 실행해도 매번 같은 8건만 저장됐습니다.

## 문제 1 — 관세청 게시판 페이징 파라미터가 틀림

`_expand_list_page_urls`가 모든 목록 URL에 `pageIndex`를 붙이는데, **관세청 게시판은 `pageIndex`를 무시**합니다. 실측:

| 파라미터 | 결과 |
|---|---|
| `pageIndex=2` | page 1과 동일 (8건) |
| **`currPage=2`** | **2026년 4월·3월 포함 7건** |
| `page` / `pageNo` / `cp` / `pageUnit` | 동일 |

즉 `list_page_count`가 관세청에 대해 아무 효과가 없었고, 최신 8건 밖으로는 도달할 수 없었습니다. 산업부(motir.go.kr)는 `pageIndex`가 정상 동작하므로 호스트별로 선택합니다.

## 문제 2 — 제목 문구가 총수출액으로 잡힘

`_extract_amount_after`가 라벨과 숫자 사이 180자를 아무 경계 없이 허용해서, 6월 발표 제목의 `반도체 수출 400억 달러 최초 돌파`가 본문보다 먼저 매칭됐습니다.

- 저장값 **400억** / 실제 **1,023억** (원문: `수출은 1,023억 달러로 전년동기대비 70.9% 증가`)
- 월간(400)이 1~20일(620)보다 작은 모순으로 드러남

`_extract_yoy_after`가 이미 쓰는 stop-pattern 방식으로 다음 지표 언급 전까지만 찾도록 맞췄습니다. 천단위 구분자도 함께 처리했습니다 — 이걸 안 하면 `1,023억`이 **23**으로 파싱됩니다.

## 결과 (실제 백필 재실행)

`monthly_months`: `['2026-05', '2026-06']` → `['2026-01' … '2026-06']`

| | 조업 | 수출 | 일평균 |
|---|---|---|---|
| 2026 Q1 | 65.5일 | 2,194억 | 33.5억 |
| 2026 Q2 | 67.0일 | 2,759억 | 41.2억 |

월간 6건 모두 해당 월 1~20일 수치보다 크다는 정합성도 확인했습니다.

## 검증

- 두 문제 각각 실패 테스트 선작성 → 구현 (TDD)
- 기존 `pageIndex=2` 단언은 `currPage=2`로 갱신, 호스트별 파라미터 테스트 신규 추가
- `pytest tests/unit_test` 7687 passed / `pytest tests/integration_test` 279 passed
- 실제 관세청 페이지 대상으로 백필 재실행해 위 표의 값 확인

## 범위 밖

산업부 상세 페이지는 본문 수치가 HTML에 없고 첨부(hwp/pdf)에만 있어 계속 파싱에서 탈락합니다. 관세청만으로 월간이 채워져 이번엔 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
