### PR TITLE
Add candidate capacity observation to strategy report

### DIFF
--- a/services/strategy_log_report_service.py
+++ b/services/strategy_log_report_service.py
@@ -309,6 +309,7 @@ _MA_PROXIMITY_LOWER_PCT = -2.0
 _MA_PROXIMITY_UPPER_PCT = 4.0
 _MA_NEAR_MISS_MAX_EXCESS_PCT = 4.0
 _MAX_EXECUTION_QUALITY_ROWS = 5
+_MAX_CANDIDATE_LIQUIDITY_ROWS = 5
 _MAX_SAME_DAY_EXIT_VIOLATIONS_SHOWN = 5
 _KOSDAQ_CANDIDATE_WARNING_MIN = 5
 
@@ -336,6 +337,13 @@ def _format_krw(value: Any, *, force_integer: bool = False) -> str:
     if force_integer or amount.is_integer():
         return f"₩{int(round(amount)):,}"
     return f"₩{amount:,.2f}"
+
+
+def _format_eok_won(value: Any) -> str:
+    amount = _to_float(value)
+    if amount is None or amount <= 0:
+        return "N/A"
+    return f"{amount / 100_000_000:.0f}억"
 
 
 def _first_number(data: dict, *keys: str) -> Optional[float]:
@@ -1991,6 +1999,153 @@ class StrategyLogReportService:
 
         return "\n".join(lines)
 
+    def _build_candidate_liquidity_section(self, records: List[dict]) -> Optional[str]:
+        """후보군 유동성/capacity 관찰 섹션.
+
+        전략 로그가 후보별 `avg_trading_value_5d`와 주문금액을 제공할 때만 노출한다.
+        값이 없는 기존 전략 로그는 조용히 생략해 리포트 노이즈를 만들지 않는다.
+        """
+        records = self._latest_candidate_liquidity_records(records)
+        if not records:
+            return None
+
+        by_strategy: Dict[str, List[dict]] = {}
+        for record in records:
+            by_strategy.setdefault(record["strategy"], []).append(record)
+
+        rows = []
+        for strategy, items in by_strategy.items():
+            avg_tv_values = [
+                item["avg_trading_value_5d"]
+                for item in items
+                if item.get("avg_trading_value_5d") is not None
+            ]
+            participation_values = [
+                item["order_to_avg_trading_value_pct"]
+                for item in items
+                if item.get("order_to_avg_trading_value_pct") is not None
+            ]
+            if not avg_tv_values:
+                continue
+            rows.append({
+                "strategy": strategy,
+                "count": len(avg_tv_values),
+                "avg_tv": sum(avg_tv_values) / len(avg_tv_values),
+                "p25_tv": self._percentile(avg_tv_values, 25),
+                "min_tv": min(avg_tv_values),
+                "avg_participation": (
+                    sum(participation_values) / len(participation_values)
+                    if participation_values else None
+                ),
+                "max_participation": max(participation_values) if participation_values else None,
+            })
+
+        if not rows:
+            return None
+        rows.sort(key=lambda row: (row["avg_tv"], row["strategy"]))
+
+        lines = ["<b>📏 후보 유동성/capacity 관찰</b>"]
+        for row in rows[:_MAX_CANDIDATE_LIQUIDITY_ROWS]:
+            participation = ""
+            if row["avg_participation"] is not None and row["max_participation"] is not None:
+                participation = (
+                    f", 주문/5일대금 평균 {row['avg_participation']:.2f}%, "
+                    f"최대 {row['max_participation']:.2f}%"
+                )
+            lines.append(
+                f"• {_esc(row['strategy'])}: {row['count']}종목, "
+                f"5일평균대금 평균 {_format_eok_won(row['avg_tv'])}, "
+                f"P25 {_format_eok_won(row['p25_tv'])}, "
+                f"최소 {_format_eok_won(row['min_tv'])}{participation}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _latest_candidate_liquidity_records(records: List[dict]) -> List[dict]:
+        latest: Dict[Tuple[str, str], dict] = {}
+        anonymous: List[dict] = []
+        for idx, record in enumerate(records):
+            code = str(record.get("code") or "").strip()
+            if not code:
+                anonymous.append({**record, "_idx": idx})
+                continue
+            key = (str(record.get("strategy") or ""), code)
+            prev = latest.get(key)
+            if prev is None or str(record.get("timestamp", "")) >= str(prev.get("timestamp", "")):
+                latest[key] = record
+        return [*latest.values(), *anonymous]
+
+    def _extract_candidate_liquidity_records(
+        self,
+        strategy: str,
+        timestamp: str,
+        data: Mapping[str, Any],
+        name_map: Mapping[str, str],
+    ) -> List[dict]:
+        payloads: List[Mapping[str, Any]] = []
+        candidates = data.get("candidates")
+        if isinstance(candidates, list):
+            payloads.extend(item for item in candidates if isinstance(item, Mapping))
+        else:
+            payloads.append(data)
+
+        records: List[dict] = []
+        for payload in payloads:
+            merged = self._merge_candidate_payload(payload)
+            avg_tv = _first_number(
+                merged,
+                "avg_trading_value_5d",
+                "avg_5d_tv",
+                "trading_value_5d",
+                "avg_trading_value",
+            )
+            if avg_tv is None or avg_tv <= 0:
+                continue
+            code = str(merged.get("code") or data.get("code") or "").strip()
+            order_amount = self._candidate_order_amount_won(merged)
+            participation = (
+                order_amount / avg_tv * 100
+                if order_amount is not None and order_amount > 0
+                else None
+            )
+            records.append({
+                "timestamp": timestamp,
+                "strategy": strategy,
+                "code": code,
+                "name": name_map.get(code) or merged.get("name") or data.get("name") or code,
+                "avg_trading_value_5d": avg_tv,
+                "order_amount_won": order_amount,
+                "order_to_avg_trading_value_pct": participation,
+            })
+        return records
+
+    @staticmethod
+    def _merge_candidate_payload(payload: Mapping[str, Any]) -> dict:
+        merged = dict(payload)
+        for nested_key in ("metrics", "watchlist_item"):
+            nested = payload.get(nested_key)
+            if isinstance(nested, Mapping):
+                merged.update({k: v for k, v in nested.items() if k not in merged})
+        return merged
+
+    @staticmethod
+    def _candidate_order_amount_won(payload: Mapping[str, Any]) -> Optional[float]:
+        amount = _first_number(
+            dict(payload),
+            "planned_order_amount_won",
+            "order_amount_won",
+            "max_order_amount_won",
+            "signal_amount_won",
+            "amount_won",
+        )
+        if amount is not None:
+            return amount
+        qty = _first_number(dict(payload), "qty", "order_qty", "planned_qty")
+        price = _first_number(dict(payload), "price", "current_price", "entry_price")
+        if qty is None or price is None or qty <= 0 or price <= 0:
+            return None
+        return qty * price
+
     @staticmethod
     def _latest_execution_quality_records(records: List[dict]) -> List[dict]:
         latest: Dict[str, dict] = {}
@@ -2186,6 +2341,7 @@ class StrategyLogReportService:
         # 전략 로직과 무관한 데이터 수신/파싱 오류를 따로 집계
         data_errors_by_strategy: Dict[str, int] = {}
         execution_quality_records: List[dict] = []
+        candidate_liquidity_records: List[dict] = []
 
         for name, files in sorted(strategy_files.items()):
             bought: Dict[str, dict] = {}
@@ -2195,6 +2351,7 @@ class StrategyLogReportService:
             name_map: Dict[str, str] = {}
             early_guard_skipped: set[str] = set()
             data_error_count: int = 0
+            strategy_candidate_liquidity_records: List[dict] = []
 
             for fpath in sorted(files):
                 for _level, ts, data in self._iter_events(fpath, date_prefix):
@@ -2203,6 +2360,10 @@ class StrategyLogReportService:
 
                     if code and data.get('name'):
                         name_map[code] = data['name']
+
+                    strategy_candidate_liquidity_records.extend(
+                        self._extract_candidate_liquidity_records(name, ts, data, name_map)
+                    )
 
                     if event == 'scan_with_watchlist':
                         scan_count = max(scan_count, data.get('count', 0))
@@ -2314,6 +2475,8 @@ class StrategyLogReportService:
 
             if not self._is_strategy_enabled_for_report(name, enabled_strategy_keys):
                 continue
+
+            candidate_liquidity_records.extend(strategy_candidate_liquidity_records)
 
             if data_error_count > 0:
                 data_errors_by_strategy[name] = data_error_count
@@ -2459,6 +2622,7 @@ class StrategyLogReportService:
         degradation_section = self._build_strategy_degradation_section(target_date)
         journal_accumulation_section = self._build_standard_journal_accumulation_section(target_date)
         profitability_gate_section = self._build_profitability_gate_section(target_date)
+        candidate_liquidity_section = self._build_candidate_liquidity_section(candidate_liquidity_records)
         volatility_section = self._build_volatility_section(strategy_summaries)
         signal_metadata_section = self._build_signal_metadata_section(strategy_summaries)
         multiple_testing_section = self._build_multiple_testing_section(target_date)
@@ -2493,6 +2657,7 @@ class StrategyLogReportService:
                     journal_accumulation_section,
                     profitability_gate_section,
                     execution_quality_section,
+                    candidate_liquidity_section,
                     volatility_section,
                     signal_metadata_section,
                     multiple_testing_section,
@@ -2526,6 +2691,8 @@ class StrategyLogReportService:
             body += f"\n\n{profitability_gate_section}"
         if execution_quality_section:
             body += f"\n\n{execution_quality_section}"
+        if candidate_liquidity_section:
+            body += f"\n\n{candidate_liquidity_section}"
         if volatility_section:
             body += f"\n\n{volatility_section}"
         if signal_metadata_section:

--- a/tests/unit_test/services/test_strategy_log_report_service.py
+++ b/tests/unit_test/services/test_strategy_log_report_service.py
@@ -1446,6 +1446,51 @@ async def test_report_marks_incomplete_fill_quality_strategy(log_dir):
     assert "비활성화 후보" in report
 
 
+@pytest.mark.asyncio
+async def test_report_includes_candidate_liquidity_capacity_observation(log_dir):
+    """후보 로그에 유동성/주문금액이 있으면 capacity 관찰 섹션을 노출한다."""
+    log_path = os.path.join(log_dir, "20260418_093000_CapacityStrategy.log.json")
+    _write_log(log_path, [
+        {
+            "timestamp": "2026-04-18 09:30:00,000",
+            "level": "INFO",
+            "name": "strategy.CapacityStrategy",
+            "data": {
+                "event": "scan_with_watchlist",
+                "count": 3,
+                "candidates": [
+                    {
+                        "code": "000001",
+                        "name": "대형후보",
+                        "avg_trading_value_5d": 20_000_000_000,
+                        "planned_order_amount_won": 100_000_000,
+                    },
+                    {
+                        "code": "000002",
+                        "name": "중형후보",
+                        "avg_trading_value_5d": 10_000_000_000,
+                        "planned_order_amount_won": 100_000_000,
+                    },
+                    {
+                        "code": "000003",
+                        "name": "얇은후보",
+                        "avg_trading_value_5d": 5_000_000_000,
+                        "planned_order_amount_won": 100_000_000,
+                    },
+                ],
+            },
+        }
+    ])
+
+    svc = StrategyLogReportService(log_dir=log_dir)
+    report = await svc.generate_report("20260418")
+
+    assert "후보 유동성/capacity 관찰" in report
+    assert "CapacityStrategy: 3종목" in report
+    assert "5일평균대금 평균 117억, P25 75억, 최소 50억" in report
+    assert "주문/5일대금 평균 1.17%, 최대 2.00%" in report
+
+
 # ── _build_metric_str ─────────────────────────────────────────────
 
 def test_build_metric_str_low_execution_strength():

--- a/todo_list.md
+++ b/todo_list.md
@@ -372,7 +372,7 @@
 
 ### R-6. 비용 모델 — capacity/시장충격 [관찰]
 
-- [ ] (관찰) 전략별 후보 종목 평균 거래대금 분포 + 주문 규모 대비 시장충격 추정을 리포트에 노출할지 검토. (`max_top_of_book_participation_pct` 이미 존재)
+- [x] **후보 유동성/capacity 관찰 섹션 추가 (2026-08-19)**: 전략 로그에 후보별 `avg_trading_value_5d` 와 주문금액(`planned_order_amount_won`/`order_amount_won` 또는 qty×price)이 실리면 일일 전략 리포트가 전략별 5일 평균 거래대금 평균/P25/최소와 주문금액 대비 5일 평균 거래대금 비율(평균/최대)을 노출한다. 기존 `max_top_of_book_participation_pct` 는 실주문 최우선호가 차단으로 유지하고, 이 항목은 후보군 liquidity/capacity 관찰용으로만 둔다.
 
 ### 보류 — 정책 합의 후 재승격
 


### PR DESCRIPTION
## Summary
- add a daily strategy report section for candidate liquidity/capacity observations when logs provide avg trading value and planned order amount
- parse candidate liquidity from scan candidate lists, metrics, or watchlist_item payloads without surfacing empty sections
- mark R-6 complete in todo_list.md

## Tests
- python -m pytest tests/unit_test/services/test_strategy_log_report_service.py -v
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v