### PR TITLE
Fix NXT favorite price alerts

### DIFF
--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -83,6 +83,7 @@ class KoreaInvestWebSocketAPI:
         self._rt_tr_cached = False
         self._rt_tr_realtime_price = None
         self._rt_tr_unified_realtime_price = None
+        self._rt_tr_nxt_realtime_price = None
         self._rt_tr_realtime_quote = None
         self._rt_program_trading_tr_ids = set()
         self._rt_market_status_tr_ids = set()
@@ -304,6 +305,9 @@ class KoreaInvestWebSocketAPI:
                 message_type = 'realtime_price'
             elif tr_id == self._rt_tr_unified_realtime_price:  # H0UNCNT0 (KRX+NXT 통합 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)  # H0STCNT0와 동일 포맷
+                message_type = 'realtime_price'
+            elif tr_id == self._rt_tr_nxt_realtime_price:  # H0NXCNT0 (NXT 주식 체결)
+                parsed_data = self._parse_stock_contract_data(data_body)
                 message_type = 'realtime_price'
             elif tr_id == self._rt_tr_realtime_quote:  # H0STASP0 (주식 호가)
                 parsed_data = self._parse_stock_quote_data(data_body)
@@ -767,6 +771,7 @@ class KoreaInvestWebSocketAPI:
         ws_cfg = self._env.active_config['tr_ids']['websocket']
         self._rt_tr_realtime_price = ws_cfg['realtime_price']
         self._rt_tr_unified_realtime_price = ws_cfg.get('unified_realtime_price', 'H0UNCNT0')
+        self._rt_tr_nxt_realtime_price = ws_cfg.get('nxt_realtime_price', 'H0NXCNT0')
         self._rt_tr_realtime_quote = ws_cfg['realtime_quote']
         self._rt_program_trading_tr_ids = self._get_program_trading_tr_ids()
         self._rt_market_status_tr_ids = self._get_market_status_tr_ids()

--- a/core/market_clock.py
+++ b/core/market_clock.py
@@ -63,6 +63,18 @@ class MarketClock:
         # [최적화 2] 무거운 datetime 조합과 타임존 연산 없이 순수 시간(time) 객체만으로 비교
         return self._open_time_obj <= now.time() <= self._close_time_obj
 
+    def is_nxt_operating_hours(self, now=None) -> bool:
+        """
+        NXT 포함 실시간 스트리밍 가능 시간(08:00~20:00) 여부를 확인합니다.
+        영업일 여부는 MarketCalendarService에서 판단합니다.
+        """
+        now = now or self.get_current_kst_time()
+
+        if now.weekday() >= 5:
+            return False
+
+        return dt_time(8, 0) <= now.time() <= dt_time(20, 0)
+
     def get_market_open_time(self, target_dt: Optional[datetime] = None) -> datetime:
         """오늘 날짜 또는 지정된 날짜 기준 시장 개장 시간(09:00) 반환"""
         now = target_dt or self.get_current_kst_time()

--- a/services/market_calendar_service.py
+++ b/services/market_calendar_service.py
@@ -153,10 +153,18 @@ class MarketCalendarService:
         
         return self._business_days_cache.get(date_str, False)
 
-    async def is_market_open_now(self) -> bool:
-        """현재 시점이 휴일이 아니며, 장 운영 시간(09:00~15:40) 이내인지 확인합니다."""
+    async def is_market_open_now(self, *, include_nxt: bool = False) -> bool:
+        """현재 시점이 휴일이 아니며, 장 운영 시간 이내인지 확인합니다.
+
+        include_nxt=True 이면 실시간 구독용으로 NXT 확장 시간(08:00~20:00)을 포함한다.
+        """
         # 장 운영 시간이 아니면 달력(API/캐시)을 확인할 필요도 없이 바로 False 반환 (성능 최적화)
-        if not self._market_clock.is_market_operating_hours():
+        is_operating_hours = self._market_clock.is_market_operating_hours()
+        if not is_operating_hours and include_nxt:
+            nxt_checker = getattr(self._market_clock, "is_nxt_operating_hours", None)
+            if callable(nxt_checker):
+                is_operating_hours = bool(nxt_checker())
+        if not is_operating_hours:
             return False
 
         if await self.is_business_day():

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -379,7 +379,7 @@ class SubscriptionPolicy:
     async def _ensure_websocket_connected_for_subscribe(self, codes: Set[str]) -> bool:
         if not codes:
             return True
-        if self._market_calendar and not await self._market_calendar.is_market_open_now():
+        if self._market_calendar and not await self._is_realtime_market_open_now():
             return True
 
         connector = getattr(self._streaming, "connect_websocket", None)
@@ -407,7 +407,7 @@ class SubscriptionPolicy:
             return False
 
     async def _do_subscribe(self, code: str, stream_type: StreamingType) -> None:
-        if self._market_calendar and not await self._market_calendar.is_market_open_now():
+        if self._market_calendar and not await self._is_realtime_market_open_now():
             self._streaming_logger.log_subscribe_pending(code=code, message="SubscriptionPolicy: 장 외 시간 — 구독 보류")
             return
         try:
@@ -494,6 +494,13 @@ class SubscriptionPolicy:
             len(self._active_codes_price)
             + len(self._active_codes_pt)
         )
+
+    async def _is_realtime_market_open_now(self) -> bool:
+        """실시간 스트리밍 구독은 NXT 확장 거래시간을 포함해 장중 여부를 판단한다."""
+        try:
+            return await self._market_calendar.is_market_open_now(include_nxt=True)
+        except TypeError:
+            return await self._market_calendar.is_market_open_now()
 
 # Backward-compatibility alias
 PriceSubscriptionService = SubscriptionPolicy

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -40,6 +40,7 @@ def websocket_api_instance():
             "websocket": {
                 "realtime_price": "H0STCNT0",
                 "realtime_quote": "H0STASP0",
+                "nxt_realtime_price": "H0NXCNT0",
                 "realtime_futs_optn_contract": "H0IFCNT0",
                 "unified_market_status": "H0UNMKO0",
                 "order_notice_real": "H0STCNI0",
@@ -472,6 +473,7 @@ def test_handle_message_caches_realtime_tr_ids(websocket_api_instance):
     assert api._rt_tr_realtime_price == "H0STCNT0"
     assert api._rt_tr_realtime_quote == "H0STASP0"
     assert api._rt_tr_unified_realtime_price == "H0UNCNT0"
+    assert api._rt_tr_nxt_realtime_price == "H0NXCNT0"
     assert "H0STPGM0" in api._rt_program_trading_tr_ids
 
 
@@ -2452,6 +2454,24 @@ def test_handle_websocket_message_unified_realtime_price(websocket_api_instance)
     assert result["data"]["유가증권단축종목코드"] == "0003"
 
 
+def test_handle_websocket_message_nxt_realtime_price(websocket_api_instance):
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+    data_parts = [''] * 60
+    data_parts[0] = '000660'
+    data_parts[2] = '250000'
+    message = f"0|H0NXCNT0|dummy|{'^'.join(data_parts)}"
+
+    api._handle_websocket_message(message)
+
+    api.on_realtime_message_callback.assert_called_once()
+    result = api.on_realtime_message_callback.call_args[0][0]
+    assert result["type"] == "realtime_price"
+    assert result["tr_id"] == "H0NXCNT0"
+    assert result["data"]["유가증권단축종목코드"] == "000660"
+    assert result["data"]["주식현재가"] == "250000"
+
+
 def test_handle_websocket_message_program_trading_success(websocket_api_instance):
     api = websocket_api_instance
     api.on_realtime_message_callback = MagicMock()
@@ -2704,7 +2724,7 @@ def test_tr_ids_config_yaml_websocket_required_keys():
         config = yaml.safe_load(f)
 
     websocket_cfg = config['tr_ids']['websocket']
-    required_keys = ['realtime_price', 'realtime_quote', 'realtime_program_trading']
+    required_keys = ['realtime_price', 'realtime_quote', 'nxt_realtime_price', 'realtime_program_trading']
     for key in required_keys:
         assert key in websocket_cfg, (
             f"tr_ids_config.yaml의 tr_ids.websocket.{key} 키가 누락되었습니다. "

--- a/tests/unit_test/core/test_market_clock.py
+++ b/tests/unit_test/core/test_market_clock.py
@@ -180,6 +180,21 @@ def test_is_market_open_after_close(market_clock):
     assert not market_clock.is_market_operating_hours(now=weekday_after_close)
 
 
+def test_is_nxt_operating_hours_after_krx_close(market_clock):
+    """NXT 애프터마켓 시간은 실시간 스트리밍 가능 시간으로 본다."""
+    weekday_after_krx_close = market_clock.market_timezone.localize(
+        dt.datetime(2026, 8, 12, 16, 53, 0)
+    )
+    assert market_clock.is_nxt_operating_hours(now=weekday_after_krx_close) is True
+
+
+def test_is_nxt_operating_hours_after_nxt_close(market_clock):
+    weekday_after_nxt_close = market_clock.market_timezone.localize(
+        dt.datetime(2026, 8, 12, 20, 1, 0)
+    )
+    assert market_clock.is_nxt_operating_hours(now=weekday_after_nxt_close) is False
+
+
 def test_sleep_positive_seconds(market_clock, mock_logger):
     """
     sleep 메서드 커버: seconds > 0인 경우 (라인 99-101)

--- a/tests/unit_test/services/test_market_calendar_service.py
+++ b/tests/unit_test/services/test_market_calendar_service.py
@@ -274,6 +274,28 @@ async def test_is_market_open_now_keeps_holiday_closed_when_latest_trading_date_
     assert await manager.is_market_open_now() is False
     manager.get_latest_trading_date.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_is_market_open_now_includes_nxt_hours_for_realtime_streaming(manager, mock_deps):
+    """실시간 구독은 KRX 마감 후 NXT 애프터마켓 시간도 장중으로 처리할 수 있다."""
+    tm, _ = mock_deps
+    tm.is_market_operating_hours = MagicMock(return_value=False)
+    tm.is_nxt_operating_hours = MagicMock(return_value=True)
+    manager.is_business_day = AsyncMock(return_value=True)
+
+    assert await manager.is_market_open_now(include_nxt=True) is True
+    manager.is_business_day.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_is_market_open_now_default_excludes_nxt_hours(manager, mock_deps):
+    """기본 장중 판정은 기존 KRX 시간 의미를 유지한다."""
+    tm, _ = mock_deps
+    tm.is_market_operating_hours = MagicMock(return_value=False)
+    tm.is_nxt_operating_hours = MagicMock(return_value=True)
+
+    assert await manager.is_market_open_now() is False
+
 # ── get_next_open_time Tests ──────────────────────────────────────────
 
 def _is_weekday_side_effect(date_str):


### PR DESCRIPTION
## Summary
- Treat NXT extended trading hours as open for realtime WebSocket subscriptions
- Parse NXT realtime price frames (H0NXCNT0) as realtime_price ticks
- Add regression tests for NXT hours and NXT realtime price dispatch

## Tests
- chcp 65001; $env:PYTHONIOENCODING='utf-8'; $env:PYTHONUTF8='1'; C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v