### PR TITLE
Summarize overseas dry-run signals by strategy

### DIFF
--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -1,8 +1,8 @@
 # task/background/after_market/overseas_dryrun_task.py
-"""해외 VBO dry-run after-market 태스크 (Phase 3c).
+"""해외 dry-run after-market 태스크 (Phase 3c).
 
-OverseasVBODryRunService 의 일봉 기반 dry-run 신호 산출을 after-market 스케줄러에
-얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
+해외 dry-run suite 의 일봉 기반 신호 산출을 after-market 스케줄러에 얹어 매일 1회
+실행하고, shadow 저널을 파일로 flush 한다.
 
 트리거는 미국장 전용 TimeDispatcher(time_dispatcher_us)가 담당한다 — NY 정규장
 마감(16:00 ET) 감지 후 task delay(30분)만큼 대기해 16:30 ET 효과로 티켓을 발행하면
@@ -11,12 +11,13 @@ WorkerPool 이 execute() 를 호출한다(Ticket-driven, worker_pool 주입). O-
 휴장일에는 latest_trading_date 가 직전 거래일로 유지되고 중복 발행이 차단된다.
 (_loop_* 프로퍼티는 시스템 상태 화면의 트리거 표기용 메타데이터로 유지된다.)
 
-**주문 경로 없음** — OverseasVBODryRunService 가 order_execution 의존을 갖지 않아
-실주문이 발생하지 않는다.
+**주문 경로 없음** — dry-run 서비스들은 order_execution 의존을 갖지 않아 실주문이
+발생하지 않는다.
 """
 from __future__ import annotations
 
 import logging
+from collections import Counter, defaultdict
 from typing import Optional, TYPE_CHECKING
 
 from common.overseas_types import OverseasExchange
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
 
 
 class OverseasDryRunTask(AfterMarketTask):
-    """해외 VBO dry-run 신호를 장 마감 후 1회 산출·기록하는 태스크."""
+    """해외 dry-run 신호를 장 마감 후 1회 산출·기록하는 태스크."""
 
     def __init__(
         self,
@@ -91,6 +92,47 @@ class OverseasDryRunTask(AfterMarketTask):
             return f"{yyyymmdd[:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]}"
         return yyyymmdd
 
+    @classmethod
+    def _strategy_label(cls, signal: dict) -> str:
+        strategy = str(signal.get("strategy") or "")
+        reason = str(signal.get("reason") or signal.get("entry_reason") or "")
+        if "BGU" in strategy or "buyable_gap_up" in reason:
+            return "BGU"
+        if "PP" in strategy or "pocket_pivot" in reason:
+            return "PP"
+        if "VBO" in strategy or "vbo" in reason:
+            return "VBO"
+        return "기타"
+
+    @classmethod
+    def _summarize_signals(cls, signals: list[dict]) -> tuple[dict[str, int], str]:
+        counts: Counter[str] = Counter()
+        names_by_label: dict[str, list[str]] = defaultdict(list)
+        for sig in signals or []:
+            label = cls._strategy_label(sig)
+            counts[label] += 1
+            name = str(sig.get("name") or sig.get("code") or "").strip()
+            if name:
+                names_by_label[label].append(name)
+
+        ordered_labels = [label for label in ("VBO", "PP", "BGU", "기타") if counts.get(label)]
+        summary = {label: counts[label] for label in ordered_labels}
+        lines = []
+        for label in ordered_labels:
+            examples = ", ".join(names_by_label[label][:3])
+            suffix = f" ({examples})" if examples else ""
+            lines.append(f"- {label}: {counts[label]}개{suffix}")
+        return summary, "\n".join(lines)
+
+    @classmethod
+    def _format_notification_body(cls, market_date_text: str, signals: list[dict]) -> str:
+        _, detail = cls._summarize_signals(signals)
+        total = len(signals or [])
+        body = f"미국 거래일 {market_date_text} 기준 dry-run 리포트: 총 {total}개 신호"
+        if detail:
+            body = f"{body}\n{detail}"
+        return body
+
     async def _on_market_closed(self, latest_trading_date: str) -> None:
         market_date_text = self._format_market_date(latest_trading_date)
         exchange_value = self._exchange.value
@@ -108,6 +150,7 @@ class OverseasDryRunTask(AfterMarketTask):
             return
         try:
             signals = await self._dryrun_service.scan_dry_run(self._exchange)
+            summary, _ = self._summarize_signals(signals or [])
             if self._journal is not None:
                 self._journal.flush_to_file(latest_trading_date)
             self._logger.info(
@@ -117,14 +160,15 @@ class OverseasDryRunTask(AfterMarketTask):
                     "market_date_text": market_date_text,
                     "exchange": exchange_value,
                     "signals": len(signals or []),
+                    "summary": summary,
                 }
             )
             if self._notification_service:
                 await self._notification_service.emit(
                     NotificationCategory.BACKGROUND,
                     NotificationLevel.INFO,
-                    "해외 VBO dry-run 완료",
-                    f"미국 거래일 {market_date_text} 기준 dry-run 리포트: {len(signals or [])}개 신호",
+                    "해외 dry-run 완료",
+                    self._format_notification_body(market_date_text, signals or []),
                 )
             self._last_run_date = latest_trading_date  # 성공 시에만 dedup 마킹 → 실패 시 재시도
         except Exception as e:
@@ -142,6 +186,6 @@ class OverseasDryRunTask(AfterMarketTask):
                 await self._notification_service.emit(
                     NotificationCategory.BACKGROUND,
                     NotificationLevel.ERROR,
-                    "해외 VBO dry-run 실패",
+                    "해외 dry-run 실패",
                     str(e),
                 )

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -1,4 +1,4 @@
-"""해외 VBO dry-run after-market 태스크 테스트 (Phase 3c).
+"""해외 dry-run after-market 태스크 테스트 (Phase 3c).
 
 미국장 after-market 스케줄러(16:30 ET 트리거)에 등록해 매일 1회 dry-run 신호를
 산출·flush 한다. 주문 경로 없음(서비스에 order 의존 부재).
@@ -12,9 +12,11 @@ from interfaces.schedulable_task import TaskPriority
 from common.overseas_types import OverseasExchange
 
 
-def _make_task(exchange=OverseasExchange.NASD):
+def _make_task(exchange=OverseasExchange.NASD, signals=None):
     dryrun = MagicMock()
-    dryrun.scan_dry_run = AsyncMock(return_value=[{"code": "AAA", "action": "BUY"}])
+    dryrun.scan_dry_run = AsyncMock(return_value=signals if signals is not None else [
+        {"code": "AAA", "action": "BUY", "reason": "vbo_daily_breakout"},
+    ])
     journal = MagicMock()
     logger = MagicMock()
     notification_service = AsyncMock()
@@ -66,13 +68,49 @@ async def test_on_market_closed_runs_scan_and_flushes():
             "market_date_text": "2026-07-06",
             "exchange": "NASD",
             "signals": 1,
+            "summary": {"VBO": 1},
         }
     )
     notification_service.emit.assert_awaited_once_with(
         NotificationCategory.BACKGROUND,
         NotificationLevel.INFO,
-        "해외 VBO dry-run 완료",
-        "미국 거래일 2026-07-06 기준 dry-run 리포트: 1개 신호",
+        "해외 dry-run 완료",
+        "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 1개 신호\n- VBO: 1개 (AAA)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_market_closed_notification_groups_vbo_pp_bgu_signals():
+    signals = [
+        {"code": "AAA", "action": "BUY", "reason": "vbo_daily_breakout"},
+        {"code": "BBB", "name": "Beta", "strategy": "O'NeilPP_overseas", "action": "BUY"},
+        {"code": "CCC", "strategy": "O'NeilPP_overseas", "action": "BUY"},
+        {"code": "DDD", "strategy": "O'NeilBGU_overseas", "action": "BUY"},
+    ]
+    task, _, _, notification_service, logger = _make_task(signals=signals)
+
+    await task._on_market_closed("20260706")
+
+    logger.info.assert_any_call(
+        {
+            "event": "overseas_dryrun_done",
+            "market_date": "20260706",
+            "market_date_text": "2026-07-06",
+            "exchange": "NASD",
+            "signals": 4,
+            "summary": {"VBO": 1, "PP": 2, "BGU": 1},
+        }
+    )
+    notification_service.emit.assert_awaited_once_with(
+        NotificationCategory.BACKGROUND,
+        NotificationLevel.INFO,
+        "해외 dry-run 완료",
+        (
+            "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 4개 신호\n"
+            "- VBO: 1개 (AAA)\n"
+            "- PP: 2개 (Beta, CCC)\n"
+            "- BGU: 1개 (DDD)"
+        ),
     )
 
 

--- a/view/web/bootstrap/scheduler_bootstrap.py
+++ b/view/web/bootstrap/scheduler_bootstrap.py
@@ -148,7 +148,7 @@ class SchedulerBootstrap:
         self._register(self._optional_task("program_capture_subscription_task"))
 
     def _register_overseas_tasks(self) -> None:
-        # 해외 VBO dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
+        # 해외 dry-run (주문 경로 없음). 미구성 시 _register 가 no-op.
         # 미국장 TimeDispatcher(time_dispatcher_us)에 등록 → NY 마감 후 delay 만큼 대기 뒤
         # 티켓 발행(task_config 의 overseas_vbo_dryrun delay 로 16:30 ET 효과 트리거).
         self._register(


### PR DESCRIPTION
## Summary
- group overseas dry-run notifications by VBO, PP, and BGU
- include per-strategy counts and sample symbols in the notification body
- add the grouped summary to structured task logs

## Tests
- pytest tests/unit_test -q
- pytest tests/integration_test -q