### PR TITLE
feat(web): 현재가 KRX/NXT 탭 거래소별 실시간 체결가 구독

### DIFF
--- a/brokers/broker_api_wrapper.py
+++ b/brokers/broker_api_wrapper.py
@@ -423,6 +423,14 @@ class BrokerAPIWrapper:
         """실시간 통합 체결가(H0UNCNT0) 구독 해지합니다."""
         return await self._client.unsubscribe_unified_price(stock_code)
 
+    async def subscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0) 구독합니다."""
+        return await self._client.subscribe_nxt_price(stock_code)
+
+    async def unsubscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0) 구독 해지합니다."""
+        return await self._client.unsubscribe_nxt_price(stock_code)
+
     async def wait_unified_price_ack(self, stock_code: str, timeout: float = None) -> bool:
         """통합 체결가 구독 ACK 확정을 기다립니다 (구독 active 마킹 게이트용)."""
         return await self._client.wait_for_unified_price_ack(stock_code, timeout)

--- a/brokers/korea_investment/korea_invest_client.py
+++ b/brokers/korea_investment/korea_invest_client.py
@@ -332,6 +332,14 @@ class KoreaInvestApiClient:
         """실시간 통합 체결가(H0UNCNT0) 구독을 해지합니다."""
         return await self._websocketAPI.unsubscribe_unified_price(stock_code)
 
+    async def subscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0) 구독합니다."""
+        return await self._websocketAPI.subscribe_nxt_price(stock_code)
+
+    async def unsubscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0) 구독을 해지합니다."""
+        return await self._websocketAPI.unsubscribe_nxt_price(stock_code)
+
     async def wait_for_unified_price_ack(self, stock_code: str, timeout: float = None) -> bool:
         """통합 체결가 구독 ACK 확정을 기다립니다."""
         return await self._websocketAPI.wait_for_unified_price_ack(stock_code, timeout)

--- a/brokers/korea_investment/korea_invest_websocket_api.py
+++ b/brokers/korea_investment/korea_invest_websocket_api.py
@@ -302,12 +302,15 @@ class KoreaInvestWebSocketAPI:
             # --- 주식 관련 실시간 데이터 파싱 ---
             if tr_id == self._rt_tr_realtime_price:  # H0STCNT0 (주식 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)
+                parsed_data['_exchange'] = 'KRX'
                 message_type = 'realtime_price'
             elif tr_id == self._rt_tr_unified_realtime_price:  # H0UNCNT0 (KRX+NXT 통합 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)  # H0STCNT0와 동일 포맷
+                parsed_data['_exchange'] = 'UN'
                 message_type = 'realtime_price'
             elif tr_id == self._rt_tr_nxt_realtime_price:  # H0NXCNT0 (NXT 주식 체결)
                 parsed_data = self._parse_stock_contract_data(data_body)
+                parsed_data['_exchange'] = 'NXT'
                 message_type = 'realtime_price'
             elif tr_id == self._rt_tr_realtime_quote:  # H0STASP0 (주식 호가)
                 parsed_data = self._parse_stock_quote_data(data_body)
@@ -1052,6 +1055,18 @@ class KoreaInvestWebSocketAPI:
         """실시간 통합 체결가(H0UNCNT0) 구독을 해지합니다."""
         tr_id = self._env.active_config['tr_ids']['websocket'].get('unified_realtime_price', 'H0UNCNT0')
         self._logger.info(f"종목 {stock_code} 통합 체결가 구독 해지 ({tr_id})...")
+        return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
+
+    async def subscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0)를 구독합니다."""
+        tr_id = self._env.active_config['tr_ids']['websocket'].get('nxt_realtime_price', 'H0NXCNT0')
+        self._logger.info(f"종목 {stock_code} NXT 체결가 구독 요청 ({tr_id})...")
+        return await self.send_realtime_request(tr_id, stock_code, tr_type="1")
+
+    async def unsubscribe_nxt_price(self, stock_code: str) -> bool:
+        """실시간 NXT 체결가(H0NXCNT0) 구독을 해지합니다."""
+        tr_id = self._env.active_config['tr_ids']['websocket'].get('nxt_realtime_price', 'H0NXCNT0')
+        self._logger.info(f"종목 {stock_code} NXT 체결가 구독 해지 ({tr_id})...")
         return await self.send_realtime_request(tr_id, stock_code, tr_type="2")
 
     async def subscribe_index_futures_contract(self, futures_code: str) -> bool:

--- a/services/price_stream_service.py
+++ b/services/price_stream_service.py
@@ -50,7 +50,7 @@ class PriceStreamService:
         self._orderbook_recorder = orderbook_recorder
         self._latest_prices: Dict[str, dict] = {}
         self._latest_conclusions: Dict[str, dict] = {}  # code → conclusion snapshot dict
-        self._sse_queues: Dict[str, List[asyncio.Queue]] = {}  # code → SSE 구독 큐 목록
+        self._sse_queues: Dict[tuple, List[asyncio.Queue]] = {}  # (code, exchange) → SSE 구독 큐 목록
         self._last_tick_ts: Dict[str, float] = {}
         self._last_any_tick_ts: float = 0.0
         self._subscription_requested_ts: Dict[str, float] = {}
@@ -140,6 +140,13 @@ class PriceStreamService:
         if not stock_code or not current_price:
             key = str(stock_code).strip() if stock_code else "__unknown__"
             self._tick_ingest_malformed[key] = self._tick_ingest_malformed.get(key, 0) + 1
+            return
+
+        exchange = self._tick_exchange(realtime_data)
+        if exchange != 'UN':
+            # 거래소 지정 틱(KRX/NXT)은 화면 표시 전용이다. 종목코드 단위 공유 캐시·저장소는
+            # 통합(H0UNCNT0) 기준이므로 오염시키지 않고 같은 거래소 SSE 큐로만 전달한다.
+            self._fanout_sse_tick(stock_code, exchange, self._build_sse_tick(stock_code, realtime_data))
             return
 
         self._tick_ingest_received[stock_code] = self._tick_ingest_received.get(stock_code, 0) + 1
@@ -238,23 +245,7 @@ class PriceStreamService:
         except Exception as e:
             self._logger.warning(f"StockRepository 실시간 틱 캐시 갱신 실패: {e}")
 
-        if stock_code in self._sse_queues:
-            tick = {
-                "code": stock_code,
-                "price": float(current_price),
-                "volume": vol_int,
-                "change": realtime_data.get('전일대비', '0'),
-                "rate": realtime_data.get('전일대비율', '0.00'),
-                "sign": realtime_data.get('전일대비부호', '3'),
-                "open": _sf(realtime_data.get('주식시가', '')) or 0.0,
-                "high": _sf(realtime_data.get('주식최고가', '')) or 0.0,
-                "low": _sf(realtime_data.get('주식최저가', '')) or 0.0,
-            }
-            for q in self._sse_queues[stock_code]:
-                try:
-                    q.put_nowait(tick)
-                except asyncio.QueueFull:
-                    pass
+        self._fanout_sse_tick(stock_code, 'UN', self._build_sse_tick(stock_code, realtime_data))
 
         if self._favorite_price_alert_service is not None:
             try:
@@ -485,16 +476,56 @@ class PriceStreamService:
 
         return sorted(stale_codes)
 
-    def create_subscriber_queue(self, code: str) -> asyncio.Queue:
+    @staticmethod
+    def _tick_exchange(realtime_data: dict) -> str:
+        """틱이 어느 거래소 스트림에서 왔는지 반환한다 (태그가 없으면 통합)."""
+        exchange = str(realtime_data.get('_exchange') or 'UN').upper()
+        return exchange if exchange in ('KRX', 'NXT', 'UN') else 'UN'
+
+    @staticmethod
+    def _build_sse_tick(stock_code: str, realtime_data: dict) -> dict:
+        """SSE로 내보낼 틱 payload를 구성한다."""
+        def _num(val, default=0.0) -> float:
+            try:
+                return float(val) if val and val != 'N/A' else default
+            except (ValueError, TypeError):
+                return default
+
+        return {
+            "code": stock_code,
+            "price": _num(realtime_data.get('주식현재가')),
+            "volume": int(_num(realtime_data.get('누적거래량'))),
+            "change": realtime_data.get('전일대비', '0'),
+            "rate": realtime_data.get('전일대비율', '0.00'),
+            "sign": realtime_data.get('전일대비부호', '3'),
+            "open": _num(realtime_data.get('주식시가')),
+            "high": _num(realtime_data.get('주식최고가')),
+            "low": _num(realtime_data.get('주식최저가')),
+        }
+
+    def _fanout_sse_tick(self, code: str, exchange: str, tick: dict) -> None:
+        """해당 종목·거래소를 보고 있는 SSE 구독자에게만 틱을 전달한다."""
+        for q in self._sse_queues.get((code, exchange), []):
+            try:
+                q.put_nowait(tick)
+            except asyncio.QueueFull:
+                pass
+
+    def create_subscriber_queue(self, code: str, exchange: str = 'UN') -> asyncio.Queue:
         """SSE 클라이언트용 큐를 생성하고 등록한다."""
         queue: asyncio.Queue = asyncio.Queue()
-        self._sse_queues.setdefault(code, []).append(queue)
+        self._sse_queues.setdefault((code, exchange), []).append(queue)
         return queue
 
-    def remove_subscriber_queue(self, code: str, queue: asyncio.Queue) -> None:
+    def remove_subscriber_queue(self, code: str, queue: asyncio.Queue, exchange: str = 'UN') -> None:
         """SSE 클라이언트 큐를 제거한다. 구독자가 없으면 항목 삭제."""
-        queues = self._sse_queues.get(code, [])
+        key = (code, exchange)
+        queues = self._sse_queues.get(key, [])
         if queue in queues:
             queues.remove(queue)
         if not queues:
-            self._sse_queues.pop(code, None)
+            self._sse_queues.pop(key, None)
+
+    def subscriber_count(self, code: str, exchange: str = 'UN') -> int:
+        """해당 종목·거래소의 SSE 구독자 수를 반환한다."""
+        return len(self._sse_queues.get((code, exchange), []))

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -283,6 +283,22 @@ class StreamingService:
             self._price_stream_service.clear_subscription_state(code)
         return result
 
+    async def subscribe_exchange_price(self, code: str, exchange: str) -> bool:
+        """거래소 지정 체결가(KRX=H0STCNT0 / NXT=H0NXCNT0)를 구독한다 — 화면 표시 전용.
+
+        통합(H0UNCNT0) 구독은 PriceSubscriptionService 정책이 관리하고, 이 경로는
+        SSE 연결이 살아있는 동안에만 유지되는 별도 구독이다.
+        """
+        if exchange == "NXT":
+            return await self.broker.subscribe_nxt_price(code)
+        return await self.broker.subscribe_realtime_price(code)
+
+    async def unsubscribe_exchange_price(self, code: str, exchange: str) -> bool:
+        """거래소 지정 체결가 구독을 해지한다."""
+        if exchange == "NXT":
+            return await self.broker.unsubscribe_nxt_price(code)
+        return await self.broker.unsubscribe_realtime_price(code)
+
     async def subscribe_order_notice(self):
         """국내주식 체결통보 구독 (BrokerAPIWrapper 위임)."""
         return await self.broker.subscribe_order_notice()

--- a/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
+++ b/tests/unit_test/brokers/korea_investment/test_korea_invest_websocket_api.py
@@ -3072,3 +3072,34 @@ async def test_get_subscription_ledger_classifies_price_pt_and_others(websocket_
     assert ledger["total"] == 6
     assert ledger["price_codes"] == {"005930", "000660"}
     assert ledger["program_trading_codes"] == {"005930"}
+
+
+@pytest.mark.parametrize("tr_id,expected_exchange", [
+    ("H0STCNT0", "KRX"),
+    ("H0NXCNT0", "NXT"),
+    ("H0UNCNT0", "UN"),
+])
+def test_realtime_price_tick_carries_exchange_tag(websocket_api_instance, tr_id, expected_exchange):
+    """체결 틱은 어느 거래소 스트림에서 왔는지 태그를 함께 전달한다."""
+    api = websocket_api_instance
+    api.on_realtime_message_callback = MagicMock()
+
+    api._handle_websocket_message(_make_realtime_price_message(tr_id))
+
+    called = api.on_realtime_message_callback.call_args[0][0]
+    assert called['type'] == 'realtime_price'
+    assert called['data']['_exchange'] == expected_exchange
+
+
+@pytest.mark.asyncio
+async def test_subscribe_nxt_price_uses_nxt_tr_id(websocket_api_instance):
+    """NXT 체결가 구독/해지는 H0NXCNT0을 사용한다."""
+    api = websocket_api_instance
+    api.send_realtime_request = AsyncMock(return_value=True)
+
+    assert await api.subscribe_nxt_price("005930") is True
+    api.send_realtime_request.assert_awaited_once_with("H0NXCNT0", "005930", tr_type="1")
+
+    api.send_realtime_request.reset_mock()
+    await api.unsubscribe_nxt_price("005930")
+    api.send_realtime_request.assert_awaited_once_with("H0NXCNT0", "005930", tr_type="2")

--- a/tests/unit_test/services/test_price_stream_service.py
+++ b/tests/unit_test/services/test_price_stream_service.py
@@ -273,23 +273,23 @@ def test_create_subscriber_queue(price_stream_service):
     """큐 생성 후 해당 종목코드로 등록되는지 검증"""
     q = price_stream_service.create_subscriber_queue('005930')
     assert isinstance(q, asyncio.Queue)
-    assert q in price_stream_service._sse_queues['005930']
+    assert q in price_stream_service._sse_queues[('005930', 'UN')]
 
 
 def test_create_subscriber_queue_multiple(price_stream_service):
     """동일 종목에 복수의 큐 등록 가능한지 검증"""
     q1 = price_stream_service.create_subscriber_queue('005930')
     q2 = price_stream_service.create_subscriber_queue('005930')
-    assert len(price_stream_service._sse_queues['005930']) == 2
-    assert q1 in price_stream_service._sse_queues['005930']
-    assert q2 in price_stream_service._sse_queues['005930']
+    assert len(price_stream_service._sse_queues[('005930', 'UN')]) == 2
+    assert q1 in price_stream_service._sse_queues[('005930', 'UN')]
+    assert q2 in price_stream_service._sse_queues[('005930', 'UN')]
 
 
 def test_remove_subscriber_queue_cleans_up_empty_key(price_stream_service):
     """마지막 큐 제거 시 종목코드 항목이 삭제되는지 검증"""
     q = price_stream_service.create_subscriber_queue('005930')
     price_stream_service.remove_subscriber_queue('005930', q)
-    assert '005930' not in price_stream_service._sse_queues
+    assert ('005930', 'UN') not in price_stream_service._sse_queues
 
 
 def test_remove_subscriber_queue_keeps_remaining(price_stream_service):
@@ -297,7 +297,7 @@ def test_remove_subscriber_queue_keeps_remaining(price_stream_service):
     q1 = price_stream_service.create_subscriber_queue('005930')
     q2 = price_stream_service.create_subscriber_queue('005930')
     price_stream_service.remove_subscriber_queue('005930', q1)
-    assert price_stream_service._sse_queues['005930'] == [q2]
+    assert price_stream_service._sse_queues[('005930', 'UN')] == [q2]
 
 
 def test_remove_subscriber_queue_nonexistent_no_error(price_stream_service):
@@ -497,3 +497,51 @@ def test_on_price_tick_invalid_quality_not_cached(mock_stock_repo, mock_logger):
     assert svc.get_cached_price("005930") is None
     mock_stock_repo.update_realtime_data.assert_not_called()
     mock_logger.warning.assert_called()
+
+
+def test_exchange_specific_tick_only_feeds_matching_sse_queue(price_stream_service, mock_stock_repo):
+    """거래소 지정(KRX/NXT) 틱은 공유 캐시를 건드리지 않고 같은 거래소 SSE 큐로만 전달된다."""
+    krx_queue = price_stream_service.create_subscriber_queue('005930', exchange='KRX')
+    un_queue = price_stream_service.create_subscriber_queue('005930', exchange='UN')
+
+    price_stream_service.on_price_tick({
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '70000',
+        '누적거래량': '1000',
+        '_exchange': 'KRX',
+    })
+
+    assert krx_queue.qsize() == 1
+    assert krx_queue.get_nowait()["price"] == 70000.0
+    assert un_queue.qsize() == 0
+    assert price_stream_service._latest_prices == {}
+    mock_stock_repo.update_realtime_data.assert_not_called()
+
+
+def test_unified_tick_does_not_feed_exchange_specific_queue(price_stream_service, mock_stock_repo):
+    """통합(UN) 틱은 기존 동작(캐시·저장소 갱신)을 유지하고 거래소 지정 큐로는 가지 않는다."""
+    krx_queue = price_stream_service.create_subscriber_queue('005930', exchange='KRX')
+    un_queue = price_stream_service.create_subscriber_queue('005930', exchange='UN')
+
+    price_stream_service.on_price_tick({
+        '유가증권단축종목코드': '005930',
+        '주식현재가': '70000',
+        '누적거래량': '1000',
+    })
+
+    assert un_queue.qsize() == 1
+    assert krx_queue.qsize() == 0
+    assert price_stream_service._latest_prices['005930']['price'] == '70000'
+    mock_stock_repo.update_realtime_data.assert_called_once()
+
+
+def test_subscriber_count_tracks_exchange_scope(price_stream_service):
+    """SSE 구독자 수는 거래소 단위로 집계된다 (구독 생성·해지 판단 근거)."""
+    assert price_stream_service.subscriber_count('005930', exchange='KRX') == 0
+
+    q = price_stream_service.create_subscriber_queue('005930', exchange='KRX')
+    assert price_stream_service.subscriber_count('005930', exchange='KRX') == 1
+    assert price_stream_service.subscriber_count('005930', exchange='UN') == 0
+
+    price_stream_service.remove_subscriber_queue('005930', q, exchange='KRX')
+    assert price_stream_service.subscriber_count('005930', exchange='KRX') == 0

--- a/tests/unit_test/view/web/routes/test_web_routes_streaming.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_streaming.py
@@ -161,8 +161,8 @@ async def test_stream_price_yields_tick_and_cleanup():
             events.append(chunk)
 
     assert any(f"data: {json.dumps(tick_data)}" in e for e in events)
-    mock_stream_svc.create_subscriber_queue.assert_called_once_with("005930")
-    mock_stream_svc.remove_subscriber_queue.assert_called_once_with("005930", real_queue)
+    mock_stream_svc.create_subscriber_queue.assert_called_once_with("005930", exchange="UN")
+    mock_stream_svc.remove_subscriber_queue.assert_called_once_with("005930", real_queue, exchange="UN")
     mock_sub_svc.remove_subscription.assert_awaited_once()
 
 
@@ -220,4 +220,65 @@ async def test_stream_price_works_without_sub_svc():
         async for _ in response.body_iterator:
             pass
 
-    mock_stream_svc.remove_subscriber_queue.assert_called_once_with("005930", real_queue)
+    mock_stream_svc.remove_subscriber_queue.assert_called_once_with("005930", real_queue, exchange="UN")
+
+
+async def test_stream_price_exchange_specific_uses_exchange_stream():
+    """KRX/NXT 탭 SSE는 통합 구독 정책 대신 거래소 지정 스트림을 직접 구독·해지한다."""
+    real_queue = asyncio.Queue()
+    mock_stream_svc = MagicMock()
+    mock_stream_svc.create_subscriber_queue.return_value = real_queue
+    mock_stream_svc.subscriber_count.side_effect = [1, 0]
+    mock_sub_svc = AsyncMock()
+    mock_streaming_svc = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.price_stream_service = mock_stream_svc
+    ctx.price_subscription_service = mock_sub_svc
+    ctx.streaming_service = mock_streaming_svc
+
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=True)
+
+    with patch("view.web.routes.streaming._get_ctx", return_value=ctx), \
+         patch("view.web.routes.streaming.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01), \
+         patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
+        mock_wait_for.side_effect = asyncio.TimeoutError()
+
+        response = await stream_stock_price("005930", mock_request, exchange="KRX")
+        async for _ in response.body_iterator:
+            pass
+
+    mock_stream_svc.create_subscriber_queue.assert_called_once_with("005930", exchange="KRX")
+    mock_streaming_svc.subscribe_exchange_price.assert_awaited_once_with("005930", "KRX")
+    mock_streaming_svc.unsubscribe_exchange_price.assert_awaited_once_with("005930", "KRX")
+    mock_sub_svc.add_subscription.assert_not_awaited()
+
+
+async def test_stream_price_exchange_specific_shares_one_subscription():
+    """같은 종목·거래소에 구독자가 남아 있으면 스트림 구독을 유지한다."""
+    real_queue = asyncio.Queue()
+    mock_stream_svc = MagicMock()
+    mock_stream_svc.create_subscriber_queue.return_value = real_queue
+    mock_stream_svc.subscriber_count.side_effect = [2, 1]
+    mock_streaming_svc = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.price_stream_service = mock_stream_svc
+    ctx.price_subscription_service = AsyncMock()
+    ctx.streaming_service = mock_streaming_svc
+
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=True)
+
+    with patch("view.web.routes.streaming._get_ctx", return_value=ctx), \
+         patch("view.web.routes.streaming.SSE_KEEPALIVE_TIMEOUT_SEC", 0.01), \
+         patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
+        mock_wait_for.side_effect = asyncio.TimeoutError()
+
+        response = await stream_stock_price("005930", mock_request, exchange="NXT")
+        async for _ in response.body_iterator:
+            pass
+
+    mock_streaming_svc.subscribe_exchange_price.assert_not_awaited()
+    mock_streaming_svc.unsubscribe_exchange_price.assert_not_awaited()

--- a/view/web/routes/streaming.py
+++ b/view/web/routes/streaming.py
@@ -59,8 +59,8 @@ def get_streaming_status():
 
 
 @router.get("/streaming/price/{code}")
-async def stream_stock_price(code: str, request: Request):
-    """SSE: 특정 종목 실시간 체결가를 브라우저로 스트리밍."""
+async def stream_stock_price(code: str, request: Request, exchange: str = "UN"):
+    """SSE: 특정 종목 실시간 체결가를 브라우저로 스트리밍. exchange=KRX|NXT|UN 선택 가능."""
     ctx = _get_ctx()
     stream_svc = getattr(ctx, "price_stream_service", None)
     sub_svc = getattr(ctx, "price_subscription_service", None)
@@ -68,10 +68,23 @@ async def stream_stock_price(code: str, request: Request):
     if not stream_svc:
         raise HTTPException(status_code=503, detail="PriceStreamService가 초기화되지 않았습니다")
 
-    queue = stream_svc.create_subscriber_queue(code)
+    exch = exchange.upper()
+    if exch not in ("KRX", "NXT", "UN"):
+        exch = "UN"
+    exchange_svc = getattr(ctx, "streaming_service", None) if exch != "UN" else None
+
+    queue = stream_svc.create_subscriber_queue(code, exchange=exch)
     category = f"sse_ui_{id(queue)}"
-    if sub_svc:
-        await sub_svc.add_subscription(code, SubscriptionPriority.LOW, category, StreamingType.UNIFIED_PRICE)
+    if exch == "UN":
+        if sub_svc:
+            await sub_svc.add_subscription(code, SubscriptionPriority.LOW, category, StreamingType.UNIFIED_PRICE)
+    elif exchange_svc and stream_svc.subscriber_count(code, exchange=exch) == 1:
+        # 통합 구독은 SubscriptionPolicy(40슬롯)가 관리한다. 거래소 지정 스트림은 화면 표시 전용이라
+        # 같은 종목·거래소의 첫 구독자일 때만 열고 마지막 구독자가 떠날 때 닫는다.
+        try:
+            await exchange_svc.subscribe_exchange_price(code, exch)
+        except Exception as e:
+            ctx.logger.warning(f"[streaming] 거래소 지정 구독 실패 ({code}/{exch}): {e}")
 
     async def event_generator():
         try:
@@ -89,8 +102,14 @@ async def stream_stock_price(code: str, request: Request):
         except asyncio.CancelledError:
             pass
         finally:
-            stream_svc.remove_subscriber_queue(code, queue)
-            if sub_svc:
-                await sub_svc.remove_subscription(code, category)
+            stream_svc.remove_subscriber_queue(code, queue, exchange=exch)
+            if exch == "UN":
+                if sub_svc:
+                    await sub_svc.remove_subscription(code, category)
+            elif exchange_svc and stream_svc.subscriber_count(code, exchange=exch) == 0:
+                try:
+                    await exchange_svc.unsubscribe_exchange_price(code, exch)
+                except Exception as e:
+                    ctx.logger.warning(f"[streaming] 거래소 지정 구독 해지 실패 ({code}/{exch}): {e}")
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/view/web/static/js/candle_chart.js
+++ b/view/web/static/js/candle_chart.js
@@ -568,11 +568,10 @@ function subscribeRealtimePrice(code) {
         priceEventSource = null;
     }
 
-    // 실시간 틱은 통합(H0UNCNT0) 체결가라 KRX/NXT 탭에 반영하면 통합 시세로 움직인다.
+    // 선택한 거래소의 체결 스트림만 구독한다 (KRX=H0STCNT0 / NXT=H0NXCNT0 / 통합=H0UNCNT0).
     const exch = (typeof _currentExchange !== 'undefined') ? _currentExchange : 'UN';
-    if (exch !== 'UN') return;
 
-    priceEventSource = new EventSource(`/api/streaming/price/${code}`);
+    priceEventSource = new EventSource(`/api/streaming/price/${code}?exchange=${exch}`);
 
     priceEventSource.onmessage = function (event) {
         const tick = JSON.parse(event.data);

--- a/view/web/templates/stock.html
+++ b/view/web/templates/stock.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/candle_chart.js?v=5"></script>
+<script src="/static/js/candle_chart.js?v=6"></script>
 <script>
     // 종목 리스트: localStorage에서 즉시 복원, 없으면 API 로드 후 저장
     var ALL_STOCKS = (function() {


### PR DESCRIPTION
## 배경

#871에서 통합(H0UNCNT0) 틱이 KRX/NXT 탭 표시값을 덮어쓰는 문제를 막았지만, 실시간 스트림이 통합 하나뿐이라 **KRX/NXT 탭은 조회 시점 시세로 고정**되고 자동 갱신이 없었다. 거래소별 체결 스트림을 구독해 선택한 거래소 기준으로 실시간 갱신되도록 한다.

## 변경 내용

- **틱 출처 태깅** (`korea_invest_websocket_api.py`) — 체결 틱에 `_exchange`(KRX/NXT/UN)를 붙인다. H0STCNT0/H0NXCNT0/H0UNCNT0가 동일한 포맷이라 지금까지는 수신 측에서 출처를 구분할 수 없었다.
- **NXT 체결가 구독 경로 추가** — `subscribe_nxt_price`/`unsubscribe_nxt_price`(H0NXCNT0)를 웹소켓 API → `KoreaInvestApiClient` → `BrokerAPIWrapper`로 위임 연결. 파서는 이미 존재했다.
- **거래소 지정 구독** (`streaming_service.py`) — `subscribe_exchange_price(code, exchange)` / `unsubscribe_exchange_price`. KRX는 H0STCNT0, NXT는 H0NXCNT0을 사용하며, 통합 구독 진단(`mark_subscription_requested` 등)을 건드리지 않도록 브로커에 직접 위임한다.
- **SSE 큐를 (종목, 거래소) 단위로 분리** (`price_stream_service.py`) — 거래소 지정 틱은 `_latest_prices`·`StockRepository`·관심종목 알림·품질/수집 통계를 모두 건너뛰고 **같은 거래소 SSE 큐로만** 전달한다. 전략·주문 경로가 쓰는 통합 기준 캐시는 그대로 유지된다. 통합 틱 처리 흐름은 변경 없음(틱 payload 구성만 `_build_sse_tick`으로 공통화).
- **SSE 엔드포인트** (`routes/streaming.py`) — `GET /api/streaming/price/{code}?exchange=KRX|NXT|UN`. 통합은 기존 `SubscriptionPolicy`(40슬롯) 경로 그대로, 거래소 지정은 같은 종목·거래소의 첫 구독자에서 열고 마지막 구독자가 떠날 때 닫는다(구독자 수 기반 공유).
- **프론트** (`candle_chart.js`) — 선택한 거래소로 SSE를 구독한다. 탭 전환 시 재조회 경로에서 기존 스트림을 닫고 새 거래소로 다시 연결된다.

## 동작 변화

- KRX / NXT 탭도 해당 거래소 체결 틱으로 실시간 갱신된다(가격·전일대비·당일 고저·차트 마지막 봉).
- 통합 탭과 전략·주문 경로의 동작은 이전과 동일하다.

## 알려진 제약

- 거래소 지정 구독은 화면을 열어둔 동안 KIS 웹소켓 슬롯을 1개 추가로 사용한다(통합 40슬롯 정책과 별도). 한도를 넘으면 KIS가 신규 구독을 거절하므로, 그 경우 해당 탭은 갱신 없이 조회 시점 시세로 남는다(기존 동작으로 degrade).
- SSE 종료 시점에 웹소켓이 끊겨 있으면 해지 요청이 실패해 재연결 시 복구 목록에 남을 수 있다. 틱은 큐가 없어 무시되지만 슬롯 1개가 앱 재시작 전까지 유지될 수 있다.
- KIS 실계좌에서 통합/거래소 지정 구독을 동시에 유지할 수 있는지는 이 환경에서 검증할 수 없어 코드 경로로만 확인했다.

## 테스트

- 단위: `pytest tests/unit_test` → 7891 passed / 1 failed. 실패한 `test_initialization_kiwoom_requires_env`는 `main`에서도 동일하게 실패하는 기존 항목으로 이번 변경과 무관.
- 통합: `pytest tests/integration_test` → 변경 전후 실패 목록 동일(로컬 설정 부재로 인한 기존 실패 7건 + 에러 43건).
- 추가 테스트 9건: 틱 `_exchange` 태깅(3), H0NXCNT0 구독/해지 TR ID, 거래소 지정 틱이 공유 캐시를 건드리지 않고 같은 거래소 큐로만 가는지, 통합 틱이 거래소 지정 큐로 새지 않는지, 구독자 수 거래소 단위 집계, SSE 라우트의 거래소 지정 구독/해지와 구독 공유.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjnRNSRGFycJQyXoJ4pdQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjnRNSRGFycJQyXoJ4pdQ5)_