### PR TITLE
feat(web): 수출입동향에 제주지역 월별 수출입동향 추가

### DIFF
--- a/services/trade_trend_service.py
+++ b/services/trade_trend_service.py
@@ -44,6 +44,25 @@ class JejuSemiconductorTradeReport:
 
 
 @dataclass(frozen=True)
+class JejuRegionTradeMonth:
+    period: str
+    export_amount_usd: int
+    import_amount_usd: int
+    trade_balance_usd: int
+    export_mom_pct: Optional[float] = None
+    export_yoy_pct: Optional[float] = None
+    import_mom_pct: Optional[float] = None
+    import_yoy_pct: Optional[float] = None
+
+    @property
+    def period_label(self) -> str:
+        key = _period_key(self.period)
+        if not key:
+            return self.period
+        return f"{int(key[:4])}년 {int(key[4:])}월"
+
+
+@dataclass(frozen=True)
 class NationalTradeTrendRelease:
     source: str
     phase: str
@@ -159,6 +178,17 @@ class CustomsTradeStatClient:
         params = {
             "searchBgnDe": yyyymm,
             "searchEndDe": yyyymm,
+            self._sido_param_name: self._sido_code,
+            "serviceKey": self._service_key,
+        }
+        return await self._get("getsidotradeList", params)
+
+    async def fetch_sido_total_range(
+        self, begin_yyyymm: str, end_yyyymm: str
+    ) -> list[TradeStatItem]:
+        params = {
+            "searchBgnDe": begin_yyyymm,
+            "searchEndDe": end_yyyymm,
             self._sido_param_name: self._sido_code,
             "serviceKey": self._service_key,
         }
@@ -343,6 +373,64 @@ def build_jeju_semiconductor_report(
 
 def select_export_row(rows: list[TradeStatItem]) -> Optional[TradeStatItem]:
     return _first_export(rows)
+
+
+def _period_key(period: str) -> str:
+    """관세청 기간 표기("2026.05")를 "202605" 형태로 정규화한다."""
+    match = re.match(r"\s*(\d{4})\D*(\d{1,2})", str(period or ""))
+    if not match:
+        return ""
+    return f"{int(match.group(1)):04d}{int(match.group(2)):02d}"
+
+
+def shift_yyyymm(yyyymm: str, delta_months: int) -> str:
+    year = int(yyyymm[:4])
+    month = int(yyyymm[4:6]) + delta_months
+    year += (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    return f"{year:04d}{month:02d}"
+
+
+def build_jeju_region_trade_series(
+    rows: list[TradeStatItem],
+) -> list[JejuRegionTradeMonth]:
+    """월별 제주지역 수출입 실적에 전월비·전년동월비를 붙여 최신순으로 반환한다."""
+    by_key: dict[str, TradeStatItem] = {}
+    for row in rows:
+        key = _period_key(row.period)
+        if key:
+            by_key[key] = row
+
+    series: list[JejuRegionTradeMonth] = []
+    for key in sorted(by_key, reverse=True):
+        row = by_key[key]
+        previous_month = by_key.get(shift_yyyymm(key, -1))
+        previous_year = by_key.get(shift_yyyymm(key, -12))
+        series.append(
+            JejuRegionTradeMonth(
+                period=row.period,
+                export_amount_usd=row.export_amount_usd,
+                import_amount_usd=row.import_amount_usd,
+                trade_balance_usd=row.trade_balance_usd,
+                export_mom_pct=_pct(
+                    row.export_amount_usd,
+                    previous_month.export_amount_usd if previous_month else None,
+                ),
+                export_yoy_pct=_pct(
+                    row.export_amount_usd,
+                    previous_year.export_amount_usd if previous_year else None,
+                ),
+                import_mom_pct=_pct(
+                    row.import_amount_usd,
+                    previous_month.import_amount_usd if previous_month else None,
+                ),
+                import_yoy_pct=_pct(
+                    row.import_amount_usd,
+                    previous_year.import_amount_usd if previous_year else None,
+                ),
+            )
+        )
+    return series
 
 
 def _clean_text(text: str) -> str:

--- a/tests/unit_test/services/test_trade_trend_service.py
+++ b/tests/unit_test/services/test_trade_trend_service.py
@@ -7,6 +7,7 @@ import pytest
 
 from services.trade_trend_service import (
     CustomsTradeStatClient,
+    build_jeju_region_trade_series,
     NationalTradeTrendRelease,
     NationalTradeTrendWebClient,
     TradeStatItem,
@@ -109,6 +110,95 @@ async def test_customs_client_calls_sido_item_endpoint_with_configured_params():
     assert params["searchItemCd"] == "8542"
     assert params["searchSidoCd"] == "50"
     assert params["serviceKey"] == "test-key"
+
+
+JEJU_TOTAL_RANGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>00</resultCode>
+    <resultMsg>NORMAL SERVICE.</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <year>2025.05</year>
+        <statKor>제주</statKor>
+        <hsCode>-</hsCode>
+        <expDlr>10000000</expDlr>
+        <impDlr>8000000</impDlr>
+        <balPayments>2000000</balPayments>
+      </item>
+      <item>
+        <year>2026.04</year>
+        <statKor>제주</statKor>
+        <hsCode>-</hsCode>
+        <expDlr>20000000</expDlr>
+        <impDlr>9000000</impDlr>
+        <balPayments>11000000</balPayments>
+      </item>
+      <item>
+        <year>2026.05</year>
+        <statKor>제주</statKor>
+        <hsCode>-</hsCode>
+        <expDlr>25000000</expDlr>
+        <impDlr>9900000</impDlr>
+        <balPayments>15100000</balPayments>
+      </item>
+    </items>
+  </body>
+</response>
+"""
+
+
+class DummyRangeResponse:
+    status_code = 200
+    text = JEJU_TOTAL_RANGE_XML
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_customs_client_fetches_sido_total_range_with_period_range():
+    http_client = DummyHttpClient()
+    http_client.get = AsyncMock(return_value=DummyRangeResponse())
+    client = CustomsTradeStatClient(
+        service_key="test-key",
+        http_client=http_client,
+        base_url="https://example.test/openapi/service/newTradestatistics",
+        sido_param_name="searchSidoCd",
+        sido_code="50",
+    )
+
+    rows = await client.fetch_sido_total_range("202505", "202605")
+
+    assert [row.period for row in rows] == ["2025.05", "2026.04", "2026.05"]
+    url = http_client.get.await_args.args[0]
+    params = http_client.get.await_args.kwargs["params"]
+    assert url.endswith("/getsidotradeList")
+    assert params["searchBgnDe"] == "202505"
+    assert params["searchEndDe"] == "202605"
+    assert params["searchSidoCd"] == "50"
+    assert "searchItemCd" not in params
+
+
+def test_build_jeju_region_trade_series_calculates_mom_and_yoy():
+    rows = parse_customs_trade_xml(JEJU_TOTAL_RANGE_XML)
+
+    series = build_jeju_region_trade_series(rows)
+
+    assert [item.period for item in series] == ["2026.05", "2026.04", "2025.05"]
+    latest = series[0]
+    assert latest.export_amount_usd == 25000000
+    assert latest.import_amount_usd == 9900000
+    assert latest.trade_balance_usd == 15100000
+    assert latest.export_mom_pct == pytest.approx(25.0)
+    assert latest.export_yoy_pct == pytest.approx(150.0)
+    assert latest.import_mom_pct == pytest.approx(10.0)
+    assert latest.import_yoy_pct == pytest.approx(23.75)
+    # 직전월/전년동월 데이터가 없는 구간은 None 으로 둔다.
+    assert series[-1].export_mom_pct is None
+    assert series[-1].export_yoy_pct is None
 
 
 def test_build_jeju_semiconductor_report_calculates_mom_yoy_and_share():

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -236,6 +236,25 @@ def test_service_container_builds_national_trade_trend_monitor_without_key(
     assert task_kwargs["customs_client"] is None
 
 
+def test_service_container_builds_customs_client_for_web_when_monitor_disabled(
+    patched_service_container_deps,
+):
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.runtime_mode = RuntimeMode.WEB
+    ctx.full_config = {
+        "trade_trend_monitor": {"enabled": False, "customs_service_key": "customs-key"}
+    }
+
+    ServiceContainer(ctx).run()
+
+    client_cls = patched_service_container_deps["CustomsTradeStatClient"]
+    client_cls.assert_called_once()
+    assert ctx.trade_trend_customs_client is client_cls.return_value
+    assert ctx.trade_trend_monitor_task is None
+
+
 def test_service_container_builds_enabled_ai_stock_analyzer(patched_service_container_deps):
     from view.web.bootstrap.service_container import ServiceContainer
 

--- a/tests/unit_test/view/web/routes/test_trade_trend.py
+++ b/tests/unit_test/view/web/routes/test_trade_trend.py
@@ -1,12 +1,18 @@
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 import view.web.api_common as api_common
 import view.web.web_main as web_main
 from repositories.trade_trend_repository import TradeTrendRepository
-from services.trade_trend_service import NationalTradeTrendRelease
+from services.trade_trend_service import (
+    NationalTradeTrendRelease,
+    TradeStatItem,
+    shift_yyyymm,
+)
 
 
 def test_national_trade_trend_history_merges_stored_and_recent_rows():
@@ -224,3 +230,62 @@ def test_national_trade_trend_backfill_builds_client_when_missing(tmp_path, monk
         max_detail_pages=20,
         list_page_count=2,
     )
+
+
+def test_jeju_region_trade_returns_series_from_customs_client():
+    rows = [
+        TradeStatItem("2025.05", "제주", "-", 10000000, 8000000, 2000000),
+        TradeStatItem("2026.04", "제주", "-", 20000000, 9000000, 11000000),
+        TradeStatItem("2026.05", "제주", "-", 25000000, 9900000, 15100000),
+    ]
+    customs_client = SimpleNamespace(
+        fetch_sido_total_range=AsyncMock(return_value=rows),
+    )
+    ctx = SimpleNamespace(
+        full_config={"use_login": False, "auth": {"secret_key": "test-token"}},
+        trade_trend_customs_client=customs_client,
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).get("/api/trade-trends/jeju/region?months=2")
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["data"]["available"] is True
+    assert len(payload["data"]["rows"]) == 2
+    latest = payload["data"]["latest"]
+    assert latest["period"] == "2026.05"
+    assert latest["period_label"] == "2026년 5월"
+    assert latest["export_amount_usd"] == 25000000
+    assert latest["export_mom_pct"] == pytest.approx(25.0)
+    assert latest["export_yoy_pct"] == pytest.approx(150.0)
+
+    begin, end = customs_client.fetch_sido_total_range.await_args.args
+    expected_end = shift_yyyymm(datetime.now().strftime("%Y%m"), -1)
+    assert end == expected_end
+    # 표시 2개월 + 전년동월 비교용 12개월을 함께 받아온다.
+    assert begin == shift_yyyymm(expected_end, -13)
+
+
+def test_jeju_region_trade_reports_unavailable_without_customs_client():
+    ctx = SimpleNamespace(
+        full_config={"use_login": False, "auth": {"secret_key": "test-token"}},
+        trade_trend_customs_client=None,
+    )
+    api_common.set_ctx(ctx)
+
+    try:
+        response = TestClient(web_main.app).get("/api/trade-trends/jeju/region")
+    finally:
+        api_common.set_ctx(None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["data"]["available"] is False
+    assert payload["data"]["rows"] == []
+    assert payload["data"]["latest"] is None

--- a/tests/unit_test/view/web/static/test_trade_trends_js.py
+++ b/tests/unit_test/view/web/static/test_trade_trends_js.py
@@ -312,3 +312,22 @@ return {
         "nestedCount": 2,
         "maxValue": 31.2,
     }
+
+
+def test_jeju_region_money_formats_usd_as_million_unit():
+    result = run_trade_trends_js(
+        """
+const { formatJejuMillionUsd } = sandbox.module.exports;
+return {
+  amount: formatJejuMillionUsd(25000000),
+  small: formatJejuMillionUsd(123456),
+  empty: formatJejuMillionUsd(null)
+};
+"""
+    )
+
+    assert result == {
+        "amount": "25.0백만 달러",
+        "small": "0.1백만 달러",
+        "empty": "-",
+    }

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -311,33 +311,37 @@ class ServiceContainer:
         ctx.trade_trend_monitor_task = None
         raw_trade_trend_config = config_dict.get("trade_trend_monitor") or {}
         trade_trend_config = TradeTrendMonitorConfig.model_validate(raw_trade_trend_config)
+        # 제주지역 수출입동향 웹 조회는 모니터 활성화 여부와 무관하게 관세청 키만 있으면 쓴다.
+        ctx.trade_trend_customs_client = None
+        if needs_web and trade_trend_config.customs_service_key:
+            ctx.trade_trend_customs_client = CustomsTradeStatClient(
+                service_key=trade_trend_config.customs_service_key,
+                base_url=trade_trend_config.customs_base_url,
+                timeout_sec=float(trade_trend_config.request_timeout_sec),
+                sido_param_name=trade_trend_config.sido_param_name,
+                sido_code=trade_trend_config.sido_code,
+            )
         if trade_trend_config.enabled:
             if not needs_web:
                 ctx.logger.info("수출입동향 모니터는 WEB 런타임에서만 동작합니다.")
             elif getattr(ctx, "telegram_reporter", None) is None:
                 ctx.logger.warning("수출입동향 모니터가 활성화됐지만 텔레그램 리포터가 없어 비활성화합니다.")
             else:
-                ctx.trade_trend_customs_client = None
+                monitor_customs_client = None
                 if trade_trend_config.jeju_semiconductor_enabled:
                     if not trade_trend_config.customs_service_key:
                         ctx.logger.warning(
                             "제주 반도체 수출 모니터는 관세청 API 키가 없어 스킵합니다."
                         )
                     else:
-                        ctx.trade_trend_customs_client = CustomsTradeStatClient(
-                            service_key=trade_trend_config.customs_service_key,
-                            base_url=trade_trend_config.customs_base_url,
-                            timeout_sec=float(trade_trend_config.request_timeout_sec),
-                            sido_param_name=trade_trend_config.sido_param_name,
-                            sido_code=trade_trend_config.sido_code,
-                        )
+                        monitor_customs_client = ctx.trade_trend_customs_client
                 ctx.national_trade_trend_client = NationalTradeTrendWebClient(
                     list_urls=list(trade_trend_config.national_list_urls),
                     timeout_sec=float(trade_trend_config.request_timeout_sec),
                     max_detail_pages=int(trade_trend_config.national_max_detail_pages),
                 )
                 ctx.trade_trend_monitor_task = TradeTrendMonitorTask(
-                    customs_client=ctx.trade_trend_customs_client,
+                    customs_client=monitor_customs_client,
                     national_client=ctx.national_trade_trend_client,
                     repository_path=trade_trend_config.state_file_path,
                     telegram_reporter=ctx.telegram_reporter,

--- a/view/web/routes/trade_trend.py
+++ b/view/web/routes/trade_trend.py
@@ -7,8 +7,11 @@ from fastapi import APIRouter, Query
 
 from repositories.trade_trend_repository import TradeTrendRepository
 from services.trade_trend_service import (
+    JejuRegionTradeMonth,
     NationalTradeTrendRelease,
     NationalTradeTrendWebClient,
+    build_jeju_region_trade_series,
+    shift_yyyymm,
 )
 from view.web.api_common import _get_ctx
 
@@ -179,5 +182,56 @@ async def backfill_national_trade_trend_history(
             "saved_count": saved_count,
             "stored_count": len(stored_rows),
             "rows": stored_rows,
+        },
+    }
+
+
+def _jeju_month_to_dict(month: JejuRegionTradeMonth) -> dict:
+    return {
+        "period": month.period,
+        "period_label": month.period_label,
+        "export_amount_usd": month.export_amount_usd,
+        "import_amount_usd": month.import_amount_usd,
+        "trade_balance_usd": month.trade_balance_usd,
+        "export_mom_pct": month.export_mom_pct,
+        "export_yoy_pct": month.export_yoy_pct,
+        "import_mom_pct": month.import_mom_pct,
+        "import_yoy_pct": month.import_yoy_pct,
+    }
+
+
+@router.get("/trade-trends/jeju/region")
+async def get_jeju_region_trade_trend(
+    months: int = Query(12, ge=1, le=60),
+):
+    """관세청 시도별 통계로 제주지역 월별 수출입 동향을 반환한다."""
+    ctx = _get_ctx()
+    client = getattr(ctx, "trade_trend_customs_client", None)
+    if client is None:
+        return {
+            "success": True,
+            "data": {
+                "rows": [],
+                "latest": None,
+                "available": False,
+                "message": "관세청 수출입통계 API 키가 설정되지 않아 제주지역 동향을 조회할 수 없습니다.",
+            },
+        }
+
+    # 지역별 월간 통계는 익월 중순 이후 확정되므로 전월을 최신 기준으로 본다.
+    end_month = shift_yyyymm(datetime.now().strftime("%Y%m"), -1)
+    # 표시 구간 전체에 전년동월비를 붙이려면 12개월치를 더 받아야 한다.
+    begin_month = shift_yyyymm(end_month, -(months - 1 + 12))
+
+    stat_rows = await client.fetch_sido_total_range(begin_month, end_month)
+    rows = [_jeju_month_to_dict(item) for item in build_jeju_region_trade_series(stat_rows)][:months]
+    return {
+        "success": True,
+        "data": {
+            "rows": rows,
+            "latest": rows[0] if rows else None,
+            "available": True,
+            "begin_month": begin_month,
+            "end_month": end_month,
         },
     }

--- a/view/web/static/js/trade_trends.js
+++ b/view/web/static/js/trade_trends.js
@@ -1,4 +1,5 @@
 let tradeTrendRows = [];
+let jejuRegionRows = [];
 let tradeTrendFilter = 'all';
 let tradeTrendChartPhase = null;
 
@@ -399,7 +400,65 @@ if (typeof module !== 'undefined' && module.exports) {
         buildTradeTrendPhaseItems,
         buildTradeTrendQuarterItems,
         tradeDailyAverage,
+        formatJejuMillionUsd,
     };
+}
+
+function formatJejuMillionUsd(value) {
+    if (value === null || value === undefined || value === '') return '-';
+    return `${(Number(value) / 1000000).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}백만 달러`;
+}
+
+async function loadJejuRegionTrade() {
+    const status = document.getElementById('jeju-trade-status');
+    if (status) status.textContent = '조회 중';
+    try {
+        const res = await fetch('/api/trade-trends/jeju/region?months=12');
+        const payload = await res.json();
+        if (!res.ok || !payload.success) {
+            throw new Error(payload.detail || '제주지역 수출입동향 조회 실패');
+        }
+        jejuRegionRows = payload.data.rows || [];
+        renderJejuRegionSummary(payload.data.latest);
+        renderJejuRegionTable();
+        if (status) {
+            status.textContent = payload.data.available
+                ? `최근 ${jejuRegionRows.length}개월`
+                : (payload.data.message || '조회할 수 없습니다.');
+        }
+    } catch (error) {
+        if (status) status.textContent = `조회 실패: ${error.message}`;
+        jejuRegionRows = [];
+        renderJejuRegionSummary(null);
+        renderJejuRegionTable();
+    }
+}
+
+function renderJejuRegionSummary(latest) {
+    document.getElementById('jeju-latest-period').textContent = latest ? latest.period_label : '-';
+    document.getElementById('jeju-latest-export').textContent = latest ? formatJejuMillionUsd(latest.export_amount_usd) : '-';
+    document.getElementById('jeju-latest-import').textContent = latest ? formatJejuMillionUsd(latest.import_amount_usd) : '-';
+    document.getElementById('jeju-latest-balance').textContent = latest ? formatJejuMillionUsd(latest.trade_balance_usd) : '-';
+}
+
+function renderJejuRegionTable() {
+    const tbody = document.getElementById('jeju-trade-body');
+    if (!tbody) return;
+    if (!jejuRegionRows.length) {
+        tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:18px;">표시할 제주지역 수출입동향이 없습니다.</td></tr>';
+        return;
+    }
+    tbody.innerHTML = jejuRegionRows.map((row) => `
+        <tr>
+            <td><strong>${escapeHtml(row.period_label || row.period || '-')}</strong></td>
+            <td>${formatJejuMillionUsd(row.export_amount_usd)}</td>
+            <td class="${Number(row.export_mom_pct || 0) >= 0 ? 'text-red' : 'text-blue'}">${tradePct(row.export_mom_pct)}</td>
+            <td class="${Number(row.export_yoy_pct || 0) >= 0 ? 'text-red' : 'text-blue'}">${tradePct(row.export_yoy_pct)}</td>
+            <td>${formatJejuMillionUsd(row.import_amount_usd)}</td>
+            <td class="${Number(row.import_yoy_pct || 0) >= 0 ? 'text-red' : 'text-blue'}">${tradePct(row.import_yoy_pct)}</td>
+            <td><strong>${formatJejuMillionUsd(row.trade_balance_usd)}</strong></td>
+        </tr>
+    `).join('');
 }
 
 function renderTradeTrendHighlights(rows) {

--- a/view/web/templates/trade_trends.html
+++ b/view/web/templates/trade_trends.html
@@ -38,6 +38,50 @@
         </div>
     </div>
 
+    <div class="card">
+        <div class="trade-trend-toolbar">
+            <div>
+                <h2>제주지역 수출입동향</h2>
+                <div id="jeju-trade-status" class="trade-trend-muted">조회 대기 중</div>
+            </div>
+            <button class="btn btn-secondary" onclick="loadJejuRegionTrade()">새로고침</button>
+        </div>
+        <div class="summary-bar trade-trend-summary">
+            <div class="summary-item">
+                <div class="label">최신 월</div>
+                <div class="value" id="jeju-latest-period">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">수출</div>
+                <div class="value" id="jeju-latest-export">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">수입</div>
+                <div class="value" id="jeju-latest-import">-</div>
+            </div>
+            <div class="summary-item">
+                <div class="label">무역수지</div>
+                <div class="value" id="jeju-latest-balance">-</div>
+            </div>
+        </div>
+        <div class="table-container">
+            <table class="data-table trade-trend-table">
+                <thead>
+                    <tr>
+                        <th>기간</th>
+                        <th>수출</th>
+                        <th>수출 MoM</th>
+                        <th>수출 YoY</th>
+                        <th>수입</th>
+                        <th>수입 YoY</th>
+                        <th>무역수지</th>
+                    </tr>
+                </thead>
+                <tbody id="jeju-trade-body"></tbody>
+            </table>
+        </div>
+    </div>
+
     <div class="trade-trend-grid">
         <div class="card trade-trend-chart-card">
             <h2>최근 흐름</h2>
@@ -85,8 +129,9 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/trade_trends.js?v=4"></script>
+<script src="/static/js/trade_trends.js?v=5"></script>
 <script>
     loadTradeTrendHistory();
+    loadJejuRegionTrade();
 </script>
 {% endblock %}


### PR DESCRIPTION
## 요약

수출입동향 페이지에 **제주지역 수출입동향** 섹션을 추가했다. 기존에는 전국 발표(관세청/산업부 보도자료)만 표시했고, 제주 관련 데이터는 텔레그램 알림용 "제주 반도체" 리포트로만 존재했다. 이번 변경으로 제주지역 전체 수출/수입/무역수지를 월별로 웹에서 조회할 수 있다.

## 변경 내용

### 서비스 (`services/trade_trend_service.py`)
- `CustomsTradeStatClient.fetch_sido_total_range(begin_yyyymm, end_yyyymm)` — 관세청 `getsidotradeList`를 월 **범위**로 1회 호출해 시계열을 받는다 (기존 `fetch_sido_total_month`과 동일 엔드포인트/시도코드)
- `JejuRegionTradeMonth` 데이터클래스 + `build_jeju_region_trade_series(rows)` — 월별 수출/수입/무역수지에 전월비(MoM)·전년동월비(YoY)를 붙여 최신순 반환. 비교 대상 월이 없으면 `None`
- `shift_yyyymm(yyyymm, delta)` 헬퍼

### API (`view/web/routes/trade_trend.py`)
- `GET /api/trade-trends/jeju/region?months=12` 신규
- 최신 기준월은 전월(지역 통계는 익월 중순 확정), YoY를 표시 구간 전체에 붙이기 위해 12개월을 더 조회한 뒤 `months`개만 반환
- 관세청 키가 없으면 200 + `available: false` + 안내 메시지

### 조립 (`view/web/bootstrap/service_container.py`)
- 관세청 키만 설정돼 있으면 텔레그램 모니터 활성화 여부와 무관하게 웹 조회용 `trade_trend_customs_client`를 구성
- 모니터 태스크에는 기존대로 `jeju_semiconductor_enabled`일 때만 클라이언트를 전달 (동작 변화 없음)

### UI (`trade_trends.html`, `trade_trends.js`)
- 전국 요약 카드 아래에 제주지역 카드 추가: 최신 월/수출/수입/무역수지 요약 + 12개월 테이블(수출, 수출 MoM, 수출 YoY, 수입, 수입 YoY, 무역수지)
- 금액은 백만 달러 단위 표기, 스크립트 버전 v5

## 테스트

TDD로 진행했다 (실패 테스트 작성 → 구현).

신규 테스트 5건:
- 범위 조회 파라미터 검증 (`searchBgnDe`/`searchEndDe`/시도코드, `searchItemCd` 미포함)
- MoM/YoY 계산 및 비교월 부재 시 `None`
- 라우트 정상 응답(조회 구간 계산 포함) / 관세청 키 미설정 응답
- JS 금액 포맷터

실행 결과:
- `pytest tests/unit_test`: 7898 passed, 1 failed — 실패한 `test_initialization_kiwoom_requires_env`는 변경 전 클린 트리에서도 동일하게 실패하는 환경 이슈
- `pytest tests/integration_test`: 변경 전 baseline과 결과 완전 동일 (config.yaml/네트워크 부재로 인한 기존 실패)

## 확인 필요한 가정

관세청 `getsidotradeList`가 `searchBgnDe`/`searchEndDe` 범위 조회 시 월별 행(`year` = "YYYY.MM")을 반환한다고 가정했다. 범위 조회가 합계 1행만 반환한다면 월별 반복 호출로 바꿔야 한다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyBBjSczboYkhQewiko724)_