### PR TITLE
Fix market indices hang on common page

### DIFF
--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -119,6 +119,36 @@ async def test_get_stock_detail_timeout(web_client, mock_web_ctx):
     assert "초과" in json_resp["msg1"]
 
 
+@pytest.mark.asyncio
+async def test_get_market_index_timeout(web_client, mock_web_ctx):
+    """GET /api/market-index/{index_code}은 타임아웃 시 에러 응답을 반환한다."""
+    import asyncio
+
+    mock_web_ctx.stock_query_service.get_index_chart.side_effect = asyncio.TimeoutError()
+
+    response = web_client.get("/api/market-index/0001?period=1D")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "1"
+    assert "초과" in json_resp["msg1"]
+
+
+@pytest.mark.asyncio
+async def test_get_market_index_flow_timeout(web_client, mock_web_ctx):
+    """GET /api/market-index/{index_code}/flow는 타임아웃 시 에러 응답을 반환한다."""
+    import asyncio
+
+    mock_web_ctx.stock_query_service.get_index_flow.side_effect = asyncio.TimeoutError()
+
+    response = web_client.get("/api/market-index/0001/flow")
+
+    assert response.status_code == 200
+    json_resp = response.json()
+    assert json_resp["rt_cd"] == "1"
+    assert "초과" in json_resp["msg1"]
+
+
 def test_ai_stock_analysis_requires_enabled_ai(web_client, mock_web_ctx):
     mock_web_ctx.ai_stock_analyzer = None
 

--- a/tests/unit_test/view/web/test_market_indices_contracts.py
+++ b/tests/unit_test/view/web/test_market_indices_contracts.py
@@ -121,6 +121,20 @@ def test_domestic_index_flow_is_wired_to_its_own_endpoint():
         assert label in script, f"{label} 수급 항목이 없음"
 
 
+def test_market_indices_rerenders_after_pjax_navigation():
+    script = _market_indices_js()
+
+    assert "pjax:ready" in script
+    assert "renderMarketIndices" in script
+
+
+def test_domestic_index_card_does_not_block_on_flow_query():
+    script = _market_indices_js()
+
+    assert "appendMarketIndexFlow(doc, card, entry.code).catch" in script
+    assert "await appendMarketIndexFlow(doc, card, entry.code)" not in script
+
+
 def test_market_index_flow_route_exists():
     routes = Path("view/web/routes/stock.py").read_text(encoding="utf-8")
 

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -164,7 +164,14 @@ async def get_market_index(index_code: str, period: str = "1D"):
     period: 1D(10분봉) / 1W / 1M / 1Y
     """
     ctx = _get_ctx()
-    resp = await ctx.stock_query_service.get_index_chart(index_code, period=period)
+    try:
+        resp = await asyncio.wait_for(
+            ctx.stock_query_service.get_index_chart(index_code, period=period),
+            timeout=12.0,
+        )
+    except asyncio.TimeoutError:
+        ctx.logger.warning(f"[stock] 지수 차트 조회 타임아웃 ({index_code}, {period}, 12s 초과)")
+        return {"rt_cd": "1", "msg1": "지수 API 응답 시간이 초과되었습니다.", "data": None}
     return _serialize_response(resp)
 
 
@@ -175,7 +182,14 @@ async def get_market_index_flow(index_code: str):
     기간과 무관한 값이라 차트와 별도 엔드포인트로 둔다.
     """
     ctx = _get_ctx()
-    resp = await ctx.stock_query_service.get_index_flow(index_code)
+    try:
+        resp = await asyncio.wait_for(
+            ctx.stock_query_service.get_index_flow(index_code),
+            timeout=12.0,
+        )
+    except asyncio.TimeoutError:
+        ctx.logger.warning(f"[stock] 지수 수급 조회 타임아웃 ({index_code}, 12s 초과)")
+        return {"rt_cd": "1", "msg1": "지수 수급 API 응답 시간이 초과되었습니다.", "data": None}
     return _serialize_response(resp)
 
 

--- a/view/web/static/js/market_indices.js
+++ b/view/web/static/js/market_indices.js
@@ -346,7 +346,7 @@ async function buildMarketIndexKisCard(doc, entry) {
     card.appendChild(body);
 
     await selectMarketIndexPeriod(card, entry.code, MARKET_INDEX_DEFAULT_PERIOD);
-    await appendMarketIndexFlow(doc, card, entry.code);
+    appendMarketIndexFlow(doc, card, entry.code).catch(() => {});
     return card;
 }
 
@@ -383,3 +383,4 @@ async function renderMarketIndices() {
 }
 
 document.addEventListener('DOMContentLoaded', renderMarketIndices);
+document.addEventListener('pjax:ready', renderMarketIndices);

--- a/view/web/templates/index.html
+++ b/view/web/templates/index.html
@@ -104,5 +104,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/market_indices.js?v=4"></script>
+<script src="/static/js/market_indices.js?v=5"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Re-render market indices after PJAX navigation to the common page.
- Decouple index flow loading from initial chart/card rendering so the index appears first.
- Add 12s timeout handling for market index chart and flow API routes.

## Root Cause
The common page market index script only initialized on DOMContentLoaded, while common navigation can happen through PJAX. Domestic index cards also awaited the flow API after chart loading, so a slow flow response delayed the visible index card.

## Validation
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/unit_test -v
- C:\\Users\\Kyungsoo\\anaconda3\\envs\\py310\\python.exe -m pytest tests/integration_test -v -n0