### PR TITLE
Add USD trade ledger for the US market

### DIFF
--- a/repositories/overseas_trade_repository.py
+++ b/repositories/overseas_trade_repository.py
@@ -1,0 +1,221 @@
+# repositories/overseas_trade_repository.py
+"""미국장 전용 USD 거래 원장 (SQLite).
+
+`VirtualTradeRepository` 와 **의도적으로 분리**한다. 그쪽은 원화·국내 6자리 코드
+기준이고 국내 브로커 잔고 대사에 물려 있어서, USD 체결을 섞으면 전략별 성과 통계와
+대사 고아가 오염된다. 통화가 다른 원장은 아예 다른 파일로 둔다.
+
+**기록 시점**: 해외는 국내 `FillReconciliationService` 같은 체결 대사 경로가 아직
+없어서, *주문 접수 성공* 시점에 기록한다. 따라서 체결되지 않은 지정가 주문도
+HOLD 로 잡힐 수 있다 — `get_overseas_order_history`(체결/미체결 조회) 기반 대사는
+후속 작업이다.
+
+**부분 매도**: `log_sell(qty=...)` 은 체결분만 SOLD 로 분리하고 잔량을 HOLD 로
+남긴다. 국내 원장에서 이 처리를 빠뜨려(PR #700) 잔량이 원장에서 사라지고 다음
+대사에서 고아로 재등록되던 결함이 있었다 — 같은 실수를 반복하지 않는다.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from common.overseas_types import OverseasExchange
+
+# 미국주식 온라인 수수료(편도, %). 국내 증권거래세 0.2% 는 한국 전용이라 재사용 금지.
+# 환전 스프레드·SEC/TAF 등 매도 제비용은 미반영 — commission_only 가정.
+US_COMMISSION_PCT_PER_SIDE = 0.25
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS overseas_trades (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol      TEXT    NOT NULL,
+    exchange    TEXT    NOT NULL,
+    currency    TEXT    NOT NULL DEFAULT 'USD',
+    buy_date    TEXT    NOT NULL,
+    buy_price   REAL    NOT NULL,
+    qty         INTEGER NOT NULL,
+    sell_date   TEXT,
+    sell_price  REAL,
+    return_rate REAL    NOT NULL DEFAULT 0.0,
+    status      TEXT    NOT NULL,
+    reason      TEXT    NOT NULL DEFAULT '',
+    source      TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_overseas_trades_symbol_status
+    ON overseas_trades(symbol, status);
+"""
+
+_COLUMNS = (
+    "id", "symbol", "exchange", "currency", "buy_date", "buy_price", "qty",
+    "sell_date", "sell_price", "return_rate", "status", "reason", "source",
+)
+
+
+@dataclass(frozen=True)
+class OverseasSellResult:
+    """매도 기록 결과. 실제로 청산된 수량과 lot 별 수익률을 노출한다."""
+    sold_qty: int
+    return_rates: tuple[float, ...] = ()
+
+
+class OverseasTradeRepository:
+    DEFAULT_DB_PATH = "data/OverseasTradeRepository/overseas_trade.db"
+
+    def __init__(self, db_path: str | None = None, now_provider=None) -> None:
+        self.db_path = db_path or self.DEFAULT_DB_PATH
+        self._now = now_provider or datetime.now
+        dir_path = os.path.dirname(self.db_path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        self._db = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.executescript(_DDL)
+
+    # ---- 기록 ----
+
+    def log_buy(self, symbol: str, exchange, price, qty: int, source: str = "") -> None:
+        """매수 lot 을 추가한다. 같은 심볼을 다시 사도 평단 병합 없이 별도 lot 으로 둔다
+        (진입가별 청산 추적을 잃지 않기 위해)."""
+        with self._db:
+            self._db.execute(
+                "INSERT INTO overseas_trades "
+                "(symbol, exchange, currency, buy_date, buy_price, qty, status, source) "
+                "VALUES (?, ?, 'USD', ?, ?, ?, 'HOLD', ?)",
+                (
+                    str(symbol).upper(),
+                    self._exchange_value(exchange),
+                    self._now().strftime("%Y-%m-%d %H:%M:%S"),
+                    float(price),
+                    int(qty),
+                    source,
+                ),
+            )
+
+    def log_sell(self, symbol: str, price, qty: int | None = None, reason: str = "") -> OverseasSellResult:
+        """보유 lot 을 오래된 것부터 청산한다.
+
+        `qty` 미지정이면 전량. 지정 수량이 lot 수량보다 작으면 **체결분만 SOLD 로
+        분리하고 잔량은 HOLD 로 남긴다** — 잔량이 사라지면 관리 주체가 없어진다.
+        """
+        symbol = str(symbol).upper()
+        sell_price = float(price)
+        sold_date = self._now().strftime("%Y-%m-%d %H:%M:%S")
+
+        holds = self._db.execute(
+            "SELECT * FROM overseas_trades WHERE symbol=? AND status='HOLD' ORDER BY id",
+            (symbol,),
+        ).fetchall()
+        if not holds:
+            return OverseasSellResult(sold_qty=0)
+
+        remaining = sum(int(row["qty"]) for row in holds) if qty is None else int(qty)
+        if remaining <= 0:
+            return OverseasSellResult(sold_qty=0)
+
+        sold_qty = 0
+        rates: list[float] = []
+        with self._db:
+            for row in holds:
+                if remaining <= 0:
+                    break
+                held = int(row["qty"])
+                take = min(held, remaining)
+                rate = self.calculate_return(row["buy_price"], sell_price, apply_cost=True)
+
+                if take == held:
+                    self._db.execute(
+                        "UPDATE overseas_trades SET status='SOLD', sell_date=?, sell_price=?, "
+                        "return_rate=?, reason=? WHERE id=?",
+                        (sold_date, sell_price, rate, reason, row["id"]),
+                    )
+                else:
+                    # 부분 청산: 잔량 lot 을 줄이고 체결분을 별도 SOLD 행으로 분리한다.
+                    self._db.execute(
+                        "UPDATE overseas_trades SET qty=? WHERE id=?",
+                        (held - take, row["id"]),
+                    )
+                    self._db.execute(
+                        "INSERT INTO overseas_trades "
+                        "(symbol, exchange, currency, buy_date, buy_price, qty, sell_date, "
+                        "sell_price, return_rate, status, reason, source) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'SOLD', ?, ?)",
+                        (
+                            row["symbol"], row["exchange"], row["currency"], row["buy_date"],
+                            row["buy_price"], take, sold_date, sell_price, rate, reason,
+                            row["source"],
+                        ),
+                    )
+                sold_qty += take
+                remaining -= take
+                rates.append(rate)
+
+        return OverseasSellResult(sold_qty=sold_qty, return_rates=tuple(rates))
+
+    async def log_buy_async(self, symbol: str, exchange, price, qty: int, source: str = "") -> None:
+        await asyncio.to_thread(self.log_buy, symbol, exchange, price, qty, source)
+
+    async def log_sell_async(self, symbol: str, price, qty: int | None = None,
+                             reason: str = "") -> OverseasSellResult:
+        return await asyncio.to_thread(self.log_sell, symbol, price, qty, reason)
+
+    # ---- 조회 ----
+
+    def get_all_trades(self) -> list[dict]:
+        rows = self._db.execute("SELECT * FROM overseas_trades ORDER BY id").fetchall()
+        return [self._to_dict(row) for row in rows]
+
+    def get_holds(self) -> list[dict]:
+        rows = self._db.execute(
+            "SELECT * FROM overseas_trades WHERE status='HOLD' ORDER BY id"
+        ).fetchall()
+        return [self._to_dict(row) for row in rows]
+
+    def get_summary(self) -> dict:
+        """성과 요약. 승률/평균수익률은 청산된 거래만으로 계산한다."""
+        rows = self._db.execute(
+            "SELECT return_rate FROM overseas_trades WHERE status='SOLD'"
+        ).fetchall()
+        total = self._db.execute("SELECT COUNT(*) FROM overseas_trades").fetchone()[0]
+        if not rows:
+            return {"total_trades": total, "sold_trades": 0, "win_rate": 0.0, "avg_return": 0.0}
+
+        returns = [float(row["return_rate"]) for row in rows]
+        wins = sum(1 for r in returns if r > 0)
+        return {
+            "total_trades": total,
+            "sold_trades": len(returns),
+            "win_rate": round(wins / len(returns) * 100, 2),
+            "avg_return": round(sum(returns) / len(returns), 2),
+        }
+
+    # ---- 계산 ----
+
+    @staticmethod
+    def calculate_return(buy_price, sell_price, apply_cost: bool = True) -> float:
+        """수익률(%). apply_cost 면 왕복 수수료(편도 0.25%)를 차감한다."""
+        buy = float(buy_price or 0)
+        sell = float(sell_price or 0)
+        if buy <= 0:
+            return 0.0
+        profit = sell - buy
+        if apply_cost:
+            rate = US_COMMISSION_PCT_PER_SIDE / 100
+            profit -= (buy * rate) + (sell * rate)
+        return round(profit / buy * 100, 2)
+
+    # ---- 내부 ----
+
+    @staticmethod
+    def _exchange_value(exchange) -> str:
+        if isinstance(exchange, OverseasExchange):
+            return exchange.value
+        return str(exchange).upper()
+
+    @staticmethod
+    def _to_dict(row: sqlite3.Row) -> dict:
+        return {key: row[key] for key in _COLUMNS}

--- a/tests/unit_test/repositories/test_overseas_trade_repository.py
+++ b/tests/unit_test/repositories/test_overseas_trade_repository.py
@@ -1,0 +1,129 @@
+"""미국장 전용 USD 원장 테스트.
+
+핵심 계약 2가지:
+1. **부분 매도 분할** — PR #700 의 진범이 `log_sell` 이 qty 를 무시하고 lot 전체를
+   SOLD 로 뒤집은 것이었다. 잔량이 원장에서 사라지면 다음 대사에서 고아가 된다.
+2. **국내 비용 모델 미사용** — 증권거래세 0.2% 는 한국 전용이다. 미국은 온라인
+   수수료 0.25%/side(왕복 0.5%) 기준으로 계산해야 한다.
+"""
+import pytest
+
+from common.overseas_types import OverseasExchange
+from repositories.overseas_trade_repository import OverseasTradeRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return OverseasTradeRepository(db_path=str(tmp_path / "overseas_trade.db"))
+
+
+def test_log_buy_creates_hold_lot(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, source="manual")
+
+    holds = repo.get_holds()
+    assert len(holds) == 1
+    assert holds[0]["symbol"] == "AAPL"
+    assert holds[0]["exchange"] == "NASD"
+    assert holds[0]["currency"] == "USD"
+    assert holds[0]["qty"] == 3
+    assert holds[0]["status"] == "HOLD"
+
+
+def test_repeated_buy_keeps_separate_lots(repo):
+    """같은 심볼 재매수는 평단 병합이 아니라 별도 lot — 진입가별 청산 추적을 유지한다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3)
+    repo.log_buy("AAPL", OverseasExchange.NASD, 200.0, 2)
+
+    holds = repo.get_holds()
+    assert [h["qty"] for h in holds] == [3, 2]
+    assert [h["buy_price"] for h in holds] == [190.0, 200.0]
+
+
+def test_partial_sell_keeps_remainder_as_hold(repo):
+    """체결분만 SOLD 로 분리하고 잔량은 HOLD 로 남는다 (#700 회귀 잠금)."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 10)
+
+    repo.log_sell("AAPL", 200.0, qty=4)
+
+    holds = repo.get_holds()
+    assert len(holds) == 1
+    assert holds[0]["qty"] == 6
+
+    solds = [t for t in repo.get_all_trades() if t["status"] == "SOLD"]
+    assert len(solds) == 1
+    assert solds[0]["qty"] == 4
+    assert solds[0]["sell_price"] == 200.0
+    assert solds[0]["buy_price"] == 190.0
+
+
+def test_full_sell_closes_lot(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 5)
+
+    repo.log_sell("AAPL", 200.0)
+
+    assert repo.get_holds() == []
+    solds = [t for t in repo.get_all_trades() if t["status"] == "SOLD"]
+    assert len(solds) == 1
+    assert solds[0]["qty"] == 5
+
+
+def test_sell_spans_oldest_lots_first(repo):
+    """여러 lot 보유 시 오래된 lot 부터 청산한다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3)
+    repo.log_buy("AAPL", OverseasExchange.NASD, 200.0, 4)
+
+    repo.log_sell("AAPL", 210.0, qty=5)
+
+    holds = repo.get_holds()
+    assert [(h["buy_price"], h["qty"]) for h in holds] == [(200.0, 2)]
+    solds = sorted(
+        (t for t in repo.get_all_trades() if t["status"] == "SOLD"),
+        key=lambda t: t["buy_price"],
+    )
+    assert [(s["buy_price"], s["qty"]) for s in solds] == [(190.0, 3), (200.0, 2)]
+
+
+def test_sell_more_than_held_closes_only_held(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 2)
+
+    result = repo.log_sell("AAPL", 200.0, qty=10)
+
+    assert result.sold_qty == 2
+    assert repo.get_holds() == []
+
+
+def test_sell_without_position_is_noop(repo):
+    result = repo.log_sell("AAPL", 200.0, qty=1)
+
+    assert result.sold_qty == 0
+    assert repo.get_all_trades() == []
+
+
+def test_summary_counts_only_sold(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 100.0, 1)
+    repo.log_buy("MSFT", OverseasExchange.NASD, 100.0, 1)
+    repo.log_sell("AAPL", 110.0)
+
+    summary = repo.get_summary()
+
+    assert summary["total_trades"] == 2   # HOLD + SOLD
+    assert summary["sold_trades"] == 1
+    assert summary["win_rate"] == 100.0
+
+
+def test_return_uses_us_cost_model_not_domestic_tax(repo):
+    """국내 증권거래세(0.2%)가 아니라 미국 왕복 수수료 0.5% 를 반영한다."""
+    gross = repo.calculate_return(100.0, 110.0, apply_cost=False)
+    net = repo.calculate_return(100.0, 110.0, apply_cost=True)
+
+    assert gross == 10.0
+    # 매수 100*0.25% + 매도 110*0.25% = 0.525 → (110-100-0.525)/100 = 9.475%
+    assert net == pytest.approx(9.48, abs=0.01)
+
+
+def test_sold_row_stores_net_return(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 100.0, 1)
+    repo.log_sell("AAPL", 110.0)
+
+    sold = [t for t in repo.get_all_trades() if t["status"] == "SOLD"][0]
+    assert sold["return_rate"] == pytest.approx(9.48, abs=0.01)

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -895,6 +895,35 @@ def test_manual_overseas_order_service_wired_with_kill_switch(patched_service_co
     assert kwargs["journal_strategy_name"] == "수동매매_해외"
 
 
+def test_overseas_trade_repository_wired_when_overseas_enabled(patched_service_container_deps):
+    """미국 거래는 원화 원장(VirtualTrade)이 아니라 USD 전용 원장에 기록한다."""
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasOrderExecutionService", autospec=True), \
+         patch("view.web.bootstrap.service_container.OverseasTradeRepository", autospec=True) as repo_cls:
+        ServiceContainer(ctx).run()
+
+    assert ctx.overseas_trade_repository is repo_cls.return_value
+
+
+def test_overseas_trade_repository_absent_without_overseas_enabled(patched_service_container_deps):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.overseas_stock_code_repository = MagicMock()
+    ServiceContainer(ctx).run()
+
+    assert ctx.overseas_trade_repository is None
+
+
 def test_manual_overseas_order_service_absent_without_overseas_enabled(patched_service_container_deps):
     """overseas_us 가 enabled 가 아니면 수동 주문 게이팅 서비스도 없다."""
     from view.web.bootstrap.service_container import ServiceContainer

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -416,6 +416,109 @@ async def test_place_overseas_order_rejects_disabled_exchange(web_client, mock_w
     svc.place_entry.assert_not_awaited()
 
 
+def _install_overseas_ledger(ctx):
+    """미국장 전용 USD 원장 mock 을 심고 반환한다."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    ledger = MagicMock()
+    ledger.log_buy_async = AsyncMock()
+    ledger.log_sell_async = AsyncMock()
+    ctx.overseas_trade_repository = ledger
+    return ledger
+
+
+@pytest.mark.asyncio
+async def test_successful_overseas_buy_is_recorded_in_ledger(web_client, mock_web_ctx):
+    """미국 주문 체결 기록이 없으면 성과요약이 공백으로 남는다 — 성공 시 원장에 남긴다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(mock_web_ctx)
+    ledger = _install_overseas_ledger(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "buy",
+        "qty": 3, "limit_price": 190.25, "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    ledger.log_buy_async.assert_awaited_once_with(
+        "AAPL", OverseasExchange.NASD, 190.25, 3, source="manual",
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_overseas_sell_is_recorded_in_ledger(web_client, mock_web_ctx):
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(mock_web_ctx)
+    ledger = _install_overseas_ledger(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "sell",
+        "qty": 2, "limit_price": 195.5, "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    ledger.log_sell_async.assert_awaited_once_with(
+        "AAPL", 195.5, qty=2, reason="manual",
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_overseas_order_is_not_recorded(web_client, mock_web_ctx):
+    """주문이 거부되면 포지션이 없다 — 기록하면 유령 보유가 생긴다."""
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(
+        mock_web_ctx,
+        resp=ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="주문 거부", data=None),
+    )
+    ledger = _install_overseas_ledger(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "buy",
+        "qty": 3, "limit_price": 190.25, "currency": "USD",
+    }
+    web_client.post("/api/overseas/order", json=payload)
+
+    ledger.log_buy_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_blocked_order_is_not_recorded(web_client, mock_web_ctx):
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(
+        mock_web_ctx,
+        resp=ResCommonResponse(rt_cd=ErrorCode.KILL_SWITCH_BLOCKED.value, msg1="차단", data=None),
+    )
+    ledger = _install_overseas_ledger(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "buy",
+        "qty": 3, "limit_price": 190.25, "currency": "USD",
+    }
+    web_client.post("/api/overseas/order", json=payload)
+
+    ledger.log_buy_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ledger_failure_does_not_mask_order_result(web_client, mock_web_ctx):
+    """원장 기록 실패가 주문 성공 응답을 가리면 안 된다(주문은 이미 나갔다)."""
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(mock_web_ctx)
+    ledger = _install_overseas_ledger(mock_web_ctx)
+    ledger.log_buy_async.side_effect = RuntimeError("disk full")
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "buy",
+        "qty": 3, "limit_price": 190.25, "currency": "USD",
+    }
+    response = web_client.post("/api/overseas/order", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["data"]["ord_no"] == "A12345"
+
+
 @pytest.mark.asyncio
 async def test_place_overseas_order_sell_uses_place_exit(web_client, mock_web_ctx):
     """매도는 청산 경로(place_exit)로 위임된다."""

--- a/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
@@ -214,3 +214,45 @@ async def test_ranking_timeout_returns_error_payload(web_client, mock_web_ctx):
 
         assert response.status_code == 200
         assert response.json()["rt_cd"] == "1"
+
+
+async def test_trades_returns_summary_and_rows(web_client, mock_web_ctx):
+    """GET /api/overseas/trades — USD 원장 성과 요약 + 거래 목록"""
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        ledger = MagicMock()
+        ledger.get_summary.return_value = {
+            "total_trades": 2, "sold_trades": 1, "win_rate": 100.0, "avg_return": 9.48,
+        }
+        ledger.get_all_trades.return_value = [
+            {"symbol": "AAPL", "status": "SOLD", "return_rate": 9.48},
+        ]
+        mock_web_ctx.overseas_trade_repository = ledger
+
+        response = web_client.get("/api/overseas/trades")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["rt_cd"] == "0"
+        assert body["data"]["summary"]["win_rate"] == 100.0
+        assert body["data"]["trades"][0]["symbol"] == "AAPL"
+
+
+async def test_trades_requires_overseas_enabled(web_client, mock_web_ctx):
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.enabled_market_modes = ["domestic"]
+        mock_web_ctx.overseas_trade_repository = MagicMock()
+
+        response = web_client.get("/api/overseas/trades")
+
+        assert response.status_code == 400
+
+
+async def test_trades_without_ledger_returns_503(web_client, mock_web_ctx):
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        mock_web_ctx.overseas_trade_repository = None
+
+        response = web_client.get("/api/overseas/trades")
+
+        assert response.status_code == 503

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -89,6 +89,7 @@ from view.web.bootstrap.query_bootstrap import QueryBootstrap
 from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
 from view.web.market_mode_utils import is_market_enabled
 from repositories.dart_disclosure_repository import DartDisclosureRepository
+from repositories.overseas_trade_repository import OverseasTradeRepository
 from repositories.youtube_channel_repository import YoutubeChannelRepository
 from repositories.youtube_digest_repository import YoutubeDigestRepository
 from services.youtube_transcript_collector_service import YoutubeTranscriptCollectorService
@@ -868,6 +869,7 @@ class ServiceContainer:
                 ctx.overseas_vbo_dryrun_service = None
                 ctx.overseas_dryrun_task = None
                 ctx.overseas_manual_order_service = None
+                ctx.overseas_trade_repository = None
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
@@ -986,6 +988,8 @@ class ServiceContainer:
         `live_enabled=False` 잠금이 그대로 유지된다.
         """
         ctx = self._ctx
+        # 미국 거래는 원화 원장(VirtualTradeRepository)이 아니라 USD 전용 원장에 남긴다.
+        ctx.overseas_trade_repository = OverseasTradeRepository()
         ctx.overseas_manual_order_service = OverseasOrderExecutionService(
             broker=ctx.broker,
             live_enabled=True,

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -131,7 +131,32 @@ async def place_overseas_order(req: OverseasOrderRequest, request: Request):
             reason="manual",
             signal={"source": "manual"},
         )
+    await _record_overseas_trade(ctx, req, resp)
     return _serialize_response(resp)
+
+
+async def _record_overseas_trade(ctx, req: OverseasOrderRequest, resp) -> None:
+    """주문이 접수된 경우에만 USD 원장에 남긴다.
+
+    거부/차단 응답을 기록하면 유령 보유가 생긴다. 해외는 체결 대사 경로가 아직 없어
+    *접수 시점* 기록이며, 미체결 지정가도 보유로 잡힐 수 있다(대사는 후속 작업).
+    """
+    if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+        return
+    ledger = getattr(ctx, "overseas_trade_repository", None)
+    if ledger is None:
+        return
+    try:
+        if req.side == "buy":
+            await ledger.log_buy_async(
+                req.symbol, req.exchange, req.limit_price, req.qty, source="manual",
+            )
+        else:
+            await ledger.log_sell_async(
+                req.symbol, req.limit_price, qty=req.qty, reason="manual",
+            )
+    except Exception as e:  # 원장 실패가 이미 나간 주문의 결과를 가리면 안 된다
+        ctx.logger.warning(f"[overseas_order] USD 원장 기록 실패: {e}")
 
 
 @router.post("/overseas/order/cancel")

--- a/view/web/routes/overseas_market.py
+++ b/view/web/routes/overseas_market.py
@@ -39,6 +39,29 @@ async def get_overseas_top_market_cap(limit: int = Query(30, ge=1, le=500)):
     return {"rt_cd": "0", "msg1": "미국 시가총액 조회 성공", "data": data}
 
 
+@router.get("/overseas/trades")
+async def get_overseas_trades():
+    """미국장 USD 원장의 성과 요약 + 거래 목록.
+
+    국내 `/api/virtual/*` 와 원장이 분리돼 있다 — 통화가 달라 같은 표에 섞을 수 없다.
+    """
+    ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(
+            status_code=400,
+            detail="미국주식 거래 기록은 overseas_us가 enabled된 run에서만 사용할 수 있습니다.",
+        )
+    ledger = getattr(ctx, "overseas_trade_repository", None)
+    if ledger is None:
+        raise HTTPException(status_code=503, detail="미국주식 거래 원장이 준비되지 않았습니다.")
+
+    return {
+        "rt_cd": "0",
+        "msg1": "미국주식 거래 기록 조회 성공",
+        "data": {"summary": ledger.get_summary(), "trades": ledger.get_all_trades()},
+    }
+
+
 @router.get("/overseas/ranking/{category}")
 async def get_overseas_ranking(category: str, limit: int = Query(30, ge=1, le=500)):
     """S&P 500 유니버스 기준 미국 랭킹 (rise/fall/volume/trading_value)."""


### PR DESCRIPTION
## 배경

#830 으로 미국 수동주문이 kill-switch 와 저널을 타게 됐지만 **성과요약은 여전히 공백**이었다.
`VirtualTradeRepository` 는 원화·국내 6자리 코드 기준이고 국내 브로커 잔고 대사에 물려
있어 USD 체결을 넣으면 전략별 통계와 대사 고아가 오염된다.

사용자 결정: **별도 원장**.

## 변경

- `repositories/overseas_trade_repository.py` (신규) — `data/OverseasTradeRepository/overseas_trade.db` (WAL)
- `service_container` 배선 (`overseas_us` enabled 시에만, 아니면 None)
- 수동 주문 성공 시 기록 — buy → `log_buy_async`, sell → `log_sell_async`
- `GET /api/overseas/trades` — `{summary, trades}`

## 처음부터 제대로 잡은 것 2가지

**1. 부분 매도 분할.** `log_sell(qty=...)` 은 체결분만 SOLD 로 분리하고 잔량을 HOLD 로
남긴다. 국내 원장에서 이걸 빠뜨린 게 PR #700 의 진범이었다 — 잔량이 원장에서 사라져
`broker_reconciled` 고아로 재등록되고 관리 주체가 없어졌다. 여러 lot 보유 시 오래된
lot 부터 청산한다.

**2. 비용 모델 분리.** `TransactionCostUtils` 의 0.2% 는 한국 증권거래세다. 미국은
온라인 수수료 0.25%/side 기준으로 계산한다(환전 스프레드·SEC/TAF 는 미반영 —
`commission_only` 가정, `analyze_overseas_dryrun.py` 와 같은 기준).

## 알려진 한계 (후속)

**기록 시점이 체결이 아니라 주문 접수다.** 해외는 국내 `FillReconciliationService`
같은 체결 대사 경로가 없어서, 체결되지 않은 지정가 주문도 HOLD 로 잡힐 수 있다.
`get_overseas_order_history`(체결/미체결 조회)는 이미 배선돼 있으므로 이를 이용한
대사가 다음 단계다. docstring 과 라우트 주석에 명시했다.

UI 성과 요약도 후속 — 이 PR 은 원장·기록·조회 API 까지다.

## 검증

- 단위 7,737 passed / 통합 279 passed (실패 0)
- 1차 실행에서 `test_worker_pool` 1건, `test_it_api_larry_williams_vbo_strategy` 1건이
  실패했으나 **둘 다 isolation 통과 + 전체 재실행 통과** — 병렬 부하 flaky 이고
  변경 범위(worker_pool/VBO 미변경)와 무관하다.
- 신규 테스트 19건: 부분매도 잔량 유지·오래된 lot 우선 청산·초과 매도·미보유 매도 no-op·
  요약 집계·미국 비용 모델(국내 세율 재사용 금지 회귀 잠금)·주문 성공/실패/차단별 기록 여부·
  원장 예외가 주문 응답을 가리지 않음·컨테이너 배선·조회 API 3종.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
