### PR TITLE
Reconcile USD ledger against broker fills

### DIFF
--- a/repositories/overseas_trade_repository.py
+++ b/repositories/overseas_trade_repository.py
@@ -5,10 +5,10 @@
 기준이고 국내 브로커 잔고 대사에 물려 있어서, USD 체결을 섞으면 전략별 성과 통계와
 대사 고아가 오염된다. 통화가 다른 원장은 아예 다른 파일로 둔다.
 
-**기록 시점**: 해외는 국내 `FillReconciliationService` 같은 체결 대사 경로가 아직
-없어서, *주문 접수 성공* 시점에 기록한다. 따라서 체결되지 않은 지정가 주문도
-HOLD 로 잡힐 수 있다 — `get_overseas_order_history`(체결/미체결 조회) 기반 대사는
-후속 작업이다.
+**기록 시점**: 해외는 국내 `FillReconciliationService` 같은 실시간 체결 경로가 없어서
+*주문 접수 성공* 시점에 기록한다. 따라서 체결되지 않은 지정가 주문도 일단 HOLD 로
+잡힌다 — 이를 사후 보정하는 것이 `OverseasFillReconcileService`(브로커 체결내역 대조)
+이며, 그 매칭 키가 `order_no` 다.
 
 **부분 매도**: `log_sell(qty=...)` 은 체결분만 SOLD 로 분리하고 잔량을 HOLD 로
 남긴다. 국내 원장에서 이 처리를 빠뜨려(PR #700) 잔량이 원장에서 사라지고 다음
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS overseas_trades (
     return_rate REAL    NOT NULL DEFAULT 0.0,
     status      TEXT    NOT NULL,
     reason      TEXT    NOT NULL DEFAULT '',
-    source      TEXT    NOT NULL DEFAULT ''
+    source      TEXT    NOT NULL DEFAULT '',
+    order_no    TEXT    NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_overseas_trades_symbol_status
     ON overseas_trades(symbol, status);
@@ -52,6 +53,7 @@ CREATE INDEX IF NOT EXISTS idx_overseas_trades_symbol_status
 _COLUMNS = (
     "id", "symbol", "exchange", "currency", "buy_date", "buy_price", "qty",
     "sell_date", "sell_price", "return_rate", "status", "reason", "source",
+    "order_no",
 )
 
 
@@ -75,17 +77,32 @@ class OverseasTradeRepository:
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.executescript(_DDL)
+        self._ensure_columns()
+
+    def _ensure_columns(self) -> None:
+        """기존 DB에 신규 컬럼이 없으면 ALTER TABLE 로 추가 (idempotent)."""
+        existing = {row[1] for row in self._db.execute("PRAGMA table_info(overseas_trades)").fetchall()}
+        if "order_no" not in existing:
+            with self._db:
+                self._db.execute(
+                    "ALTER TABLE overseas_trades ADD COLUMN order_no TEXT NOT NULL DEFAULT ''"
+                )
 
     # ---- 기록 ----
 
-    def log_buy(self, symbol: str, exchange, price, qty: int, source: str = "") -> None:
+    def log_buy(self, symbol: str, exchange, price, qty: int, source: str = "",
+                order_no: str = "") -> None:
         """매수 lot 을 추가한다. 같은 심볼을 다시 사도 평단 병합 없이 별도 lot 으로 둔다
-        (진입가별 청산 추적을 잃지 않기 위해)."""
+        (진입가별 청산 추적을 잃지 않기 위해).
+
+        `order_no` 는 체결 대사의 매칭 키다 — 같은 심볼의 lot 이 여러 개면 수량 총합만으로는
+        어느 lot 이 미체결인지 구분할 수 없다.
+        """
         with self._db:
             self._db.execute(
                 "INSERT INTO overseas_trades "
-                "(symbol, exchange, currency, buy_date, buy_price, qty, status, source) "
-                "VALUES (?, ?, 'USD', ?, ?, ?, 'HOLD', ?)",
+                "(symbol, exchange, currency, buy_date, buy_price, qty, status, source, order_no) "
+                "VALUES (?, ?, 'USD', ?, ?, ?, 'HOLD', ?, ?)",
                 (
                     str(symbol).upper(),
                     self._exchange_value(exchange),
@@ -93,6 +110,7 @@ class OverseasTradeRepository:
                     float(price),
                     int(qty),
                     source,
+                    str(order_no or ""),
                 ),
             )
 
@@ -142,12 +160,12 @@ class OverseasTradeRepository:
                     self._db.execute(
                         "INSERT INTO overseas_trades "
                         "(symbol, exchange, currency, buy_date, buy_price, qty, sell_date, "
-                        "sell_price, return_rate, status, reason, source) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'SOLD', ?, ?)",
+                        "sell_price, return_rate, status, reason, source, order_no) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'SOLD', ?, ?, ?)",
                         (
                             row["symbol"], row["exchange"], row["currency"], row["buy_date"],
                             row["buy_price"], take, sold_date, sell_price, rate, reason,
-                            row["source"],
+                            row["source"], row["order_no"],
                         ),
                     )
                 sold_qty += take
@@ -156,12 +174,52 @@ class OverseasTradeRepository:
 
         return OverseasSellResult(sold_qty=sold_qty, return_rates=tuple(rates))
 
-    async def log_buy_async(self, symbol: str, exchange, price, qty: int, source: str = "") -> None:
-        await asyncio.to_thread(self.log_buy, symbol, exchange, price, qty, source)
+    async def log_buy_async(self, symbol: str, exchange, price, qty: int, source: str = "",
+                            order_no: str = "") -> None:
+        await asyncio.to_thread(self.log_buy, symbol, exchange, price, qty, source, order_no)
 
     async def log_sell_async(self, symbol: str, price, qty: int | None = None,
                              reason: str = "") -> OverseasSellResult:
         return await asyncio.to_thread(self.log_sell, symbol, price, qty, reason)
+
+    # ---- 체결 대사 보정 ----
+    #
+    # 기록이 *주문 접수* 시점이라 원장은 브로커 체결내역보다 과다 계상될 수 있다.
+    # 보정은 **줄이는 방향만** 허용한다 — 늘리면 브로커에 없는 보유를 만든다.
+
+    def mark_canceled(self, trade_id: int, reason: str = "") -> bool:
+        """미체결/취소로 확인된 lot 을 CANCELED 로 표시한다.
+
+        행을 지우지 않는다 — 주문이 실제로 나갔다는 사실 자체는 기록으로 남겨야 한다.
+        HOLD 가 아닌 행(이미 청산됨)은 건드리지 않는다. 실현 성과가 사라지기 때문이다.
+        """
+        with self._db:
+            cur = self._db.execute(
+                "UPDATE overseas_trades SET status='CANCELED', reason=? "
+                "WHERE id=? AND status='HOLD'",
+                (reason, int(trade_id)),
+            )
+        return cur.rowcount > 0
+
+    def adjust_qty(self, trade_id: int, filled_qty: int, reason: str = "") -> bool:
+        """부분체결 lot 의 수량을 체결분으로 줄인다. 0 이면 CANCELED 로 넘긴다."""
+        filled = int(filled_qty)
+        if filled < 0:
+            return False
+        row = self._db.execute(
+            "SELECT qty FROM overseas_trades WHERE id=? AND status='HOLD'",
+            (int(trade_id),),
+        ).fetchone()
+        if row is None or filled > int(row["qty"]):
+            return False
+        if filled == 0:
+            return self.mark_canceled(trade_id, reason=reason)
+        with self._db:
+            cur = self._db.execute(
+                "UPDATE overseas_trades SET qty=?, reason=? WHERE id=? AND status='HOLD'",
+                (filled, reason, int(trade_id)),
+            )
+        return cur.rowcount > 0
 
     # ---- 조회 ----
 
@@ -176,13 +234,25 @@ class OverseasTradeRepository:
         return [self._to_dict(row) for row in rows]
 
     def get_summary(self) -> dict:
-        """성과 요약. 승률/평균수익률은 청산된 거래만으로 계산한다."""
+        """성과 요약. 승률/평균수익률은 청산된 거래만으로 계산한다.
+
+        CANCELED(대사에서 미체결로 확인된 lot)는 실제로 성립한 적 없는 거래이므로
+        total 에서 제외한다 — 남겨 두면 성과 분모가 부풀려진다.
+        """
         rows = self._db.execute(
             "SELECT return_rate FROM overseas_trades WHERE status='SOLD'"
         ).fetchall()
-        total = self._db.execute("SELECT COUNT(*) FROM overseas_trades").fetchone()[0]
+        total = self._db.execute(
+            "SELECT COUNT(*) FROM overseas_trades WHERE status!='CANCELED'"
+        ).fetchone()[0]
+        canceled = self._db.execute(
+            "SELECT COUNT(*) FROM overseas_trades WHERE status='CANCELED'"
+        ).fetchone()[0]
         if not rows:
-            return {"total_trades": total, "sold_trades": 0, "win_rate": 0.0, "avg_return": 0.0}
+            return {
+                "total_trades": total, "sold_trades": 0, "win_rate": 0.0,
+                "avg_return": 0.0, "canceled_trades": canceled,
+            }
 
         returns = [float(row["return_rate"]) for row in rows]
         wins = sum(1 for r in returns if r > 0)
@@ -191,6 +261,7 @@ class OverseasTradeRepository:
             "sold_trades": len(returns),
             "win_rate": round(wins / len(returns) * 100, 2),
             "avg_return": round(sum(returns) / len(returns), 2),
+            "canceled_trades": canceled,
         }
 
     # ---- 계산 ----

--- a/services/overseas_fill_reconcile_service.py
+++ b/services/overseas_fill_reconcile_service.py
@@ -1,0 +1,172 @@
+"""미국장 USD 원장 체결 대사 (Phase 2).
+
+`OverseasTradeRepository` 는 해외에 실시간 체결 경로가 없어 *주문 접수* 시점에 기록한다.
+따라서 체결되지 않은 지정가 주문도 HOLD 로 잡힌다. 이 서비스는 브로커 체결내역
+(`inquire_overseas_ccnl`)을 진실로 삼아 그 과다 계상을 사후 보정한다.
+
+**보정은 줄이는 방향만** 한다. 늘리면 브로커에 없는 보유를 만들고, 판정이 애매한 lot 을
+미체결로 단정하면 실제 보유가 원장에서 사라진다 — 그래서 매칭 실패는 `unfilled` 가 아니라
+`unknown` 이고 무조작이다.
+
+`OverseasReconcileService`(잔고 drift 비교)와는 다른 축이다. 그쪽은 브로커 *잔고* 대비
+포지션 drift 를 보고, 이쪽은 브로커 *체결내역* 대비 원장 lot 을 본다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from common.types import ErrorCode, ResCommonResponse
+
+# KIS 해외 주문체결내역(TTTS3035R) 응답의 체결수량 후보 키. 표본별로 갈려서 관용 파싱한다.
+_FILLED_QTY_KEYS = ("ft_ccld_qty", "ccld_qty", "tot_ccld_qty", "FT_CCLD_QTY", "CCLD_QTY")
+_ORDER_NO_KEYS = ("odno", "ODNO")
+
+VERDICT_OK = "ok"
+VERDICT_PARTIAL = "partial"
+VERDICT_UNFILLED = "unfilled"
+VERDICT_UNKNOWN = "unknown"
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(float(str(value).replace(",", "")))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _first_key(row: Dict[str, Any], keys) -> str:
+    for key in keys:
+        if key in row and str(row[key]).strip() != "":
+            return str(row[key]).strip()
+    return ""
+
+
+class OverseasFillReconcileService:
+    def __init__(
+        self,
+        *,
+        trade_repository,
+        stock_query_service,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._ledger = trade_repository
+        self._query = stock_query_service
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def reconcile(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        exchange: str = "NASD",
+        apply: bool = False,
+    ) -> ResCommonResponse:
+        """`exchange` 의 HOLD lot 을 브로커 체결내역과 대조한다.
+
+        `apply=False`(기본)면 판정만 반환하고 원장은 건드리지 않는다.
+        """
+        exchange = str(exchange).upper()
+        resp = await self._query.get_overseas_order_history(
+            symbol="%",
+            exchange=exchange,
+            start_date=start_date,
+            end_date=end_date,
+            side_code="00",
+            ccld_nccs_dvsn="00",
+        )
+        if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
+            # 조회 실패로 빈 체결내역을 받으면 전 lot 이 미체결로 보인다 — 반드시 중단한다.
+            self._logger.warning(
+                f"[overseas_fill_reconcile] 체결내역 조회 실패 — exchange={exchange} "
+                f"msg1={getattr(resp, 'msg1', '')}"
+            )
+            return ResCommonResponse(
+                rt_cd=ErrorCode.API_ERROR.value,
+                msg1="해외 체결내역 조회에 실패해 대사를 중단했습니다.",
+                data=None,
+            )
+
+        filled_by_order = self._filled_qty_by_order(resp.data)
+        holds = [h for h in self._ledger.get_holds() if str(h.get("exchange", "")).upper() == exchange]
+
+        diffs: List[Dict[str, Any]] = []
+        counts = {VERDICT_OK: 0, VERDICT_PARTIAL: 0, VERDICT_UNFILLED: 0, VERDICT_UNKNOWN: 0}
+        for hold in holds:
+            order_no = str(hold.get("order_no") or "").strip()
+            ledger_qty = _to_int(hold.get("qty"))
+            if not order_no or order_no not in filled_by_order:
+                verdict, filled = VERDICT_UNKNOWN, None
+            else:
+                filled = filled_by_order[order_no]
+                if filled <= 0:
+                    verdict = VERDICT_UNFILLED
+                elif filled < ledger_qty:
+                    verdict = VERDICT_PARTIAL
+                else:
+                    verdict = VERDICT_OK
+
+            corrected = False
+            if apply and verdict == VERDICT_UNFILLED:
+                corrected = self._ledger.mark_canceled(
+                    hold["id"], reason=f"fill_reconcile: 미체결({start_date}~{end_date})",
+                )
+            elif apply and verdict == VERDICT_PARTIAL:
+                corrected = self._ledger.adjust_qty(
+                    hold["id"], filled,
+                    reason=f"fill_reconcile: 부분체결 {filled}/{ledger_qty}",
+                )
+
+            counts[verdict] += 1
+            diffs.append({
+                "trade_id": hold["id"],
+                "symbol": hold.get("symbol", ""),
+                "order_no": order_no,
+                "ledger_qty": ledger_qty,
+                "filled_qty": filled,
+                "verdict": verdict,
+                "corrected": corrected,
+            })
+
+        if apply and (counts[VERDICT_UNFILLED] or counts[VERDICT_PARTIAL]):
+            self._logger.info(
+                f"[overseas_fill_reconcile] 원장 보정 — exchange={exchange} "
+                f"unfilled={counts[VERDICT_UNFILLED]} partial={counts[VERDICT_PARTIAL]}"
+            )
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="해외 체결 대사 완료",
+            data={
+                "exchange": exchange,
+                "start_date": start_date,
+                "end_date": end_date,
+                "applied": bool(apply),
+                "checked": len(holds),
+                "counts": counts,
+                "diffs": diffs,
+            },
+        )
+
+    @staticmethod
+    def _filled_qty_by_order(data: Any) -> Dict[str, int]:
+        """체결내역 응답에서 {주문번호: 체결수량 합}을 만든다.
+
+        한 주문이 여러 체결 행으로 쪼개져 오므로 합산한다.
+        """
+        if isinstance(data, dict):
+            rows = data.get("output")
+        else:
+            rows = data
+        if not isinstance(rows, list):
+            return {}
+
+        totals: Dict[str, int] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            order_no = _first_key(row, _ORDER_NO_KEYS)
+            if not order_no:
+                continue
+            totals[order_no] = totals.get(order_no, 0) + _to_int(_first_key(row, _FILLED_QTY_KEYS))
+        return totals

--- a/tests/unit_test/repositories/test_overseas_trade_repository.py
+++ b/tests/unit_test/repositories/test_overseas_trade_repository.py
@@ -127,3 +127,115 @@ def test_sold_row_stores_net_return(repo):
 
     sold = [t for t in repo.get_all_trades() if t["status"] == "SOLD"][0]
     assert sold["return_rate"] == pytest.approx(9.48, abs=0.01)
+
+
+# --- 체결 대사 (Phase 2) ---
+#
+# 기록 시점이 *주문 접수* 이라 미체결 지정가도 HOLD 로 잡힌다. 대사가 lot 단위로
+# 성립하려면 주문번호가 있어야 한다 — 같은 심볼의 lot 이 여러 개면 수량 총합만으로는
+# 어느 lot 이 미체결인지 구분할 수 없다.
+
+
+def test_log_buy_stores_order_no(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, source="manual", order_no="0001234")
+
+    assert repo.get_holds()[0]["order_no"] == "0001234"
+
+
+def test_order_no_defaults_to_empty(repo):
+    """주문번호 없이 기록된 lot 도 유효하다(대사 대상에서 빠질 뿐)."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3)
+
+    assert repo.get_holds()[0]["order_no"] == ""
+
+
+def test_mark_canceled_removes_from_holds_without_deleting_row(repo):
+    """미체결 lot 은 행을 지우지 않고 CANCELED 로 표시한다 — 기록 파괴 금지."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    trade_id = repo.get_holds()[0]["id"]
+
+    repo.mark_canceled(trade_id, reason="fill_reconcile: 미체결")
+
+    assert repo.get_holds() == []
+    rows = repo.get_all_trades()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "CANCELED"
+    assert rows[0]["reason"] == "fill_reconcile: 미체결"
+
+
+def test_mark_canceled_ignores_non_hold_row(repo):
+    """이미 청산된 lot 을 취소로 뒤집으면 실현 성과가 사라진다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 100.0, 1)
+    repo.log_sell("AAPL", 110.0)
+    trade_id = repo.get_all_trades()[0]["id"]
+
+    assert repo.mark_canceled(trade_id, reason="fill_reconcile: 미체결") is False
+    assert repo.get_all_trades()[0]["status"] == "SOLD"
+
+
+def test_adjust_qty_shrinks_partially_filled_lot(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 5, order_no="0001234")
+    trade_id = repo.get_holds()[0]["id"]
+
+    assert repo.adjust_qty(trade_id, 2, reason="fill_reconcile: 부분체결") is True
+
+    holds = repo.get_holds()
+    assert holds[0]["qty"] == 2
+    assert holds[0]["reason"] == "fill_reconcile: 부분체결"
+
+
+def test_adjust_qty_rejects_increase(repo):
+    """대사는 과다 기록을 줄이는 방향만 허용한다 — 늘리면 없는 보유를 만든다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 2, order_no="0001234")
+    trade_id = repo.get_holds()[0]["id"]
+
+    assert repo.adjust_qty(trade_id, 5, reason="fill_reconcile") is False
+    assert repo.get_holds()[0]["qty"] == 2
+
+
+def test_adjust_qty_to_zero_marks_canceled(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 2, order_no="0001234")
+    trade_id = repo.get_holds()[0]["id"]
+
+    assert repo.adjust_qty(trade_id, 0, reason="fill_reconcile: 미체결") is True
+
+    assert repo.get_holds() == []
+    assert repo.get_all_trades()[0]["status"] == "CANCELED"
+
+
+def test_summary_excludes_canceled_lots(repo):
+    """취소 lot 이 total 에 남으면 성과 분모가 부풀려진다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 100.0, 1)
+    repo.log_buy("MSFT", OverseasExchange.NASD, 100.0, 1, order_no="0009999")
+    repo.mark_canceled(repo.get_holds()[1]["id"], reason="fill_reconcile: 미체결")
+
+    summary = repo.get_summary()
+
+    assert summary["total_trades"] == 1
+    assert summary["canceled_trades"] == 1
+
+
+def test_existing_db_without_order_no_is_migrated(tmp_path):
+    """order_no 도입 이전 DB 도 재기동 시 그대로 열려야 한다."""
+    import sqlite3
+
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        "CREATE TABLE overseas_trades ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, symbol TEXT NOT NULL, exchange TEXT NOT NULL,"
+        "currency TEXT NOT NULL DEFAULT 'USD', buy_date TEXT NOT NULL, buy_price REAL NOT NULL,"
+        "qty INTEGER NOT NULL, sell_date TEXT, sell_price REAL,"
+        "return_rate REAL NOT NULL DEFAULT 0.0, status TEXT NOT NULL,"
+        "reason TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT '');"
+        "INSERT INTO overseas_trades (symbol, exchange, buy_date, buy_price, qty, status) "
+        "VALUES ('AAPL', 'NASD', '2026-08-13 10:00:00', 190.0, 3, 'HOLD');"
+    )
+    conn.commit()
+    conn.close()
+
+    repo = OverseasTradeRepository(db_path=db_path)
+
+    holds = repo.get_holds()
+    assert len(holds) == 1
+    assert holds[0]["order_no"] == ""

--- a/tests/unit_test/services/test_overseas_fill_reconcile_service.py
+++ b/tests/unit_test/services/test_overseas_fill_reconcile_service.py
@@ -1,0 +1,167 @@
+"""미국장 USD 원장 체결 대사 테스트.
+
+핵심 계약 3가지:
+1. **진실 소스는 브로커 체결내역** — 원장은 주문 접수 시점 기록이라 과다 계상될 수 있다.
+2. **불확실하면 건드리지 않는다** — 주문번호가 없거나 조회 구간에 없는 lot 을 미체결로
+   단정하면 실제 보유가 원장에서 사라진다.
+3. **기본은 판정만** — `apply=True` 를 명시해야 원장이 바뀐다.
+"""
+import pytest
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+from repositories.overseas_trade_repository import OverseasTradeRepository
+from services.overseas_fill_reconcile_service import OverseasFillReconcileService
+
+
+class _StubQueryService:
+    """`get_overseas_order_history` 만 흉내내는 스텁."""
+
+    def __init__(self, rows, rt_cd=ErrorCode.SUCCESS.value):
+        self._rows = rows
+        self._rt_cd = rt_cd
+        self.calls = []
+
+    async def get_overseas_order_history(self, **kwargs):
+        self.calls.append(kwargs)
+        return ResCommonResponse(rt_cd=self._rt_cd, msg1="", data={"output": self._rows})
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return OverseasTradeRepository(db_path=str(tmp_path / "overseas_trade.db"))
+
+
+def _service(repo, rows, rt_cd=ErrorCode.SUCCESS.value):
+    query = _StubQueryService(rows, rt_cd=rt_cd)
+    return OverseasFillReconcileService(
+        trade_repository=repo, stock_query_service=query,
+    ), query
+
+
+async def test_fully_filled_lot_is_ok_and_untouched(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "3"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.rt_cd == ErrorCode.SUCCESS.value
+    assert resp.data["counts"]["ok"] == 1
+    assert repo.get_holds()[0]["qty"] == 3
+
+
+async def test_unfilled_lot_is_canceled_when_applied(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "0", "nccs_qty": "3"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["unfilled"] == 1
+    assert repo.get_holds() == []
+    assert repo.get_all_trades()[0]["status"] == "CANCELED"
+
+
+async def test_partial_fill_shrinks_lot_when_applied(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 5, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "2"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["partial"] == 1
+    assert repo.get_holds()[0]["qty"] == 2
+
+
+async def test_dry_run_reports_without_touching_ledger(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 5, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "0"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813")
+
+    assert resp.data["applied"] is False
+    assert resp.data["counts"]["unfilled"] == 1
+    assert resp.data["diffs"][0]["corrected"] is False
+    assert repo.get_holds()[0]["qty"] == 5
+
+
+async def test_lot_without_order_no_is_unknown_and_untouched(repo):
+    """order_no 도입 이전 기록은 매칭 키가 없다 — 미체결로 단정하면 보유가 사라진다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3)
+    service, _ = _service(repo, [{"odno": "0009999", "ft_ccld_qty": "3"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["unknown"] == 1
+    assert repo.get_holds()[0]["qty"] == 3
+
+
+async def test_order_missing_from_history_is_unknown_not_unfilled(repo):
+    """조회 구간 밖 주문은 '체결 0' 이 아니라 '판정 불가' 다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0007777", "ft_ccld_qty": "1"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["unknown"] == 1
+    assert repo.get_holds()[0]["qty"] == 3
+
+
+async def test_broker_failure_leaves_ledger_untouched(repo):
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    service, _ = _service(repo, [], rt_cd=ErrorCode.API_ERROR.value)
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.rt_cd == ErrorCode.API_ERROR.value
+    assert repo.get_holds()[0]["qty"] == 3
+
+
+async def test_only_requested_exchange_is_reconciled(repo):
+    """NYSE lot 을 NASD 체결내역으로 판정하면 잘못된 취소가 난다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 3, order_no="0001234")
+    repo.log_buy("BRK", OverseasExchange.NYSE, 400.0, 1, order_no="0005678")
+    service, query = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "0"}])
+
+    resp = await service.reconcile(
+        start_date="20260813", end_date="20260813", exchange="NASD", apply=True,
+    )
+
+    assert resp.data["checked"] == 1
+    assert query.calls[0]["exchange"] == "NASD"
+    assert [h["symbol"] for h in repo.get_holds()] == ["BRK"]
+
+
+async def test_partial_fill_aggregates_split_executions(repo):
+    """한 주문이 여러 체결 행으로 쪼개져 오면 합산해야 한다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 5, order_no="0001234")
+    service, _ = _service(repo, [
+        {"odno": "0001234", "ft_ccld_qty": "2"},
+        {"odno": "0001234", "ft_ccld_qty": "1"},
+    ])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["partial"] == 1
+    assert repo.get_holds()[0]["qty"] == 3
+
+
+async def test_overfilled_lot_is_ok_not_shrunk(repo):
+    """체결이 원장보다 많으면(분할 lot 등) 줄이지 않는다 — 보유를 없앨 수 없다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 190.0, 2, order_no="0001234")
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "5"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["counts"]["ok"] == 1
+    assert repo.get_holds()[0]["qty"] == 2
+
+
+async def test_sold_lots_are_not_reconciled(repo):
+    """청산된 lot 을 다시 대사하면 실현 성과가 취소로 뒤집힌다."""
+    repo.log_buy("AAPL", OverseasExchange.NASD, 100.0, 1, order_no="0001234")
+    repo.log_sell("AAPL", 110.0)
+    service, _ = _service(repo, [{"odno": "0001234", "ft_ccld_qty": "0"}])
+
+    resp = await service.reconcile(start_date="20260813", end_date="20260813", apply=True)
+
+    assert resp.data["checked"] == 0
+    assert repo.get_all_trades()[0]["status"] == "SOLD"

--- a/tests/unit_test/view/web/routes/test_web_routes_order.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_order.py
@@ -442,8 +442,32 @@ async def test_successful_overseas_buy_is_recorded_in_ledger(web_client, mock_we
 
     assert response.status_code == 200
     ledger.log_buy_async.assert_awaited_once_with(
-        "AAPL", OverseasExchange.NASD, 190.25, 3, source="manual",
+        "AAPL", OverseasExchange.NASD, 190.25, 3, source="manual", order_no="",
     )
+
+
+@pytest.mark.asyncio
+async def test_overseas_buy_records_broker_order_no(web_client, mock_web_ctx):
+    """주문번호가 없으면 체결 대사가 lot 을 매칭하지 못한다 — 응답의 ODNO 를 원장에 남긴다."""
+    from common.overseas_types import OverseasOrderReport
+
+    mock_web_ctx.market_mode = "overseas_us"
+    _install_overseas_manual_service(
+        mock_web_ctx,
+        resp=ResCommonResponse(rt_cd="0", msg1="Order Placed", data=OverseasOrderReport(
+            symbol="AAPL", exchange=OverseasExchange.NASD, side="buy", qty=3,
+            limit_price="190.25", broker_order_no="0001234",
+        )),
+    )
+    ledger = _install_overseas_ledger(mock_web_ctx)
+
+    payload = {
+        "symbol": "AAPL", "exchange": "NASD", "side": "buy",
+        "qty": 3, "limit_price": 190.25, "currency": "USD",
+    }
+    web_client.post("/api/overseas/order", json=payload)
+
+    assert ledger.log_buy_async.await_args.kwargs["order_no"] == "0001234"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
@@ -4,6 +4,8 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from common.types import ResCommonResponse
+
 
 def _enable_overseas(ctx):
     ctx.enabled_market_modes = ["domestic", "overseas_us"]
@@ -254,5 +256,75 @@ async def test_trades_without_ledger_returns_503(web_client, mock_web_ctx):
         mock_web_ctx.overseas_trade_repository = None
 
         response = web_client.get("/api/overseas/trades")
+
+        assert response.status_code == 503
+
+
+def _install_fill_reconcile(ctx, data=None):
+    from unittest.mock import AsyncMock
+
+    service = MagicMock()
+    service.reconcile = AsyncMock(return_value=ResCommonResponse(
+        rt_cd="0", msg1="해외 체결 대사 완료",
+        data=data or {
+            "applied": False, "checked": 1,
+            "counts": {"ok": 1, "partial": 0, "unfilled": 0, "unknown": 0},
+            "diffs": [],
+        },
+    ))
+    ctx.overseas_fill_reconcile_service = service
+    return service
+
+
+async def test_reconcile_defaults_to_dry_run(web_client, mock_web_ctx):
+    """apply 를 명시하지 않으면 원장을 건드리지 않는 판정만 돈다."""
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        service = _install_fill_reconcile(mock_web_ctx)
+
+        response = web_client.post(
+            "/api/overseas/trades/reconcile?start_date=20260813&end_date=20260813"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["rt_cd"] == "0"
+        assert service.reconcile.await_args.kwargs["apply"] is False
+
+
+async def test_reconcile_passes_apply_flag(web_client, mock_web_ctx):
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        service = _install_fill_reconcile(mock_web_ctx)
+
+        web_client.post(
+            "/api/overseas/trades/reconcile"
+            "?start_date=20260813&end_date=20260813&exchange=NYSE&apply=true"
+        )
+
+        kwargs = service.reconcile.await_args.kwargs
+        assert kwargs["apply"] is True
+        assert kwargs["exchange"] == "NYSE"
+
+
+async def test_reconcile_requires_overseas_enabled(web_client, mock_web_ctx):
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        mock_web_ctx.enabled_market_modes = ["domestic"]
+        _install_fill_reconcile(mock_web_ctx)
+
+        response = web_client.post(
+            "/api/overseas/trades/reconcile?start_date=20260813&end_date=20260813"
+        )
+
+        assert response.status_code == 400
+
+
+async def test_reconcile_without_service_returns_503(web_client, mock_web_ctx):
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        mock_web_ctx.overseas_fill_reconcile_service = None
+
+        response = web_client.post(
+            "/api/overseas/trades/reconcile?start_date=20260813&end_date=20260813"
+        )
 
         assert response.status_code == 503

--- a/todo_list.md
+++ b/todo_list.md
@@ -249,9 +249,10 @@
   - **착수 조건 미충족**: O-3 스윕이 전 조합 음의 기댓값을 보였으므로 현 규칙으로 실주문 전환할 근거가 없다. 장중 paper(#776) 데이터로 교차검증하거나, 유니버스/규칙 자체를 바꿔 엣지를 먼저 입증해야 한다.
   - **수동 주문 경로는 선반영 (#830, 2026-08-13)**: `POST /api/overseas/order` 가 broker 를 직접 호출해 kill-switch 와 기록을 우회하던 문제를 수정. 수동 전용 `OverseasOrderExecutionService` 인스턴스(`overseas_manual_order_service`, `live_enabled=True`) 경유로 전환했고 **자동 경로는 별도 인스턴스라 `live_enabled=False` 잠금 불변**. 취소는 리스크 축소 행위라 게이트 대상에서 제외. 주문 저널은 EventShadowJournal(`journal_strategy_name="수동매매_해외"`).
   - **USD 전용 원장 Phase 1 (#833, 2026-08-13)**: 통화 설계는 **별도 원장**으로 확정(사용자 결정) — `repositories/overseas_trade_repository.py` + `GET /api/overseas/trades`. `VirtualTradeRepository` 는 원화·국내 대사 원장이라 USD 편입 시 성과·대사가 오염되므로 영구 분리한다. 부분매도 lot 분할과 미국 비용 모델(0.25%/side)을 처음부터 적용했다.
-    - 남은 것: **기록 시점이 체결이 아니라 주문 접수** — 미체결 지정가도 HOLD 로 잡힌다. `get_overseas_order_history` 기반 체결 대사 + UI 성과 요약이 Phase 2.
+  - **USD 원장 Phase 2 — 체결 대사 (2026-08-17)**: 기록 시점이 주문 접수라 미체결 지정가도 HOLD 로 잡히던 것을 `OverseasFillReconcileService`(브로커 체결내역 `inquire_overseas_ccnl` 대조)로 사후 보정한다. `POST /api/overseas/trades/reconcile` — 기본은 판정만, `apply=true` 일 때만 원장 변경. 보정은 **줄이는 방향만**(미체결 → `CANCELED` 표시로 행 유지, 부분체결 → 체결분으로 qty 축소)이고 매칭 실패는 `unfilled` 가 아니라 `unknown` 무조작이다 — 판정 불가를 미체결로 단정하면 실제 보유가 원장에서 사라진다. lot 단위 매칭을 위해 원장에 `order_no` 컬럼을 추가했다(같은 심볼 lot 이 여러 개면 수량 총합으로는 구분 불가). `get_summary()` 는 CANCELED 를 total 에서 제외한다.
+    - 남은 것: **UI 성과 요약** — `GET /api/overseas/trades` 를 소비하는 화면이 없어 `get_summary()` 가 노출되지 않는다. 대사 결과(`unknown`/`CANCELED`) 표시도 함께.
 
-주요 파일: `brokers/korea_investment/korea_invest_overseas_stock_api.py`, `brokers/broker_api_wrapper.py`, `services/overseas_order_execution_service.py`, `services/overseas_position_sizing_service.py`, `services/overseas_reconcile_service.py`, `services/stock_query_service.py`, `view/web/bootstrap/{service_container,strategy_factory}.py`, `config/tr_ids_config.yaml`
+주요 파일: `brokers/korea_investment/korea_invest_overseas_stock_api.py`, `brokers/broker_api_wrapper.py`, `services/overseas_order_execution_service.py`, `services/overseas_position_sizing_service.py`, `services/overseas_reconcile_service.py`, `services/overseas_fill_reconcile_service.py`, `services/stock_query_service.py`, `repositories/overseas_trade_repository.py`, `view/web/routes/{order,overseas_market}.py`, `view/web/bootstrap/{service_container,strategy_factory}.py`, `config/tr_ids_config.yaml`
 
 ---
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -90,6 +90,7 @@ from view.web.bootstrap.realtime_bootstrap import RealtimeBootstrap
 from view.web.market_mode_utils import is_market_enabled
 from repositories.dart_disclosure_repository import DartDisclosureRepository
 from repositories.overseas_trade_repository import OverseasTradeRepository
+from services.overseas_fill_reconcile_service import OverseasFillReconcileService
 from repositories.youtube_channel_repository import YoutubeChannelRepository
 from repositories.youtube_digest_repository import YoutubeDigestRepository
 from services.gemini_youtube_video_analyzer_service import (
@@ -887,6 +888,7 @@ class ServiceContainer:
                 ctx.overseas_dryrun_task = None
                 ctx.overseas_manual_order_service = None
                 ctx.overseas_trade_repository = None
+                ctx.overseas_fill_reconcile_service = None
         except Exception as e:
             ctx.logger.critical(f"[ServiceBootstrap:Universe] 초기화 실패: {e}", exc_info=True)
             raise
@@ -1007,6 +1009,13 @@ class ServiceContainer:
         ctx = self._ctx
         # 미국 거래는 원화 원장(VirtualTradeRepository)이 아니라 USD 전용 원장에 남긴다.
         ctx.overseas_trade_repository = OverseasTradeRepository()
+        # 원장은 주문 접수 시점 기록이라 미체결 지정가도 HOLD 로 잡힌다 — 브로커 체결내역
+        # 대조로 사후 보정한다(`POST /api/overseas/trades/reconcile`).
+        ctx.overseas_fill_reconcile_service = OverseasFillReconcileService(
+            trade_repository=ctx.overseas_trade_repository,
+            stock_query_service=ctx.stock_query_service,
+            logger=ctx.logger,
+        )
         ctx.overseas_manual_order_service = OverseasOrderExecutionService(
             broker=ctx.broker,
             live_enabled=True,

--- a/view/web/routes/order.py
+++ b/view/web/routes/order.py
@@ -138,8 +138,9 @@ async def place_overseas_order(req: OverseasOrderRequest, request: Request):
 async def _record_overseas_trade(ctx, req: OverseasOrderRequest, resp) -> None:
     """주문이 접수된 경우에만 USD 원장에 남긴다.
 
-    거부/차단 응답을 기록하면 유령 보유가 생긴다. 해외는 체결 대사 경로가 아직 없어
-    *접수 시점* 기록이며, 미체결 지정가도 보유로 잡힐 수 있다(대사는 후속 작업).
+    거부/차단 응답을 기록하면 유령 보유가 생긴다. 해외는 실시간 체결 경로가 없어
+    *접수 시점* 기록이며, 미체결 지정가도 일단 보유로 잡힌다 — 사후 보정은
+    `OverseasFillReconcileService` 가 하고, 그 매칭 키가 여기서 남기는 주문번호다.
     """
     if getattr(resp, "rt_cd", None) != ErrorCode.SUCCESS.value:
         return
@@ -150,6 +151,7 @@ async def _record_overseas_trade(ctx, req: OverseasOrderRequest, resp) -> None:
         if req.side == "buy":
             await ledger.log_buy_async(
                 req.symbol, req.exchange, req.limit_price, req.qty, source="manual",
+                order_no=str(getattr(resp.data, "broker_order_no", "") or ""),
             )
         else:
             await ledger.log_sell_async(

--- a/view/web/routes/overseas_market.py
+++ b/view/web/routes/overseas_market.py
@@ -62,6 +62,34 @@ async def get_overseas_trades():
     }
 
 
+@router.post("/overseas/trades/reconcile")
+async def reconcile_overseas_trades(
+    start_date: str = Query(..., min_length=8, max_length=8),
+    end_date: str = Query(..., min_length=8, max_length=8),
+    exchange: str = Query("NASD"),
+    apply: bool = Query(False),
+):
+    """USD 원장 HOLD lot 을 브로커 체결내역과 대조한다.
+
+    원장은 *주문 접수* 시점 기록이라 미체결 지정가도 보유로 잡힌다. `apply=true` 일 때만
+    원장을 보정하고, 기본은 판정만 반환한다.
+    """
+    ctx = _get_ctx()
+    if not is_market_enabled(ctx, "overseas_us"):
+        raise HTTPException(
+            status_code=400,
+            detail="미국주식 체결 대사는 overseas_us가 enabled된 run에서만 사용할 수 있습니다.",
+        )
+    service = getattr(ctx, "overseas_fill_reconcile_service", None)
+    if service is None:
+        raise HTTPException(status_code=503, detail="미국주식 체결 대사 서비스가 준비되지 않았습니다.")
+
+    resp = await service.reconcile(
+        start_date=start_date, end_date=end_date, exchange=exchange, apply=apply,
+    )
+    return {"rt_cd": resp.rt_cd, "msg1": resp.msg1, "data": resp.data}
+
+
 @router.get("/overseas/ranking/{category}")
 async def get_overseas_ranking(category: str, limit: int = Query(30, ge=1, le=500)):
     """S&P 500 유니버스 기준 미국 랭킹 (rise/fall/volume/trading_value)."""


### PR DESCRIPTION
## 배경

미국장 USD 원장(`OverseasTradeRepository`)은 해외에 실시간 체결 경로가 없어 **주문 접수** 시점에 기록한다. 따라서 체결되지 않은 지정가 주문도 HOLD 로 잡혀 성과 분모가 부풀려진다. #833 에서 남긴 Phase 2 잔여 과제다.

## 변경

- **`OverseasFillReconcileService` 신규** — 브로커 체결내역(`inquire_overseas_ccnl`)을 진실로 삼아 HOLD lot 을 대조하고 `ok`/`partial`/`unfilled`/`unknown` 으로 판정한다.
- **보정은 줄이는 방향만** — 미체결은 행을 지우지 않고 `CANCELED` 로 표시(주문이 실제로 나갔다는 사실은 기록으로 남긴다), 부분체결은 체결분으로 `qty` 축소. 늘리는 보정은 브로커에 없는 보유를 만들기 때문에 허용하지 않는다.
- **판정 불가는 무조작** — `order_no` 가 없거나 조회 구간에 없는 주문은 `unfilled` 이 아니라 `unknown` 이다. 미체결로 단정하면 실제 보유가 원장에서 사라진다. 같은 이유로 **브로커 조회 실패 시 대사를 중단**한다(빈 체결내역은 전 lot 을 미체결로 보이게 한다).
- **`order_no` 컬럼 추가** — lot 단위 매칭의 전제. 같은 심볼 lot 이 여러 개면 수량 총합만으로 어느 lot 이 미체결인지 구분할 수 없다. 기존 DB 는 idempotent `ALTER TABLE` 로 마이그레이션하고, 수동 주문 라우트가 응답의 `ODNO` 를 기록한다.
- **`POST /api/overseas/trades/reconcile`** — 기본은 판정만(dry-run), `apply=true` 일 때만 원장 변경.
- `get_summary()` 는 `CANCELED` 를 `total_trades` 에서 제외하고 `canceled_trades` 를 노출한다.

자동 전략 경로의 `live_enabled=False` 잠금은 손대지 않았다.

## 테스트

TDD — 원장 9건 + 서비스 11건 + 라우트 5건을 먼저 실패시킨 뒤 구현했다.

- `pytest tests/unit_test` → **7817 passed**
- `pytest tests/integration_test` → **279 passed**

메모리 규칙대로 `test_service_container.py` 도 함께 실행했다(container 배선 변경).

## 남은 것

UI 성과 요약 — `GET /api/overseas/trades` 를 소비하는 화면이 없어 `get_summary()` 가 아직 노출되지 않는다. 대사 결과(`unknown`/`CANCELED`) 표시와 함께 다음 작업으로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
