### PR TITLE
Drop the dead market-timing lookups from two strategies

### DIFF
--- a/strategies/larry_williams_channel_breakout_strategy.py
+++ b/strategies/larry_williams_channel_breakout_strategy.py
@@ -97,11 +97,7 @@ class LarryWilliamsChannelBreakoutStrategy(LiveStrategy):
 
         self._logger.info({"event": "scan_with_watchlist", "count": len(watchlist)})
 
-        # 시장 국면 게이트 — state 변경 전 차단
-        market_timing = {
-            "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
-            "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
-        }
+        # 시장 국면 판정은 스케줄러 공통 주문 게이트가 한다(#766). 전략은 조회하지 않는다.
         today_str = now.strftime("%Y%m%d")
         candidates = []
         for code, item in watchlist.items():

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -139,13 +139,7 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
             return signals
         self._logger.info({"event": "pool_b_loaded", "count": len(candidates)})
 
-        # 2-1) 시장 국면 게이트 — universe 가 있을 때만 수행 (state 변경 전)
-        market_timing: Dict[str, bool] = {}
-        if self._universe is not None:
-            market_timing = {
-                "KOSPI": await self._universe.is_market_timing_ok("KOSPI", caller=self.name, logger=self._logger),
-                "KOSDAQ": await self._universe.is_market_timing_ok("KOSDAQ", caller=self.name, logger=self._logger),
-            }
+        # 시장 국면 판정은 스케줄러 공통 주문 게이트가 한다(#766). 전략은 조회하지 않는다.
         candidate_codes = [c["code"] for c in candidates if c.get("code")]
         await self._sqs.prefetch_prices(candidate_codes)
 

--- a/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_channel_breakout_market_gate.py
@@ -1,7 +1,11 @@
-"""LarryWilliamsCB 전략의 시장 국면 게이트 단위 테스트.
+"""LarryWilliamsCB 전략과 시장 국면의 관계를 잠그는 단위 테스트.
 
-- bear regime → 종목 skip, entry_rejected/reason=market_timing_off
-- bull regime → 기존 로직 진행
+#766 이 마켓타이밍 차단을 스케줄러 공통 주문 게이트로 옮긴 뒤로, 이 전략은 레짐에 따라
+스캔을 바꾸지 않는다. 그래서 여기서 잠그는 것은 '차단'이 아니라 **차단하지 않음**이다.
+
+- bear regime 이어도 관찰용 진입 평가는 계속한다
+- 전략 수준의 entry_rejected/market_timing_off 는 남기지 않는다
+- 마켓타이밍을 조회하지도 않는다
 """
 import os
 import tempfile
@@ -114,3 +118,15 @@ async def test_bull_regime_proceeds_to_entry_check(tmp_path):
     sqs.get_ohlcv.return_value = MagicMock(rt_cd="0", data=[{"close": 100}])
     await strategy.scan()
     sqs.get_ohlcv.assert_awaited()  # 게이트 통과 → 진입 평가 시작
+
+
+@pytest.mark.asyncio
+async def test_scan_does_not_query_market_timing_at_all(tmp_path):
+    """마켓타이밍 판정은 스케줄러 공통 주문 게이트가 한다 — 전략은 조회하지 않는다."""
+    watchlist = {"035720": _make_watchlist_item("035720", "KOSDAQ", "카카오")}
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False}, watchlist)
+    strategy, _ = _make_strategy(universe, state_file=str(tmp_path / "lwcb_state.json"))
+
+    await strategy.scan()
+
+    universe.is_market_timing_ok.assert_not_called()

--- a/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_market_gate.py
@@ -1,8 +1,12 @@
-"""LarryWilliamsVBO 전략의 시장 국면 게이트 단위 테스트.
+"""LarryWilliamsVBO 전략과 시장 국면의 관계를 잠그는 단위 테스트.
 
-- bear regime → 종목 skip, entry_rejected/reason=market_timing_off
-- bull regime → 기존 로직 진행 (게이트 통과)
-- universe_service 없음 → 게이트 우회 (fallback 호환)
+#766 이 마켓타이밍 차단을 스케줄러 공통 주문 게이트로 옮긴 뒤로, 이 전략은 레짐에 따라
+스캔을 바꾸지 않는다. 그래서 여기서 잠그는 것은 '차단'이 아니라 **차단하지 않음**이다.
+
+- bear regime 이어도 관찰용 진입 평가는 계속한다
+- 전략 수준의 entry_rejected/market_timing_off 는 남기지 않는다
+- 마켓타이밍을 조회하지도 않는다
+- universe_service 없음 → fallback 경로 호환
 """
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -140,3 +144,18 @@ async def test_universe_none_bypasses_market_gate():
     # universe 없으면 게이트 미수행 — 가격 조회까지 도달
     await strategy.scan()
     sqs.handle_get_current_stock_price.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scan_does_not_query_market_timing_at_all():
+    """마켓타이밍 판정은 스케줄러 공통 주문 게이트가 한다 — 전략은 조회하지 않는다.
+
+    #766 이 차단 코드를 스케줄러로 옮기면서 전략에는 결과를 쓰지 않는 조회만 남았다.
+    조회가 남아 있으면 '이 전략이 마켓타이밍을 본다'고 코드가 거짓말을 한다.
+    """
+    universe = _make_universe({"KOSPI": True, "KOSDAQ": False})
+    strategy, _ = _make_strategy(universe)
+
+    await strategy.scan()
+
+    universe.is_market_timing_ok.assert_not_called()


### PR DESCRIPTION
todo M-7 잔여 항목.

## 무엇이 죽어 있었나

#766 이 마켓타이밍 차단을 `StrategyScheduler._filter_market_timing_blocked_buys` 로 옮기면서 전략에는 **결과를 쓰지 않는 조회만** 남았다.

- `larry_williams_vbo_strategy.py` — `market_timing` 이 선언·대입 후 **0회 읽힘**
- `larry_williams_channel_breakout_strategy.py` — 대입 후 **0회 읽힘**

각각 scan 마다 KOSPI/KOSDAQ 2회를 부른다.

## todo 의 전제 하나를 정정한다

todo 는 "scan 마다 2회 호출"을 낭비로 적었는데, **성능 문제가 아니다.** `is_market_timing_ok` 는 `_market_timing_date != today` 일 때만 실제 계산하고 이후로는 dict 조회다(하루 1회 캐시).

진짜 문제는 **코드가 거짓말을 한다**는 것이다. 읽는 사람에게 "이 전략은 시장 국면을 본다"고 말하지만 실제로는 보지 않는다. 실제 판정은 스케줄러가 한다. 그래서 제거할 가치가 있다.

## 파급 — 로그/알림은 살아남는다

todo 는 "제거하면 `market_timing_updated` 로그 이벤트가 함께 사라진다"고 우려했으나, 확인 결과 **사라지지 않는다.**

- 유니버스 서비스는 전 전략이 공유하는 **단일 인스턴스**(`ctx.oneil_universe_service`)다. 나머지 5개 전략의 첫 호출이 `_update_market_timing` 을 그대로 발생시킨다.
- 소비처(`strategy_log_report_service.py:2210`)는 시장별 **최신** 이벤트만 보므로 전략 수와 무관하다.
- 남는 좁은 경우: **이 두 전략만 켜진 날**에는 이벤트가 나지 않는다. 일간 알림이 전략 스캔의 캐시 미스에 얹혀 있는 구조 자체가 원인이고, 이건 별개 과제로 남긴다.

`oneil_pocket_pivot_strategy.py:728` 은 실제 게이트로 쓰므로 건드리지 않았다.

## 테스트

- **신규 2건** — 두 전략의 `scan()` 이 `is_market_timing_ok` 를 **호출하지 않음**을 단정. 제거 전 "Called 2 times" 로 실패하는 것을 확인했다.
- 기존 `market_gate` 테스트들이 회귀 가드다 — 레짐과 무관하게 스캔이 계속되고 `entry_rejected/market_timing_off` 를 남기지 않음을 이미 동작으로 단정하고 있어, 호출 제거 후에도 그대로 통과한다.
- 두 테스트 파일의 docstring 이 **삭제한 죽은 코드와 같은 거짓말**을 하고 있었다("bear regime → 종목 skip, entry_rejected/reason=market_timing_off"). 본문은 정반대를 단정하고 있어 실제 계약에 맞춰 고쳤다.

```
pytest tests/unit_test        → 7788 passed
pytest tests/integration_test → 279 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
