### PR TITLE
Fix NXT current price served from code-keyed KRX cache

### DIFF
--- a/brokers/korea_investment/korea_invest_quotations_api.py
+++ b/brokers/korea_investment/korea_invest_quotations_api.py
@@ -120,6 +120,12 @@ class KoreaInvestApiQuotations(KoreaInvestApiBase):
             if "new_hgpr_lwpr_cls_code" not in response_data_dict:
                 response_data_dict["new_hgpr_lwpr_cls_code"] = "-"
 
+            # NXT 미거래 종목은 KIS가 전 필드 0인 응답을 준다. 0원을 시세로 표시하지 않도록 실패 처리.
+            if market_code == "NX" and str(response_data_dict.get("stck_prpr") or "0") == "0":
+                msg = f"{stock_code} NXT 시세 없음 (미거래 종목)"
+                self._logger.warning(msg)
+                return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=msg, data=None)
+
             response.data['output'] = ResStockFullInfoApiOutput.from_dict(response_data_dict)
         except (KeyError, ValidationError, TypeError) as e:
             error_msg = f"현재가 응답 데이터 파싱 실패: {stock_code}, 오류: {e}"

--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -108,7 +108,10 @@ class MarketDataService:
     async def get_current_price(self, stock_code, exchange: Exchange = Exchange.KRX, count_stats: bool = True, caller: str = "unknown", force_fresh: bool = False) -> ResCommonResponse:
         if _is_overseas_exchange(exchange):
             return await self._get_overseas_current_price(stock_code, exchange)
-        if not force_fresh:
+        # 단기 캐시/DB 스냅샷은 종목코드 단위(KRX 기준)라 거래소를 구분하지 못한다.
+        # KRX 외 거래소(NXT/통합) 요청은 읽기·쓰기 모두 우회하고 API 결과를 그대로 쓴다.
+        is_exchange_specific = exchange != Exchange.KRX
+        if not force_fresh and not is_exchange_specific:
             # 1. StockRepository 단기 캐시 확인 (웹소켓 틱 갱신 또는 최근 API 조회 결과)
             if self._stock_repo:
                 cached_data = self._stock_repo.get_current_price(stock_code, max_age_sec=3.0, count_stats=count_stats, caller=caller)
@@ -145,8 +148,8 @@ class MarketDataService:
         if invalid:
             return invalid
 
-        # 3. 조회 결과를 StockRepository에 갱신
-        if resp and resp.rt_cd == ErrorCode.SUCCESS.value and self._stock_repo:
+        # 3. 조회 결과를 StockRepository에 갱신 (KRX 응답만 — 거래소별 값은 캐시를 오염시킨다)
+        if resp and resp.rt_cd == ErrorCode.SUCCESS.value and self._stock_repo and not is_exchange_specific:
             self._stock_repo.set_current_price(stock_code, resp.data)
 
         return resp

--- a/services/stock_query_service.py
+++ b/services/stock_query_service.py
@@ -58,6 +58,7 @@ class StockQueryService:
             "force_fresh_bypass": 0,
             "full_output_required": 0,
             "stream_unavailable_fallback": 0,
+            "exchange_specific_bypass": 0,
             "conclusion_hit": 0,
             "conclusion_stale_fallback": 0,
             "conclusion_missing_fallback": 0,
@@ -225,7 +226,14 @@ class StockQueryService:
         if force_fresh:
             self._count_price_lookup("force_fresh_bypass", count_stats)
 
-        if not force_fresh and self.price_stream_service is not None:
+        # snapshot 캐시는 종목코드 단위라 거래소를 구분하지 못한다.
+        # KRX 외 거래소(NXT/통합) 요청은 해당 거래소 시세를 받아야 하므로 REST로 직행한다.
+        is_exchange_specific = exchange != Exchange.KRX
+        if is_exchange_specific and not force_fresh:
+            self._count_price_lookup("exchange_specific_bypass", count_stats)
+            fallback_force_fresh = True
+
+        if not is_exchange_specific and not force_fresh and self.price_stream_service is not None:
             snap = self.price_stream_service.get_cached_price(stock_code)
             if snap is None:
                 # 구독 중이나 tick 미수신 → REST fallback
@@ -262,7 +270,7 @@ class StockQueryService:
                             "caller": caller,
                             "reason": "full_output_required",
                         })
-        elif not force_fresh:
+        elif not is_exchange_specific and not force_fresh:
             self._count_price_lookup("stream_unavailable_fallback", count_stats)
 
         self._count_price_lookup("rest_fallback", count_stats)
@@ -290,7 +298,9 @@ class StockQueryService:
                     )
 
         # REST 성공 응답을 snapshot 캐시에 backfill (다음 동일 종목 조회 hit 유도)
+        # 단, KRX 외 거래소 응답은 종목코드 단위 캐시를 오염시키므로 backfill하지 않는다.
         if (self.price_stream_service is not None
+                and not is_exchange_specific
                 and resp is not None
                 and resp.rt_cd == ErrorCode.SUCCESS.value):
             try:

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_quotations_api.py
@@ -187,6 +187,45 @@ async def test_get_current_price_accepts_single_item_output_list(mock_quotations
 
 
 @pytest.mark.asyncio
+async def test_get_current_price_nxt_zero_payload_is_error(mock_quotations):
+    """NXT 미거래 종목은 KIS가 전 필드 0인 응답을 준다 → 0원으로 표시하지 않고 실패로 반환.
+
+    실전 로그 확인: 067310 NX 조회가 stck_prpr="0", prdy_vrss="0"로 응답 (2026-08-19 08:55).
+    """
+    from common.types import Exchange
+
+    output = _BASE_DUMMY_DATA.copy()
+    output.update({"stck_prpr": "0", "prdy_vrss": "0", "prdy_ctrt": "0.00", "acml_vol": "0"})
+    mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상 처리",
+        data={"output": output},
+    ))
+
+    result = await mock_quotations.get_current_price("067310", exchange=Exchange.NXT)
+
+    assert result.rt_cd != ErrorCode.SUCCESS.value
+    assert "NXT" in result.msg1
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_krx_zero_payload_is_passed_through(mock_quotations):
+    """KRX(J) 0원 응답은 거래정지 종목 등 기존 소비처가 처리하므로 그대로 통과시킨다."""
+    output = _BASE_DUMMY_DATA.copy()
+    output.update({"stck_prpr": "0", "prdy_vrss": "0", "prdy_ctrt": "0.00", "acml_vol": "0"})
+    mock_quotations.call_api = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상 처리",
+        data={"output": output},
+    ))
+
+    result = await mock_quotations.get_current_price("067310")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["output"].stck_prpr == "0"
+
+
+@pytest.mark.asyncio
 async def test_get_current_price_nxt_includes_fid_input_date_1(mock_quotations):
     """NXT(exchange=NXT) 현재가 조회는 KIS가 요구하는 fid_input_date_1을 포함해야 한다.
 

--- a/tests/unit_test/services/test_market_data_service.py
+++ b/tests/unit_test/services/test_market_data_service.py
@@ -97,6 +97,58 @@ async def test_get_current_price_uses_cache_by_default(trading_service_fixture, 
 
 
 @pytest.mark.asyncio
+async def test_get_current_price_nxt_skips_code_keyed_cache(trading_service_fixture, mock_deps):
+    """exchange=NXT는 종목코드 단위 캐시(KRX 값)를 쓰지 않고 broker API를 호출한다."""
+    from common.types import Exchange
+    service = trading_service_fixture
+    mock_deps.stock_repo.get_current_price.return_value = {"stck_prpr": "268500", "code": "005930"}
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": {"stck_prpr": "252000"}})
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    result = await service.get_current_price("005930", exchange=Exchange.NXT)
+
+    mock_deps.broker.get_current_price.assert_awaited_once()
+    assert result == broker_resp
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_nxt_skips_db_snapshot_outside_krx_hours(trading_service_fixture, mock_deps):
+    """KRX 장 마감 시간대라도 NXT 요청은 DB 스냅샷 대신 broker API를 호출한다."""
+    from common.types import Exchange
+    service = trading_service_fixture
+    service._mcs = AsyncMock()
+    service._mcs.is_market_open_now.return_value = False  # KRX 기준 장 마감 (예: 08:30 NXT 프리마켓)
+    service._mcs.get_latest_trading_date.return_value = "20260818"
+
+    mock_deps.stock_repo.get_current_price.return_value = None
+    mock_deps.stock_repo.get_latest_daily_snapshot.return_value = {
+        "output": {"stck_prpr": "268500"}, "_trade_date": "20260818"
+    }
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": {"stck_prpr": "252000"}})
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    result = await service.get_current_price("005930", exchange=Exchange.NXT)
+
+    mock_deps.stock_repo.get_latest_daily_snapshot.assert_not_awaited()
+    mock_deps.broker.get_current_price.assert_awaited_once()
+    assert result == broker_resp
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_nxt_does_not_write_code_keyed_cache(trading_service_fixture, mock_deps):
+    """NXT 응답을 종목코드 단위 캐시에 쓰면 KRX 조회가 오염되므로 저장하지 않는다."""
+    from common.types import Exchange
+    service = trading_service_fixture
+    mock_deps.stock_repo.get_current_price.return_value = None
+    broker_resp = ResCommonResponse(rt_cd="0", msg1="정상", data={"output": {"stck_prpr": "252000"}})
+    mock_deps.broker.get_current_price.return_value = broker_resp
+
+    await service.get_current_price("005930", exchange=Exchange.NXT)
+
+    mock_deps.stock_repo.set_current_price.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_current_price_data_quality_invalid_response_not_cached(trading_service_fixture, mock_deps):
     service = trading_service_fixture
     service._data_quality_service = DataQualityService()

--- a/tests/unit_test/services/test_stock_query_service.py
+++ b/tests/unit_test/services/test_stock_query_service.py
@@ -212,6 +212,69 @@ class TestDataHandlers(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(self.stockQueryService._price_lookup_stats["snapshot_hit"], before + 1)
 
+    async def test_get_current_price_nxt_bypasses_fresh_snapshot(self):
+        """exchange=NXT → snapshot 캐시(종목코드 단위)를 우회하고 REST로 직행."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap(price="75000")
+        self._setup_sqs_with_pss(snap=snap)
+
+        await self.stockQueryService.get_current_price("005930", exchange=Exchange.NXT)
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        kwargs = self.mock_market_data_service.get_current_price.await_args.kwargs
+        self.assertEqual(kwargs["exchange"], Exchange.NXT)
+        self.assertTrue(kwargs["force_fresh"])
+
+    async def test_get_current_price_un_bypasses_fresh_snapshot(self):
+        """exchange=UN(통합)도 거래소별 값이 필요하므로 snapshot 우회."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap(price="75000")
+        self._setup_sqs_with_pss(snap=snap)
+
+        await self.stockQueryService.get_current_price("005930", exchange=Exchange.UN)
+
+        self.mock_market_data_service.get_current_price.assert_awaited_once()
+        self.assertTrue(self.mock_market_data_service.get_current_price.await_args.kwargs["force_fresh"])
+
+    async def test_get_current_price_krx_still_uses_fresh_snapshot(self):
+        """기본 KRX 경로는 기존대로 snapshot hit 유지 (회귀 방지)."""
+        from common.types import Exchange
+        snap = self._make_fresh_snap(price="75000")
+        self._setup_sqs_with_pss(snap=snap)
+
+        result = await self.stockQueryService.get_current_price("005930", exchange=Exchange.KRX)
+
+        self.mock_market_data_service.get_current_price.assert_not_awaited()
+        self.assertEqual(result.data["output"].stck_prpr, "75000")
+
+    async def test_get_current_price_nxt_does_not_backfill_snapshot(self):
+        """NXT 응답을 종목코드 단위 snapshot에 backfill하면 KRX 값이 오염되므로 금지."""
+        from common.types import Exchange
+        mock_pss = self._setup_sqs_with_pss(snap=None)
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={"output": self._create_dummy_stock_info({"stck_prpr": "252000"})},
+        )
+
+        await self.stockQueryService.get_current_price("005930", exchange=Exchange.NXT)
+
+        mock_pss.cache_price_snapshot.assert_not_called()
+
+    async def test_get_current_price_krx_still_backfills_snapshot(self):
+        """KRX 응답은 기존대로 snapshot backfill 유지 (회귀 방지)."""
+        from common.types import Exchange
+        mock_pss = self._setup_sqs_with_pss(snap=None)
+        self.mock_market_data_service.get_current_price.return_value = ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={"output": self._create_dummy_stock_info({"stck_prpr": "252000"})},
+        )
+
+        await self.stockQueryService.get_current_price("005930", exchange=Exchange.KRX)
+
+        mock_pss.cache_price_snapshot.assert_called_once()
+
     async def test_get_current_price_stale_snapshot_falls_back_to_rest(self):
         """stale snapshot (age > threshold) → REST fallback."""
         from common.types import Exchange


### PR DESCRIPTION
## 문제

웹 종목 조회에서 **NXT 토글을 눌러도 현재가가 갱신되지 않는다.** 스크린샷 사례(2026-08-19 08:5x, NXT 프리마켓)에서는 `268,500원 / 전일대비 0 (0.00%)`가 고정 표시되었는데, 이는 NXT 시세가 아니라 KIS 기준 **전일 종가(`prev_close`)** 였다.

## 원인

현재가 조회 경로 앞단의 캐시 3층이 전부 **종목코드만 키로 쓰고 `exchange`를 무시**한다. 그 결과 NXT 요청이 KRX 값을 그대로 돌려받고, NX REST 호출 자체가 발생하지 않는다.

실측 (운영 앱, 2026-08-19 09:03:18~25): `KRX → NXT → NXT` 연속 호출 3건이 모두 동일값 `250500`을 반환했고, 로그에 `inquire-price` HTTP 요청은 **0건**이었다.

| 층 | 위치 | 문제 |
|---|---|---|
| 웹소켓 snapshot | `stock_query_service.py:229` | `get_cached_price(stock_code)` — exchange 없음. 5초 이내면 무조건 반환하고 REST 생략 |
| 단기 캐시 | `market_data_service.py:114` | `get_current_price(stock_code, max_age_sec=3.0)` — exchange 없음. `mark_streaming` 종목은 TTL이 무한(`stock_price_repository.py:66`)이라 값이 영구히 고정 |
| DB 스냅샷 | `market_data_service.py:125` | `is_market_open_now()`가 KRX 시간만 봐서 NXT 단독 시간대(08:00~09:00, 15:40~20:00)에 전일 종가 반환 + NX API 미호출 |

NX REST 경로 자체는 정상이다 (08:55:41 로그: `fid_cond_mrkt_div_code=NX&...&fid_input_date_1=20260819` → 252,000원 정상 응답).

## 수정

- **`StockQueryService.get_current_price`**: KRX 외 거래소(NXT/통합)는 snapshot 조회를 우회하고 `force_fresh`로 REST 직행. 응답도 snapshot에 backfill하지 않는다(KRX 값 오염 방지). 통계 키 `exchange_specific_bypass` 추가.
- **`MarketDataService.get_current_price`**: KRX 외 거래소는 단기 캐시와 DB 스냅샷을 **읽지도 쓰지도** 않는다.
- **`KoreaInvestApiQuotations.get_current_price`**: NX 응답이 전 필드 0이면(NXT 미거래 종목) 0원을 시세로 표시하지 않도록 실패로 반환. 실전 로그 확인 — 067310 NX 조회가 `stck_prpr:"0"`으로 응답(08:55:29). J(KRX)의 0원 응답은 거래정지 종목 처리 경로가 이미 있으므로 그대로 둔다.

`is_market_open_now(include_nxt=True)` 변경은 하지 않았다. KRX 요청이 08:30에 전일 스냅샷을 받는 것은 올바른 동작이고, NXT 요청은 위 우회로 해당 분기에 도달하지 않는다.

## 테스트

TDD — 실패 테스트 선작성 후 구현. 신규 10건 (SQS 5, MDS 3, quotations 2), KRX 기존 동작 회귀 방지 테스트 포함.

- `pytest tests/unit_test` → **7845 passed**
- `pytest tests/integration_test` → **279 passed**

내부 호출자 중 `Exchange.UN`을 쓰는 곳은 없고 `Exchange.NXT`는 웹 UI 토글 경로뿐이라, 이 우회로 인한 API 부하 증가는 사용자 클릭 단위로 제한된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
