### PR TITLE
Brief low-score disclosure digests

### DIFF
--- a/services/telegram_notifier.py
+++ b/services/telegram_notifier.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _DISCLOSURE_AI_SUMMARY_MAX_CHARS = 1000
 _DISCLOSURE_DIGEST_SUMMARY_MAX_CHARS = 160
+_DISCLOSURE_DIGEST_BRIEF_SCORE_THRESHOLD = 30
 _DISCLOSURE_DIGEST_PREVIEW_LIMIT = 3
 _DISCLOSURE_MASS_REPORT_TYPES = (
     "임원주요주주특정증권등소유상황보고서",
@@ -60,16 +61,22 @@ def _disclosure_digest_group_key(item, index: int) -> tuple[str, ...]:
 
 def _disclosure_digest_summary_line(items) -> str:
     for item in items:
-        summary = str(getattr(item, "summary", "") or "").strip()
-        if not summary:
-            continue
-        summary = " ".join(summary.split())
-        if len(summary) > _DISCLOSURE_DIGEST_SUMMARY_MAX_CHARS:
-            summary = (
-                summary[: _DISCLOSURE_DIGEST_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
-            )
-        return f"• 내용: {html.escape(summary, quote=False)}\n"
+        summary = _disclosure_digest_summary_text(item)
+        if summary:
+            return f"• 내용: {html.escape(summary, quote=False)}\n"
     return ""
+
+
+def _disclosure_digest_summary_text(item) -> str:
+    summary = str(getattr(item, "summary", "") or "").strip()
+    if not summary:
+        return ""
+    summary = " ".join(summary.split())
+    if len(summary) > _DISCLOSURE_DIGEST_SUMMARY_MAX_CHARS:
+        summary = (
+            summary[: _DISCLOSURE_DIGEST_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
+        )
+    return summary
 
 
 def _serialized_report_send(func):
@@ -765,6 +772,18 @@ class TelegramReporter:
             if len(group) == 1:
                 importance = group[0].importance
                 report_name = html.escape(str(disclosure.report_name), quote=False)
+                if int(importance.score) < _DISCLOSURE_DIGEST_BRIEF_SCORE_THRESHOLD:
+                    summary = _disclosure_digest_summary_text(group[0])
+                    content = report_name
+                    if summary:
+                        content = (
+                            f"{report_name}: {html.escape(summary, quote=False)}"
+                        )
+                    parts.append(
+                        f"\n<b>{company} ({stock_code})</b>\n"
+                        f"• {content}\n"
+                    )
+                    continue
                 summary_line = _disclosure_digest_summary_line(group)
                 parts.append(
                     f"\n<b>{company} ({stock_code})</b>\n"

--- a/tests/unit_test/services/test_dart_disclosure_telegram.py
+++ b/tests/unit_test/services/test_dart_disclosure_telegram.py
@@ -145,7 +145,7 @@ async def test_send_disclosure_digest_includes_one_line_summary_when_available()
     rows = [
         _stored(
             "풍문또는보도에대한해명",
-            10,
+            30,
             summary="언론의 특정 공급계약 추진 보도는 사실이 아니라고 해명했습니다.",
         )
     ]
@@ -155,6 +155,29 @@ async def test_send_disclosure_digest_includes_one_line_summary_when_available()
     assert sent is True
     message = reporter._send_message.await_args.args[0]
     assert "• 내용: 언론의 특정 공급계약 추진 보도는 사실이 아니라고 해명했습니다." in message
+
+
+async def test_send_disclosure_digest_under_30_points_uses_single_content_line():
+    reporter = TelegramReporter("token", "chat")
+    reporter._send_message = AsyncMock(return_value=True)
+    rows = [
+        _stored(
+            "증권발행실적보고서",
+            10,
+            summary="미래에셋증권은 제4047회 ELB를 10.8억원 규모로 발행 완료했고 제4048회 ELB는 청약 미달로 취소되었습니다.",
+        )
+    ]
+
+    await reporter.send_disclosure_digest(rows, "20260813")
+
+    message = reporter._send_message.await_args.args[0]
+    assert (
+        "• 증권발행실적보고서: 미래에셋증권은 제4047회 ELB를 10.8억원 규모로 발행 완료했고 제4048회 ELB는 청약 미달로 취소되었습니다."
+        in message
+    )
+    assert "• 내용:" not in message
+    assert "• 중요도:" not in message
+    assert ">원문</a>" not in message
 
 
 async def test_send_disclosure_digest_uses_group_summary_and_escapes_html():


### PR DESCRIPTION
﻿## What changed
- Formats daily disclosure digest entries below 30 points as a single report-title + summary line.
- Omits the detail summary label, importance line, and DART source link for those low-score single disclosures.
- Adds regression coverage for the low-score digest format while preserving the existing 30-point-and-up format.

## Why
Low-importance disclosures made the daily digest too verbose. This keeps low-score items scannable while retaining fuller detail for higher-score disclosures.

## Validation
- `python -m pytest tests/unit_test/services/test_dart_disclosure_telegram.py -v`
- `chcp 65001; ...; python -m pytest tests/unit_test -v`
- `chcp 65001; ...; python -m pytest tests/integration_test -v`
