### PR TITLE
Widen quarter window and drop months without working days

### DIFF
--- a/tests/unit_test/view/web/static/test_trade_trends_js.py
+++ b/tests/unit_test/view/web/static/test_trade_trends_js.py
@@ -176,6 +176,95 @@ return {
     }
 
 
+def test_quarter_model_excludes_months_without_working_days():
+    """조업일수 없는 산업부 행이 섞이면 분자만 커져 일평균이 부풀려진다."""
+    result = run_trade_trends_js(
+        """
+const { buildTradeTrendChartModel } = sandbox.module.exports;
+const rows = [
+  {
+    period_label: '2025년 7월',
+    phase: 'motie_monthly',
+    published_at: '2025-08-01',
+    export_amount_100m_usd: 608,
+    import_amount_100m_usd: 540,
+    working_days_current: null
+  },
+  {
+    period_label: '2025년 8월',
+    phase: 'customs_monthly',
+    published_at: '2025-09-01',
+    export_amount_100m_usd: 600,
+    import_amount_100m_usd: 520,
+    working_days_current: 20
+  },
+  {
+    period_label: '2025년 9월',
+    phase: 'customs_monthly',
+    published_at: '2025-10-01',
+    export_amount_100m_usd: 640,
+    import_amount_100m_usd: 560,
+    working_days_current: 20
+  }
+];
+const model = buildTradeTrendChartModel(rows, 'quarter');
+const item = model.items[0];
+return {
+  label: item.label,
+  monthCount: item.month_count,
+  exportAmount: item.export_amount_100m_usd,
+  workingDays: item.working_days_current,
+  exportDaily: item.export_daily_avg_100m_usd
+};
+"""
+    )
+
+    assert result == {
+        "label": "2025 Q3 (2/3개월)",
+        "monthCount": 2,
+        "exportAmount": 1240,
+        "workingDays": 40,
+        "exportDaily": 31,
+    }
+
+
+def test_quarter_model_is_not_capped_by_the_monthly_tab_window():
+    """분기 카드는 월간 탭의 8개월 표시 상한이 아니라 8분기까지 채운다."""
+    result = run_trade_trends_js(
+        """
+const { buildTradeTrendChartModel } = sandbox.module.exports;
+const rows = [];
+for (let index = 0; index < 15; index += 1) {
+  const year = 2025 + Math.floor(index / 12);
+  const month = (index % 12) + 1;
+  rows.push({
+    period_label: `${year}년 ${month}월`,
+    phase: 'customs_monthly',
+    published_at: `${year}-${String(month).padStart(2, '0')}-28`,
+    export_amount_100m_usd: 600,
+    import_amount_100m_usd: 500,
+    semiconductor_export_amount_100m_usd: 240,
+    working_days_current: 20
+  });
+}
+const model = buildTradeTrendChartModel(rows, 'quarter');
+return {
+  monthlyLabels: buildTradeTrendChartModel(rows, 'monthly').items.length,
+  quarterLabels: model.items.map((item) => item.label)
+};
+"""
+    )
+
+    assert result["monthlyLabels"] == 8
+    assert result["quarterLabels"] == [
+        "2025 Q1",
+        "2025 Q2",
+        "2025 Q3",
+        "2025 Q4",
+        "2026 Q1",
+    ]
+
+
 def test_month_progress_model_scales_nested_phase_cards_by_daily_average():
     result = run_trade_trends_js(
         """

--- a/view/web/static/js/trade_trends.js
+++ b/view/web/static/js/trade_trends.js
@@ -216,7 +216,7 @@ function latestTradeTrendPhase(rowsWithMonth) {
     return latest ? latest.phase : 'customs_10d';
 }
 
-function buildTradeTrendPhaseItems(rowsWithMonth, phase) {
+function buildTradeTrendPhaseItems(rowsWithMonth, phase, monthLimit = 8) {
     const latestByMonth = new Map();
     rowsWithMonth
         .filter((item) => item.phase === phase)
@@ -226,14 +226,16 @@ function buildTradeTrendPhaseItems(rowsWithMonth, phase) {
         });
     return Array.from(latestByMonth.entries())
         .sort(([left], [right]) => left.localeCompare(right))
-        .slice(-8)
+        .slice(-monthLimit)
         .map(([month, row]) => tradeTrendComparisonItem(formatTradeMonth(month), row));
 }
 
 function buildTradeTrendQuarterItems(rowsWithMonth) {
-    const monthlyRows = buildTradeTrendPhaseItems(rowsWithMonth, 'monthly')
+    // 분기 카드 8개를 채우려면 24개월이 필요하다. 월간 탭의 8개월 상한과는 별개다.
+    // 조업일수 없는 행(산업부 발표)은 일평균 분모에 못 들어가므로 합산에서 제외한다.
+    const monthlyRows = buildTradeTrendPhaseItems(rowsWithMonth, 'monthly', 24)
         .map((item) => item.row)
-        .filter(Boolean);
+        .filter((row) => row && Number(row.working_days_current) > 0);
     const quarters = new Map();
     monthlyRows.forEach((row) => {
         const month = tradeMonthKey(row);


### PR DESCRIPTION
## 배경

2025년 백필(#823 이후)로 월간 행이 2건 → 13건으로 늘면서 분기 탭의 두 가지 문제가 드러났습니다.

## 문제 1 — 분기 카드가 3개를 못 넘음

`buildTradeTrendQuarterItems`는 자체적으로 `.slice(-8)`(8분기)을 갖고 있지만, 입력을 `buildTradeTrendPhaseItems`에서 받는데 이쪽이 **월간 탭용 8개월**로 이미 잘라서 줍니다. 8개월 = 최대 3분기라 8분기 상한은 도달 불가능한 死코드였습니다.

저장된 13개월 중 5개월(2025-03·04·07·08·09)이 화면에 전혀 안 나왔습니다. 월 상한을 인자로 빼고, 분기 경로만 24개월을 요청합니다. 월간 탭은 8개월 그대로입니다.

## 문제 2 — 조업일수 없는 행이 일평균을 부풀림

산업부(motie) 발표에는 조업일수가 없습니다(`working_days_current: null`). 관세청 행과 한 분기에 섞이면 **수출액은 더해지고 조업일수는 안 더해져** 일평균이 폭등합니다.

| | 수정 전 | 실제 |
|---|---|---|
| 2025 Q3 일평균 | **77.2억** | ~28억 |

2025 Q1·Q2는 조업 0일이 되어 일평균 0억, 즉 막대가 "수출 0"으로 읽혔습니다.

분자와 분모를 같은 달로 맞추기 위해 조업일수 없는 행은 분기 집계에서 제외합니다. `(n/3개월)` 표시가 실제 기여한 달을 그대로 알려줍니다.

## 결과 (실제 저장 데이터)

```
2025 Q3 (1/3개월)   조업 24.0일   수출   660억   일평균 27.5억
2025 Q4 (2/3개월)   조업 42.5일   수출 1,206억   일평균 28.4억
2026 Q1             조업 65.5일   수출 2,194억   일평균 33.5억
2026 Q2             조업 67.0일   수출 2,759억   일평균 41.2억
```

## 검증

- 두 문제 각각 실패 테스트 선작성 → 구현 (TDD). 문제 2는 `46.2 vs 31`로 재현
- `pytest tests/unit_test` 7689 passed / `pytest tests/integration_test` 279 passed
- 실제 `data/trade_trend_state.json`로 모델을 돌려 위 표 확인

## 알려진 한계

2025-03·04·07·08은 산업부 발표만 있어 조업일수가 없고, 이제 분기 집계에서 빠집니다. 수출 총액 자체는 저장돼 있으므로 관세청 조업일수를 별도 소스로 붙이면 살릴 수 있습니다. 이번 범위 밖입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
