### PR TITLE
Add paper account expiry alerts

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -16,6 +16,15 @@ paper_stock_account_number: "모의_계좌번호"
 paper_url: "https://openapivts.koreainvestment.com:29443"
 paper_websocket_url: "ws://ops.koreainvestment.com:31000"
 
+# 모의투자 계좌는 3개월마다 재신청이 필요합니다.
+# KIS Developers > 모의투자 > 나의계좌 > 투자기간 종료일을 넣으세요.
+paper_account_expiry_alert:
+  enabled: true
+  expires_at: null  # 예: "2026-11-19"
+  warning_days: 7
+  check_interval_sec: 3600
+  state_file_path: "data/paper_account_expiry_alert_state.json"
+
 # 실전/모의 선택 (true: 모의, false: 실전)
 is_paper_trading: true
 

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -260,6 +260,16 @@ class OrderExecutionConfig(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class PaperAccountExpiryAlertConfig(BaseModel):
+    enabled: bool = True
+    expires_at: Optional[str] = None
+    warning_days: int = Field(default=7, ge=0, le=31)
+    check_interval_sec: int = Field(default=3600, ge=60)
+    state_file_path: str = "data/paper_account_expiry_alert_state.json"
+
+    model_config = {"extra": "allow"}
+
+
 class DataQualityConfig(BaseModel):
     enabled: bool = True
     max_tick_age_sec: float = 30.0
@@ -591,6 +601,9 @@ class AppConfig(BaseModel):
     risk_gate: RiskGateConfig = Field(default_factory=RiskGateConfig)
     order_policy: OrderPolicyConfig = Field(default_factory=OrderPolicyConfig)
     order_execution: OrderExecutionConfig = Field(default_factory=OrderExecutionConfig)
+    paper_account_expiry_alert: PaperAccountExpiryAlertConfig = Field(
+        default_factory=PaperAccountExpiryAlertConfig
+    )
     data_quality: DataQualityConfig = Field(default_factory=DataQualityConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     dart_disclosure: DartDisclosureConfig = Field(default_factory=DartDisclosureConfig)

--- a/services/paper_account_expiry_alert_service.py
+++ b/services/paper_account_expiry_alert_service.py
@@ -1,0 +1,164 @@
+"""Paper trading account expiry alert service."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime
+from typing import Optional
+
+from services.notification_service import (
+    NotificationCategory,
+    NotificationLevel,
+    NotificationService,
+)
+
+
+class PaperAccountExpiryAlertService:
+    """Emit a daily warning near the KIS paper account expiry date."""
+
+    def __init__(
+        self,
+        *,
+        expires_at: Optional[str],
+        notification_service: Optional[NotificationService],
+        market_clock,
+        warning_days: int = 7,
+        state_file: str = "data/paper_account_expiry_alert_state.json",
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._expires_at_raw = expires_at
+        self._expires_at = self._parse_date(expires_at)
+        self._warning_days = max(0, int(warning_days))
+        self._ns = notification_service
+        self._market_clock = market_clock
+        self._state_file = state_file
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def check_and_notify(self, is_paper_trading: bool, account_number: str) -> dict:
+        if not is_paper_trading:
+            return {"alerted": False, "reason": "not_paper_trading"}
+        if self._expires_at is None:
+            return {"alerted": False, "reason": "expiry_not_configured"}
+        if self._ns is None or self._market_clock is None:
+            return {"alerted": False, "reason": "notification_dependencies_missing"}
+
+        today = self._today()
+        days_left = (self._expires_at - today).days
+        if days_left > self._warning_days:
+            return {
+                "alerted": False,
+                "reason": "outside_warning_window",
+                "days_left": days_left,
+                "expires_at": self._expires_at.isoformat(),
+            }
+
+        account = str(account_number or "").strip()
+        if self._already_alerted(today, account):
+            return {
+                "alerted": False,
+                "reason": "already_alerted_today",
+                "days_left": days_left,
+                "expires_at": self._expires_at.isoformat(),
+            }
+
+        title = "모의투자 계좌 만료" if days_left < 0 else "모의투자 계좌 만료 예정"
+        level = NotificationLevel.ERROR if days_left < 0 else NotificationLevel.WARNING
+        message = self._build_message(account, days_left)
+        await self._ns.emit(
+            NotificationCategory.SYSTEM,
+            level,
+            title,
+            message,
+            metadata={
+                "dedup_key": f"paper_account_expiry:{account}:{self._expires_at.isoformat()}",
+                "force_external": True,
+                "account_number": account,
+                "expires_at": self._expires_at.isoformat(),
+                "days_left": days_left,
+            },
+        )
+        self._save_state(today, account)
+        return {
+            "alerted": True,
+            "days_left": days_left,
+            "expires_at": self._expires_at.isoformat(),
+        }
+
+    def _today(self) -> date:
+        now = self._market_clock.get_current_kst_time()
+        return now.date() if isinstance(now, datetime) else now
+
+    def _build_message(self, account: str, days_left: int) -> str:
+        account_text = self._mask_account(account)
+        expires_at = self._expires_at.isoformat()
+        if days_left < 0:
+            status = f"{abs(days_left)}일 전에 만료"
+        elif days_left == 0:
+            status = "오늘 만료"
+        else:
+            status = f"{days_left}일 남음"
+        return (
+            f"모의투자 계좌({account_text}) 유효기간이 {expires_at} 기준 {status}입니다. "
+            "KIS Developers에서 모의투자 계좌를 재신청한 뒤 "
+            "config.yaml의 paper_stock_account_number와 paper_account_expiry_alert.expires_at을 갱신하세요."
+        )
+
+    def _already_alerted(self, today: date, account: str) -> bool:
+        state = self._load_state()
+        return (
+            state.get("last_alert_date") == today.isoformat()
+            and state.get("account_number") == account
+            and state.get("expires_at") == self._expires_at.isoformat()
+        )
+
+    def _load_state(self) -> dict:
+        try:
+            with open(self._state_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            self._logger.warning(f"[PaperAccountExpiryAlert] state load failed: {exc}")
+            return {}
+
+    def _save_state(self, today: date, account: str) -> None:
+        try:
+            dirname = os.path.dirname(self._state_file)
+            if dirname:
+                os.makedirs(dirname, exist_ok=True)
+            with open(self._state_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "last_alert_date": today.isoformat(),
+                        "account_number": account,
+                        "expires_at": self._expires_at.isoformat(),
+                    },
+                    f,
+                    ensure_ascii=False,
+                )
+        except Exception as exc:
+            self._logger.warning(f"[PaperAccountExpiryAlert] state save failed: {exc}")
+
+    @staticmethod
+    def _parse_date(value: Optional[str]) -> Optional[date]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y.%m.%d"):
+            try:
+                return datetime.strptime(text, fmt).date()
+            except ValueError:
+                continue
+        raise ValueError(
+            "paper_account_expiry_alert.expires_at은 YYYY-MM-DD, YYYY/MM/DD, YYYY.MM.DD 형식이어야 합니다."
+        )
+
+    @staticmethod
+    def _mask_account(account: str) -> str:
+        if len(account) <= 4:
+            return "***"
+        return f"{account[:2]}***{account[-2:]}"

--- a/task/background/intraday/paper_account_expiry_alert_task.py
+++ b/task/background/intraday/paper_account_expiry_alert_task.py
@@ -1,0 +1,112 @@
+"""Daily paper account expiry alert task."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, List, Optional
+
+from interfaces.schedulable_task import SchedulableTask, TaskPriority, TaskState
+
+
+class PaperAccountExpiryAlertTask(SchedulableTask):
+    CHECK_INTERVAL_SEC = 60 * 60
+
+    def __init__(
+        self,
+        *,
+        alert_service,
+        env,
+        market_clock,
+        logger: Optional[logging.Logger] = None,
+        check_interval_sec: int = CHECK_INTERVAL_SEC,
+    ) -> None:
+        self._alert_service = alert_service
+        self._env = env
+        self._market_clock = market_clock
+        self._logger = logger or logging.getLogger(__name__)
+        self._check_interval_sec = int(check_interval_sec)
+        self._state = TaskState.IDLE
+        self._tasks: List[asyncio.Task] = []
+        self._last_checked_date: Optional[str] = None
+        self._last_result: Dict = {"alerted": False, "reason": "never_checked"}
+
+    @property
+    def task_name(self) -> str:
+        return "paper_account_expiry_alert"
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.NORMAL
+
+    @property
+    def state(self) -> TaskState:
+        return self._state
+
+    async def start(self) -> None:
+        if any(not task.done() for task in self._tasks):
+            return
+        if self._state == TaskState.STOPPED:
+            self._state = TaskState.IDLE
+        self._tasks.append(asyncio.create_task(self._loop()))
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        self._state = TaskState.STOPPED
+
+    async def suspend(self) -> None:
+        if self._state == TaskState.RUNNING:
+            self._state = TaskState.SUSPENDED
+
+    async def resume(self) -> None:
+        if self._state == TaskState.SUSPENDED:
+            self._state = TaskState.IDLE
+
+    def get_progress(self) -> Dict:
+        return {
+            "running": self._state == TaskState.RUNNING,
+            "last_checked_date": self._last_checked_date,
+            "last_result": self._last_result,
+        }
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._check_interval_sec)
+                if self._state == TaskState.SUSPENDED:
+                    continue
+                if await self._should_run_now():
+                    self._state = TaskState.RUNNING
+                    try:
+                        await self.run_once()
+                    finally:
+                        if self._state == TaskState.RUNNING:
+                            self._state = TaskState.IDLE
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._logger.error(f"[PaperAccountExpiryAlert] loop error: {exc}", exc_info=True)
+
+    async def _should_run_now(self) -> bool:
+        if self._market_clock is None:
+            return False
+        date_key = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
+        return self._last_checked_date != date_key
+
+    async def run_once(self) -> Dict:
+        if self._market_clock is None:
+            return {"alerted": False, "reason": "market_clock_missing"}
+        date_key = self._market_clock.get_current_kst_time().strftime("%Y%m%d")
+        if self._last_checked_date == date_key:
+            return {"alerted": False, "reason": "already_checked_today"}
+
+        is_paper = bool(getattr(self._env, "is_paper_trading", False))
+        account = str(getattr(self._env, "paper_stock_account_number", "") or "")
+        result = await self._alert_service.check_and_notify(is_paper, account)
+        self._last_checked_date = date_key
+        self._last_result = result
+        return result

--- a/tests/unit_test/services/test_paper_account_expiry_alert_service.py
+++ b/tests/unit_test/services/test_paper_account_expiry_alert_service.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.notification_service import NotificationCategory, NotificationLevel
+from services.paper_account_expiry_alert_service import PaperAccountExpiryAlertService
+
+
+def _clock(now: datetime):
+    clock = MagicMock()
+    clock.get_current_kst_time.return_value = now
+    return clock
+
+
+@pytest.mark.asyncio
+async def test_emits_daily_warning_from_seven_days_before_expiry(tmp_path):
+    ns = AsyncMock()
+    service = PaperAccountExpiryAlertService(
+        expires_at="2026/11/19",
+        warning_days=7,
+        notification_service=ns,
+        market_clock=_clock(datetime(2026, 11, 12, 8, 30)),
+        state_file=str(tmp_path / "state.json"),
+        logger=MagicMock(),
+    )
+
+    result = await service.check_and_notify(
+        is_paper_trading=True,
+        account_number="50202454",
+    )
+
+    assert result["alerted"] is True
+    assert result["days_left"] == 7
+    ns.emit.assert_awaited_once()
+    args, kwargs = ns.emit.await_args
+    assert args[:3] == (
+        NotificationCategory.SYSTEM,
+        NotificationLevel.WARNING,
+        "모의투자 계좌 만료 예정",
+    )
+    assert "2026-11-19" in args[3]
+    assert "7일" in args[3]
+    assert kwargs["metadata"]["force_external"] is True
+
+
+@pytest.mark.asyncio
+async def test_deduplicates_same_account_and_expiry_once_per_day(tmp_path):
+    ns = AsyncMock()
+    service = PaperAccountExpiryAlertService(
+        expires_at="2026-11-19",
+        notification_service=ns,
+        market_clock=_clock(datetime(2026, 11, 18, 8, 30)),
+        state_file=str(tmp_path / "state.json"),
+        logger=MagicMock(),
+    )
+
+    first = await service.check_and_notify(True, "50202454")
+    second = await service.check_and_notify(True, "50202454")
+
+    assert first["alerted"] is True
+    assert second["alerted"] is False
+    assert second["reason"] == "already_alerted_today"
+    ns.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_not_paper_or_outside_warning_window(tmp_path):
+    ns = AsyncMock()
+    service = PaperAccountExpiryAlertService(
+        expires_at="2026-11-19",
+        notification_service=ns,
+        market_clock=_clock(datetime(2026, 11, 11, 8, 30)),
+        state_file=str(tmp_path / "state.json"),
+        logger=MagicMock(),
+    )
+
+    real_result = await service.check_and_notify(False, "50202454")
+    early_result = await service.check_and_notify(True, "50202454")
+
+    assert real_result == {"alerted": False, "reason": "not_paper_trading"}
+    assert early_result["alerted"] is False
+    assert early_result["reason"] == "outside_warning_window"
+    assert early_result["days_left"] == 8
+    ns.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_expired_account_still_alerts_daily(tmp_path):
+    ns = AsyncMock()
+    service = PaperAccountExpiryAlertService(
+        expires_at="2026.11.19",
+        notification_service=ns,
+        market_clock=_clock(datetime(2026, 11, 20, 8, 30)),
+        state_file=str(tmp_path / "state.json"),
+        logger=MagicMock(),
+    )
+
+    result = await service.check_and_notify(True, "50202454")
+
+    assert result["alerted"] is True
+    assert result["days_left"] == -1
+    args, _ = ns.emit.await_args
+    assert args[1] == NotificationLevel.ERROR
+    assert args[2] == "모의투자 계좌 만료"

--- a/tests/unit_test/task/background/intraday/test_paper_account_expiry_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_paper_account_expiry_alert_task.py
@@ -1,0 +1,70 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from interfaces.schedulable_task import TaskState
+from task.background.intraday.paper_account_expiry_alert_task import (
+    PaperAccountExpiryAlertTask,
+)
+
+
+@pytest.mark.asyncio
+async def test_task_runs_once_per_day():
+    clock = MagicMock()
+    clock.get_current_kst_time.return_value = datetime(2026, 11, 12, 8, 30)
+    service = AsyncMock()
+    service.check_and_notify.return_value = {"alerted": True, "days_left": 7}
+    task = PaperAccountExpiryAlertTask(
+        alert_service=service,
+        env=MagicMock(is_paper_trading=True, paper_stock_account_number="50202454"),
+        market_clock=clock,
+        logger=MagicMock(),
+    )
+
+    first = await task.run_once()
+    second = await task.run_once()
+
+    assert first == {"alerted": True, "days_left": 7}
+    assert second == {"alerted": False, "reason": "already_checked_today"}
+    service.check_and_notify.assert_awaited_once_with(True, "50202454")
+
+
+@pytest.mark.asyncio
+async def test_task_lifecycle_cancels_background_loop():
+    task = PaperAccountExpiryAlertTask(
+        alert_service=AsyncMock(),
+        env=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    try:
+        await task.start()
+        await task.start()
+        assert len(task._tasks) == 1
+        assert task.state == TaskState.IDLE
+    finally:
+        await task.stop()
+
+    assert task.state == TaskState.STOPPED
+    assert task._tasks == []
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_when_due_and_handles_errors():
+    task = PaperAccountExpiryAlertTask(
+        alert_service=AsyncMock(),
+        env=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+    task._should_run_now = AsyncMock(side_effect=[True, RuntimeError("boom"), asyncio.CancelledError()])
+    task.run_once = AsyncMock()
+
+    with patch("task.background.intraday.paper_account_expiry_alert_task.asyncio.sleep", new_callable=AsyncMock):
+        await task._loop()
+
+    task.run_once.assert_awaited_once()
+    task._logger.error.assert_called_once()

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -114,6 +114,7 @@ class SchedulerBootstrap:
 
     def _register_trading_tasks(self) -> None:
         ctx = self._ctx
+        self._register(self._optional_task("paper_account_expiry_alert_task"))
         self._register(ctx.pre_market_health_check_task)
         self._register(ctx.opening_position_reconcile_task, TaskPriority.HIGH)
         self._register(ctx.cache_warmup_task)

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -16,6 +16,7 @@ from config.config_loader import (
     AiAnalysisConfig,
     DartDisclosureConfig,
     OrderPolicyConfig,
+    PaperAccountExpiryAlertConfig,
     PositionSizingConfig,
     RiskGateConfig,
     TradeTrendMonitorConfig,
@@ -51,6 +52,7 @@ from task.background.after_market.theme_classification_task import ThemeClassifi
 from services.opening_position_reconcile_service import OpeningPositionReconcileService
 from services.order_execution_service import OrderExecutionService
 from services.order_policy_service import OrderPolicyService
+from services.paper_account_expiry_alert_service import PaperAccountExpiryAlertService
 from services.position_sizing_service import PositionSizingService
 from services.risk_gate_service import RiskGateService
 from services.overseas_candidate_service import OverseasCandidateService
@@ -76,6 +78,7 @@ from task.background.always_on.dart_disclosure_monitor_task import DartDisclosur
 from task.background.always_on.trade_trend_monitor_task import TradeTrendMonitorTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
+from task.background.intraday.paper_account_expiry_alert_task import PaperAccountExpiryAlertTask
 from task.background.intraday.program_capture_subscription_task import ProgramCaptureSubscriptionTask
 from task.background.intraday.theme_intraday_leader_alert_task import ThemeIntradayLeaderAlertTask
 from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
@@ -401,8 +404,30 @@ class ServiceContainer:
                     notification_service=ctx.notification_service,
                     logger=ctx.logger,
                 )
+                expiry_cfg = PaperAccountExpiryAlertConfig.model_validate(
+                    config_dict.get("paper_account_expiry_alert") or {}
+                )
+                ctx.paper_account_expiry_alert_task = (
+                    PaperAccountExpiryAlertTask(
+                        alert_service=PaperAccountExpiryAlertService(
+                            expires_at=expiry_cfg.expires_at,
+                            warning_days=expiry_cfg.warning_days,
+                            notification_service=ctx.notification_service,
+                            market_clock=ctx.market_clock,
+                            state_file=expiry_cfg.state_file_path,
+                            logger=ctx.logger,
+                        ),
+                        env=ctx.env,
+                        market_clock=ctx.market_clock,
+                        logger=ctx.logger,
+                        check_interval_sec=expiry_cfg.check_interval_sec,
+                    )
+                    if expiry_cfg.enabled
+                    else None
+                )
             else:
                 ctx.pre_market_health_check_task = None
+                ctx.paper_account_expiry_alert_task = None
 
             if needs_batch:
                 ctx.daily_price_collector_task = DailyPriceCollectorTask(
@@ -594,6 +619,7 @@ class ServiceContainer:
                 ctx.newhigh_strategy_coverage_backtest_task = None
                 ctx.after_market_reconcile_task = None
                 ctx.opening_position_reconcile_task = None
+                ctx.paper_account_expiry_alert_task = None
                 ctx.microstructure_capture_task = None
                 ctx.theme_intraday_leader_alert_task = None
                 if needs_web:

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -38,6 +38,7 @@ from interfaces.schedulable_task import TaskPriority
 from task.background.intraday.strategy_scheduler_task_adapter import StrategySchedulerTaskAdapter
 from task.background.intraday.websocket_watchdog_task import WebSocketWatchdogTask
 from task.background.intraday.pre_market_health_check_task import PreMarketHealthCheckTask
+from task.background.intraday.paper_account_expiry_alert_task import PaperAccountExpiryAlertTask
 from task.background.intraday.opening_position_reconcile_task import OpeningPositionReconcileTask
 from task.background.after_market.ranking_task import RankingTask
 from task.background.after_market.minervini_update_task import MinerviniUpdateTask
@@ -152,6 +153,7 @@ class WebAppContext:
         self.minervini_update_task: MinerviniUpdateTask = None
         self.websocket_watchdog_task: WebSocketWatchdogTask = None
         self.pre_market_health_check_task: PreMarketHealthCheckTask = None
+        self.paper_account_expiry_alert_task: PaperAccountExpiryAlertTask = None
         self.opening_position_reconcile_task: OpeningPositionReconcileTask = None
         self.after_market_reconcile_task: AfterMarketReconcileTask = None
         self.daily_price_collector_task: DailyPriceCollectorTask = None


### PR DESCRIPTION
## Summary
- Add a daily KIS paper-account expiry alert that starts within the configured warning window, defaulting to 7 days before expiry.
- Wire the alert into web/trading background startup and scheduler registration.
- Add config schema/example entries and focused unit coverage for alerting, deduplication, expired accounts, and task lifecycle.

## Root Cause
- The failed orders were sent through the paper trading endpoint/TR/account, but KIS rejected them because the paper account itself had expired even though the API application validity is longer.

## Validation
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest -o addopts='' tests/unit_test/services/test_paper_account_expiry_alert_service.py tests/unit_test/task/background/intraday/test_paper_account_expiry_alert_task.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v