### PR TITLE
Balance periodic disclosure AI summaries

### DIFF
--- a/services/ai_disclosure_analyzer.py
+++ b/services/ai_disclosure_analyzer.py
@@ -22,6 +22,14 @@ _SYSTEM_PROMPT = (
     "없으면 event_key는 빈 문자열로 둔다. 반드시 JSON 객체만 반환한다."
 )
 
+_PERIODIC_REPORT_KEYWORDS = ("사업보고서", "반기보고서", "분기보고서")
+_PERIODIC_REPORT_REQUIRED_TERMS = (
+    ("상반기 실적", ("실적", "영업이익", "매출", "순이익", "영업손익", "손익")),
+    ("자본거래·희석", ("신주", "ADR", "유상증자", "자기주식", "소각", "처분", "희석", "자본거래")),
+    ("시장 반응", ("주가", "시장 반응", "하락", "상승", "급락", "급등", "고점")),
+    ("재무·리스크", ("연결재무제표", "설비투자", "현금흐름", "차입", "우발채무", "소송", "리스크", "위험")),
+)
+
 
 @dataclass(frozen=True)
 class AiDisclosureAnalysis:
@@ -51,7 +59,7 @@ class AiDisclosureAnalyzer:
                 max_tokens=self._max_tokens,
                 usage_type="disclosure",
             )
-            return self._parse_analysis(raw)
+            return self._apply_report_type_guard(disclosure, self._parse_analysis(raw))
         except Exception as exc:
             self._logger.warning(
                 f"AI 공시 분석 실패 — 제목 규칙으로 폴백: {type(exc).__name__}: {exc}"
@@ -80,12 +88,66 @@ class AiDisclosureAnalyzer:
             "[공시 원문 시작]\n"
             f"{str(document_text or '')[:16_000]}\n"
             "[공시 원문 끝]\n\n"
+            f"{AiDisclosureAnalyzer._periodic_report_instruction(disclosure)}"
             '다음 형식으로 반환: {"summary":"...", "score":75, '
             '"reasons":["구체적 근거 1","구체적 근거 2"], '
             '"event_key":"사건종류|회차·계약상대 등 식별자|금액·기준일"}\n'
             "event_key는 같은 기업의 동일 경제적 사건 문서에서 완전히 같은 값이어야 "
             "하며, 문서 제목·접수번호는 넣지 않는다. 동일성을 확신할 수 없으면 \"\"."
         )
+
+    @classmethod
+    def _periodic_report_instruction(cls, disclosure: DartDisclosure) -> str:
+        if not cls._is_periodic_report(disclosure.report_name):
+            return ""
+        return (
+            "[정기보고서 점검 기준]\n"
+            "- 사업/반기/분기보고서는 이미 알려진 긍정 이벤트만으로 HIGH를 주지 않는다.\n"
+            "- 상반기 실적(매출·영업이익·순이익), 신주 발행·자기주식 등 자본거래와 희석 가능성, "
+            "주가와 시장 반응, 연결재무제표·설비투자·현금흐름·우발채무·소송을 균형 있게 확인한다.\n"
+            "- 위 항목 중 핵심 누락이 있으면 summary에 누락 항목을 명시하고 score는 60점 이하로 둔다.\n\n"
+        )
+
+    @classmethod
+    def _apply_report_type_guard(
+        cls,
+        disclosure: DartDisclosure,
+        analysis: AiDisclosureAnalysis,
+    ) -> AiDisclosureAnalysis:
+        if (
+            not cls._is_periodic_report(disclosure.report_name)
+            or analysis.importance.score < 70
+            or cls._has_periodic_report_balance(analysis)
+        ):
+            return analysis
+
+        reasons = list(dict.fromkeys([
+            *analysis.importance.reasons,
+            "정기보고서 핵심 점검 항목 누락으로 HIGH 제한",
+        ]))
+        importance = DisclosureImportance(
+            score=60,
+            level=cls._level(60),
+            reasons=reasons,
+        )
+        return AiDisclosureAnalysis(
+            summary=analysis.summary,
+            importance=importance,
+            event_key=analysis.event_key,
+        )
+
+    @staticmethod
+    def _is_periodic_report(report_name: str) -> bool:
+        return any(keyword in str(report_name or "") for keyword in _PERIODIC_REPORT_KEYWORDS)
+
+    @classmethod
+    def _has_periodic_report_balance(cls, analysis: AiDisclosureAnalysis) -> bool:
+        text = " ".join([analysis.summary, *analysis.importance.reasons])
+        matched_categories = 0
+        for _, terms in _PERIODIC_REPORT_REQUIRED_TERMS:
+            if any(term.lower() in text.lower() for term in terms):
+                matched_categories += 1
+        return matched_categories >= 3
 
     @classmethod
     def _parse_analysis(cls, raw: str) -> AiDisclosureAnalysis:

--- a/tests/unit_test/services/test_ai_disclosure_analyzer.py
+++ b/tests/unit_test/services/test_ai_disclosure_analyzer.py
@@ -55,6 +55,47 @@ async def test_analyze_returns_structured_result_and_passes_document_text():
     assert '"event_key"' in user_prompt
 
 
+async def test_periodic_report_prompt_requires_balanced_half_year_review():
+    ai_client = MagicMock()
+    ai_client.complete = AsyncMock(
+        return_value=(
+            '{"summary":"무디스 등급 상향, 자사주 소각, HBM4E 샘플 공급이 긍정적입니다.",'
+            '"score":75,"reasons":["신용등급 및 신제품 긍정 재료"],'
+            '"event_key":"정기보고서|2026반기"}'
+        )
+    )
+    analyzer = AiDisclosureAnalyzer(ai_client, logger=MagicMock())
+    disclosure = DartDisclosure(
+        corp_class="Y",
+        corp_name="SK하이닉스",
+        corp_code="00164779",
+        stock_code="000660",
+        report_name="반기보고서 (2026.06)",
+        receipt_no="20260814000001",
+        filer_name="SK하이닉스",
+        receipt_date="20260814",
+        remarks="유",
+    )
+
+    result = await analyzer.analyze(
+        disclosure,
+        DisclosureImportance(30, "NORMAL", ["정기보고서"]),
+        (
+            "무디스 A3 상향, 자기주식 소각, HBM4E 샘플 공급. "
+            "상반기 연결재무제표와 우발채무 내용은 별도 표에 기재."
+        ),
+    )
+
+    assert result.importance.score == 60
+    assert result.importance.level == "MEDIUM"
+    assert "정기보고서 핵심 점검 항목 누락으로 HIGH 제한" in result.importance.reasons
+    user_prompt = ai_client.complete.await_args.kwargs["user"]
+    assert "정기보고서 점검 기준" in user_prompt
+    assert "상반기 실적" in user_prompt
+    assert "신주 발행·자기주식" in user_prompt
+    assert "우발채무·소송" in user_prompt
+
+
 async def test_analyze_returns_none_when_ai_fails():
     ai_client = MagicMock()
     ai_client.complete = AsyncMock(side_effect=AiClientError("NETWORK", "timeout"))


### PR DESCRIPTION
## Summary
- add periodic-report guidance so business/half-year/quarterly disclosures require balanced financial, dilution, market reaction, and risk review
- cap periodic-report AI results below HIGH when the generated summary only covers positive events and misses core review areas
- add regression coverage for SK Hynix-style half-year report summaries

## Tests
- pytest tests/unit_test -v
- pytest tests/integration_test -v