### PR TITLE
Flag suspect trade records without rewriting them

### DIFF
--- a/repositories/virtual_trade_repository.py
+++ b/repositories/virtual_trade_repository.py
@@ -53,7 +53,8 @@ LIVE_STRATEGY_STATE_FILES = {
 _SELECT_TRADES = (
     "SELECT strategy, code, buy_date, buy_price, qty, sell_date, sell_price, return_rate, status, reason, "
     "volatility_20d_annualized, config_hash, invalidation_price, stop_loss_price, target_price, "
-    "entry_reason, trailing_rule, expected_holding_period_days, confidence, required_data, market_regime "
+    "entry_reason, trailing_rule, expected_holding_period_days, confidence, required_data, market_regime, "
+    "data_quality_flag "
     "FROM trades ORDER BY id"
 )
 _INSERT_TRADE = (
@@ -194,6 +195,11 @@ class VirtualTradeRepository:
         if "market_regime" not in existing:
             with self._db:
                 self._db.execute("ALTER TABLE trades ADD COLUMN market_regime TEXT")
+        # 0-2: 소급 재구성이 불가한 오염 기록의 의심 표식. 수치를 재작성하지 않고
+        # 이 컬럼으로만 표시한다(설정은 scripts/flag_suspect_trades.py).
+        if "data_quality_flag" not in existing:
+            with self._db:
+                self._db.execute("ALTER TABLE trades ADD COLUMN data_quality_flag TEXT")
 
     # ---- 레거시 데이터 마이그레이션 (CSV/JSON → SQLite, 최초 1회) ----
 

--- a/scripts/flag_suspect_trades.py
+++ b/scripts/flag_suspect_trades.py
@@ -1,0 +1,93 @@
+"""오염이 의심되는 원장 행에 의심 표식을 남긴다(수치는 재작성하지 않는다).
+
+배경: PR #700 이전 `log_sell` 이 qty 를 무시하고 lot 전체를 SOLD 로 뒤집던 결함 때문에,
+절반만 체결된 주문이 전량 청산으로 기록됐다. 나머지 절반이 미청산이라 **당시 수익률을
+소급 재구성할 수 없다** — 그래서 값을 고치지 않고 `data_quality_flag` 로 표식만 남긴다.
+표식이 붙은 행은 웹 매도 기록 표에 ⚠ 로 표시되고, 성과 집계 수치 자체는 바뀌지 않는다.
+
+알려진 대상(06-28 tiered 도입 이후 SOLD 15건 중 5건, 전부 VBO):
+    trade id 251 · 261 · 263 · 265 · 269
+
+사용:
+    # dry-run (기본) — 변경 없이 대상 행만 출력
+    python scripts/flag_suspect_trades.py --trade-id 251 --trade-id 261 \
+        --note "부분매도 전량기록 의심 (PR #700 이전)"
+
+    # 실제 반영 (DB 백업 후)
+    python scripts/flag_suspect_trades.py --trade-id 251 --note "..." --apply
+
+주의: 이 DB 는 WAL 모드다 — 백업은 반드시 `sqlite3` backup API 로. 파일 복사는
+`-wal` 의 최신 커밋을 놓쳐 조용히 불완전한 스냅샷을 만든다.
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+
+DEFAULT_DB = "data/VirtualTradeRepository/virtual_trade.db"
+
+
+def _ensure_flag_column(conn: sqlite3.Connection) -> None:
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(trades)").fetchall()}
+    if "data_quality_flag" not in existing:
+        conn.execute("ALTER TABLE trades ADD COLUMN data_quality_flag TEXT")
+
+
+def _fetch_rows(conn: sqlite3.Connection, trade_ids: list[int]) -> list[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    rows = []
+    for trade_id in trade_ids:
+        row = conn.execute("SELECT * FROM trades WHERE id=?", (trade_id,)).fetchone()
+        if row is None:
+            sys.exit(f"[중단] trade id={trade_id} 행이 없습니다.")
+        rows.append(row)
+    return rows
+
+
+def _print_plan(rows: list[sqlite3.Row], note: str, apply: bool) -> None:
+    print("=" * 72)
+    print(f"의심 표식 대상 {len(rows)}건  note={note!r}")
+    print("=" * 72)
+    for row in rows:
+        # dry-run 은 컬럼 추가 전이라 아직 없을 수 있다.
+        before = row["data_quality_flag"] if "data_quality_flag" in row.keys() else None
+        print(
+            f"  id={row['id']}  {row['strategy']}  {row['code']}  "
+            f"status={row['status']}  return_rate={row['return_rate']}"
+        )
+        print(f"      flag: {before!r} -> {note!r}")
+    print("-" * 72)
+    print("수익률/상태/수량은 변경하지 않는다 — 표식만 남긴다.")
+    if not apply:
+        print("dry-run 입니다. 실제로 반영하려면 --apply 를 붙이세요.")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="오염 의심 거래에 data_quality_flag 표식을 남긴다.")
+    parser.add_argument("--trade-id", type=int, action="append", required=True,
+                        help="대상 trade id (여러 번 지정 가능)")
+    parser.add_argument("--note", required=True, help="표식 문구 (의심 사유)")
+    parser.add_argument("--db", default=DEFAULT_DB, help=f"DB 경로 (기본: {DEFAULT_DB})")
+    parser.add_argument("--apply", action="store_true", help="실제 DB 에 반영 (기본은 dry-run)")
+    args = parser.parse_args(argv)
+
+    conn = sqlite3.connect(args.db)
+    try:
+        rows = _fetch_rows(conn, args.trade_id)
+        _print_plan(rows, args.note, args.apply)
+        if not args.apply:
+            return
+        with conn:
+            _ensure_flag_column(conn)
+            conn.executemany(
+                "UPDATE trades SET data_quality_flag=? WHERE id=?",
+                [(args.note, row["id"]) for row in rows],
+            )
+        print(f"반영 완료 — {len(rows)}건에 표식을 남겼습니다.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/repositories/test_virtual_trade_repository.py
+++ b/tests/unit_test/repositories/test_virtual_trade_repository.py
@@ -1386,3 +1386,38 @@ def test_get_holds_by_strategy_broken_regime_json_returns_none(virutal_trade_rep
     holds = repo.get_holds_by_strategy("전략A")
 
     assert holds[0]["market_regime"] is None
+
+
+def test_data_quality_flag_column_is_migrated(temp_db, mock_market_clock):
+    """컬럼이 없는 기존 DB 도 data_quality_flag 를 얻는다(idempotent 마이그레이션)."""
+    legacy = sqlite3.connect(temp_db)
+    legacy.execute(
+        "CREATE TABLE trades ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, strategy TEXT NOT NULL, code TEXT NOT NULL, "
+        "buy_date TEXT NOT NULL, buy_price REAL NOT NULL, qty INTEGER NOT NULL DEFAULT 1, "
+        "sell_date TEXT, sell_price REAL, return_rate REAL NOT NULL DEFAULT 0.0, "
+        "status TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '')"
+    )
+    legacy.commit()
+    legacy.close()
+
+    repo = VirtualTradeRepository(db_path=temp_db, market_clock=mock_market_clock)
+
+    columns = {row[1] for row in repo._db.execute("PRAGMA table_info(trades)").fetchall()}
+    assert "data_quality_flag" in columns
+
+
+def test_get_all_trades_exposes_data_quality_flag(virutal_trade_repository):
+    """오염 의심 플래그는 웹 응답까지 실려 나가야 표식으로 보인다(미설정 시 None)."""
+    repo = virutal_trade_repository
+    repo.log_buy("전략A", "005930", 70000)
+    repo.log_buy("전략A", "000020", 5000)
+    repo._db.execute(
+        "UPDATE trades SET data_quality_flag='부분매도 전량기록 의심' WHERE code='005930'"
+    )
+    repo._db.commit()
+
+    by_code = {t["code"]: t for t in repo.get_all_trades()}
+
+    assert by_code["005930"]["data_quality_flag"] == "부분매도 전량기록 의심"
+    assert by_code["000020"]["data_quality_flag"] is None

--- a/tests/unit_test/scripts/test_flag_suspect_trades.py
+++ b/tests/unit_test/scripts/test_flag_suspect_trades.py
@@ -1,0 +1,101 @@
+"""오염 의심 거래 플래그 스크립트 테스트.
+
+핵심 계약: dry-run 이 기본이고 `--apply` 없이는 DB 가 바뀌지 않는다. 오염 기록은
+소급 재구성이 불가해 **재작성이 아니라 표식만** 남기므로, 스크립트가 다른 컬럼을
+건드리면 안 된다.
+"""
+import sqlite3
+
+import pytest
+
+from scripts.flag_suspect_trades import main
+
+
+def _make_db(tmp_path, *, with_flag_column: bool = True) -> str:
+    db_path = str(tmp_path / "virtual_trade.db")
+    conn = sqlite3.connect(db_path)
+    columns = (
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, strategy TEXT NOT NULL, code TEXT NOT NULL, "
+        "buy_date TEXT NOT NULL, buy_price REAL NOT NULL, qty INTEGER NOT NULL DEFAULT 1, "
+        "sell_date TEXT, sell_price REAL, return_rate REAL NOT NULL DEFAULT 0.0, "
+        "status TEXT NOT NULL, reason TEXT NOT NULL DEFAULT ''"
+    )
+    if with_flag_column:
+        columns += ", data_quality_flag TEXT"
+    conn.execute(f"CREATE TABLE trades ({columns})")
+    conn.executemany(
+        "INSERT INTO trades (strategy, code, buy_date, buy_price, qty, sell_date, sell_price, "
+        "return_rate, status, reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("래리윌리엄스VBO", "005930", "2026-06-28", 70000.0, 10, "2026-06-28", 71000.0, 1.4, "SOLD", ""),
+            ("래리윌리엄스VBO", "000020", "2026-06-29", 5000.0, 20, "2026-06-29", 4900.0, -2.0, "SOLD", ""),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _flags(db_path) -> dict:
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT id, data_quality_flag FROM trades ORDER BY id").fetchall()
+    conn.close()
+    return dict(rows)
+
+
+def test_dry_run_does_not_modify_db(tmp_path, capsys):
+    db_path = _make_db(tmp_path)
+
+    main(["--trade-id", "1", "--note", "부분매도 전량기록 의심", "--db", db_path])
+
+    assert _flags(db_path) == {1: None, 2: None}
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_apply_flags_only_given_ids(tmp_path):
+    db_path = _make_db(tmp_path)
+
+    main(["--trade-id", "1", "--note", "부분매도 전량기록 의심", "--db", db_path, "--apply"])
+
+    assert _flags(db_path) == {1: "부분매도 전량기록 의심", 2: None}
+
+
+def test_apply_does_not_touch_performance_columns(tmp_path):
+    """재작성 금지 — 수익률/상태는 그대로 두고 표식만 붙인다."""
+    db_path = _make_db(tmp_path)
+
+    main(["--trade-id", "2", "--note", "의심", "--db", db_path, "--apply"])
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute("SELECT return_rate, status, sell_price FROM trades WHERE id=2").fetchone()
+    conn.close()
+    assert row == (-2.0, "SOLD", 4900.0)
+
+
+def test_adds_column_when_missing(tmp_path):
+    db_path = _make_db(tmp_path, with_flag_column=False)
+
+    main(["--trade-id", "1", "--note", "의심", "--db", db_path, "--apply"])
+
+    assert _flags(db_path) == {1: "의심", 2: None}
+
+
+def test_dry_run_without_column_leaves_schema_untouched(tmp_path):
+    """dry-run 은 스키마도 건드리지 않는다."""
+    db_path = _make_db(tmp_path, with_flag_column=False)
+
+    main(["--trade-id", "1", "--note", "의심", "--db", db_path])
+
+    conn = sqlite3.connect(db_path)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(trades)").fetchall()}
+    conn.close()
+    assert "data_quality_flag" not in columns
+
+
+def test_unknown_trade_id_aborts_without_partial_write(tmp_path):
+    db_path = _make_db(tmp_path)
+
+    with pytest.raises(SystemExit):
+        main(["--trade-id", "1", "--trade-id", "999", "--note", "의심", "--db", db_path, "--apply"])
+
+    assert _flags(db_path) == {1: None, 2: None}

--- a/tests/unit_test/view/web/test_web_pages.py
+++ b/tests/unit_test/view/web/test_web_pages.py
@@ -126,6 +126,18 @@ def test_virtual_static_js_exposes_divergence_workflow():
     assert "slippage_pct" in script
 
 
+def test_virtual_static_js_marks_suspect_records():
+    """오염 의심 플래그가 붙은 매도 기록은 수익률 옆에 표식이 보여야 한다.
+
+    소급 재구성이 불가한 오염 기록(PR #700 이전 부분매도 전량기록)은 숫자를 고치지
+    않고 표식만 남긴다 — 표식이 사라지면 오염 수치가 정상 성과로 읽힌다.
+    """
+    script = Path("view/web/static/js/virtual.js").read_text(encoding="utf-8")
+
+    assert "data_quality_flag" in script
+    assert "suspectHtml" in script
+
+
 def test_stock_static_js_does_not_expose_overseas_mode():
     """stock.js는 한국장 전용이며 미국장 조회는 overseas.js가 소유한다."""
     script = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")

--- a/view/web/static/js/virtual.js
+++ b/view/web/static/js/virtual.js
@@ -932,6 +932,11 @@ function renderVirtualSoldTable() {
         const curPrice = item.current_price ? Number(item.current_price).toLocaleString() : '';
         const days = calcDaysHeld(item.buy_date, item.sell_date);
 
+        // 소급 재구성이 불가한 오염 기록 — 수치는 그대로 두고 신뢰하지 말라는 표식만 붙인다.
+        const suspectHtml = item.data_quality_flag
+            ? ` <span title="기록 오염 의심: ${item.data_quality_flag}" style="cursor:help;">⚠</span>`
+            : '';
+
         const cacheAge = item.cache_ts ? Math.floor(Date.now() / 1000 - item.cache_ts) : 0;
         const isOldCache = item.is_cached && cacheAge > 60;
         const cacheStyle = isOldCache ? 'color: #ff4d4d; opacity: 1; font-weight: bold;' : 'opacity: 0.6;';
@@ -960,7 +965,7 @@ function renderVirtualSoldTable() {
                 </td>
                 <td>${buyPrice}</td>
                 <td>${sellPrice}<div style="font-size:0.8em; color:var(--text-secondary);">${curPrice}${cacheLabel}${forceBtn}</div></td>
-                <td class="${rorClass}"><strong>${ror.toFixed(2)}%</strong>${costHtml}${holdRorHtml}</td>
+                <td class="${rorClass}"><strong>${ror.toFixed(2)}%</strong>${suspectHtml}${costHtml}${holdRorHtml}</td>
                 <td>${days}일<div style="font-size:0.8em; color:var(--text-secondary);">${buyDate} ~ ${sellDate}</div></td>
             </tr>
         `);


### PR DESCRIPTION
## 배경

PR #700 이전 `log_sell` 이 qty 를 무시하고 lot 전체를 SOLD 로 뒤집던 결함 때문에,
절반만 체결된 주문이 전량 청산으로 기록됐다. 오염 5건(trade id 251·261·263·265·269,
전부 VBO)은 **나머지 절반이 미청산이라 당시 수익률을 소급 재구성할 수 없다.**
todo 0-2 에 "재작성하지 말 것"이 명시돼 있다.

## 변경

수치를 고치지 않고 **의심 표식만** 남긴다.

- `trades.data_quality_flag` 컬럼 추가 (idempotent 마이그레이션, 기존 패턴 재사용).
  `_SELECT_TRADES` 에 포함 → `/api/virtual/history` 응답까지 자동 노출.
- `scripts/flag_suspect_trades.py` (신규): dry-run 기본, `--apply` 필요.
  `repair_partial_sell_ledger.py` 선례를 따라 **기동 코드가 아니라 스크립트**로 분리.
  dry-run 은 스키마도 건드리지 않는다. 오염 5건 id 와 근거를 docstring 에 기록.
- `virtual.js`: 플래그된 매도 기록의 수익률 옆에 ⚠ 표식 + 사유 tooltip.

**집계 수치는 바꾸지 않는다.** win_rate/avg_return 에서 제외하면 과거 숫자가 조용히
달라지므로, "재작성 금지" 정신에 맞춰 표식만 붙이고 판단은 사람에게 남긴다.

## 프로덕션 DB 미변경

이 PR 은 코드만 바꾼다. 실제 5건 적용은 사용자가 백업 후 직접 실행한다:

```bash
python scripts/flag_suspect_trades.py --trade-id 251 --trade-id 261 --trade-id 263 --trade-id 265 --trade-id 269 --note "부분매도 전량기록 의심 (PR #700 이전)" --apply
```

※ 이 DB 는 WAL 모드 — 백업은 `sqlite3` backup API 로 (파일 복사 금지). 스크립트
docstring 에도 명시했다.

## 검증

- 단위 7,714 passed / 3 failed — 실패 3건은 `test_trade_trends_js.py` 로 **main 에도
  존재하는 기존 회귀**(직전 PR #830 에서 stash 후 재현 확인).
- 통합 279 passed.
- 신규 테스트 8건: 마이그레이션·API 노출(미설정 시 None)·dry-run 무변경(데이터/스키마)·
  지정 id 만 플래그·성과 컬럼 불변·없는 id 중단 시 부분 반영 없음·UI 표식 소스 계약.
- UI 표식은 소스 계약 테스트로 잠갔고 브라우저 실물 확인은 하지 않았다(한 줄 렌더 변경).

## 남는 것 (todo 0-2)

기존 고아 10종목 처리 방침은 여전히 미결정 — 7월 4건은 복구 가능하나 원 전략이 전부
당일청산 VBO 라 **복구 = 익일 강제청산 지시**이므로 청산 의사 결정이 선행이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
