### PR TITLE
fix(web): 현재가 KRX/NXT 탭에 통합 시세가 섞이는 문제 수정

### DIFF
--- a/tests/integration_test/test_it_web_api_paper.py
+++ b/tests/integration_test/test_it_web_api_paper.py
@@ -58,7 +58,7 @@ class TestStockPricePaper:
 
         # 서비스가 올바른 종목코드로 호출되었는지 검증
         from common.types import Exchange
-        mock_paper_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX)
+        mock_paper_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX, force_fresh=True)
 
     def test_get_stock_price_api_error(self, paper_client, mock_paper_ctx):
         """API 오류 시 에러 응답을 반환한다."""

--- a/tests/integration_test/test_it_web_api_real.py
+++ b/tests/integration_test/test_it_web_api_real.py
@@ -59,7 +59,7 @@ class TestStockPriceReal:
         assert body["data"]["prdy_vrss"] == "1200"
         assert body["data"]["prdy_ctrt"] == "1.73"
         from common.types import Exchange
-        mock_real_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX)
+        mock_real_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with("005930", caller="stock.py - get_stock_price", exchange=Exchange.KRX, force_fresh=True)
         
     def test_get_stock_price_error(self, real_client, mock_real_ctx):
         """실전 모드 API 오류 시 에러 응답."""

--- a/tests/integration_test/test_it_web_app_e2e_smoke.py
+++ b/tests/integration_test/test_it_web_app_e2e_smoke.py
@@ -332,6 +332,7 @@ def test_real_app_stock_price_api_uses_service_and_foreground(
         "005930",
         caller="stock.py - get_stock_price",
         exchange=Exchange.KRX,
+        force_fresh=True,
     )
     fake_web_ctx.pm.log_timer.assert_called_with("get_stock_price(005930)", "timer-token")
     assert fake_web_ctx.foreground_scheduler.enter_count == 1

--- a/tests/unit_test/view/web/routes/test_web_routes_stock.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_stock.py
@@ -44,6 +44,45 @@ async def test_get_stock_price(web_client, mock_web_ctx):
         "005930",
         caller="stock.py - get_stock_price",
         exchange=Exchange.KRX,
+        force_fresh=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_price_krx_bypasses_unified_cache(web_client, mock_web_ctx):
+    """KRX/NXT 요청은 통합 틱으로 갱신되는 캐시를 우회해 해당 거래소 시세만 사용한다."""
+    from common.types import Exchange
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data={"code": "005930", "price": 70000}
+    )
+
+    response = web_client.get("/api/stock/005930?exchange=NXT")
+
+    assert response.status_code == 200
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with(
+        "005930",
+        caller="stock.py - get_stock_price",
+        exchange=Exchange.NXT,
+        force_fresh=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_price_unified_exchange_allows_cache(web_client, mock_web_ctx):
+    """통합(UN) 요청은 통합 틱 캐시와 정합하므로 force_fresh를 강제하지 않는다."""
+    from common.types import Exchange
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="Success", data={"code": "005930", "price": 70000}
+    )
+
+    response = web_client.get("/api/stock/005930?exchange=UN")
+
+    assert response.status_code == 200
+    mock_web_ctx.stock_query_service.handle_get_current_stock_price.assert_awaited_once_with(
+        "005930",
+        caller="stock.py - get_stock_price",
+        exchange=Exchange.UN,
+        force_fresh=False,
     )
 
 

--- a/view/web/routes/stock.py
+++ b/view/web/routes/stock.py
@@ -462,8 +462,15 @@ async def get_stock_price(code: str, exchange: str = Query("KRX")):
         exchange_enum = Exchange.KRX
     t_start = ctx.pm.start_timer()
     try:
+        # 종목코드 단위 캐시는 통합(H0UNCNT0) 틱으로 갱신되므로 KRX/NXT 요청에는 통합 시세가 섞인다.
+        # 통합(UN) 요청만 캐시를 허용하고, 거래소를 특정한 요청은 해당 거래소 REST 시세를 새로 조회한다.
         resp = await asyncio.wait_for(
-            ctx.stock_query_service.handle_get_current_stock_price(code, caller="stock.py - get_stock_price", exchange=exchange_enum),
+            ctx.stock_query_service.handle_get_current_stock_price(
+                code,
+                caller="stock.py - get_stock_price",
+                exchange=exchange_enum,
+                force_fresh=exchange_enum != Exchange.UN,
+            ),
             timeout=12.0,
         )
     except asyncio.TimeoutError:

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -568,6 +568,10 @@ function subscribeRealtimePrice(code) {
         priceEventSource = null;
     }
 
+    // 실시간 틱은 통합(H0UNCNT0) 체결가라 KRX/NXT 탭에 반영하면 통합 시세로 움직인다.
+    const exch = (typeof _currentExchange !== 'undefined') ? _currentExchange : 'UN';
+    if (exch !== 'UN') return;
+
     priceEventSource = new EventSource(`/api/streaming/price/${code}`);
 
     priceEventSource.onmessage = function (event) {

--- a/view/web/static/js/stock.js
+++ b/view/web/static/js/stock.js
@@ -1,6 +1,6 @@
 /* view/web/static/js/stock.js — 종목 조회 (searchStock) */
 
-let _currentExchange = 'KRX';
+let _currentExchange = 'UN';
 let _currentStockCode = null;
 
 // stock.js 단독 로드 환경에서도 AI 요청 타임아웃을 안전하게 표시한다.

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/candle_chart.js?v=4"></script>
+<script src="/static/js/candle_chart.js?v=5"></script>
 <script>
     // 종목 리스트: localStorage에서 즉시 복원, 없으면 API 로드 후 저장
     var ALL_STOCKS = (function() {
@@ -55,7 +55,7 @@
     }
 </script>
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/stock.js?v=16"></script>
+<script src="/static/js/stock.js?v=17"></script>
 <script>
     (function() {
         const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 문제

현재가 화면에서 거래소를 `KRX`로 선택해도 가격이 통합(KRX+NXT) 시세처럼 움직였다.

실시간 체결 스트림이 `H0UNCNT0`(KRX+NXT **통합** 체결가) 하나뿐인데, 이 틱이 두 경로로 KRX 표시값에 섞였다.

1. **프론트** — `candle_chart.js:subscribeRealtimePrice()`가 선택 거래소와 무관하게 항상 SSE(`/api/streaming/price/{code}`)를 구독해, 통합 틱이 `rt-price`·`rt-change-rate`·차트 마지막 봉을 덮어썼다.
2. **백엔드** — 통합 틱이 `StockPriceRepository.update_current_price()`로 종목코드 단위 현재가 캐시의 `stck_prpr`을 갱신하는데, `MarketDataService.get_current_price()`는 `exchange != KRX`일 때만 캐시를 우회한다. 따라서 **KRX 요청은 통합 틱이 덮어쓴 캐시를 그대로 반환**했다 (구독 중인 종목은 캐시 TTL도 무한).

REST 자체는 정상이다 (`_exchange_to_market_code`: KRX→`J`, NXT→`NX`, UN→`UN`).

## 변경 내용

- `view/web/routes/stock.py` — 현재가 조회 시 `force_fresh=(exchange != UN)`. 통합 요청만 캐시를 사용하고, 거래소를 특정한 요청(KRX/NXT)은 해당 거래소 REST 시세를 새로 조회한다.
- `view/web/static/js/candle_chart.js` — 통합 탭이 아니면 실시간 틱 SSE를 구독하지 않는다 (가격 박스·차트 양쪽 격리, 서버 구독도 생성되지 않음).
- `view/web/static/js/stock.js` — 거래소 기본 선택을 `UN`(통합)으로 변경. 기본 화면이 실제로 보여주던 값이 통합 시세였으므로, 실시간 갱신 동작은 유지하면서 표시 라벨과 데이터 출처를 일치시킨다.
- `view/web/templates/stock.html` — 변경된 JS 캐시버스팅 버전 갱신 (`stock.js` v16→v17, `candle_chart.js` v4→v5).

## 동작 변화

- 기본 탭은 통합(UN): 지금과 동일하게 실시간으로 갱신된다.
- KRX / NXT 탭: 조회 시점의 해당 거래소 시세로 고정되며 자동 갱신은 없다(재조회 시 갱신). 거래소별 실시간 갱신은 `H0STCNT0`(KRX) / `H0NXCNT0`(NXT) 구독 추가가 필요해 이번 범위에 포함하지 않았다.

## 테스트

- 단위: `pytest tests/unit_test` → 7882 passed / 1 failed. 실패한 `test_initialization_kiwoom_requires_env`는 `main`에서도 동일하게 실패하는 기존 항목으로 이번 변경과 무관.
- 통합: `pytest tests/integration_test` → 변경 전후 실패 목록 동일함을 확인(로컬 설정 부재로 인한 기존 실패 7건 + 에러 43건).
- 라우트 kwargs 변경에 맞춰 어서션 갱신: 단위 1건, 통합 3건.
- 추가 테스트: KRX/NXT 요청은 `force_fresh=True`, 통합(UN) 요청은 `force_fresh=False`로 호출되는지 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjnRNSRGFycJQyXoJ4pdQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjnRNSRGFycJQyXoJ4pdQ5)_