### PR TITLE
Fix sidecar alert severity icons

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -106,7 +106,7 @@ class MarketStatusAlertService:
         if change_rate >= self._BUY_SIDECAR_WATCH_THRESHOLD_PCT:
             expected_keys.add(buy_sidecar_watch_key)
             await self._report_index_alert(
-                key=buy_sidecar_watch_key, severity="error",
+                key=buy_sidecar_watch_key, severity="warning",
                 title=f"{index_name} 매수 사이드카 가능 구간",
                 index_code=index_code, index_name=index_name, change_rate=change_rate,
                 threshold_pct=self._BUY_SIDECAR_WATCH_THRESHOLD_PCT,

--- a/services/operator_alert_service.py
+++ b/services/operator_alert_service.py
@@ -180,7 +180,10 @@ class OperatorAlertService:
 
     async def _emit(self, alert: OperatorAlert) -> None:
         """NotificationService 로 이벤트 전파. metadata에 transition/dedup_key/source 주입."""
-        level = _LEVEL_MAP.get(alert.severity, NotificationLevel.WARNING)
+        if alert.transition == AlertTransition.RESOLVED:
+            level = NotificationLevel.INFO
+        else:
+            level = _LEVEL_MAP.get(alert.severity, NotificationLevel.WARNING)
         meta = {
             **alert.metadata,
             "transition": alert.transition.value,

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -114,7 +114,7 @@ async def test_market_status_alert_service_reports_buy_sidecar_watch_near_five_p
     kwargs = operator_alert.report.await_args.kwargs
     assert args[0] == AlertSource.MARKET_STATUS
     assert args[1] == "market_index:buy_sidecar_watch:0001"
-    assert args[2] == "error"
+    assert args[2] == "warning"
     assert args[3] == "코스피 매수 사이드카 가능 구간"
     assert kwargs["metadata"]["event_type"] == "buy_sidecar_watch"
 

--- a/tests/unit_test/test_operator_alert_service.py
+++ b/tests/unit_test/test_operator_alert_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from common.operator_alert_types import AlertSource, AlertTransition
+from services.notification_service import NotificationLevel
 from services.operator_alert_service import OperatorAlertService
 
 
@@ -138,6 +139,17 @@ async def test_resolve_emits_resolved(svc, notification_service):
     call_kwargs = notification_service.emit.call_args
     meta = call_kwargs.args[4] if len(call_kwargs.args) >= 5 else call_kwargs.kwargs.get("metadata", {})
     assert meta.get("transition") == AlertTransition.RESOLVED.value
+
+
+@pytest.mark.asyncio
+async def test_resolve_emits_info_level(svc, notification_service):
+    """해제 알림은 원래 severity와 무관하게 정상화 정보로 보낸다."""
+    await svc.report(AlertSource.KILL_SWITCH, "kill_switch:global", "critical", "T", "M")
+    notification_service.emit.reset_mock()
+
+    await svc.resolve(AlertSource.KILL_SWITCH, "kill_switch:global", "운영자 해제")
+
+    assert notification_service.emit.await_args.args[1] == NotificationLevel.INFO
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- downgrade index-based buy sidecar watch alerts from error to warning
- emit operator alert resolved transitions as info notifications
- add tests for sidecar watch severity and resolved notification level

## Tests
- pytest tests/unit_test/services/test_market_status_alert_service.py tests/unit_test/test_operator_alert_service.py tests/unit_test/services/test_telegram_notifier.py -v
- pytest tests/unit_test -v
- pytest tests/integration_test -v