### PR TITLE
Fix websocket slot accounting drifting from KIS registrations

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -451,6 +451,9 @@ class BrokerAPIWrapper:
     async def unsubscribe_program_trading(self, stock_code: str):
         return await self._client.unsubscribe_program_trading(stock_code)
 
+    def get_subscription_ledger(self) -> dict:
+        return self._client.get_subscription_ledger()
+
     async def subscribe_market_status(self, stock_code: str):
         return await self._client.subscribe_market_status(stock_code)
 

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -374,6 +374,9 @@ class KoreaInvestApiClient:
     async def unsubscribe_program_trading(self, stock_code: str):
         return await self._websocketAPI.unsubscribe_program_trading(stock_code)
 
+    def get_subscription_ledger(self) -> dict:
+        return self._websocketAPI.get_subscription_ledger()
+
     async def subscribe_market_status(self, stock_code: str):
         return await self._websocketAPI.subscribe_market_status(stock_code)
 

--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -814,6 +814,21 @@ class KoreaInvestWebSocketAPI:
         )
         return tuple(dict.fromkeys(tr_ids))
 
+    def get_subscription_ledger(self) -> dict:
+        """현재 KIS 에 등록된 실시간 구독 원장을 반환한다 (슬롯 회계용).
+
+        total 은 등록된 (tr_id, tr_key) 전체 수다. 장운영정보·체결통보처럼 구독 정책이
+        관리하지 않는 등록도 KIS 한도를 동일하게 소비하므로 함께 센다.
+        """
+        websocket_config = self._env.active_config.get('tr_ids', {}).get('websocket', {})
+        price_tr_id = websocket_config.get('unified_realtime_price', 'H0UNCNT0')
+        pt_tr_ids = self._get_program_trading_tr_ids()
+        return {
+            "total": len(self._subscribed_items),
+            "price_codes": {key for tr_id, key in self._subscribed_items if tr_id == price_tr_id},
+            "program_trading_codes": {key for tr_id, key in self._subscribed_items if tr_id in pt_tr_ids},
+        }
+
     async def _resubscribe_all(self):
         """재연결 시 기존 구독 항목들을 다시 구독 요청합니다."""
         items = list(self._subscribed_items)

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -217,6 +217,10 @@ class StreamingService:
             return True
         return await waiter(code, timeout)
 
+    def get_subscription_ledger(self) -> dict:
+        """KIS 실등록 구독 원장 (BrokerAPIWrapper 위임)."""
+        return self.broker.get_subscription_ledger()
+
     async def subscribe_market_status(self, code: str):
         """장운영정보 실시간 구독 (BrokerAPIWrapper 위임)."""
         return await self.broker.subscribe_market_status(code)

--- a/services/subscription_policy.py
+++ b/services/subscription_policy.py
@@ -294,7 +294,16 @@ class SubscriptionPolicy:
         desired_price: Set[str] = set()
         desired_pt: Set[str] = set()
 
-        available_slots = max(0, self.MAX_WS_SLOTS - self._external_reserved_slots)
+        ledger = self._get_broker_ledger()
+        if ledger is None:
+            reserved = self._external_reserved_slots
+        else:
+            # 정책이 소유하지 않는 등록(장운영정보/체결통보 등)도 KIS 한도를 소비한다.
+            reserved = max(
+                0,
+                ledger["total"] - len(ledger["price_codes"]) - len(ledger["program_trading_codes"]),
+            )
+        available_slots = max(0, self.MAX_WS_SLOTS - reserved)
 
         # 2. 슬롯 할당 (Greedy)
         for code in ranked_codes:
@@ -315,24 +324,32 @@ class SubscriptionPolicy:
                 break
 
         # 3. 변경 대상 추출 (타입별 분리)
-        to_unsubscribe_price = self._active_codes_price - desired_price
+        # 브로커에 등록돼 있으나 정책이 원하지 않는 종목(고아)도 해지 대상에 포함한다.
+        # 정책 장부만 초기화되고 KIS 등록은 남는 경로가 있어, 회수하지 않으면 슬롯이 영구 소모된다.
+        registered_price = ledger["price_codes"] if ledger else set()
+        registered_pt = ledger["program_trading_codes"] if ledger else set()
+
+        to_unsubscribe_price = (self._active_codes_price | registered_price) - desired_price
         to_subscribe_price = desired_price - self._active_codes_price
-        
-        to_unsubscribe_pt = self._active_codes_pt - desired_pt
+
+        to_unsubscribe_pt = (self._active_codes_pt | registered_pt) - desired_pt
         to_subscribe_pt = desired_pt - self._active_codes_pt
 
         # 4. 실제 구독/해지 수행
-        for code in to_unsubscribe_price:
+        for code in sorted(to_unsubscribe_price):
             await self._do_unsubscribe(code, StreamingType.UNIFIED_PRICE)
-        for code in to_unsubscribe_pt:
+        for code in sorted(to_unsubscribe_pt):
             await self._do_unsubscribe(code, StreamingType.PROGRAM_TRADING)
 
         if not await self._ensure_websocket_connected_for_subscribe(to_subscribe_price | to_subscribe_pt):
             return
 
-        for code in to_subscribe_price:
+        # 슬롯이 모자라 브로커가 일부를 거절하더라도 우선순위 높은 종목이 먼저 자리를 잡도록
+        # ranked_codes 순서를 그대로 따른다 (set 순회는 비결정적이라 LOW 가 먼저 채갈 수 있다).
+        subscribe_rank = {code: i for i, code in enumerate(ranked_codes)}
+        for code in sorted(to_subscribe_price, key=lambda c: subscribe_rank.get(c, len(ranked_codes))):
             await self._do_subscribe(code, StreamingType.UNIFIED_PRICE)
-        for code in to_subscribe_pt:
+        for code in sorted(to_subscribe_pt, key=lambda c: subscribe_rank.get(c, len(ranked_codes))):
             await self._do_subscribe(code, StreamingType.PROGRAM_TRADING)
 
         # 5. [기존 로직 복원] 한도 초과(Dropped) 경고 로그
@@ -479,11 +496,39 @@ class SubscriptionPolicy:
             if self._streaming_logger:
                 self._streaming_logger.log_unsubscribe_failure(code=code, reason=str(e))
 
+    def _get_broker_ledger(self) -> Optional[dict]:
+        """브로커가 보고하는 실제 KIS 등록 원장. 제공하지 않으면 None.
+
+        정책 내부 장부(_active_codes_*)는 재연결·직접 구독 경로에서 실제 등록과
+        어긋날 수 있으므로, 가능하면 브로커 원장을 슬롯 회계의 진실 소스로 쓴다.
+        """
+        getter = getattr(self._streaming, "get_subscription_ledger", None)
+        if not callable(getter):
+            return None
+        try:
+            ledger = getter()
+        except Exception as e:
+            self._logger.warning(f"SubscriptionPolicy: 구독 원장 조회 실패 — 내부 장부 사용 ({e})")
+            return None
+        if not isinstance(ledger, dict):
+            return None
+        try:
+            return {
+                "total": int(ledger["total"]),
+                "price_codes": set(ledger["price_codes"]),
+                "program_trading_codes": set(ledger["program_trading_codes"]),
+            }
+        except (KeyError, TypeError, ValueError):
+            return None
+
     def _calculate_used_slots(self) -> int:
         """
         현재 사용 중인 웹소켓 슬롯 개수를 계산합니다.
         (일반 호가/체결(Price) = 1슬롯, 프로그램 매매(PT) = 1슬롯)
         """
+        ledger = self._get_broker_ledger()
+        if ledger is not None:
+            return ledger["total"]
         return (
             self._external_reserved_slots
             +

--- a/task/background/intraday/websocket_watchdog_task.py
+++ b/task/background/intraday/websocket_watchdog_task.py
@@ -615,7 +615,10 @@ class WebSocketWatchdogTask(SchedulableTask):
             reserve = getattr(self._price_subscription_service, "set_external_reserved_slots", None)
             if callable(reserve):
                 reserve(reserved_slots)
-            self._price_subscription_service.clear_active_state()
+            # 연결을 실제로 끊는 복원에서만 정책 장부를 비운다. 살아있는 소켓에서 비우면
+            # KIS 에 남은 등록이 정책이 추적하지 못하는 고아 슬롯이 된다.
+            if reset_connection:
+                self._price_subscription_service.clear_active_state()
 
         # 시작 단계에서 먼저 등록된 가격 구독을 비우고 하나의 슬롯 계획으로 다시 구성한다.
         if self._streaming_service and reset_connection:

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -3052,3 +3052,23 @@ async def test_hard_error_discards_stale_subscription_membership(websocket_api_i
     assert ("H0UNCNT0", "005930") not in api._subscribed_items
     confirmed = await api.wait_for_subscription_ack("H0UNCNT0", "005930", timeout=0.05)
     assert confirmed is False
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_ledger_classifies_price_pt_and_others(websocket_api_instance):
+    """KIS 등록 원장을 체결가/프로그램매매/기타로 분류한다 — 슬롯 회계의 진실 소스."""
+    api = websocket_api_instance
+    api._subscribed_items = {
+        ("H0UNCNT0", "005930"),
+        ("H0UNCNT0", "000660"),
+        ("H0STPGM0", "005930"),
+        ("H0STMKO0", "000000"),   # 장운영정보 — 정책이 모르지만 KIS 한도는 소비한다
+        ("H0UNMKO0", "000000"),
+        ("H0STCNI9", "@0173312"),  # 체결통보
+    }
+
+    ledger = api.get_subscription_ledger()
+
+    assert ledger["total"] == 6
+    assert ledger["price_codes"] == {"005930", "000660"}
+    assert ledger["program_trading_codes"] == {"005930"}

--- a/tests/unit_test/services/test_subscription_policy.py
+++ b/tests/unit_test/services/test_subscription_policy.py
@@ -441,3 +441,49 @@ async def test_do_unsubscribe_success_and_exception(policy, mock_streaming, mock
     await policy._do_unsubscribe("B", StreamingType.PROGRAM_TRADING)
     # 구체화된 에러 로깅 검증
     mock_streaming_logger.log_unsubscribe_failure.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_rebalance_reserves_slots_for_registrations_policy_does_not_own(policy, mock_streaming):
+    """정책이 소유하지 않은 KIS 등록(장운영정보·체결통보 등)만큼 가용 슬롯이 줄어든다.
+
+    2026-08-19 장애: 정책은 30/40 이라 믿었지만 KIS 는 이미 41/41 이라
+    이후 모든 구독이 MAX SUBSCRIBE OVER 로 거절됐다.
+    """
+    mock_streaming.get_subscription_ledger = MagicMock(return_value={
+        "total": 11,
+        "price_codes": set(),
+        "program_trading_codes": set(),
+    })
+    codes = [f"{i:06d}" for i in range(40)]
+
+    await policy.sync_subscriptions(codes, "portfolio", SubscriptionPriority.HIGH)
+
+    assert len(policy._active_codes_price) == SubscriptionPolicy.MAX_WS_SLOTS - 11
+
+
+@pytest.mark.asyncio
+async def test_rebalance_releases_broker_registrations_policy_no_longer_wants(policy, mock_streaming):
+    """정책이 원하지 않는데 KIS 에 남아 있는 등록(고아)을 회수한다."""
+    mock_streaming.get_subscription_ledger = MagicMock(return_value={
+        "total": 3,
+        "price_codes": {"111111"},
+        "program_trading_codes": {"222222"},
+    })
+
+    await policy.add_subscription("005930", SubscriptionPriority.HIGH, "portfolio")
+
+    mock_streaming.unsubscribe_unified_price.assert_any_await("111111")
+    mock_streaming.unsubscribe_program_trading.assert_any_await("222222")
+
+
+@pytest.mark.asyncio
+async def test_subscribe_order_follows_priority_not_set_iteration(policy, mock_streaming):
+    """슬롯 경합 시 우선순위 높은 종목이 먼저 구독 요청된다."""
+    for code in ("000001", "000002", "000003", "000004"):
+        await policy.add_subscription(code, SubscriptionPriority.LOW, "ui_view", rebalance=False)
+    await policy.add_subscription("999998", SubscriptionPriority.HIGH, "portfolio", rebalance=False)
+    await policy.add_subscription("999999", SubscriptionPriority.HIGH, "portfolio")
+
+    requested = [c.args[0] for c in mock_streaming.subscribe_unified_price.await_args_list]
+    assert requested == ["999998", "999999", "000001", "000002", "000003", "000004"]

--- a/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
+++ b/tests/unit_test/task/background/intraday/test_websocket_watchdog_task.py
@@ -1603,3 +1603,34 @@ async def test_force_reconnect_logs_active_pt_count(watchdog_task, mock_price_su
         total=1,
     )
     
+
+
+@pytest.mark.asyncio
+async def test_restore_without_connection_reset_keeps_policy_active_state():
+    """연결을 리셋하지 않는 복원은 정책 장부를 비우지 않는다.
+
+    2026-08-19 장애: 살아있는 소켓에서 clear_active_state() 를 호출해
+    KIS 등록 6건이 정책이 추적하지 못하는 고아 슬롯으로 남았다.
+    """
+    streaming_service = MagicMock()
+    streaming_service.connect_websocket = AsyncMock(return_value=True)
+    mcs = AsyncMock()
+    mcs.is_market_open_now = AsyncMock(return_value=True)
+    price_svc = MagicMock()
+    price_svc.clear_active_state = MagicMock()
+    price_svc._rebalance = AsyncMock()
+    price_svc._refs = {"005930": 1}
+    price_svc._active_codes_price = {"005930"}
+
+    svc = WebSocketWatchdogTask(
+        streaming_service=streaming_service,
+        market_calendar_service=mcs,
+        streaming_stock_repo=None,
+        price_subscription_service=price_svc,
+        streaming_logger=None,
+    )
+
+    await svc._restore_all_subscriptions(reset_connection=False)
+
+    price_svc.clear_active_state.assert_not_called()
+    price_svc._rebalance.assert_awaited_once()


### PR DESCRIPTION
## 문제

특정 종목(예: 제주반도체 080220)의 현재가 창이 열려 있어도 가격이 갱신되지 않는다.

현재가 창의 가격은 SSE(`/api/streaming/price/{code}`)로 들어오는 웹소켓 체결틱으로만 갱신되는데, 해당 종목이 KIS에 아예 등록되지 않아 틱이 0건이었다.

## 실측 근거 (2026-08-19)

ACK 로그로 복원한 KIS 실등록 원장 — **41/41 (브로커 하드캡 포화)**:

| tr_id | 건수 | 정책 인지 |
|---|---|---|
| H0UNCNT0 (통합체결가) | 22 | 22 |
| H0STPGM0 (프로그램매매) | 14 | **8** → 6건 고아 |
| H0STMKO0/H0UNMKO0 (장운영정보) | 4 | 0 |
| H0STCNI9 (체결통보) | 1 | 0 |

정책은 `30/40`이라 믿었지만 실제는 `41/41`. 그 결과:

1. `09:30:44` — 워치독이 소켓 재연결 없이 `clear_active_state()`로 정책 장부만 초기화 → PT 6건이 회수 불가능한 고아로 남음
2. `09:31:09` — 080220의 체결가 등록 해지 → 0.2초 뒤 다른 종목이 슬롯 선점
3. `09:31:10~` — 080220 재구독이 전부 `MAX SUBSCRIBE OVER`로 거절 (21회+, 09:40까지 지속)

## 변경

- **`KoreaInvestWebSocketAPI.get_subscription_ledger()`** — KIS 실등록 원장을 체결가/프로그램매매/기타로 분류해 노출. 정책이 관리하지 않는 장운영정보·체결통보도 KIS 한도를 소비하므로 `total`에 포함한다. (client → wrapper → StreamingService 패스스루)
- **`SubscriptionPolicy`** — 가용 슬롯을 브로커 실등록 기준으로 계산. 추정치(`_external_reserved_slots`)로 인한 과다 배정 제거. 브로커가 원장을 제공하지 않으면 기존 방식 유지.
- **`SubscriptionPolicy._rebalance`** — 브로커에 남아 있으나 정책이 원하지 않는 등록(고아)을 해지해 슬롯 회수. 구독 순서도 우선순위 정렬을 따라, 슬롯 경합 시 LOW가 MEDIUM보다 먼저 자리를 채가지 않게 한다.
- **`WebSocketWatchdogTask`** — `clear_active_state()`를 연결을 실제로 끊는 복원에서만 호출 (고아 생성 경로 차단).

## 테스트

TDD로 5개 실패 테스트 선작성 후 통과시킴:

- `test_get_subscription_ledger_classifies_price_pt_and_others` — 원장 분류
- `test_rebalance_reserves_slots_for_registrations_policy_does_not_own` — 미소유 등록만큼 가용 슬롯 축소
- `test_rebalance_releases_broker_registrations_policy_no_longer_wants` — 고아 회수
- `test_subscribe_order_follows_priority_not_set_iteration` — 우선순위 결정적 구독 순서
- `test_restore_without_connection_reset_keeps_policy_active_state` — 살아있는 소켓에서 장부 미초기화

```
pytest tests/unit_test        → 7850 passed
pytest tests/integration_test →  279 passed
```

## 남은 사항 (이번 PR 범위 밖)

- `config.yaml`의 `market_status_alert.monitor_codes`에 `080220`이 들어 있어 장운영정보로 2슬롯을 추가 소비한다. `000000`이 전체 시장을 커버하므로 제거하면 2슬롯을 즉시 회수할 수 있다. 개인 설정 파일이라 변경하지 않았다.
- KIS가 ACK 후에도 프레임을 보내지 않는 no-tick 종목 자체는 이 PR에서 다루지 않는다. 격리된 종목이 슬롯을 계속 점유하는 문제는 별건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
