### PR TITLE
Decode node output as UTF-8 in trade_trends JS tests

### DIFF
--- a/tests/unit_test/view/web/static/test_trade_trends_js.py
+++ b/tests/unit_test/view/web/static/test_trade_trends_js.py
@@ -31,6 +31,9 @@ process.stdout.write(JSON.stringify(result));
         check=True,
         capture_output=True,
         text=True,
+        # node 는 항상 UTF-8 로 쓴다. 지정하지 않으면 Windows 로케일(cp949)로 디코딩돼
+        # 한글이 담긴 결과에서 reader 스레드가 죽고 stdout 이 None 이 된다.
+        encoding="utf-8",
         cwd=ROOT,
     )
     return json.loads(result.stdout)


### PR DESCRIPTION
## 증상

`tests/unit_test/view/web/static/test_trade_trends_js.py` 의 quarter 모델 테스트 3건이
Windows 로컬에서 실패했다. Linux CI 는 통과하므로 지금까지 드러나지 않았다.

```
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
UnicodeDecodeError: 'cp949' codec can't decode byte 0xec in position 80
```

## 원인

헬퍼가 `subprocess.run([node, "-e", code], text=True, ...)` 로 node 를 돌리면서
`encoding` 을 주지 않았다. node 는 항상 UTF-8 로 쓰는데 `text=True` 는 시스템
로케일(여기선 cp949)로 디코딩하므로, 결과 JSON 에 한글이 섞이면 reader 스레드가
`UnicodeDecodeError` 로 죽고 `result.stdout` 이 `None` 이 된다.

파일의 6건 중 **결과 JSON 에 한글(`period_label`)을 되돌려주는 3건만** 실패한 이유가
이것이다. 나머지 3건은 숫자/영문만 반환한다.

## 수정

`encoding="utf-8"` 추가. 형제 node 하네스 3개는 이미 갖고 있고
(`test_js_files.py`, `test_common_js_session_expiry.py`,
`test_it_stock_js_dom_regression.py`), 이 파일만 빠져 있었다.

## 검증

- 수정 전: 단위 3 failed / 7,714 passed
- 수정 후: **단위 7,717 passed (실패 0)**, 통합 279 passed
- 신규 테스트 없음 — 실패하던 3건이 red 상태였고, 한글 출력을 되돌려주는 유일한
  테스트들이라 그대로 회귀 가드가 된다. (TDD 예외 사유)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
