### PR TITLE
feat(web): 현재가 조회 당일 시세 고가·저가 강조 표시

### DIFF
--- a/tests/unit_test/view/web/test_stock_js_contracts.py
+++ b/tests/unit_test/view/web/test_stock_js_contracts.py
@@ -36,3 +36,19 @@ def test_ai_analysis_requests_allow_server_retry_and_hide_abort_message():
     assert stock_js.count("60000,") >= 2
     assert "isAiRequestAbort(error)" in stock_js
     assert "AI 응답 시간이 초과되었습니다. 다시 시도해주세요." in stock_js
+
+
+def test_daily_price_high_low_are_visually_emphasized():
+    """당일 시세의 고가·저가는 강조 마크업과 전용 스타일을 갖는다."""
+    stock_js = Path("view/web/static/js/stock.js").read_text(encoding="utf-8")
+
+    # 강조 마크업 (고가=상승색, 저가=하락색 행)
+    assert 'class="day-range-row high"' in stock_js
+    assert 'class="day-range-row low"' in stock_js
+    assert 'id="rt-high" class="day-range-val"' in stock_js
+    assert 'id="rt-low" class="day-range-val"' in stock_js
+
+    # 강조 스타일 정의
+    assert ".stock-info-box .detail-group p.day-range-row.high" in stock_js
+    assert ".stock-info-box .detail-group p.day-range-row.low" in stock_js
+    assert ".stock-info-box .detail-group .day-range-val" in stock_js

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -252,6 +252,24 @@ async function searchStock(codeOverride, exchangeOverride) {
                     margin: 0.4rem 0; display: flex; justify-content: space-between;
                 }
                  .stock-info-box .detail-group p strong { color: var(--text-secondary); }
+                .stock-info-box .detail-group p.day-range-row {
+                    align-items: center; gap: 0.6rem; margin: 0.45rem 0;
+                    padding: 0.35rem 0.6rem; border-radius: 6px; border-left: 4px solid transparent;
+                }
+                .stock-info-box .detail-group p.day-range-row.high {
+                    background-color: rgba(233, 69, 96, 0.12); border-left-color: #e94560;
+                }
+                .stock-info-box .detail-group p.day-range-row.low {
+                    background-color: rgba(30, 144, 255, 0.12); border-left-color: #1e90ff;
+                }
+                .stock-info-box .detail-group p.day-range-row strong { font-weight: 700; white-space: nowrap; }
+                .stock-info-box .detail-group p.day-range-row.high strong { color: #e94560; }
+                .stock-info-box .detail-group p.day-range-row.low strong { color: #1e90ff; }
+                .stock-info-box .detail-group .day-range-val {
+                    font-size: 1.25rem; font-weight: 700; line-height: 1.2;
+                }
+                .stock-info-box .detail-group p.day-range-row.high .day-range-val { color: #e94560; }
+                .stock-info-box .detail-group p.day-range-row.low .day-range-val { color: #1e90ff; }
                  .stock-info-box .price.text-red { color: #e94560; }
                  .stock-info-box .price.text-blue { color: #1e90ff; }
                  .fav-star-btn {
@@ -396,8 +414,8 @@ async function searchStock(codeOverride, exchangeOverride) {
                     <div class="detail-group">
                         <h4>📊 당일 시세</h4>
                         <p><strong>시가:</strong> <span>${fnum(data.open)}</span></p>
-                        <p><strong>고가:</strong> <span id="rt-high">${fnum(data.high)}</span></p>
-                        <p><strong>저가:</strong> <span id="rt-low">${fnum(data.low)}</span></p>
+                        <p class="day-range-row high"><strong>고가:</strong> <span id="rt-high" class="day-range-val">${fnum(data.high)}</span></p>
+                        <p class="day-range-row low"><strong>저가:</strong> <span id="rt-low" class="day-range-val">${fnum(data.low)}</span></p>
                         <p><strong>기준가:</strong> <span>${fnum(data.prev_close)}</span></p>
                     </div>
                     <div class="detail-group">


### PR DESCRIPTION
당일 시세 그룹에서 고가·저가가 시가·기준가와 동일한 서체로 표시되어
한눈에 구분되지 않는 문제를 개선한다.

- 고가 행은 상승색(#e94560), 저가 행은 하락색(#1e90ff)으로 강조 (연한 배경 + 좌측 액센트 바 + 라벨/값 컬러링)
- 값은 1.25rem bold 로 확대하여 가독성 확보
- 라벨 줄바꿈 방지(white-space: nowrap) 및 라벨-값 최소 간격 확보

SSE 실시간 틱 갱신은 rt-high/rt-low id 를 그대로 사용하므로 영향 없음.


Claude-Session: https://claude.ai/code/session_01GGW7qePZ3v3sV1GY9ZTExH