### PR TITLE
Fix trade trend duplicate release detection

### DIFF
--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -241,7 +241,7 @@ class NationalTradeTrendWebClient:
             if release.export_amount_100m_usd is None and release.import_amount_100m_usd is None:
                 continue
             releases.append(release)
-        return _attach_previous_month_changes(releases)
+        return _attach_previous_month_changes(_coalesce_duplicate_period_releases(releases))
 
     async def _fetch_text(self, url: str) -> str:
         if self._http_client is not None:
@@ -477,6 +477,32 @@ def _attach_previous_month_changes(
             )
         )
     return enriched
+
+
+def _coalesce_duplicate_period_releases(
+    releases: list[NationalTradeTrendRelease],
+) -> list[NationalTradeTrendRelease]:
+    by_period: dict[tuple[str, str], NationalTradeTrendRelease] = {}
+    order: list[tuple[str, str]] = []
+    for release in releases:
+        key = (release.phase, release.period_label)
+        if key not in by_period:
+            by_period[key] = release
+            order.append(key)
+            continue
+        if _release_preference_score(release) > _release_preference_score(by_period[key]):
+            by_period[key] = release
+    return [by_period[key] for key in order]
+
+
+def _release_preference_score(release: NationalTradeTrendRelease) -> int:
+    if "www.customs.go.kr" in release.url:
+        return 3
+    if "motir.go.kr" in release.url or "motie.go.kr" in release.url:
+        return 2
+    if "tradedata.go.kr" in release.url:
+        return 1
+    return 0
 
 
 def _float(pattern: str, text: str) -> Optional[float]:

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -434,6 +434,52 @@ async def test_national_web_client_discovers_tradedata_links_and_reads_hwpx_atta
 
 
 @pytest.mark.asyncio
+async def test_national_web_client_coalesces_same_period_from_customs_and_tradedata():
+    customs_list_html = """
+    <a href="javascript:" data-id="10173983" data-url="official" class="nttInfoBtn"
+       title="2026년 8월 1일 ~ 8월 20일 수출입 현황 [잠정치]">
+        2026년 8월 1일 ~ 8월 20일 수출입 현황 [잠정치]
+    </a>
+    """
+    tradedata_list_html = """
+    <a href="javascript:ets_f_prccMenuAdmin('/cts/hmpg/openETS0100210Q.do',
+        {blbrTpcd:'21', ntarSrno:'2414', menuId:'ETS_MNK_50100000'});">
+        [잠정치] 2026년 8월(1~20일) 수출입 현황
+    </a>
+    """
+    detail_html = """
+    동기간 수출은 552억 달러로 전년동기대비 56.0% 증가, 수입은 412억 달러로
+    19.0% 증가했으며, 무역수지는 140억 달러 흑자
+    """
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(
+        side_effect=[
+            DummyTextResponse(customs_list_html),
+            DummyTextResponse(tradedata_list_html),
+            DummyTextResponse(detail_html),
+            DummyTextResponse(detail_html),
+        ]
+    )
+    client = NationalTradeTrendWebClient(
+        http_client=http_client,
+        list_urls=[
+            "https://www.customs.go.kr/kcs/na/ntt/selectNttList.do?mi=2891&bbsId=1362",
+            "https://tradedata.go.kr/cts/index.do",
+        ],
+        max_detail_pages=5,
+    )
+
+    releases = await client.fetch_recent_releases()
+
+    assert len(releases) == 1
+    assert releases[0].period_label == "2026년 8월 1~20일"
+    assert releases[0].url == (
+        "https://www.customs.go.kr/kcs/na/ntt/selectNttInfo.do"
+        "?bbsId=1362&mi=2891&nttSn=10173983&nttSnUrl=official"
+    )
+
+
+@pytest.mark.asyncio
 async def test_national_web_client_calculates_previous_month_changes_for_same_phase():
     list_html = """
     <a href="/now">2026년 8월 1일 ~ 8월 10일 수출입 현황 [잠정치]</a>


### PR DESCRIPTION
## Summary
- Coalesce national trade trend releases with the same phase and period before previous-month enrichment
- Prefer the official customs.go.kr detail page over mirrored tradedata.go.kr pages
- Add regression coverage for duplicated 8/1~20-style releases across both sources

## Verification
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v

## Operational Check
- Enabled the local ignored national trade trend monitor config
- Restarted the web app and confirmed the 2026년 8월 1~20일 release was marked sent at 2026-08-21T16:10:16+09:00