### PR TITLE
Add overseas dry-run edge judgement

### DIFF
--- a/scripts/analyze_overseas_dryrun.py
+++ b/scripts/analyze_overseas_dryrun.py
@@ -39,6 +39,7 @@ DEFAULT_SIGNAL_SOURCES = [
     "overseas_rsi2_dryrun",
     "overseas_osb_dryrun",
 ]
+DEFAULT_STRATEGY_LABELS = ["VBO", "PP", "BGU", "CB", "RSI2", "OSB"]
 DEFAULT_ROUND_TRIP_COST_PCT = 0.5
 DEFAULT_COST_MODEL = "commission_only"
 DEFAULT_ENTRY_PRICE_ASSUMPTION = "daily_breakout_target"
@@ -270,6 +271,88 @@ def compute_dryrun_report(records: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def compute_edge_judgement(
+    report: Dict[str, Any],
+    *,
+    min_trading_days: int = 5,
+    min_strategy_sample: int = 5,
+    min_avg_return_pct: float = 0.0,
+    strategy_labels: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """해외 dry-run 누적 리포트에 canary 후보/보류 판정을 붙인다.
+
+    기본 판정은 보수적이다. 최소 거래일과 전략별 평가 표본이 모두 충족된 뒤,
+    비용 반영 평균 수익률이 0%를 초과해야만 `PASS_CANDIDATE` 로 둔다. 멀티데이
+    재구성 섹션이 있으면 해당 net 수익률을 우선하고, 없으면 same-day realized
+    표본을 사용한다.
+    """
+    labels = strategy_labels or DEFAULT_STRATEGY_LABELS
+    by_date = report.get("by_date") or {}
+    by_strategy = report.get("by_strategy") or {}
+    multiday_by_strategy = ((report.get("multiday") or {}).get("by_strategy") or {})
+    trading_days = len(by_date)
+
+    strategy_results: Dict[str, Dict[str, Any]] = {}
+    pass_count = 0
+    wait_count = 0
+    for label in labels:
+        same_day = by_strategy.get(label) or {}
+        multiday = multiday_by_strategy.get(label) or {}
+        signals = int(same_day.get("signals") or 0)
+
+        avg_return = None
+        sample = 0
+        basis = "same_day_realized"
+        if multiday:
+            sample = int(multiday.get("count") or 0)
+            avg_return = _to_float(multiday.get("avg_net_return_pct"))
+            basis = "multiday_net"
+        else:
+            sample = int(same_day.get("realized_sample") or 0)
+            if sample > 0:
+                avg_return = _to_float(same_day.get("sum_realized_pct"))
+                if avg_return is not None:
+                    avg_return = avg_return / sample
+
+        if signals <= 0:
+            status = "NO_SIGNALS"
+        elif trading_days < min_trading_days:
+            status = "WAIT_DAYS"
+            wait_count += 1
+        elif sample < min_strategy_sample:
+            status = "WAIT_SAMPLE"
+            wait_count += 1
+        elif avg_return is not None and avg_return > min_avg_return_pct:
+            status = "PASS_CANDIDATE"
+            pass_count += 1
+        else:
+            status = "FAIL_NEGATIVE_EDGE"
+
+        strategy_results[label] = {
+            "status": status,
+            "signals": signals,
+            "sample": sample,
+            "avg_return_pct": avg_return,
+            "avg_return_basis": basis,
+        }
+
+    if pass_count > 0:
+        overall = "CANARY_CANDIDATE"
+    elif wait_count > 0 or trading_days < min_trading_days:
+        overall = "WAIT_DATA"
+    else:
+        overall = "NO_GO"
+
+    return {
+        "overall_decision": overall,
+        "trading_days": trading_days,
+        "min_trading_days": min_trading_days,
+        "min_strategy_sample": min_strategy_sample,
+        "min_avg_return_pct": min_avg_return_pct,
+        "strategies": strategy_results,
+    }
+
+
 def _f0(value: Any) -> float:
     """float 변환 실패 시 0.0(봉 OHLC 파싱용)."""
     try:
@@ -492,6 +575,30 @@ def format_markdown_report(report: Dict[str, Any]) -> str:
     def _fmt(v: Optional[float], suffix: str = "") -> str:
         return f"{v:.3f}{suffix}" if isinstance(v, (int, float)) else "—"
 
+    judgement = report.get("edge_judgement")
+    if judgement:
+        lines.append("## 엣지 판정")
+        lines.append("")
+        lines.append(f"- overall_decision: `{judgement.get('overall_decision')}`")
+        lines.append(
+            f"- trading_days: {judgement.get('trading_days', 0)} / "
+            f"{judgement.get('min_trading_days', 0)}"
+        )
+        lines.append(
+            f"- min_strategy_sample: {judgement.get('min_strategy_sample', 0)}, "
+            f"min_avg_return_pct: {_fmt(judgement.get('min_avg_return_pct'), '%')}"
+        )
+        lines.append("")
+        lines.append("| strategy | status | signals | sample | avg_return_pct | basis |")
+        lines.append("|---|---|---:|---:|---:|---|")
+        for label, b in (judgement.get("strategies") or {}).items():
+            lines.append(
+                f"| {label} | {b.get('status')} | {b.get('signals', 0)} | "
+                f"{b.get('sample', 0)} | {_fmt(b.get('avg_return_pct'), '%')} | "
+                f"{b.get('avg_return_basis', '')} |"
+            )
+        lines.append("")
+
     lines.append("## 전체 집계")
     lines.append("")
     lines.append("| 항목 | 값 |")
@@ -627,6 +734,14 @@ def build_parser() -> argparse.ArgumentParser:
                         help="멀티데이 time stop 보유일수(회고 가정값)")
     parser.add_argument("--cost-pct", type=float, default=DEFAULT_ROUND_TRIP_COST_PCT,
                         help="멀티데이 왕복 비용 %% (net 산출). 기본값 0.5%%는 미국주식 온라인 수수료 0.25%%/side 왕복 가정.")
+    parser.add_argument("--no-edge-judgement", action="store_true",
+                        help="5거래일/표본/평균수익률 기반 canary 후보 판정 섹션을 생략한다.")
+    parser.add_argument("--min-trading-days", type=int, default=5,
+                        help="엣지 판정에 필요한 최소 거래일 수.")
+    parser.add_argument("--min-strategy-sample", type=int, default=5,
+                        help="전략별 엣지 판정에 필요한 최소 평가 표본 수.")
+    parser.add_argument("--min-avg-return-pct", type=float, default=0.0,
+                        help="canary 후보 판정에 필요한 최소 평균 수익률(%%).")
     parser.add_argument("--output-json", default=None)
     parser.add_argument("--output-markdown", default=None)
     return parser
@@ -671,6 +786,20 @@ def main(argv: Optional[List[str]] = None) -> int:
             cost_pct=args.cost_pct,
         )
         report["config"]["ohlcv_dir"] = str(args.ohlcv_dir)
+
+    if not args.no_edge_judgement:
+        report["edge_judgement"] = compute_edge_judgement(
+            report,
+            min_trading_days=args.min_trading_days,
+            min_strategy_sample=args.min_strategy_sample,
+            min_avg_return_pct=args.min_avg_return_pct,
+        )
+        report["config"]["edge_judgement"] = {
+            "enabled": True,
+            "min_trading_days": args.min_trading_days,
+            "min_strategy_sample": args.min_strategy_sample,
+            "min_avg_return_pct": args.min_avg_return_pct,
+        }
 
     if args.output_json:
         out_json = Path(args.output_json)

--- a/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
+++ b/tests/unit_test/scripts/test_analyze_overseas_dryrun.py
@@ -12,6 +12,7 @@ import pytest
 
 from scripts.analyze_overseas_dryrun import (
     build_parser,
+    compute_edge_judgement,
     compute_dryrun_report,
     compute_multiday_report,
     format_markdown_report,
@@ -315,6 +316,54 @@ def test_compute_empty_records():
     assert report["totals"]["win_rate"] is None
 
 
+# ── edge judgement ───────────────────────────────────────────────────────────
+
+def test_compute_edge_judgement_waits_for_min_trading_days():
+    report = compute_dryrun_report([
+        {"code": "AAA", "strategy_label": "VBO", "exchange": "NASD", "trade_date": "20260601",
+         "realized_pct": 1.0, "exit_reason": "eod", "qty": None, "notional_usd": None},
+    ])
+
+    judgement = compute_edge_judgement(report, min_trading_days=5, min_strategy_sample=1)
+
+    assert judgement["overall_decision"] == "WAIT_DATA"
+    assert judgement["trading_days"] == 1
+    assert judgement["strategies"]["VBO"]["status"] == "WAIT_DAYS"
+
+
+def test_compute_edge_judgement_flags_negative_edge_after_sample():
+    records = [
+        {"code": f"A{i}", "strategy_label": "VBO", "exchange": "NASD", "trade_date": f"2026060{i}",
+         "realized_pct": -0.5, "exit_reason": "eod", "qty": None, "notional_usd": None}
+        for i in range(1, 6)
+    ]
+    report = compute_dryrun_report(records)
+
+    judgement = compute_edge_judgement(report, min_trading_days=5, min_strategy_sample=5)
+
+    assert judgement["overall_decision"] == "NO_GO"
+    assert judgement["strategies"]["VBO"]["status"] == "FAIL_NEGATIVE_EDGE"
+    assert judgement["strategies"]["VBO"]["avg_return_pct"] == pytest.approx(-0.5)
+
+
+def test_compute_edge_judgement_uses_multiday_net_returns_for_non_vbo():
+    records = [
+        {"code": f"P{i}", "strategy_label": "PP", "exchange": "NASD", "trade_date": f"2026060{i}",
+         "realized_pct": None, "exit_reason": "", "qty": None, "notional_usd": None}
+        for i in range(1, 6)
+    ]
+    report = compute_dryrun_report(records)
+    report["multiday"] = {
+        "by_strategy": {"PP": {"count": 5, "avg_net_return_pct": 0.8}},
+    }
+
+    judgement = compute_edge_judgement(report, min_trading_days=5, min_strategy_sample=5)
+
+    assert judgement["overall_decision"] == "CANARY_CANDIDATE"
+    assert judgement["strategies"]["PP"]["status"] == "PASS_CANDIDATE"
+    assert judgement["strategies"]["PP"]["avg_return_basis"] == "multiday_net"
+
+
 # ── markdown / main ────────────────────────────────────────────────────────
 
 def test_format_markdown_smoke():
@@ -336,10 +385,33 @@ def test_format_markdown_smoke():
     assert "일봉 기반 would-be 진입가" in md
 
 
+def test_format_markdown_includes_edge_judgement():
+    report = compute_dryrun_report([
+        {"code": f"A{i}", "strategy_label": "VBO", "exchange": "NASD", "trade_date": f"2026060{i}",
+         "realized_pct": -0.5, "exit_reason": "eod", "qty": None, "notional_usd": None}
+        for i in range(1, 6)
+    ])
+    report["edge_judgement"] = compute_edge_judgement(report, min_trading_days=5, min_strategy_sample=5)
+
+    md = format_markdown_report(report)
+
+    assert "엣지 판정" in md
+    assert "NO_GO" in md
+    assert "FAIL_NEGATIVE_EDGE" in md
+
+
 def test_parser_defaults_to_us_online_round_trip_commission():
     args = build_parser().parse_args(["--date-from", "20260601", "--date-to", "20260605"])
 
     assert args.cost_pct == pytest.approx(0.5)
+
+
+def test_parser_enables_edge_judgement_by_default():
+    args = build_parser().parse_args(["--date-from", "20260601", "--date-to", "20260605"])
+
+    assert args.no_edge_judgement is False
+    assert args.min_trading_days == 5
+    assert args.min_strategy_sample == 5
 
 
 # ── multiday 회고 재구성 ─────────────────────────────────────────────────────
@@ -524,3 +596,4 @@ def test_main_writes_json(tmp_path):
     report = json.loads(out_json.read_text(encoding="utf-8"))
     assert report["totals"]["signals"] == 2
     assert report["totals"]["wins"] == 1
+    assert report["edge_judgement"]["overall_decision"] == "WAIT_DATA"

--- a/todo_list.md
+++ b/todo_list.md
@@ -239,6 +239,7 @@
 - [x] `scripts/analyze_overseas_dryrun.py`의 왕복 비용 기본값 0.2%를 미국주식 온라인 기본 수수료 0.25%/side 기준 0.5%로 보정 (2026-07-04). 환전 스프레드·SEC/TAF 등 매도 제비용은 별도이므로 리포트에 `commission_only` 가정으로 명시.
 - [x] 일봉 기반 would-be 진입가의 낙관 편향(장중 실체결가 대비 유리하게 잡힘)을 dry-run Markdown 리포트 `가정/주의` 섹션에 명시.
 - [x] **분석기 다전략 확장 (2026-08-22)**: `scripts/analyze_overseas_dryrun.py --all-sources`가 VBO/PP/BGU/CB/RSI2/OSB shadow source를 함께 읽고, 당일 실현손익이 없는 PP/BGU/CB/RSI2/OSB 신호도 표본에서 누락하지 않는다. JSON/Markdown 리포트와 멀티데이 리포트에 전략별 신호 수·실현 표본·승률/평균 수익률 집계를 추가했다.
+- [x] **성과 판정 자동화 (2026-08-23)**: `scripts/analyze_overseas_dryrun.py`가 기본으로 `edge_judgement`를 생성해 5거래일 미만(`WAIT_DAYS`), 전략별 표본 부족(`WAIT_SAMPLE`), 비용후 평균 수익률 음수/0 이하(`FAIL_NEGATIVE_EDGE`), canary 후보(`PASS_CANDIDATE`)를 분리한다. 전체 판정은 `WAIT_DATA` / `NO_GO` / `CANARY_CANDIDATE`로 JSON·Markdown에 함께 노출한다.
 - [x] **누적 표본 1차 점검 (2026-08-22)**: 20260722~20260821 shadow journal 통합 리포트(`reports/overseas_dryrun_all_sources_20260722_20260821.md`)를 생성했다. 현재 누적분은 VBO 523건뿐이며 PP/BGU/CB source는 아직 0건이다. VBO는 비용후 평균 −1.054%, 멀티데이 재구성 평균 −1.624%로 Phase 5 근거가 없고, PP/BGU/CB는 전략 불가 판정이 아니라 **표본 미축적** 상태다.
 - [x] **RSI2 dry-run 추가 (2026-08-22)**: 돌파류와 다른 평균회귀 축을 보기 위해 해외 RSI2 Pullback dry-run을 suite에 추가했다. 국내 Minervini Stage2는 해외에 같은 데이터 소스가 없어 일봉 `close > 200MA` 장기 상승추세로 대체하고, RSI(2) ≤ 10 종가 신호를 기록한다. 실주문 경로 없음.
 - [x] **OSB dry-run 추가 (2026-08-23)**: 국내 `OneilSqueezeBreakoutStrategy` 중 해외 일봉으로 재현 가능한 스퀴즈 + 20일 고점 돌파 + 거래량 폭증 + 캔들 품질 조건을 suite에 추가했다. 국내 전용 프로그램 순매수·체결강도·마켓타이밍 필터는 신호 metadata의 `excluded_filters`로 명시하고 실주문 경로는 두지 않는다.
@@ -261,7 +262,7 @@
 
 해외 dry-run 이 VBO 단일에서 4전략으로 늘었는데 todo 에는 미등재였다. `O'NeilPP_overseas`(#874) · `O'NeilBGU_overseas`(#875) · `LarryWilliamsCB_overseas`(#877) 를 `OverseasDryRunSuiteService` 가 한 after-market 태스크에서 합성 실행하고, 완료 알림은 전략 라벨(VBO/PP/BGU/CB)별 신호 수·예시 종목을 요약한다(#876). 주문 경로는 없다(dry-run 서비스는 `order_execution` 의존을 갖지 않는다).
 
-- [ ] **전략별 would-be 성과 축적·판정** — 분석 경로는 #878 로 갖춰졌다(`--all-sources`/`DEFAULT_SIGNAL_SOURCES` 로 VBO·PP·BGU·CB 저널을 함께 읽고 `by_strategy` 집계, 당일 실현손익 없는 신호도 표본 유지). 남은 것은 5거래일+ 축적 후 O-3 와 같은 기준(왕복비용 0.5%, 비관·낙관 bracket)으로 전략별 엣지를 판정하는 것뿐이다.
+- [ ] **전략별 would-be 성과 축적·판정** — 분석 경로는 `--all-sources`/`DEFAULT_SIGNAL_SOURCES` 와 `edge_judgement` 로 갖춰졌다(VBO·PP·BGU·CB·RSI2·OSB 저널 집계, 당일 실현손익 없는 신호도 표본 유지). 남은 것은 5거래일+ 실제 표본 축적 후 O-3 와 같은 기준(왕복비용 0.5%, 비관·낙관 bracket)으로 출력된 전략별 판정을 확인하는 것이다.
 - [ ] **일봉 낙관 편향 보정치는 VBO 에서만 실측됐다** — O-3 교차검증의 진입 슬리피지 +0.462%p·낙관 과대 1.138%p 는 VBO 장중 paper(`OverseasIntradayVBOService`) 대조로 얻은 값이고, 신규 3전략에는 장중 paper 경로가 없다(`services/overseas_intraday_*` 는 VBO 뿐). 세 전략의 일봉 dry-run 수치를 실행 기대값으로 그대로 읽지 말 것 — 최소한 VBO 편향폭을 하한 보정으로 얹어 해석한다.
 - ※ Phase 5(실주문 전환) 착수 조건은 불변이다. 전략 수가 는 것은 **후보 확대이지 엣지 입증이 아니다.**
 


### PR DESCRIPTION
## Summary
- add default edge judgement to overseas dry-run analysis reports
- classify strategy readiness as WAIT_DAYS, WAIT_SAMPLE, FAIL_NEGATIVE_EDGE, or PASS_CANDIDATE
- expose overall WAIT_DATA / NO_GO / CANARY_CANDIDATE decisions in JSON and Markdown
- document that only sample accumulation remains for O-4 strategy judgement

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/scripts/test_analyze_overseas_dryrun.py -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -q
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -q