### PR TITLE
Show the US heatmap auto-refresh interval

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -47,6 +47,7 @@ const SCAFFOLD = `
       <option value="1y">1년</option>
     </select>
   </span>
+  <span id="heatmap-page-overseas-interval" class="heatmap-updated" style="display:none;"></span>
   <button type="button" id="heatmap-page-refresh">새로고침</button>
   <span class="heatmap-zoom">
     <button type="button" id="heatmap-page-zoom-out">−</button>
@@ -1042,6 +1043,32 @@ test("수동 새로고침은 자동 갱신 타이머를 다시 건다", async ()
   assert(timer.starts === startsAfterInit + 1,
     `방금 받아왔으므로 다음 자동 갱신까지 한 주기를 새로 세야 함 (실제 ${timer.starts - startsAfterInit})`);
   assert(timer.cleared.length >= 1, "이전 타이머는 해제돼야 함");
+});
+
+// 자동 갱신 주기 표기 — 미국 탭은 60초마다 스스로 갱신되지만, 그 사실이 화면에 없으면
+// 멈춘 화면과 구분되지 않아 새로고침 버튼을 누르게 된다.
+
+test("미국 탭은 자동 갱신 주기를 표기한다", async () => {
+  const { window } = autoRefreshPage({ realtime: true });
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+
+  const label = window.document.getElementById("heatmap-page-overseas-interval");
+  assert(label.style.display !== "none", "미국 탭에서는 보여야 함");
+  assert(/60/.test(label.textContent), `주기(초)가 표기돼야 함 (실제 "${label.textContent}")`);
+});
+
+test("국내 탭에서는 갱신 주기 표기를 감춘다", async () => {
+  const { window } = autoRefreshPage({ realtime: true });
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  await window.setHeatmapTab("domestic");
+
+  const label = window.document.getElementById("heatmap-page-overseas-interval");
+  assert(label.style.display === "none",
+    "국내는 종가면 폴링을 건너뛴다 — 같은 주기를 약속하면 거짓이 된다");
 });
 
 test("전용 페이지 경로에서는 로드 시 자동으로 초기화한다", async () => {

--- a/tests/unit_test/view/web/test_market_heatmap_contracts.py
+++ b/tests/unit_test/view/web/test_market_heatmap_contracts.py
@@ -246,3 +246,14 @@ def test_heatmap_page_hosts_a_manual_refresh_button():
     # 연타로 중복 요청이 나가지 않도록 조회 중에는 잠근다.
     assert "button.disabled = true" in page_script
     assert ".heatmap-refresh:disabled" in template, "잠긴 상태가 보이지 않으면 연타하게 된다"
+
+
+def test_heatmap_page_shows_us_auto_refresh_interval():
+    """미국 탭은 자동 갱신되는데 주기가 화면에 없으면 정지한 화면과 구분되지 않는다."""
+    template = _heatmap_page_template()
+    page_script = _heatmap_page_js()
+
+    assert 'id="heatmap-page-overseas-interval"' in template
+    # 주기 문구를 하드코딩하면 상수를 바꿀 때 표기만 남아 거짓이 된다.
+    assert "HEATMAP_PAGE_OVERSEAS_REFRESH_MS" in page_script
+    assert "heatmap-page-overseas-interval" in page_script

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -74,6 +74,14 @@ function _heatmapPageShow(el, visible) {
     if (el) el.style.display = visible ? '' : 'none';
 }
 
+// 자동 갱신 주기 표기 — 미국 탭은 스스로 갱신되지만 그 사실이 화면에 없으면 멈춘 화면과
+// 구분되지 않는다. 문구를 상수에서 만들어 주기를 바꿔도 표기가 따라오게 한다.
+function _renderHeatmapPageInterval() {
+    const el = document.getElementById('heatmap-page-overseas-interval');
+    if (!el) return;
+    el.textContent = `${Math.round(HEATMAP_PAGE_OVERSEAS_REFRESH_MS / 1000)}초마다 자동 갱신`;
+}
+
 async function setHeatmapTab(market) {
     const source = HEATMAP_PAGE_SOURCES[market];
     if (!source) return;
@@ -90,6 +98,9 @@ async function setHeatmapTab(market) {
     // 미국 스냅샷(Yahoo)은 일간 등락률만 있어 기간 선택이 의미가 없고, 시장도 S&P 500 고정이다.
     _heatmapPageShow(document.getElementById('heatmap-page-period-wrap'), market === 'domestic');
     _heatmapPageShow(document.getElementById('heatmap-page-market-wrap'), market === 'domestic');
+    // 주기 표기는 미국 탭에만 둔다 — 국내는 종가 응답이면 폴링을 건너뛰므로 같은 주기를
+    // 약속하면 거짓이 된다.
+    _heatmapPageShow(document.getElementById('heatmap-page-overseas-interval'), market === 'overseas');
 
     // 실패한 탭은 lastData 가 없으므로 다시 열 때 재시도된다.
     if (!source.lastData) await _loadHeatmap(source);
@@ -465,6 +476,7 @@ async function initHeatmapPage() {
     if (searchInput) searchInput.value = '';
     _heatmapPagePan = null;
     _applyHeatmapPageZoom();
+    _renderHeatmapPageInterval();
     _bindHeatmapPageWheelZoom(viewport);
     _bindHeatmapPageDragPan(viewport);
 

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -56,6 +56,8 @@
             <div class="heatmap-toolbar">
                 <span id="heatmap-page-domestic-caption" class="heatmap-updated">기준일: --</span>
                 <span id="heatmap-page-overseas-caption" class="heatmap-updated" style="display:none;">최신 업데이트: --</span>
+                <span id="heatmap-page-overseas-interval" class="heatmap-updated" style="display:none;"
+                      title="미국 탭은 이 주기로 스스로 다시 조회합니다 (국내 종가는 값이 바뀌지 않아 폴링하지 않습니다)"></span>
                 <span class="heatmap-search" id="heatmap-page-search-wrap"
                       title="종목명·코드로 찾습니다 (일치 종목을 강조하고 나머지는 흐리게)">
                     <input type="search" id="heatmap-page-search" placeholder="종목명·코드 검색"


### PR DESCRIPTION
## 배경

미국 탭은 60초마다 스스로 다시 조회하는데(`HEATMAP_PAGE_OVERSEAS_REFRESH_MS`) 화면에 그 사실이 없었다. 갱신되는 히트맵과 멈춘 히트맵이 구분되지 않아, 값이 최신인지 확인할 방법이 #846 의 수동 새로고침 버튼을 눌러 보는 것뿐이었다.

## 변경

- `최신 업데이트: ...` 캡션 옆에 `60초마다 자동 갱신` 표기를 추가한다.
- 문구는 **상수에서 생성**한다(하드코딩 아님) — 주기를 바꿨을 때 표기만 남아 거짓이 되는 것을 막는다.
- **미국 탭에만** 노출한다. 국내는 서버가 `daily_prices` 종가로 답하면 폴링을 건너뛰므로 같은 주기를 약속하면 거짓이 된다. 이 차이는 tooltip 으로 설명한다.

## 테스트

TDD — jsdom 2건 + 소스 계약 1건을 먼저 실패시킨 뒤 구현했다.

- `node tests/frontend/run_heatmap_page_dom_tests.mjs` → **50/50 passed**
- `pytest tests/unit_test` → **7818 passed**
- `pytest tests/integration_test` → **279 passed**

브라우저 수동 확인은 하지 않았다 — 실행하면 KIS 연결과 백그라운드 태스크가 함께 뜨는 실거래 앱이라, 이 저장소가 프론트 회귀에 쓰는 jsdom 하네스(#846 과 동일 경로)로 검증했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
