### PR TITLE
Normalize stock codes in market status alerts

### DIFF
--- a/services/market_status_alert_service.py
+++ b/services/market_status_alert_service.py
@@ -45,7 +45,7 @@ class MarketStatusAlertService:
             await self._resolve_for_code(data)
             return
 
-        code = str(data.get("유가증권단축종목코드") or data.get("종목코드") or "UNKNOWN")
+        code = self._normalize_code(data.get("유가증권단축종목코드") or data.get("종목코드")) or "UNKNOWN"
         exchange = str(data.get("거래소구분코드") or data.get("EXCH_CLS_CODE") or "UNKNOWN")
         reason = str(data.get("거래정지사유내용") or "").strip()
         direction = self._classify_direction(reason)
@@ -170,7 +170,7 @@ class MarketStatusAlertService:
 
     async def on_futures_contract(self, data: dict[str, Any]) -> None:
         """코스피200 지수선물 체결가로 매수 사이드카 발동 조건을 감시한다."""
-        code = str(data.get("선물단축종목코드") or data.get("종목코드") or "UNKNOWN")
+        code = self._normalize_code(data.get("선물단축종목코드") or data.get("종목코드")) or "UNKNOWN"
         rate = self._signed_rate(
             data,
             rate_keys=("선물전일대비율", "전일대비율"),
@@ -340,10 +340,22 @@ class MarketStatusAlertService:
     def _direction_label(direction: Optional[str]) -> str:
         return {"buy": "매수", "sell": "매도", "up": "상승", "down": "하락"}.get(direction, "")
 
+    @staticmethod
+    def _normalize_code(code) -> str:
+        """종목코드를 6자리로 맞춘다 (`FavoritePriceAlertService._normalize_code` 와 같은 규칙).
+
+        dedup 키에 코드가 그대로 박히므로, 발동과 해제가 다른 표기로 오면 키가 어긋나
+        알림이 해제되지 않고 재발동한다. 선물코드처럼 숫자가 아닌 값은 건드리지 않는다.
+        """
+        normalized = str(code or "").strip()
+        if normalized.isdigit() and len(normalized) <= 6:
+            return normalized.zfill(6)
+        return normalized
+
     async def _resolve_for_code(self, data: dict[str, Any]) -> None:
         if self._operator_alert_service is None:
             return
-        code = str(data.get("유가증권단축종목코드") or data.get("종목코드") or "")
+        code = self._normalize_code(data.get("유가증권단축종목코드") or data.get("종목코드"))
         if not code:
             return
         active_keys = self._active_keys_by_code.pop(code, set())

--- a/tests/unit_test/services/test_market_status_alert_service.py
+++ b/tests/unit_test/services/test_market_status_alert_service.py
@@ -360,3 +360,65 @@ async def test_market_status_alert_service_resets_move_5_recovery_count_on_relap
         "market_index:move_5:down:0001",
         "지수 등락률 정상화",
     )
+
+
+# ── 종목코드 정규화 계약 ──────────────────────────────────────
+# 관심종목 알림에서 두 번(#755·#771) 고쳤던 것과 같은 결함 계열이다. dedup 키에 코드가
+# 그대로 박히므로, 발동과 해제가 다른 표기로 오면 키가 어긋나 알림이 해제되지 않고 재발동한다.
+
+@pytest.mark.asyncio
+async def test_dedup_key_uses_zero_padded_stock_code():
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(operator_alert_service=operator_alert, logger=MagicMock())
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "5930",           # 선행 0 이 빠진 표기
+        "거래정지여부": "Y",
+        "거래정지사유내용": "서킷브레이커 발동으로 매매거래중단",
+        "거래소구분코드": "KRX",
+    })
+
+    assert operator_alert.report.await_args.args[1] == "market_status:circuit_breaker:KRX:005930"
+    assert operator_alert.report.await_args.kwargs["metadata"]["stock_code"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_alert_resolves_even_when_the_code_arrives_padded_differently():
+    """짧은 코드로 발동하고 패딩된 코드로 정상화가 와도 해제돼야 한다."""
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(operator_alert_service=operator_alert, logger=MagicMock())
+
+    await service.on_market_status({
+        "유가증권단축종목코드": "5930",
+        "거래정지여부": "Y",
+        "거래정지사유내용": "서킷브레이커 발동으로 매매거래중단",
+        "거래소구분코드": "KRX",
+    })
+    await service.on_market_status({
+        "유가증권단축종목코드": "005930",        # 같은 종목, 다른 표기
+        "거래정지여부": "N",
+        "거래정지사유내용": "",
+        "거래소구분코드": "KRX",
+    })
+
+    operator_alert.resolve.assert_awaited_once_with(
+        AlertSource.MARKET_STATUS,
+        "market_status:circuit_breaker:KRX:005930",
+        "장운영정보 정상화",
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_numeric_codes_are_left_alone():
+    """선물 코드·미상(UNKNOWN) 처럼 숫자가 아닌 값은 건드리지 않는다."""
+    operator_alert = AsyncMock()
+    service = MarketStatusAlertService(operator_alert_service=operator_alert, logger=MagicMock())
+
+    await service.on_market_status({
+        "종목코드": "K200F",
+        "거래정지여부": "Y",
+        "거래정지사유내용": "서킷브레이커 발동으로 매매거래중단",
+        "거래소구분코드": "KRX",
+    })
+
+    assert operator_alert.report.await_args.args[1] == "market_status:circuit_breaker:KRX:K200F"


### PR DESCRIPTION
todo M-5 의 "반복 수정이 몰린 두 지점 회귀 커버리지 점검" 중 **종목코드 정규화** 축.

## 결함

`MarketStatusAlertService` 는 dedup 키에 종목코드를 그대로 박는데(`market_status:circuit_breaker:KRX:005930`) **코드를 정규화하지 않는다.** 발동(`_classify_event` 경로)과 해제(`_resolve_for_code`)가 서로 다른 표기로 오면 키가 어긋나 **알림이 해제되지 않고 재발동**한다.

관심종목 알림에서 **두 번**(#755 `deduplicate favorite price threshold alerts`, #771 `Fix favorite price alert deduplication`) 고쳤던 것과 같은 결함 계열이다. 그쪽은 `_normalize_code` 로 6자리 zero-pad 를 하는데, 이 서비스에는 그 교훈이 적용되지 않았다.

**왜 안 잡혔나**: 기존 테스트 15건이 전부 이미 패딩된 `"005930"` 만 쓴다. 정규화 계약을 잠그는 케이스가 하나도 없어, 알림 종류를 옮겨가며 같은 결함이 재발할 수 있는 상태였다 — todo 가 세운 가설 그대로다.

## 수정

종목/선물/해제 3개 진입점에 `FavoritePriceAlertService._normalize_code` 와 **같은 규칙**을 적용한다. 선물코드처럼 숫자가 아닌 값(`K200F`)은 건드리지 않는다.

## 테스트 (신규 3건)

- dedup 키가 zero-pad 된 코드를 쓴다 (`5930` → `005930`)
- **짧은 코드로 발동하고 패딩된 코드로 정상화가 와도 해제된다** — 실제 실패 시나리오
- 숫자가 아닌 코드는 그대로 둔다

제거 전 앞의 2건이 의도한 이유로 실패하는 것을 확인했다.

```
pytest tests/unit_test        → 7791 passed
pytest tests/integration_test → 279 passed
```

## 남은 M-5 축

**재시작 복원**은 이 PR 범위 밖이다. 조사 결과 `MarketStatusAlertService` 는 dedup 상태(`_active_keys_by_code` 등)를 **전부 메모리**에 두고 상태 파일이 없다. 반면 관심종목 알림은 #756 에서 `StrategyStateIO` 로 영속화했다. 같은 교훈이 적용되지 않은 두 번째 지점이지만, 영속화는 별도 크기의 작업이라 분리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
