### PR TITLE
Add overseas channel breakout dry-run

### DIFF
--- a/services/overseas_channel_breakout_dryrun_service.py
+++ b/services/overseas_channel_breakout_dryrun_service.py
@@ -1,0 +1,223 @@
+"""해외 Larry Williams Channel Breakout dry-run 신호 서비스.
+
+국내 `LarryWilliamsChannelBreakoutStrategy` 의 일봉 기반 진입 조건 중 해외 데이터로
+재현 가능한 채널 돌파, 거래량, ADX 필터를 완성 일봉에 적용한다. 주문 경로는 없고
+shadow 저널에 would-be 신호만 기록한다.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+@dataclass
+class OverseasChannelBreakoutConfig:
+    adx_period: int = 14
+    adx_threshold: float = 25.0
+    adx_slope_lookback: int = 3
+    channel_high_period: int = 20
+    channel_low_period: int = 10
+    volume_multiplier: float = 1.5
+    hard_stop_pct: float = -7.0
+    partial_profit_trigger_pct: float = 15.0
+
+
+class OverseasChannelBreakoutDryRunService:
+    STRATEGY_NAME = "LarryWilliamsCB_overseas"
+    SIGNAL_SOURCE = "overseas_cb_dryrun"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        indicator_service,
+        shadow_journal=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        config: Optional[OverseasChannelBreakoutConfig] = None,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        position_sizing_service=None,
+        fx_provider=None,
+    ) -> None:
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._indicator = indicator_service
+        self._journal = shadow_journal
+        self._logger = logger or logging.getLogger(__name__)
+        self._cfg = config or OverseasChannelBreakoutConfig()
+        self._default_exchange = exchange
+        self._sizing_service = position_sizing_service
+        self._fx_provider = fx_provider
+
+    async def scan_dry_run(
+        self,
+        exchange: Optional[OverseasExchange] = None,
+        *,
+        top_n: Optional[int] = None,
+        min_avg_trading_value: Optional[float] = None,
+        record: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """후보를 평가해 CB BUY would-be 신호를 반환하고(선택) shadow 저널에 기록한다."""
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(
+            ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
+        )
+
+        fx_rate = await self._resolve_fx_rate()
+        signals: List[Dict[str, Any]] = []
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            try:
+                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=60, exchange=ex)
+            except Exception as e:
+                self._logger.warning({"event": "overseas_cb_ohlcv_error", "code": code, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+
+            sig = self._evaluate(code, cand, resp.data)
+            if not sig:
+                continue
+            if self._sizing_service is not None:
+                sizing = self._sizing_service.size(
+                    limit_price_usd=sig["entry_price"], fx_krw_per_usd=fx_rate
+                )
+                sig["qty"] = sizing.get("qty")
+                sig["notional_usd"] = sizing.get("notional_usd")
+                if sizing.get("fx_krw_per_usd") is not None:
+                    sig["fx_krw_per_usd"] = sizing.get("fx_krw_per_usd")
+                if sizing.get("krw_exposure") is not None:
+                    sig["krw_exposure"] = sizing.get("krw_exposure")
+            signals.append(sig)
+            if record and self._journal is not None:
+                self._journal.record(
+                    strategy_name=self.STRATEGY_NAME,
+                    code=code,
+                    signal=sig,
+                    snapshot={
+                        "exchange": ex.value,
+                        "avg_trading_value": cand.get("avg_trading_value"),
+                        "bar": self._bar_ohlc(resp.data[-1]),
+                    },
+                    signal_source=self.SIGNAL_SOURCE,
+                )
+
+        self._logger.info({
+            "event": "overseas_cb_dryrun_scan",
+            "exchange": ex.value,
+            "candidates": len(candidates or []),
+            "signals": len(signals),
+        })
+        return signals
+
+    async def _resolve_fx_rate(self) -> Optional[float]:
+        if self._sizing_service is None or self._fx_provider is None:
+            return None
+        try:
+            rate = await self._fx_provider()
+        except Exception as e:
+            self._logger.warning({"event": "overseas_cb_fx_error", "error": str(e)})
+            return None
+        try:
+            rate = float(rate) if rate is not None else None
+        except (TypeError, ValueError):
+            return None
+        return rate if (rate is not None and rate > 0) else None
+
+    def _evaluate(
+        self,
+        code: str,
+        candidate: Dict[str, Any],
+        rows: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        min_rows = max(
+            self._cfg.channel_high_period,
+            self._cfg.channel_low_period,
+            self._cfg.adx_period + self._cfg.adx_slope_lookback,
+        ) + 1
+        if not rows or len(rows) < min_rows:
+            return None
+
+        cur = rows[-1]
+        history = rows[:-1]
+        close = self._f(cur.get("close"))
+        volume = self._f(cur.get("volume"))
+        if close <= 0 or volume <= 0:
+            return None
+
+        channel_high_rows = history[-self._cfg.channel_high_period:]
+        channel_high = max((self._f(r.get("high")) for r in channel_high_rows), default=0.0)
+        if channel_high <= 0 or close <= channel_high:
+            return None
+
+        avg_volume_rows = history[-self._cfg.channel_high_period:]
+        volumes = [self._f(r.get("volume")) for r in avg_volume_rows if self._f(r.get("volume")) > 0]
+        if len(volumes) < self._cfg.channel_high_period:
+            return None
+        avg_volume = sum(volumes) / len(volumes)
+        if volume < avg_volume * self._cfg.volume_multiplier:
+            return None
+
+        adx_result = self._indicator.calc_adx_sync(
+            history,
+            period=self._cfg.adx_period,
+            slope_lookback=self._cfg.adx_slope_lookback,
+        )
+        if not adx_result:
+            return None
+        adx = self._f(adx_result.get("adx"))
+        if adx < self._cfg.adx_threshold or not adx_result.get("adx_rising"):
+            return None
+
+        channel_low_20d = min(
+            (self._f(r.get("low")) for r in channel_high_rows if self._f(r.get("low")) > 0),
+            default=0.0,
+        )
+        channel_low_rows = history[-self._cfg.channel_low_period:]
+        channel_low = min(
+            (self._f(r.get("low")) for r in channel_low_rows if self._f(r.get("low")) > 0),
+            default=0.0,
+        )
+        price_stop = close * (1 + self._cfg.hard_stop_pct / 100)
+        stop_price = max(channel_low_20d, price_stop)
+        volume_ratio = volume / avg_volume if avg_volume > 0 else 0.0
+        target_price = close * (1 + self._cfg.partial_profit_trigger_pct / 100)
+
+        return {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "name": candidate.get("name", code),
+            "action": "BUY",
+            "date": cur.get("date"),
+            "entry_price": close,
+            "entry_reason": "overseas_channel_breakout",
+            "channel_high": channel_high,
+            "channel_low_10d": channel_low,
+            "stop_price": stop_price,
+            "target_price": target_price,
+            "volume": volume,
+            "avg_volume": avg_volume,
+            "volume_ratio": volume_ratio,
+            "adx": adx,
+            "reason": (
+                f"CB진입(20일 채널 돌파 {close:.2f}>{channel_high:.2f}, "
+                f"ADX={adx:.1f}, 거래량 {volume_ratio:.2f}x)"
+            ),
+        }
+
+    @staticmethod
+    def _bar_ohlc(bar: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: bar.get(k) for k in ("date", "open", "high", "low", "close", "volume")}
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -98,6 +98,8 @@ class OverseasDryRunTask(AfterMarketTask):
         reason = str(signal.get("reason") or signal.get("entry_reason") or "")
         if "BGU" in strategy or "buyable_gap_up" in reason:
             return "BGU"
+        if "CB" in strategy or "channel_breakout" in reason:
+            return "CB"
         if "PP" in strategy or "pocket_pivot" in reason:
             return "PP"
         if "VBO" in strategy or "vbo" in reason:
@@ -115,7 +117,7 @@ class OverseasDryRunTask(AfterMarketTask):
             if name:
                 names_by_label[label].append(name)
 
-        ordered_labels = [label for label in ("VBO", "PP", "BGU", "기타") if counts.get(label)]
+        ordered_labels = [label for label in ("VBO", "PP", "BGU", "CB", "기타") if counts.get(label)]
         summary = {label: counts[label] for label in ordered_labels}
         lines = []
         for label in ordered_labels:

--- a/tests/unit_test/services/test_overseas_channel_breakout_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_channel_breakout_dryrun_service.py
@@ -1,0 +1,145 @@
+"""해외 Larry Williams Channel Breakout dry-run 신호 서비스 테스트."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_channel_breakout_dryrun_service import OverseasChannelBreakoutDryRunService
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ohlcv(bars):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+
+
+def _cb_bars(*, current_close=125.0, current_volume=200_000):
+    bars = []
+    for i in range(35):
+        close = 100.0 + i * 0.2
+        bars.append(_bar(f"202604{i + 1:02d}", close, 119.0, 95.0 + i * 0.1, close, 100_000))
+    bars.append(_bar("20260506", 121.0, 126.0, 120.0, current_close, current_volume))
+    return bars
+
+
+@pytest.fixture
+def svc():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "MSFT", "name": "Microsoft", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    indicator = MagicMock()
+    indicator.calc_adx_sync = MagicMock(return_value={"adx": 30.0, "adx_rising": True})
+    journal = MagicMock()
+    service = OverseasChannelBreakoutDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        indicator_service=indicator,
+        shadow_journal=journal,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(
+        service=service,
+        candidate_service=candidate_service,
+        sqs=sqs,
+        indicator=indicator,
+        journal=journal,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_on_channel_breakout(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars()))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig["strategy"] == "LarryWilliamsCB_overseas"
+    assert sig["code"] == "MSFT"
+    assert sig["action"] == "BUY"
+    assert sig["entry_reason"] == "overseas_channel_breakout"
+    assert sig["entry_price"] == 125.0
+    assert sig["channel_high"] == 119.0
+    assert sig["volume_ratio"] == 2.0
+    assert sig["adx"] == 30.0
+    assert sig["stop_price"] > 0
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_without_channel_breakout(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars(current_close=118.0)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+    svc.journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_volume_is_low(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars(current_volume=120_000)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_adx_filter_fails(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars()))
+    svc.indicator.calc_adx_sync.return_value = {"adx": 20.0, "adx_rising": True}
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_records_to_shadow_journal_with_cb_source(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars()))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NYSE)
+
+    svc.journal.record.assert_called_once()
+    _, kwargs = svc.journal.record.call_args
+    assert kwargs["code"] == "MSFT"
+    assert kwargs["strategy_name"] == "LarryWilliamsCB_overseas"
+    assert kwargs["signal_source"] == "overseas_cb_dryrun"
+    assert kwargs["snapshot"]["exchange"] == "NYSE"
+    assert kwargs["snapshot"]["bar"]["date"] == "20260506"
+
+
+@pytest.mark.asyncio
+async def test_scan_includes_qty_when_sizing_injected():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "MSFT", "name": "Microsoft", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_cb_bars()))
+    indicator = MagicMock()
+    indicator.calc_adx_sync = MagicMock(return_value={"adx": 30.0, "adx_rising": True})
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 4, "notional_usd": 500.0, "reason": "slot"})
+
+    service = OverseasChannelBreakoutDryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        indicator_service=indicator,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing,
+    )
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 4
+    assert signals[0]["notional_usd"] == 500.0
+    assert sizing.size.call_args.kwargs["limit_price_usd"] == signals[0]["entry_price"]
+    assert not hasattr(service, "_order_execution_service")

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -80,12 +80,13 @@ async def test_on_market_closed_runs_scan_and_flushes():
 
 
 @pytest.mark.asyncio
-async def test_on_market_closed_notification_groups_vbo_pp_bgu_signals():
+async def test_on_market_closed_notification_groups_vbo_pp_bgu_cb_signals():
     signals = [
         {"code": "AAA", "action": "BUY", "reason": "vbo_daily_breakout"},
         {"code": "BBB", "name": "Beta", "strategy": "O'NeilPP_overseas", "action": "BUY"},
         {"code": "CCC", "strategy": "O'NeilPP_overseas", "action": "BUY"},
         {"code": "DDD", "strategy": "O'NeilBGU_overseas", "action": "BUY"},
+        {"code": "EEE", "strategy": "LarryWilliamsCB_overseas", "action": "BUY"},
     ]
     task, _, _, notification_service, logger = _make_task(signals=signals)
 
@@ -97,8 +98,8 @@ async def test_on_market_closed_notification_groups_vbo_pp_bgu_signals():
             "market_date": "20260706",
             "market_date_text": "2026-07-06",
             "exchange": "NASD",
-            "signals": 4,
-            "summary": {"VBO": 1, "PP": 2, "BGU": 1},
+            "signals": 5,
+            "summary": {"VBO": 1, "PP": 2, "BGU": 1, "CB": 1},
         }
     )
     notification_service.emit.assert_awaited_once_with(
@@ -106,10 +107,11 @@ async def test_on_market_closed_notification_groups_vbo_pp_bgu_signals():
         NotificationLevel.INFO,
         "해외 dry-run 완료",
         (
-            "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 4개 신호\n"
+            "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 5개 신호\n"
             "- VBO: 1개 (AAA)\n"
             "- PP: 2개 (Beta, CCC)\n"
-            "- BGU: 1개 (DDD)"
+            "- BGU: 1개 (DDD)\n"
+            "- CB: 1개 (EEE)"
         ),
     )
 

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -784,7 +784,7 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
 
 
 def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patched_service_container_deps):
-    """해외 dry-run 태스크는 VBO, PP, BGU 서비스를 함께 실행하는 suite 를 주입받는다."""
+    """해외 dry-run 태스크는 VBO, PP, BGU, CB 서비스를 함께 실행하는 suite 를 주입받는다."""
     from config.config_loader import AppConfig
     from view.web.bootstrap.service_container import ServiceContainer
 
@@ -802,6 +802,7 @@ def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patch
          patch("view.web.bootstrap.service_container.OverseasVBODryRunService", autospec=True) as vbo_cls, \
          patch("view.web.bootstrap.service_container.OverseasPocketPivotDryRunService", autospec=True) as pp_cls, \
          patch("view.web.bootstrap.service_container.OverseasBuyableGapUpDryRunService", autospec=True) as bgu_cls, \
+         patch("view.web.bootstrap.service_container.OverseasChannelBreakoutDryRunService", autospec=True) as cb_cls, \
          patch("view.web.bootstrap.service_container.OverseasDryRunSuiteService", autospec=True) as suite_cls, \
          patch("view.web.bootstrap.service_container.OverseasDryRunTask", autospec=True) as task_cls:
         ServiceContainer(ctx).run()
@@ -814,13 +815,19 @@ def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patch
     assert bgu_kwargs["candidate_service"] is candidate_cls.return_value
     assert bgu_kwargs["position_sizing_service"] is sizing_cls.return_value
     assert callable(bgu_kwargs["fx_provider"])
+    cb_kwargs = cb_cls.call_args.kwargs
+    assert cb_kwargs["candidate_service"] is candidate_cls.return_value
+    assert cb_kwargs["indicator_service"] is ctx.indicator_service
+    assert cb_kwargs["position_sizing_service"] is sizing_cls.return_value
+    assert callable(cb_kwargs["fx_provider"])
     suite_cls.assert_called_once_with(
-        [vbo_cls.return_value, pp_cls.return_value, bgu_cls.return_value],
+        [vbo_cls.return_value, pp_cls.return_value, bgu_cls.return_value, cb_cls.return_value],
         logger=ctx.logger,
     )
     assert task_cls.call_args.kwargs["dryrun_service"] is suite_cls.return_value
     assert ctx.overseas_pp_dryrun_service is pp_cls.return_value
     assert ctx.overseas_bgu_dryrun_service is bgu_cls.return_value
+    assert ctx.overseas_cb_dryrun_service is cb_cls.return_value
 
 
 def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -62,6 +62,7 @@ from services.overseas_position_sizing_service import OverseasPositionSizingServ
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.overseas_pocket_pivot_dryrun_service import OverseasPocketPivotDryRunService
 from services.overseas_buyable_gap_up_dryrun_service import OverseasBuyableGapUpDryRunService
+from services.overseas_channel_breakout_dryrun_service import OverseasChannelBreakoutDryRunService
 from services.overseas_dryrun_suite_service import OverseasDryRunSuiteService
 from services.strategy_log_report_service import StrategyLogReportService
 from task.background.after_market.after_market_reconcile_task import AfterMarketReconcileTask
@@ -942,6 +943,7 @@ class ServiceContainer:
                 ctx.overseas_vbo_dryrun_service = None
                 ctx.overseas_pp_dryrun_service = None
                 ctx.overseas_bgu_dryrun_service = None
+                ctx.overseas_cb_dryrun_service = None
                 ctx.overseas_dryrun_task = None
                 ctx.overseas_manual_order_service = None
                 ctx.overseas_trade_repository = None
@@ -1003,6 +1005,7 @@ class ServiceContainer:
         ctx.overseas_vbo_dryrun_service = None
         ctx.overseas_pp_dryrun_service = None
         ctx.overseas_bgu_dryrun_service = None
+        ctx.overseas_cb_dryrun_service = None
         ctx.overseas_dryrun_task = None
         if getattr(ctx, "event_shadow_journal_service", None) is None:
             ctx.event_shadow_journal_service = EventShadowJournalService(
@@ -1055,11 +1058,21 @@ class ServiceContainer:
             position_sizing_service=overseas_position_sizing_service,
             fx_provider=_overseas_fx_provider,
         )
+        ctx.overseas_cb_dryrun_service = OverseasChannelBreakoutDryRunService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            indicator_service=ctx.indicator_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+            position_sizing_service=overseas_position_sizing_service,
+            fx_provider=_overseas_fx_provider,
+        )
         overseas_dryrun_suite = OverseasDryRunSuiteService(
             [
                 ctx.overseas_vbo_dryrun_service,
                 ctx.overseas_pp_dryrun_service,
                 ctx.overseas_bgu_dryrun_service,
+                ctx.overseas_cb_dryrun_service,
             ],
             logger=ctx.logger,
         )

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -209,6 +209,7 @@ class WebAppContext:
         self.overseas_vbo_dryrun_service = None
         self.overseas_pp_dryrun_service = None
         self.overseas_bgu_dryrun_service = None
+        self.overseas_cb_dryrun_service = None
         self.overseas_dryrun_task = None
         self._last_missing_reason_log_ts: dict[tuple[str, str], float] = {}
         self._last_rest_price_refresh_ts: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- add an overseas Larry Williams Channel Breakout dry-run service using completed daily OHLCV
- wire CB into the overseas VBO/PP/BGU dry-run suite
- include CB in overseas dry-run notification summaries

## Tests
- pytest tests/unit_test -q
- pytest tests/integration_test -q