### PR TITLE
Fix market alert telegram icons

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -225,7 +225,7 @@ class MarketStatusAlertService:
             "event_type": event_type, "index_code": index_code,
             "index_name": index_name, "change_rate": change_rate,
             "threshold_pct": threshold_pct, "pre_alert": True,
-            "telegram_channel": "report",
+            "telegram_channel": "report", "force_external": True,
         }
         message = f"{index_name}({index_code}) 전일 대비 {change_rate:+.2f}%"
         if self._operator_alert_service is not None:

--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -23,6 +23,12 @@ _DISCLOSURE_DIGEST_PREVIEW_LIMIT = 3
 _DISCLOSURE_MASS_REPORT_TYPES = (
     "임원주요주주특정증권등소유상황보고서",
 )
+_MARKET_PRE_ALERT_EVENT_TYPES = {
+    "buy_sidecar_watch",
+    "move_5",
+    "fall_8",
+    "futures_buy_sidecar",
+}
 
 
 def _normalize_disclosure_report_type(value: str) -> str:
@@ -80,6 +86,23 @@ def _telegram_html_to_parts(text: str) -> tuple[str, str]:
     if not lines:
         return "Telegram 알림", ""
     return lines[0], "\n".join(lines[1:])
+
+
+def _level_emoji_for_event(event: NotificationEvent) -> str:
+    metadata = event.metadata or {}
+    if str(metadata.get("transition") or "").upper() == "RESOLVED":
+        return "✅"
+    if (
+        metadata.get("source") == "MARKET_STATUS"
+        and metadata.get("event_type") in _MARKET_PRE_ALERT_EVENT_TYPES
+    ):
+        return "⚠️"
+    return {
+        "info": "ℹ️",
+        "warning": "⚠️",
+        "error": "❌",
+        "critical": "🚨"
+    }.get(event.level.value.lower(), "🔔")
 
 
 def _format_disclosure_ai_summary_html(summary_text: str) -> str:
@@ -149,13 +172,7 @@ class TelegramNotifier:
         else:
             return
         
-        # 특정 레벨(예: info, warning, error, critical)에 따라 이모지나 포맷을 다르게 할 수 있습니다.
-        level_emoji = {
-            "info": "ℹ️",
-            "warning": "⚠️",
-            "error": "❌",
-            "critical": "🚨"
-        }.get(event.level.value.lower(), "🔔")
+        level_emoji = _level_emoji_for_event(event)
 
         # 메타데이터에 수익률(return_rate) 정보가 있으면 메시지 본문에 이모지와 함께 삽입
         message_body = event.message

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -117,6 +117,7 @@ async def test_market_status_alert_service_reports_buy_sidecar_watch_near_five_p
     assert args[2] == "warning"
     assert args[3] == "코스피 매수 사이드카 가능 구간"
     assert kwargs["metadata"]["event_type"] == "buy_sidecar_watch"
+    assert kwargs["metadata"]["force_external"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_telegram_notifier.py
+++ b/tests/unit_test/services/test_telegram_notifier.py
@@ -200,6 +200,64 @@ async def test_handle_event_escapes_dynamic_html_text(telegram_notifier):
 
 
 @pytest.mark.asyncio
+async def test_handle_event_formats_market_pre_alert_as_warning_even_if_error_level(telegram_notifier):
+    """시장 사전경고는 외부 라우팅 때문에 ERROR로 들어와도 장애처럼 보이지 않게 표시한다."""
+    event = NotificationEvent(
+        id="sidecar-watch",
+        timestamp="2026-08-13T09:14:12+09:00",
+        category=NotificationCategory.SYSTEM,
+        level=NotificationLevel.ERROR,
+        title="코스피 매수 사이드카 가능 구간",
+        message="코스피(0001) 전일 대비 +4.63%",
+        metadata={
+            "source": "MARKET_STATUS",
+            "event_type": "buy_sidecar_watch",
+            "pre_alert": True,
+        },
+    )
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        await telegram_notifier.handle_event(event)
+
+    text = mock_post.call_args.kwargs["json"]["text"]
+    assert text.startswith("⚠️ ")
+    assert not text.startswith("❌ ")
+
+
+@pytest.mark.asyncio
+async def test_handle_event_formats_resolved_market_alert_as_recovered_even_if_error_level(telegram_notifier):
+    """시장 상태 해제 알림은 기존 severity가 ERROR였어도 복구 상태로 표시한다."""
+    event = NotificationEvent(
+        id="sidecar-watch-resolved",
+        timestamp="2026-08-13T09:15:13+09:00",
+        category=NotificationCategory.SYSTEM,
+        level=NotificationLevel.ERROR,
+        title="코스피 매수 사이드카 가능 구간 해제",
+        message="지수 등락률 정상화",
+        metadata={
+            "source": "MARKET_STATUS",
+            "event_type": "buy_sidecar_watch",
+            "transition": "RESOLVED",
+        },
+    )
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        await telegram_notifier.handle_event(event)
+
+    text = mock_post.call_args.kwargs["json"]["text"]
+    assert text.startswith("✅ ")
+    assert not text.startswith("❌ ")
+
+
+@pytest.mark.asyncio
 async def test_handle_event_backlog_bot(telegram_notifier, background_event):
     """BACKGROUND 카테고리 이벤트가 backlog_bot_token API URL로 전송되는지 테스트"""
     with patch("aiohttp.ClientSession.post") as mock_post:


### PR DESCRIPTION
## Summary
- Render market-status pre-alerts with warning icons instead of failure icons, even if legacy/error-level events reach Telegram.
- Render resolved operator alerts with a recovered icon.
- Force external delivery for market index pre-alerts so warning-level alerts still reach Telegram under current routing config.

## Validation
- PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest tests/unit_test -v
- PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest tests/integration_test -v