### PR TITLE
Reduce duplicate market alert noise

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -35,6 +35,7 @@ class MarketStatusAlertService:
         self._active_futures_keys_by_code: dict[str, set[str]] = {}
         self._move_5_recovery_samples_by_code: dict[str, int] = {}
         self._futures_sidecar_started_sec_by_code: dict[str, int] = {}
+        self._buy_sidecar_watch_reported_keys_by_date: dict[str, set[str]] = {}
 
     async def on_market_status(self, data: dict[str, Any]) -> None:
         """StreamingService handler entrypoint."""
@@ -102,16 +103,25 @@ class MarketStatusAlertService:
             key for key in active_keys if key.startswith("market_index:buy_sidecar_watch:")
         }
 
-        buy_sidecar_watch_key = f"market_index:buy_sidecar_watch:{index_code}"
+        trading_date = datetime.now().strftime("%Y%m%d")
+        self._reset_buy_sidecar_watch_history(trading_date)
+        buy_sidecar_watch_key = f"market_index:buy_sidecar_watch:{index_code}:{trading_date}"
         if change_rate >= self._BUY_SIDECAR_WATCH_THRESHOLD_PCT:
-            expected_keys.add(buy_sidecar_watch_key)
-            await self._report_index_alert(
-                key=buy_sidecar_watch_key, severity="warning",
-                title=f"{index_name} 매수 사이드카 가능 구간",
-                index_code=index_code, index_name=index_name, change_rate=change_rate,
-                threshold_pct=self._BUY_SIDECAR_WATCH_THRESHOLD_PCT,
-                event_type="buy_sidecar_watch",
+            reported_keys = self._buy_sidecar_watch_reported_keys_by_date.setdefault(
+                trading_date, set()
             )
+            if buy_sidecar_watch_key in active_keys:
+                expected_keys.add(buy_sidecar_watch_key)
+            elif buy_sidecar_watch_key not in reported_keys:
+                expected_keys.add(buy_sidecar_watch_key)
+                reported_keys.add(buy_sidecar_watch_key)
+                await self._report_index_alert(
+                    key=buy_sidecar_watch_key, severity="warning",
+                    title=f"{index_name} 매수 사이드카 가능 구간",
+                    index_code=index_code, index_name=index_name, change_rate=change_rate,
+                    threshold_pct=self._BUY_SIDECAR_WATCH_THRESHOLD_PCT,
+                    event_type="buy_sidecar_watch",
+                )
         elif active_buy_sidecar_watch_keys and change_rate > self._BUY_SIDECAR_WATCH_RESOLVE_PCT:
             expected_keys.update(active_buy_sidecar_watch_keys)
 
@@ -317,3 +327,12 @@ class MarketStatusAlertService:
                 dedup_key,
                 "지수선물 등락률 정상화",
             )
+
+    def _reset_buy_sidecar_watch_history(self, trading_date: str) -> None:
+        stale_dates = [
+            reported_date
+            for reported_date in self._buy_sidecar_watch_reported_keys_by_date
+            if reported_date != trading_date
+        ]
+        for reported_date in stale_dates:
+            self._buy_sidecar_watch_reported_keys_by_date.pop(reported_date, None)

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -278,6 +278,15 @@ class PriceStreamService:
                 return True
         return False
 
+    @staticmethod
+    def _is_upper_limit_snapshot(rate, sign) -> bool:
+        if str(sign or "").strip() == "1":
+            return True
+        try:
+            return float(str(rate or "0").replace(",", "")) >= 29.5
+        except (TypeError, ValueError):
+            return False
+
     def cache_conclusion_snapshot(self, code: str, execution_strength_pct: float) -> None:
         """체결강도 REST 응답을 캐시에 저장한다."""
         if not code:
@@ -315,6 +324,7 @@ class PriceStreamService:
         high: Optional[str] = None,
         low: Optional[str] = None,
         open_price: Optional[str] = None,
+        evaluate_favorite_alert: bool = True,
     ) -> None:
         """REST 스냅샷 현재가를 최신가 캐시에 반영한다."""
         if not code or not price:
@@ -361,6 +371,23 @@ class PriceStreamService:
             self._stock_repo.update_realtime_data(code, float(price), vol_int, rate=rate)
         except Exception as e:
             self._logger.warning(f"StockRepository 현재가 스냅샷 캐시 갱신 실패: {e}")
+
+        if evaluate_favorite_alert and self._favorite_price_alert_service is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(
+                    self._favorite_price_alert_service.handle_price_tick(
+                        code,
+                        price=price,
+                        rate=rate,
+                        sign=sign,
+                        is_upper_limit=self._is_upper_limit_snapshot(rate, sign),
+                    )
+                )
+            except RuntimeError:
+                pass
+            except Exception as e:
+                self._logger.warning(f"관심종목 REST 가격 알림 평가 실패: {e}")
 
     def get_liquidity_snapshot(self, code: str) -> Optional[dict]:
         """체결틱 스냅샷에서 거래량/거래대금/수신시각을 반환한다.

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -113,11 +113,27 @@ async def test_market_status_alert_service_reports_buy_sidecar_watch_near_five_p
     args = operator_alert.report.await_args.args
     kwargs = operator_alert.report.await_args.kwargs
     assert args[0] == AlertSource.MARKET_STATUS
-    assert args[1] == "market_index:buy_sidecar_watch:0001"
+    assert args[1].startswith("market_index:buy_sidecar_watch:0001:")
     assert args[2] == "warning"
     assert args[3] == "코스피 매수 사이드카 가능 구간"
     assert kwargs["metadata"]["event_type"] == "buy_sidecar_watch"
     assert kwargs["metadata"]["force_external"] is True
+
+
+@pytest.mark.asyncio
+async def test_market_status_alert_service_reports_buy_sidecar_watch_once_per_day():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(
+        operator_alert_service=operator_alert,
+        logger=MagicMock(),
+    )
+
+    await service.on_index_change("0001", "코스피", 4.62)
+    await service.on_index_change("0001", "코스피", 4.40)
+    await service.on_index_change("0001", "코스피", 4.61)
+
+    assert operator_alert.report.await_count == 1
+    assert operator_alert.resolve.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -138,6 +138,36 @@ def test_cache_price_snapshot_updates_cache_without_tick_tracking(price_stream_s
     mock_stock_repo.update_realtime_data.assert_called_once_with("005930", 71000.0, 3210, rate="0.71")
 
 
+@pytest.mark.asyncio
+async def test_cache_price_snapshot_schedules_favorite_price_alert(mock_stock_repo, mock_logger):
+    """REST 보정 스냅샷도 관심종목 임계 알림 평가로 전달한다."""
+    alert_service = MagicMock()
+    alert_service.handle_price_tick = AsyncMock()
+    service = PriceStreamService(
+        stock_repo=mock_stock_repo,
+        logger=mock_logger,
+        favorite_price_alert_service=alert_service,
+    )
+
+    service.cache_price_snapshot(
+        "080220",
+        price="91300",
+        change="4300",
+        rate="5.02",
+        sign="2",
+        volume="12345",
+    )
+
+    alert_service.handle_price_tick.assert_called_once_with(
+        "080220",
+        price="91300",
+        rate="5.02",
+        sign="2",
+        is_upper_limit=False,
+    )
+    await asyncio.sleep(0)
+
+
 def test_on_price_tick_stores_liquidity_fields(price_stream_service):
     """체결틱의 누적거래량/누적거래대금이 snapshot 에 보관된다."""
     data = {

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -485,6 +485,7 @@ async def test_refresh_price_from_rest_caches_snapshot(mock_deps):
         rate="1.45",
         sign="2",
         volume="12345",
+        evaluate_favorite_alert=False,
     )
     ctx.streaming_event_logger.log_missing_reason.assert_not_called()
 

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -682,6 +682,7 @@ class WebAppContext:
             rate=_get("prdy_ctrt", "0.00"),
             sign=_get("prdy_vrss_sign", "3"),
             volume=_get("acml_vol", "0"),
+            evaluate_favorite_alert=False,
         )
         if self.favorite_price_alert_service:
             await self.favorite_price_alert_service.handle_price_tick(


### PR DESCRIPTION
## Summary
- limit KOSPI/KOSDAQ buy sidecar watch pre-alerts to one report per trading day
- keep the active alert resolved normally when the index falls back below the watch band
- evaluate favorite price alerts from REST price snapshots while avoiding duplicate evaluation in the web refresh path

## Validation
- PYTHONUTF8=1 python -m pytest tests/unit_test -v
- PYTHONUTF8=1 python -m pytest tests/integration_test -v