### PR TITLE
Track Gemini YouTube fallback usage

### DIFF
--- a/services/gemini_youtube_video_analyzer_service.py
+++ b/services/gemini_youtube_video_analyzer_service.py
@@ -32,12 +32,14 @@ class GeminiYoutubeVideoAnalyzerService:
         model: str = "gemini-2.5-flash",
         http_client: Optional[httpx.AsyncClient] = None,
         timeout_sec: float = 60.0,
+        usage_limiter=None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._api_key = str(api_key or "").strip()
         self._model = str(model or "gemini-2.5-flash")
         self._http_client = http_client
         self._timeout_sec = float(timeout_sec)
+        self._usage_limiter = usage_limiter
         self._logger = logger or logging.getLogger(__name__)
 
     async def build_digest(
@@ -111,6 +113,8 @@ class GeminiYoutubeVideoAnalyzerService:
             ],
         }
         headers = {"x-goog-api-key": self._api_key}
+        if self._usage_limiter is not None:
+            await self._usage_limiter.reserve("youtube")
         if self._http_client is not None:
             response = await self._http_client.post(
                 _INTERACTIONS_URL,

--- a/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
+++ b/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
@@ -56,6 +56,40 @@ async def test_build_digest_summarizes_public_youtube_urls():
     }
 
 
+async def test_build_digest_reserves_ai_usage_before_each_video_request():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({"output_text": "요약"}))
+    limiter = AsyncMock()
+    limiter.reserve = AsyncMock()
+    svc = GeminiYoutubeVideoAnalyzerService(
+        api_key="test-key",
+        http_client=http,
+        usage_limiter=limiter,
+    )
+
+    await svc.build_digest([_video("v1"), _video("v2")], report_date="20260810")
+
+    assert limiter.reserve.await_count == 2
+    limiter.reserve.assert_any_await("youtube")
+
+
+async def test_build_digest_does_not_call_gemini_when_usage_limit_blocks():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({"output_text": "요약"}))
+    limiter = AsyncMock()
+    limiter.reserve = AsyncMock(side_effect=RuntimeError("daily limit"))
+    svc = GeminiYoutubeVideoAnalyzerService(
+        api_key="test-key",
+        http_client=http,
+        usage_limiter=limiter,
+    )
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    http.post.assert_not_awaited()
+
+
 async def test_build_digest_reports_empty_when_no_video_url():
     svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=AsyncMock())
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -474,6 +474,7 @@ class ServiceContainer:
                     api_key=ai_config.api_key,
                     model=ai_config.model,
                     timeout_sec=float(ai_config.timeout_sec),
+                    usage_limiter=ctx.ai_usage_limiter,
                     logger=ctx.logger,
                 )
             ctx.youtube_digest_task = YoutubeDigestTask(


### PR DESCRIPTION
## Summary
- pass the AI usage limiter into the Gemini YouTube URL fallback service
- reserve youtube usage before each Gemini URL analysis request
- cover reservation and limit-blocking behavior in unit tests

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest -o addopts= tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest -o addopts= tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py tests/unit_test/task/background/intraday/test_youtube_digest_task.py tests/unit_test/repositories/test_youtube_digest_repository.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v