### PR TITLE
Fix heatmap auto refresh cache bypass

### DIFF
--- a/tests/frontend/run_heatmap_page_dom_tests.mjs
+++ b/tests/frontend/run_heatmap_page_dom_tests.mjs
@@ -877,7 +877,13 @@ function overseasCalls(calls) {
 }
 
 test("미국 탭을 보고 있으면 1분마다 조용히 다시 조회한다", async () => {
+  const fetchOptions = [];
   const { window, calls, timer } = autoRefreshPage();
+  const traced = window.fetchWithTimeout;
+  window.fetchWithTimeout = (url, options, ...rest) => {
+    fetchOptions.push(options || {});
+    return traced(url, options, ...rest);
+  };
 
   await window.initHeatmapPage();
   await window.setHeatmapTab("overseas");
@@ -888,6 +894,8 @@ test("미국 탭을 보고 있으면 1분마다 조용히 다시 조회한다", 
 
   assert(overseasCalls(calls).length === before + 1,
     `주기마다 미국 스냅샷을 다시 받아야 함 (실제 ${overseasCalls(calls).length - before}회)`);
+  assert(fetchOptions.at(-1).cache === "no-store",
+    "자동 갱신은 브라우저 HTTP 캐시를 우회해야 함");
   const panel = window.document.getElementById("heatmap-page-overseas");
   assert(!panel.innerHTML.includes("조회 중"), "자동 갱신이 로딩 문구로 화면을 깜빡이면 안 됨");
   assert(panel.querySelectorAll(".heatmap-tile").length > 0, "갱신 후에도 타일이 남아야 함");

--- a/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_overseas_market.py
@@ -35,6 +35,22 @@ async def test_top_market_cap_returns_items(web_client, mock_web_ctx):
         mock_web_ctx.overseas_market_stats_service.get_top_market_cap.assert_awaited_once_with(limit=10)
 
 
+async def test_top_market_cap_disables_http_cache(web_client, mock_web_ctx):
+    """자동 갱신 화면이 같은 URL을 호출해도 HTTP 캐시가 이전 스냅샷을 돌려주면 안 된다."""
+    with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
+        _enable_overseas(mock_web_ctx)
+        mock_web_ctx.overseas_market_stats_service = MagicMock()
+        mock_web_ctx.overseas_market_stats_service.get_top_market_cap = AsyncMock(
+            return_value={"fx_rate": None, "items": [], "updated_at": 1787148000}
+        )
+
+        response = web_client.get("/api/overseas/top-market-cap?limit=10")
+
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-store"
+        assert response.headers["pragma"] == "no-cache"
+
+
 async def test_top_market_cap_defaults_limit_to_30(web_client, mock_web_ctx):
     with patch("view.web.routes.overseas_market._get_ctx", return_value=mock_web_ctx):
         _enable_overseas(mock_web_ctx)

--- a/view/web/routes/overseas_market.py
+++ b/view/web/routes/overseas_market.py
@@ -2,12 +2,17 @@
 미국장 시가총액/랭킹 API 엔드포인트 (overseas_marketcap.html).
 """
 import asyncio
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Response
 from services.overseas_market_stats_service import RANKING_CATEGORIES
 from view.web.api_common import _get_ctx
 from view.web.market_mode_utils import is_market_enabled
 
 router = APIRouter(tags=["overseas-market"])
+
+
+def _disable_http_cache(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
 
 
 def _require_overseas(ctx, what: str):
@@ -23,8 +28,12 @@ def _require_overseas(ctx, what: str):
 
 
 @router.get("/overseas/top-market-cap")
-async def get_overseas_top_market_cap(limit: int = Query(30, ge=1, le=500)):
+async def get_overseas_top_market_cap(
+    response: Response,
+    limit: int = Query(30, ge=1, le=500),
+):
     """S&P 500 유니버스 기준 미국 시가총액 상위 종목."""
+    _disable_http_cache(response)
     ctx = _get_ctx()
     service = _require_overseas(ctx, "미국주식 시가총액")
     try:

--- a/view/web/static/js/market_heatmap.js
+++ b/view/web/static/js/market_heatmap.js
@@ -327,7 +327,7 @@ async function _loadHeatmap(source, options = {}) {
     // 조회 조건(기간 등)이 바뀌는 소스는 url 을 함수로 준다 — 호출 시점에 평가한다.
     const url = typeof source.url === 'function' ? source.url() : source.url;
     try {
-        const res = await fetchWithTimeout(url, {}, 30000);
+        const res = await fetchWithTimeout(url, { cache: 'no-store' }, 30000);
         const { json, error } = await readJsonResponse(res);
         if (!isLatestRequest()) return;
 


### PR DESCRIPTION
## Summary
- send heatmap fetches with cache: no-store so periodic refreshes do not reuse browser HTTP cache
- mark the overseas top-market-cap API response as no-store/no-cache
- add frontend and route regression coverage for the cache-bypass contract

## Tests
- node tests/frontend/run_heatmap_page_dom_tests.mjs
- pytest tests/unit_test/view/web/routes/test_web_routes_overseas_market.py -v
- pytest tests/unit_test -v
- pytest tests/integration_test -v