### PR TITLE
feat(web): 현재가 조회 당일 시세 고가·저가 강조 표시

### DIFF
--- a/tests/unit_test/view/web/test_stock_js_contracts.py
+++ b/tests/unit_test/view/web/test_stock_js_contracts.py
@@ -36,3 +36,19 @@ def test_ai_analysis_requests_allow_server_retry_and_hide_abort_message():
     assert stock_js.count("60000,") >= 2
     assert "isAiRequestAbort(error)" in stock_js
     assert "AI 응답 시간이 초과되었습니다. 다시 시도해주세요." in stock_js
+
+
+def test_daily_price_high_low_are_visually_emphasized():
+    """당일 시세의 고가·저가는 강조 마크업과 전용 스타일을 갖는다."""
+    stock_js = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
+
+    # 강조 마크업 (고가=상승색, 저가=하락색 행)
+    assert 'class="day-range-row high"' in stock_js
+    assert 'class="day-range-row low"' in stock_js
+    assert 'id="rt-high" class="day-range-val"' in stock_js
+    assert 'id="rt-low" class="day-range-val"' in stock_js
+
+    # 강조 스타일 정의
+    assert ".stock-info-box .detail-group p.day-range-row.high" in stock_js
+    assert ".stock-info-box .detail-group p.day-range-row.low" in stock_js
+    assert ".stock-info-box .detail-group .day-range-val" in stock_js

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -252,6 +252,24 @@ async function searchStock(codeOverride, exchangeOverride) {
                     margin: 0.4rem 0; display: flex; justify-content: space-between;
                 }
                  .stock-info-box .detail-group p strong { color: var(--text-secondary); }
+                .stock-info-box .detail-group p.day-range-row {
+                    align-items: center; gap: 0.6rem; margin: 0.45rem 0;
+                    padding: 0.35rem 0.6rem; border-radius: 6px; border-left: 4px solid transparent;
+                }
+                .stock-info-box .detail-group p.day-range-row.high {
+                    background-color: rgba(233, 69, 96, 0.12); border-left-color: #e94560;
+                }
+                .stock-info-box .detail-group p.day-range-row.low {
+                    background-color: rgba(30, 144, 255, 0.12); border-left-color: #1e90ff;
+                }
+                .stock-info-box .detail-group p.day-range-row strong { font-weight: 700; white-space: nowrap; }
+                .stock-info-box .detail-group p.day-range-row.high strong { color: #e94560; }
+                .stock-info-box .detail-group p.day-range-row.low strong { color: #1e90ff; }
+                .stock-info-box .detail-group .day-range-val {
+                    font-size: 1.25rem; font-weight: 700; line-height: 1.2;
+                }
+                .stock-info-box .detail-group p.day-range-row.high .day-range-val { color: #e94560; }
+                .stock-info-box .detail-group p.day-range-row.low .day-range-val { color: #1e90ff; }
                  .stock-info-box .price.text-red { color: #e94560; }
                  .stock-info-box .price.text-blue { color: #1e90ff; }
                  .fav-star-btn {
@@ -396,8 +414,8 @@ async function searchStock(codeOverride, exchangeOverride) {
                     <div class="detail-group">
                         <h4>📊 당일 시세</h4>
                         <p><strong>시가:</strong> <span>${fnum(data.open)}</span></p>
-                        <p><strong>고가:</strong> <span id="rt-high">${fnum(data.high)}</span></p>
-                        <p><strong>저가:</strong> <span id="rt-low">${fnum(data.low)}</span></p>
+                        <p class="day-range-row high"><strong>고가:</strong> <span id="rt-high" class="day-range-val">${fnum(data.high)}</span></p>
+                        <p class="day-range-row low"><strong>저가:</strong> <span id="rt-low" class="day-range-val">${fnum(data.low)}</span></p>
                         <p><strong>기준가:</strong> <span>${fnum(data.prev_close)}</span></p>
                     </div>
                     <div class="detail-group">


### PR DESCRIPTION
## 배경

현재가 조회 화면의 **📊 당일 시세** 그룹에서 고가·저가가 시가·기준가와 완전히 동일한 서체·색상으로 표시되어, 당일 변동 범위를 한눈에 파악하기 어려웠습니다.

## 변경 내용

`view/web/static/js/stock.js` 의 당일 시세 그룹에서 **고가·저가 두 행만** 강조합니다.

- 고가 행 = 상승색(`#e94560`), 저가 행 = 하락색(`#1e90ff`)
  - 연한 배경(12% alpha) + 좌측 4px 액센트 바 + 라벨/값 컬러링
- 값 서체를 `1.25rem` bold 로 확대
- 라벨 줄바꿈 방지(`white-space: nowrap`) 및 라벨–값 최소 간격(`gap: 0.6rem`) 확보

시가·기준가는 기존 스타일 그대로 두어 대비가 생기도록 했습니다.
SSE 실시간 틱 갱신은 `rt-high` / `rt-low` id 를 그대로 사용하므로 동작에 영향이 없습니다.

## 테스트

TDD 로 진행했습니다 — 강조 마크업·스타일을 검증하는 정적 계약 테스트를 먼저 작성해 실패를 확인한 뒤 구현했습니다.

- 신규: `tests/unit_test/view/web/test_stock_js_contracts.py::test_daily_price_high_low_are_visually_emphasized`
- `pytest tests/unit_test` — 7875 passed
  - `test_initialization_kiwoom_requires_env` 1건 실패는 `data.krx.co.kr` 외부 호출이 개발 컨테이너 네트워크 allowlist 에 막혀 발생하며, 이번 변경과 무관합니다.
- `pytest tests/integration_test` — 변경 전/후 결과 동일 (215 passed / 7 failed / 43 errors)
  - 실패·에러는 gitignore 대상인 `config/config.yaml` 부재로 발생합니다. `git stash` 로 되돌린 클린 트리에서 재실행해 수치가 완전히 동일함을 확인했습니다. CI 는 `config.yaml.example` 로 mock config 를 생성하므로 해당되지 않습니다.
- `node tests/frontend/run_stock_dom_tests.mjs` — 10/10 passed
- `node tests/frontend/run_autocomplete_dom_tests.mjs` — 6/6 passed

렌더 결과는 실제 `stock.js` 의 `<style>` 블록과 당일 시세 마크업을 추출해 headless Chromium 으로 확인했으며, 그 과정에서 좁은 폭에서 라벨이 `고`/`가:` 로 줄바꿈되는 문제를 발견해 `white-space: nowrap` 으로 수정했습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGW7qePZ3v3sV1GY9ZTExH)_