### PR TITLE
Add a manual refresh button to the heatmap page

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -47,6 +47,7 @@ const SCAFFOLD = `
       <option value="1y">1년</option>
     </select>
   </span>
+  <button type="button" id="heatmap-page-refresh">새로고침</button>
   <span class="heatmap-zoom">
     <button type="button" id="heatmap-page-zoom-out">−</button>
     <span id="heatmap-page-zoom-level">100%</span>
@@ -961,6 +962,86 @@ test("pjax 재진입은 자동 갱신 타이머를 겹쳐 걸지 않는다", asy
 
   assert(timer.starts === 2, `재진입마다 타이머를 다시 걸어야 함 (실제 ${timer.starts}회)`);
   assert(timer.cleared.length === 1, `이전 타이머를 해제해야 함 (실제 ${timer.cleared.length}회)`);
+});
+
+// 수동 새로고침 — 자동 갱신과 달리 '지금 보고 싶다'는 사용자 의사이므로
+// 종가(realtime=false) 상태에서도 동작해야 한다.
+
+test("새로고침 버튼은 보고 있는 탭을 다시 조회한다", async () => {
+  const { window, calls } = autoRefreshPage({ realtime: true });
+
+  await window.initHeatmapPage();
+  calls.length = 0;
+  await window.refreshHeatmapPage();
+
+  const domestic = calls.filter(url => url.startsWith("/api/heatmap/domestic"));
+  assert(domestic.length === 1, `국내 탭을 다시 조회해야 함 (실제 ${domestic.length}회)`);
+  assert(window.document.querySelectorAll("#heatmap-page-domestic .heatmap-tile").length > 0,
+    "갱신 후에도 타일이 남아야 함");
+});
+
+test("종가 상태여도 새로고침 버튼은 조회한다", async () => {
+  const { window, calls, timer } = autoRefreshPage({ realtime: false });
+
+  await window.initHeatmapPage();
+  calls.length = 0;
+  await timer.fn();
+  assert(calls.length === 0, "자동 갱신은 종가에서 건너뛴다(전제)");
+
+  await window.refreshHeatmapPage();
+  assert(calls.filter(url => url.startsWith("/api/heatmap/domestic")).length === 1,
+    "수동은 사용자 의사이므로 종가여도 다시 조회해야 함");
+});
+
+test("미국 탭에서 새로고침하면 미국만 조회한다", async () => {
+  const { window, calls } = autoRefreshPage({ realtime: true });
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  calls.length = 0;
+  await window.refreshHeatmapPage();
+
+  assert(overseasCalls(calls).length === 1, "미국 스냅샷을 다시 받아야 함");
+  assert(!calls.some(url => url.startsWith("/api/heatmap/domestic")),
+    "보고 있지 않은 국내 탭을 조회할 이유가 없음");
+});
+
+test("새로고침 중에는 버튼을 잠가 중복 요청을 막는다", async () => {
+  let release;
+  const gate = new Promise(done => { release = done; });
+  let served = 0;
+  const window = makeWindow(routed({
+    "/api/market-mode": () => marketMode(["domestic"]),
+    // 첫 조회(초기화)는 바로 응답하고, 두 번째(수동 새로고침)만 붙잡아 '조회 중' 상태를 만든다.
+    "/api/heatmap/domestic": async () => {
+      served += 1;
+      if (served > 1) await gate;
+      return success({ ...domesticSnapshot(), realtime: true });
+    },
+  }));
+  setPageVisible(window, true);
+
+  await window.initHeatmapPage();
+  const button = window.document.getElementById("heatmap-page-refresh");
+  assert(!button.disabled, "평소에는 눌릴 수 있어야 함");
+
+  const pending = window.refreshHeatmapPage();
+  assert(button.disabled, "조회 중에는 잠겨야 함");
+  release();
+  await pending;
+  assert(!button.disabled, "끝나면 다시 눌릴 수 있어야 함");
+});
+
+test("수동 새로고침은 자동 갱신 타이머를 다시 건다", async () => {
+  const { window, timer } = autoRefreshPage({ realtime: true });
+
+  await window.initHeatmapPage();
+  const startsAfterInit = timer.starts;
+  await window.refreshHeatmapPage();
+
+  assert(timer.starts === startsAfterInit + 1,
+    `방금 받아왔으므로 다음 자동 갱신까지 한 주기를 새로 세야 함 (실제 ${timer.starts - startsAfterInit})`);
+  assert(timer.cleared.length >= 1, "이전 타이머는 해제돼야 함");
 });
 
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -233,3 +233,16 @@ def test_heatmap_follows_domestic_up_red_convention():
         assert int(hex_color[0:2], 16) > int(hex_color[4:6], 16), f"#{hex_color} 는 상승 색으로 부적절"
     for hex_color in re.findall(r"#([0-9a-f]{6})", down_block):
         assert int(hex_color[4:6], 16) > int(hex_color[0:2], 16), f"#{hex_color} 는 하락 색으로 부적절"
+
+
+def test_heatmap_page_hosts_a_manual_refresh_button():
+    """자동 갱신(60초)과 별개로 즉시 다시 조회할 수단이 있어야 한다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert 'id="heatmap-page-refresh"' in template
+    assert "refreshHeatmapPage()" in template
+    assert "async function refreshHeatmapPage" in page_script
+    # 연타로 중복 요청이 나가지 않도록 조회 중에는 잠근다.
+    assert "button.disabled = true" in page_script
+    assert ".heatmap-refresh:disabled" in template, "잠긴 상태가 보이지 않으면 연타하게 된다"

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -39,6 +39,7 @@ let _heatmapPagePeriod = HEATMAP_PAGE_DEFAULT_PERIOD;
 let _heatmapPageMarket = HEATMAP_PAGE_DEFAULT_MARKET;
 let _heatmapPageTab = 'domestic';
 let _heatmapPageRefreshTimer = null;
+let _heatmapPageRefreshing = false;
 
 function _heatmapPageZoom() {
     return HEATMAP_PAGE_ZOOM_STEPS[_heatmapPageZoomIndex];
@@ -407,6 +408,28 @@ async function _refreshHeatmapPageTick() {
 
     await _loadHeatmap(HEATMAP_PAGE_SOURCES[_heatmapPageTab], { showLoading: false });
     _applyHeatmapPageSearch();
+}
+
+// 수동 새로고침 — 자동 갱신과 두 가지가 다르다.
+//  1) 종가(realtime=false) 상태에서도 조회한다. 자동은 값이 안 바뀌어 건너뛰지만
+//     버튼을 누른 건 '지금 보고 싶다'는 사용자 의사다.
+//  2) 방금 받아왔으므로 다음 자동 갱신까지 한 주기를 새로 센다.
+async function refreshHeatmapPage() {
+    if (_heatmapPageRefreshing) return;
+    const source = HEATMAP_PAGE_SOURCES[_heatmapPageTab];
+    if (!source) return;
+
+    _heatmapPageRefreshing = true;
+    const button = document.getElementById('heatmap-page-refresh');
+    if (button) button.disabled = true;
+    try {
+        await _loadHeatmap(source, { showLoading: false });
+        _applyHeatmapPageSearch();
+        _startHeatmapPageAutoRefresh();
+    } finally {
+        _heatmapPageRefreshing = false;
+        if (button) button.disabled = false;
+    }
 }
 
 function _stopHeatmapPageAutoRefresh() {

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -33,6 +33,14 @@
             border: 1px solid var(--border); border-radius: 5px; font-size: 0.85rem;
         }
         .heatmap-zoom button:hover { border-color: var(--accent, #4a90e2); }
+        .heatmap-refresh {
+            padding: 3px 10px; cursor: pointer; font-size: 0.85rem;
+            background: var(--bg-secondary); color: var(--text-primary);
+            border: 1px solid var(--border); border-radius: 5px;
+        }
+        .heatmap-refresh:hover:not(:disabled) { border-color: var(--accent, #4a90e2); }
+        /* 조회 중에는 눌리지 않는다는 것이 보여야 한다 — 안 그러면 연타하게 된다. */
+        .heatmap-refresh:disabled { opacity: 0.5; cursor: progress; }
         #heatmap-page-zoom-level { font-size: 0.78rem; color: var(--text-secondary); min-width: 44px; text-align: center; }
         @media (max-width: 640px) { .heatmap-page-viewport { height: calc(100vh - 340px); } }
     </style>
@@ -76,6 +84,11 @@
                         <option value="1y">1년</option>
                     </select>
                 </span>
+                <button type="button" id="heatmap-page-refresh" class="heatmap-refresh"
+                        onclick="refreshHeatmapPage()"
+                        title="지금 보고 있는 탭을 즉시 다시 조회합니다 (평소에는 60초마다 자동 갱신)">
+                    ⟳ 새로고침
+                </button>
                 <span class="heatmap-zoom"
                       title="히트맵 위에서 마우스 휠로도 확대·축소할 수 있습니다 (스크롤바 위에서는 휠=위아래 이동, Ctrl+휠=좌우 이동)">
                     <button type="button" onclick="zoomHeatmapPage(-1)" title="축소" aria-label="축소">−</button>


### PR DESCRIPTION
## 왜

히트맵은 60초마다 자동 갱신되지만(#834·#841) **지금 당장 다시 받고 싶을 때 수단이 없었다.** 브라우저 새로고침은 배율·검색·탭 상태를 전부 잃는다.

## 자동 갱신과 다른 두 가지

- **종가(`realtime=false`) 상태에서도 조회한다.** 자동 폴링은 값이 안 바뀌어 건너뛰지만, 버튼을 누른 건 "지금 보고 싶다"는 사용자 의사다.
- **방금 받아왔으므로 다음 자동 갱신까지 한 주기를 새로 센다.** 안 그러면 수동 직후 자동 갱신이 겹쳐 돈다.

## 연타 방지

조회 중에는 버튼을 잠그고 **그 상태가 보이게** 한다(`:disabled { opacity: .5; cursor: progress }`). 안 보이면 연타하게 되고, 국내는 클릭당 네이버 최대 20요청이라 연타가 그대로 외부 부하가 된다.

로딩 문구는 띄우지 않는다 — 자동 갱신과 같은 이유로 화면이 깜빡이고 배율·검색 상태가 흔들려 보인다.

## 테스트

TDD (신규 5건이 `window.refreshHeatmapPage is not a function` 으로 먼저 실패하는 것을 확인).

- 보고 있는 탭을 다시 조회한다
- **종가 상태여도 조회한다** (같은 틱에서 자동 갱신은 건너뛰는 것을 함께 단정해 대비를 명시)
- 미국 탭에서는 미국만 조회한다(보고 있지 않은 탭은 건드리지 않음)
- 조회 중 버튼 잠금 → 완료 후 해제
- 수동 새로고침이 자동 타이머를 다시 건다

계약 테스트 1건으로 버튼·핸들러·잠금 스타일의 존재를 잠갔다.

```
pytest tests/unit_test        → 7792 passed
pytest tests/integration_test → 279 passed
node run_heatmap_page_dom_tests.mjs → 48/48
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
