### PR TITLE
Show the domestic heatmap live during market hours

### DIFF
--- a/services/naver_market_snapshot_service.py
+++ b/services/naver_market_snapshot_service.py
@@ -1,0 +1,203 @@
+# services/naver_market_snapshot_service.py
+"""국내 장중 시세 스냅샷 (네이버 금융 시가총액 페이지).
+
+KIS 에는 전종목 시세 API 가 없고, 2026-08-14 장중 실측에서 다른 경로가 전부 막혀 있음을 확인했다.
+
+- FDR `StockListing('KRX')` 는 GitHub 에 커밋된 일별 CSV 캐시라 장중에 값이 변하지 않는다.
+- KRX MDC `getJsonData.cmd` 는 세션 쿠키를 세워도 `LOGOUT` 을 돌려준다.
+  같은 엔드포인트를 쓰는 pykrx 와 FDR 의 비캐시 경로도 그래서 함께 죽어 있다.
+
+히트맵은 전종목이 아니라 **시총 상위 N** 만 필요하고 네이버 시총 페이지가 이미 시총
+내림차순이라, 상위 몇 페이지만 받으면 된다(페이지당 50종목). 실측으로 코스피·코스닥
+10페이지씩 20요청이 병렬 5.4초에 961종목이었다.
+
+행 모양은 `StockOhlcvRepository.get_market_cap_snapshot` 과 일부러 같게 맞춘다 —
+라우트가 장중/장외에 따라 두 소스를 갈아끼우기만 하면 되도록.
+시가총액은 네이버가 이미 억원 단위로 주므로 daily_prices.market_cap 과 단위가 같다.
+"""
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+import aiohttp
+import pytz
+from bs4 import BeautifulSoup
+
+_BASE_URL = "https://finance.naver.com/sise/sise_market_sum.naver"
+_SOSOK = {"KOSPI": 0, "KOSDAQ": 1}
+_SOSOK_NAME = {0: "KOSPI", 1: "KOSDAQ"}
+_PAGE_SIZE = 50  # 네이버 시총 페이지가 한 장에 싣는 종목 수
+
+
+class NaverMarketSnapshotService:
+    """네이버 시총 페이지에서 국내 장중 스냅샷을 모아 TTL 캐시로 재사용한다."""
+
+    # limit 이 아무리 커도 시장당 이 페이지 수를 넘기지 않는다(= 최대 12요청/시장).
+    # 히트맵 최대 limit 500 은 10페이지면 덮이고, 나머지는 여유분이다.
+    _MAX_PAGES = 12
+    _PAGE_TIMEOUT_SEC = 10
+
+    def __init__(
+        self,
+        page_fetcher=None,
+        logger=None,
+        ttl_sec: float = 45.0,
+        clock=time.monotonic,
+        today_provider=None,
+        max_concurrency: int = 6,
+    ):
+        self._page_fetcher = page_fetcher or self._fetch_page
+        self._logger = logger or logging.getLogger(__name__)
+        self._ttl_sec = ttl_sec
+        self._clock = clock
+        self._today_provider = today_provider or self._today_kst
+        self._max_concurrency = max_concurrency
+        self._lock = asyncio.Lock()
+        self._cache: dict[int, list[dict]] = {}
+        self._cached_at: dict[int, float] = {}
+        self._cached_pages: dict[int, int] = {}
+
+    async def get_snapshot(self, limit: int, market: Optional[str] = None) -> list[dict]:
+        """시총 상위 종목 스냅샷. market 이 None/'ALL' 이면 코스피+코스닥을 합쳐 정렬한다."""
+        wanted = self._target_sosoks(market)
+        if not wanted:
+            return []
+
+        pages = min(-(-limit // _PAGE_SIZE), self._MAX_PAGES)
+        collected: list[dict] = []
+        for sosok in wanted:
+            collected.extend(await self._market_rows(sosok, pages))
+
+        collected.sort(key=lambda row: row["market_cap"], reverse=True)
+        return collected[:limit]
+
+    def _target_sosoks(self, market: Optional[str]) -> list[int]:
+        if not market or market == "ALL":
+            return list(_SOSOK.values())
+        sosok = _SOSOK.get(str(market).upper())
+        return [sosok] if sosok is not None else []
+
+    async def _market_rows(self, sosok: int, pages: int) -> list[dict]:
+        async with self._lock:
+            cached = self._cache.get(sosok)
+            cached_at = self._cached_at.get(sosok)
+            fresh = cached_at is not None and (self._clock() - cached_at) <= self._ttl_sec
+            # 캐시가 더 얕은 깊이로 받아둔 것이면 다시 받아야 한다(limit 200 뒤에 500 이 올 수 있다).
+            if fresh and self._cached_pages.get(sosok, 0) >= pages:
+                return cached
+
+            rows = await self._collect_market(sosok, pages)
+            # 마크업 개편 등으로 0행이 되면 캐시하지 않는다 — 다음 요청이 다시 시도하고,
+            # 그 사이 라우트는 저장소(daily_prices)로 폴백한다.
+            if rows:
+                self._cache[sosok] = rows
+                self._cached_at[sosok] = self._clock()
+                self._cached_pages[sosok] = pages
+            return rows
+
+    async def _collect_market(self, sosok: int, pages: int) -> list[dict]:
+        """필요한 페이지 수만큼 병렬로 받는다. 시장 끝을 넘은 페이지는 0행으로 와 무해하다."""
+        semaphore = asyncio.Semaphore(self._max_concurrency)
+        results = await asyncio.gather(
+            *(self._page_rows(semaphore, sosok, page) for page in range(1, pages + 1))
+        )
+
+        rows: list[dict] = []
+        seen: set[str] = set()
+        for page_rows in results:
+            for row in page_rows:
+                if row["code"] in seen:
+                    continue
+                seen.add(row["code"])
+                rows.append(row)
+
+        if not rows:
+            self._logger.warning(
+                {"event": "naver_snapshot_empty", "sosok": sosok,
+                 "msg": "네이버 시총 페이지에서 한 행도 파싱하지 못함 (마크업 변경 의심)"}
+            )
+        return rows
+
+    async def _page_rows(self, semaphore, sosok: int, page: int) -> list[dict]:
+        async with semaphore:
+            try:
+                html = await self._page_fetcher(sosok, page)
+            except Exception as exc:
+                self._logger.warning(
+                    {"event": "naver_snapshot_page_error", "sosok": sosok, "page": page, "error": str(exc)}
+                )
+                # 실패를 '빈 페이지'로 돌려주면 뒤 페이지까지 끊긴다. 여기서는 빈 목록이지만
+                # 호출부가 '실패'와 '마지막 페이지'를 구분하지 못해도 손해는 조기 중단뿐이다.
+                return []
+        return self._parse(html, sosok)
+
+    def _parse(self, html: str, sosok: int) -> list[dict]:
+        soup = BeautifulSoup(html or "", "html.parser")
+        table = soup.find("table", class_="type_2")
+        if not table:
+            return []
+
+        today = self._today_provider()
+        market = _SOSOK_NAME[sosok]
+        rows = []
+        for tr in table.find_all("tr"):
+            link = tr.find("a", class_="tltle")
+            if not link:
+                continue
+            cells = tr.find_all("td", class_="number")
+            if len(cells) < 5:
+                continue
+            code = (link.get("href") or "").split("code=")[-1].strip()
+            price = _to_int(cells[0].get_text())
+            cap = _to_int(cells[4].get_text())
+            rate = _to_rate(cells[2].get_text())
+            if not code or price is None or cap is None or rate is None:
+                continue
+            rows.append({
+                "code": code,
+                "name": link.get_text(strip=True),
+                "current_price": price,
+                "change_rate": rate,
+                "market_cap": cap,
+                "market": market,
+                "trade_date": today,
+            })
+        return rows
+
+    async def _fetch_page(self, sosok: int, page: int) -> str:
+        url = f"{_BASE_URL}?sosok={sosok}&page={page}"
+        timeout = aiohttp.ClientTimeout(total=self._PAGE_TIMEOUT_SEC)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=_HEADERS) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"HTTP {response.status}")
+                # 네이버 금융은 아직 euc-kr 이라 aiohttp 자동 판별에 맡기면 깨진다.
+                return await response.text(encoding="euc-kr")
+
+    @staticmethod
+    def _today_kst() -> str:
+        return datetime.now(pytz.timezone("Asia/Seoul")).strftime("%Y%m%d")
+
+
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
+
+
+def _to_int(text: str):
+    try:
+        return int(str(text).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_rate(text: str):
+    """'+2.43%' → '2.43', '-1.20%' → '-1.20'. 저장소가 TEXT 로 주는 모양에 맞춘다."""
+    cleaned = str(text).replace("%", "").replace("+", "").replace(",", "").strip()
+    try:
+        return f"{float(cleaned):.2f}"
+    except (TypeError, ValueError):
+        return None

--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -857,11 +857,11 @@ function setPageVisible(window, visible) {
   Object.defineProperty(window.document, "hidden", { value: !visible, configurable: true });
 }
 
-function autoRefreshPage() {
+function autoRefreshPage({ realtime = false } = {}) {
   const calls = [];
   const window = makeWindow(routed({
     "/api/market-mode": () => marketMode(["domestic", "overseas_us"]),
-    "/api/heatmap/domestic": () => success(domesticSnapshot()),
+    "/api/heatmap/domestic": () => success({ ...domesticSnapshot(), realtime }),
     "/api/overseas/top-market-cap": () => success({ items: [overseasItem({})], updated_at: 1767225600 }),
   }));
   const traced = window.fetchWithTimeout;
@@ -891,14 +891,41 @@ test("미국 탭을 보고 있으면 1분마다 조용히 다시 조회한다", 
   assert(panel.querySelectorAll(".heatmap-tile").length > 0, "갱신 후에도 타일이 남아야 함");
 });
 
-test("한국 탭은 자동 재조회하지 않는다 (하루 한 번 수집되는 스냅샷)", async () => {
-  const { window, calls, timer } = autoRefreshPage();
+test("국내 캡션은 실시간인지 종가인지를 밝힌다", async () => {
+  const live = autoRefreshPage({ realtime: true });
+  await live.window.initHeatmapPage();
+  const liveText = live.window.document.getElementById("heatmap-page-domestic-caption").textContent;
+  assert(liveText.includes("실시간"), `장중이면 실시간임을 알려야 함 (실제 ${liveText})`);
+  assert(!liveText.includes("종가"), `실시간인데 종가라고 하면 안 됨 (실제 ${liveText})`);
+
+  const closed = autoRefreshPage({ realtime: false });
+  await closed.window.initHeatmapPage();
+  const closedText = closed.window.document.getElementById("heatmap-page-domestic-caption").textContent;
+  assert(closedText.includes("종가"), `장외면 종가 기준임을 알려야 함 (실제 ${closedText})`);
+});
+
+test("국내가 실시간 응답이면 한국 탭도 조용히 다시 조회한다", async () => {
+  const { window, calls, timer } = autoRefreshPage({ realtime: true });
 
   await window.initHeatmapPage();
   calls.length = 0;
   await timer.fn();
 
-  assert(calls.length === 0, `되물어도 같은 종가라 조회할 이유가 없음 (실제 ${calls})`);
+  const domestic = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domestic.length === 1, `장중이면 국내도 갱신해야 함 (실제 ${domestic.length}회)`);
+  const panel = window.document.getElementById("heatmap-page-domestic");
+  assert(!panel.innerHTML.includes("조회 중"), "자동 갱신이 화면을 깜빡이면 안 됨");
+  assert(panel.querySelectorAll(".heatmap-tile").length > 0, "갱신 후에도 타일이 남아야 함");
+});
+
+test("국내가 종가 응답이면 한국 탭은 자동 재조회하지 않는다", async () => {
+  const { window, calls, timer } = autoRefreshPage({ realtime: false });
+
+  await window.initHeatmapPage();
+  calls.length = 0;
+  await timer.fn();
+
+  assert(calls.length === 0, `장외엔 되물어도 같은 종가라 조회할 이유가 없음 (실제 ${calls})`);
 });
 
 test("창이 백그라운드면 자동 갱신을 건너뛴다", async () => {

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -165,7 +165,10 @@ def mock_web_ctx():
     ctx.initialized = True
     ctx.market_mode = "domestic"
     ctx.enabled_market_modes = ["domestic"]
-    
+    # 국내 히트맵의 장중 소스. MagicMock 이 자동 생성한 truthy 목이 조용히 끼어들지 않도록
+    # 기본은 '미배선'으로 두고, 필요한 테스트만 명시적으로 채운다.
+    ctx.naver_market_snapshot_service = None
+
     # 하위 서비스 Mocking
     ctx.stock_query_service = AsyncMock()
     ctx.streaming_service = AsyncMock()

--- a/tests/unit_test/services/test_naver_market_snapshot_service.py
+++ b/tests/unit_test/services/test_naver_market_snapshot_service.py
@@ -1,0 +1,198 @@
+"""NaverMarketSnapshotService 단위 테스트.
+
+네트워크는 타지 않는다 — page_fetcher 를 주입해 실제 마크업을 축약한 픽스처를 먹인다.
+픽스처는 2026-08-14 실제 응답의 table.type_2 구조를 그대로 옮긴 것이다.
+"""
+import pytest
+
+from services.naver_market_snapshot_service import NaverMarketSnapshotService
+
+
+def _row(code, name, price, rate_text, cap):
+    """네이버 시총 페이지의 데이터 행 한 줄 (td.number 순서가 계약이다)."""
+    return f"""
+    <tr onMouseOver="mouseOver(this)">
+      <td class="no">1</td>
+      <td><a href="/item/main.naver?code={code}" class="tltle">{name}</a></td>
+      <td class="number">{price}</td>
+      <td class="number">
+        <em class="bu_p bu_pup"><span class="blind">상승</span></em><span class="tah p11 red02"> 6,500 </span>
+      </td>
+      <td class="number"><span class="tah p11 red01"> {rate_text} </span></td>
+      <td class="number">100</td>
+      <td class="number">{cap}</td>
+      <td class="number">5,846,279</td>
+      <td class="number">46.70</td>
+      <td class="number">21,668,266</td>
+      <td class="number">22.19</td>
+      <td class="number">10.85</td>
+      <td class="center"><a href="/item/board.naver?code={code}">토론</a></td>
+    </tr>
+    """
+
+
+def _page(*rows):
+    return f"""
+    <table class="type_2">
+      <tr><th scope="col">N</th><th scope="col">종목명</th><th scope="col">현재가</th>
+          <th scope="col">전일비</th><th scope="col">등락률</th><th scope="col">액면가</th>
+          <th scope="col">시가총액</th></tr>
+      <tr><td colspan="13" class="division_line"></td></tr>
+      {''.join(rows)}
+    </table>
+    """
+
+
+KOSPI_PAGE = _page(
+    _row("005930", "삼성전자", "274,500", "+2.43%", "16,048,035"),
+    _row("000660", "SK하이닉스", "1,688,000", "+5.96%", "12,330,711"),
+)
+KOSDAQ_PAGE = _page(
+    _row("247540", "에코프로비엠", "180,000", "-1.20%", "176,000"),
+)
+
+
+def _fetcher(pages, calls=None):
+    """(sosok, page) -> HTML. 등록되지 않은 페이지는 빈 표(마지막 페이지)로 응답한다."""
+    async def fetch(sosok, page):
+        if calls is not None:
+            calls.append((sosok, page))
+        return pages.get((sosok, page), _page())
+    return fetch
+
+
+def _service(pages, calls=None, **kwargs):
+    kwargs.setdefault("today_provider", lambda: "20260814")
+    kwargs.setdefault("clock", lambda: 0.0)
+    return NaverMarketSnapshotService(page_fetcher=_fetcher(pages, calls), **kwargs)
+
+
+async def test_parses_rows_into_repository_shape():
+    service = _service({(0, 1): KOSPI_PAGE})
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert rows[0] == {
+        "code": "005930",
+        "name": "삼성전자",
+        "current_price": 274500,
+        "change_rate": "2.43",
+        "market_cap": 16048035,
+        "market": "KOSPI",
+        "trade_date": "20260814",
+    }
+
+
+async def test_market_cap_keeps_naver_unit_which_matches_the_db():
+    """네이버 시총은 이미 억원 단위라 daily_prices.market_cap 과 그대로 비교된다."""
+    service = _service({(0, 1): KOSPI_PAGE})
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI")
+
+    # 2026-08-13 종가 기준 DB 값이 15,668,027(억) 이었다 — 같은 자릿수여야 한다.
+    assert rows[0]["market_cap"] == 16048035
+
+
+async def test_keeps_the_sign_of_falling_stocks():
+    service = _service({(1, 1): KOSDAQ_PAGE})
+
+    rows = await service.get_snapshot(limit=10, market="KOSDAQ")
+
+    assert rows[0]["change_rate"] == "-1.20"
+    assert rows[0]["market"] == "KOSDAQ"
+
+
+async def test_merges_markets_sorted_by_market_cap_desc():
+    service = _service({(0, 1): KOSPI_PAGE, (1, 1): KOSDAQ_PAGE})
+
+    rows = await service.get_snapshot(limit=10, market=None)
+
+    assert [r["code"] for r in rows] == ["005930", "000660", "247540"]
+
+
+async def test_limit_slices_after_the_merge():
+    service = _service({(0, 1): KOSPI_PAGE, (1, 1): KOSDAQ_PAGE})
+
+    rows = await service.get_snapshot(limit=2, market=None)
+
+    assert [r["code"] for r in rows] == ["005930", "000660"]
+
+
+async def test_market_filter_does_not_fetch_the_other_market():
+    calls = []
+    service = _service({(0, 1): KOSPI_PAGE}, calls=calls)
+
+    await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert all(sosok == 0 for sosok, _ in calls), f"코스닥을 긁을 이유가 없다: {calls}"
+
+
+async def test_fetches_only_as_many_pages_as_the_limit_needs():
+    """limit 이 필요한 페이지 수를 이미 말해준다 — 그만큼만 긁는다."""
+    calls = []
+    service = _service({(0, 1): KOSPI_PAGE}, calls=calls)
+
+    await service.get_snapshot(limit=100, market="KOSPI")
+
+    pages = sorted(page for sosok, page in calls if sosok == 0)
+    assert pages == [1, 2], f"페이지당 50종목이면 limit 100 은 2페이지 (실제 {pages})"
+
+
+async def test_caps_pages_so_a_huge_limit_cannot_hammer_naver():
+    calls = []
+    service = _service({(0, 1): KOSPI_PAGE}, calls=calls)
+
+    await service.get_snapshot(limit=1000, market="KOSPI")
+
+    pages = [page for sosok, page in calls if sosok == 0]
+    assert len(pages) <= NaverMarketSnapshotService._MAX_PAGES, f"상한을 넘김 (실제 {len(pages)})"
+
+
+async def test_reuses_the_snapshot_within_ttl():
+    calls = []
+    now = [0.0]
+    service = _service({(0, 1): KOSPI_PAGE}, calls=calls, clock=lambda: now[0], ttl_sec=45.0)
+
+    await service.get_snapshot(limit=10, market="KOSPI")
+    before = len(calls)
+    now[0] = 44.0
+    await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert len(calls) == before, "TTL 안에서는 다시 긁지 않아야 함"
+
+
+async def test_refetches_after_ttl():
+    calls = []
+    now = [0.0]
+    service = _service({(0, 1): KOSPI_PAGE}, calls=calls, clock=lambda: now[0], ttl_sec=45.0)
+
+    await service.get_snapshot(limit=10, market="KOSPI")
+    before = len(calls)
+    now[0] = 46.0
+    await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert len(calls) > before, "TTL 이 지나면 새 스냅샷을 받아야 함"
+
+
+async def test_partial_page_failure_still_returns_what_was_collected():
+    async def flaky(sosok, page):
+        if page == 2:
+            raise RuntimeError("네이버 응답 없음")
+        return KOSPI_PAGE if page == 1 else _page()
+
+    service = NaverMarketSnapshotService(
+        page_fetcher=flaky, today_provider=lambda: "20260814", clock=lambda: 0.0
+    )
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert [r["code"] for r in rows] == ["005930", "000660"], "한 페이지가 죽어도 화면이 비면 안 됨"
+
+
+async def test_returns_empty_when_markup_no_longer_parses():
+    """마크업이 바뀌면 조용히 빈 목록이 된다 — 라우트가 저장소로 폴백할 수 있어야 한다."""
+    service = _service({(0, 1): "<html><body>개편된 페이지</body></html>"})
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI")
+
+    assert rows == []

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -638,7 +638,9 @@ async def test_get_domestic_heatmap_with_market_filter(web_client, mock_web_ctx)
     assert response.status_code == 200
     body = response.json()
     assert body["rt_cd"] == "0"
-    assert body["data"] == {"trade_date": None, "items": [], "period": "1d", "base_date": None}
+    assert body["data"] == {
+        "trade_date": None, "items": [], "period": "1d", "base_date": None, "realtime": False,
+    }
     mock_web_ctx.stock_repository.get_market_cap_snapshot.assert_awaited_once_with(limit=100, market="KOSDAQ")
 
 
@@ -651,3 +653,104 @@ async def test_get_domestic_heatmap_without_repository(web_client, mock_web_ctx)
 
     assert response.status_code == 200
     assert response.json()["rt_cd"] != "0"
+
+
+def _naver_service(rows=None, error=None):
+    """장중 스냅샷 서비스 대역. rows 를 주면 그대로, error 를 주면 던진다."""
+    service = AsyncMock()
+    if error is not None:
+        service.get_snapshot.side_effect = error
+    else:
+        service.get_snapshot.return_value = rows or []
+    return service
+
+
+_LIVE_ROW = {
+    "code": "005930", "name": "삼성전자", "change_rate": "2.43", "market_cap": 16048035,
+    "market": "KOSPI", "current_price": 274500, "trade_date": "20260814",
+}
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_uses_live_snapshot_during_market_hours(web_client, mock_web_ctx):
+    """장중에는 daily_prices 종가 대신 네이버 실시간 스냅샷을 쓴다."""
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service([_LIVE_ROW])
+
+    response = web_client.get("/api/heatmap/domestic?limit=300")
+
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["realtime"] is True
+    assert body["data"]["items"][0]["change_rate"] == "2.43"
+    assert body["data"]["trade_date"] == "20260814"
+    mock_web_ctx.naver_market_snapshot_service.get_snapshot.assert_awaited_once_with(
+        limit=300, market=None
+    )
+    assert not mock_web_ctx.stock_repository.get_market_cap_snapshot.called
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_uses_stored_snapshot_outside_market_hours(web_client, mock_web_ctx):
+    """장외에는 네이버도 종가만 주므로 긁지 않고 저장소를 쓴다."""
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=False)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service([_LIVE_ROW])
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[{
+        "code": "005930", "name": "삼성전자", "change_rate": "4.89", "market_cap": 15668027,
+        "market": "KOSPI", "current_price": 268000, "trade_date": "20260813",
+    }])
+
+    response = web_client.get("/api/heatmap/domestic?limit=300")
+
+    body = response.json()
+    assert body["data"]["realtime"] is False
+    assert body["data"]["trade_date"] == "20260813"
+    assert not mock_web_ctx.naver_market_snapshot_service.get_snapshot.called
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_falls_back_when_live_snapshot_is_empty(web_client, mock_web_ctx):
+    """마크업이 바뀌어 파싱이 0행이 되어도 화면이 비면 안 된다."""
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service([])
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[{
+        "code": "005930", "name": "삼성전자", "change_rate": "4.89", "market_cap": 15668027,
+        "market": "KOSPI", "current_price": 268000, "trade_date": "20260813",
+    }])
+
+    response = web_client.get("/api/heatmap/domestic?limit=300")
+
+    body = response.json()
+    assert body["data"]["realtime"] is False
+    assert len(body["data"]["items"]) == 1
+    assert mock_web_ctx.stock_repository.get_market_cap_snapshot.called
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_falls_back_when_live_snapshot_raises(web_client, mock_web_ctx):
+    """스크래핑이 터져도 장마감 스냅샷으로 화면을 살린다."""
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service(error=RuntimeError("네이버 응답 없음"))
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[{
+        "code": "005930", "name": "삼성전자", "change_rate": "4.89", "market_cap": 15668027,
+        "market": "KOSPI", "current_price": 268000, "trade_date": "20260813",
+    }])
+
+    response = web_client.get("/api/heatmap/domestic?limit=300")
+
+    body = response.json()
+    assert body["rt_cd"] == "0"
+    assert body["data"]["realtime"] is False
+    assert len(body["data"]["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_live_snapshot_honours_market_filter(web_client, mock_web_ctx):
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service([_LIVE_ROW])
+
+    web_client.get("/api/heatmap/domestic?limit=100&market=KOSDAQ")
+
+    mock_web_ctx.naver_market_snapshot_service.get_snapshot.assert_awaited_once_with(
+        limit=100, market="KOSDAQ"
+    )

--- a/view/web/bootstrap/query_bootstrap.py
+++ b/view/web/bootstrap/query_bootstrap.py
@@ -7,6 +7,7 @@ from repositories.period_ranking_repository import PeriodRankingRepository
 from repositories.sp500_repository import SP500Repository
 from scheduler.strategy_scheduler_store import StrategySchedulerStore
 from services.market_cap_gap_service import MarketCapGapService, YahooUsMarketCapProvider
+from services.naver_market_snapshot_service import NaverMarketSnapshotService
 from services.overseas_market_stats_service import OverseasMarketStatsService
 from services.stock_query_service import StockQueryService
 from view.web.market_mode_utils import is_market_enabled
@@ -63,6 +64,7 @@ class QueryBootstrap:
                 self._build_market_cap_gap_tasks(config, needs_batch)
 
             self._build_overseas_market_stats()
+            self._build_domestic_live_snapshot(is_overseas_us)
 
             ctx.stock_query_service = StockQueryService(
                 market_data_service=ctx.market_data_service,
@@ -81,6 +83,16 @@ class QueryBootstrap:
                 exc_info=True,
             )
             raise
+
+    def _build_domestic_live_snapshot(self, is_overseas_us: bool) -> None:
+        """국내 히트맵의 장중 시세 소스 (네이버 시총 페이지).
+
+        국내장 run 에서만 만든다. 미국장 전용 run 은 이 화면을 쓰지 않는다.
+        """
+        ctx = self._ctx
+        ctx.naver_market_snapshot_service = (
+            None if is_overseas_us else NaverMarketSnapshotService(logger=ctx.logger)
+        )
 
     def _build_overseas_market_stats(self) -> None:
         """미국장 시가총액/랭킹 화면용 통계 서비스.

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -214,6 +214,26 @@ def _heatmap_period_change_rate(row: dict, closes: dict):
         return None
 
 
+async def _domestic_heatmap_rows(ctx, repository, *, limit: int, market: Optional[str]):
+    """(행 목록, 실시간 여부). 장중에는 네이버 스냅샷, 장외에는 daily_prices 종가를 쓴다.
+
+    장외에 네이버를 긁어봐야 같은 종가가 오므로 요청을 아낀다. 장중이라도 스크래핑이
+    비거나 터지면 저장소로 되돌아간다 — 마크업 변경으로 화면이 통째로 비는 것보다
+    하루 지난 종가라도 그리는 편이 낫다.
+    """
+    service = getattr(ctx, "naver_market_snapshot_service", None)
+    if service is not None and await ctx.is_market_open_now():
+        try:
+            rows = await service.get_snapshot(limit=limit, market=market)
+        except Exception as exc:
+            ctx.logger.warning(f"국내 히트맵 장중 스냅샷 실패 — 저장소로 폴백: {exc}")
+        else:
+            if rows:
+                return rows, True
+
+    return await repository.get_market_cap_snapshot(limit=limit, market=market), False
+
+
 @router.get("/heatmap/domestic")
 async def get_domestic_heatmap(
     limit: int = Query(300, ge=1, le=1000),
@@ -237,7 +257,7 @@ async def get_domestic_heatmap(
     if not repository:
         return {"rt_cd": ErrorCode.API_ERROR.value, "msg1": "StockRepository 미설정", "data": None}
 
-    rows = await repository.get_market_cap_snapshot(limit=limit, market=market)
+    rows, realtime = await _domestic_heatmap_rows(ctx, repository, limit=limit, market=market)
 
     base_date = None
     closes = {}
@@ -278,6 +298,7 @@ async def get_domestic_heatmap(
             "items": items,
             "period": period,
             "base_date": base_date,
+            "realtime": realtime,
         },
     }
 

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -387,17 +387,25 @@ function resetHeatmapPageZoom() {
     }
 }
 
-// 자동 갱신 — 보고 있는 미국 탭만 조용히(로딩 문구 없이) 갈아끼운다. 매 주기마다
+// 자동 갱신 — 보고 있는 탭만 조용히(로딩 문구 없이) 갈아끼운다. 매 주기마다
 // '조회 중...' 을 띄우면 화면이 1분마다 깜빡이고 배율·검색 상태가 눈에 띄게 흔들린다.
+//
+// 국내는 서버가 장중에만 실시간 스냅샷을 주고 장외에는 daily_prices 종가를 준다.
+// 종가 응답(realtime=false)에는 되물어도 같은 값이 오므로 폴링하지 않는다.
+function _heatmapPageWorthRefreshing(market) {
+    if (market === 'overseas') return true;
+    return Boolean(HEATMAP_PAGE_SOURCES.domestic.lastData?.realtime);
+}
+
 async function _refreshHeatmapPageTick() {
     // pjax 로 다른 화면에 가 있으면 스스로 멈춘다 (타이머는 문서를 떠나도 계속 돈다).
     if (!document.getElementById('heatmap-page-viewport')) {
         _stopHeatmapPageAutoRefresh();
         return;
     }
-    if (document.hidden || _heatmapPageTab !== 'overseas') return;
+    if (document.hidden || !_heatmapPageWorthRefreshing(_heatmapPageTab)) return;
 
-    await _loadHeatmap(HEATMAP_PAGE_SOURCES.overseas, { showLoading: false });
+    await _loadHeatmap(HEATMAP_PAGE_SOURCES[_heatmapPageTab], { showLoading: false });
     _applyHeatmapPageSearch();
 }
 

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -246,11 +246,23 @@ function _heatmapDateText(value) {
 function _domesticCaption(data) {
     const latest = _heatmapDateText(data.trade_date);
     const periodLabel = HEATMAP_PERIOD_LABELS[String(data.period || '')];
-    if (!periodLabel) return latest ? `기준일: ${latest} 종가` : '기준일: --';
+    // 장중에는 서버가 실시간 스냅샷을 준다(realtime). 같은 화면이 종가일 때와 구분되지 않으면
+    // 언제 기준인지 알 수 없으므로 표기를 나눈다.
+    const nowText = data.realtime ? _heatmapClockText() : null;
+    if (!periodLabel) {
+        if (nowText) return `실시간 ${nowText} 기준`;
+        return latest ? `기준일: ${latest} 종가` : '기준일: --';
+    }
 
     const base = _heatmapDateText(data.base_date);
     if (!base) return `${periodLabel} 비교 데이터가 없습니다`;
+    if (nowText) return `${periodLabel} 등락률: ${base} 종가 → 실시간 ${nowText}`;
     return `${periodLabel} 등락률: ${base} → ${latest || '--'} 종가`;
+}
+
+function _heatmapClockText() {
+    const now = new Date();
+    return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
 }
 
 function _renderHeatmapCaption(elementId, text) {


### PR DESCRIPTION
## 왜

국내 히트맵은 `daily_prices`(장마감 +10분 수집) 종가라 **장중 내내 고정**이었다. "실시간 전종목 시세 소스가 없다"는 게 지금까지의 전제였는데, 2026-08-14 장중에 다시 실측해보니 전제가 틀렸다.

| 소스 | 결과 |
|---|---|
| FDR `StockListing('KRX')` | **GitHub 일별 CSV 캐시** — 08:22/08:24/09:05/09:20 네 캡처가 거래량까지 전일 종가와 동일. 장중 갱신 메커니즘 자체가 없다. NXT 미구현 |
| KRX MDC `getJsonData.cmd` | 세션 쿠키를 세워도 `LOGOUT` 400 |
| pykrx / FDR 비캐시 | 위와 같은 엔드포인트를 써서 함께 사망 |
| **네이버 시총 페이지** | **동작** — 09:08 삼성전자 271,750(+1.40%) → 09:09 272,750(+1.77%) |

핵심은 **히트맵이 전종목이 아니라 시총 상위 N 만 필요**하다는 점이다. 네이버 시총 페이지가 이미 시총 내림차순이라 필요한 페이지만 받으면 되고, limit 500 이 20요청(시장당 10) 병렬 5.4초에 덮인다.

## 무엇을

- **`NaverMarketSnapshotService` 신규** — 행 모양을 `get_market_cap_snapshot` 과 일부러 같게 맞춰 라우트가 소스만 갈아끼우면 되게 했다. 시가총액은 네이버가 이미 **억원** 단위로 줘서 `daily_prices.market_cap` 과 단위가 같다(변환 없음). TTL 45초, `limit` 이 필요한 페이지 수를 정하고 시장당 최대 12페이지로 상한.
- **라우트는 장중에만 네이버를 쓴다.** 장외엔 네이버도 종가만 주므로 긁을 이유가 없다. 스크래핑이 비거나 터지면 저장소로 폴백한다 — 마크업이 바뀌어 화면이 통째로 비는 것보다 하루 지난 종가라도 그리는 편이 낫다.
- **응답에 `realtime`** 을 실어 캡션이 "실시간 HH:MM 기준" / "기준일 … 종가" 를 구분하고, 화면은 **실시간 응답일 때만** 국내 탭을 60초로 폴링한다(장외에 무의미한 요청을 보내지 않는다 — #834 에서 세운 원칙 유지).

`period` 경로는 손대지 않았는데, 기간 수익률이 `current_price` 를 쓰므로 **장중에는 기간 히트맵도 자동으로 실시간**이 된다.

**비목표**: 업종(섹터) 축. 시총 페이지에 업종 컬럼이 없어 다른 페이지가 필요하다 → 별도 작업. (todo M-4 의 잔여 항목은 `pykrx.get_index_portfolio_deposit_file` 을 쓰기로 돼 있는데, 그 함수는 지금 **예외 없이 빈 리스트**를 반환한다. 소스부터 다시 정해야 한다.)

## 테스트

TDD 로 진행했다(각 단계마다 의도한 이유로 실패하는 것을 먼저 확인).

- `test_naver_market_snapshot_service.py` **신규 12건** — 실제 마크업을 축약한 픽스처 파싱, 억원 단위, 하락 부호, 시총 내림차순 병합, limit 슬라이스, 시장 필터가 반대편을 안 긁는 것, 필요한 페이지만 받는 것, 페이지 수 상한, TTL 재사용/만료, 부분 실패 degrade, 마크업 개편 시 빈 목록. **네트워크를 타지 않는다**(page_fetcher 주입).
- 라우트 **신규 5건** — 장중 네이버 / 장외 저장소 / 빈 결과 폴백 / 예외 폴백 / market 필터 전달.
- jsdom **신규 3건** — 실시간이면 국내도 폴링, 종가면 폴링 안 함, 캡션 구분.
- `conftest.py` 의 `mock_web_ctx` 에 `naver_market_snapshot_service = None` 기본값 추가 — MagicMock 이 자동 생성한 truthy 목이 기존 히트맵 테스트에 조용히 끼어드는 것을 막는다.

실제 네트워크로 이음매도 확인했다: 장중 → `realtime=True` 300행(삼성전자 274,500 +2.43%), 장외 → 저장소, 스크래핑 실패 → 저장소 폴백.

```
pytest tests/unit_test        → 7767 passed
pytest tests/integration_test → 279 passed
node run_heatmap_page_dom_tests.mjs   → 43/43
node run_market_heatmap_dom_tests.mjs → 13/13
```

## 알려진 취약성

HTML 파싱이라 네이버가 마크업을 바꾸면 깨진다. 그때 조용히 틀린 값이 아니라 **0행 → warning → 저장소 폴백**으로 떨어지도록 설계했고, 그 경로를 테스트로 잠갔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
