### PR TITLE
Relax market timing recovery gate

### DIFF
--- a/common/oneil_common_types.py
+++ b/common/oneil_common_types.py
@@ -26,6 +26,7 @@ class OneilUniverseConfig(BaseStrategyConfig):
     market_ma_min_net_change_pct: float = -0.10
     market_ma_daily_dip_tolerance_pct: float = -0.20
     market_ma_hard_decline_pct: float = -0.50
+    market_ma_recovery_close_buffer_pct: float = 3.00
 
     # V2 스코어링
     rs_period_days: int = 63

--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -35,6 +35,7 @@ class MarketRegimeConfig:
     min_net_change_pct: float = -0.10
     daily_dip_tolerance_pct: float = -0.20
     hard_decline_pct: float = -0.50
+    recovery_close_buffer_pct: float = 3.00
 
 
 @dataclass
@@ -78,13 +79,15 @@ class MarketRegimeService:
             return self._cfg.kosdaq_index_code
         raise ValueError(f"Unknown market: {market}")
 
-    @staticmethod
-    def _is_recovery_ready(closes: List[float], ma_values: List[float]) -> bool:
+    def _is_recovery_ready(self, closes: List[float], ma_values: List[float]) -> bool:
         """급락 해소 뒤의 회복 진입 조건을 판정한다."""
         ma_is_not_falling = ma_values[-1] >= ma_values[-2]
         close_is_above_ma = closes[-1] >= ma_values[-1]
+        close_is_strongly_above_ma = closes[-1] >= ma_values[-1] * (
+            1 + self._cfg.recovery_close_buffer_pct / 100
+        )
         recent_price_rise = closes[-1] > closes[-2] or closes[-2] > closes[-3]
-        return ma_is_not_falling and close_is_above_ma and recent_price_rise
+        return (ma_is_not_falling or close_is_strongly_above_ma) and close_is_above_ma and recent_price_rise
 
     async def classify(self, market: str, logger: Optional[logging.Logger] = None) -> RegimeSnapshot:
         """오늘 기준 캐시된 분류를 반환. 캐시가 비어 있으면 SQS로 재계산."""

--- a/services/oneil_universe_service.py
+++ b/services/oneil_universe_service.py
@@ -99,6 +99,7 @@ class OneilUniverseService:
                 min_net_change_pct=self._cfg.market_ma_min_net_change_pct,
                 daily_dip_tolerance_pct=self._cfg.market_ma_daily_dip_tolerance_pct,
                 hard_decline_pct=self._cfg.market_ma_hard_decline_pct,
+                recovery_close_buffer_pct=self._cfg.market_ma_recovery_close_buffer_pct,
             )
             market_regime_service = MarketRegimeService(
                 stock_query_service=stock_query_service,
@@ -1053,7 +1054,8 @@ class OneilUniverseService:
                     msg += f"\n• 최초 전환 가능: 최소 {snap.recovery_earliest_days}거래일 후 (이후 종가 조건 충족 시)"
                 if not is_rising and snap.recovery_earliest_days is not None:
                     msg += (
-                        f"\n• 회복 전환 조건: 급락 구간 해소 후 MA({self._cfg.market_ma_period}) 비하락, "
+                        f"\n• 회복 전환 조건: 급락 구간 해소 후 MA({self._cfg.market_ma_period}) 비하락 "
+                        f"또는 종가가 MA 대비 +{self._cfg.market_ma_recovery_close_buffer_pct:.1f}% 이상, "
                         f"종가가 MA 위, 최근 2거래일 중 1일 이상 상승"
                     )
                 if not is_rising and snap.next_close_floor is not None:

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -148,6 +148,40 @@ async def test_classify_recovers_after_hard_decline_window_clears():
 
 
 @pytest.mark.asyncio
+async def test_classify_recovers_when_close_strongly_reclaims_falling_ma():
+    """MA가 아직 하락 중이어도 종가가 MA 위로 강하게 회복하면 회복 국면으로 본다."""
+    closes = [7000, 7000, 7000] + [6450] * 17 + [6750, 6800, 6850]
+    sqs = MagicMock()
+    sqs.get_recent_daily_index_ohlcv = AsyncMock(
+        return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_build_ohlcv(closes))
+    )
+    tm = MagicMock()
+    tm.get_current_kst_time = MagicMock(return_value=datetime.strptime("20260514", "%Y%m%d"))
+    tm.is_market_operating_hours = MagicMock(return_value=False)
+    cfg = MarketRegimeConfig(
+        kospi_index_code="0001",
+        kosdaq_index_code="1001",
+        ma_period=20,
+        rising_days=3,
+        min_net_change_pct=-0.10,
+        daily_dip_tolerance_pct=-0.20,
+        hard_decline_pct=-0.50,
+        recovery_close_buffer_pct=3.00,
+    )
+    svc = MarketRegimeService(stock_query_service=sqs, market_clock=tm, config=cfg)
+
+    snap = await svc.classify("KOSPI")
+
+    assert snap.net_change_pct < -0.10
+    assert snap.max_daily_drop_pct >= -0.50
+    assert snap.ma_values[-1] < snap.ma_values[-2]
+    assert snap.current_close >= snap.ma_values[-1] * 1.03
+    assert snap.trend_status == "recovery"
+    assert snap.regime_label == "bull"
+    assert snap.is_rising is True
+
+
+@pytest.mark.asyncio
 async def test_classify_uptrend_under_pressure_returns_sideways():
     """순증감은 양호하지만 일일 dip 이 -0.2% 미만 ~ -0.5% 이상이면 uptrend_under_pressure → sideways."""
     # 평균 MA가 약간 상승하면서 중간에 한 번 -0.3% 정도 일일 하락 유도


### PR DESCRIPTION
﻿## What changed
- Added a configurable strong-close recovery exception to market regime classification.
- If the index close is at least 3.0% above the latest MA, recent price action is rising, and no hard MA decline is present, a weak MA trend can recover to bull.
- Propagated the new Oneil universe config value into MarketRegimeService and updated the market timing notification text.
- Added a regression test for the falling-MA but strongly recovered-close case.

## Why
The previous gate required MA non-decline before allowing recovery. That blocked strong rebound cases where price had already reclaimed the MA by a wide margin, but the lagging MA was still being pulled down by older closes.

## Validation
- `python -m pytest tests\unit_test\services\test_market_regime_service.py -v`
- `python -m pytest tests\unit_test\services\test_oneil_universe_service.py::test_update_market_timing_emits_notifications tests\unit_test\services\test_oneil_universe_service.py::test_update_market_timing_updates_cache -v`
- `python -m pytest tests\unit_test -v`
- `python -m pytest tests\integration_test -v`
