### PR TITLE
Auto-refresh favorites and fix stalled US heatmap polls

### DIFF
--- a/services/overseas_market_stats_service.py
+++ b/services/overseas_market_stats_service.py
@@ -76,13 +76,17 @@ class OverseasMarketStatsService:
             if self._cached_at is not None and (self._clock() - self._cached_at) <= self._ttl_sec:
                 return self._snapshots, self._fx_rate, self._updated_at
 
+            # TTL 은 수집 '완료'가 아니라 '시작'부터 잰다. 완료 시각으로 재면 수집이
+            # 느린 날일수록 남은 TTL 이 화면 폴링 주기 안쪽으로 밀려들어와, 60초마다
+            # 되묻는데도 같은 스냅샷만 돌아오는 주기가 생긴다.
+            started = self._clock()
             snapshots, fx_rate = await asyncio.gather(
                 self._provider.fetch_snapshots(symbols),
                 self._fetch_fx_rate(),
             )
             self._snapshots = snapshots
             self._fx_rate = fx_rate
-            self._cached_at = self._clock()
+            self._cached_at = started
             self._updated_at = self._wall_clock()
             return self._snapshots, self._fx_rate, self._updated_at
 

--- a/tests/frontend/run_favorite_dom_tests.mjs
+++ b/tests/frontend/run_favorite_dom_tests.mjs
@@ -1,0 +1,234 @@
+/*
+ * jsdom 기반 관심종목 페이지(/favorite) 회귀 테스트.
+ *
+ * 이 화면은 열어둔 채로 시세를 지켜보는 용도라 주기적으로 스스로 다시 조회한다.
+ * 자동 갱신은 (1) 화면을 깜빡이지 않고 (2) 사용자가 잡아둔 정렬을 흔들지 않으며
+ * (3) 안 보는 창에서는 쉬어야 한다 — 그 계약을 여기서 잠근다.
+ *
+ * 실행: node run_favorite_dom_tests.mjs
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { applyCommonStubs, test, assert, run } from "./harness.mjs";
+
+const FAVORITE_JS = resolve(import.meta.dirname, "../../view/web/static/js/favorite.js");
+
+const SCAFFOLD = `
+<div id="section-favorite" class="section">
+  <div class="card">
+    <input type="text" id="fav-search-input">
+    <ul id="fav-autocomplete-list"></ul>
+    <button class="btn" onclick="loadFavoriteList()">새로고침</button>
+    <span id="favorite-updated">최근 업데이트: --</span>
+  </div>
+  <div class="card">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th class="sortable" data-sort="name">종목명(Code)</th>
+          <th class="sortable" data-sort="minervini_stage">Stage</th>
+          <th class="sortable" data-sort="rs_rating">RS</th>
+          <th class="sortable" data-sort="price">현재가</th>
+          <th class="sortable" data-sort="rate">등락률</th>
+          <th>액션</th>
+        </tr>
+      </thead>
+      <tbody id="favorite-list-body"></tbody>
+    </table>
+  </div>
+</div>
+`;
+
+// '/favorite' 로 만들면 DOMContentLoaded 자동 초기화가 끼어들어 호출 수가 흔들린다.
+function makeWindow(fetchImpl, url = "http://localhost/favorite-test") {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
+    url,
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+  applyCommonStubs(window);
+  // favorite.js 는 로드 시점에 자동완성을 건다 — 페이지 모듈은 이 테스트 대상이 아니다.
+  window.StockAutocomplete = () => {};
+  window.showToast = () => {};
+  window.fetch = fetchImpl;
+  window.eval(readFileSync(FAVORITE_JS, "utf8"));
+  return window;
+}
+
+function favoriteItem(overrides) {
+  return {
+    code: "005930",
+    name: "삼성전자",
+    price: 70000,
+    rate: 1.5,
+    rs_rating: 90,
+    minervini_stage: 2,
+    ...overrides,
+  };
+}
+
+// 매 호출마다 다른 목록을 주도록 해, 자동 갱신이 실제로 화면을 갈아끼웠는지 볼 수 있게 한다.
+function favoritePage(pages) {
+  const calls = [];
+  const window = makeWindow(async (url) => {
+    calls.push(url);
+    const page = pages[Math.min(calls.length - 1, pages.length - 1)];
+    if (page instanceof Error) throw page;
+    return { ok: true, status: 200, json: async () => page };
+  });
+  return { window, calls };
+}
+
+// 자동 갱신은 분 단위라 실시간으로 기다릴 수 없다. 창의 setInterval 을 가로채 콜백을
+// 직접 굴려 계약(주기·건너뛸 조건·정리)만 확인한다.
+function captureTimer(window) {
+  const timer = { fn: null, ms: null, starts: 0, cleared: [] };
+  window.setInterval = (fn, ms) => {
+    timer.fn = fn;
+    timer.ms = ms;
+    timer.starts += 1;
+    return timer.starts;
+  };
+  window.clearInterval = (id) => { timer.cleared.push(id); };
+  return timer;
+}
+
+// jsdom 의 visibilityState 기본값은 'prerender'(= hidden true) 라 손대지 않으면
+// 자동 갱신이 늘 건너뛰어진다. 보이는 창인지를 테스트가 명시한다.
+function setPageVisible(window, visible) {
+  Object.defineProperty(window.document, "hidden", { value: !visible, configurable: true });
+}
+
+function rowCodes(window) {
+  return [...window.document.querySelectorAll("#favorite-list-body tr")]
+    .map(tr => tr.id.replace("fav-row-", ""));
+}
+
+test("목록을 그리고 최근 업데이트 시각을 표기한다", async () => {
+  const { window } = favoritePage([[favoriteItem({})]]);
+
+  await window.loadFavoriteList();
+
+  assert(rowCodes(window).includes("005930"), "관심종목 행이 그려져야 함");
+  const label = window.document.getElementById("favorite-updated").textContent;
+  assert(/최근 업데이트: .*\d/.test(label), `갱신 시각이 표기돼야 함 (실제 "${label}")`);
+  assert(/\b30\b/.test(label), `자동 갱신 주기(초)도 함께 알려야 함 (실제 "${label}")`);
+});
+
+test("주기마다 조용히 다시 조회한다", async () => {
+  const { window, calls } = favoritePage([
+    [favoriteItem({})],
+    [favoriteItem({ code: "000660", name: "SK하이닉스" })],
+  ]);
+  const timer = captureTimer(window);
+  setPageVisible(window, true);
+
+  await window.initFavoritePage();
+  assert(timer.ms === 30000, `자동 갱신 주기는 30초여야 함 (실제 ${timer.ms})`);
+
+  const before = calls.length;
+  await timer.fn();
+
+  assert(calls.length === before + 1, `주기마다 목록을 다시 받아야 함 (실제 ${calls.length - before}회)`);
+  assert(rowCodes(window).includes("000660"), "새로 받은 목록으로 갈아끼워야 함");
+  const body = window.document.getElementById("favorite-list-body").innerHTML;
+  assert(!body.includes("로딩 중"), "자동 갱신이 로딩 문구로 화면을 깜빡이면 안 됨");
+});
+
+test("자동 갱신은 사용자가 잡아둔 정렬을 유지한다", async () => {
+  const twoRows = [favoriteItem({ code: "000660", name: "SK하이닉스", rate: 5.0 }), favoriteItem({ rate: 1.0 })];
+  const { window } = favoritePage([twoRows, twoRows]);
+  const timer = captureTimer(window);
+  setPageVisible(window, true);
+
+  await window.initFavoritePage();
+  window.sortFavorites("rate");  // 등락률 내림차순
+  assert(rowCodes(window)[0] === "000660", "정렬 직후 상위는 등락률이 높은 종목이어야 함(전제)");
+
+  await timer.fn();
+
+  assert(rowCodes(window)[0] === "000660", "자동 갱신이 정렬을 원래대로 되돌리면 안 됨");
+});
+
+test("자동 갱신 실패는 보고 있던 목록을 지우지 않는다", async () => {
+  const { window } = favoritePage([[favoriteItem({})], new Error("network")]);
+  const timer = captureTimer(window);
+  setPageVisible(window, true);
+
+  await window.initFavoritePage();
+  const stamp = window.document.getElementById("favorite-updated").textContent;
+  await timer.fn();
+
+  assert(rowCodes(window).includes("005930"), "한 번 실패했다고 보고 있던 시세를 지우면 안 됨");
+  assert(window.document.getElementById("favorite-updated").textContent === stamp,
+    "갱신 시각이 멈춰 있는 것으로 실패를 알린다");
+});
+
+test("수동 새로고침 실패는 실패를 화면에 알린다", async () => {
+  const { window } = favoritePage([new Error("network")]);
+
+  await window.loadFavoriteList();
+
+  const body = window.document.getElementById("favorite-list-body").innerHTML;
+  assert(body.includes("불러오기 실패"), `버튼을 누른 실패는 알려야 함 (실제 "${body}")`);
+});
+
+test("창이 백그라운드면 자동 갱신을 건너뛴다", async () => {
+  const { window, calls } = favoritePage([[favoriteItem({})]]);
+  const timer = captureTimer(window);
+  setPageVisible(window, false);
+
+  await window.initFavoritePage();
+  const before = calls.length;
+  await timer.fn();
+
+  assert(calls.length === before, "안 보는 창 때문에 계속 조회하면 안 됨");
+});
+
+test("백그라운드에서 돌아오면 다음 주기를 기다리지 않고 갱신한다", async () => {
+  const { window, calls } = favoritePage([[favoriteItem({})]]);
+  const timer = captureTimer(window);
+  setPageVisible(window, false);
+
+  await window.initFavoritePage();
+  const before = calls.length;
+  await timer.fn();
+
+  setPageVisible(window, true);
+  window.document.dispatchEvent(new window.Event("visibilitychange"));
+  await new Promise(done => setTimeout(done, 0));
+
+  assert(calls.length === before + 1, `돌아온 즉시 한 번 갱신해야 함 (실제 ${calls.length - before}회)`);
+});
+
+test("다른 화면으로 떠나면 자동 갱신 타이머를 스스로 멈춘다", async () => {
+  const { window, calls } = favoritePage([[favoriteItem({})]]);
+  const timer = captureTimer(window);
+  setPageVisible(window, true);
+
+  await window.initFavoritePage();
+  window.document.getElementById("favorite-list-body").remove();
+  const before = calls.length;
+  await timer.fn();
+
+  assert(calls.length === before, "떠난 화면을 위해 조회하면 안 됨");
+  assert(timer.cleared.length >= 1, "타이머를 해제해야 함");
+});
+
+test("pjax 재진입은 자동 갱신 타이머를 겹쳐 걸지 않는다", async () => {
+  const { window } = favoritePage([[favoriteItem({})]]);
+  setPageVisible(window, true);
+  // 이 화면 전용 스크립트라 로드 시 자동 초기화가 따라붙는다 — 먼저 끝나게 두고 센다.
+  await new Promise(done => setTimeout(done, 0));
+  const timer = captureTimer(window);
+
+  await window.initFavoritePage();
+  await window.initFavoritePage();
+
+  assert(timer.starts === 2, `재진입마다 타이머를 다시 걸어야 함 (실제 ${timer.starts}회)`);
+  assert(timer.cleared.length === timer.starts,
+    `새로 걸 때마다 직전 타이머를 해제해야 함 (건 횟수 ${timer.starts}, 해제 ${timer.cleared.length})`);
+});
+
+await run();

--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -942,6 +942,26 @@ test("창이 백그라운드면 자동 갱신을 건너뛴다", async () => {
   assert(calls.length === 0, "안 보는 창 때문에 외부 API 를 계속 두드리면 안 됨");
 });
 
+// 백그라운드 동안 건너뛴 주기는 그대로 지연이 된다 — 브라우저가 숨은 탭의 타이머를
+// 늦추기까지 해서, 돌아왔을 때 화면이 몇 분 전 값인 채로 다음 주기를 기다리게 된다.
+test("백그라운드에서 돌아오면 다음 주기를 기다리지 않고 갱신한다", async () => {
+  const { window, calls, timer } = autoRefreshPage();
+
+  await window.initHeatmapPage();
+  await window.setHeatmapTab("overseas");
+  setPageVisible(window, false);
+  calls.length = 0;
+  await timer.fn();
+  assert(calls.length === 0, "숨은 동안은 건너뛴다(전제)");
+
+  setPageVisible(window, true);
+  window.document.dispatchEvent(new window.Event("visibilitychange"));
+  await new Promise(done => setTimeout(done, 0));
+
+  assert(overseasCalls(calls).length === 1,
+    `돌아온 즉시 한 번 갱신해야 함 (실제 ${overseasCalls(calls).length}회)`);
+});
+
 test("다른 화면으로 떠나면 자동 갱신 타이머를 스스로 멈춘다", async () => {
   const { window, calls, timer } = autoRefreshPage();
 

--- a/tests/frontend/run_overseas_dom_tests.mjs
+++ b/tests/frontend/run_overseas_dom_tests.mjs
@@ -29,6 +29,7 @@ const SCAFFOLD = `
 <section id="overseas-panel-favorite" hidden>
   <input id="overseas-fav-symbol" type="text">
   <ul id="overseas-fav-autocomplete-list"></ul>
+  <span id="overseas-favorite-updated">최근 업데이트: --</span>
   <table><tbody id="overseas-favorite-body"></tbody></table>
 </section>
 <section id="overseas-panel-orders" hidden></section>
@@ -478,6 +479,128 @@ test("삭제 버튼은 해당 심볼만 DELETE 하고 행을 제거한다", asyn
   const body = window.document.getElementById("overseas-favorite-body").textContent;
   assert(!body.includes("AAPL"), "삭제한 행이 사라져야 함");
   assert(body.includes("MSFT"), "다른 행은 남아야 함");
+});
+
+// 즐겨찾기는 열어둔 채로 시세를 지켜보는 화면이라 스스로 다시 조회한다. 다만 국내와 달리
+// 실시간 스트림이 없어 심볼 수만큼 해외 시세 API 를 부르므로, 보고 있을 때만 돌아야 한다.
+
+function favoriteAutoRefreshWindow(pages) {
+  const window = makeWindow();
+  const calls = [];
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    calls.push(url);
+    const page = pages[Math.min(calls.length - 1, pages.length - 1)];
+    if (page instanceof Error) throw page;
+    return { ok: true, status: 200, json: async () => page };
+  };
+  return { window, calls };
+}
+
+// initOverseasPage 는 실전 배너 타이머(3초)도 건다 — 주기로 즐겨찾기 타이머만 골라낸다.
+function captureIntervals(window) {
+  const entries = [];
+  const cleared = [];
+  window.setInterval = (fn, ms) => {
+    entries.push({ fn, ms });
+    return entries.length;
+  };
+  window.clearInterval = (id) => { cleared.push(id); };
+  return {
+    entries,
+    cleared,
+    favorite: () => [...entries].reverse().find(entry => entry.ms === 60000),
+  };
+}
+
+function setPageVisible(window, visible) {
+  Object.defineProperty(window.document, "hidden", { value: !visible, configurable: true });
+}
+
+const APPLE = [{ code: "AAPL", name: "Apple Inc.", exchange: "NASD", price: 190.5, rate: 1.23 }];
+const MSFT = [{ code: "MSFT", name: "Microsoft", exchange: "NASD", price: 410, rate: 0.4 }];
+
+test("즐겨찾기 목록을 그리면 최근 업데이트 시각을 표기한다", async () => {
+  const { window } = favoriteAutoRefreshWindow([APPLE]);
+
+  await window.loadOverseasFavorites();
+  await flush();
+
+  const label = window.document.getElementById("overseas-favorite-updated").textContent;
+  assert(/최근 업데이트: .*\d/.test(label), `갱신 시각이 표기돼야 함 (실제 "${label}")`);
+  assert(/\b60\b/.test(label), `자동 갱신 주기(초)도 함께 알려야 함 (실제 "${label}")`);
+});
+
+test("즐겨찾기 탭을 보고 있으면 주기마다 조용히 다시 조회한다", async () => {
+  const { window, calls } = favoriteAutoRefreshWindow([APPLE, MSFT]);
+  const timers = captureIntervals(window);
+  setPageVisible(window, true);
+
+  window.initOverseasPage();
+  await window.setOverseasTab("favorite");
+  await flush();
+
+  const timer = timers.favorite();
+  assert(timer, "즐겨찾기 자동 갱신 주기는 60초여야 함");
+
+  const before = calls.length;
+  await timer.fn();
+
+  assert(calls.length === before + 1, `주기마다 목록을 다시 받아야 함 (실제 ${calls.length - before}회)`);
+  const body = window.document.getElementById("overseas-favorite-body");
+  assert(body.textContent.includes("MSFT"), "새로 받은 목록으로 갈아끼워야 함");
+  assert(!body.innerHTML.includes("로딩 중"), "자동 갱신이 로딩 문구로 화면을 깜빡이면 안 됨");
+});
+
+test("다른 탭을 보고 있으면 즐겨찾기를 되묻지 않는다", async () => {
+  const { window, calls } = favoriteAutoRefreshWindow([APPLE]);
+  const timers = captureIntervals(window);
+  setPageVisible(window, true);
+
+  window.initOverseasPage();
+  await window.setOverseasTab("favorite");
+  await window.setOverseasTab("overview");
+  await flush();
+
+  const before = calls.length;
+  await timers.favorite().fn();
+
+  assert(calls.length === before, "안 보는 탭 때문에 심볼 수만큼 해외 시세를 부르면 안 됨");
+});
+
+test("창이 백그라운드면 즐겨찾기 자동 갱신을 건너뛴다", async () => {
+  const { window, calls } = favoriteAutoRefreshWindow([APPLE]);
+  const timers = captureIntervals(window);
+  setPageVisible(window, false);
+
+  window.initOverseasPage();
+  await window.setOverseasTab("favorite");
+  await flush();
+
+  const before = calls.length;
+  await timers.favorite().fn();
+
+  assert(calls.length === before, "안 보는 창 때문에 계속 조회하면 안 됨");
+});
+
+test("즐겨찾기 자동 갱신 실패는 보고 있던 목록을 지우지 않는다", async () => {
+  const { window } = favoriteAutoRefreshWindow([APPLE, new Error("network")]);
+  const timers = captureIntervals(window);
+  setPageVisible(window, true);
+
+  window.initOverseasPage();
+  await window.setOverseasTab("favorite");
+  await flush();
+  const stamp = window.document.getElementById("overseas-favorite-updated").textContent;
+
+  await timers.favorite().fn();
+
+  const body = window.document.getElementById("overseas-favorite-body").textContent;
+  assert(body.includes("AAPL"), "한 번 실패했다고 보고 있던 시세를 지우면 안 됨");
+  assert(window.document.getElementById("overseas-favorite-updated").textContent === stamp,
+    "갱신 시각이 멈춰 있는 것으로 실패를 알린다");
 });
 
 // USD 거래 원장 — 원화 원장(/api/virtual/*)과 분리돼 있어 성과 요약을 볼 화면이 여기뿐이다.

--- a/tests/unit_test/services/test_overseas_market_stats_service.py
+++ b/tests/unit_test/services/test_overseas_market_stats_service.py
@@ -197,6 +197,30 @@ async def test_default_ttl_is_shorter_than_the_screen_poll_interval(universe, pr
     assert provider.fetch_snapshots.await_count == 2
 
 
+async def test_ttl_window_covers_the_collection_time(universe, provider):
+    """TTL 기준점은 수집 '완료'가 아니라 '시작'이다.
+
+    완료 시각으로 재면 느린 수집(500종목 배치)일수록 남은 TTL 이 화면 폴링 주기
+    안쪽으로 밀려들어와, 60초마다 되묻는데도 같은 스냅샷만 되받는 날이 생긴다.
+    """
+    now = [0.0]
+
+    async def _slow_fetch(_symbols):
+        now[0] += 20.0  # 외부 배치 조회가 느린 날
+        return [_snap("AAPL")]
+
+    provider.fetch_snapshots = AsyncMock(side_effect=_slow_fetch)
+    service = OverseasMarketStatsService(
+        universe_factory=lambda: universe, provider=provider, ttl_sec=45.0, clock=lambda: now[0]
+    )
+
+    await service.get_top_market_cap()  # 0초 시작 → 20초 완료
+    now[0] = 60.0  # 화면의 다음 폴링
+    await service.get_top_market_cap()
+
+    assert provider.fetch_snapshots.await_count == 2
+
+
 async def test_empty_universe_returns_empty_without_calling_provider(provider):
     empty = MagicMock()
     empty.all_symbols.return_value = []

--- a/view/web/static/js/favorite.js
+++ b/view/web/static/js/favorite.js
@@ -3,6 +3,12 @@
 let _favoriteData = [];
 let _favSortState = { key: null, dir: 'desc' };
 
+// 자동 갱신 주기. 국내 현재가는 웹소켓 틱이 채운 메모리 캐시에서 나오므로 되묻는 비용이
+// 낮다 — 대부분 외부 호출 없이 끝난다.
+const FAVORITE_REFRESH_MS = 30 * 1000;
+
+let _favoriteRefreshTimer = null;
+
 /* ── 종목명 자동완성 (autocomplete.js 모듈 사용) ── */
 StockAutocomplete({
     inputId: 'fav-search-input',
@@ -18,11 +24,14 @@ StockAutocomplete({
 });
 
 /* ── 목록 로드 ── */
-async function loadFavoriteList() {
+// showLoading:false 는 자동 갱신용이다 — 매 주기마다 '로딩 중'으로 비우면 화면이 깜빡이고,
+// 한 번 실패했다고 보고 있던 시세까지 지우면 손해가 더 크다.
+async function loadFavoriteList(options = {}) {
     const tbody = document.getElementById('favorite-list-body');
     if (!tbody) return;
 
-    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
+    const silent = options.showLoading === false;
+    if (!silent) tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
 
     try {
         const resp = await fetch('/api/favorite');
@@ -31,9 +40,20 @@ async function loadFavoriteList() {
 
             _favoriteData = items || [];
             renderFavoriteTable();
+            _renderFavoriteUpdatedAt(new Date());
     } catch (e) {
+        // 자동 갱신 실패는 멈춘 갱신 시각으로 드러난다.
+        if (silent) return;
         tbody.innerHTML = `<tr><td colspan="5" style="text-align:center; color:#ff6b6b;">불러오기 실패: ${e.message}</td></tr>`;
     }
+}
+
+// 값이 그대로인 것과 갱신이 멈춘 것을 화면에서 구분할 수 있어야 한다.
+function _renderFavoriteUpdatedAt(when) {
+    const el = document.getElementById('favorite-updated');
+    if (!el) return;
+    el.textContent = `최근 업데이트: ${when.toLocaleTimeString('ko-KR')}`
+        + ` (${Math.round(FAVORITE_REFRESH_MS / 1000)}초마다 자동 갱신)`;
 }
 
 function renderFavoriteTable() {
@@ -179,8 +199,49 @@ window.addEventListener('beforeunload', function () {
     navigator.sendBeacon('/api/streaming/unsubscribe-favorite');
 });
 
-/* ── 초기 로드 ── */
-document.addEventListener('DOMContentLoaded', loadFavoriteList);
+/* ── 자동 갱신 ── */
+async function _favoriteRefreshTick() {
+    // pjax 로 다른 화면에 가 있으면 스스로 멈춘다 (타이머는 문서를 떠나도 계속 돈다).
+    if (!document.getElementById('favorite-list-body')) {
+        _stopFavoriteAutoRefresh();
+        return;
+    }
+    if (document.hidden) return;
+    await loadFavoriteList({ showLoading: false });
+}
+
+function _stopFavoriteAutoRefresh() {
+    if (_favoriteRefreshTimer === null) return;
+    clearInterval(_favoriteRefreshTimer);
+    _favoriteRefreshTimer = null;
+}
+
+function _startFavoriteAutoRefresh() {
+    _stopFavoriteAutoRefresh();  // pjax 재진입 시 타이머가 겹쳐 걸리지 않게 한다.
+    _favoriteRefreshTimer = setInterval(_favoriteRefreshTick, FAVORITE_REFRESH_MS);
+}
+
+// 브라우저는 숨은 탭의 타이머를 늦추고, 위 tick 도 숨은 동안은 건너뛴다 — 돌아왔을 때
+// 다음 주기까지 기다리면 화면이 몇 분 전 시세인 채로 남는다. 복귀 즉시 한 번 당겨 받는다.
+let _favoriteVisibilityBound = false;
+
+function _bindFavoriteVisibility() {
+    if (_favoriteVisibilityBound) return;
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) return;
+        void _favoriteRefreshTick();
+    });
+    _favoriteVisibilityBound = true;
+}
+
+/* ── 초기화 (최초 로드 / pjax 재방문 공용) ── */
+async function initFavoritePage() {
+    _bindFavoriteVisibility();
+    _startFavoriteAutoRefresh();
+    await loadFavoriteList();
+}
+
+document.addEventListener('DOMContentLoaded', () => { void initFavoritePage(); });
 
 /* ── Pjax 재방문 시 재초기화 ── */
 document.addEventListener('pjax:ready', (e) => {
@@ -194,5 +255,5 @@ document.addEventListener('pjax:ready', (e) => {
         },
         onConfirm: function() { addFavoriteFromInput(); }
     });
-    loadFavoriteList();
+    void initFavoritePage();
 });

--- a/view/web/static/js/heatmap_page.js
+++ b/view/web/static/js/heatmap_page.js
@@ -454,6 +454,19 @@ function _startHeatmapPageAutoRefresh() {
     _heatmapPageRefreshTimer = setInterval(_refreshHeatmapPageTick, HEATMAP_PAGE_OVERSEAS_REFRESH_MS);
 }
 
+// 브라우저는 숨은 탭의 타이머를 늦추고, 위 tick 도 숨은 동안은 건너뛴다 — 돌아왔을 때
+// 다음 주기까지 기다리면 화면이 몇 분 전 값인 채로 남는다. 복귀 즉시 한 번 당겨 받는다.
+let _heatmapPageVisibilityBound = false;
+
+function _bindHeatmapPageVisibility() {
+    if (_heatmapPageVisibilityBound) return;
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) return;
+        void _refreshHeatmapPageTick();
+    });
+    _heatmapPageVisibilityBound = true;
+}
+
 async function initHeatmapPage() {
     const viewport = document.getElementById('heatmap-page-viewport');
     if (!viewport) return;
@@ -479,6 +492,7 @@ async function initHeatmapPage() {
     _renderHeatmapPageInterval();
     _bindHeatmapPageWheelZoom(viewport);
     _bindHeatmapPageDragPan(viewport);
+    _bindHeatmapPageVisibility();
 
     // 미국장이 꺼진 run 에서는 API 가 400 을 내므로 탭 자체를 감춘다.
     if (!await _heatmapOverseasEnabled()) {

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -669,6 +669,12 @@ async function cancelOverseasOrder(orderNo, symbol, exchange, qty) {
 
 let _overseasFavoriteData = [];
 
+// 자동 갱신 주기. 국내(30초)와 달리 실시간 스트림이 없어 심볼 수만큼 해외 현재가 API 를
+// 부르므로 넉넉히 잡고, 보고 있는 탭일 때만 돈다.
+const OVERSEAS_FAVORITE_REFRESH_MS = 60 * 1000;
+
+let _overseasFavoriteRefreshTimer = null;
+
 function _initOverseasFavoriteAutocomplete() {
     if (typeof StockAutocomplete !== 'function') return;
     if (!document.getElementById('overseas-fav-symbol')) return;
@@ -719,20 +725,70 @@ function renderOverseasFavoriteTable() {
     });
 }
 
-async function loadOverseasFavorites() {
+// showLoading:false 는 자동 갱신용이다 — 매 주기마다 '로딩 중'으로 비우면 화면이 깜빡이고,
+// 한 번 실패했다고 보고 있던 시세까지 지우면 손해가 더 크다.
+async function loadOverseasFavorites(options = {}) {
     const tbody = document.getElementById('overseas-favorite-body');
     if (!tbody) return;
-    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
+    const silent = options.showLoading === false;
+    if (!silent) tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">로딩 중...</td></tr>';
 
     try {
         const res = await fetchWithTimeout('/api/favorite?market=overseas_us', {}, 12000);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         _overseasFavoriteData = await res.json() || [];
         renderOverseasFavoriteTable();
+        _renderOverseasFavoriteUpdatedAt(new Date());
     } catch (e) {
         console.error('[overseas] 즐겨찾기 조회 오류', e);
+        // 자동 갱신 실패는 멈춘 갱신 시각으로 드러난다.
+        if (silent) return;
         tbody.innerHTML = `<tr><td colspan="6" style="text-align:center; color:#ff6b6b;">불러오기 실패: ${escapeHtml(e.message)}</td></tr>`;
     }
+}
+
+// 값이 그대로인 것과 갱신이 멈춘 것을 화면에서 구분할 수 있어야 한다.
+function _renderOverseasFavoriteUpdatedAt(when) {
+    const el = document.getElementById('overseas-favorite-updated');
+    if (!el) return;
+    el.textContent = `최근 업데이트: ${when.toLocaleTimeString('ko-KR')}`
+        + ` (${Math.round(OVERSEAS_FAVORITE_REFRESH_MS / 1000)}초마다 자동 갱신)`;
+}
+
+async function _overseasFavoriteRefreshTick() {
+    // pjax 로 다른 화면에 가 있으면 스스로 멈춘다 (타이머는 문서를 떠나도 계속 돈다).
+    if (!document.getElementById('overseas-favorite-body')) {
+        _stopOverseasFavoriteAutoRefresh();
+        return;
+    }
+    const panel = document.getElementById('overseas-panel-favorite');
+    // 안 보는 창/탭 때문에 심볼 수만큼 해외 시세를 부를 이유가 없다.
+    if (document.hidden || !panel || panel.hidden) return;
+    await loadOverseasFavorites({ showLoading: false });
+}
+
+function _stopOverseasFavoriteAutoRefresh() {
+    if (_overseasFavoriteRefreshTimer === null) return;
+    clearInterval(_overseasFavoriteRefreshTimer);
+    _overseasFavoriteRefreshTimer = null;
+}
+
+function _startOverseasFavoriteAutoRefresh() {
+    _stopOverseasFavoriteAutoRefresh();  // pjax 재진입 시 타이머가 겹쳐 걸리지 않게 한다.
+    _overseasFavoriteRefreshTimer = setInterval(_overseasFavoriteRefreshTick, OVERSEAS_FAVORITE_REFRESH_MS);
+}
+
+// 브라우저는 숨은 탭의 타이머를 늦추고, 위 tick 도 숨은 동안은 건너뛴다 — 돌아왔을 때
+// 다음 주기까지 기다리면 화면이 몇 분 전 시세인 채로 남는다. 복귀 즉시 한 번 당겨 받는다.
+let _overseasFavoriteVisibilityBound = false;
+
+function _bindOverseasFavoriteVisibility() {
+    if (_overseasFavoriteVisibilityBound) return;
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) return;
+        void _overseasFavoriteRefreshTick();
+    });
+    _overseasFavoriteVisibilityBound = true;
 }
 
 async function addOverseasFavorite() {
@@ -781,6 +837,8 @@ function initOverseasPage() {
     _refreshOverseasRealBanner();
     void _refreshOverseasAvailability();
     _initOverseasFavoriteAutocomplete();
+    _bindOverseasFavoriteVisibility();
+    _startOverseasFavoriteAutoRefresh();
     const initialTab = _initialOverseasTab();
     if (initialTab !== 'overview') void setOverseasTab(initialTab);
     if (!window.__overseasRealBannerTimer) {

--- a/view/web/templates/favorite.html
+++ b/view/web/templates/favorite.html
@@ -16,6 +16,8 @@
             </div>
             <button class="btn" onclick="addFavoriteFromInput()">★ 추가</button>
             <button class="btn" onclick="loadFavoriteList()" style="margin-left:4px;">새로고침</button>
+            <span id="favorite-updated" style="color:var(--text-secondary); font-size:0.85rem;"
+                  title="이 목록은 주기적으로 스스로 다시 조회합니다 (창을 보고 있는 동안에만)">최근 업데이트: --</span>
         </div>
     </div>
 
@@ -66,5 +68,5 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=1"></script>
-<script src="/static/js/favorite.js?v=6"></script>
+<script src="/static/js/favorite.js?v=7"></script>
 {% endblock %}

--- a/view/web/templates/heatmap.html
+++ b/view/web/templates/heatmap.html
@@ -118,5 +118,5 @@
 
 {% block scripts %}
 <script src="/static/js/market_heatmap.js?v=6"></script>
-<script src="/static/js/heatmap_page.js?v=6"></script>
+<script src="/static/js/heatmap_page.js?v=7"></script>
 {% endblock %}

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -73,6 +73,8 @@
                 </div>
                 <button class="btn" data-overseas-required onclick="addOverseasFavorite()">★ 추가</button>
                 <button class="btn" data-overseas-required onclick="loadOverseasFavorites()">새로고침</button>
+                <span id="overseas-favorite-updated" style="color:var(--text-secondary); font-size:0.85rem;"
+                      title="이 목록은 주기적으로 스스로 다시 조회합니다 (즐겨찾기 탭을 보고 있는 동안에만)">최근 업데이트: --</span>
             </div>
         </div>
         <div class="card">
@@ -154,5 +156,5 @@
 {% block scripts %}
 <script src="/static/js/autocomplete.js?v=2"></script>
 <script src="/static/js/overseas_autocomplete.js?v=1"></script>
-<script src="/static/js/overseas.js?v=8"></script>
+<script src="/static/js/overseas.js?v=9"></script>
 {% endblock %}


### PR DESCRIPTION
## 무엇을

1. **즐겨찾기 주기 자동 새로고침 + 최근 업데이트 시각 표기** (국내 `/favorite` 30초, 미국장 즐겨찾기 탭 60초)
2. **미국 히트맵이 "1분 주기"라면서 간헐적으로 갱신되지 않던 문제 수정**

## 왜 히트맵이 간헐적으로 멈춰 보였나

`OverseasMarketStatsService` 가 스냅샷 TTL(45초)의 기준점을 수집 **완료** 시각으로 찍고 있었다.
화면은 60초마다 되묻지만, 실제로 다시 수집이 일어나는 시점은 `수집시작 + 수집시간 + 45초`다.
Yahoo 500종목 배치가 15초를 넘긴 날에는 다음 폴링이 TTL 안쪽에 떨어져 **같은 스냅샷(`updated_at` 동일)** 을
되받았다 — 화면은 요청을 보내는데 캡션의 시각이 안 움직이는, 딱 "간헐적으로 안 되는" 모습이다.

기준점을 수집 **시작** 으로 옮겨, 수집이 아무리 느려도 60초 폴링이 항상 45초 TTL 을 넘게 했다.
(실패 시에는 예전처럼 아무것도 캐시하지 않는다 — 성공한 뒤에만 시작 시각을 기록한다.)

여기에 더해, 숨은 탭에서 돌아왔을 때 다음 주기까지 기다리던 지연도 없앴다.
브라우저가 백그라운드 타이머를 늦추는 데다 tick 자체도 `document.hidden` 이면 건너뛰므로,
복귀 시점에 화면이 몇 분 전 값인 채로 남아 있었다. 히트맵·즐겨찾기 모두 `visibilitychange` 에서 한 번 당겨 받는다.

## 즐겨찾기 자동 갱신 계약

- **조용히** 갱신한다 — 매 주기마다 '로딩 중'으로 비우면 화면이 깜빡인다
- **실패해도 보고 있던 시세를 지우지 않는다** — 멈춘 갱신 시각이 실패 신호다
- **사용자가 잡아둔 정렬을 유지한다**
- **안 보는 창/탭에서는 쉰다** (미국장은 심볼 수만큼 해외 시세 API 를 부르므로 특히)
- 화면을 떠나면 타이머를 스스로 멈추고, pjax 재진입 시 겹쳐 걸지 않는다

주기가 다른 이유: 국내 현재가는 웹소켓 틱이 채운 메모리 캐시에서 나와 되묻는 비용이 낮고(30초),
미국장은 실시간 스트림이 없어 심볼마다 해외 현재가 API 를 한 번씩 부른다(60초).

## 검증

- `tests/frontend/run_favorite_dom_tests.mjs` 신규 9케이스 (pytest gate 가 glob 으로 자동 수집)
- `run_overseas_dom_tests.mjs` +5, `run_heatmap_page_dom_tests.mjs` +1
- `test_ttl_window_covers_the_collection_time` — 수집이 20초 걸리는 가짜 시계에서 60초 뒤 폴링이 재수집을 유발하는지 (수정 전 실패 확인함)
- 단위 7861 passed / 통합 280 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
