### PR TITLE
키움 시세 API 구현 (K-1 Phase 4)

### DIFF
--- a/brokers/kiwoom/kiwoom_client.py
+++ b/brokers/kiwoom/kiwoom_client.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, TYPE_CHECKING
 
+from brokers.kiwoom.kiwoom_quotations_api import KiwoomQuotationsApi
 from common.types import ErrorCode, Exchange, ResCommonResponse
 
 if TYPE_CHECKING:
@@ -17,6 +18,7 @@ class KiwoomApiClient:
         self.market_clock = market_clock
         self._mcs = market_calendar_service
         self._streaming_logger = streaming_logger
+        self._quotations = KiwoomQuotationsApi(env, logger=self._logger, market_clock=market_clock)
 
     def _unsupported(self, feature: str) -> ResCommonResponse:
         return ResCommonResponse(
@@ -26,15 +28,25 @@ class KiwoomApiClient:
         )
 
     async def get_stock_info_by_code(self, stock_code: str, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
-        return self._unsupported("get_stock_info_by_code")
+        return await self._quotations.get_stock_info_by_code(stock_code, exchange=exchange)
 
     async def get_current_price(self, code: str, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
-        return self._unsupported("get_current_price")
+        return await self._quotations.get_current_price(code, exchange=exchange)
 
     async def inquire_daily_itemchartprice(self, stock_code: str, start_date: str, end_date: str,
                                            fid_period_div_code: str = "D",
                                            exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
-        return self._unsupported("inquire_daily_itemchartprice")
+        return await self._quotations.inquire_daily_itemchartprice(
+            stock_code, start_date, end_date,
+            fid_period_div_code=fid_period_div_code, exchange=exchange,
+        )
+
+    async def get_intraday_minutes(self, stock_code: str, tick_scope: str = "1",
+                                   base_date: str = "",
+                                   exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        return await self._quotations.get_intraday_minutes(
+            stock_code, tick_scope=tick_scope, base_date=base_date, exchange=exchange,
+        )
 
     async def get_account_balance(self, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
         return self._unsupported("get_account_balance")

--- a/brokers/kiwoom/kiwoom_params_provider.py
+++ b/brokers/kiwoom/kiwoom_params_provider.py
@@ -1,0 +1,41 @@
+"""키움 REST 시세 API 의 request body 를 조립한다.
+
+종목코드는 거래소별 접미사를 붙인다 — KRX `039490` / NXT `039490_NX` / SOR `039490_AL`
+(공식 스펙 `stk_cd` 필드 설명). 통합(UN)은 키움에 대응 개념이 없어 KRX 로 취급한다.
+"""
+from common.types import Exchange
+
+_EXCHANGE_SUFFIX = {
+    Exchange.KRX: "",
+    Exchange.NXT: "_NX",
+    Exchange.UN: "",
+}
+
+
+def stock_code(code: str, exchange: Exchange = Exchange.KRX) -> str:
+    return f"{code}{_EXCHANGE_SUFFIX.get(exchange, '')}"
+
+
+def stock_info(code: str, exchange: Exchange = Exchange.KRX) -> dict:
+    return {"stk_cd": stock_code(code, exchange)}
+
+
+def daily_chart(code: str, base_date: str, exchange: Exchange = Exchange.KRX,
+                adjusted: bool = True) -> dict:
+    return {
+        "stk_cd": stock_code(code, exchange),
+        "base_dt": base_date,
+        "upd_stkpc_tp": "1" if adjusted else "0",
+    }
+
+
+def minute_chart(code: str, tick_scope: str, base_date: str = "",
+                 exchange: Exchange = Exchange.KRX, adjusted: bool = True) -> dict:
+    body = {
+        "stk_cd": stock_code(code, exchange),
+        "tic_scope": str(tick_scope),
+        "upd_stkpc_tp": "1" if adjusted else "0",
+    }
+    if base_date:
+        body["base_dt"] = base_date
+    return body

--- a/brokers/kiwoom/kiwoom_quotations_api.py
+++ b/brokers/kiwoom/kiwoom_quotations_api.py
@@ -1,0 +1,209 @@
+"""키움 REST 시세 API (Phase 4).
+
+키움 원본 응답을 서비스 계층이 그대로 소비할 수 있도록 공통 도메인 타입
+(`ResStockFullInfoApiOutput` / `ResDailyChartApiItem`)으로 변환한다 — 계획서
+"서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘긴다" 방침.
+
+주의: 키움 시세 값에는 부호 접두가 붙는다(`+70100`, `-69500`). OHLC/현재가는
+절대값으로 정규화하고, 전일대비처럼 부호 자체가 의미인 필드만 원본을 보존한다.
+"""
+from typing import Optional
+
+from pydantic import ValidationError
+
+from brokers.kiwoom.kiwoom_api_base import KiwoomApiBase
+from brokers.kiwoom import kiwoom_params_provider as Params
+from brokers.kiwoom.kiwoom_url_provider import KiwoomApiId, path_for
+from common.types import (
+    ErrorCode,
+    Exchange,
+    ResCommonResponse,
+    ResDailyChartApiItem,
+    ResStockFullInfoApiOutput,
+)
+
+# 공식 스펙 ka10080 `tic_scope` 허용값.
+_TICK_SCOPES = {"1", "3", "5", "10", "15", "30", "45", "60"}
+_PERIOD_CODES = {"D", "W", "M", "Y"}
+
+# 응답 배열 키 (공식 스펙 response.body)
+_DAILY_ROWS_KEY = "stk_dt_pole_chart_qry"
+_MINUTE_ROWS_KEY = "stk_min_pole_chart_qry"
+
+# 키움 ka10001 -> ResStockFullInfoApiOutput. 값은 절대값 정규화 대상.
+_PRICE_FIELDS = {
+    "cur_prc": "stck_prpr",
+    "open_pric": "stck_oprc",
+    "high_pric": "stck_hgpr",
+    "low_pric": "stck_lwpr",
+    "250hgst": "d250_hgpr",
+    "250lwst": "d250_lwpr",
+    "upl_pric": "stck_mxpr",
+    "lst_pric": "stck_llam",
+    "base_pric": "stck_sdpr",
+}
+
+# 부호·문자열을 그대로 옮기는 필드.
+# 종목명(`stk_nm`)·ROE 는 `ResStockFullInfoApiOutput` 에 대응 필드가 없어 매핑하지 않는다.
+# 종목명은 KIS 경로와 마찬가지로 `StockCodeRepository` 가 담당한다. pydantic 이 모르는
+# 키를 조용히 버리므로, 대응 필드 없는 매핑을 넣으면 값이 소리 없이 사라진다.
+_PLAIN_FIELDS = {
+    "pred_pre": "prdy_vrss",
+    "pre_sig": "prdy_vrss_sign",
+    "flu_rt": "prdy_ctrt",
+    "trde_qty": "acml_vol",
+    "mac": "hts_avls",
+    "per": "per",
+    "eps": "eps",
+    "pbr": "pbr",
+    "bps": "bps",
+    "cap": "cpfn",
+    "flo_stk": "lstn_stcn",
+    "for_exh_rt": "hts_frgn_ehrt",
+}
+
+
+# 기본값이 없는 모델 필드 — 키움 응답에 대응 값이 없어도 채워 넣어야 한다.
+_REQUIRED_OUTPUT_FIELDS = tuple(
+    name for name, field in ResStockFullInfoApiOutput.model_fields.items() if field.is_required()
+)
+
+
+def _strip_sign(value) -> str:
+    """`+70100` / `-69500` 같은 부호 접두를 떼고 숫자 문자열만 남긴다."""
+    text = str(value if value is not None else "").strip()
+    if text.startswith(("+", "-")):
+        return text[1:]
+    return text
+
+
+class KiwoomQuotationsApi(KiwoomApiBase):
+    """키움 시세 조회 API."""
+
+    def _to_full_info(self, payload: dict) -> Optional[ResStockFullInfoApiOutput]:
+        mapped = {}
+        for src, dst in _PRICE_FIELDS.items():
+            if payload.get(src) not in (None, ""):
+                mapped[dst] = _strip_sign(payload[src])
+        for src, dst in _PLAIN_FIELDS.items():
+            if payload.get(src) not in (None, ""):
+                mapped[dst] = str(payload[src]).strip()
+
+        if not mapped.get("stck_prpr"):
+            return None
+
+        # 모델 필수 필드는 키움 응답에 없을 수 있다(장 전 기준가 미제공 등).
+        # 빈 문자열로 채워 나머지 매핑이 통째로 버려지지 않게 한다.
+        for required in _REQUIRED_OUTPUT_FIELDS:
+            mapped.setdefault(required, "")
+
+        try:
+            return ResStockFullInfoApiOutput(**mapped)
+        except ValidationError as e:
+            self._logger.error(f"키움 종목 정보 변환 실패: {e}")
+            return None
+
+    async def _call(self, api_id: str, body: dict) -> ResCommonResponse:
+        return await self.call_api("POST", path_for(api_id), api_id=api_id, data=body)
+
+    async def get_stock_info_by_code(self, stock_code: str,
+                                     exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        """종목 기본 정보를 조회한다 (ka10001). data 에 ResStockFullInfoApiOutput."""
+        response = await self._call(KiwoomApiId.STOCK_INFO, Params.stock_info(stock_code, exchange))
+        if response.rt_cd != ErrorCode.SUCCESS.value:
+            return response
+
+        info = self._to_full_info(response.data if isinstance(response.data, dict) else {})
+        if info is None:
+            msg = f"{stock_code} 키움 종목 정보 응답에 현재가가 없습니다."
+            self._logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.PARSING_ERROR.value, msg1=msg, data=None)
+
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="종목 정보 조회 성공", data=info)
+
+    async def get_current_price(self, stock_code: str,
+                                exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        """현재가를 조회한다 (ka10001).
+
+        키움에는 KIS `inquire-price` 에 대응하는 별도 API 가 없어 기본정보로 대신한다.
+        data 형태는 KIS 계약과 같게 `{'output': ResStockFullInfoApiOutput}` 로 맞춘다.
+        """
+        response = await self.get_stock_info_by_code(stock_code, exchange)
+        if response.rt_cd != ErrorCode.SUCCESS.value:
+            return response
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="현재가 조회 성공",
+            data={"output": response.data},
+        )
+
+    def _to_chart_items(self, rows, date_key: str):
+        items = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                items.append(ResDailyChartApiItem(
+                    stck_bsop_date=str(row[date_key]),
+                    stck_oprc=_strip_sign(row.get("open_pric")),
+                    stck_hgpr=_strip_sign(row.get("high_pric")),
+                    stck_lwpr=_strip_sign(row.get("low_pric")),
+                    stck_clpr=_strip_sign(row.get("cur_prc")),
+                    acml_vol=_strip_sign(row.get("trde_qty")),
+                ))
+            except (KeyError, ValidationError) as e:
+                self._logger.warning(f"키움 차트 행 변환 실패(스킵): {e}, row={row}")
+        return items
+
+    def _chart_response(self, response: ResCommonResponse, rows_key: str, date_key: str,
+                        stock_code: str) -> ResCommonResponse:
+        if response.rt_cd != ErrorCode.SUCCESS.value:
+            return ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1=response.msg1, data=[])
+
+        payload = response.data if isinstance(response.data, dict) else {}
+        rows = payload.get(rows_key) or []
+        items = self._to_chart_items(rows, date_key)
+
+        if not items:
+            msg = f"차트 데이터가 비어있음 (stock_code: {stock_code})"
+            self._logger.warning(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.MISSING_KEY.value, msg1=msg, data=[])
+
+        return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=items)
+
+    async def inquire_daily_itemchartprice(self, stock_code: str,
+                                           start_date: str = "",
+                                           end_date: str = "",
+                                           fid_period_div_code: str = "D",
+                                           exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        """일봉 차트를 조회한다 (ka10081).
+
+        키움 일봉은 `base_dt` 기준 과거 방향으로 내려주므로 조회 종료일을 기준일자로 쓴다.
+        주/월/년봉은 별도 api-id 라 Phase 4 범위 밖 — 명시적으로 거절한다.
+        """
+        if fid_period_div_code not in _PERIOD_CODES:
+            msg = f"지원하지 않는 fid_period_div_code: {fid_period_div_code}"
+            self._logger.error(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+        if fid_period_div_code != "D":
+            msg = f"키움 시세 1차 범위는 일봉(D)만 지원합니다: {fid_period_div_code}"
+            self._logger.error(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+
+        body = Params.daily_chart(stock_code, end_date or start_date, exchange)
+        response = await self._call(KiwoomApiId.DAILY_CHART, body)
+        return self._chart_response(response, _DAILY_ROWS_KEY, "dt", stock_code)
+
+    async def get_intraday_minutes(self, stock_code: str, tick_scope: str = "1",
+                                   base_date: str = "",
+                                   exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        """분봉 차트를 조회한다 (ka10080). 일자 대신 체결시간(`cntr_tm`)이 키다."""
+        if str(tick_scope) not in _TICK_SCOPES:
+            msg = f"지원하지 않는 분봉 틱범위: {tick_scope} (허용: {sorted(_TICK_SCOPES, key=int)})"
+            self._logger.error(msg)
+            return ResCommonResponse(rt_cd=ErrorCode.INVALID_INPUT.value, msg1=msg, data=[])
+
+        body = Params.minute_chart(stock_code, tick_scope, base_date, exchange)
+        response = await self._call(KiwoomApiId.MINUTE_CHART, body)
+        return self._chart_response(response, _MINUTE_ROWS_KEY, "cntr_tm", stock_code)

--- a/brokers/kiwoom/kiwoom_url_provider.py
+++ b/brokers/kiwoom/kiwoom_url_provider.py
@@ -1,0 +1,26 @@
+"""키움 REST 시세 API 의 endpoint 경로와 api-id 를 한 곳에 모은다.
+
+출처: 키움 공식 저장소 `Kiwoom-Securities/kiwoom-rest-api` 의
+`kiwoom/_data/kiwoom_api_spec.json`. 차트 계열(일봉/분봉)은 api-id 만 다르고
+경로는 `/api/dostk/chart` 로 같다.
+"""
+
+
+class KiwoomApiId:
+    STOCK_INFO = "ka10001"        # 주식기본정보요청
+    DAILY_CHART = "ka10081"       # 주식일봉차트조회요청
+    MINUTE_CHART = "ka10080"      # 주식분봉차트조회요청
+
+
+_PATHS = {
+    KiwoomApiId.STOCK_INFO: "/api/dostk/stkinfo",
+    KiwoomApiId.DAILY_CHART: "/api/dostk/chart",
+    KiwoomApiId.MINUTE_CHART: "/api/dostk/chart",
+}
+
+
+def path_for(api_id: str) -> str:
+    try:
+        return _PATHS[api_id]
+    except KeyError:
+        raise ValueError(f"경로가 등록되지 않은 키움 api-id: {api_id}")

--- a/tests/unit_test/brokers/kiwoom/test_kiwoom_client_quotations.py
+++ b/tests/unit_test/brokers/kiwoom/test_kiwoom_client_quotations.py
@@ -1,0 +1,77 @@
+"""KiwoomApiClient 가 시세 메서드를 quotations API 로 위임하는지 확인한다.
+
+Phase 4 범위는 시세뿐이므로 계좌·주문은 여전히 "기능 미구현" 을 돌려줘야 한다 —
+골격이 조용히 잘못된 값을 흘리지 않는다는 현재의 안전 속성을 유지하기 위함이다.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+from brokers.kiwoom.kiwoom_client import KiwoomApiClient
+from common.types import ErrorCode, Exchange, ResCommonResponse
+
+
+def _client():
+    env = MagicMock()
+    env.get_base_url.return_value = "https://mockapi.kiwoom.com"
+    env.get_access_token = AsyncMock(return_value="tok")
+    client = KiwoomApiClient(env, logger=MagicMock())
+    client._quotations = MagicMock()
+    return client
+
+
+def _ok(data=None):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=data)
+
+
+class TestQuotationDelegation:
+    async def test_get_current_price_delegates(self):
+        client = _client()
+        client._quotations.get_current_price = AsyncMock(return_value=_ok({"output": "x"}))
+
+        result = await client.get_current_price("005930", exchange=Exchange.NXT)
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        client._quotations.get_current_price.assert_awaited_once_with("005930", exchange=Exchange.NXT)
+
+    async def test_get_stock_info_delegates(self):
+        client = _client()
+        client._quotations.get_stock_info_by_code = AsyncMock(return_value=_ok("info"))
+
+        result = await client.get_stock_info_by_code("005930")
+
+        assert result.data == "info"
+        client._quotations.get_stock_info_by_code.assert_awaited_once_with("005930", exchange=Exchange.KRX)
+
+    async def test_daily_chart_delegates(self):
+        client = _client()
+        client._quotations.inquire_daily_itemchartprice = AsyncMock(return_value=_ok([]))
+
+        await client.inquire_daily_itemchartprice("005930", "20250901", "20250908")
+
+        client._quotations.inquire_daily_itemchartprice.assert_awaited_once_with(
+            "005930", "20250901", "20250908",
+            fid_period_div_code="D", exchange=Exchange.KRX,
+        )
+
+    async def test_minute_chart_delegates(self):
+        client = _client()
+        client._quotations.get_intraday_minutes = AsyncMock(return_value=_ok([]))
+
+        await client.get_intraday_minutes("005930", tick_scope="5")
+
+        client._quotations.get_intraday_minutes.assert_awaited_once_with(
+            "005930", tick_scope="5", base_date="", exchange=Exchange.KRX,
+        )
+
+
+class TestStillUnimplemented:
+    async def test_account_and_order_remain_unsupported(self):
+        client = _client()
+
+        for coro in (
+            client.get_account_balance(),
+            client.place_stock_order("005930", "1000", "1", True),
+            client.cancel_stock_order(),
+        ):
+            result = await coro
+            assert result.rt_cd == ErrorCode.API_ERROR.value
+            assert "기능 미구현" in result.msg1

--- a/tests/unit_test/brokers/kiwoom/test_kiwoom_quotations_api.py
+++ b/tests/unit_test/brokers/kiwoom/test_kiwoom_quotations_api.py
@@ -1,0 +1,248 @@
+"""키움 시세 API (Phase 4) 단위 테스트.
+
+스펙 출처: 키움 공식 저장소 `Kiwoom-Securities/kiwoom-rest-api` 의
+`kiwoom/_data/kiwoom_api_spec.json` — ka10001(주식기본정보) · ka10081(일봉) · ka10080(분봉).
+응답 예시의 필드명·부호 표기(`+600`)를 그대로 fixture 로 쓴다.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from brokers.kiwoom.kiwoom_quotations_api import (
+    _PLAIN_FIELDS,
+    _PRICE_FIELDS,
+    KiwoomQuotationsApi,
+)
+from common.types import (
+    ErrorCode,
+    Exchange,
+    ResCommonResponse,
+    ResStockFullInfoApiOutput,
+)
+
+
+def _make_api(response):
+    env = MagicMock()
+    env.get_base_url.return_value = "https://mockapi.kiwoom.com"
+    env.get_access_token = AsyncMock(return_value="tok")
+
+    api = KiwoomQuotationsApi(env, logger=MagicMock())
+    api.call_api = AsyncMock(return_value=response)
+    return api
+
+
+def _ok(payload):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=payload)
+
+
+# 공식 스펙 response_example 축약본
+_KA10001 = {
+    "stk_cd": "005930",
+    "stk_nm": "삼성전자",
+    "cur_prc": "+70100",
+    "open_pric": "69800",
+    "high_pric": "70500",
+    "low_pric": "-69600",
+    "pred_pre": "+600",
+    "pre_sig": "2",
+    "flu_rt": "+0.86",
+    "trde_qty": "9263135",
+    "mac": "4184000",
+    "per": "13.10",
+    "eps": "5350",
+    "pbr": "1.20",
+    "250hgst": "88800",
+    "250lwst": "49900",
+    "return_code": 0,
+    "return_msg": "정상적으로 처리되었습니다",
+}
+
+_KA10081 = {
+    "stk_cd": "005930",
+    "stk_dt_pole_chart_qry": [
+        {"cur_prc": "70100", "trde_qty": "9263135", "trde_prica": "648525", "dt": "20250908",
+         "open_pric": "69800", "high_pric": "70500", "low_pric": "69600",
+         "pred_pre": "+600", "pred_pre_sig": "2", "trde_tern_rt": "+0.16"},
+        {"cur_prc": "-69500", "trde_qty": "11526724", "trde_prica": "804642", "dt": "20250905",
+         "open_pric": "70300", "high_pric": "70400", "low_pric": "69500",
+         "pred_pre": "-600", "pred_pre_sig": "5", "trde_tern_rt": "+0.19"},
+    ],
+    "return_code": 0,
+}
+
+_KA10080 = {
+    "stk_cd": "005930",
+    "stk_min_pole_chart_qry": [
+        {"cur_prc": "+70100", "trde_qty": "1234", "cntr_tm": "20250908153000",
+         "open_pric": "69800", "high_pric": "70500", "low_pric": "69600",
+         "pred_pre": "+600", "pred_pre_sig": "2"},
+    ],
+    "return_code": 0,
+}
+
+
+class TestGetCurrentPrice:
+    async def test_maps_kiwoom_fields_to_common_output(self):
+        api = _make_api(_ok(_KA10001))
+
+        result = await api.get_current_price("005930")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        output = result.data["output"]
+        # 키움 가격은 부호 접두(+/-)가 붙는다 — 시세는 절대값으로 정규화해야 한다.
+        assert output.stck_prpr == "70100"
+        assert output.stck_lwpr == "69600"
+        assert output.hts_avls == "4184000"
+        # 전일대비는 부호 자체가 의미라 보존한다.
+        assert output.prdy_vrss == "+600"
+        assert output.prdy_ctrt == "+0.86"
+        assert output.acml_vol == "9263135"
+
+    async def test_uses_ka10001_with_plain_code_for_krx(self):
+        api = _make_api(_ok(_KA10001))
+
+        await api.get_current_price("005930", exchange=Exchange.KRX)
+
+        _, kwargs = api.call_api.call_args
+        assert kwargs["api_id"] == "ka10001"
+        assert kwargs["data"]["stk_cd"] == "005930"
+
+    async def test_appends_nxt_suffix_to_stock_code(self):
+        api = _make_api(_ok(_KA10001))
+
+        await api.get_current_price("039490", exchange=Exchange.NXT)
+
+        _, kwargs = api.call_api.call_args
+        assert kwargs["data"]["stk_cd"] == "039490_NX"
+
+    async def test_propagates_business_error(self):
+        api = _make_api(ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="한도초과", data=None))
+
+        result = await api.get_current_price("005930")
+
+        assert result.rt_cd == ErrorCode.API_ERROR.value
+
+    async def test_empty_payload_does_not_raise(self):
+        api = _make_api(_ok({}))
+
+        result = await api.get_current_price("005930")
+
+        # 빈 응답을 0원 시세로 흘려보내면 안 된다.
+        assert result.rt_cd != ErrorCode.SUCCESS.value
+
+
+class TestGetStockInfoByCode:
+    async def test_returns_full_info_model(self):
+        api = _make_api(_ok(_KA10001))
+
+        result = await api.get_stock_info_by_code("005930")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert result.data.stck_oprc == "69800"
+        assert result.data.stck_prpr == "70100"
+        assert result.data.per == "13.10"
+        assert result.data.d250_hgpr == "88800"
+
+
+class TestDailyChart:
+    async def test_maps_daily_rows(self):
+        api = _make_api(_ok(_KA10081))
+
+        result = await api.inquire_daily_itemchartprice("005930", "20250901", "20250908")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert len(result.data) == 2
+        first = result.data[0]
+        assert first.stck_bsop_date == "20250908"
+        assert first.stck_clpr == "70100"
+        assert first.stck_oprc == "69800"
+        assert first.acml_vol == "9263135"
+        # 부호 접두가 붙은 종가도 정규화된다.
+        assert result.data[1].stck_clpr == "69500"
+
+    async def test_sends_required_body_fields(self):
+        api = _make_api(_ok(_KA10081))
+
+        await api.inquire_daily_itemchartprice("005930", "20250901", "20250908")
+
+        _, kwargs = api.call_api.call_args
+        assert kwargs["api_id"] == "ka10081"
+        body = kwargs["data"]
+        assert body["stk_cd"] == "005930"
+        assert body["base_dt"] == "20250908"   # 기준일자는 조회 종료일
+        assert body["upd_stkpc_tp"] == "1"     # 수정주가 적용
+
+    async def test_empty_rows_return_missing_key(self):
+        api = _make_api(_ok({"stk_cd": "005930", "stk_dt_pole_chart_qry": [], "return_code": 0}))
+
+        result = await api.inquire_daily_itemchartprice("005930", "20250901", "20250908")
+
+        assert result.rt_cd == ErrorCode.MISSING_KEY.value
+        assert result.data == []
+
+    async def test_rejects_unsupported_period(self):
+        api = _make_api(_ok(_KA10081))
+
+        result = await api.inquire_daily_itemchartprice("005930", "", "", fid_period_div_code="X")
+
+        assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+        api.call_api.assert_not_awaited()
+
+    async def test_skips_rows_missing_required_fields(self):
+        broken = {"stk_cd": "005930", "return_code": 0, "stk_dt_pole_chart_qry": [
+            {"dt": "20250908", "open_pric": "1", "high_pric": "2", "low_pric": "3", "cur_prc": "4"},
+            {"open_pric": "1"},  # 일자 없음 → 스킵
+        ]}
+        api = _make_api(_ok(broken))
+
+        result = await api.inquire_daily_itemchartprice("005930", "", "20250908")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert len(result.data) == 1
+
+
+class TestMinuteChart:
+    async def test_maps_minute_rows_using_cntr_tm(self):
+        api = _make_api(_ok(_KA10080))
+
+        result = await api.get_intraday_minutes("005930", tick_scope="1")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert len(result.data) == 1
+        assert result.data[0].stck_bsop_date == "20250908153000"
+        assert result.data[0].stck_clpr == "70100"
+
+    async def test_sends_tick_scope(self):
+        api = _make_api(_ok(_KA10080))
+
+        await api.get_intraday_minutes("005930", tick_scope="5")
+
+        _, kwargs = api.call_api.call_args
+        assert kwargs["api_id"] == "ka10080"
+        assert kwargs["data"]["tic_scope"] == "5"
+
+    async def test_rejects_unsupported_tick_scope(self):
+        api = _make_api(_ok(_KA10080))
+
+        result = await api.get_intraday_minutes("005930", tick_scope="7")
+
+        assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+        api.call_api.assert_not_awaited()
+
+
+def test_every_mapping_target_exists_on_the_model():
+    """대응 필드 없는 매핑은 pydantic 이 조용히 버려 값이 소리 없이 사라진다.
+
+    (실제로 `hts_kor_isnm`·`roe` 를 매핑했다가 이 방식으로 유실되는 것을 확인했다.)
+    """
+    targets = {**_PRICE_FIELDS, **_PLAIN_FIELDS}
+    unknown = sorted(
+        f"{src} -> {dst}"
+        for src, dst in targets.items()
+        if dst not in ResStockFullInfoApiOutput.model_fields
+    )
+
+    assert not unknown, (
+        "ResStockFullInfoApiOutput 에 없는 매핑 대상이 있습니다(값이 조용히 유실됨):\n"
+        + "\n".join(unknown)
+    )

--- a/todo_list.md
+++ b/todo_list.md
@@ -385,7 +385,11 @@
 `docs/kiwoom_api_integration_plan.md`(Phase 0~9)와 스켈레톤이 머지됐는데 todo 에는 미등재였다. 현재 머지 범위는 **환경/토큰/HTTP base + wrapper 진입점**뿐이다 — `brokers/kiwoom/{kiwoom_env,kiwoom_token_provider,kiwoom_api_base,kiwoom_client}.py`, `BrokerAPIWrapper(broker="kiwoom")` 분기, `config.yaml.example` 의 `kiwoom.paper/real` 블록, 단위·통합 테스트.
 
 - 현 상태의 안전성: `KiwoomApiClient` 는 시세·계좌·주문 전 메서드가 `ErrorCode.API_ERROR` + "기능 미구현" 을 돌려주는 골격이고, `BrokerBootstrap` 은 `broker=` 를 넘기지 않아 앱 조립 경로에서 키움이 선택되지 않는다. **조용히 잘못된 값이 흐르는 경로는 없다.**
-- [ ] Phase 4~6: 시세·계좌·주문 API 구현. 서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘기고, 키움 전용 기능은 공통 인터페이스에 끼워 넣지 말고 `capabilities`/브로커별 확장으로 분리(계획서 방침).
+- [~] **Phase 4 시세 API 완료 (2026-08-23)**: `kiwoom_quotations_api.py`(+`kiwoom_url_provider`/`kiwoom_params_provider`) 로 현재가·일봉·분봉을 구현하고 `KiwoomApiClient` 에 위임 연결했다. 스펙은 추측하지 않고 **키움 공식 저장소 `Kiwoom-Securities/kiwoom-rest-api` 의 `kiwoom/_data/kiwoom_api_spec.json`(337 API)** 에서 확인했다 — ka10001 `POST /api/dostk/stkinfo` · ka10081/ka10080 `POST /api/dostk/chart`, 응답 배열 키 `stk_dt_pole_chart_qry`/`stk_min_pole_chart_qry`.
+  - 실측 함정 2건: ① 키움 시세 값은 **부호 접두**가 붙는다(`+70100`/`-69500`) — OHLC·현재가는 절대값 정규화, 전일대비는 부호 보존. ② `ResStockFullInfoApiOutput` 에 **없는 키로 매핑하면 pydantic 이 조용히 버린다** — 실제로 `hts_kor_isnm`(종목명)·`roe` 를 매핑했다가 값이 소리 없이 유실되는 것을 확인했고, 매핑 대상이 모델에 실재하는지 검사하는 테스트로 고정했다. 종목명은 KIS 경로와 동일하게 `StockCodeRepository` 담당.
+  - 키움에는 KIS `inquire-price` 대응 API 가 없어 현재가도 ka10001 로 처리하되, data 형태는 KIS 계약(`{'output': ...}`)에 맞췄다. 주/월/년봉은 별도 api-id 라 명시적으로 거절한다(1차 범위는 일봉).
+  - `BrokerBootstrap` 은 여전히 `broker=` 를 넘기지 않아 앱 조립 경로 영향 없음. 계좌·주문은 `_unsupported` 유지(테스트로 고정).
+- [ ] Phase 5~6: 계좌·주문 API 구현. 서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘기고, 키움 전용 기능은 공통 인터페이스에 끼워 넣지 말고 `capabilities`/브로커별 확장으로 분리(계획서 방침).
 - [ ] Phase 7: `KiwoomClient` 완성 + wrapper 연결 → 계획서의 1차 완료 기준(토큰·현재가/일봉/분봉·잔고/예수금·매수/매도 mock 테스트 + 단위·통합 전체 통과) 충족.
 - [ ] 외부 선행 조건(**사용자 액션**): 키움 계좌 · `openapi.kiwoom.com` API 사용신청(실전/모의 키 별도) · 모의투자 신청 · 실전 호출 IP 등록 확인 → `config/config.yaml` 의 `kiwoom.paper/real` 입력. 이게 없으면 Phase 4 이후는 mock 테스트까지만 진행 가능하고 스모크 테스트는 막힌다.
 - [ ] Phase 8~9(2차): WebSocket · 조건검색 등 키움 특화 기능 — 1차 완료 후 재판단.


### PR DESCRIPTION
## 요약

K-1 Phase 4(시세 API). 현재가·일봉·분봉을 구현하고 `KiwoomApiClient` 에 위임 연결한다.
계좌·주문은 Phase 5~6 범위라 `"기능 미구현"` 응답을 그대로 유지한다.

## 스펙 출처 — 추측하지 않았다

공식 문서 도메인(`openapi.kiwoom.com`)은 이 환경의 egress 프록시가 차단해서, 키움 공식 저장소
[`Kiwoom-Securities/kiwoom-rest-api`](https://github.com/Kiwoom-Securities/Kiwoom-REST-API) 의
기계가독 스펙 `kiwoom/_data/kiwoom_api_spec.json`(337 API, HEAD `6964258`)에서 확인했다.

| api-id | 명 | Method | URL | 필수 body | 응답 배열 키 |
|---|---|---|---|---|---|
| ka10001 | 주식기본정보요청 | POST | `/api/dostk/stkinfo` | `stk_cd` | (단일 dict) |
| ka10081 | 주식일봉차트조회 | POST | `/api/dostk/chart` | `stk_cd`,`base_dt`,`upd_stkpc_tp` | `stk_dt_pole_chart_qry` |
| ka10080 | 주식분봉차트조회 | POST | `/api/dostk/chart` | `stk_cd`,`tic_scope`,`upd_stkpc_tp` | `stk_min_pole_chart_qry` |

거래소 접미사도 스펙 그대로다 — KRX `039490` / NXT `039490_NX`.
스펙의 `return_code`/`return_msg`·`api-id` 헤더 규약이 기존 `KiwoomApiBase` 골격과 일치하는 것도 확인했다(base 무수정).

## 구현 중 확인한 함정 2건

**① 키움 시세 값에는 부호 접두가 붙는다** (`+70100`, `-69500`)
OHLC·현재가는 절대값으로 정규화하고, 부호 자체가 의미인 전일대비(`pred_pre`)는 원본을 보존한다.

**② 모델에 없는 키로 매핑하면 pydantic 이 조용히 버린다**
처음에 `stk_nm → hts_kor_isnm`(종목명)과 `roe` 를 매핑했는데, `ResStockFullInfoApiOutput` 에 두 필드가 **없어서** 값이 예외 없이 사라졌다. 매핑을 제거하고, **매핑 대상이 모델에 실재하는지 전수 검사하는 테스트**로 고정했다. 종목명은 KIS 경로와 동일하게 `StockCodeRepository` 담당이다.

이 저장소가 유지해 온 "조용히 잘못된 값이 흐르는 경로는 없다" 속성을 지키기 위한 조치다.

## 설계 메모

- 키움에는 KIS `inquire-price` 에 대응하는 별도 API 가 없어 현재가도 ka10001 로 처리하되, `data` 형태는 KIS 계약(`{'output': ResStockFullInfoApiOutput}`)에 맞춰 서비스 계층 소비 방식을 유지했다.
- 주/월/년봉은 별도 api-id 라 1차 범위 밖 — 명시적으로 `INVALID_INPUT` 으로 거절한다(조용히 일봉을 주지 않는다).
- 필수 모델 필드(`stck_sdpr` 등)가 키움 응답에 없을 수 있어 빈 문자열로 채운다. 단 현재가(`stck_prpr`)가 없으면 매핑 전체를 실패시킨다 — 빈 응답이 0원 시세로 흐르지 않게.
- `BrokerBootstrap` 은 여전히 `broker=` 를 넘기지 않으므로 **앱 조립 경로 영향 없음**(Phase 7 범위).

## 테스트

TDD로 테스트 선작성 → 실패 확인 → 구현. 신규 29건.

- `test_kiwoom_quotations_api.py` — 필드 매핑·부호 정규화·거래소 접미사·빈 응답·에러 전파·행 스킵·매핑 무결성
- `test_kiwoom_client_quotations.py` — 위임 확인 + 계좌/주문 미구현 유지
- `pytest tests/unit_test` — **7970 passed**
- `pytest tests/integration_test` — **283 passed**

## 남은 결정 (사용자)

`todo_list.md` K-1 의 "착수 시 범위를 어디까지 잡을지" 는 아직 열려 있다 — 1차(Phase 4~7)로 끝낼지, 2-4 무틱의 자체 우회로 평가를 위해 Phase 8(WebSocket)까지 갈지. 이번 PR 은 두 경우 모두에 필요한 부분이라 해당 결정과 무관하다.
실계좌 스모크 테스트는 키움 API 키 발급(사용자 액션)이 선행돼야 하므로 mock 테스트까지만 진행했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb)_