### PR TITLE
Gate manual overseas orders through kill switch and journal

### DIFF
--- a/services/overseas_order_execution_service.py
+++ b/services/overseas_order_execution_service.py
@@ -19,6 +19,11 @@ canary/kill-switch/reconcile 다.
 
 스케줄러/factory 배선(자동 발사)은 Phase 5 소관 — 본 서비스는 테스트된 게이팅
 컴포넌트로만 제공된다.
+
+웹 수동 주문 라우트(`POST /api/overseas/order`)도 kill-switch/저널 게이팅을 얻기 위해
+이 서비스를 재사용한다(`live_enabled=True` 전용 인스턴스). 자동 전략 경로는 별도
+인스턴스라 `live_enabled=False` 잠금이 그대로 유지된다. 저널 기록이 섞이지 않도록
+`journal_strategy_name` 으로 경로를 구분한다.
 """
 from __future__ import annotations
 
@@ -41,6 +46,7 @@ class OverseasOrderExecutionService:
         default_exchange: OverseasExchange = OverseasExchange.NASD,
         journal=None,
         kill_switch=None,
+        journal_strategy_name: str = "LarryWilliamsVBO_overseas",
         logger: Optional[logging.Logger] = None,
     ) -> None:
         # broker 는 live_enabled=True 일 때만 필요. paper 모드에선 None 허용(구조적 잠금).
@@ -48,6 +54,8 @@ class OverseasOrderExecutionService:
         self._live_enabled = bool(live_enabled)
         self._default_exchange = default_exchange
         self._journal = journal
+        # 저널 상 경로 구분(자동 VBO / 수동 주문). 소비 측이 섞어 읽지 않도록 한다.
+        self._journal_strategy_name = journal_strategy_name
         # live 실주문 직전 차단 게이트(check_orders_allowed). paper 모드는 실주문이 없어 미적용.
         self._kill_switch = kill_switch
         self._logger = logger or logging.getLogger(__name__)
@@ -175,7 +183,7 @@ class OverseasOrderExecutionService:
             order["signal"] = signal
         try:
             self._journal.record(
-                strategy_name="LarryWilliamsVBO_overseas",
+                strategy_name=self._journal_strategy_name,
                 code=symbol,
                 signal=order,
                 snapshot={"exchange": ex.value},

--- a/tests/unit_test/services/test_overseas_order_execution_service.py
+++ b/tests/unit_test/services/test_overseas_order_execution_service.py
@@ -192,3 +192,26 @@ async def test_journal_records_order_when_provided():
     kwargs = journal.record.call_args.kwargs
     assert kwargs["code"] == "AAPL"
     assert kwargs["signal_source"] == OverseasOrderExecutionService.SIGNAL_SOURCE_PAPER
+
+
+@pytest.mark.asyncio
+async def test_journal_defaults_to_vbo_strategy_name():
+    """기본 저널 전략명은 VBO 자동 경로 이름 — 회귀 잠금."""
+    journal = MagicMock()
+    svc = OverseasOrderExecutionService(None, live_enabled=False, journal=journal)
+    await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    assert journal.record.call_args.kwargs["strategy_name"] == "LarryWilliamsVBO_overseas"
+
+
+@pytest.mark.asyncio
+async def test_journal_strategy_name_override():
+    """수동 주문 경로가 자기 이름으로 기록할 수 있어야 한다(자동 VBO 기록과 혼동 방지)."""
+    journal = MagicMock()
+    svc = OverseasOrderExecutionService(
+        _broker(), live_enabled=True, journal=journal,
+        journal_strategy_name="수동매매_해외",
+    )
+    await svc.place_entry(code="AAPL", qty=6, limit_price=150.0)
+    kwargs = journal.record.call_args.kwargs
+    assert kwargs["strategy_name"] == "수동매매_해외"
+    assert kwargs["signal_source"] == OverseasOrderExecutionService.SIGNAL_SOURCE_LIVE

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -871,6 +871,67 @@ def test_intraday_vbo_built_with_order_path_locked(patched_service_container_dep
     assert task_cls.call_args.kwargs["shadow_journal"] is paper_journal
 
 
+def test_manual_overseas_order_service_wired_with_kill_switch(patched_service_container_deps):
+    """수동 해외주문 경로는 kill-switch 게이트를 거쳐야 한다 — 라우트가 broker 를 직접
+    호출하면 킬스위치가 우회되므로 게이팅 서비스를 배선한다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasOrderExecutionService", autospec=True) as order_cls:
+        ServiceContainer(ctx).run()
+
+    assert ctx.overseas_manual_order_service is order_cls.return_value
+    kwargs = order_cls.call_args.kwargs
+    assert kwargs["live_enabled"] is True  # 수동 주문은 실제로 발사되는 경로
+    assert kwargs["kill_switch"] is ctx.kill_switch_service
+    assert kwargs["broker"] is ctx.broker
+    assert kwargs["journal_strategy_name"] == "수동매매_해외"
+
+
+def test_manual_overseas_order_service_absent_without_overseas_enabled(patched_service_container_deps):
+    """overseas_us 가 enabled 가 아니면 수동 주문 게이팅 서비스도 없다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.overseas_stock_code_repository = MagicMock()
+    ServiceContainer(ctx).run()
+
+    assert ctx.overseas_manual_order_service is None
+
+
+def test_manual_order_service_does_not_unlock_automatic_path(patched_service_container_deps):
+    """수동 경로가 live_enabled=True 여도 자동 VBO 경로는 잠금(False)을 유지한다."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        overseas_stock={"allow_live_trading": True, "intraday_vbo": {"enabled": True}},
+    )
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasOrderExecutionService", autospec=True) as order_cls, \
+         patch("view.web.bootstrap.service_container.OverseasIntradayVBOService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasIntradayVBOTask", autospec=True):
+        ServiceContainer(ctx).run()
+
+    live_flags = [c.kwargs["live_enabled"] for c in order_cls.call_args_list]
+    assert live_flags == [True, False]  # [수동, 자동] — 자동은 잠금 유지
+
+
 def test_domestic_active_without_overseas_enabled_skips_dryrun_task(patched_service_container_deps):
     """overseas_us 가 enabled 에 없으면 dry-run 태스크는 조립되지 않는다(None)."""
     from view.web.bootstrap.service_container import ServiceContainer

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -270,13 +270,27 @@ async def test_place_order_market_price_lookup_exception(web_client, mock_web_ct
     mock_web_ctx.virtual_trade_service.log_buy.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_place_overseas_limit_order_calls_broker(web_client, mock_web_ctx):
-    """POST /api/overseas/order는 해외 mode에서 수동 지정가 주문만 브로커에 위임한다."""
-    mock_web_ctx.market_mode = "overseas_us"
-    mock_web_ctx.broker.place_overseas_limit_order.return_value = ResCommonResponse(
-        rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"}
+def _install_overseas_manual_service(ctx, resp=None):
+    """수동 해외주문은 kill-switch/저널 게이팅을 거쳐야 하므로 라우트가 직접 broker를
+    호출하지 않는다. 게이팅 서비스를 mock 으로 심고 반환한다."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    svc = MagicMock()
+    svc.place_entry = AsyncMock(
+        return_value=resp or ResCommonResponse(rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"})
     )
+    svc.place_exit = AsyncMock(
+        return_value=resp or ResCommonResponse(rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"})
+    )
+    ctx.overseas_manual_order_service = svc
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_limit_order_goes_through_gating_service(web_client, mock_web_ctx):
+    """POST /api/overseas/order는 broker 직접 호출이 아니라 게이팅 서비스를 경유한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    svc = _install_overseas_manual_service(mock_web_ctx)
 
     payload = {
         "symbol": "AAPL",
@@ -290,18 +304,20 @@ async def test_place_overseas_limit_order_calls_broker(web_client, mock_web_ctx)
 
     assert response.status_code == 200
     assert response.json()["data"]["ord_no"] == "A12345"
-    mock_web_ctx.broker.place_overseas_limit_order.assert_awaited_once_with(
-        symbol="AAPL",
+    svc.place_entry.assert_awaited_once_with(
+        code="AAPL",
         exchange=OverseasExchange.NASD,
-        side="buy",
         qty=3,
         limit_price=190.25,
+        signal={"source": "manual"},
     )
+    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_place_overseas_order_requires_overseas_mode(web_client, mock_web_ctx):
     """overseas_us가 enabled되지 않은 run에서는 해외 주문 endpoint가 닫혀 있어야 한다."""
+    svc = _install_overseas_manual_service(mock_web_ctx)
     payload = {
         "symbol": "AAPL",
         "exchange": "NASD",
@@ -313,7 +329,7 @@ async def test_place_overseas_order_requires_overseas_mode(web_client, mock_web_
     response = web_client.post("/api/overseas/order", json=payload)
 
     assert response.status_code == 400
-    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+    svc.place_entry.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -321,9 +337,7 @@ async def test_place_overseas_order_allowed_when_domestic_active_but_overseas_en
     """국내 active run에서도 overseas_us가 enabled이면 해외 수동 지정가 주문을 허용한다."""
     mock_web_ctx.market_mode = "domestic"
     mock_web_ctx.enabled_market_modes = ["domestic", "overseas_us"]
-    mock_web_ctx.broker.place_overseas_limit_order.return_value = ResCommonResponse(
-        rt_cd="0", msg1="Order Placed", data={"ord_no": "A12345"}
-    )
+    svc = _install_overseas_manual_service(mock_web_ctx)
 
     payload = {
         "symbol": "AAPL",
@@ -336,12 +350,12 @@ async def test_place_overseas_order_allowed_when_domestic_active_but_overseas_en
     response = web_client.post("/api/overseas/order", json=payload)
 
     assert response.status_code == 200
-    mock_web_ctx.broker.place_overseas_limit_order.assert_awaited_once_with(
-        symbol="AAPL",
+    svc.place_entry.assert_awaited_once_with(
+        code="AAPL",
         exchange=OverseasExchange.NASD,
-        side="buy",
         qty=1,
         limit_price=190.0,
+        signal={"source": "manual"},
     )
 
 
@@ -357,6 +371,7 @@ async def test_place_overseas_real_order_requires_allow_live_trading(web_client,
     mock_web_ctx.full_config["overseas_stock"] = {
         "allow_live_trading": False,
     }
+    svc = _install_overseas_manual_service(mock_web_ctx)
 
     payload = {
         "symbol": "AAPL",
@@ -372,7 +387,7 @@ async def test_place_overseas_real_order_requires_allow_live_trading(web_client,
     assert response.status_code == 200
     assert response.json()["rt_cd"] == ErrorCode.ORDER_POLICY_BLOCKED.value
     assert response.json()["data"]["rule"] == "overseas_live_trading_disabled"
-    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+    svc.place_entry.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -385,6 +400,7 @@ async def test_place_overseas_order_rejects_disabled_exchange(web_client, mock_w
         auth=SimpleNamespace(secret_key="secret"),
         overseas_stock=SimpleNamespace(enabled_exchanges=["NYSE"]),
     )
+    svc = _install_overseas_manual_service(mock_web_ctx)
 
     payload = {
         "symbol": "AAPL",
@@ -397,6 +413,81 @@ async def test_place_overseas_order_rejects_disabled_exchange(web_client, mock_w
     response = web_client.post("/api/overseas/order", json=payload)
 
     assert response.status_code == 400
+    svc.place_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_sell_uses_place_exit(web_client, mock_web_ctx):
+    """매도는 청산 경로(place_exit)로 위임된다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    svc = _install_overseas_manual_service(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "sell",
+        "qty": 2,
+        "limit_price": 195.5,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    svc.place_exit.assert_awaited_once_with(
+        code="AAPL",
+        exchange=OverseasExchange.NASD,
+        qty=2,
+        limit_price=195.5,
+        reason="manual",
+        signal={"source": "manual"},
+    )
+    svc.place_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_blocked_by_kill_switch(web_client, mock_web_ctx):
+    """kill-switch 차단 응답을 라우트가 그대로 전달한다(국내 주문과 동일한 규율)."""
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(
+        mock_web_ctx,
+        resp=ResCommonResponse(
+            rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value,
+            msg1="Kill Switch 활성 — 일일 손실 한도 초과",
+            data=None,
+        ),
+    )
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["rt_cd"] == ErrorCode.KILL_SWITCH_BLOCKED.value
+
+
+@pytest.mark.asyncio
+async def test_place_overseas_order_without_service_returns_503(web_client, mock_web_ctx):
+    """게이팅 서비스가 없으면 broker 로 우회하지 않고 503 으로 실패한다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    mock_web_ctx.overseas_manual_order_service = None
+
+    payload = {
+        "symbol": "AAPL",
+        "exchange": "NASD",
+        "side": "buy",
+        "qty": 1,
+        "limit_price": 190.0,
+        "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 503
     mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
 
 
@@ -415,6 +506,7 @@ async def test_place_overseas_real_order_requires_confirmation_when_live_allowed
             enabled_exchanges=["NASD", "NYSE", "AMEX"],
         ),
     )
+    svc = _install_overseas_manual_service(mock_web_ctx)
 
     payload = {
         "symbol": "AAPL",
@@ -428,7 +520,7 @@ async def test_place_overseas_real_order_requires_confirmation_when_live_allowed
     response = web_client.post("/api/overseas/order", json=payload)
 
     assert response.status_code == 400
-    mock_web_ctx.broker.place_overseas_limit_order.assert_not_awaited()
+    svc.place_entry.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -867,6 +867,7 @@ class ServiceContainer:
                 ctx.overseas_candidate_service = None
                 ctx.overseas_vbo_dryrun_service = None
                 ctx.overseas_dryrun_task = None
+                ctx.overseas_manual_order_service = None
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
@@ -915,19 +916,21 @@ class ServiceContainer:
         """해외 VBO dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
 
         overseas_us active 분기와 국내 active 공존 경로가 공유한다.
-        `overseas_stock_code_repository` 가 없으면 no-op. shadow 저널은 realtime 경로에서
-        만든 인스턴스를 재사용하고, 없으면(overseas active 등) 새로 만든다.
+        `overseas_stock_code_repository` 가 없으면 dry-run 부분은 no-op(수동 주문 게이팅
+        서비스는 종목코드 저장소와 무관하므로 그 전에 배선한다). shadow 저널은 realtime
+        경로에서 만든 인스턴스를 재사용하고, 없으면(overseas active 등) 새로 만든다.
         """
         ctx = self._ctx
         ctx.overseas_candidate_service = None
         ctx.overseas_vbo_dryrun_service = None
         ctx.overseas_dryrun_task = None
-        if getattr(ctx, "overseas_stock_code_repository", None) is None:
-            return
         if getattr(ctx, "event_shadow_journal_service", None) is None:
             ctx.event_shadow_journal_service = EventShadowJournalService(
                 log_root="logs/strategies", logger=ctx.logger,
             )
+        self._build_overseas_manual_order_service()
+        if getattr(ctx, "overseas_stock_code_repository", None) is None:
+            return
         overseas_stock_cfg = getattr(ctx.full_config, "overseas_stock", None)
         overseas_position_sizing_service = OverseasPositionSizingService(
             slot_usd=getattr(overseas_stock_cfg, "dryrun_slot_usd", 1000.0),
@@ -973,6 +976,24 @@ class ServiceContainer:
             worker_pool=ctx.worker_pool,
         )
         self._build_overseas_intraday_vbo(overseas_stock_cfg, overseas_position_sizing_service)
+
+    def _build_overseas_manual_order_service(self) -> None:
+        """웹 수동 해외주문(`POST /api/overseas/order`) 전용 게이팅 서비스 배선.
+
+        라우트가 broker 를 직접 호출하면 kill-switch 와 저널 기록을 우회한다(국내 수동
+        주문은 `OrderExecutionService` 경유라 둘 다 걸린다). 수동 주문은 원래 발사되는
+        경로이므로 `live_enabled=True` 이며, **자동 전략 경로는 별도 인스턴스**라
+        `live_enabled=False` 잠금이 그대로 유지된다.
+        """
+        ctx = self._ctx
+        ctx.overseas_manual_order_service = OverseasOrderExecutionService(
+            broker=ctx.broker,
+            live_enabled=True,
+            journal=ctx.event_shadow_journal_service,
+            kill_switch=getattr(ctx, "kill_switch_service", None),
+            journal_strategy_name="수동매매_해외",
+            logger=ctx.logger,
+        )
 
     def _build_overseas_intraday_vbo(self, overseas_stock_cfg, position_sizing_service) -> None:
         """해외 장중 VBO 폴링 경로 조립 (config 로 opt-in, 기본 off).

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -87,7 +87,11 @@ async def place_order(req: OrderRequest, request: Request):
 
 @router.post("/overseas/order")
 async def place_overseas_order(req: OverseasOrderRequest, request: Request):
-    """해외주식 수동 지정가 주문. v1은 미국 3시장 + USD 지정가만 지원한다."""
+    """해외주식 수동 지정가 주문. v1은 미국 3시장 + USD 지정가만 지원한다.
+
+    kill-switch 차단과 저널 기록을 얻기 위해 broker 직접 호출이 아니라
+    `overseas_manual_order_service` 를 경유한다(국내 주문의 OrderExecutionService 대응).
+    """
     ctx = _get_ctx()
     if not is_market_enabled(ctx, "overseas_us"):
         raise HTTPException(status_code=400, detail="해외주식 주문은 overseas_us가 enabled된 run에서만 사용할 수 있습니다.")
@@ -106,13 +110,27 @@ async def place_overseas_order(req: OverseasOrderRequest, request: Request):
         if req.real_order_confirmation != "REAL":
             raise HTTPException(status_code=400, detail="실전 주문 확인 문자열이 필요합니다.")
 
-    resp = await ctx.broker.place_overseas_limit_order(
-        symbol=req.symbol,
-        exchange=req.exchange,
-        side=req.side,
-        qty=req.qty,
-        limit_price=req.limit_price,
-    )
+    service = getattr(ctx, "overseas_manual_order_service", None)
+    if service is None:
+        raise HTTPException(status_code=503, detail="해외주식 주문 서비스가 준비되지 않았습니다.")
+
+    if req.side == "buy":
+        resp = await service.place_entry(
+            code=req.symbol,
+            exchange=req.exchange,
+            qty=req.qty,
+            limit_price=req.limit_price,
+            signal={"source": "manual"},
+        )
+    else:
+        resp = await service.place_exit(
+            code=req.symbol,
+            exchange=req.exchange,
+            qty=req.qty,
+            limit_price=req.limit_price,
+            reason="manual",
+            signal={"source": "manual"},
+        )
     return _serialize_response(resp)
 
 


### PR DESCRIPTION
## 문제

`POST /api/overseas/order` 가 `ctx.broker.place_overseas_limit_order` 를 직접 호출해
kill-switch 게이트와 거래 기록을 통째로 우회했다.

- 국내 수동주문(`POST /api/order`)은 `OrderExecutionService` → `FillReconciliationService`
  경유라 게이트와 기록이 모두 걸린다.
- 미국 수동주문은 실전에서 실제로 발사 가능한 경로인데(ADMIN + `REAL` 확인 문자열),
  걸리는 보호막이 `BrokerAPIWrapper` 서킷브레이커 하나뿐이었다.
- 결과: kill-switch가 trip된 상태에서도 미국 수동주문이 나가고, 체결된 포지션을
  시스템이 전혀 모른다.

## 변경

`OverseasOrderExecutionService` 에 kill-switch 차단(`_kill_switch_block`)과
저널 기록(`_record_journal`)이 **이미 구현돼 있었으나** 자동 VBO paper 경로에만
배선돼 있었다. 이를 수동 경로에서도 재사용한다.

- `service_container`: 수동 주문 전용 인스턴스(`live_enabled=True`, kill_switch 주입)를
  `overseas_manual_order_service` 로 배선. **자동 전략 경로는 별도 인스턴스**라
  `live_enabled=False` 잠금 불변.
- `routes/order.py`: buy → `place_entry`, sell → `place_exit`. 서비스 부재 시 broker로
  우회하지 않고 503.
- `journal_strategy_name` 인자 추가(기본값은 기존 VBO 이름) — 수동 기록이 VBO 신호로
  읽히지 않게 구분.
- **주문 취소는 변경 없음** — 취소는 리스크 축소 행위라 kill-switch 대상이 아니다.

부수 효과로 브로커 API의 `limit_price: str` 계약에 맞게 변환된다(기존 라우트는 float 전달).

## 범위 제외

`VirtualTradeRepository` 편입은 하지 않았다. 원화·국내 6자리 코드 기준 원장이고
국내 브로커 잔고 대사에 물려 있어, USD 체결을 넣으면 국내 성과 통계와 대사 고아를
오염시킨다. 통화 설계 결정이 선행되어야 한다. → 미국장 성과요약 공백은 여전히 남는다.

## 검증

- 단위: 7,705 passed / 3 failed — 실패 3건은 `test_trade_trends_js.py` 로
  **이 변경 없이도 main에서 동일하게 실패**하는 기존 회귀(stash 후 재현 확인).
- 통합: 279 passed.
- 신규 테스트 9건: 게이팅 서비스 경유·매도 경로·kill-switch 차단 전달·서비스 부재 503·
  컨테이너 배선(kill_switch 주입, `live_enabled` [수동 True, 자동 False] 회귀 잠금)·
  저널 전략명 기본값/오버라이드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
