### PR TITLE
Tag backtest journal records with regime

### DIFF
--- a/services/backtest_period_runner.py
+++ b/services/backtest_period_runner.py
@@ -125,6 +125,7 @@ class BacktestPeriodRunner:
         self._market_regime_service = market_regime_service
         self._market_resolver = market_resolver
         self._position_excursions: dict[str, dict[str, object]] = {}
+        self._regime_snapshot_cache: dict[tuple[str, str], object] = {}
 
     async def run(self, dates: Sequence[str]) -> BacktestPeriodRunResult:
         result = BacktestPeriodRunResult(
@@ -156,11 +157,17 @@ class BacktestPeriodRunner:
 
             report = await self._execute_signal(signal, date_ymd, side=OrderSide.SELL, order=order)
             sell_metrics = self._sell_realized_metrics(report)
+            market_regime = self._position_market_regime(report.order.code)
             self._ledger.apply_execution(report)
             self._forget_position_excursion_if_closed(report)
             result.execution_reports.append(report)
             result.journal_records.append(
-                self._execution_record(report, realized_metrics=sell_metrics, signal=signal)
+                self._execution_record(
+                    report,
+                    realized_metrics=sell_metrics,
+                    signal=signal,
+                    market_regime=market_regime,
+                )
             )
 
     async def _run_entries(self, date_ymd: str, result: BacktestPeriodRunResult) -> None:
@@ -213,12 +220,18 @@ class BacktestPeriodRunner:
                 )
                 continue
 
+            market_regime = await self._market_regime_for_signal(signal, date_ymd)
             report = await self._execute_signal(signal, date_ymd, side=OrderSide.BUY, order=decision.order)
             self._ledger.apply_execution(report)
-            self._remember_position_excursion(report, date_ymd)
+            self._remember_position_excursion(report, date_ymd, market_regime=market_regime)
             result.execution_reports.append(report)
             result.journal_records.append(
-                self._execution_record(report, signal=signal, portfolio_warnings=decision.warnings)
+                self._execution_record(
+                    report,
+                    signal=signal,
+                    portfolio_warnings=decision.warnings,
+                    market_regime=market_regime,
+                )
             )
             if report.filled_qty <= 0:
                 result.journal_records.append(
@@ -254,9 +267,7 @@ class BacktestPeriodRunner:
             try:
                 market = self._market_resolver(str(signal.code))
                 if market not in snapshots:
-                    snapshots[market] = await self._market_regime_service.classify_on_date(
-                        market, date_ymd
-                    )
+                    snapshots[market] = await self._get_regime_snapshot(market, date_ymd)
                 if getattr(snapshots[market], "is_rising", False):
                     passed.append(signal)
                     continue
@@ -266,6 +277,38 @@ class BacktestPeriodRunner:
             except Exception:
                 passed.append(signal)
         return passed
+
+    async def _get_regime_snapshot(self, market: str, date_ymd: str):
+        cache_key = (date_ymd, market)
+        if cache_key not in self._regime_snapshot_cache:
+            self._regime_snapshot_cache[cache_key] = await self._market_regime_service.classify_on_date(
+                market, date_ymd
+            )
+        return self._regime_snapshot_cache[cache_key]
+
+    async def _market_regime_for_signal(self, signal: TradeSignal, date_ymd: str) -> dict | None:
+        if self._market_regime_service is None or self._market_resolver is None:
+            return None
+        try:
+            stock_market = self._market_resolver(str(signal.code))
+        except Exception:
+            stock_market = None
+
+        labels: dict[str, str | None] = {}
+        for market, key in (("KOSPI", "kospi"), ("KOSDAQ", "kosdaq")):
+            try:
+                snap = await self._get_regime_snapshot(market, date_ymd)
+                labels[key] = getattr(snap, "regime_label", None)
+            except Exception:
+                labels[key] = None
+
+        if labels.get("kospi") is None and labels.get("kosdaq") is None and stock_market is None:
+            return None
+        return {
+            "kospi": labels.get("kospi"),
+            "kosdaq": labels.get("kosdaq"),
+            "stock_market": stock_market,
+        }
 
     async def _execute_signal(
         self,
@@ -416,9 +459,11 @@ class BacktestPeriodRunner:
         realized_metrics: dict | None = None,
         signal: TradeSignal | None = None,
         portfolio_warnings: Sequence[str] = (),
+        market_regime: dict | None = None,
     ) -> dict:
         record = normalize_backtest_execution(
             report,
+            market_regime=market_regime,
             volatility_20d_annualized=(
                 signal.volatility_20d_annualized if signal is not None else None
             ),
@@ -443,6 +488,8 @@ class BacktestPeriodRunner:
         self,
         report: BacktestExecutionReport,
         buy_ymd: str,
+        *,
+        market_regime: dict | None = None,
     ) -> None:
         if report.order.side != OrderSide.BUY or report.filled_qty <= 0:
             return
@@ -451,7 +498,13 @@ class BacktestPeriodRunner:
             "mfe": _max_optional(current.get("mfe"), report.mfe),
             "mae": _min_optional(current.get("mae"), report.mae),
             "buy_ymd": current.get("buy_ymd", buy_ymd),
+            "market_regime": current.get("market_regime", market_regime),
         }
+
+    def _position_market_regime(self, code: str) -> dict | None:
+        current = self._position_excursions.get(code, {})
+        regime = current.get("market_regime") if isinstance(current, dict) else None
+        return dict(regime) if isinstance(regime, dict) else None
 
     def _forget_position_excursion_if_closed(self, report: BacktestExecutionReport) -> None:
         position = self._ledger.positions.get(report.order.code)

--- a/tests/unit_test/services/test_backtest_period_runner.py
+++ b/tests/unit_test/services/test_backtest_period_runner.py
@@ -672,22 +672,30 @@ async def test_period_runner_consecutive_day_buy_sell_invokes_mtm_provider_but_u
 
 
 class _FakeRegimeSnapshot:
-    def __init__(self, is_rising: bool) -> None:
+    def __init__(self, is_rising: bool, regime_label: str | None = None) -> None:
         self.is_rising = is_rising
         self.trend_status = "rising" if is_rising else "falling"
+        self.regime_label = regime_label or ("bull" if is_rising else "bear")
 
 
 class _FakeRegimeService:
-    def __init__(self, is_rising: bool = True, raises: bool = False) -> None:
+    def __init__(
+        self,
+        is_rising: bool = True,
+        raises: bool = False,
+        labels_by_market: dict[str, str] | None = None,
+    ) -> None:
         self._is_rising = is_rising
         self._raises = raises
+        self._labels_by_market = labels_by_market or {}
         self.calls: list[tuple[str, str]] = []
 
     async def classify_on_date(self, market: str, date: str, logger=None):
         self.calls.append((market, date))
         if self._raises:
             raise RuntimeError("index ohlcv unavailable")
-        return _FakeRegimeSnapshot(self._is_rising)
+        label = self._labels_by_market.get(market)
+        return _FakeRegimeSnapshot(self._is_rising, regime_label=label)
 
 
 def _gate_runner(*, regime_service, market="KOSPI", gate=True):
@@ -729,6 +737,42 @@ async def test_market_timing_gate_allows_buy_when_regime_rising():
 
 
 @pytest.mark.asyncio
+async def test_backtest_sold_record_keeps_entry_date_index_regime_snapshot():
+    """Profitability gate 입력용 SOLD record 는 entry date 의 지수 regime 태그를 보존한다."""
+    strategy = FakeStrategy()
+    provider = StaticBarProvider({
+        ("20260501", "005930", "BUY"): BacktestBar(
+            "20260501 091000", 70_000, 70_500, 69_500, 70_200, 1_000
+        ),
+        ("20260502", "005930", "SELL"): BacktestBar(
+            "20260502 100000", 77_000, 77_500, 76_500, 77_100, 1_000
+        ),
+    })
+    regime = _FakeRegimeService(
+        is_rising=True,
+        labels_by_market={"KOSPI": "bull", "KOSDAQ": "bear"},
+    )
+    runner = BacktestPeriodRunner(
+        strategy=strategy,
+        bar_provider=provider,
+        ledger=BacktestPortfolioLedger(initial_cash=1_000_000),
+        market_regime_service=regime,
+        market_resolver=lambda code: "KOSPI",
+    )
+
+    result = await runner.run(["20260501", "20260502"])
+
+    sold_record = next(r for r in result.journal_records if r["status"] == "SOLD")
+    assert sold_record["market_regime"] == {
+        "kospi": "bull",
+        "kosdaq": "bear",
+        "stock_market": "KOSPI",
+    }
+    assert ("KOSPI", "20260501") in regime.calls
+    assert ("KOSDAQ", "20260501") in regime.calls
+
+
+@pytest.mark.asyncio
 async def test_market_timing_gate_classifies_on_backtest_date_not_today():
     """PIT 보장 — 오늘 레짐이 아니라 그 거래일 레짐으로 판정해야 한다."""
     regime = _FakeRegimeService(is_rising=True)
@@ -736,7 +780,7 @@ async def test_market_timing_gate_classifies_on_backtest_date_not_today():
 
     await runner.run(["20260501"])
 
-    assert regime.calls == [("KOSPI", "20260501")]
+    assert set(regime.calls) == {("KOSPI", "20260501"), ("KOSDAQ", "20260501")}
 
 
 @pytest.mark.asyncio
@@ -767,7 +811,7 @@ async def test_market_timing_gate_can_be_disabled_by_config():
     result = await runner.run(["20260501"])
 
     assert [report.order.side.value for report in result.execution_reports] == ["BUY"]
-    assert regime.calls == []
+    assert set(regime.calls) == {("KOSPI", "20260501"), ("KOSDAQ", "20260501")}
 
 
 @pytest.mark.asyncio

--- a/todo_list.md
+++ b/todo_list.md
@@ -336,7 +336,7 @@
   - 남은 좁은 경우 — **이 두 전략만 켜진 날**에는 이벤트·일간 알림이 나지 않는다. 일간 알림이 전략 스캔의 캐시 미스에 얹혀 있는 구조가 원인이다(아래 별도 항목).
   - `oneil_pocket_pivot_strategy.py:728` 은 실제 게이트로 쓰므로 유지.
 - [x] **마켓타이밍 일간 알림·로그 태스크 분리 (2026-08-18)**: `MarketTimingDailyUpdateTask`를 추가해 KOSPI/KOSDAQ 일간 `market_timing_updated` 로그와 외부 알림을 장전 태스크가 담당하게 했다. 전략의 `is_market_timing_ok()` 호출은 캐시만 데우고 발행하지 않으므로, 어떤 전략이 먼저 스캔하느냐에 따라 발신 주체가 바뀌거나 전략 구성 때문에 알림이 빠지는 경로를 막았다.
-- [ ] 1-6 profitability gate 의 regime 태깅이 #770 의 지수 기반 판정과 정합한지 확인 (별도).
+- [x] **profitability gate regime 태깅 정합성 확인·보정 (2026-08-19)**: 실측 결과 백테스트 마켓타이밍 게이트는 #770 의 `MarketRegimeService.classify_on_date()` 를 쓰지만, 체결 journal 에는 해당 날짜의 `market_regime` 이 전달되지 않아 profitability gate 의 regime 분해 표본이 비는 경로가 있었다. `BacktestPeriodRunner` 가 BUY 시점의 KOSPI/KOSDAQ 지수 regime snapshot 과 종목 시장(`stock_market`)을 journal 에 남기고, SOLD record 에도 매수 시점 regime 을 이어가도록 보정했다. 이제 profitability gate 의 regime bucket 입력이 백테스트 게이트 판정과 같은 날짜 기준을 쓴다.
 
 ---
 


### PR DESCRIPTION
## Summary
- carry entry-date KOSPI/KOSDAQ market regime snapshots into backtest execution journal records
- preserve the entry regime on SOLD records so profitability gate regime buckets use the same PIT index classification as the backtest market-timing gate
- mark the M-7 follow-up item complete in todo_list.md

## Tests
- python -m pytest tests/unit_test/services/test_backtest_period_runner.py -v
- python -m pytest tests/unit_test/services/test_strategy_profitability_gate_service.py tests/unit_test/services/test_regime_performance_service.py tests/unit_test/common/test_trade_journal_schema_regime.py tests/unit_test/services/test_strategy_log_report_regime.py -v
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v