### PR TITLE
Update overseas dry-run edge report

### DIFF
--- a/reports/overseas_dryrun_all_sources_20260722_20260821.json
+++ b/reports/overseas_dryrun_all_sources_20260722_20260821.json
@@ -168,13 +168,21 @@
       "overseas_dryrun",
       "overseas_pp_dryrun",
       "overseas_bgu_dryrun",
-      "overseas_cb_dryrun"
+      "overseas_cb_dryrun",
+      "overseas_rsi2_dryrun",
+      "overseas_osb_dryrun"
     ],
-    "shadow_dir": "logs/strategies/event_shadow",
+    "shadow_dir": "logs\\strategies\\event_shadow",
     "round_trip_cost_pct": 0.5,
     "cost_model": "commission_only",
     "entry_price_assumption": "daily_breakout_target",
-    "ohlcv_dir": "data\\overseas_ohlcv"
+    "ohlcv_dir": "data\\overseas_ohlcv",
+    "edge_judgement": {
+      "enabled": true,
+      "min_trading_days": 5,
+      "min_strategy_sample": 5,
+      "min_avg_return_pct": 0.0
+    }
   },
   "multiday": {
     "reconstructed_count": 188,
@@ -217,6 +225,57 @@
       "trailing_stop_pct": 8.0,
       "time_stop_days": 20,
       "round_trip_cost_pct": 0.5
+    }
+  },
+  "edge_judgement": {
+    "overall_decision": "NO_GO",
+    "trading_days": 22,
+    "min_trading_days": 5,
+    "min_strategy_sample": 5,
+    "min_avg_return_pct": 0.0,
+    "strategies": {
+      "VBO": {
+        "status": "FAIL_NEGATIVE_EDGE",
+        "signals": 523,
+        "sample": 188,
+        "avg_return_pct": -1.6237272458931098,
+        "avg_return_basis": "multiday_net"
+      },
+      "PP": {
+        "status": "NO_SIGNALS",
+        "signals": 0,
+        "sample": 0,
+        "avg_return_pct": null,
+        "avg_return_basis": "same_day_realized"
+      },
+      "BGU": {
+        "status": "NO_SIGNALS",
+        "signals": 0,
+        "sample": 0,
+        "avg_return_pct": null,
+        "avg_return_basis": "same_day_realized"
+      },
+      "CB": {
+        "status": "NO_SIGNALS",
+        "signals": 0,
+        "sample": 0,
+        "avg_return_pct": null,
+        "avg_return_basis": "same_day_realized"
+      },
+      "RSI2": {
+        "status": "NO_SIGNALS",
+        "signals": 0,
+        "sample": 0,
+        "avg_return_pct": null,
+        "avg_return_basis": "same_day_realized"
+      },
+      "OSB": {
+        "status": "NO_SIGNALS",
+        "signals": 0,
+        "sample": 0,
+        "avg_return_pct": null,
+        "avg_return_basis": "same_day_realized"
+      }
     }
   }
 }

--- a/reports/overseas_dryrun_all_sources_20260722_20260821.md
+++ b/reports/overseas_dryrun_all_sources_20260722_20260821.md
@@ -1,11 +1,26 @@
 # Overseas Dry-run Would-be Performance
 
-- date: `20260722 ~ 20260821`  signal_source: `['overseas_dryrun', 'overseas_pp_dryrun', 'overseas_bgu_dryrun', 'overseas_cb_dryrun']`  shadow_dir: `logs/strategies/event_shadow`
+- date: `20260722 ~ 20260821`  signal_source: `['overseas_dryrun', 'overseas_pp_dryrun', 'overseas_bgu_dryrun', 'overseas_cb_dryrun', 'overseas_rsi2_dryrun', 'overseas_osb_dryrun']`  shadow_dir: `logs\strategies\event_shadow`
 
 ## 가정/주의
 
 - 왕복 비용 0.500% (`commission_only`): 미국주식 온라인 기본 수수료 0.25%/side를 왕복으로 반영한 값이며, 환전 스프레드·SEC/TAF 등 매도 제비용은 별도입니다.
 - 일봉 기반 would-be 진입가: 당일 intraday 체결 경로가 아니라 `open + K * prev_range` 목표가 체결을 가정하므로 실제 장중 체결가보다 낙관적일 수 있습니다.
+
+## 엣지 판정
+
+- overall_decision: `NO_GO`
+- trading_days: 22 / 5
+- min_strategy_sample: 5, min_avg_return_pct: 0.000%
+
+| strategy | status | signals | sample | avg_return_pct | basis |
+|---|---|---:|---:|---:|---|
+| VBO | FAIL_NEGATIVE_EDGE | 523 | 188 | -1.624% | multiday_net |
+| PP | NO_SIGNALS | 0 | 0 | — | same_day_realized |
+| BGU | NO_SIGNALS | 0 | 0 | — | same_day_realized |
+| CB | NO_SIGNALS | 0 | 0 | — | same_day_realized |
+| RSI2 | NO_SIGNALS | 0 | 0 | — | same_day_realized |
+| OSB | NO_SIGNALS | 0 | 0 | — | same_day_realized |
 
 ## 전체 집계
 


### PR DESCRIPTION
## Summary
- regenerate the 20260722-20260821 overseas dry-run report with RSI2/OSB sources included
- include the new edge_judgement section in JSON and Markdown outputs
- current result is NO_GO: VBO fails negative-edge check and the other overseas dry-run strategies have no signals in this historical window

## Verification
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe scripts\analyze_overseas_dryrun.py --shadow-dir logs\strategies\event_shadow --date-from 20260722 --date-to 20260821 --all-sources --ohlcv-dir data\overseas_ohlcv --output-json reports\overseas_dryrun_all_sources_20260722_20260821.json --output-markdown reports\overseas_dryrun_all_sources_20260722_20260821.md