### PR TITLE
Add overseas pocket pivot dry-run

### DIFF
--- a/services/overseas_dryrun_suite_service.py
+++ b/services/overseas_dryrun_suite_service.py
@@ -1,0 +1,29 @@
+"""여러 해외 dry-run 서비스를 한 번의 after-market 태스크에서 실행하는 합성 서비스."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, List, Optional
+
+from common.overseas_types import OverseasExchange
+
+
+class OverseasDryRunSuiteService:
+    def __init__(self, services: Iterable[Any], logger: Optional[logging.Logger] = None) -> None:
+        self._services = list(services or [])
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def scan_dry_run(self, exchange: OverseasExchange = OverseasExchange.NASD) -> List[dict]:
+        signals: List[dict] = []
+        for service in self._services:
+            try:
+                result = await service.scan_dry_run(exchange)
+            except Exception as e:
+                self._logger.error({
+                    "event": "overseas_dryrun_suite_service_error",
+                    "service": service.__class__.__name__,
+                    "exchange": exchange.value,
+                    "error": str(e),
+                }, exc_info=True)
+                continue
+            signals.extend(result or [])
+        return signals

--- a/services/overseas_pocket_pivot_dryrun_service.py
+++ b/services/overseas_pocket_pivot_dryrun_service.py
@@ -1,0 +1,230 @@
+"""해외 Pocket Pivot dry-run 신호 서비스.
+
+국내 `OneilPocketPivotStrategy` 의 Pocket Pivot 판정 중 가격/거래량 기반 부분만
+해외 완성 일봉에 적용한다. 프로그램 순매수·체결강도는 국내 전용 데이터라 이
+서비스에서는 쓰지 않는다. 주문 경로는 없고 shadow 저널에 would-be 신호만 기록한다.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+@dataclass
+class OverseasPocketPivotConfig:
+    pp_ma_proximity_lower_pct: float = -2.0
+    pp_ma_proximity_upper_pct: float = 4.0
+    pp_down_day_lookback: int = 10
+    pp_down_vol_threshold_ratio: float = 0.9
+    pp_min_candle_relative_pos: float = 0.5
+    pp_stop_loss_below_ma_pct: float = -2.0
+    partial_profit_trigger_pct: float = 15.0
+
+
+class OverseasPocketPivotDryRunService:
+    STRATEGY_NAME = "O'NeilPP_overseas"
+    SIGNAL_SOURCE = "overseas_pp_dryrun"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        shadow_journal=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        config: Optional[OverseasPocketPivotConfig] = None,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        position_sizing_service=None,
+        fx_provider=None,
+    ) -> None:
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._journal = shadow_journal
+        self._logger = logger or logging.getLogger(__name__)
+        self._cfg = config or OverseasPocketPivotConfig()
+        self._default_exchange = exchange
+        self._sizing_service = position_sizing_service
+        self._fx_provider = fx_provider
+
+    async def scan_dry_run(
+        self,
+        exchange: Optional[OverseasExchange] = None,
+        *,
+        top_n: Optional[int] = None,
+        min_avg_trading_value: Optional[float] = None,
+        record: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """후보를 평가해 PP BUY would-be 신호를 반환하고(선택) shadow 저널에 기록한다."""
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(
+            ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
+        )
+
+        fx_rate = await self._resolve_fx_rate()
+        signals: List[Dict[str, Any]] = []
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            try:
+                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=60, exchange=ex)
+            except Exception as e:
+                self._logger.warning({"event": "overseas_pp_ohlcv_error", "code": code, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+
+            sig = self._evaluate(code, cand, resp.data)
+            if not sig:
+                continue
+            if self._sizing_service is not None:
+                sizing = self._sizing_service.size(
+                    limit_price_usd=sig["entry_price"], fx_krw_per_usd=fx_rate
+                )
+                sig["qty"] = sizing.get("qty")
+                sig["notional_usd"] = sizing.get("notional_usd")
+                if sizing.get("fx_krw_per_usd") is not None:
+                    sig["fx_krw_per_usd"] = sizing.get("fx_krw_per_usd")
+                if sizing.get("krw_exposure") is not None:
+                    sig["krw_exposure"] = sizing.get("krw_exposure")
+            signals.append(sig)
+            if record and self._journal is not None:
+                self._journal.record(
+                    strategy_name=self.STRATEGY_NAME,
+                    code=code,
+                    signal=sig,
+                    snapshot={
+                        "exchange": ex.value,
+                        "avg_trading_value": cand.get("avg_trading_value"),
+                        "bar": self._bar_ohlc(resp.data[-1]),
+                    },
+                    signal_source=self.SIGNAL_SOURCE,
+                )
+
+        self._logger.info({
+            "event": "overseas_pp_dryrun_scan",
+            "exchange": ex.value,
+            "candidates": len(candidates or []),
+            "signals": len(signals),
+        })
+        return signals
+
+    async def _resolve_fx_rate(self) -> Optional[float]:
+        if self._sizing_service is None or self._fx_provider is None:
+            return None
+        try:
+            rate = await self._fx_provider()
+        except Exception as e:
+            self._logger.warning({"event": "overseas_pp_fx_error", "error": str(e)})
+            return None
+        try:
+            rate = float(rate) if rate is not None else None
+        except (TypeError, ValueError):
+            return None
+        return rate if (rate is not None and rate > 0) else None
+
+    def _evaluate(
+        self,
+        code: str,
+        candidate: Dict[str, Any],
+        rows: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        if not rows or len(rows) < max(10, self._cfg.pp_down_day_lookback):
+            return None
+
+        cur = rows[-1]
+        prev = rows[-2] if len(rows) >= 2 else None
+        current = self._f(cur.get("close"))
+        prev_close = self._f(prev.get("close") if prev else 0)
+        volume = self._f(cur.get("volume"))
+        if current <= 0 or prev_close <= 0 or volume <= 0:
+            return None
+        if current <= prev_close:
+            return None
+
+        closes = [self._f(r.get("close")) for r in rows if self._f(r.get("close")) > 0]
+        if len(closes) < 10:
+            return None
+
+        ma_10d = sum(closes[-10:]) / 10
+        ma_20d = sum(closes[-20:]) / 20 if len(closes) >= 20 else 0.0
+        ma_50d = sum(closes[-50:]) / 50 if len(closes) >= 50 else 0.0
+        supporting_ma, support_ma_value = self._find_supporting_ma(current, ma_10d, ma_20d, ma_50d)
+        if not supporting_ma:
+            return None
+
+        high = self._f(cur.get("high"))
+        low = self._f(cur.get("low"))
+        day_range = high - low
+        if day_range > 0:
+            relative_pos = (current - low) / day_range
+            if relative_pos < self._cfg.pp_min_candle_relative_pos:
+                return None
+
+        recent = rows[-self._cfg.pp_down_day_lookback:]
+        down_day_volumes = [
+            self._f(r.get("volume"))
+            for r in recent
+            if self._f(r.get("close")) < self._f(r.get("open")) and self._f(r.get("volume")) > 0
+        ]
+        if not down_day_volumes:
+            return None
+        max_down_vol = max(down_day_volumes)
+        threshold_vol = max_down_vol * self._cfg.pp_down_vol_threshold_ratio
+        if volume <= threshold_vol:
+            return None
+
+        volume_ratio = volume / max_down_vol if max_down_vol > 0 else 0.0
+        stop_price = support_ma_value * (1 + self._cfg.pp_stop_loss_below_ma_pct / 100)
+        target_price = current * (1 + self._cfg.partial_profit_trigger_pct / 100)
+        return {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "name": candidate.get("name", code),
+            "action": "BUY",
+            "date": cur.get("date"),
+            "entry_price": current,
+            "entry_reason": "overseas_pocket_pivot",
+            "supporting_ma": supporting_ma,
+            "support_ma_value": support_ma_value,
+            "volume": volume,
+            "max_down_volume": max_down_vol,
+            "volume_ratio": volume_ratio,
+            "stop_price": stop_price,
+            "target_price": target_price,
+            "reason": (
+                f"PP진입({supporting_ma}MA지지, "
+                f"거래량 {volume_ratio:.2f}x 하락최대대비)"
+            ),
+        }
+
+    def _find_supporting_ma(
+        self,
+        current: float,
+        ma_10d: float,
+        ma_20d: float,
+        ma_50d: float,
+    ) -> tuple[str, float]:
+        for value, name in ((ma_10d, "10"), (ma_20d, "20"), (ma_50d, "50")):
+            if value <= 0:
+                continue
+            lower = value * (1 + self._cfg.pp_ma_proximity_lower_pct / 100)
+            upper = value * (1 + self._cfg.pp_ma_proximity_upper_pct / 100)
+            if lower <= current <= upper:
+                return name, value
+        return "", 0.0
+
+    @staticmethod
+    def _bar_ohlc(bar: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: bar.get(k) for k in ("date", "open", "high", "low", "close", "volume")}
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/tests/unit_test/services/test_overseas_dryrun_suite_service.py
+++ b/tests/unit_test/services/test_overseas_dryrun_suite_service.py
@@ -1,0 +1,34 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange
+from services.overseas_dryrun_suite_service import OverseasDryRunSuiteService
+
+
+@pytest.mark.asyncio
+async def test_scan_dry_run_runs_all_services_and_concatenates_signals():
+    first = AsyncMock()
+    first.scan_dry_run = AsyncMock(return_value=[{"code": "AAA"}])
+    second = AsyncMock()
+    second.scan_dry_run = AsyncMock(return_value=[{"code": "BBB"}])
+    suite = OverseasDryRunSuiteService([first, second])
+
+    signals = await suite.scan_dry_run(OverseasExchange.NYSE)
+
+    assert signals == [{"code": "AAA"}, {"code": "BBB"}]
+    first.scan_dry_run.assert_awaited_once_with(OverseasExchange.NYSE)
+    second.scan_dry_run.assert_awaited_once_with(OverseasExchange.NYSE)
+
+
+@pytest.mark.asyncio
+async def test_scan_dry_run_continues_when_one_service_fails():
+    failing = AsyncMock()
+    failing.scan_dry_run = AsyncMock(side_effect=RuntimeError("boom"))
+    healthy = AsyncMock()
+    healthy.scan_dry_run = AsyncMock(return_value=[{"code": "AAA"}])
+    suite = OverseasDryRunSuiteService([failing, healthy])
+
+    signals = await suite.scan_dry_run(OverseasExchange.NASD)
+
+    assert signals == [{"code": "AAA"}]

--- a/tests/unit_test/services/test_overseas_pocket_pivot_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_pocket_pivot_dryrun_service.py
@@ -1,0 +1,137 @@
+"""해외 Pocket Pivot dry-run 신호 서비스 테스트.
+
+완성 일봉 기준으로 PP 조건을 판정하고 shadow 저널에 would-be 신호만 기록한다.
+해외 자동 주문은 아직 열지 않는다.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_pocket_pivot_dryrun_service import OverseasPocketPivotDryRunService
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ohlcv(bars):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+
+
+def _pp_bars(*, current_volume=1600, current_close=103.0):
+    bars = []
+    for i in range(10):
+        # 하락일 최대 거래량 1500. 현재 거래량 1600이면 90% 허들 통과.
+        bars.append(_bar(f"202605{1 + i:02d}", 104, 106, 99, 100, 1000 + i * 50))
+    bars.append(_bar("20260511", 100, 104, 98, 101, current_volume))
+    bars.append(_bar("20260512", 101, 106, 100, current_close, current_volume))
+    return bars
+
+
+@pytest.fixture
+def svc():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    journal = MagicMock()
+    service = OverseasPocketPivotDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=journal,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(service=service, candidate_service=candidate_service, sqs=sqs, journal=journal)
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_on_pocket_pivot(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars()))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig["strategy"] == "O'NeilPP_overseas"
+    assert sig["code"] == "AAA"
+    assert sig["action"] == "BUY"
+    assert sig["entry_reason"] == "overseas_pocket_pivot"
+    assert sig["supporting_ma"] in {"10", "20", "50"}
+    assert sig["volume_ratio"] > 1.0
+    assert sig["stop_price"] > 0
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_volume_does_not_clear_down_day_threshold(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars(current_volume=800)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+    svc.journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_price_is_not_near_moving_average(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars(current_close=120.0)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_passes_exchange_to_candidates_and_ohlcv(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars()))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NYSE)
+
+    _, cand_kwargs = svc.candidate_service.get_candidates.call_args
+    assert cand_kwargs.get("exchange") == OverseasExchange.NYSE or svc.candidate_service.get_candidates.call_args[0][0] == OverseasExchange.NYSE
+    _, ohlcv_kwargs = svc.sqs.get_recent_daily_ohlcv.await_args
+    assert ohlcv_kwargs.get("exchange") == OverseasExchange.NYSE
+
+
+@pytest.mark.asyncio
+async def test_scan_records_to_shadow_journal_with_pp_source(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars()))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    svc.journal.record.assert_called_once()
+    _, kwargs = svc.journal.record.call_args
+    assert kwargs["code"] == "AAA"
+    assert kwargs["strategy_name"] == "O'NeilPP_overseas"
+    assert kwargs["signal_source"] == "overseas_pp_dryrun"
+    assert kwargs["snapshot"]["bar"]["date"] == "20260512"
+
+
+@pytest.mark.asyncio
+async def test_scan_includes_qty_when_sizing_injected():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "AAA", "name": "Aaa", "exchange": "NASD", "avg_trading_value": 10_000_000.0},
+    ])
+    sqs = MagicMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_pp_bars(current_close=103.0)))
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 10, "notional_usd": 1000.0, "reason": "slot"})
+
+    service = OverseasPocketPivotDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing,
+    )
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 10
+    assert signals[0]["notional_usd"] == 1000.0
+    assert sizing.size.call_args.kwargs["limit_price_usd"] == signals[0]["entry_price"]
+    assert not hasattr(service, "_order_execution_service")

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -783,6 +783,40 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
     assert callable(fx_provider)
 
 
+def test_service_container_wires_overseas_pp_into_dryrun_suite(patched_service_container_deps):
+    """해외 dry-run 태스크는 VBO와 PP 서비스를 함께 실행하는 suite 를 주입받는다."""
+    from config.config_loader import AppConfig
+    from view.web.bootstrap.service_container import ServiceContainer
+
+    ctx = _make_fake_context()
+    ctx.market_mode = "overseas_us"
+    ctx.full_config = AppConfig(
+        web={"host": "localhost", "port": 8080},
+        market_mode="overseas_us",
+        overseas_stock={"dryrun_slot_usd": 750.0, "dryrun_max_qty": 4},
+    )
+    ctx.overseas_stock_code_repository = MagicMock()
+
+    with patch("view.web.bootstrap.service_container.OverseasPositionSizingService", autospec=True) as sizing_cls, \
+         patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True) as candidate_cls, \
+         patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True) as vbo_cls, \
+         patch("view.web.bootstrap.service_container.OverseasPocketPivotDryRunService", autospec=True) as pp_cls, \
+         patch("view.web.bootstrap.service_container.OverseasDryRunSuiteService", autospec=True) as suite_cls, \
+         patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True) as task_cls:
+        ServiceContainer(ctx).run()
+
+    pp_kwargs = pp_cls.call_args.kwargs
+    assert pp_kwargs["candidate_service"] is candidate_cls.return_value
+    assert pp_kwargs["position_sizing_service"] is sizing_cls.return_value
+    assert callable(pp_kwargs["fx_provider"])
+    suite_cls.assert_called_once_with(
+        [vbo_cls.return_value, pp_cls.return_value],
+        logger=ctx.logger,
+    )
+    assert task_cls.call_args.kwargs["dryrun_service"] is suite_cls.return_value
+    assert ctx.overseas_pp_dryrun_service is pp_cls.return_value
+
+
 def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):
     """overseas_us dry-run 태스크는 미국장 cron으로, 한국 캘린더/티켓 큐 없이 배선한다."""
     from config.config_loader import AppConfig

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -60,6 +60,8 @@ from services.overseas_intraday_vbo_service import OverseasIntradayVBOService
 from services.overseas_order_execution_service import OverseasOrderExecutionService
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
+from services.overseas_pocket_pivot_dryrun_service import OverseasPocketPivotDryRunService
+from services.overseas_dryrun_suite_service import OverseasDryRunSuiteService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
 from task.background.after_market.cache_warmup_task import CacheWarmupTask
@@ -937,6 +939,7 @@ class ServiceContainer:
             else:
                 ctx.overseas_candidate_service = None
                 ctx.overseas_vbo_dryrun_service = None
+                ctx.overseas_pp_dryrun_service = None
                 ctx.overseas_dryrun_task = None
                 ctx.overseas_manual_order_service = None
                 ctx.overseas_trade_repository = None
@@ -996,6 +999,7 @@ class ServiceContainer:
         ctx = self._ctx
         ctx.overseas_candidate_service = None
         ctx.overseas_vbo_dryrun_service = None
+        ctx.overseas_pp_dryrun_service = None
         ctx.overseas_dryrun_task = None
         if getattr(ctx, "event_shadow_journal_service", None) is None:
             ctx.event_shadow_journal_service = EventShadowJournalService(
@@ -1032,11 +1036,23 @@ class ServiceContainer:
             position_sizing_service=overseas_position_sizing_service,
             fx_provider=_overseas_fx_provider,
         )
+        ctx.overseas_pp_dryrun_service = OverseasPocketPivotDryRunService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+            position_sizing_service=overseas_position_sizing_service,
+            fx_provider=_overseas_fx_provider,
+        )
+        overseas_dryrun_suite = OverseasDryRunSuiteService(
+            [ctx.overseas_vbo_dryrun_service, ctx.overseas_pp_dryrun_service],
+            logger=ctx.logger,
+        )
         # 미국 정규장 마감(16:00 ET) 직후 트리거. O-1: 규칙 기반 NYSE 캘린더를
         # 주입해 미국 휴장일에는 실행을 스킵한다 (기존: 주말 필터만).
         dryrun_us_clock = MarketClock.for_us_equities(logger=ctx.logger)
         ctx.overseas_dryrun_task = OverseasDryRunTask(
-            dryrun_service=ctx.overseas_vbo_dryrun_service,
+            dryrun_service=overseas_dryrun_suite,
             shadow_journal=ctx.event_shadow_journal_service,
             market_calendar_service=USMarketCalendarService(
                 market_clock=dryrun_us_clock, logger=ctx.logger,

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -207,6 +207,7 @@ class WebAppContext:
         # Phase 3c: 해외 VBO dry-run 파이프라인 (overseas_us 모드에서만 구성)
         self.overseas_candidate_service = None
         self.overseas_vbo_dryrun_service = None
+        self.overseas_pp_dryrun_service = None
         self.overseas_dryrun_task = None
         self._last_missing_reason_log_ts: dict[tuple[str, str], float] = {}
         self._last_rest_price_refresh_ts: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- add an overseas Pocket Pivot dry-run service using completed daily OHLCV and shadow-journal recording
- run overseas VBO and PP dry-runs through a shared suite service
- wire the PP service into the overseas web service container

## Tests
- pytest tests/unit_test -q
- pytest tests/integration_test -q