### PR TITLE
Report overseas dry-run readiness

### DIFF
--- a/reports/overseas_dryrun_all_sources_20260722_20260821.json
+++ b/reports/overseas_dryrun_all_sources_20260722_20260821.json
@@ -1,0 +1,222 @@
+{
+  "decidability": {
+    "decided": 260,
+    "undecided": 263,
+    "undecided_ratio": 0.502868068833652,
+    "decided_avg_realized_pct": 0.9149675693928552,
+    "decided_win_rate": 0.5769230769230769,
+    "pessimistic_avg_realized_pct": -1.0537446117741067,
+    "optimistic_avg_realized_pct": 0.32555691466220066,
+    "optimistic_sample": 401
+  },
+  "totals": {
+    "signals": 523,
+    "realized_sample": 523,
+    "wins": 150,
+    "losses": 373,
+    "win_rate": 0.28680688336520077,
+    "avg_realized_pct": -1.0537446117741067,
+    "median_realized_pct": -2.9999999999999916,
+    "sum_realized_pct": -551.1084319578578,
+    "min_realized_pct": -3.0000000000000138,
+    "max_realized_pct": 63.561400806500124
+  },
+  "by_exit_reason": {
+    "stop": 122,
+    "eod": 260,
+    "undecided": 141
+  },
+  "by_strategy": {
+    "VBO": {
+      "signals": 523,
+      "realized_sample": 523,
+      "wins": 150,
+      "sum_realized_pct": -551.1084319578578
+    }
+  },
+  "by_exchange": {
+    "NASD": {
+      "signals": 523,
+      "wins": 150,
+      "sum_realized_pct": -551.1084319578578
+    }
+  },
+  "by_date": {
+    "20260722": {
+      "signals": 29,
+      "wins": 11,
+      "sum_realized_pct": -28.487169324210917
+    },
+    "20260723": {
+      "signals": 23,
+      "wins": 6,
+      "sum_realized_pct": -27.113221146933792
+    },
+    "20260727": {
+      "signals": 12,
+      "wins": 7,
+      "sum_realized_pct": 1.3522699707203443
+    },
+    "20260728": {
+      "signals": 21,
+      "wins": 2,
+      "sum_realized_pct": -36.25623978147706
+    },
+    "20260729": {
+      "signals": 19,
+      "wins": 3,
+      "sum_realized_pct": -25.32811672437509
+    },
+    "20260730": {
+      "signals": 33,
+      "wins": 5,
+      "sum_realized_pct": -56.52091256236209
+    },
+    "20260731": {
+      "signals": 18,
+      "wins": 8,
+      "sum_realized_pct": -15.777262662313063
+    },
+    "20260803": {
+      "signals": 30,
+      "wins": 6,
+      "sum_realized_pct": -55.03457951965972
+    },
+    "20260804": {
+      "signals": 34,
+      "wins": 14,
+      "sum_realized_pct": -26.66275259821759
+    },
+    "20260805": {
+      "signals": 14,
+      "wins": 2,
+      "sum_realized_pct": -35.21903397531325
+    },
+    "20260806": {
+      "signals": 34,
+      "wins": 9,
+      "sum_realized_pct": -51.984851571105054
+    },
+    "20260807": {
+      "signals": 15,
+      "wins": 5,
+      "sum_realized_pct": -13.419902383985406
+    },
+    "20260810": {
+      "signals": 22,
+      "wins": 9,
+      "sum_realized_pct": -15.85623853794069
+    },
+    "20260811": {
+      "signals": 58,
+      "wins": 15,
+      "sum_realized_pct": -89.03779201500257
+    },
+    "20260812": {
+      "signals": 23,
+      "wins": 3,
+      "sum_realized_pct": -38.98275079403316
+    },
+    "20260813": {
+      "signals": 37,
+      "wins": 16,
+      "sum_realized_pct": -8.019515753600896
+    },
+    "20260814": {
+      "signals": 12,
+      "wins": 3,
+      "sum_realized_pct": -14.961540783624336
+    },
+    "20260817": {
+      "signals": 21,
+      "wins": 3,
+      "sum_realized_pct": -29.291997726411008
+    },
+    "20260818": {
+      "signals": 18,
+      "wins": 2,
+      "sum_realized_pct": -34.37590273612759
+    },
+    "20260819": {
+      "signals": 23,
+      "wins": 15,
+      "sum_realized_pct": 81.07442508428409
+    },
+    "20260820": {
+      "signals": 10,
+      "wins": 1,
+      "sum_realized_pct": -20.866411404055764
+    },
+    "20260821": {
+      "signals": 17,
+      "wins": 5,
+      "sum_realized_pct": -10.338935012113692
+    }
+  },
+  "sizing": {
+    "sized_count": 523,
+    "total_notional_usd": 433259.2431,
+    "avg_notional_usd": 828.4116,
+    "fx_sized_count": 0,
+    "total_krw_exposure": 0.0,
+    "avg_krw_exposure": null
+  },
+  "config": {
+    "date_from": "20260722",
+    "date_to": "20260821",
+    "signal_source": [
+      "overseas_dryrun",
+      "overseas_pp_dryrun",
+      "overseas_bgu_dryrun",
+      "overseas_cb_dryrun"
+    ],
+    "shadow_dir": "logs/strategies/event_shadow",
+    "round_trip_cost_pct": 0.5,
+    "cost_model": "commission_only",
+    "entry_price_assumption": "daily_breakout_target",
+    "ohlcv_dir": "data\\overseas_ohlcv"
+  },
+  "multiday": {
+    "reconstructed_count": 188,
+    "unmatched_count": 335,
+    "wins": 42,
+    "losses": 146,
+    "win_rate": 0.22340425531914893,
+    "avg_holding_days": 1.0106382978723405,
+    "net_return_pct": {
+      "avg": -1.6237272458931098,
+      "median": -3.5000000000000027,
+      "sum": -305.26072222790464,
+      "min": -9.97400120994365,
+      "max": 23.86374648278299
+    },
+    "gross_return_pct": {
+      "avg": -1.1237272458931096,
+      "median": -3.0000000000000027,
+      "sum": -211.26072222790458,
+      "min": -9.47400120994365,
+      "max": 24.36374648278299
+    },
+    "by_exit_reason": {
+      "stop": 136,
+      "trailing": 2,
+      "terminal": 50
+    },
+    "by_strategy": {
+      "VBO": {
+        "count": 188,
+        "avg_net_return_pct": -1.6237272458931098
+      }
+    },
+    "same_day_vs_multiday": {
+      "same_day_avg_realized_pct": -1.2222690265623097,
+      "multiday_avg_gross_pct": -1.1237272458931096,
+      "gap_pct": 0.09854178066920016
+    },
+    "params": {
+      "trailing_stop_pct": 8.0,
+      "time_stop_days": 20,
+      "round_trip_cost_pct": 0.5
+    }
+  }
+}

--- a/reports/overseas_dryrun_all_sources_20260722_20260821.md
+++ b/reports/overseas_dryrun_all_sources_20260722_20260821.md
@@ -1,0 +1,110 @@
+# Overseas Dry-run Would-be Performance
+
+- date: `20260722 ~ 20260821`  signal_source: `['overseas_dryrun', 'overseas_pp_dryrun', 'overseas_bgu_dryrun', 'overseas_cb_dryrun']`  shadow_dir: `logs/strategies/event_shadow`
+
+## 가정/주의
+
+- 왕복 비용 0.500% (`commission_only`): 미국주식 온라인 기본 수수료 0.25%/side를 왕복으로 반영한 값이며, 환전 스프레드·SEC/TAF 등 매도 제비용은 별도입니다.
+- 일봉 기반 would-be 진입가: 당일 intraday 체결 경로가 아니라 `open + K * prev_range` 목표가 체결을 가정하므로 실제 장중 체결가보다 낙관적일 수 있습니다.
+
+## 전체 집계
+
+| 항목 | 값 |
+|---|---:|
+| signals | 523 |
+| realized_sample | 523 |
+| wins / losses | 150 / 373 |
+| win_rate | 0.287 |
+| avg_realized_pct | -1.054% |
+| median_realized_pct | -3.000% |
+| sum_realized_pct | -551.108% |
+
+## 전략별
+
+| strategy | signals | realized_sample | wins | sum_realized_pct |
+|---|---:|---:|---:|---:|
+| VBO | 523 | 523 | 150 | -551.108% |
+
+## 청산 판정 가능성 (bracket)
+
+일봉은 저가 발생 시각을 담지 않아 `저 <= 손절가` 건은 손절 체결 여부를 확정할 수 없습니다(진입 전 저가로도 성립). 비관 평균만 보면 하향 편향되므로 판정 가능 건 집계와 비관·낙관 양끝을 함께 봅니다.
+
+| 항목 | 값 |
+|---|---:|
+| decided / undecided | 260 / 263 |
+| undecided_ratio | 0.503 |
+| decided_avg_realized_pct | 0.915% |
+| decided_win_rate | 0.577 |
+| pessimistic_avg_realized_pct | -1.054% |
+| optimistic_avg_realized_pct | 0.326% |
+
+## 청산 사유
+
+| reason | 건수 |
+|---|---:|
+| eod | 260 |
+| stop | 122 |
+| undecided | 141 |
+
+## 거래소별
+
+| exchange | signals | wins | sum_realized_pct |
+|---|---:|---:|---:|
+| NASD | 523 | 150 | -551.108% |
+
+## 거래일별
+
+| date | signals | wins | sum_realized_pct |
+|---|---:|---:|---:|
+| 20260722 | 29 | 11 | -28.487% |
+| 20260723 | 23 | 6 | -27.113% |
+| 20260727 | 12 | 7 | 1.352% |
+| 20260728 | 21 | 2 | -36.256% |
+| 20260729 | 19 | 3 | -25.328% |
+| 20260730 | 33 | 5 | -56.521% |
+| 20260731 | 18 | 8 | -15.777% |
+| 20260803 | 30 | 6 | -55.035% |
+| 20260804 | 34 | 14 | -26.663% |
+| 20260805 | 14 | 2 | -35.219% |
+| 20260806 | 34 | 9 | -51.985% |
+| 20260807 | 15 | 5 | -13.420% |
+| 20260810 | 22 | 9 | -15.856% |
+| 20260811 | 58 | 15 | -89.038% |
+| 20260812 | 23 | 3 | -38.983% |
+| 20260813 | 37 | 16 | -8.020% |
+| 20260814 | 12 | 3 | -14.962% |
+| 20260817 | 21 | 3 | -29.292% |
+| 20260818 | 18 | 2 | -34.376% |
+| 20260819 | 23 | 15 | 81.074% |
+| 20260820 | 10 | 1 | -20.866% |
+| 20260821 | 17 | 5 | -10.339% |
+
+## 사이징 (would-be USD 노출)
+
+- sized_count: 523
+- total_notional_usd: 433259.243
+- avg_notional_usd: 828.412
+- fx_sized_count: 0
+- total_krw_exposure: 0.000
+- avg_krw_exposure: —
+
+## 멀티데이 회고 재구성 (would-be 멀티세션 보유)
+
+- reconstructed_count: 188
+- unmatched_count: 335
+- win_rate: 0.223
+- avg_holding_days: 1.011
+- avg_net_return_pct: -1.624%
+- same_day_avg_realized_pct: -1.222%
+- multiday_avg_gross_pct: -1.124%
+- **gap_pct (multiday − same_day): 0.099%**
+
+| exit_reason | count |
+| --- | ---: |
+| stop | 136 |
+| terminal | 50 |
+| trailing | 2 |
+
+| strategy | count | avg_net_return_pct |
+| --- | ---: | ---: |
+| VBO | 188 | -1.624% |

--- a/todo_list.md
+++ b/todo_list.md
@@ -239,6 +239,7 @@
 - [x] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 미국주식 온라인 기본 수수료 0.25%/side 기준 0.5%로 보정 (2026-07-04). 환전 스프레드·SEC/TAF 등 매도 제비용은 별도이므로 리포트에 `commission_only` 가정으로 명시.
 - [x] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run Markdown 리포트 `가정/주의` 섹션에 명시.
 - [x] **분석기 다전략 확장 (2026-08-22)**: `scripts/analyze_overseas_dryrun.py --all-sources`가 VBO/PP/BGU/CB shadow source를 함께 읽고, 당일 실현손익이 없는 PP/BGU/CB 신호도 표본에서 누락하지 않는다. JSON/Markdown 리포트와 멀티데이 리포트에 전략별 신호 수·실현 표본·승률/평균 수익률 집계를 추가했다.
+- [x] **누적 표본 1차 점검 (2026-08-22)**: 20260722~20260821 shadow journal 통합 리포트(`reports/overseas_dryrun_all_sources_20260722_20260821.md`)를 생성했다. 현재 누적분은 VBO 523건뿐이며 PP/BGU/CB source는 아직 0건이다. VBO는 비용후 평균 −1.054%, 멀티데이 재구성 평균 −1.624%로 Phase 5 근거가 없고, PP/BGU/CB는 전략 불가 판정이 아니라 **표본 미축적** 상태다.
 
 주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_{vbo,pocket_pivot,buyable_gap_up,channel_breakout}_dryrun_service.py`, `services/overseas_dryrun_suite_service.py`, `task/background/after_market/overseas_dryrun_task.py`
 


### PR DESCRIPTION
## Summary
- generate the all-source overseas dry-run report for 20260722-20260821
- record that the current accumulated sample contains VBO only, with PP/BGU/CB still at zero shadow samples
- document that VBO remains negative after costs, so Phase 5 live/canary still lacks an edge basis

## Tests
- Not run: report/documentation-only update.