### PR TITLE
Rename overseas dry-run suite metadata

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -121,7 +121,8 @@ overseas_stock:
   manual_order_only: true
   # 실전 해외 주문은 기본 차단. 운영 검증 후 별도 승인으로만 true 전환.
   allow_live_trading: false
-  # 해외 VBO dry-run would-be 수량 계산용 고정 USD 슬롯. 실주문 경로 없음.
+  # 해외 dry-run suite(VBO/PP/BGU/CB) would-be 수량 계산용 고정 USD 슬롯.
+  # 실주문 경로 없음.
   dryrun_slot_usd: 1000.0
   dryrun_max_qty:
   # 미국 정규장 REST 폴링 VBO(장중 경로). dry-run 은 마감 후 사후 평가라 발사 대상이

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -1,8 +1,8 @@
 # task/background/after_market/overseas_dryrun_task.py
-"""해외 dry-run after-market 태스크 (Phase 3c).
+"""해외 dry-run after-market 태스크.
 
-해외 dry-run suite 의 일봉 기반 신호 산출을 after-market 스케줄러에 얹어 매일 1회
-실행하고, shadow 저널을 파일로 flush 한다.
+해외 dry-run suite 의 일봉 기반 신호(VBO/PP/BGU/CB) 산출을 after-market 스케줄러에
+얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
 
 트리거는 미국장 전용 TimeDispatcher(time_dispatcher_us)가 담당한다 — NY 정규장
 마감(16:00 ET) 감지 후 task delay(30분)만큼 대기해 16:30 ET 효과로 티켓을 발행하면
@@ -58,11 +58,11 @@ class OverseasDryRunTask(AfterMarketTask):
 
     @property
     def task_name(self) -> str:
-        return "overseas_vbo_dryrun"
+        return "overseas_dryrun"
 
     @property
     def _scheduler_label(self) -> str:
-        return "OverseasVBODryRun"
+        return "OverseasDryRun"
 
     # ── 트리거 표기용 메타데이터 (16:30 ET) ──
     # Ticket-driven 모드(worker_pool 주입)에서는 스케줄링에 사용되지 않으며,

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -34,8 +34,8 @@ def _make_task(exchange=OverseasExchange.NASD, signals=None):
 
 def test_task_metadata():
     task, _, _, _, _ = _make_task()
-    assert task.task_name == "overseas_vbo_dryrun"
-    assert task._scheduler_label == "OverseasVBODryRun"
+    assert task.task_name == "overseas_dryrun"
+    assert task._scheduler_label == "OverseasDryRun"
     assert task.priority == TaskPriority.LOW
 
 

--- a/todo_list.md
+++ b/todo_list.md
@@ -217,9 +217,9 @@
 
 ---
 
-## 해외주식 전략 적용 (VBO 일봉)
+## 해외주식 전략 적용 (VBO/PP/BGU/CB 일봉 dry-run)
 
-결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다. 첫 대상 = `LarryWilliamsVBOStrategy`. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
+결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다. 첫 장중 대상 = `LarryWilliamsVBOStrategy`. After-market dry-run suite 는 VBO/PP/BGU/CB를 함께 기록·알림·분석한다. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
 
 **정정 (2026-08-11)**: 종전 "해외 주문 TR은 실전(TTTS6036U 등)만, 모의 주문 TR 없음"은 stale이다. #606에서 모의 미지원인 주간거래 TTTS603x → 모의 검증 가능한 정규장 TTTT100xU로 전환하며 `tr_ids_config.yaml`에 real/paper 쌍이 모두 추가됐고(VTTT1002U 매수 / VTTT1006U 매도 / VTTT1004U 정정취소), `trid_provider.py`가 `is_paper_trading`으로 분기한다. 따라서 "모의가 없어 배선=실계좌 발사"라는 잠금 명분은 무효이고, 남은 유효 사유는 Phase 5 미완과 엣지 부재(아래 스윕 결과)뿐이다. 단 **모의 서버의 실제 주문 수락 여부는 아직 미검증** — `scripts/probe_overseas_paper_order.py --send`로 확인 후 이 문단을 갱신할 것. (2026-08-17: 전송 없는 안전장치 검사는 4개 전부 통과 — base_url `openapivts`, 모의 계좌, 매수 `VTTT1002U`, 정정취소 `VTTT1004U`, 프로브가 현재가의 절반으로 체결 불가. 남은 것은 `--send` 1회 실행뿐이다.)
 
@@ -233,8 +233,9 @@
 
 - [x] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 미국주식 온라인 기본 수수료 0.25%/side 기준 0.5%로 보정 (2026-07-04). 환전 스프레드·SEC/TAF 등 매도 제비용은 별도이므로 리포트에 `commission_only` 가정으로 명시.
 - [x] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run Markdown 리포트 `가정/주의` 섹션에 명시.
+- [x] **분석기 다전략 확장 (2026-08-22)**: `scripts/analyze_overseas_dryrun.py --all-sources`가 VBO/PP/BGU/CB shadow source를 함께 읽고, 당일 실현손익이 없는 PP/BGU/CB 신호도 표본에서 누락하지 않는다. JSON/Markdown 리포트와 멀티데이 리포트에 전략별 신호 수·실현 표본·승률/평균 수익률 집계를 추가했다.
 
-주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_vbo_dryrun_service.py`
+주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_{vbo,pocket_pivot,buyable_gap_up,channel_breakout}_dryrun_service.py`, `services/overseas_dryrun_suite_service.py`, `task/background/after_market/overseas_dryrun_task.py`
 
 ### O-3. 청산 편향 수정 + 장중 경로 + 파라미터 스윕 [완료 — #769/#776, 2026-08-05]
 

--- a/view/web/bootstrap/service_container.py
+++ b/view/web/bootstrap/service_container.py
@@ -993,7 +993,7 @@ class ServiceContainer:
         )
 
     def _build_overseas_dryrun_pipeline(self) -> None:
-        """해외 VBO dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
+        """해외 VBO/PP/BGU/CB dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
 
         overseas_us active 분기와 국내 active 공존 경로가 공유한다.
         `overseas_stock_code_repository` 가 없으면 dry-run 부분은 no-op(수동 주문 게이팅


### PR DESCRIPTION
## Summary
- rename the overseas after-market dry-run task metadata from VBO-specific to suite-level names
- update config and todo text to reflect VBO/PP/BGU/CB dry-run coverage
- keep the existing strategy summary behavior and live-order lock unchanged

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py tests/unit_test/services/test_overseas_dryrun_suite_service.py tests/unit_test/scripts/test_analyze_overseas_dryrun.py -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -q