### PR TITLE
Add overseas RSI2 dry-run strategy

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -121,7 +121,7 @@ overseas_stock:
   manual_order_only: true
   # 실전 해외 주문은 기본 차단. 운영 검증 후 별도 승인으로만 true 전환.
   allow_live_trading: false
-  # 해외 dry-run suite(VBO/PP/BGU/CB) would-be 수량 계산용 고정 USD 슬롯.
+  # 해외 dry-run suite(VBO/PP/BGU/CB/RSI2) would-be 수량 계산용 고정 USD 슬롯.
   # 실주문 경로 없음.
   dryrun_slot_usd: 1000.0
   dryrun_max_qty:

--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -2,8 +2,8 @@
 
 해외 dry-run suite 가 shadow journal 에 남긴 신호는 실주문 없는 "만약 진입했다면"
 가정 신호다. VBO 는 same-day exit 결과(`exit_price`/`exit_reason`/`realized_pct`)가
-동봉되며, PP/BGU/CB 는 진입가/손절가를 기준으로 멀티데이 OHLCV 재구성에서 성과를
-산출한다.
+동봉되며, PP/BGU/CB/RSI2 는 진입가/손절가를 기준으로 멀티데이 OHLCV 재구성에서
+성과를 산출한다.
 
 집계 지표:
   - decidability : same-day 청산 판정 가능/불가 분리 + 비관·낙관 bracket (게이팅 기준)
@@ -36,6 +36,7 @@ DEFAULT_SIGNAL_SOURCES = [
     "overseas_pp_dryrun",
     "overseas_bgu_dryrun",
     "overseas_cb_dryrun",
+    "overseas_rsi2_dryrun",
 ]
 DEFAULT_ROUND_TRIP_COST_PCT = 0.5
 DEFAULT_COST_MODEL = "commission_only"
@@ -57,6 +58,8 @@ def _strategy_label(raw_strategy: str = "", signal_source: str = "", reason: str
         return "CB"
     if "PP" in text or "pocket_pivot" in text or "overseas_pp" in text:
         return "PP"
+    if "RSI2" in text or "rsi2" in text or "overseas_rsi2" in text:
+        return "RSI2"
     if "VBO" in text or "vbo" in text or signal_source == "overseas_dryrun":
         return "VBO"
     return "기타"
@@ -602,7 +605,7 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="해외 VBO dry-run shadow would-be 성과 분석",
+        description="해외 dry-run shadow would-be 성과 분석",
     )
     parser.add_argument("--shadow-dir", default="logs/strategies/event_shadow")
     parser.add_argument("--date-from", required=True, help="YYYYMMDD")
@@ -611,7 +614,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--all-sources",
         action="store_true",
-        help="VBO/PP/BGU/CB dry-run signal_source를 모두 분석한다.",
+        help="VBO/PP/BGU/CB/RSI2 dry-run signal_source를 모두 분석한다.",
     )
     parser.add_argument("--ohlcv-dir", default=None,
                         help="멀티데이 회고 재구성용 per-code 일봉 디렉토리(<CODE>.jsonl). 지정 시 multiday 섹션 추가.")

--- a/services/overseas_rsi2_dryrun_service.py
+++ b/services/overseas_rsi2_dryrun_service.py
@@ -1,0 +1,202 @@
+"""해외 RSI2 Pullback dry-run 신호 서비스.
+
+국내 `RSI2PullbackStrategy` 의 일봉 기반 평균회귀 아이디어 중 해외 데이터로
+재현 가능한 부분만 적용한다. Minervini Stage 2 는 해외에 같은 소스가 없으므로
+장기 상승추세(`close > 200MA`)로 대체한다. 주문 경로는 없고 shadow 저널에
+would-be 신호만 기록한다.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode
+
+
+@dataclass
+class OverseasRSI2Config:
+    rsi_period: int = 2
+    rsi_threshold: float = 10.0
+    trend_ma_period: int = 200
+    take_profit_ma_period: int = 5
+    hard_stop_pct: float = -5.0
+    min_history_days: int = 202
+
+
+class OverseasRSI2DryRunService:
+    STRATEGY_NAME = "RSI2Pullback_overseas"
+    SIGNAL_SOURCE = "overseas_rsi2_dryrun"
+
+    def __init__(
+        self,
+        candidate_service,
+        stock_query_service,
+        shadow_journal=None,
+        logger: Optional[logging.Logger] = None,
+        *,
+        config: Optional[OverseasRSI2Config] = None,
+        exchange: OverseasExchange = OverseasExchange.NASD,
+        position_sizing_service=None,
+        fx_provider=None,
+    ) -> None:
+        self._candidate_service = candidate_service
+        self._sqs = stock_query_service
+        self._journal = shadow_journal
+        self._logger = logger or logging.getLogger(__name__)
+        self._cfg = config or OverseasRSI2Config()
+        self._default_exchange = exchange
+        self._sizing_service = position_sizing_service
+        self._fx_provider = fx_provider
+
+    async def scan_dry_run(
+        self,
+        exchange: Optional[OverseasExchange] = None,
+        *,
+        top_n: Optional[int] = None,
+        min_avg_trading_value: Optional[float] = None,
+        record: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """후보를 평가해 RSI2 BUY would-be 신호를 반환하고 shadow 저널에 기록한다."""
+        ex = exchange or self._default_exchange
+        candidates = await self._candidate_service.get_candidates(
+            ex, top_n=top_n, min_avg_trading_value=min_avg_trading_value
+        )
+
+        fx_rate = await self._resolve_fx_rate()
+        signals: List[Dict[str, Any]] = []
+        limit = max(self._cfg.trend_ma_period + self._cfg.rsi_period + 5, self._cfg.min_history_days)
+        for cand in candidates or []:
+            code = cand.get("code")
+            if not code:
+                continue
+            try:
+                resp = await self._sqs.get_recent_daily_ohlcv(code, limit=limit, exchange=ex)
+            except Exception as e:
+                self._logger.warning({"event": "overseas_rsi2_ohlcv_error", "code": code, "error": str(e)})
+                continue
+            if not resp or resp.rt_cd != ErrorCode.SUCCESS.value or not resp.data:
+                continue
+
+            sig = self._evaluate(code, cand, resp.data)
+            if not sig:
+                continue
+            if self._sizing_service is not None:
+                sizing = self._sizing_service.size(
+                    limit_price_usd=sig["entry_price"], fx_krw_per_usd=fx_rate
+                )
+                sig["qty"] = sizing.get("qty")
+                sig["notional_usd"] = sizing.get("notional_usd")
+                if sizing.get("fx_krw_per_usd") is not None:
+                    sig["fx_krw_per_usd"] = sizing.get("fx_krw_per_usd")
+                if sizing.get("krw_exposure") is not None:
+                    sig["krw_exposure"] = sizing.get("krw_exposure")
+            signals.append(sig)
+            if record and self._journal is not None:
+                self._journal.record(
+                    strategy_name=self.STRATEGY_NAME,
+                    code=code,
+                    signal=sig,
+                    snapshot={
+                        "exchange": ex.value,
+                        "avg_trading_value": cand.get("avg_trading_value"),
+                        "bar": self._bar_ohlc(resp.data[-1]),
+                    },
+                    signal_source=self.SIGNAL_SOURCE,
+                )
+
+        self._logger.info({
+            "event": "overseas_rsi2_dryrun_scan",
+            "exchange": ex.value,
+            "candidates": len(candidates or []),
+            "signals": len(signals),
+        })
+        return signals
+
+    async def _resolve_fx_rate(self) -> Optional[float]:
+        if self._sizing_service is None or self._fx_provider is None:
+            return None
+        try:
+            rate = await self._fx_provider()
+        except Exception as e:
+            self._logger.warning({"event": "overseas_rsi2_fx_error", "error": str(e)})
+            return None
+        try:
+            rate = float(rate) if rate is not None else None
+        except (TypeError, ValueError):
+            return None
+        return rate if (rate is not None and rate > 0) else None
+
+    def _evaluate(
+        self,
+        code: str,
+        candidate: Dict[str, Any],
+        rows: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        min_rows = max(self._cfg.min_history_days, self._cfg.trend_ma_period + self._cfg.rsi_period)
+        if not rows or len(rows) < min_rows:
+            return None
+
+        closes = [self._f(r.get("close")) for r in rows]
+        if any(v <= 0 for v in closes[-min_rows:]):
+            return None
+        cur = rows[-1]
+        current = closes[-1]
+        ma_200d = sum(closes[-self._cfg.trend_ma_period:]) / self._cfg.trend_ma_period
+        if current <= ma_200d:
+            return None
+
+        rsi2 = self._rsi(closes, self._cfg.rsi_period)
+        if rsi2 is None or rsi2 > self._cfg.rsi_threshold:
+            return None
+
+        ma_5d = sum(closes[-self._cfg.take_profit_ma_period:]) / self._cfg.take_profit_ma_period
+        stop_price = current * (1 + self._cfg.hard_stop_pct / 100)
+        confidence = max(0.0, min(1.0, (self._cfg.rsi_threshold - rsi2) / max(self._cfg.rsi_threshold, 1.0)))
+        return {
+            "strategy": self.STRATEGY_NAME,
+            "code": code,
+            "name": candidate.get("name", code),
+            "action": "BUY",
+            "date": cur.get("date"),
+            "entry_price": current,
+            "entry_reason": "overseas_rsi2_pullback",
+            "rsi2": rsi2,
+            "rsi_threshold": self._cfg.rsi_threshold,
+            "ma_200d": ma_200d,
+            "ma_5d": ma_5d,
+            "target_ma_period": self._cfg.take_profit_ma_period,
+            "stop_price": stop_price,
+            "confidence": confidence,
+            "reason": (
+                f"RSI2진입(RSI({self._cfg.rsi_period})={rsi2:.2f} <= "
+                f"{self._cfg.rsi_threshold:.1f}, 종가>200MA)"
+            ),
+        }
+
+    @classmethod
+    def _rsi(cls, closes: List[float], period: int) -> Optional[float]:
+        if period <= 0 or len(closes) < period + 1:
+            return None
+        deltas = [closes[i] - closes[i - 1] for i in range(1, len(closes))]
+        recent = deltas[-period:]
+        gains = [d for d in recent if d > 0]
+        losses = [-d for d in recent if d < 0]
+        avg_gain = sum(gains) / period
+        avg_loss = sum(losses) / period
+        if avg_loss == 0:
+            return 100.0 if avg_gain > 0 else 50.0
+        rs = avg_gain / avg_loss
+        return 100.0 - (100.0 / (1.0 + rs))
+
+    @staticmethod
+    def _bar_ohlc(bar: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: bar.get(k) for k in ("date", "open", "high", "low", "close", "volume")}
+
+    @staticmethod
+    def _f(x) -> float:
+        try:
+            return float(x or 0)
+        except (TypeError, ValueError):
+            return 0.0

--- a/task/background/after_market/overseas_dryrun_task.py
+++ b/task/background/after_market/overseas_dryrun_task.py
@@ -1,7 +1,7 @@
 # task/background/after_market/overseas_dryrun_task.py
 """해외 dry-run after-market 태스크.
 
-해외 dry-run suite 의 일봉 기반 신호(VBO/PP/BGU/CB) 산출을 after-market 스케줄러에
+해외 dry-run suite 의 일봉 기반 신호(VBO/PP/BGU/CB/RSI2) 산출을 after-market 스케줄러에
 얹어 매일 1회 실행하고, shadow 저널을 파일로 flush 한다.
 
 트리거는 미국장 전용 TimeDispatcher(time_dispatcher_us)가 담당한다 — NY 정규장
@@ -102,6 +102,8 @@ class OverseasDryRunTask(AfterMarketTask):
             return "CB"
         if "PP" in strategy or "pocket_pivot" in reason:
             return "PP"
+        if "RSI2" in strategy or "rsi2" in reason:
+            return "RSI2"
         if "VBO" in strategy or "vbo" in reason:
             return "VBO"
         return "기타"
@@ -117,7 +119,7 @@ class OverseasDryRunTask(AfterMarketTask):
             if name:
                 names_by_label[label].append(name)
 
-        ordered_labels = [label for label in ("VBO", "PP", "BGU", "CB", "기타") if counts.get(label)]
+        ordered_labels = [label for label in ("VBO", "PP", "BGU", "CB", "RSI2", "기타") if counts.get(label)]
         summary = {label: counts[label] for label in ordered_labels}
         lines = []
         for label in ordered_labels:

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -110,14 +110,15 @@ def test_load_filters_signal_source_and_date_range(tmp_path):
     assert aaa["exit_reason"] == "eod"
 
 
-def test_load_multi_source_keeps_pp_bgu_cb_without_same_day_realized(tmp_path):
-    """PP/BGU/CB는 same-day realized_pct가 없어도 전략별/멀티데이 분석 대상으로 로드한다."""
+def test_load_multi_source_keeps_pp_bgu_cb_rsi2_without_same_day_realized(tmp_path):
+    """PP/BGU/CB/RSI2는 same-day realized_pct가 없어도 전략별/멀티데이 분석 대상으로 로드한다."""
     shadow = tmp_path / "event_shadow"
     _write_jsonl(shadow, "20260601", [
         _rec(code="VBO", exchange="NASD", date="20260601", realized_pct=2.0, exit_reason="eod"),
         _entry_rec(code="PPA", strategy="O'NeilPP_overseas", signal_source="overseas_pp_dryrun"),
         _entry_rec(code="BGA", strategy="O'NeilBGU_overseas", signal_source="overseas_bgu_dryrun"),
         _entry_rec(code="CBA", strategy="LarryWilliamsCB_overseas", signal_source="overseas_cb_dryrun"),
+        _entry_rec(code="RSA", strategy="RSI2Pullback_overseas", signal_source="overseas_rsi2_dryrun"),
     ])
 
     records = load_dryrun_records_multi_source(
@@ -129,11 +130,12 @@ def test_load_multi_source_keeps_pp_bgu_cb_without_same_day_realized(tmp_path):
             "overseas_pp_dryrun",
             "overseas_bgu_dryrun",
             "overseas_cb_dryrun",
+            "overseas_rsi2_dryrun",
         ],
     )
 
-    assert [r["code"] for r in records] == ["VBO", "PPA", "BGA", "CBA"]
-    assert {r["strategy_label"] for r in records} == {"VBO", "PP", "BGU", "CB"}
+    assert [r["code"] for r in records] == ["VBO", "PPA", "BGA", "CBA", "RSA"]
+    assert {r["strategy_label"] for r in records} == {"VBO", "PP", "BGU", "CB", "RSI2"}
     pp = next(r for r in records if r["strategy_label"] == "PP")
     assert pp["realized_pct"] is None
     assert pp["entry_price"] == 100.0

--- a/tests/unit_test/services/test_overseas_rsi2_dryrun_service.py
+++ b/tests/unit_test/services/test_overseas_rsi2_dryrun_service.py
@@ -1,0 +1,130 @@
+"""해외 RSI2 dry-run 신호 서비스 테스트.
+
+완성 일봉 기준으로 장기 상승추세 + RSI(2) 과매도 조건을 판정하고 shadow 저널에
+would-be 신호만 기록한다. 해외 자동 주문 경로는 열지 않는다.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.overseas_types import OverseasExchange
+from common.types import ErrorCode, ResCommonResponse
+from services.overseas_rsi2_dryrun_service import OverseasRSI2DryRunService
+
+
+def _bar(d, o, h, l, c, v=1000):
+    return {"date": d, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _ohlcv(bars):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=bars)
+
+
+def _rsi2_bars(*, last_close=104.0, last_open=108.0):
+    bars = []
+    price = 80.0
+    for i in range(205):
+        price += 0.15
+        bars.append(_bar(f"2025{i + 1:04d}", price - 0.2, price + 0.5, price - 0.5, price, 10_000))
+    # RSI(2)를 낮추기 위한 연속 하락 2일. 마지막 종가는 200MA 위에 유지.
+    bars.append(_bar("20260520", 112.0, 113.0, 106.0, 108.0, 12_000))
+    bars.append(_bar("20260521", last_open, 109.0, 103.0, last_close, 13_000))
+    return bars
+
+
+@pytest.fixture
+def svc():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "MSFT", "name": "Microsoft", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    journal = MagicMock()
+    service = OverseasRSI2DryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=journal,
+        logger=MagicMock(),
+    )
+    return SimpleNamespace(service=service, candidate_service=candidate_service, sqs=sqs, journal=journal)
+
+
+@pytest.mark.asyncio
+async def test_scan_emits_buy_on_rsi2_pullback(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_rsi2_bars()))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig["strategy"] == "RSI2Pullback_overseas"
+    assert sig["code"] == "MSFT"
+    assert sig["action"] == "BUY"
+    assert sig["entry_reason"] == "overseas_rsi2_pullback"
+    assert sig["rsi2"] <= 10.0
+    assert sig["ma_200d"] > 0
+    assert sig["entry_price"] == 104.0
+    assert sig["stop_price"] == pytest.approx(98.8)
+    assert sig["target_ma_period"] == 5
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_not_enough_history(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_rsi2_bars()[-20:]))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+    svc.journal.record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_when_rsi_above_threshold(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_rsi2_bars(last_close=111.0, last_open=108.0)))
+
+    signals = await svc.service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_scan_records_to_shadow_journal_with_rsi2_source(svc):
+    svc.sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_rsi2_bars()))
+
+    await svc.service.scan_dry_run(exchange=OverseasExchange.NYSE)
+
+    svc.journal.record.assert_called_once()
+    _, kwargs = svc.journal.record.call_args
+    assert kwargs["code"] == "MSFT"
+    assert kwargs["strategy_name"] == "RSI2Pullback_overseas"
+    assert kwargs["signal_source"] == "overseas_rsi2_dryrun"
+    assert kwargs["snapshot"]["exchange"] == "NYSE"
+    assert kwargs["snapshot"]["bar"]["date"] == "20260521"
+
+
+@pytest.mark.asyncio
+async def test_scan_includes_qty_when_sizing_injected():
+    candidate_service = MagicMock()
+    candidate_service.get_candidates = AsyncMock(return_value=[
+        {"code": "MSFT", "name": "Microsoft", "exchange": "NASD", "avg_trading_value": 100_000_000.0},
+    ])
+    sqs = MagicMock()
+    sqs.get_recent_daily_ohlcv = AsyncMock(return_value=_ohlcv(_rsi2_bars()))
+    sizing = MagicMock()
+    sizing.size = MagicMock(return_value={"qty": 7, "notional_usd": 728.0, "reason": "slot"})
+
+    service = OverseasRSI2DryRunService(
+        candidate_service=candidate_service,
+        stock_query_service=sqs,
+        shadow_journal=MagicMock(),
+        logger=MagicMock(),
+        position_sizing_service=sizing,
+    )
+
+    signals = await service.scan_dry_run(exchange=OverseasExchange.NASD)
+
+    assert signals[0]["qty"] == 7
+    assert signals[0]["notional_usd"] == 728.0
+    assert sizing.size.call_args.kwargs["limit_price_usd"] == signals[0]["entry_price"]
+    assert not hasattr(service, "_order_execution_service")

--- a/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
+++ b/tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py
@@ -87,6 +87,7 @@ async def test_on_market_closed_notification_groups_vbo_pp_bgu_cb_signals():
         {"code": "CCC", "strategy": "O'NeilPP_overseas", "action": "BUY"},
         {"code": "DDD", "strategy": "O'NeilBGU_overseas", "action": "BUY"},
         {"code": "EEE", "strategy": "LarryWilliamsCB_overseas", "action": "BUY"},
+        {"code": "FFF", "strategy": "RSI2Pullback_overseas", "action": "BUY"},
     ]
     task, _, _, notification_service, logger = _make_task(signals=signals)
 
@@ -98,8 +99,8 @@ async def test_on_market_closed_notification_groups_vbo_pp_bgu_cb_signals():
             "market_date": "20260706",
             "market_date_text": "2026-07-06",
             "exchange": "NASD",
-            "signals": 5,
-            "summary": {"VBO": 1, "PP": 2, "BGU": 1, "CB": 1},
+            "signals": 6,
+            "summary": {"VBO": 1, "PP": 2, "BGU": 1, "CB": 1, "RSI2": 1},
         }
     )
     notification_service.emit.assert_awaited_once_with(
@@ -107,11 +108,12 @@ async def test_on_market_closed_notification_groups_vbo_pp_bgu_cb_signals():
         NotificationLevel.INFO,
         "해외 dry-run 완료",
         (
-            "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 5개 신호\n"
+            "미국 거래일 2026-07-06 기준 dry-run 리포트: 총 6개 신호\n"
             "- VBO: 1개 (AAA)\n"
             "- PP: 2개 (Beta, CCC)\n"
             "- BGU: 1개 (DDD)\n"
-            "- CB: 1개 (EEE)"
+            "- CB: 1개 (EEE)\n"
+            "- RSI2: 1개 (FFF)"
         ),
     )
 

--- a/tests/unit_test/view/web/bootstrap/test_service_container.py
+++ b/tests/unit_test/view/web/bootstrap/test_service_container.py
@@ -795,7 +795,7 @@ def test_service_container_wires_overseas_dryrun_position_sizing(patched_service
 
 
 def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patched_service_container_deps):
-    """해외 dry-run 태스크는 VBO, PP, BGU, CB 서비스를 함께 실행하는 suite 를 주입받는다."""
+    """해외 dry-run 태스크는 VBO, PP, BGU, CB, RSI2 서비스를 함께 실행하는 suite 를 주입받는다."""
     from config.config_loader import AppConfig
     from view.web.bootstrap.service_container import ServiceContainer
 
@@ -814,6 +814,7 @@ def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patch
          patch("view.web.bootstrap.overseas_bootstrap.OverseasPocketPivotDryRunService", autospec=True) as pp_cls, \
          patch("view.web.bootstrap.overseas_bootstrap.OverseasBuyableGapUpDryRunService", autospec=True) as bgu_cls, \
          patch("view.web.bootstrap.overseas_bootstrap.OverseasChannelBreakoutDryRunService", autospec=True) as cb_cls, \
+         patch("view.web.bootstrap.overseas_bootstrap.OverseasRSI2DryRunService", autospec=True) as rsi2_cls, \
          patch("view.web.bootstrap.overseas_bootstrap.OverseasDryRunSuiteService", autospec=True) as suite_cls, \
          patch("view.web.bootstrap.overseas_bootstrap.OverseasDryRunTask", autospec=True) as task_cls:
         ServiceContainer(ctx).run()
@@ -831,14 +832,25 @@ def test_service_container_wires_overseas_oneil_services_into_dryrun_suite(patch
     assert cb_kwargs["indicator_service"] is ctx.indicator_service
     assert cb_kwargs["position_sizing_service"] is sizing_cls.return_value
     assert callable(cb_kwargs["fx_provider"])
+    rsi2_kwargs = rsi2_cls.call_args.kwargs
+    assert rsi2_kwargs["candidate_service"] is candidate_cls.return_value
+    assert rsi2_kwargs["position_sizing_service"] is sizing_cls.return_value
+    assert callable(rsi2_kwargs["fx_provider"])
     suite_cls.assert_called_once_with(
-        [vbo_cls.return_value, pp_cls.return_value, bgu_cls.return_value, cb_cls.return_value],
+        [
+            vbo_cls.return_value,
+            pp_cls.return_value,
+            bgu_cls.return_value,
+            cb_cls.return_value,
+            rsi2_cls.return_value,
+        ],
         logger=ctx.logger,
     )
     assert task_cls.call_args.kwargs["dryrun_service"] is suite_cls.return_value
     assert ctx.overseas_pp_dryrun_service is pp_cls.return_value
     assert ctx.overseas_bgu_dryrun_service is bgu_cls.return_value
     assert ctx.overseas_cb_dryrun_service is cb_cls.return_value
+    assert ctx.overseas_rsi2_dryrun_service is rsi2_cls.return_value
 
 
 def test_service_container_wires_overseas_dryrun_us_market_clock(patched_service_container_deps):

--- a/todo_list.md
+++ b/todo_list.md
@@ -222,9 +222,9 @@
 
 ---
 
-## 해외주식 전략 적용 (VBO/PP/BGU/CB 일봉 dry-run)
+## 해외주식 전략 적용 (VBO/PP/BGU/CB/RSI2 일봉 dry-run)
 
-결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다. 첫 장중 대상 = `LarryWilliamsVBOStrategy`. After-market dry-run suite 는 VBO/PP/BGU/CB를 함께 기록·알림·분석한다. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
+결론: 일봉 셋업형 전략 + 장중 REST 폴링 경로(#776) 적용 가능 — 해외는 웹소켓/분봉이 없어 폴링이 유일한 장중 틱 소스다. 첫 장중 대상 = `LarryWilliamsVBOStrategy`. After-market dry-run suite 는 VBO/PP/BGU/CB/RSI2를 함께 기록·알림·분석한다. Phase 1~4(데이터 어댑터·일봉 백테스트·dry-run·주문/사이징) 완료, 자동 전략 경로 `live_enabled=False` 잠금.
 
 **정정 (2026-08-11)**: 종전 "해외 주문 TR은 실전(TTTS6036U 등)만, 모의 주문 TR 없음"은 stale이다. #606에서 모의 미지원인 주간거래 TTTS603x → 모의 검증 가능한 정규장 TTTT100xU로 전환하며 `tr_ids_config.yaml`에 real/paper 쌍이 모두 추가됐고(VTTT1002U 매수 / VTTT1006U 매도 / VTTT1004U 정정취소), `trid_provider.py`가 `is_paper_trading`으로 분기한다. 따라서 "모의가 없어 배선=실계좌 발사"라는 잠금 명분은 무효이고, 남은 유효 사유는 Phase 5 미완과 엣지 부재(아래 스윕 결과)뿐이다. 단 **모의 서버의 실제 주문 수락 여부는 아직 미검증** — `scripts/probe_overseas_paper_order.py --send`로 확인 후 이 문단을 갱신할 것. (2026-08-17: 전송 없는 안전장치 검사는 4개 전부 통과 — base_url `openapivts`, 모의 계좌, 매수 `VTTT1002U`, 정정취소 `VTTT1004U`, 프로브가 현재가의 절반으로 체결 불가. 남은 것은 `--send` 1회 실행뿐이다.)
 
@@ -238,10 +238,11 @@
 
 - [x] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 미국주식 온라인 기본 수수료 0.25%/side 기준 0.5%로 보정 (2026-07-04). 환전 스프레드·SEC/TAF 등 매도 제비용은 별도이므로 리포트에 `commission_only` 가정으로 명시.
 - [x] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run Markdown 리포트 `가정/주의` 섹션에 명시.
-- [x] **분석기 다전략 확장 (2026-08-22)**: `scripts/analyze_overseas_dryrun.py --all-sources`가 VBO/PP/BGU/CB shadow source를 함께 읽고, 당일 실현손익이 없는 PP/BGU/CB 신호도 표본에서 누락하지 않는다. JSON/Markdown 리포트와 멀티데이 리포트에 전략별 신호 수·실현 표본·승률/평균 수익률 집계를 추가했다.
+- [x] **분석기 다전략 확장 (2026-08-22)**: `scripts/analyze_overseas_dryrun.py --all-sources`가 VBO/PP/BGU/CB/RSI2 shadow source를 함께 읽고, 당일 실현손익이 없는 PP/BGU/CB/RSI2 신호도 표본에서 누락하지 않는다. JSON/Markdown 리포트와 멀티데이 리포트에 전략별 신호 수·실현 표본·승률/평균 수익률 집계를 추가했다.
 - [x] **누적 표본 1차 점검 (2026-08-22)**: 20260722~20260821 shadow journal 통합 리포트(`reports/overseas_dryrun_all_sources_20260722_20260821.md`)를 생성했다. 현재 누적분은 VBO 523건뿐이며 PP/BGU/CB source는 아직 0건이다. VBO는 비용후 평균 −1.054%, 멀티데이 재구성 평균 −1.624%로 Phase 5 근거가 없고, PP/BGU/CB는 전략 불가 판정이 아니라 **표본 미축적** 상태다.
+- [x] **RSI2 dry-run 추가 (2026-08-22)**: 돌파류와 다른 평균회귀 축을 보기 위해 해외 RSI2 Pullback dry-run을 suite에 추가했다. 국내 Minervini Stage2는 해외에 같은 데이터 소스가 없어 일봉 `close > 200MA` 장기 상승추세로 대체하고, RSI(2) ≤ 10 종가 신호를 기록한다. 실주문 경로 없음.
 
-주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_{vbo,pocket_pivot,buyable_gap_up,channel_breakout}_dryrun_service.py`, `services/overseas_dryrun_suite_service.py`, `task/background/after_market/overseas_dryrun_task.py`
+주요 파일: `scripts/analyze_overseas_dryrun.py`, `services/overseas_{vbo,pocket_pivot,buyable_gap_up,channel_breakout,rsi2}_dryrun_service.py`, `services/overseas_dryrun_suite_service.py`, `task/background/after_market/overseas_dryrun_task.py`
 
 ### O-3. 청산 편향 수정 + 장중 경로 + 파라미터 스윕 [완료 — #769/#776, 2026-08-05]
 

--- a/view/web/bootstrap/overseas_bootstrap.py
+++ b/view/web/bootstrap/overseas_bootstrap.py
@@ -1,7 +1,7 @@
 """OverseasBootstrap — 해외(미국장) 서비스·태스크 조립을 전담한다.
 
 `ServiceContainer.run()` 에서 옮겨온 4개 조립 경로를 담는다 — 관심종목 등락 알림,
-dry-run 파이프라인(전략 4종 + suite + after-market 태스크), 수동 주문 게이팅 서비스,
+dry-run 파이프라인(전략 5종 + suite + after-market 태스크), 수동 주문 게이팅 서비스,
 장중 VBO 폴링 경로. 조립 순서·조건·후주입은 이관 전과 동일하다.
 
 **자동 전략 경로의 `live_enabled=False` 잠금은 이 파일이 유일한 조립 지점이다** —
@@ -25,6 +25,7 @@ from services.overseas_intraday_vbo_service import OverseasIntradayVBOService
 from services.overseas_order_execution_service import OverseasOrderExecutionService
 from services.overseas_pocket_pivot_dryrun_service import OverseasPocketPivotDryRunService
 from services.overseas_position_sizing_service import OverseasPositionSizingService, extract_fx_krw_per_usd
+from services.overseas_rsi2_dryrun_service import OverseasRSI2DryRunService
 from services.overseas_vbo_dryrun_service import OverseasVBODryRunService
 from services.us_market_calendar_service import USMarketCalendarService
 from task.background.after_market.overseas_dryrun_task import OverseasDryRunTask
@@ -80,7 +81,7 @@ class OverseasBootstrap:
         )
 
     def build_dryrun_pipeline(self) -> None:
-        """해외 VBO/PP/BGU/CB dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
+        """해외 VBO/PP/BGU/CB/RSI2 dry-run 파이프라인 조립 (주문 경로 없음 — 실주문 불가).
 
         overseas_us active 분기와 국내 active 공존 경로가 공유한다.
         `overseas_stock_code_repository` 가 없으면 dry-run 부분은 no-op(수동 주문 게이팅
@@ -93,6 +94,7 @@ class OverseasBootstrap:
         ctx.overseas_pp_dryrun_service = None
         ctx.overseas_bgu_dryrun_service = None
         ctx.overseas_cb_dryrun_service = None
+        ctx.overseas_rsi2_dryrun_service = None
         ctx.overseas_dryrun_task = None
         if getattr(ctx, "event_shadow_journal_service", None) is None:
             ctx.event_shadow_journal_service = EventShadowJournalService(
@@ -154,12 +156,21 @@ class OverseasBootstrap:
             position_sizing_service=overseas_position_sizing_service,
             fx_provider=_overseas_fx_provider,
         )
+        ctx.overseas_rsi2_dryrun_service = OverseasRSI2DryRunService(
+            candidate_service=ctx.overseas_candidate_service,
+            stock_query_service=ctx.stock_query_service,
+            shadow_journal=ctx.event_shadow_journal_service,
+            logger=ctx.logger,
+            position_sizing_service=overseas_position_sizing_service,
+            fx_provider=_overseas_fx_provider,
+        )
         overseas_dryrun_suite = OverseasDryRunSuiteService(
             [
                 ctx.overseas_vbo_dryrun_service,
                 ctx.overseas_pp_dryrun_service,
                 ctx.overseas_bgu_dryrun_service,
                 ctx.overseas_cb_dryrun_service,
+                ctx.overseas_rsi2_dryrun_service,
             ],
             logger=ctx.logger,
         )


### PR DESCRIPTION
## Summary
- add an overseas RSI2 Pullback dry-run service using daily OHLCV only
- wire RSI2 into the overseas dry-run suite, after-market summary, and all-source analyzer
- document that overseas RSI2 uses close > 200MA as the daily-data substitute for domestic Stage 2

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_overseas_rsi2_dryrun_service.py tests/unit_test/services/test_overseas_dryrun_suite_service.py tests/unit_test/services/test_overseas_pocket_pivot_dryrun_service.py tests/unit_test/services/test_overseas_buyable_gap_up_dryrun_service.py tests/unit_test/services/test_overseas_channel_breakout_dryrun_service.py tests/unit_test/task/background/after_market/test_overseas_dryrun_task.py tests/unit_test/scripts/test_analyze_overseas_dryrun.py tests/unit_test/view/web/bootstrap/test_service_container.py::test_service_container_wires_overseas_oneil_services_into_dryrun_suite -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/scheduler/test_worker_pool.py::test_handle_logs_perf_timers_when_profiler_enabled -q -n0
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -q

Note: the first full unit run had one unrelated xdist timing failure in test_worker_pool; that test passed standalone and the full unit suite passed on rerun.