### PR TITLE
Fix favorite alert signed rate handling

### DIFF
--- a/services/favorite_price_alert_service.py
+++ b/services/favorite_price_alert_service.py
@@ -74,6 +74,7 @@ class FavoritePriceAlertService:
         *,
         price,
         rate,
+        change=None,
         sign=None,
         is_upper_limit: bool = False,
     ) -> bool:
@@ -92,7 +93,9 @@ class FavoritePriceAlertService:
         rate_value = self._to_float(rate)
         if rate_value is None:
             return False
-        rate_value = self._apply_kis_sign(rate_value, sign)
+        rate_value = self._resolve_signed_rate(normalized, rate_value, rate, sign, change)
+        if rate_value is None:
+            return False
 
         if self._is_upper_limit(rate_value, sign=sign, is_upper_limit=is_upper_limit):
             if normalized in self._upper_limit_alerted_codes:
@@ -136,7 +139,9 @@ class FavoritePriceAlertService:
                 "code": normalized,
                 "name": name,
                 "price": self._to_float(price),
+                "change": self._to_float(change),
                 "rate": rate_value,
+                "sign": None if sign is None else str(sign),
                 "threshold_pct": threshold_pct,
                 "dedup_key": f"favorite_price:{normalized}:{threshold_pct}",
                 "force_external": True,
@@ -276,6 +281,33 @@ class FavoritePriceAlertService:
             return -rate
         if sign_value in {"1", "2"} and rate < 0:
             return abs(rate)
+        return rate
+
+    def _resolve_signed_rate(self, code: str, rate: float, raw_rate, sign, change=None) -> Optional[float]:
+        """KIS의 절대 등락률 + 별도 부호 형식에서 부호 누락 오판을 방지한다."""
+        sign_value = str(sign or "").strip()
+        if sign_value:
+            return self._apply_kis_sign(rate, sign_value)
+
+        raw_text = str(raw_rate or "").strip()
+        if raw_text.startswith(("+", "-")):
+            return rate
+
+        change_value = self._to_float(change)
+        if change_value is not None:
+            if change_value < 0 and rate > 0:
+                return -rate
+            if change_value > 0 and rate < 0:
+                return abs(rate)
+            if change_value == 0:
+                return 0.0
+
+        if (
+            self._market == MARKET_DOMESTIC
+            and rate > 0
+            and self._lowest_negative_alert_bucket.get(code, 0) < 0
+        ):
+            return -rate
         return rate
 
     def _stock_name(self, code: str) -> str:

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -263,6 +263,7 @@ class PriceStreamService:
                     stock_code,
                     price=current_price,
                     rate=realtime_data.get('전일대비율'),
+                    change=realtime_data.get('전일대비'),
                     sign=realtime_data.get('전일대비부호'),
                     is_upper_limit=self._is_upper_limit_tick(realtime_data),
                 )
@@ -412,6 +413,7 @@ class PriceStreamService:
                     code,
                     price=price,
                     rate=rate,
+                    change=change,
                     sign=sign,
                     is_upper_limit=self._is_upper_limit_snapshot(rate, sign),
                 )

--- a/tests/unit_test/services/test_favorite_price_alert_service.py
+++ b/tests/unit_test/services/test_favorite_price_alert_service.py
@@ -188,6 +188,44 @@ async def test_applies_kis_negative_sign_to_unsigned_rate():
 
 
 @pytest.mark.asyncio
+async def test_applies_negative_change_to_unsigned_rate_without_sign():
+    """부호 코드가 누락돼도 전일대비 금액이 음수이면 하락 알림으로 판단한다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["009150"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("009150", price="1325000", change="-71000", rate="5.09")
+
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert "-5%" in args[2]
+    assert "전일대비 -5.09%" in args[3]
+    assert kwargs["metadata"]["rate"] == -5.09
+    assert kwargs["metadata"]["change"] == -71000.0
+    assert kwargs["metadata"]["threshold_pct"] == -5
+
+
+@pytest.mark.asyncio
+async def test_does_not_flip_prior_negative_bucket_to_positive_without_explicit_sign():
+    """부호 없는 양수 등락률은 기존 하락 상태를 상승 알림으로 뒤집지 않는다."""
+    repo = MagicMock()
+    repo.get_all = AsyncMock(return_value=["009150"])
+    notifications = MagicMock()
+    notifications.emit = AsyncMock()
+    svc = FavoritePriceAlertService(repo, notifications)
+
+    await svc.handle_price_tick("009150", price="1326000", rate="5.01", sign="5")
+    await svc.handle_price_tick("009150", price="1325000", rate="5.09", sign=None)
+
+    notifications.emit.assert_awaited_once()
+    args, kwargs = notifications.emit.call_args
+    assert "-5%" in args[2]
+    assert kwargs["metadata"]["threshold_pct"] == -5
+
+
+@pytest.mark.asyncio
 async def test_alerts_upper_limit_separately_from_twenty_five_percent_bucket():
     repo = MagicMock()
     repo.get_all = AsyncMock(return_value=["005930"])

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -162,6 +162,7 @@ async def test_cache_price_snapshot_schedules_favorite_price_alert(mock_stock_re
         "080220",
         price="91300",
         rate="5.02",
+        change="4300",
         sign="2",
         is_upper_limit=False,
     )
@@ -385,6 +386,7 @@ async def test_on_price_tick_schedules_favorite_price_alert(mock_stock_repo, moc
         "005930",
         price="75000",
         rate="5.12",
+        change=None,
         sign=None,
         is_upper_limit=False,
     )
@@ -412,6 +414,7 @@ async def test_on_price_tick_passes_sign_and_upper_limit_to_favorite_price_alert
         "005930",
         price="85000",
         rate="29.92",
+        change=None,
         sign="1",
         is_upper_limit=True,
     )

--- a/tests/unit_test/view/web/test_web_app_initializer.py
+++ b/tests/unit_test/view/web/test_web_app_initializer.py
@@ -516,6 +516,7 @@ async def test_refresh_price_from_rest_evaluates_favorite_alert(mock_deps):
     ctx.favorite_price_alert_service.handle_price_tick.assert_awaited_once_with(
         "080220",
         price="50200",
+        change="-4900",
         rate="-8.89",
         sign="5",
     )
@@ -1233,6 +1234,7 @@ def test_web_realtime_callback_evaluates_favorite_alert_from_program_trading_pri
     mock_schedule.assert_called_once_with(
         "080220",
         price="85300",
+        change="-5100",
         rate="-5.64",
         sign="5",
     )
@@ -1250,6 +1252,7 @@ def test_schedule_favorite_alert_from_program_price_creates_task(mock_deps):
         ctx._schedule_favorite_alert_from_program_price(
             "080220",
             price="85300",
+            change="-5100",
             rate="-5.64",
             sign="5",
         )
@@ -1257,6 +1260,7 @@ def test_schedule_favorite_alert_from_program_price_creates_task(mock_deps):
     ctx.favorite_price_alert_service.handle_price_tick.assert_called_once_with(
         "080220",
         price="85300",
+        change="-5100",
         rate="-5.64",
         sign="5",
     )

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -547,6 +547,7 @@ class WebAppContext:
                         self._schedule_favorite_alert_from_program_price(
                             code,
                             price=item.get('price'),
+                            change=item.get('change'),
                             rate=item.get('rate'),
                             sign=item.get('sign'),
                         )
@@ -559,7 +560,7 @@ class WebAppContext:
         if self.streaming_service:
             self.streaming_service.dispatch_realtime_message(data)
 
-    def _schedule_favorite_alert_from_program_price(self, code: str, *, price, rate, sign) -> None:
+    def _schedule_favorite_alert_from_program_price(self, code: str, *, price, change, rate, sign) -> None:
         """프로그램매매 프레임에 보강된 가격으로 관심종목 등락률 알림을 평가한다."""
         if not code or price is None or rate is None or not self.favorite_price_alert_service:
             return
@@ -569,6 +570,7 @@ class WebAppContext:
                 self.favorite_price_alert_service.handle_price_tick(
                     code,
                     price=price,
+                    change=change,
                     rate=rate,
                     sign=sign,
                 )
@@ -692,6 +694,7 @@ class WebAppContext:
             await self.favorite_price_alert_service.handle_price_tick(
                 code,
                 price=price,
+                change=_get("prdy_vrss", "0"),
                 rate=_get("prdy_ctrt", "0.00"),
                 sign=_get("prdy_vrss_sign", "3"),
             )


### PR DESCRIPTION
## Summary
- Use signed rate resolution for favorite price alerts using KIS sign, explicit rate sign, and previous-day change amount
- Pass previous-day change through realtime, REST snapshot, and program-trading enriched price alert paths
- Add regression coverage for unsigned positive rate with negative change, matching the Samsung Electro-Mechanics false +5% alert case

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -q