### PR TITLE
Group the domestic heatmap by industry

### DIFF
--- a/repositories/stock_classification_repository.py
+++ b/repositories/stock_classification_repository.py
@@ -252,6 +252,27 @@ class StockClassificationRepository:
             }
         return result
 
+    async def get_code_category_map(self, category_type: str) -> Dict[str, str]:
+        """{종목코드: normalized_name}. 히트맵이 종목마다 업종을 붙일 때 쓴다.
+
+        get_groups() 를 뒤집어 쓰면 매 요청마다 수천 건짜리 그룹 구조를 재구성해야 한다.
+        업종은 배타적이라 코드당 그룹이 하나이므로 이 형태가 맞다.
+        """
+        await self._ensure_locks()
+        async with self._read_conn_lock:
+            try:
+                conn = await self._get_read_conn()
+                async with conn.execute(
+                    "SELECT code, normalized_name FROM stock_classifications "
+                    "WHERE category_type = ?",
+                    (category_type,),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+            except Exception as e:
+                self._logger.error(f"StockClassificationRepository.get_code_category_map 실패: {e}")
+                return {}
+        return {code: name for code, name in rows if code and name}
+
     async def get_latest_collected_at(self) -> Optional[str]:
         """가장 최근 collected_at 값 반환. 데이터가 없으면 None."""
         await self._ensure_locks()

--- a/services/theme_classification_collector_service.py
+++ b/services/theme_classification_collector_service.py
@@ -1,9 +1,9 @@
 # services/theme_classification_collector_service.py
 """
-네이버 금융 테마 분류를 스크래핑하여 StockClassificationRepository에 적재하는 서비스.
+네이버 금융 그룹 분류(테마·업종)를 스크래핑하여 StockClassificationRepository에 적재하는 서비스.
 
-- 목록: finance.naver.com/sise/sise_group.naver?type=theme  → 테마명 + detail no
-- 상세: finance.naver.com/sise/sise_group_detail.naver?type=theme&no=N → 구성종목(code, name)
+- 목록: finance.naver.com/sise/sise_group.naver?type={theme|upjong}  → 그룹명 + detail no
+- 상세: finance.naver.com/sise/sise_group_detail.naver?type={...}&no=N → 구성종목(code, name)
 - 개별 실패는 warning 후 skip(부분 성공 허용). 파싱은 정적 메서드로 분리해 테스트 가능.
 - HTML 구조 변경 시 깨질 수 있으므로 graceful degrade(예외 흡수, 0 반환)를 유지한다.
 """
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from repositories.stock_classification_repository import StockClassificationRepository
 
 _BASE = "https://finance.naver.com"
-_LIST_URL = _BASE + "/sise/sise_group.naver?type=theme"
-_DETAIL_URL = _BASE + "/sise/sise_group_detail.naver?type=theme&no={no}"
+_LIST_URL = _BASE + "/sise/sise_group.naver?type={group_type}"
+_DETAIL_URL = _BASE + "/sise/sise_group_detail.naver?type={group_type}&no={no}"
 _DEFAULT_ALIAS_CONFIG = os.path.join("config", "theme_aliases.yaml")
 
 _RE_DETAIL_NO = re.compile(r"no=(\d+)")
@@ -31,10 +31,15 @@ _RE_CODE = re.compile(r"code=(\d{6})")
 
 
 class ThemeClassificationCollectorService:
-    """네이버 테마 분류 수집기 (NAVER, category_type=theme)."""
+    """네이버 그룹 분류 수집기 (NAVER) — 테마(category_type=theme)와 업종(industry).
+
+    두 분류는 URL 의 type 값만 다르고 목록·상세 마크업이 같아 파서를 공유한다.
+    파서를 복제하면 네이버가 마크업을 바꿀 때 한쪽만 고쳐지는 일이 생긴다.
+    """
 
     SOURCE = "NAVER"
     CATEGORY_TYPE = "theme"
+    INDUSTRY_CATEGORY_TYPE = "industry"
 
     def __init__(
         self,
@@ -56,35 +61,55 @@ class ThemeClassificationCollectorService:
 
     async def collect_naver_themes(self) -> int:
         """네이버 테마 전체를 수집·저장하고 저장한 레코드 수를 반환한다."""
+        return await self._collect_groups("theme", self.CATEGORY_TYPE, use_aliases=True)
+
+    async def collect_naver_industries(self) -> int:
+        """네이버 업종 전체를 수집·저장하고 저장한 레코드 수를 반환한다.
+
+        업종은 테마와 달리 **배타적**이다(2026-08-14 실측: 두 업종 이상에 속한 종목 0건).
+        그래서 히트맵의 섹터 블록처럼 '종목 하나 = 그룹 하나'를 전제하는 화면에 바로 쓸 수 있다.
+        alias 는 테마명을 묶기 위한 개념이라 업종에는 적용하지 않는다 — 적용하면 분류가 뒤섞인다.
+        """
+        return await self._collect_groups("upjong", self.INDUSTRY_CATEGORY_TYPE, use_aliases=False)
+
+    async def _collect_groups(self, group_type: str, category_type: str, *, use_aliases: bool) -> int:
+        """네이버 그룹(테마/업종) 분류를 수집해 (SOURCE, category_type) 으로 통째 교체한다."""
         try:
-            list_html = await self._fetch_html(_LIST_URL)
-            themes = self._parse_theme_list(list_html)
+            list_html = await self._fetch_html(_LIST_URL.format(group_type=group_type))
+            groups = self._parse_theme_list(list_html)
         except Exception as e:
-            self._logger.warning({"event": "theme_list_fetch_failed", "error": str(e)})
+            self._logger.warning({"event": "group_list_fetch_failed", "type": group_type, "error": str(e)})
             return 0
 
-        if not themes:
-            self._logger.warning({"event": "theme_list_empty"})
+        if not groups:
+            self._logger.warning({"event": "group_list_empty", "type": group_type})
             return 0
 
-        await self._sync_aliases()
-        alias_map = await self._repo.get_alias_map(self.SOURCE)
+        if use_aliases:
+            await self._sync_aliases()
+            alias_map = await self._repo.get_alias_map(self.SOURCE)
+        else:
+            alias_map = {}
         collected_at = datetime.now().isoformat(timespec="seconds")
         records: List[dict] = []
 
-        for no, raw_name in themes:
+        for no, raw_name in groups:
             try:
-                detail_html = await self._fetch_html(_DETAIL_URL.format(no=no))
+                detail_html = await self._fetch_html(
+                    _DETAIL_URL.format(group_type=group_type, no=no)
+                )
                 members = self._parse_theme_members(detail_html)
             except Exception as e:
-                self._logger.warning({"event": "theme_detail_fetch_failed", "no": no, "error": str(e)})
+                self._logger.warning(
+                    {"event": "group_detail_fetch_failed", "type": group_type, "no": no, "error": str(e)}
+                )
                 continue
 
             normalized = alias_map.get(raw_name, raw_name)
             for code, name in members:
                 records.append({
                     "source": self.SOURCE,
-                    "category_type": self.CATEGORY_TYPE,
+                    "category_type": category_type,
                     "group_name": raw_name,
                     "normalized_name": normalized,
                     "code": code,
@@ -97,9 +122,11 @@ class ThemeClassificationCollectorService:
         if not records:
             return 0
         saved = await self._repo.replace_source_classifications(
-            self.SOURCE, self.CATEGORY_TYPE, records
+            self.SOURCE, category_type, records
         )
-        self._logger.info({"event": "theme_collect_done", "themes": len(themes), "records": saved})
+        self._logger.info(
+            {"event": "group_collect_done", "type": group_type, "groups": len(groups), "records": saved}
+        )
         return saved
 
     async def _sync_aliases(self) -> None:

--- a/task/background/after_market/theme_classification_task.py
+++ b/task/background/after_market/theme_classification_task.py
@@ -44,6 +44,7 @@ class ThemeClassificationTask(AfterMarketTask):
             "running": False,
             "last_collected_at": None,
             "record_count": 0,
+            "industry_record_count": 0,
             "status": None,
             "last_error": None,
         }
@@ -77,6 +78,9 @@ class ThemeClassificationTask(AfterMarketTask):
         try:
             count = await self._collector.collect_naver_themes()
             self._progress["record_count"] = count
+            # 업종은 같은 사이트·같은 주기라 한 번의 실행에서 이어서 수집한다. 실패해도
+            # 테마 결과는 남긴다 — 둘은 서로 독립적인 분류다.
+            self._progress["industry_record_count"] = await self._collect_industries()
             self._progress["last_collected_at"] = await self._repo.get_latest_collected_at()
             self._progress["status"] = "done"
         except Exception as e:
@@ -85,6 +89,14 @@ class ThemeClassificationTask(AfterMarketTask):
             self._logger.error({"event": "theme_collect_error", "error": str(e)})
         finally:
             self._progress["running"] = False
+
+    async def _collect_industries(self) -> int:
+        try:
+            return await self._collector.collect_naver_industries()
+        except Exception as e:
+            self._progress["last_error"] = f"업종 수집 실패: {e}"
+            self._logger.error({"event": "industry_collect_error", "error": str(e)})
+            return 0
 
     async def _is_fresh(self) -> bool:
         """최근 수집 시각이 refresh_interval_days 이내면 True."""

--- a/tests/frontend/run_market_heatmap_dom_tests.mjs
+++ b/tests/frontend/run_market_heatmap_dom_tests.mjs
@@ -329,4 +329,56 @@ test("한 소스의 조회가 다른 소스의 히트맵을 덮어쓰지 않는�
   assert(doc.querySelector('#domestic-panel .heatmap-tile[data-symbol="005930"]'), "국내 히트맵이 렌더되어야 함");
 });
 
+// 업종(sector)이 채워지면 미국 맵처럼 섹터 블록으로 묶는다. 네이버 업종은 배타적이라
+// (2026-08-14 실측: 두 업종 이상 소속 0건) 종목 하나가 한 블록에만 들어간다.
+test("국내 히트맵은 업종이 오면 섹터 블록으로 묶는다", async () => {
+  const window = makeWindow(async () => success({
+    trade_date: "20260814",
+    items: [
+      domesticItem({ code: "005930", name: "삼성전자", sector: "반도체와반도체장비", market_cap: 500 }),
+      domesticItem({ code: "000660", name: "SK하이닉스", sector: "반도체와반도체장비", market_cap: 400 }),
+      domesticItem({ code: "005380", name: "현대차", sector: "자동차", market_cap: 300 }),
+    ],
+  }));
+
+  await window._loadHeatmap(domesticSource(window));
+
+  const target = window.document.getElementById("domestic-panel");
+  const sectors = [...target.querySelectorAll(".heatmap-sector")].map(el => el.dataset.sector);
+  assert(
+    JSON.stringify(sectors) === JSON.stringify(["반도체와반도체장비", "자동차"]),
+    `섹터가 시총 합계순이어야 함 (실제 ${sectors.join(", ")})`,
+  );
+  assert(target.querySelectorAll(".heatmap-tile").length === 3, "종목 타일은 그대로 3개");
+});
+
+test("업종이 없는 종목은 기타로 묶는다", async () => {
+  const window = makeWindow(async () => success({
+    trade_date: "20260814",
+    items: [
+      domesticItem({ code: "005930", sector: "반도체와반도체장비", market_cap: 500 }),
+      domesticItem({ code: "999999", name: "미분류주", sector: null, market_cap: 100 }),
+    ],
+  }));
+
+  await window._loadHeatmap(domesticSource(window));
+
+  const sectors = [...window.document.querySelectorAll("#domestic-panel .heatmap-sector")]
+    .map(el => el.dataset.sector);
+  assert(sectors.includes("기타"), `미분류는 기타로 (실제 ${sectors.join(", ")})`);
+});
+
+test("업종이 하나도 없으면 예전처럼 단일 그리드로 그린다", async () => {
+  const window = makeWindow(async () => success({
+    trade_date: "20260814",
+    items: [domesticItem({ code: "005930" }), domesticItem({ code: "000660", market_cap: 100 })],
+  }));
+
+  await window._loadHeatmap(domesticSource(window));
+
+  const target = window.document.getElementById("domestic-panel");
+  assert(!target.querySelector(".heatmap-sector-title"), "분류 수집 전에는 섹터 헤더가 없어야 함");
+  assert(target.querySelectorAll(".heatmap-tile").length === 2, "타일은 그대로 그려져야 함");
+});
+
 await run();

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -170,6 +170,8 @@ def mock_web_ctx():
     ctx.naver_market_snapshot_service = None
     # 유니버스 조회는 await 대상이라 기본을 깔아둔다(빈 집합 = 필터 없음).
     ctx.stock_repository.get_snapshot_codes = AsyncMock(return_value=set())
+    # 업종 분류도 await 대상. 기본은 '분류 없음' 이라 sector 가 None 으로 나온다.
+    ctx.stock_classification_repository.get_code_category_map = AsyncMock(return_value={})
 
     # 하위 서비스 Mocking
     ctx.stock_query_service = AsyncMock()

--- a/tests/unit_test/repositories/test_stock_classification_repository.py
+++ b/tests/unit_test/repositories/test_stock_classification_repository.py
@@ -161,3 +161,38 @@ async def test_replace_source_empty_keeps_existing(repo):
     assert n == 0
     groups = await repo.get_groups(("theme",))
     assert {m["code"] for m in groups["로봇"]["members"]} == {"005930"}
+
+
+# ── get_code_category_map: 종목 → 그룹 역방향 조회 ─────────────
+# 히트맵이 종목마다 업종을 붙일 때 쓴다. get_groups() 를 뒤집어 쓰면 매 요청마다
+# 2500건짜리 그룹 구조를 재구성해야 한다.
+
+@pytest.mark.asyncio
+async def test_code_category_map_returns_code_to_group(repo):
+    await repo.upsert_classifications([
+        _rec("NAVER", "005930", "삼성전자", group="반도체와반도체장비",
+             normalized="반도체와반도체장비", cat="industry"),
+        _rec("NAVER", "035720", "카카오", group="양방향미디어와서비스",
+             normalized="양방향미디어와서비스", cat="industry"),
+    ])
+
+    assert await repo.get_code_category_map("industry") == {
+        "005930": "반도체와반도체장비",
+        "035720": "양방향미디어와서비스",
+    }
+
+
+@pytest.mark.asyncio
+async def test_code_category_map_ignores_other_category_types(repo):
+    await repo.upsert_classifications([
+        _rec("NAVER", "005930", "삼성전자", group="반도체와반도체장비",
+             normalized="반도체와반도체장비", cat="industry"),
+        _rec("NAVER", "005930", "삼성전자", group="로봇", normalized="로봇", cat="theme"),
+    ])
+
+    assert await repo.get_code_category_map("industry") == {"005930": "반도체와반도체장비"}
+
+
+@pytest.mark.asyncio
+async def test_code_category_map_empty_when_not_collected(repo):
+    assert await repo.get_code_category_map("industry") == {}

--- a/tests/unit_test/services/test_theme_classification_collector_service.py
+++ b/tests/unit_test/services/test_theme_classification_collector_service.py
@@ -148,3 +148,66 @@ async def test_collect_without_alias_config_skips_alias_upsert(repo):
     saved = await svc.collect_naver_themes()
     assert saved == 1
     repo.upsert_aliases.assert_not_called()
+
+
+# ── 업종(upjong) 수집 ────────────────────────────────────────
+# 업종 페이지는 테마 페이지와 URL 패턴·마크업이 같아 같은 파서를 쓴다.
+# 다른 점은 type=upjong, category_type='industry', 그리고 alias 미적용이다.
+
+@pytest.mark.asyncio
+async def test_collect_industries_uses_upjong_urls(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(side_effect=[
+        _list_html([("278", "반도체와반도체장비")]),
+        _detail_html([("005930", "삼성전자")]),
+    ])
+
+    await svc.collect_naver_industries()
+
+    urls = [call.args[0] for call in svc._fetch_html.call_args_list]
+    assert all("type=upjong" in url for url in urls), f"업종 URL 이어야 함: {urls}"
+    assert "no=278" in urls[1]
+
+
+@pytest.mark.asyncio
+async def test_collect_industries_stores_industry_category(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(side_effect=[
+        _list_html([("278", "반도체와반도체장비")]),
+        _detail_html([("005930", "삼성전자"), ("000660", "SK하이닉스")]),
+    ])
+
+    saved = await svc.collect_naver_industries()
+
+    assert saved == 2
+    src, cat, recs = repo.replace_source_classifications.call_args[0]
+    assert (src, cat) == ("NAVER", "industry")
+    assert recs[0]["category_type"] == "industry"
+    assert recs[0]["group_name"] == "반도체와반도체장비"
+    assert [r["code"] for r in recs] == ["005930", "000660"]
+
+
+@pytest.mark.asyncio
+async def test_collect_industries_does_not_apply_theme_aliases(repo):
+    """alias 는 테마 전용 개념이다. 업종명을 테마 alias 로 바꾸면 분류가 뒤섞인다."""
+    repo.get_alias_map = AsyncMock(return_value={"반도체와반도체장비": "2차전지"})
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(side_effect=[
+        _list_html([("278", "반도체와반도체장비")]),
+        _detail_html([("005930", "삼성전자")]),
+    ])
+
+    await svc.collect_naver_industries()
+
+    recs = repo.replace_source_classifications.call_args[0][2]
+    assert recs[0]["normalized_name"] == "반도체와반도체장비"
+    repo.upsert_aliases.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collect_industries_empty_list_returns_zero(repo):
+    svc = ThemeClassificationCollectorService(repo, logger=MagicMock(), request_delay=0)
+    svc._fetch_html = AsyncMock(return_value="<html>개편된 페이지</html>")
+
+    assert await svc.collect_naver_industries() == 0
+    repo.replace_source_classifications.assert_not_called()

--- a/tests/unit_test/task/background/after_market/test_theme_classification_task.py
+++ b/tests/unit_test/task/background/after_market/test_theme_classification_task.py
@@ -68,3 +68,43 @@ async def test_force_run_ignores_guard():
 
     await task.force_run()
     collector.collect_naver_themes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_collects_industries_in_the_same_run():
+    """업종은 테마와 같은 사이트·같은 주기라 한 번의 실행에서 함께 수집한다.
+
+    별도 태스크로 두면 전역 수집시각(get_latest_collected_at)을 공유해 서로의
+    주기 가드를 건드린다.
+    """
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock(return_value=12)
+    collector.collect_naver_industries = AsyncMock(return_value=79)
+    repo = MagicMock()
+    repo.get_latest_collected_at = AsyncMock(return_value=None)
+    task = _make_task(collector, repo)
+
+    await task._on_market_closed("20260621")
+
+    collector.collect_naver_themes.assert_awaited_once()
+    collector.collect_naver_industries.assert_awaited_once()
+    assert task.get_progress()["record_count"] == 12
+    assert task.get_progress()["industry_record_count"] == 79
+    assert task.get_progress()["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_industry_failure_does_not_lose_the_theme_result():
+    """업종 수집이 터져도 테마 결과와 진행 상태는 남아야 한다."""
+    collector = MagicMock()
+    collector.collect_naver_themes = AsyncMock(return_value=12)
+    collector.collect_naver_industries = AsyncMock(side_effect=RuntimeError("업종 페이지 개편"))
+    repo = MagicMock()
+    repo.get_latest_collected_at = AsyncMock(return_value=None)
+    task = _make_task(collector, repo)
+
+    await task._on_market_closed("20260621")
+
+    assert task.get_progress()["record_count"] == 12
+    assert task.get_progress()["industry_record_count"] == 0
+    assert "업종" in str(task.get_progress()["last_error"]) or task.get_progress()["last_error"]

--- a/tests/unit_test/view/web/routes/test_web_routes_ranking.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_ranking.py
@@ -541,6 +541,7 @@ async def test_get_domestic_heatmap(web_client, mock_web_ctx):
         "change_rate": "-0.72",
         "market_cap": 12101797,
         "market": "KOSPI",
+        "sector": None,
     }]
     # 기본은 일간 등락률이므로 기간 기준가를 조회하지 않는다.
     assert body["data"]["period"] == "1d"
@@ -653,6 +654,42 @@ async def test_get_domestic_heatmap_without_repository(web_client, mock_web_ctx)
 
     assert response.status_code == 200
     assert response.json()["rt_cd"] != "0"
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_attaches_industry_sector(web_client, mock_web_ctx):
+    """업종 분류가 있으면 item 에 sector 를 붙인다(화면이 섹터 블록으로 묶는다)."""
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "1.0", "market_cap": 100,
+         "trade_date": "20260814", "market": "KOSPI", "current_price": 1},
+        {"code": "999999", "name": "미분류주", "change_rate": "1.0", "market_cap": 50,
+         "trade_date": "20260814", "market": "KOSPI", "current_price": 1},
+    ])
+    mock_web_ctx.stock_classification_repository.get_code_category_map = AsyncMock(
+        return_value={"005930": "반도체와반도체장비"}
+    )
+
+    body = web_client.get("/api/heatmap/domestic").json()
+
+    items = {item["code"]: item for item in body["data"]["items"]}
+    assert items["005930"]["sector"] == "반도체와반도체장비"
+    assert items["999999"]["sector"] is None, "분류가 없는 종목은 None (화면이 기타로 묶는다)"
+    mock_web_ctx.stock_classification_repository.get_code_category_map.assert_awaited_with("industry")
+
+
+@pytest.mark.asyncio
+async def test_get_domestic_heatmap_without_classification_repository(web_client, mock_web_ctx):
+    """분류 저장소가 없으면 sector 없이 기존처럼 단일 그리드로 그린다."""
+    mock_web_ctx.stock_classification_repository = None
+    mock_web_ctx.stock_repository.get_market_cap_snapshot = AsyncMock(return_value=[
+        {"code": "005930", "name": "삼성전자", "change_rate": "1.0", "market_cap": 100,
+         "trade_date": "20260814", "market": "KOSPI", "current_price": 1},
+    ])
+
+    body = web_client.get("/api/heatmap/domestic").json()
+
+    assert body["rt_cd"] == "0"
+    assert body["data"]["items"][0]["sector"] is None
 
 
 def _naver_service(rows=None, error=None):

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -40,13 +40,21 @@ def test_home_menu_links_to_heatmap_page():
     assert 'href="/heatmap"' in template, "홈에서 전용 페이지로 갈 수 있어야 함"
 
 
-def test_domestic_heatmap_uses_daily_snapshot_and_shows_base_date():
+def test_domestic_heatmap_shows_whether_it_is_live_or_a_close():
     script = _heatmap_js()
 
-    # 실시간 전종목 시세 소스가 없어 장마감 후 스냅샷을 쓴다 — 기준일을 감추지 않는다.
+    # 장중에는 실시간, 장외에는 장마감 종가다 — 어느 쪽인지 화면이 밝힌다.
     assert "/api/heatmap/domestic" in _heatmap_page_js()
     assert "기준일" in script and "종가" in script
-    # 배타적 업종 분류가 없으므로 섹터 블록 없이 단일 그룹으로 그린다.
+    assert "실시간" in script
+
+
+def test_domestic_heatmap_groups_by_industry_when_available():
+    """업종 분류가 채워지면 섹터 블록, 수집 전이면 단일 그리드."""
+    script = _heatmap_js()
+
+    assert "_groupBySector" in script
+    # 분류 수집 전에는 어느 종목에도 sector 가 없어 예전처럼 단일 그룹으로 떨어져야 한다.
     assert "sector: null" in script
 
 

--- a/view/web/routes/ranking.py
+++ b/view/web/routes/ranking.py
@@ -1,6 +1,7 @@
 """
 랭킹/시가총액 관련 API 엔드포인트 (ranking.html, marketcap.html).
 """
+import time
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -197,6 +198,9 @@ async def get_ytd_return_ranking(limit: int = Query(100, ge=1, le=500), market: 
 # "1d" 는 스냅샷에 이미 들어 있는 일간 등락률이라 추가 조회가 없다.
 # "ytd"(올해)만 달력일이 아니라 올해 첫 거래일이 기준이라 저장소에서 따로 계산한다.
 _HEATMAP_PERIOD_DAYS = {"1d": 0, "1w": 7, "1m": 30, "3m": 91, "6m": 182, "1y": 365}
+# 업종 분류 캐시 TTL — 장마감 배치가 하루 1회 갱신하므로 매 폴링마다 다시 읽을 이유가 없다.
+# 캐시 자체는 모듈 전역이 아니라 ctx 에 얹는다(전역이면 테스트 사이로 값이 샌다).
+_INDUSTRY_CACHE_TTL_SEC = 600
 _HEATMAP_PERIOD_LABELS = {
     "1d": "1일", "1w": "1주", "1m": "1개월", "3m": "3개월", "6m": "6개월", "ytd": "올해", "1y": "1년",
 }
@@ -212,6 +216,30 @@ def _heatmap_period_change_rate(row: dict, closes: dict):
         return round((float(current_price) / float(base_close) - 1.0) * 100, 2)
     except (TypeError, ValueError, ZeroDivisionError):
         return None
+
+
+async def _domestic_industry_map(ctx) -> dict:
+    """{종목코드: 업종명}. 분류는 장마감 배치가 하루 1회 갱신하는 정적 데이터라 캐시한다."""
+    repo = getattr(ctx, "stock_classification_repository", None)
+    if repo is None:
+        return {}
+
+    now = time.monotonic()
+    cache = getattr(ctx, "_heatmap_industry_cache", None)
+    if isinstance(cache, tuple) and (now - cache[0]) <= _INDUSTRY_CACHE_TTL_SEC:
+        return cache[1]
+
+    try:
+        mapping = await repo.get_code_category_map("industry") or {}
+    except Exception as exc:
+        ctx.logger.warning(f"국내 히트맵 업종 분류 조회 실패 — 섹터 없이 그린다: {exc}")
+        return {}
+
+    try:
+        ctx._heatmap_industry_cache = (now, mapping)
+    except Exception:  # pragma: no cover - ctx 가 속성 설정을 막는 경우
+        pass
+    return mapping
 
 
 async def _domestic_heatmap_rows(ctx, repository, *, limit: int, market: Optional[str]):
@@ -274,6 +302,7 @@ async def get_domestic_heatmap(
         base_date = (base or {}).get("base_date")
         closes = (base or {}).get("closes") or {}
 
+    industries = await _domestic_industry_map(ctx)
     items = [
         {
             "code": row.get("code") or "",
@@ -284,6 +313,7 @@ async def get_domestic_heatmap(
             ),
             "market_cap": row.get("market_cap"),
             "market": row.get("market") or "",
+            "sector": industries.get(row.get("code")),
         }
         for row in rows
     ]

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -160,12 +160,17 @@ function _overseasGroups(items) {
 }
 
 // 국내는 배타적 업종 분류가 없어(네이버 테마는 중복 소속) 섹터 블록 없이 단일 그룹으로 그린다.
+// 업종(sector)은 장마감 배치가 채운다. 아직 수집 전이면 어느 종목에도 없으므로
+// 예전처럼 시총순 단일 그리드로 그린다 — 섹터 블록은 분류가 생긴 뒤에만 의미가 있다.
 function _domesticGroups(items) {
     const members = [];
+    let hasSector = false;
     items.forEach(raw => {
         const row = raw && typeof raw === 'object' ? raw : {};
         const cap = _heatmapNumber(row.market_cap);
         if (cap === null || cap <= 0) return;
+        const sector = row.sector ? String(row.sector) : null;
+        if (sector) hasSector = true;
         members.push({
             symbol: String(row.code ?? ''),
             label: String(row.name ?? ''),
@@ -173,12 +178,32 @@ function _domesticGroups(items) {
             rate: _heatmapNumber(row.change_rate),
             cap,
             capText: formatMarketCap(cap),
+            sector,
         });
     });
     if (!members.length) return [];
 
     members.sort((a, b) => b.cap - a.cap);
-    return [{ sector: null, cap: members.reduce((sum, m) => sum + m.cap, 0), members }];
+    if (!hasSector) {
+        return [{ sector: null, cap: members.reduce((sum, m) => sum + m.cap, 0), members }];
+    }
+    return _groupBySector(members);
+}
+
+// 미국 맵과 같은 모양(섹터 합계 내림차순, 블록 안에서도 시총 내림차순)으로 묶는다.
+function _groupBySector(members) {
+    const groups = new Map();
+    members.forEach(member => {
+        const sector = member.sector || '기타';
+        if (!groups.has(sector)) groups.set(sector, { sector, cap: 0, members: [] });
+        const group = groups.get(sector);
+        group.cap += member.cap;
+        group.members.push(member);
+    });
+
+    const groupList = [...groups.values()].sort((a, b) => b.cap - a.cap);
+    groupList.forEach(group => group.members.sort((a, b) => b.cap - a.cap));
+    return groupList;
 }
 
 // zoom 은 캔버스를 몇 배로 늘려 그리는지(전용 페이지의 확대 배율). 타일이 그만큼 커지므로


### PR DESCRIPTION
## 왜

국내 히트맵은 배타적 업종 분류가 없어 **시총순 단일 그리드**였다(미국은 섹터 블록 2단). todo M-4 의 잔여 항목은 `pykrx.get_index_portfolio_deposit_file` 을 쓰기로 돼 있었으나 KRX 차단으로 쓸 수 없다(#842 참조).

네이버 업종 페이지를 실측해 조건을 확인했다.

| 항목 | 결과 |
|---|---|
| 업종 수 | 79 |
| **배타성** | **두 업종 이상에 속한 종목 0건** |
| top500 커버리지 | 99.6% (498/500), '기타' 0건 |
| 유니버스 전체 | 98.7% (2549/2583) |
| 수집 비용 | 79요청, 실제 적재 4029 레코드 |

배타성이 핵심이다. todo 가 "NAVER 테마를 대표 1개로 강제 배정하는 안은 채택하지 않는다(종목당 평균 2.7개 소속 → 임의 규칙이 화면 해석을 왜곡)"고 못박아 둔 문제가 **업종에는 없다** — 임의 규칙 없이 그대로 쓸 수 있다.

## 무엇을

업종 페이지는 테마 페이지와 **URL 의 `type` 값만 다르고 마크업이 같다.** 파서를 복제하면 네이버가 마크업을 바꿀 때 한쪽만 고쳐지므로, 기존 수집기를 파라미터화해 공유한다. (클래스명은 바꾸지 않았다 — 참조가 bootstrap·태스크·테스트에 퍼져 있어 요청과 무관한 줄을 건드리게 된다.)

- **`collect_naver_industries()` 신규.** alias 는 테마명을 묶는 개념이라 업종에는 적용하지 않는다 — 적용하면 분류가 뒤섞인다(테스트로 잠갔다).
- **수집은 기존 `ThemeClassificationTask` 가 같은 실행에서 이어서 한다.** 별도 태스크로 두면 전역 수집시각(`get_latest_collected_at`)을 공유해 서로의 주기 가드를 건드린다. 새 태스크·스케줄러 등록·설정 항목이 없다. 업종 수집이 실패해도 테마 결과는 남긴다.
- **`get_code_category_map()` 신규.** `get_groups()` 를 뒤집어 쓰면 매 요청마다 수천 건짜리 그룹 구조를 재구성해야 한다.
- **라우트가 item 에 `sector` 를 채운다.** 분류는 하루 1회 갱신되는 정적 데이터라 TTL 캐시(10분)를 두되, **모듈 전역이 아니라 ctx 에** 얹었다 — 전역이면 테스트 사이로 값이 샌다.
- **화면은 `sector` 가 하나라도 있으면 섹터 블록으로 묶고, 수집 전이면 예전처럼 단일 그리드**다. 미분류 종목은 '기타' 블록으로 간다.

## 테스트

TDD (각 단계마다 의도한 이유로 실패하는 것을 먼저 확인).

- 수집기 **신규 4건** — upjong URL 사용, `category_type='industry'` 저장, **테마 alias 미적용**, 빈 목록 시 0. 기존 테마 테스트 9건은 그대로 통과(회귀 가드).
- 태스크 **신규 2건** — 같은 실행에서 업종까지 수집, **업종 실패가 테마 결과를 지우지 않음**.
- 저장소 **신규 3건** — code→group 매핑, 다른 category_type 무시, 미수집 시 빈 dict.
- 라우트 **신규 2건** — sector 부착, 분류 저장소가 없으면 None.
- jsdom **신규 3건** — 섹터 블록 묶기(시총 합계순), 미분류는 '기타', **업종이 하나도 없으면 단일 그리드**.

실제 수집도 확인했다: 4029 레코드 적재 → top500 커버리지 498/500, 상위 업종은 반도체와반도체장비 54 · 제약 32 · 화학 30.

```
pytest tests/unit_test        → 7786 passed
pytest tests/integration_test → 279 passed
node run_market_heatmap_dom_tests.mjs → 16/16
node run_heatmap_page_dom_tests.mjs   → 43/43
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
