### PR TITLE
Add Gemini fallback for YouTube digest blocks

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -276,6 +276,9 @@ youtube_digest:
   proxy_https_url: ""
   proxy_locations: ["kr", "jp"]
   request_interval_sec: 5
+  # youtube-transcript-api 가 IpBlocked/RequestBlocked 를 맞으면 Gemini API에
+  # 공개 YouTube URL을 직접 넘겨 대체 리포트를 만든다. Gemini quota를 쓰므로 opt-in.
+  gemini_fallback_enabled: false
 
 # AI 분석 (Gemini/Groq/Ollama OpenAI 호환 엔드포인트 공통)
 #   관심종목 신규 공시의 실제 DART 본문을 읽어 최종 중요도와 요약을 산출

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -354,6 +354,7 @@ class YoutubeDigestConfig(BaseModel):
     proxy_https_url: str = ""
     proxy_locations: List[str] = Field(default_factory=list)
     request_interval_sec: float = Field(5.0, ge=0)
+    gemini_fallback_enabled: bool = False
 
     model_config = {"extra": "allow"}
 

--- a/repositories/youtube_digest_repository.py
+++ b/repositories/youtube_digest_repository.py
@@ -13,6 +13,7 @@ _CREATE_DIGESTS = """
 CREATE TABLE IF NOT EXISTS youtube_digests (
     report_date          TEXT PRIMARY KEY,
     digest_text          TEXT NOT NULL DEFAULT '',
+    source               TEXT NOT NULL DEFAULT 'transcript',
     video_count          INTEGER NOT NULL DEFAULT 0,
     failed_summary_count INTEGER NOT NULL DEFAULT 0,
     created_at           TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
@@ -58,9 +59,20 @@ class YoutubeDigestRepository:
     async def _setup(self, conn: aiosqlite.Connection) -> None:
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute(_CREATE_DIGESTS)
+        await self._ensure_source_column(conn)
         await conn.execute(_CREATE_MENTIONS)
         await conn.execute(_CREATE_VIDEOS)
         await conn.commit()
+
+    async def _ensure_source_column(self, conn: aiosqlite.Connection) -> None:
+        async with conn.execute("PRAGMA table_info(youtube_digests)") as cur:
+            rows = await cur.fetchall()
+        columns = {row[1] for row in rows}
+        if "source" not in columns:
+            await conn.execute(
+                "ALTER TABLE youtube_digests"
+                " ADD COLUMN source TEXT NOT NULL DEFAULT 'transcript'"
+            )
 
     async def save(self, payload: dict) -> None:
         """하루치 리포트를 저장한다. 같은 날짜가 있으면 통째로 교체한다."""
@@ -77,11 +89,12 @@ class YoutubeDigestRepository:
             )
             await conn.execute(
                 "INSERT OR REPLACE INTO youtube_digests"
-                " (report_date, digest_text, video_count, failed_summary_count)"
-                " VALUES (?, ?, ?, ?)",
+                " (report_date, digest_text, source, video_count, failed_summary_count)"
+                " VALUES (?, ?, ?, ?, ?)",
                 (
                     report_date,
                     str(payload.get("digest_text") or ""),
+                    str(payload.get("source") or "transcript"),
                     int(payload.get("video_count") or 0),
                     int(payload.get("failed_summary_count") or 0),
                 ),
@@ -126,7 +139,7 @@ class YoutubeDigestRepository:
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             async with conn.execute(
-                "SELECT report_date, digest_text, video_count, failed_summary_count,"
+                "SELECT report_date, digest_text, source, video_count, failed_summary_count,"
                 " created_at FROM youtube_digests WHERE report_date = ?",
                 (report_date,),
             ) as cur:
@@ -148,9 +161,10 @@ class YoutubeDigestRepository:
         return {
             "report_date": row[0],
             "digest_text": row[1],
-            "video_count": row[2],
-            "failed_summary_count": row[3],
-            "created_at": row[4],
+            "source": row[2],
+            "video_count": row[3],
+            "failed_summary_count": row[4],
+            "created_at": row[5],
             "mentions": [
                 {"name": m[0], "code": m[1], "count": m[2], "video_count": m[3]}
                 for m in mention_rows
@@ -173,7 +187,7 @@ class YoutubeDigestRepository:
         async with aiosqlite.connect(self._db_path) as conn:
             await self._setup(conn)
             async with conn.execute(
-                "SELECT report_date, video_count, failed_summary_count, created_at"
+                "SELECT report_date, source, video_count, failed_summary_count, created_at"
                 " FROM youtube_digests ORDER BY report_date DESC LIMIT ?",
                 (max(1, int(limit)),),
             ) as cur:
@@ -181,9 +195,10 @@ class YoutubeDigestRepository:
         return [
             {
                 "report_date": row[0],
-                "video_count": row[1],
-                "failed_summary_count": row[2],
-                "created_at": row[3],
+                "source": row[1],
+                "video_count": row[2],
+                "failed_summary_count": row[3],
+                "created_at": row[4],
             }
             for row in rows
         ]

--- a/services/gemini_youtube_video_analyzer_service.py
+++ b/services/gemini_youtube_video_analyzer_service.py
@@ -1,0 +1,172 @@
+"""Gemini YouTube URL fallback analyzer.
+
+`youtube-transcript-api` 가 IP 차단을 맞았을 때 원문 자막 수집 대신 공개
+YouTube URL을 Gemini video input으로 넘겨 최소 리포트를 만든다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+import httpx
+
+from common.types import ErrorCode, ResCommonResponse
+
+_INTERACTIONS_URL = "https://generativelanguage.googleapis.com/v1beta/interactions"
+
+_VIDEO_PROMPT = (
+    "이 영상은 한국 주식 유튜브 방송이다. 자막 원문을 보존할 수 없는 장애 fallback "
+    "상황이므로, 영상의 발언만 근거로 한국어 요약을 작성한다. "
+    "매수/매도 지시를 하지 말고 출연자 발언 정리임을 유지한다. "
+    "'핵심 주장', '언급 종목과 이유', '시장 전망', '리스크 언급' 순서로 짧게 정리한다."
+)
+
+
+class GeminiYoutubeVideoAnalyzerService:
+    """공개 YouTube URL을 Gemini 네이티브 video input으로 요약한다."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = "gemini-2.5-flash",
+        http_client: Optional[httpx.AsyncClient] = None,
+        timeout_sec: float = 60.0,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._api_key = str(api_key or "").strip()
+        self._model = str(model or "gemini-2.5-flash")
+        self._http_client = http_client
+        self._timeout_sec = float(timeout_sec)
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def build_digest(
+        self, videos: Sequence[dict], *, report_date: str
+    ) -> ResCommonResponse:
+        candidates = [video for video in (videos or []) if video.get("url")]
+        if not candidates:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.EMPTY_VALUES.value,
+                msg1="Gemini fallback 대상 YouTube URL이 없습니다.",
+                data=None,
+            )
+
+        summarized: list[dict] = []
+        failed = 0
+        for video in candidates:
+            try:
+                summary = await self._summarize_url(str(video.get("url") or ""))
+            except Exception as exc:
+                failed += 1
+                self._logger.warning(
+                    "Gemini YouTube fallback summary failed: video_id=%s error=%s",
+                    video.get("video_id"),
+                    exc,
+                )
+                continue
+            summarized.append(
+                {
+                    "video_id": str(video.get("video_id") or ""),
+                    "title": str(video.get("title") or ""),
+                    "channel_title": str(video.get("channel_title") or ""),
+                    "url": str(video.get("url") or ""),
+                    "published": str(video.get("published") or ""),
+                    "summary": summary,
+                }
+            )
+
+        if not summarized:
+            return ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1="Gemini fallback 영상 요약이 모두 실패했습니다.",
+                data=None,
+            )
+
+        digest_text = self._format_digest_text(summarized)
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상처리 되었습니다.",
+            data={
+                "report_date": str(report_date),
+                "source": "gemini_video_url",
+                "video_count": len(summarized),
+                "failed_summary_count": failed,
+                # 자막 원문이 없으므로 기존 deterministic 종목 카운트는 수행하지 않는다.
+                "mentions": [],
+                "videos": summarized,
+                "digest_text": digest_text,
+            },
+        )
+
+    async def _summarize_url(self, url: str) -> str:
+        if not self._api_key:
+            raise ValueError("Gemini API key가 필요합니다.")
+        if not self._api_key.isascii():
+            raise ValueError("Gemini API key에 ASCII 외 문자가 섞여 있습니다.")
+        payload = {
+            "model": self._model,
+            "input": [
+                {"type": "video", "uri": url},
+                {"type": "text", "text": _VIDEO_PROMPT},
+            ],
+        }
+        headers = {"x-goog-api-key": self._api_key}
+        if self._http_client is not None:
+            response = await self._http_client.post(
+                _INTERACTIONS_URL,
+                headers=headers,
+                json=payload,
+                timeout=self._timeout_sec,
+            )
+            return self._parse_response(response)
+        async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+            response = await client.post(
+                _INTERACTIONS_URL,
+                headers=headers,
+                json=payload,
+                timeout=self._timeout_sec,
+            )
+            return self._parse_response(response)
+
+    @staticmethod
+    def _parse_response(response: Any) -> str:
+        response.raise_for_status()
+        payload = response.json()
+        text = payload.get("output_text") if isinstance(payload, dict) else None
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+        steps = payload.get("steps") if isinstance(payload, dict) else None
+        extracted = GeminiYoutubeVideoAnalyzerService._extract_text_from_steps(steps)
+        if extracted:
+            return extracted
+        raise ValueError("Gemini 응답 본문이 비어 있습니다.")
+
+    @staticmethod
+    def _extract_text_from_steps(steps: Any) -> str:
+        parts: list[str] = []
+        if not isinstance(steps, list):
+            return ""
+        for step in steps:
+            content = step.get("content") if isinstance(step, dict) else None
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                text = item.get("text") if isinstance(item, dict) else None
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+
+    @staticmethod
+    def _format_digest_text(videos: Sequence[dict]) -> str:
+        lines = [
+            "Gemini YouTube URL fallback 리포트",
+            "자막 원문 수집이 차단되어 영상 URL 분석 결과로 대체했습니다.",
+            "",
+        ]
+        for video in videos:
+            title = video.get("title") or video.get("video_id") or "영상"
+            channel = video.get("channel_title") or "채널"
+            lines.append(f"[{channel}] {title}")
+            lines.append(str(video.get("summary") or "").strip())
+            lines.append("")
+        return "\n".join(lines).strip()

--- a/task/background/intraday/youtube_digest_task.py
+++ b/task/background/intraday/youtube_digest_task.py
@@ -51,6 +51,7 @@ class YoutubeDigestTask(SchedulableTask):
         notification_service=None,
         market_clock=None,
         logger: Optional[logging.Logger] = None,
+        gemini_fallback_service=None,
     ) -> None:
         self._channel_repo = channel_repository
         self._collector = collector
@@ -59,6 +60,7 @@ class YoutubeDigestTask(SchedulableTask):
         self._ns = notification_service
         self._market_clock = market_clock
         self._logger = logger or logging.getLogger(__name__)
+        self._gemini_fallback_service = gemini_fallback_service
         self._state = TaskState.IDLE
         self._tasks: List[asyncio.Task] = []
         self._last_run_date: Optional[str] = None
@@ -175,6 +177,8 @@ class YoutubeDigestTask(SchedulableTask):
                 max_videos_per_channel=self.MAX_VIDEOS_PER_CHANNEL,
             )
             if getattr(self._collector, "was_blocked", False):
+                if await self._try_gemini_fallback(items, report_date, now):
+                    return
                 await self._handle_block(report_date, now)
                 return
 
@@ -239,6 +243,45 @@ class YoutubeDigestTask(SchedulableTask):
             " 오늘 리포트는 생성되지 않습니다.",
         )
         self._mark_done(report_date, now)
+
+    async def _try_gemini_fallback(
+        self, items: list[dict], report_date: str, now
+    ) -> bool:
+        if self._gemini_fallback_service is None:
+            return False
+        videos = [item for item in (items or []) if item.get("url")]
+        if not videos:
+            self._logger.warning("[YoutubeDigest] Gemini fallback 대상 영상이 없습니다.")
+            return False
+        try:
+            result = await self._gemini_fallback_service.build_digest(
+                videos, report_date=report_date
+            )
+        except Exception as e:
+            self._last_error = f"blocked; gemini fallback failed: {e}"
+            self._logger.warning(f"[YoutubeDigest] Gemini fallback 실패: {e}")
+            return False
+        if not result or result.rt_cd != ErrorCode.SUCCESS.value:
+            message = getattr(result, "msg1", "응답 없음") if result else "응답 없음"
+            self._last_error = f"blocked; gemini fallback failed: {message}"
+            self._logger.warning(f"[YoutubeDigest] Gemini fallback 리포트 생성 실패: {message}")
+            return False
+
+        payload = dict(result.data or {})
+        payload.setdefault("source", "gemini_video_url")
+        await self._digest_repo.save(payload)
+        self._last_report_date = report_date
+        await self._emit(
+            NotificationLevel.INFO,
+            "유튜브 다이제스트",
+            self._format_message(payload),
+        )
+        self._logger.info(
+            f"[YoutubeDigest] Gemini fallback 리포트 완료: {report_date} "
+            f"영상 {payload.get('video_count')}편"
+        )
+        self._mark_done(report_date, now)
+        return True
 
     def _mark_done(self, report_date: str, now) -> None:
         self._last_run_date = report_date

--- a/tests/unit_test/repositories/test_youtube_digest_repository.py
+++ b/tests/unit_test/repositories/test_youtube_digest_repository.py
@@ -42,12 +42,23 @@ async def test_save_then_get_roundtrip(repo):
     stored = await repo.get("20260810")
 
     assert stored["report_date"] == "20260810"
+    assert stored["source"] == "transcript"
     assert stored["digest_text"] == "오늘의 공통 화두는 반도체다."
     assert stored["video_count"] == 2
     assert stored["failed_summary_count"] == 0
     assert [m["name"] for m in stored["mentions"]] == ["삼성전자", "SK하이닉스"]
     assert stored["mentions"][0]["code"] == "005930"
     assert stored["videos"][0]["summary"] == "v1 요약"
+
+
+async def test_save_then_get_preserves_gemini_fallback_source(repo):
+    await repo.save(_payload(source="gemini_video_url", mentions=[]))
+
+    stored = await repo.get("20260810")
+    recent = await repo.list_recent()
+
+    assert stored["source"] == "gemini_video_url"
+    assert recent[0]["source"] == "gemini_video_url"
 
 
 async def test_get_returns_none_for_missing_date(repo):

--- a/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
+++ b/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
@@ -1,0 +1,80 @@
+"""Gemini YouTube URL fallback 분석 서비스 단위 테스트."""
+from unittest.mock import AsyncMock
+
+from common.types import ErrorCode
+from services.gemini_youtube_video_analyzer_service import (
+    GeminiYoutubeVideoAnalyzerService,
+)
+
+
+class _Response:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def _video(video_id: str = "v1") -> dict:
+    return {
+        "video_id": video_id,
+        "title": "아침 시황",
+        "channel_title": "테스트채널",
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+        "published": "2026-08-10T07:00:00+00:00",
+    }
+
+
+async def test_build_digest_summarizes_public_youtube_urls():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({"output_text": "반도체 중심 요약"}))
+    svc = GeminiYoutubeVideoAnalyzerService(
+        api_key="test-key",
+        model="gemini-2.5-flash",
+        http_client=http,
+    )
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    data = result.data
+    assert data["source"] == "gemini_video_url"
+    assert data["video_count"] == 1
+    assert data["mentions"] == []
+    assert data["videos"][0]["summary"] == "반도체 중심 요약"
+    request = http.post.await_args
+    assert request.args[0].endswith("/v1beta/interactions")
+    assert request.kwargs["headers"]["x-goog-api-key"] == "test-key"
+    assert request.kwargs["json"]["input"][0] == {
+        "type": "video",
+        "uri": "https://www.youtube.com/watch?v=v1",
+    }
+
+
+async def test_build_digest_reports_empty_when_no_video_url():
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=AsyncMock())
+
+    result = await svc.build_digest([{"video_id": "v1"}], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.EMPTY_VALUES.value
+
+
+async def test_build_digest_keeps_going_when_one_video_fails():
+    http = AsyncMock()
+    http.post = AsyncMock(side_effect=[
+        RuntimeError("quota"),
+        _Response({"output_text": "두 번째 요약"}),
+    ])
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=http)
+
+    result = await svc.build_digest([_video("v1"), _video("v2")], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["video_count"] == 1
+    assert result.data["failed_summary_count"] == 1
+    assert result.data["videos"][0]["video_id"] == "v2"

--- a/tests/unit_test/task/background/intraday/test_youtube_digest_task.py
+++ b/tests/unit_test/task/background/intraday/test_youtube_digest_task.py
@@ -38,6 +38,7 @@ def _task(
     collect_result=None,
     was_blocked=False,
     digest_result=None,
+    gemini_fallback_result=None,
     channels=None,
 ):
     channel_repo = MagicMock()
@@ -59,6 +60,10 @@ def _task(
     digest_repo.save = AsyncMock()
     notifier = MagicMock()
     notifier.emit = AsyncMock()
+    gemini_fallback = None
+    if gemini_fallback_result is not None:
+        gemini_fallback = MagicMock()
+        gemini_fallback.build_digest = AsyncMock(return_value=gemini_fallback_result)
 
     task = YoutubeDigestTask(
         channel_repository=channel_repo,
@@ -67,6 +72,7 @@ def _task(
         digest_repository=digest_repo,
         notification_service=notifier,
         market_clock=clock or _clock(7, 30),
+        gemini_fallback_service=gemini_fallback,
     )
     return task, {
         "channel_repo": channel_repo,
@@ -74,6 +80,7 @@ def _task(
         "digest_service": digest_service,
         "digest_repo": digest_repo,
         "notifier": notifier,
+        "gemini_fallback": gemini_fallback,
     }
 
 
@@ -230,6 +237,45 @@ async def test_ip_block_is_retried_once_before_giving_up():
     await task.run_once()  # 두 번째도 차단
     clock.get_current_kst_time.return_value = _KST.localize(datetime(2026, 8, 10, 10, 0))
     assert await task._should_run_now() is False  # 포기
+
+
+async def test_ip_block_uses_gemini_fallback_when_configured():
+    """Gemini fallback 이 켜져 있으면 IP 차단을 빈 리포트로 끝내지 않는다."""
+    fallback = _ok_digest(
+        video_count=1,
+        mentions=[],
+        videos=[{
+            "video_id": "v1",
+            "title": "영상",
+            "channel_title": "채널",
+            "url": "https://www.youtube.com/watch?v=v1",
+            "published": "2026-08-10T07:00:00+00:00",
+            "summary": "Gemini 요약",
+        }],
+        digest_text="Gemini fallback 리포트",
+        source="gemini_video_url",
+    )
+    task, deps = _task(
+        collect_result=[{
+            "video_id": "v1",
+            "title": "영상",
+            "channel_title": "채널",
+            "url": "https://www.youtube.com/watch?v=v1",
+            "published": "2026-08-10T07:00:00+00:00",
+            "skip_reason": "blocked",
+            "transcript": "",
+        }],
+        was_blocked=True,
+        gemini_fallback_result=fallback,
+    )
+
+    await task.run_once()
+
+    deps["gemini_fallback"].build_digest.assert_awaited_once()
+    deps["digest_repo"].save.assert_awaited_once()
+    saved = deps["digest_repo"].save.await_args.args[0]
+    assert saved["source"] == "gemini_video_url"
+    assert task.get_progress()["last_report_date"] == "20260810"
 
 
 async def test_no_usable_video_notifies_without_calling_ai():

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -92,6 +92,9 @@ from repositories.dart_disclosure_repository import DartDisclosureRepository
 from repositories.overseas_trade_repository import OverseasTradeRepository
 from repositories.youtube_channel_repository import YoutubeChannelRepository
 from repositories.youtube_digest_repository import YoutubeDigestRepository
+from services.gemini_youtube_video_analyzer_service import (
+    GeminiYoutubeVideoAnalyzerService,
+)
 from services.youtube_transcript_collector_service import YoutubeTranscriptCollectorService
 from services.youtube_digest_service import YoutubeDigestService
 from task.background.intraday.youtube_digest_task import YoutubeDigestTask
@@ -451,6 +454,7 @@ class ServiceContainer:
         )
         ctx.youtube_digest_service = None
         ctx.youtube_digest_task = None
+        ctx.youtube_gemini_fallback_service = None
         if ctx.ai_client is not None:
             # 청크는 입력 예산보다 작아야 AiClient 가 뒤를 잘라내지 않는다.
             _yt_budget = int(ai_config.max_input_chars) or 24000
@@ -461,6 +465,17 @@ class ServiceContainer:
                 chunk_chars=max(2000, _yt_budget - 2000),
                 logger=ctx.logger,
             )
+            if (
+                youtube_config.gemini_fallback_enabled
+                and ai_config.provider.lower() == "gemini"
+                and ai_config.api_key
+            ):
+                ctx.youtube_gemini_fallback_service = GeminiYoutubeVideoAnalyzerService(
+                    api_key=ai_config.api_key,
+                    model=ai_config.model,
+                    timeout_sec=float(ai_config.timeout_sec),
+                    logger=ctx.logger,
+                )
             ctx.youtube_digest_task = YoutubeDigestTask(
                 channel_repository=ctx.youtube_channel_repository,
                 collector=ctx.youtube_transcript_collector,
@@ -469,6 +484,7 @@ class ServiceContainer:
                 notification_service=ctx.notification_service,
                 market_clock=ctx.market_clock,
                 logger=ctx.logger,
+                gemini_fallback_service=ctx.youtube_gemini_fallback_service,
             )
 
         try:


### PR DESCRIPTION
## What changed
- Added a Gemini native YouTube URL fallback analyzer for YouTube digest generation.
- Wired the fallback into YoutubeDigestTask when transcript collection is IP-blocked and the opt-in config is enabled.
- Persisted a report source field so fallback reports can be distinguished from transcript-based reports.
- Added unit coverage for fallback behavior, Gemini request payloads, and source persistence.

## Validation
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v

## Notes
- The fallback is opt-in via youtube_digest.gemini_fallback_enabled because it consumes Gemini quota and the current key previously returned quota 429 during a live probe.