### PR TITLE
Add overseas buyable gap-up dry-run

### DIFF
--- a/services/overseas_buyable_gap_up_dryrun_service.py
+++ b/services/overseas_buyable_gap_up_dryrun_service.py
@@ -1,0 +1,200 @@
+"""해외 Buyable Gap-Up dry-run 신호 서비스.
+
+국내 `OneilPocketPivotStrategy` 의 BGU 판정 중 해외 일봉으로 재현 가능한
+가격/거래량 기반 부분만 적용한다. 프로그램 순매수 필터와 장중 10분 휩소 필터는
+국내 전용·장중 전용 데이터라 이 서비스에서는 쓰지 않는다. 주문 경로는 없고
+shadow 저널에 would-be 신호만 기록한다.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+@dataclass
+class OverseasBuyableGapUpConfig:
+    bgu_gap_pct: float = 4.0
+    bgu_volume_multiplier: float = 3.0
+    bgu_avg_volume_period: int = 50
+    bgu_min_avg_volume_count: int = 20
+    partial_profit_trigger_pct: float = 15.0
+
+
+class OverseasBuyableGapUpDryRunService:
+    STRATEGY_NAME = "O'NeilBGU_overseas"
+    SIGNAL_SOURCE = "overseas_bgu_dryrun"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        shadow_journal=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        config: Optional[OverseasBuyableGapUpConfig] = None,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        position_sizing_service=None,
+        fx_provider=None,
+    ) -> None:
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._journal = shadow_journal
+        self._logger = logger or logging.getLogger(__name__)
+        self._cfg = config or OverseasBuyableGapUpConfig()
+        self._default_exchange = exchange
+        self._sizing_service = position_sizing_service
+        self._fx_provider = fx_provider
+
+    async def scan_dry_run(
+        self,
+        exchange: Optional[OverseasExchange] = None,
+        *,
+        top_n: Optional[int] = None,
+        min_avg_trading_value: Optional[float] = None,
+        record: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """후보를 평가해 BGU BUY would-be 신호를 반환하고(선택) shadow 저널에 기록한다."""
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(
+            ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
+        )
+
+        fx_rate = await self._resolve_fx_rate()
+        signals: List[Dict[str, Any]] = []
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            try:
+                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=60, exchange=ex)
+            except Exception as e:
+                self._logger.warning({"event": "overseas_bgu_ohlcv_error", "code": code, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+
+            sig = self._evaluate(code, cand, resp.data)
+            if not sig:
+                continue
+            if self._sizing_service is not None:
+                sizing = self._sizing_service.size(
+                    limit_price_usd=sig["entry_price"], fx_krw_per_usd=fx_rate
+                )
+                sig["qty"] = sizing.get("qty")
+                sig["notional_usd"] = sizing.get("notional_usd")
+                if sizing.get("fx_krw_per_usd") is not None:
+                    sig["fx_krw_per_usd"] = sizing.get("fx_krw_per_usd")
+                if sizing.get("krw_exposure") is not None:
+                    sig["krw_exposure"] = sizing.get("krw_exposure")
+            signals.append(sig)
+            if record and self._journal is not None:
+                self._journal.record(
+                    strategy_name=self.STRATEGY_NAME,
+                    code=code,
+                    signal=sig,
+                    snapshot={
+                        "exchange": ex.value,
+                        "avg_trading_value": cand.get("avg_trading_value"),
+                        "bar": self._bar_ohlc(resp.data[-1]),
+                    },
+                    signal_source=self.SIGNAL_SOURCE,
+                )
+
+        self._logger.info({
+            "event": "overseas_bgu_dryrun_scan",
+            "exchange": ex.value,
+            "candidates": len(candidates or []),
+            "signals": len(signals),
+        })
+        return signals
+
+    async def _resolve_fx_rate(self) -> Optional[float]:
+        if self._sizing_service is None or self._fx_provider is None:
+            return None
+        try:
+            rate = await self._fx_provider()
+        except Exception as e:
+            self._logger.warning({"event": "overseas_bgu_fx_error", "error": str(e)})
+            return None
+        try:
+            rate = float(rate) if rate is not None else None
+        except (TypeError, ValueError):
+            return None
+        return rate if (rate is not None and rate > 0) else None
+
+    def _evaluate(
+        self,
+        code: str,
+        candidate: Dict[str, Any],
+        rows: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        min_rows = self._cfg.bgu_min_avg_volume_count + 1
+        if not rows or len(rows) < min_rows:
+            return None
+
+        cur = rows[-1]
+        prev = rows[-2]
+        open_ = self._f(cur.get("open"))
+        high = self._f(cur.get("high"))
+        low = self._f(cur.get("low"))
+        close = self._f(cur.get("close"))
+        volume = self._f(cur.get("volume"))
+        prev_close = self._f(prev.get("close"))
+        if min(open_, high, low, close, volume, prev_close) <= 0:
+            return None
+
+        gap_ratio = (open_ - prev_close) / prev_close * 100
+        if gap_ratio < self._cfg.bgu_gap_pct:
+            return None
+
+        if close < open_:
+            return None
+
+        history = rows[:-1]
+        period = min(self._cfg.bgu_avg_volume_period, len(history))
+        volumes = [self._f(r.get("volume")) for r in history[-period:] if self._f(r.get("volume")) > 0]
+        if len(volumes) < self._cfg.bgu_min_avg_volume_count:
+            return None
+        avg_vol = sum(volumes) / len(volumes)
+        threshold_vol = avg_vol * self._cfg.bgu_volume_multiplier
+        if volume < threshold_vol:
+            return None
+
+        volume_ratio = volume / avg_vol if avg_vol > 0 else 0.0
+        target_price = close * (1 + self._cfg.partial_profit_trigger_pct / 100)
+        return {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "name": candidate.get("name", code),
+            "action": "BUY",
+            "date": cur.get("date"),
+            "entry_price": close,
+            "entry_reason": "overseas_buyable_gap_up",
+            "gap_ratio": gap_ratio,
+            "open_price": open_,
+            "prev_close": prev_close,
+            "volume": volume,
+            "avg_volume": avg_vol,
+            "volume_ratio": volume_ratio,
+            "stop_price": low,
+            "target_price": target_price,
+            "reason": (
+                f"BGU진입(갭 {gap_ratio:.1f}%, "
+                f"거래량 {volume_ratio:.2f}x 50일평균대비)"
+            ),
+        }
+
+    @staticmethod
+    def _bar_ohlc(bar: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: bar.get(k) for k in ("date", "open", "high", "low", "close", "volume")}
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/tests/unit_test/services/test_overseas_buyable_gap_up_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_buyable_gap_up_dryrun_service.py
@@ -1,0 +1,136 @@
+"""해외 Buyable Gap-Up dry-run 신호 서비스 테스트.
+
+완성 일봉 기준으로 BGU 조건을 판정하고 shadow 저널에 would-be 신호만 기록한다.
+해외 자동 주문 경로는 열지 않는다.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_buyable_gap_up_dryrun_service import OverseasBuyableGapUpDryRunService
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ohlcv(bars):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+
+
+def _bgu_bars(*, current_open=105.0, current_close=107.0, current_volume=160_000):
+    bars = [
+        _bar(f"202604{i + 1:02d}", 99, 101, 98, 100, 10_000)
+        for i in range(50)
+    ]
+    bars.append(_bar("20260521", 100, 101, 99, 100, 10_000))
+    bars.append(_bar("20260522", current_open, 109, 104, current_close, current_volume))
+    return bars
+
+
+@pytest.fixture
+def svc():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "NVDA", "name": "NVIDIA", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    journal = MagicMock()
+    service = OverseasBuyableGapUpDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=journal,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(service=service, candidate_service=candidate_service, sqs=sqs, journal=journal)
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_on_buyable_gap_up(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars()))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig["strategy"] == "O'NeilBGU_overseas"
+    assert sig["code"] == "NVDA"
+    assert sig["action"] == "BUY"
+    assert sig["entry_reason"] == "overseas_buyable_gap_up"
+    assert sig["gap_ratio"] >= 4.0
+    assert sig["volume_ratio"] >= 3.0
+    assert sig["stop_price"] == 104.0
+    assert sig["entry_price"] == 107.0
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_gap_is_too_small(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars(current_open=103.0)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+    svc.journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_close_fails_to_hold_open(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars(current_close=104.0)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_volume_does_not_clear_average_threshold(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars(current_volume=20_000)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_records_to_shadow_journal_with_bgu_source(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars()))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NYSE)
+
+    svc.journal.record.assert_called_once()
+    _, kwargs = svc.journal.record.call_args
+    assert kwargs["code"] == "NVDA"
+    assert kwargs["strategy_name"] == "O'NeilBGU_overseas"
+    assert kwargs["signal_source"] == "overseas_bgu_dryrun"
+    assert kwargs["snapshot"]["exchange"] == "NYSE"
+    assert kwargs["snapshot"]["bar"]["date"] == "20260522"
+
+
+@pytest.mark.asyncio
+async def test_scan_includes_qty_when_sizing_injected():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "NVDA", "name": "NVIDIA", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_bgu_bars()))
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 5, "notional_usd": 535.0, "reason": "slot"})
+
+    service = OverseasBuyableGapUpDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing,
+    )
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 5
+    assert signals[0]["notional_usd"] == 535.0
+    assert sizing.size.call_args.kwargs["limit_price_usd"] == signals[0]["entry_price"]
+    assert not hasattr(service, "_order_execution_service")

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -783,8 +783,8 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
     assert callable(fx_provider)
 
 
-def test_service_container_wires_overseas_pp_into_dryrun_suite(patched_service_container_deps):
-    """해외 dry-run 태스크는 VBO와 PP 서비스를 함께 실행하는 suite 를 주입받는다."""
+def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patched_service_container_deps):
+    """해외 dry-run 태스크는 VBO, PP, BGU 서비스를 함께 실행하는 suite 를 주입받는다."""
     from config.config_loader import AppConfig
     from view.web.bootstrap.service_container import ServiceContainer
 
@@ -801,6 +801,7 @@ def test_service_container_wires_overseas_pp_into_dryrun_suite(patched_service_c
          patch("view.web.bootstrap.service_container.OverseasCandidateService", autospec=True) as candidate_cls, \
          patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True) as vbo_cls, \
          patch("view.web.bootstrap.service_container.OverseasPocketPivotDryRunService", autospec=True) as pp_cls, \
+         patch("view.web.bootstrap.service_container.OverseasBuyableGapUpDryRunService", autospec=True) as bgu_cls, \
          patch("view.web.bootstrap.service_container.OverseasDryRunSuiteService", autospec=True) as suite_cls, \
          patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True) as task_cls:
         ServiceContainer(ctx).run()
@@ -809,12 +810,17 @@ def test_service_container_wires_overseas_pp_into_dryrun_suite(patched_service_c
     assert pp_kwargs["candidate_service"] is candidate_cls.return_value
     assert pp_kwargs["position_sizing_service"] is sizing_cls.return_value
     assert callable(pp_kwargs["fx_provider"])
+    bgu_kwargs = bgu_cls.call_args.kwargs
+    assert bgu_kwargs["candidate_service"] is candidate_cls.return_value
+    assert bgu_kwargs["position_sizing_service"] is sizing_cls.return_value
+    assert callable(bgu_kwargs["fx_provider"])
     suite_cls.assert_called_once_with(
-        [vbo_cls.return_value, pp_cls.return_value],
+        [vbo_cls.return_value, pp_cls.return_value, bgu_cls.return_value],
         logger=ctx.logger,
     )
     assert task_cls.call_args.kwargs["dryrun_service"] is suite_cls.return_value
     assert ctx.overseas_pp_dryrun_service is pp_cls.return_value
+    assert ctx.overseas_bgu_dryrun_service is bgu_cls.return_value
 
 
 def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -61,6 +61,7 @@ from services.overseas_order_execution_service import OverseasOrderExecutionServ
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.overseas_pocket_pivot_dryrun_service import OverseasPocketPivotDryRunService
+from services.overseas_buyable_gap_up_dryrun_service import OverseasBuyableGapUpDryRunService
 from services.overseas_dryrun_suite_service import OverseasDryRunSuiteService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
@@ -940,6 +941,7 @@ class ServiceContainer:
                 ctx.overseas_candidate_service = None
                 ctx.overseas_vbo_dryrun_service = None
                 ctx.overseas_pp_dryrun_service = None
+                ctx.overseas_bgu_dryrun_service = None
                 ctx.overseas_dryrun_task = None
                 ctx.overseas_manual_order_service = None
                 ctx.overseas_trade_repository = None
@@ -1000,6 +1002,7 @@ class ServiceContainer:
         ctx.overseas_candidate_service = None
         ctx.overseas_vbo_dryrun_service = None
         ctx.overseas_pp_dryrun_service = None
+        ctx.overseas_bgu_dryrun_service = None
         ctx.overseas_dryrun_task = None
         if getattr(ctx, "event_shadow_journal_service", None) is None:
             ctx.event_shadow_journal_service = EventShadowJournalService(
@@ -1044,8 +1047,20 @@ class ServiceContainer:
             position_sizing_service=overseas_position_sizing_service,
             fx_provider=_overseas_fx_provider,
         )
+        ctx.overseas_bgu_dryrun_service = OverseasBuyableGapUpDryRunService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+            position_sizing_service=overseas_position_sizing_service,
+            fx_provider=_overseas_fx_provider,
+        )
         overseas_dryrun_suite = OverseasDryRunSuiteService(
-            [ctx.overseas_vbo_dryrun_service, ctx.overseas_pp_dryrun_service],
+            [
+                ctx.overseas_vbo_dryrun_service,
+                ctx.overseas_pp_dryrun_service,
+                ctx.overseas_bgu_dryrun_service,
+            ],
             logger=ctx.logger,
         )
         # 미국 정규장 마감(16:00 ET) 직후 트리거. O-1: 규칙 기반 NYSE 캘린더를

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -208,6 +208,7 @@ class WebAppContext:
         self.overseas_candidate_service = None
         self.overseas_vbo_dryrun_service = None
         self.overseas_pp_dryrun_service = None
+        self.overseas_bgu_dryrun_service = None
         self.overseas_dryrun_task = None
         self._last_missing_reason_log_ts: dict[tuple[str, str], float] = {}
         self._last_rest_price_refresh_ts: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- add an overseas Buyable Gap-Up dry-run service using completed daily OHLCV
- record BGU would-be signals to the shadow journal without an order path
- wire VBO, PP, and BGU into the overseas dry-run suite

## Tests
- pytest tests/unit_test -q
- pytest tests/integration_test -q