### PR TITLE
Auto-refresh the US heatmap tab every 60 seconds

### DIFF
--- a/services/overseas_market_stats_service.py
+++ b/services/overseas_market_stats_service.py
@@ -31,7 +31,10 @@ class OverseasMarketStatsService:
         universe_factory,
         provider,
         logger=None,
-        ttl_sec: float = 300.0,
+        # 히트맵이 60초마다 되묻는다 — TTL 이 그 주기 이상이면 폴링이 캐시만 되받아
+        # 화면이 실제로는 최대 2주기만큼 늦어진다. 갱신은 요청이 올 때만 일어나므로
+        # 짧게 잡아도 외부 호출은 '화면을 열어둔 시간'에만 발생한다.
+        ttl_sec: float = 45.0,
         clock=time.monotonic,
         wall_clock=time.time,
     ):

--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -837,6 +837,105 @@ test("pjax 재진입 시 기간·시장은 기본값으로 돌아온다", async 
     "검색어도 비워져야 함");
 });
 
+// 자동 갱신은 분 단위라 실시간으로 기다릴 수 없다. 창의 setInterval 을 가로채 콜백을
+// 직접 굴려 계약(주기·대상·건너뛸 조건·정리)만 확인한다.
+function captureHeatmapTimer(window) {
+  const timer = { fn: null, ms: null, starts: 0, cleared: [] };
+  window.setInterval = (fn, ms) => {
+    timer.fn = fn;
+    timer.ms = ms;
+    timer.starts += 1;
+    return timer.starts;
+  };
+  window.clearInterval = (id) => { timer.cleared.push(id); };
+  return timer;
+}
+
+// jsdom 의 visibilityState 기본값은 'prerender'(= hidden true) 라 손대지 않으면
+// 자동 갱신이 늘 건너뛰어진다. 보이는 창인지를 테스트가 명시한다.
+function setPageVisible(window, visible) {
+  Object.defineProperty(window.document, "hidden", { value: !visible, configurable: true });
+}
+
+function autoRefreshPage() {
+  const calls = [];
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
+    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})], updated_at: 1767225600 }),
+  }));
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, ...rest) => { calls.push(url); return traced(url, ...rest); };
+  setPageVisible(window, true);
+  return { window, calls, timer: captureHeatmapTimer(window) };
+}
+
+function overseasCalls(calls) {
+  return calls.filter(url => url.startsWith("/api/overseas/top-market-cap"));
+}
+
+test("미국 탭을 보고 있으면 1분마다 조용히 다시 조회한다", async () => {
+  const { window, calls, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  const before = overseasCalls(calls).length;
+
+  assert(timer.ms === 60000, `자동 갱신 주기는 60초여야 함 (실제 ${timer.ms})`);
+  await timer.fn();
+
+  assert(overseasCalls(calls).length === before + 1,
+    `주기마다 미국 스냅샷을 다시 받아야 함 (실제 ${overseasCalls(calls).length - before}회)`);
+  const panel = window.document.getElementById("heatmap-page-overseas");
+  assert(!panel.innerHTML.includes("조회 중"), "자동 갱신이 로딩 문구로 화면을 깜빡이면 안 됨");
+  assert(panel.querySelectorAll(".heatmap-tile").length > 0, "갱신 후에도 타일이 남아야 함");
+});
+
+test("한국 탭은 자동 재조회하지 않는다 (하루 한 번 수집되는 스냅샷)", async () => {
+  const { window, calls, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  calls.length = 0;
+  await timer.fn();
+
+  assert(calls.length === 0, `되물어도 같은 종가라 조회할 이유가 없음 (실제 ${calls})`);
+});
+
+test("창이 백그라운드면 자동 갱신을 건너뛴다", async () => {
+  const { window, calls, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  setPageVisible(window, false);
+  calls.length = 0;
+  await timer.fn();
+
+  assert(calls.length === 0, "안 보는 창 때문에 외부 API 를 계속 두드리면 안 됨");
+});
+
+test("다른 화면으로 떠나면 자동 갱신 타이머를 스스로 멈춘다", async () => {
+  const { window, calls, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  calls.length = 0;
+  window.document.getElementById("heatmap-page-viewport").remove();
+  await timer.fn();
+
+  assert(calls.length === 0, "떠난 화면을 위해 조회하면 안 됨");
+  assert(timer.cleared.length === 1, `타이머를 해제해야 함 (실제 ${timer.cleared.length}회)`);
+});
+
+test("pjax 재진입은 자동 갱신 타이머를 겹쳐 걸지 않는다", async () => {
+  const { window, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  await window.initHeatmapPage();
+
+  assert(timer.starts === 2, `재진입마다 타이머를 다시 걸어야 함 (실제 ${timer.starts}회)`);
+  assert(timer.cleared.length === 1, `이전 타이머를 해제해야 함 (실제 ${timer.cleared.length}회)`);
+});
+
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {
   const calls = [];
   makeWindow(routed({

--- a/tests/unit_test/services/test_overseas_market_stats_service.py
+++ b/tests/unit_test/services/test_overseas_market_stats_service.py
@@ -183,6 +183,20 @@ async def test_snapshots_refetch_after_ttl(universe, provider):
     assert provider.fetch_snapshots.await_count == 2
 
 
+async def test_default_ttl_is_shorter_than_the_screen_poll_interval(universe, provider):
+    """히트맵은 60초마다 되묻는다 — 기본 TTL 이 그보다 길면 폴링이 캐시만 되받는다."""
+    now = [0.0]
+    service = OverseasMarketStatsService(
+        universe_factory=lambda: universe, provider=provider, clock=lambda: now[0]
+    )
+
+    await service.get_top_market_cap()
+    now[0] = 60.0
+    await service.get_top_market_cap()
+
+    assert provider.fetch_snapshots.await_count == 2
+
+
 async def test_empty_universe_returns_empty_without_calling_provider(provider):
     empty = MagicMock()
     empty.all_symbols.return_value = []

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -28,11 +28,17 @@ const HEATMAP_PAGE_DEFAULT_PERIOD = '1d';
 // 저장소가 해석하는 시장 값 — 'ALL'(공통) 은 필터 없음이다.
 const HEATMAP_PAGE_MARKETS = ['ALL', 'KOSPI', 'KOSDAQ'];
 const HEATMAP_PAGE_DEFAULT_MARKET = 'ALL';
+// 자동 갱신 주기. 미국 스냅샷만 대상이다 — 국내는 장마감 후 하루 한 번 수집되는
+// daily_prices 종가라 되물어도 같은 값이 온다. 서버 TTL(45초)보다 길게 잡아 매 주기가
+// 실제로 새 스냅샷을 받게 한다.
+const HEATMAP_PAGE_OVERSEAS_REFRESH_MS = 60 * 1000;
 
 let _heatmapPageZoomIndex = 0;
 let _heatmapPageWheelAccum = 0;
 let _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
 let _heatmapPageMarket = HEATMAP_PAGE_DEFAULT_MARKET;
+let _heatmapPageTab = 'domestic';
+let _heatmapPageRefreshTimer = null;
 
 function _heatmapPageZoom() {
     return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
@@ -70,6 +76,7 @@ function _heatmapPageShow(el, visible) {
 async function setHeatmapTab(market) {
     const source = HEATMAP_PAGE_SOURCES[market];
     if (!source) return;
+    _heatmapPageTab = market;
 
     Object.keys(HEATMAP_PAGE_SOURCES).forEach(key => {
         const active = key === market;
@@ -380,6 +387,31 @@ function resetHeatmapPageZoom() {
     }
 }
 
+// 자동 갱신 — 보고 있는 미국 탭만 조용히(로딩 문구 없이) 갈아끼운다. 매 주기마다
+// '조회 중...' 을 띄우면 화면이 1분마다 깜빡이고 배율·검색 상태가 눈에 띄게 흔들린다.
+async function _refreshHeatmapPageTick() {
+    // pjax 로 다른 화면에 가 있으면 스스로 멈춘다 (타이머는 문서를 떠나도 계속 돈다).
+    if (!document.getElementById('heatmap-page-viewport')) {
+        _stopHeatmapPageAutoRefresh();
+        return;
+    }
+    if (document.hidden || _heatmapPageTab !== 'overseas') return;
+
+    await _loadHeatmap(HEATMAP_PAGE_SOURCES.overseas, { showLoading: false });
+    _applyHeatmapPageSearch();
+}
+
+function _stopHeatmapPageAutoRefresh() {
+    if (_heatmapPageRefreshTimer === null) return;
+    clearInterval(_heatmapPageRefreshTimer);
+    _heatmapPageRefreshTimer = null;
+}
+
+function _startHeatmapPageAutoRefresh() {
+    _stopHeatmapPageAutoRefresh();  // pjax 재진입 시 타이머가 겹쳐 걸리지 않게 한다.
+    _heatmapPageRefreshTimer = setInterval(_refreshHeatmapPageTick, HEATMAP_PAGE_OVERSEAS_REFRESH_MS);
+}
+
 async function initHeatmapPage() {
     const viewport = document.getElementById('heatmap-page-viewport');
     if (!viewport) return;
@@ -411,6 +443,7 @@ async function initHeatmapPage() {
     }
 
     await setHeatmapTab('domestic');
+    _startHeatmapPageAutoRefresh();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## 무엇을 바꿨나

히트맵 전용 페이지(`/heatmap`)는 탭을 열 때 한 번만 조회하고, 그 뒤로는 브라우저를 새로고침할 때까지 화면이 고정돼 있었다. 미국 스냅샷은 서버가 TTL 캐시로 계속 새 값을 받아올 준비가 돼 있었는데 화면이 되묻지 않아 그 신선도가 쓰이지 않았다.

- **미국 탭만 60초마다 조용히 재조회**한다(`showLoading: false` — 매 주기 '조회 중...' 을 띄우면 1분마다 화면이 깜빡인다). 국내 탭은 폴링하지 않는다: `daily_prices` 는 장마감 10분 뒤 하루 한 번 수집되는 종가라 되물어도 같은 값이 온다.
- **창이 백그라운드면 건너뛰고, pjax 로 화면을 떠나면 타이머가 스스로 멈춘다.** Yahoo quote 는 유니버스 500종목을 50개씩 끊어 **호출당 11요청**이라(`fetch_snapshots`), 안 보는 창이 계속 두드리지 않게 하는 것이 비용 통제의 핵심이다. TTL 갱신은 요청이 올 때만 일어나므로 외부 호출은 '화면을 열어둔 시간'에만 발생한다.
- **서버 TTL 기본값 300초 → 45초.** 폴링 주기 이상이면 매 폴링이 캐시만 되받아 화면이 최대 2주기만큼 늦어진다. 45초로 잡아 매 폴링이 실제로 새 스냅샷을 받게 했다.

60초는 이 저장소에서 미국 데이터의 실질 해상도와 같다 — 미국장 즐겨찾기 등락률 알림도 `poll_interval_sec: 60` 으로 돌고 있다.

## 테스트

TDD 로 진행했다(먼저 6건이 의도한 이유로 실패하는 것을 확인한 뒤 구현).

jsdom 행위 테스트 5건 신규 (`run_*_dom_tests.mjs` glob 으로 통합테스트 게이트에 자동 편입):
- 미국 탭을 보고 있으면 1분마다 조용히 다시 조회한다 (주기 60초 + 로딩 문구 없음 + 타일 유지)
- 한국 탭은 자동 재조회하지 않는다
- 창이 백그라운드면 자동 갱신을 건너뛴다
- 다른 화면으로 떠나면 타이머를 스스로 멈춘다
- pjax 재진입은 타이머를 겹쳐 걸지 않는다

TTL 단위 테스트 1건 신규 — 매직넘버가 아니라 "60초 폴링이 캐시가 아닌 새 스냅샷을 받는다"는 행위로 잠갔다.

jsdom 하네스 관련 함정 하나: jsdom 의 `document.visibilityState` 기본값이 `prerender`(= `hidden === true`) 라 가시성을 명시하지 않으면 자동 갱신 테스트가 늘 통과하는 것처럼 보인다. `setPageVisible()` 헬퍼로 테스트가 명시하게 했다.

```
pytest tests/unit_test        → 7738 passed
pytest tests/integration_test → 279 passed
node run_heatmap_page_dom_tests.mjs → 41/41 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
