### PR TITLE
Keep the domestic heatmap universe the same when the market opens

### DIFF
--- a/repositories/stock_ohlcv_repository.py
+++ b/repositories/stock_ohlcv_repository.py
@@ -502,6 +502,27 @@ class StockOhlcvRepository:
             self._logger.error(f"StockOhlcvRepository daily_prices 전종목 조회 실패: {e}")
             return []
 
+    async def get_snapshot_codes(self) -> set:
+        """최신 거래일 스냅샷이 담고 있는 종목코드 집합.
+
+        히트맵이 장중에 쓰는 외부 소스(네이버)는 ETF·ETN·우선주까지 싣는다. 장외와 같은
+        종목 집합을 그리려면 이 유니버스로 잘라야 한다. 정지주(시총 0원)도 유니버스에는
+        남긴다 — 면적 계산에서만 빠질 뿐이다.
+        """
+        try:
+            async with self._get_read_connection() as conn:
+                async with conn.execute(
+                    """
+                    SELECT code FROM daily_prices
+                    WHERE trade_date = (SELECT MAX(trade_date) FROM daily_prices)
+                    """
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                return {row[0] for row in rows if row[0]}
+        except Exception as e:
+            self._logger.error(f"StockOhlcvRepository 스냅샷 종목코드 조회 실패: {e}")
+            return set()
+
     async def get_market_cap_snapshot(self, limit: int = 300, market: Optional[str] = None) -> List[Dict]:
         """최신 거래일의 시가총액 상위 종목 스냅샷 (국내 히트맵용).
 

--- a/repositories/stock_repository.py
+++ b/repositories/stock_repository.py
@@ -110,6 +110,10 @@ class StockRepository:
         """최신 거래일 기준 시가총액 상위 스냅샷 조회 (국내 히트맵용)."""
         return await self._ohlcv_repo.get_market_cap_snapshot(limit=limit, market=market)
 
+    async def get_snapshot_codes(self) -> set:
+        """최신 거래일 스냅샷의 종목코드 집합 (히트맵 장중 소스를 같은 유니버스로 자를 때 쓴다)."""
+        return await self._ohlcv_repo.get_snapshot_codes()
+
     async def get_period_base_closes(self, period_days: int = 0, ytd: bool = False) -> Dict:
         """최신 거래일에서 period_days 달력일 이전(ytd=True 면 올해 첫 거래일)의 종목별 기준종가 조회."""
         return await self._ohlcv_repo.get_period_base_closes(period_days=period_days, ytd=ytd)

--- a/services/naver_market_snapshot_service.py
+++ b/services/naver_market_snapshot_service.py
@@ -59,16 +59,30 @@ class NaverMarketSnapshotService:
         self._cached_at: dict[int, float] = {}
         self._cached_pages: dict[int, int] = {}
 
-    async def get_snapshot(self, limit: int, market: Optional[str] = None) -> list[dict]:
-        """시총 상위 종목 스냅샷. market 이 None/'ALL' 이면 코스피+코스닥을 합쳐 정렬한다."""
+    async def get_snapshot(
+        self, limit: int, market: Optional[str] = None, allowed_codes: Optional[set] = None
+    ) -> list[dict]:
+        """시총 상위 종목 스냅샷. market 이 None/'ALL' 이면 코스피+코스닥을 합쳐 정렬한다.
+
+        allowed_codes 를 주면 그 유니버스로 먼저 거른 뒤 상위 limit 을 자른다. 네이버 시총
+        페이지는 ETF·ETN·우선주까지 싣기 때문에, 히트맵이 장외에 그리던 종목 집합과
+        같게 맞추려면 이 필터가 필요하다. 자른 뒤에 거르면 limit 을 못 채운다.
+        """
         wanted = self._target_sosoks(market)
         if not wanted:
             return []
 
-        pages = min(-(-limit // _PAGE_SIZE), self._MAX_PAGES)
+        # 걸러낼 종목이 섞여 있으므로 limit 만큼의 페이지로는 모자랄 수 있다. 필터가 있으면
+        # 여유를 두고 받는다(실측상 상위 500 중 약 22% 가 ETF·ETN 이었다).
+        needed = limit * 2 if allowed_codes is not None else limit
+        pages = min(-(-needed // _PAGE_SIZE), self._MAX_PAGES)
+
         collected: list[dict] = []
         for sosok in wanted:
-            collected.extend(await self._market_rows(sosok, pages))
+            rows = await self._market_rows(sosok, pages)
+            if allowed_codes is not None:
+                rows = [row for row in rows if row["code"] in allowed_codes]
+            collected.extend(rows)
 
         collected.sort(key=lambda row: row["market_cap"], reverse=True)
         return collected[:limit]

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -168,6 +168,8 @@ def mock_web_ctx():
     # 국내 히트맵의 장중 소스. MagicMock 이 자동 생성한 truthy 목이 조용히 끼어들지 않도록
     # 기본은 '미배선'으로 두고, 필요한 테스트만 명시적으로 채운다.
     ctx.naver_market_snapshot_service = None
+    # 유니버스 조회는 await 대상이라 기본을 깔아둔다(빈 집합 = 필터 없음).
+    ctx.stock_repository.get_snapshot_codes = AsyncMock(return_value=set())
 
     # 하위 서비스 Mocking
     ctx.stock_query_service = AsyncMock()

--- a/tests/unit_test/repositories/test_stock_ohlcv_repository.py
+++ b/tests/unit_test/repositories/test_stock_ohlcv_repository.py
@@ -1129,6 +1129,38 @@ class TestCacheLoggerPaths:
         logger.log_today_candle.assert_called_once()
 
 
+class TestGetSnapshotCodes:
+    """get_snapshot_codes: 히트맵이 그리는 종목 집합(장중 실시간 소스를 같은 유니버스로 자르는 데 쓴다)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_codes_of_the_latest_trade_date_only(self, repo):
+        await repo.upsert_daily_snapshot("20260713", [_make_snapshot("OLD", market_cap=100)])
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300),
+            _make_snapshot("A002", market_cap=200),
+        ])
+
+        codes = await repo.get_snapshot_codes()
+
+        assert codes == {"A001", "A002"}
+
+    @pytest.mark.asyncio
+    async def test_keeps_halted_stocks_so_the_universe_is_not_narrowed(self, repo):
+        """시총 0원(정지주)은 면적 계산에서만 빠질 뿐 유니버스에서 빼는 대상은 아니다."""
+        await repo.upsert_daily_snapshot("20260714", [
+            _make_snapshot("A001", market_cap=300),
+            _make_snapshot("HALT", market_cap=0),
+        ])
+
+        codes = await repo.get_snapshot_codes()
+
+        assert codes == {"A001", "HALT"}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_set_when_nothing_collected(self, repo):
+        assert await repo.get_snapshot_codes() == set()
+
+
 class TestGetMarketCapSnapshot:
     """get_market_cap_snapshot: 국내 히트맵용 최신 거래일 시총 스냅샷."""
 

--- a/tests/unit_test/services/test_naver_market_snapshot_service.py
+++ b/tests/unit_test/services/test_naver_market_snapshot_service.py
@@ -189,6 +189,42 @@ async def test_partial_page_failure_still_returns_what_was_collected():
     assert [r["code"] for r in rows] == ["005930", "000660"], "한 페이지가 죽어도 화면이 비면 안 됨"
 
 
+async def test_allowed_codes_narrows_the_universe_to_the_stored_one():
+    """네이버 시총 페이지는 ETF·ETN·우선주까지 싣는다. 히트맵 유니버스(daily_prices)에
+    없는 종목이 장중에만 끼어들면 화면 구성이 장외와 달라지므로 걸러낸다."""
+    page = _page(
+        _row("069500", "KODEX 200", "40,000", "+1.00%", "60,000"),
+        _row("005930", "삼성전자", "274,500", "+2.43%", "16,048,035"),
+    )
+    service = _service({(0, 1): page})
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI", allowed_codes={"005930"})
+
+    assert [r["code"] for r in rows] == ["005930"]
+
+
+async def test_allowed_codes_filters_before_slicing_the_limit():
+    """자른 뒤에 거르면 limit 을 못 채운다 — 거르고 나서 잘라야 한다."""
+    page = _page(
+        _row("069500", "KODEX 200", "40,000", "+1.00%", "9,000,000"),
+        _row("005930", "삼성전자", "274,500", "+2.43%", "8,000,000"),
+        _row("000660", "SK하이닉스", "1,688,000", "+5.96%", "7,000,000"),
+    )
+    service = _service({(0, 1): page})
+
+    rows = await service.get_snapshot(limit=2, market="KOSPI", allowed_codes={"005930", "000660"})
+
+    assert [r["code"] for r in rows] == ["005930", "000660"]
+
+
+async def test_allowed_codes_none_keeps_everything():
+    service = _service({(0, 1): KOSPI_PAGE})
+
+    rows = await service.get_snapshot(limit=10, market="KOSPI", allowed_codes=None)
+
+    assert len(rows) == 2
+
+
 async def test_returns_empty_when_markup_no_longer_parses():
     """마크업이 바뀌면 조용히 빈 목록이 된다 — 라우트가 저장소로 폴백할 수 있어야 한다."""
     service = _service({(0, 1): "<html><body>개편된 페이지</body></html>"})

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -685,7 +685,7 @@ async def test_get_domestic_heatmap_uses_live_snapshot_during_market_hours(web_c
     assert body["data"]["items"][0]["change_rate"] == "2.43"
     assert body["data"]["trade_date"] == "20260814"
     mock_web_ctx.naver_market_snapshot_service.get_snapshot.assert_awaited_once_with(
-        limit=300, market=None
+        limit=300, market=None, allowed_codes=None
     )
     assert not mock_web_ctx.stock_repository.get_market_cap_snapshot.called
 
@@ -745,12 +745,29 @@ async def test_get_domestic_heatmap_falls_back_when_live_snapshot_raises(web_cli
 
 
 @pytest.mark.asyncio
+async def test_get_domestic_heatmap_live_snapshot_reuses_the_stored_universe(web_client, mock_web_ctx):
+    """장중 소스(네이버)는 ETF·우선주까지 싣는다. 장외와 같은 종목 집합을 그려야 하므로
+    저장소가 가진 유니버스로 잘라 넘긴다."""
+    mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
+    mock_web_ctx.naver_market_snapshot_service = _naver_service([_LIVE_ROW])
+    mock_web_ctx.stock_repository.get_snapshot_codes = AsyncMock(return_value={"005930", "000660"})
+
+    web_client.get("/api/heatmap/domestic?limit=300")
+
+    mock_web_ctx.naver_market_snapshot_service.get_snapshot.assert_awaited_once_with(
+        limit=300, market=None, allowed_codes={"005930", "000660"}
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_domestic_heatmap_live_snapshot_honours_market_filter(web_client, mock_web_ctx):
     mock_web_ctx.is_market_open_now = AsyncMock(return_value=True)
     mock_web_ctx.naver_market_snapshot_service = _naver_service([_LIVE_ROW])
 
+    mock_web_ctx.stock_repository.get_snapshot_codes = AsyncMock(return_value={"005930"})
+
     web_client.get("/api/heatmap/domestic?limit=100&market=KOSDAQ")
 
     mock_web_ctx.naver_market_snapshot_service.get_snapshot.assert_awaited_once_with(
-        limit=100, market="KOSDAQ"
+        limit=100, market="KOSDAQ", allowed_codes={"005930"}
     )

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -224,7 +224,12 @@ async def _domestic_heatmap_rows(ctx, repository, *, limit: int, market: Optiona
     service = getattr(ctx, "naver_market_snapshot_service", None)
     if service is not None and await ctx.is_market_open_now():
         try:
-            rows = await service.get_snapshot(limit=limit, market=market)
+            # 장중 소스는 ETF·ETN·우선주까지 싣는다. 장마감 스냅샷이 담는 종목 집합으로
+            # 잘라, 장이 열리고 닫힐 때 화면 구성이 바뀌지 않게 한다.
+            allowed = await repository.get_snapshot_codes()
+            rows = await service.get_snapshot(
+                limit=limit, market=market, allowed_codes=allowed or None
+            )
         except Exception as exc:
             ctx.logger.warning(f"국내 히트맵 장중 스냅샷 실패 — 저장소로 폴백: {exc}")
         else:


### PR DESCRIPTION
## 회귀

#841 이 장중 소스를 네이버 시총 페이지로 바꾸면서 **화면에 담기는 종목 집합까지 바뀌었다.** 네이버는 ETF·ETN·우선주를 함께 싣는데 `daily_prices` 는 둘 다 담지 않는다.

실측(2026-08-14, 상위 500):

| | 종목 수 | ETF/ETN | 우선주 |
|---|---|---|---|
| 현재 main | 500 | **118** | 8 |
| 이 PR | 500 | 0 | 0 |

증상은 두 가지다.

- 국내 시장 히트맵에 **TIGER 미국S&P500** 같은 해외지수 ETF 가 타일로 뜬다.
- **KODEX 200** 은 이미 개별 타일로 그려진 종목들을 면적에서 **중복 계상**한다.

장이 열리고 닫힐 때 바뀌어야 하는 것은 가격이지 구성이 아니다.

## 수정

저장소가 담고 있는 최신 거래일 종목코드 집합으로 장중 스냅샷을 자른다.

- `StockOhlcvRepository.get_snapshot_codes()` 신규. **정지주(시총 0원)는 유니버스에 남긴다** — 면적 계산에서만 빠질 뿐 화면에서 사라져야 하는 종목이 아니다.
- `get_snapshot(allowed_codes=)` 는 **자르기 전에 거른다.** 자른 뒤에 거르면 limit 을 못 채운다. 걸러질 종목이 섞여 있으므로 필터가 있을 때는 페이지를 여유 있게 받는다.

적용 후 상위 8종목이 `daily_prices` 와 정확히 일치한다: 삼성전자 · SK하이닉스 · SK스퀘어 · 삼성전기 · 현대차 · LG에너지솔루션 · 삼성바이오로직스 · 삼성생명.

## 테스트

TDD (각 단계마다 의도한 이유로 실패하는 것을 먼저 확인).

- 저장소 **신규 3건** — 최신 거래일만 반환, 정지주 유지, 미수집 시 빈 집합.
- 서비스 **신규 3건** — 유니버스로 좁히기, **자르기 전에 거르기**, `allowed_codes=None` 이면 전체 유지.
- 라우트 **신규 1건** — 저장소 유니버스를 서비스로 넘기는 것.
- `conftest` 의 `mock_web_ctx` 에 `get_snapshot_codes` 기본값(빈 집합 = 필터 없음) 추가 — await 대상이라 기본이 없으면 라우트가 예외 경로로 새어 테스트가 조용히 폴백을 검사하게 된다.

```
pytest tests/unit_test        → 7774 passed
pytest tests/integration_test → 279 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
