### PR TITLE
Drain price stream background tasks on shutdown

### DIFF
--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -59,6 +59,41 @@ class PriceStreamService:
         self._tick_ingest_quality_reject: Dict[str, int] = {}
         self._tick_ingest_dispatched: Dict[str, int] = {}
         self._tick_ingest_malformed: Dict[str, int] = {}
+        self._background_tasks: set[asyncio.Task] = set()
+
+    def _schedule_background_task(self, coro_factory, *args, **kwargs) -> None:
+        coro = None
+        try:
+            loop = asyncio.get_running_loop()
+            coro = coro_factory(*args, **kwargs)
+            task = loop.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+        except RuntimeError:
+            if coro is not None:
+                coro.close()
+        except Exception:
+            if coro is not None:
+                coro.close()
+            raise
+
+    async def shutdown(self, timeout: float = 2.0) -> None:
+        """Wait for fire-and-forget side effect tasks before the event loop closes."""
+        if not self._background_tasks:
+            return
+        tasks = set(self._background_tasks)
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            self._background_tasks.difference_update(tasks)
 
     def set_event_router(self, event_router) -> None:
         """Late injection 용. WebAppContext 조립 순서 문제로 생성자에 주입 못한 경우 사용."""
@@ -125,14 +160,14 @@ class PriceStreamService:
                 )
                 if self._notification_service is not None:
                     try:
-                        loop = asyncio.get_running_loop()
-                        loop.create_task(self._notification_service.emit(
+                        self._schedule_background_task(
+                            self._notification_service.emit,
                             NotificationCategory.SYSTEM,
                             NotificationLevel.ERROR,
                             "실시간 체결가 품질 검증 실패",
                             f"{result.code or stock_code}: {result.reason}",
                             metadata=result.to_dict(),
-                        ))
+                        )
                     except RuntimeError:
                         pass
                 self._tick_ingest_quality_reject[stock_code] = (
@@ -223,15 +258,13 @@ class PriceStreamService:
 
         if self._favorite_price_alert_service is not None:
             try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(
-                    self._favorite_price_alert_service.handle_price_tick(
-                        stock_code,
-                        price=current_price,
-                        rate=realtime_data.get('전일대비율'),
-                        sign=realtime_data.get('전일대비부호'),
-                        is_upper_limit=self._is_upper_limit_tick(realtime_data),
-                    )
+                self._schedule_background_task(
+                    self._favorite_price_alert_service.handle_price_tick,
+                    stock_code,
+                    price=current_price,
+                    rate=realtime_data.get('전일대비율'),
+                    sign=realtime_data.get('전일대비부호'),
+                    is_upper_limit=self._is_upper_limit_tick(realtime_data),
                 )
             except RuntimeError:
                 pass
@@ -240,14 +273,14 @@ class PriceStreamService:
 
         if self._event_router is not None:
             try:
-                loop = asyncio.get_running_loop()
                 snapshot = dict(self._latest_prices[stock_code])
                 snapshot["code"] = stock_code
                 snapshot["snapshot_ts"] = now_ts
-                loop.create_task(
-                    self._event_router.on_price_tick(
-                        stock_code, snapshot, snapshot_ts=now_ts
-                    )
+                self._schedule_background_task(
+                    self._event_router.on_price_tick,
+                    stock_code,
+                    snapshot,
+                    snapshot_ts=now_ts,
                 )
                 self._tick_ingest_dispatched[stock_code] = (
                     self._tick_ingest_dispatched.get(stock_code, 0) + 1
@@ -374,15 +407,13 @@ class PriceStreamService:
 
         if evaluate_favorite_alert and self._favorite_price_alert_service is not None:
             try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(
-                    self._favorite_price_alert_service.handle_price_tick(
-                        code,
-                        price=price,
-                        rate=rate,
-                        sign=sign,
-                        is_upper_limit=self._is_upper_limit_snapshot(rate, sign),
-                    )
+                self._schedule_background_task(
+                    self._favorite_price_alert_service.handle_price_tick,
+                    code,
+                    price=price,
+                    rate=rate,
+                    sign=sign,
+                    is_upper_limit=self._is_upper_limit_snapshot(rate, sign),
                 )
             except RuntimeError:
                 pass

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -168,6 +168,36 @@ async def test_cache_price_snapshot_schedules_favorite_price_alert(mock_stock_re
     await asyncio.sleep(0)
 
 
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_pending_favorite_price_alert_task(mock_stock_repo, mock_logger):
+    finished = asyncio.Event()
+
+    class SlowFavoriteAlert:
+        async def handle_price_tick(self, *args, **kwargs):
+            await asyncio.sleep(0.01)
+            finished.set()
+
+    service = PriceStreamService(
+        stock_repo=mock_stock_repo,
+        logger=mock_logger,
+        favorite_price_alert_service=SlowFavoriteAlert(),
+    )
+
+    service.cache_price_snapshot(
+        "080220",
+        price="91300",
+        change="4300",
+        rate="5.02",
+        sign="2",
+        volume="12345",
+    )
+
+    await service.shutdown()
+
+    assert finished.is_set()
+    assert service._background_tasks == set()
+
+
 def test_on_price_tick_stores_liquidity_fields(price_stream_service):
     """체결틱의 누적거래량/누적거래대금이 snapshot 에 보관된다."""
     data = {

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -518,6 +518,8 @@ class WebAppContext:
             await self.background_scheduler.shutdown()
         if self.program_trading_stream_service:
             await self.program_trading_stream_service.shutdown()
+        if self.price_stream_service:
+            await self.price_stream_service.shutdown()
         if self.broker:
             await self.broker.stop()
         if self.stock_repository:


### PR DESCRIPTION
﻿## What changed
- Tracks PriceStreamService fire-and-forget side effect tasks for data-quality notifications, favorite price alerts, and strategy event routing.
- Adds `PriceStreamService.shutdown()` to wait for pending side effect tasks and cancel them on timeout.
- Calls `price_stream_service.shutdown()` from `WebAppContext.shutdown()` before dependent resources are closed.

## Why
Full integration tests were passing but emitted pytest warnings from pending `FavoritePriceAlertService.handle_price_tick()` tasks. Those tasks could still be inside `FavoriteRepository.get_all()` / aiosqlite when pytest closed the event loop, producing `PytestUnhandledThreadExceptionWarning` and `PytestUnraisableExceptionWarning`.

## Validation
- `python -m pytest tests/unit_test/services/test_price_stream_service.py -v`
- `python -m pytest tests/unit_test/services/test_price_stream_service_event_router.py::test_router_no_running_loop_does_not_raise -v`
- `python -m pytest tests/integration_test/strategies/test_it_strategy_scan.py -v -W error::pytest.PytestUnhandledThreadExceptionWarning -W error::pytest.PytestUnraisableExceptionWarning`
- `python -m pytest tests/unit_test -v`
- `python -m pytest tests/integration_test -v`
