### PR TITLE
키움 계좌 API 구현 (K-1 Phase 5)

### DIFF
--- a/brokers/kiwoom/kiwoom_account_api.py
+++ b/brokers/kiwoom/kiwoom_account_api.py
@@ -1,0 +1,137 @@
+"""키움 계좌 API (Phase 5).
+
+kt00018(계좌평가잔고내역) + kt00001(예수금상세현황)을 합쳐 KIS `get_account_balance`
+계약과 같은 `{"output1": [...], "output2": [{...}]}` 형태로 돌려준다. 소비처
+(`order_execution_service`·`fill_reconciliation_service`·`balance.js`)가 KIS 필드명을
+직접 읽으므로 브로커를 바꿔도 그대로 동작해야 한다.
+
+실측 함정 2건 (공식 response_example 기준):
+- 금액·수량이 0 으로 좌측패딩돼 온다(`000000025789890`). 평문 정수로 정규화한다.
+- 종목코드에 `A` 접두가 붙는다(`A005930`). 떼지 않으면 `pdno` 로 종목을 찾지 못한다.
+
+계좌번호는 body 로 넘기지 않는다 — 키움은 토큰(appkey)에 계좌가 묶여 있어
+KIS 처럼 `CANO`/`ACNT_PRDT_CD` 를 실어 보낼 자리가 없다.
+"""
+import re
+
+from brokers.kiwoom.kiwoom_api_base import KiwoomApiBase
+from brokers.kiwoom.kiwoom_url_provider import KiwoomApiId, path_for
+from common.types import ErrorCode, Exchange, ResCommonResponse
+
+_HOLDINGS_KEY = "acnt_evlt_remn_indv_tot"
+
+# 키움 국내거래소구분 (kt00018 `dmst_stex_tp`). 통합(UN)은 대응 개념이 없어 KRX 로 본다.
+_EXCHANGE_CODE = {
+    Exchange.KRX: "KRX",
+    Exchange.NXT: "NXT",
+    Exchange.UN: "KRX",
+}
+
+# 키움 보유종목 -> KIS output1 필드명.
+_HOLDING_FIELDS = {
+    "stk_nm": "prdt_name",
+    "rmnd_qty": "hldg_qty",
+    "trde_able_qty": "ord_psbl_qty",
+    "cur_prc": "prpr",
+    "pur_pric": "pchs_avg_pric",
+    "pur_amt": "pchs_amt",
+    "evlt_amt": "evlu_amt",
+    "evltv_prft": "evlu_pfls_amt",
+    "pred_close_pric": "prdy_prpr",
+}
+
+# 키움 계좌합계 -> KIS output2 필드명.
+_SUMMARY_FIELDS = {
+    "tot_evlt_amt": "tot_evlu_amt",
+    "tot_evlt_pl": "evlu_pfls_smtl_amt",
+    "tot_pur_amt": "pchs_amt_smtl_amt",
+}
+
+_PADDED = re.compile(r"^([+-]?)0*(\d+)$")
+
+
+def _unpad(value) -> str:
+    """`000000025789890` / `-00000000196888` 을 평문 정수 문자열로 바꾼다.
+
+    소수(`-52.71`)나 숫자가 아닌 값은 그대로 둔다.
+    """
+    text = str(value if value is not None else "").strip()
+    match = _PADDED.match(text)
+    if not match:
+        return text
+    sign, digits = match.groups()
+    return f"{sign}{digits.lstrip('0') or '0'}"
+
+
+def _strip_code_prefix(code) -> str:
+    """키움 종목코드의 `A` 접두를 뗀다 (`A005930` -> `005930`)."""
+    text = str(code if code is not None else "").strip()
+    if len(text) > 1 and text[0].isalpha() and text[1:].isdigit():
+        return text[1:]
+    return text
+
+
+class KiwoomAccountApi(KiwoomApiBase):
+    """키움 계좌 조회 API."""
+
+    async def _call(self, api_id: str, body: dict) -> ResCommonResponse:
+        return await self.call_api("POST", path_for(api_id), api_id=api_id, data=body)
+
+    def _to_holdings(self, rows) -> list:
+        holdings = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            code = _strip_code_prefix(row.get("stk_cd"))
+            if not code:
+                self._logger.warning(f"종목코드 없는 잔고 행 스킵: {row}")
+                continue
+
+            mapped = {"pdno": code}
+            for src, dst in _HOLDING_FIELDS.items():
+                if row.get(src) not in (None, ""):
+                    mapped[dst] = _unpad(row[src])
+            # 수익률은 패딩이 없는 소수라 원본을 유지한다.
+            if row.get("prft_rt") not in (None, ""):
+                mapped["evlu_pfls_rt"] = str(row["prft_rt"]).strip()
+            holdings.append(mapped)
+        return holdings
+
+    async def get_account_balance(self, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
+        """보유 종목 + 계좌 합계 + 예수금을 KIS 계약 형태로 반환한다."""
+        balance = await self._call(KiwoomApiId.ACCOUNT_BALANCE, {
+            "qry_tp": "1",  # 1:합산
+            "dmst_stex_tp": _EXCHANGE_CODE.get(exchange, "KRX"),
+        })
+        if balance.rt_cd != ErrorCode.SUCCESS.value:
+            self._logger.warning(f"키움 잔고 조회 실패: {balance.msg1}")
+            return balance
+
+        payload = balance.data if isinstance(balance.data, dict) else {}
+        summary = {
+            dst: _unpad(payload[src])
+            for src, dst in _SUMMARY_FIELDS.items()
+            if payload.get(src) not in (None, "")
+        }
+
+        # 예수금은 별도 API 다. 실패해도 보유 종목 조회는 살린다 — 전량매도 같은
+        # output1 소비 경로가 예수금 장애로 막히지 않게. 다만 모르는 예수금을
+        # 0 으로 채우지는 않는다(키 자체를 넣지 않는다).
+        deposit = await self._call(KiwoomApiId.ACCOUNT_DEPOSIT, {"qry_tp": "2"})  # 2:일반조회
+        if deposit.rt_cd == ErrorCode.SUCCESS.value:
+            cash = deposit.data if isinstance(deposit.data, dict) else {}
+            if cash.get("entr") not in (None, ""):
+                summary["dnca_tot_amt"] = _unpad(cash["entr"])
+            if cash.get("ord_alow_amt") not in (None, ""):
+                summary["ord_psbl_cash"] = _unpad(cash["ord_alow_amt"])
+        else:
+            self._logger.warning(f"키움 예수금 조회 실패(잔고는 유지): {deposit.msg1}")
+
+        return ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={
+                "output1": self._to_holdings(payload.get(_HOLDINGS_KEY) or []),
+                "output2": [summary],
+            },
+        )

--- a/brokers/kiwoom/kiwoom_client.py
+++ b/brokers/kiwoom/kiwoom_client.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, TYPE_CHECKING
 
+from brokers.kiwoom.kiwoom_account_api import KiwoomAccountApi
 from brokers.kiwoom.kiwoom_quotations_api import KiwoomQuotationsApi
 from common.types import ErrorCode, Exchange, ResCommonResponse
 
@@ -19,6 +20,7 @@ class KiwoomApiClient:
         self._mcs = market_calendar_service
         self._streaming_logger = streaming_logger
         self._quotations = KiwoomQuotationsApi(env, logger=self._logger, market_clock=market_clock)
+        self._account = KiwoomAccountApi(env, logger=self._logger, market_clock=market_clock)
 
     def _unsupported(self, feature: str) -> ResCommonResponse:
         return ResCommonResponse(
@@ -49,7 +51,7 @@ class KiwoomApiClient:
         )
 
     async def get_account_balance(self, exchange: Exchange = Exchange.KRX) -> ResCommonResponse:
-        return self._unsupported("get_account_balance")
+        return await self._account.get_account_balance(exchange=exchange)
 
     async def place_stock_order(self, stock_code, order_price, order_qty, is_buy: bool,
                                 exchange: Exchange = Exchange.KRX) -> ResCommonResponse:

--- a/brokers/kiwoom/kiwoom_url_provider.py
+++ b/brokers/kiwoom/kiwoom_url_provider.py
@@ -10,12 +10,16 @@ class KiwoomApiId:
     STOCK_INFO = "ka10001"        # 주식기본정보요청
     DAILY_CHART = "ka10081"       # 주식일봉차트조회요청
     MINUTE_CHART = "ka10080"      # 주식분봉차트조회요청
+    ACCOUNT_BALANCE = "kt00018"   # 계좌평가잔고내역요청
+    ACCOUNT_DEPOSIT = "kt00001"   # 예수금상세현황요청
 
 
 _PATHS = {
     KiwoomApiId.STOCK_INFO: "/api/dostk/stkinfo",
     KiwoomApiId.DAILY_CHART: "/api/dostk/chart",
     KiwoomApiId.MINUTE_CHART: "/api/dostk/chart",
+    KiwoomApiId.ACCOUNT_BALANCE: "/api/dostk/acnt",
+    KiwoomApiId.ACCOUNT_DEPOSIT: "/api/dostk/acnt",
 }
 
 

--- a/tests/unit_test/brokers/kiwoom/test_kiwoom_account_api.py
+++ b/tests/unit_test/brokers/kiwoom/test_kiwoom_account_api.py
@@ -1,0 +1,169 @@
+"""키움 계좌 API (Phase 5) 단위 테스트.
+
+스펙 출처: 키움 공식 저장소 `Kiwoom-Securities/kiwoom-rest-api` 의
+`kiwoom/_data/kiwoom_api_spec.json` — kt00018(계좌평가잔고내역) · kt00001(예수금상세현황).
+fixture 는 공식 response_example 의 표기를 그대로 쓴다(0 좌측패딩 · 종목코드 `A` 접두).
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+from brokers.kiwoom.kiwoom_account_api import KiwoomAccountApi
+from common.types import ErrorCode, Exchange, ResCommonResponse
+
+
+def _make_api(responses):
+    """api_id -> ResCommonResponse 매핑으로 call_api 를 대체한다."""
+    env = MagicMock()
+    env.get_base_url.return_value = "https://mockapi.kiwoom.com"
+    env.get_access_token = AsyncMock(return_value="tok")
+
+    api = KiwoomAccountApi(env, logger=MagicMock())
+
+    async def fake_call(method, path, *, api_id, params=None, data=None):
+        return responses[api_id]
+
+    api.call_api = AsyncMock(side_effect=fake_call)
+    return api
+
+
+def _ok(payload):
+    return ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="정상", data=payload)
+
+
+# 공식 스펙 response_example 축약본 — 0 좌측패딩과 A 접두를 보존한다.
+_KT00018 = {
+    "tot_pur_amt": "000000017598258",
+    "tot_evlt_amt": "000000025789890",
+    "tot_evlt_pl": "000000008138825",
+    "tot_prft_rt": "46.25",
+    "acnt_evlt_remn_indv_tot": [
+        {
+            "stk_cd": "A005930",
+            "stk_nm": "삼성전자",
+            "evltv_prft": "-00000000196888",
+            "prft_rt": "-52.71",
+            "pur_pric": "000000000124500",
+            "rmnd_qty": "000000000000003",
+            "trde_able_qty": "000000000000003",
+            "cur_prc": "000000059000",
+            "pur_amt": "000000000373500",
+            "evlt_amt": "000000000177000",
+        },
+    ],
+    "return_code": 0,
+}
+
+_KT00001 = {
+    "entr": "000000000017534",
+    "ord_alow_amt": "000000000012000",
+    "return_code": 0,
+}
+
+_BOTH = {"kt00018": _ok(_KT00018), "kt00001": _ok(_KT00001)}
+
+
+class TestHoldingsMapping:
+    async def test_maps_holdings_to_kis_output1_contract(self):
+        api = _make_api(_BOTH)
+
+        result = await api.get_account_balance()
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        holdings = result.data["output1"]
+        assert len(holdings) == 1
+        row = holdings[0]
+        # 키움 종목코드는 `A` 접두가 붙는다 — 떼지 않으면 pdno 로 종목을 못 찾는다.
+        assert row["pdno"] == "005930"
+        assert row["prdt_name"] == "삼성전자"
+        # 값은 0 으로 좌측패딩돼 온다 — 평문 정수로 정규화한다.
+        assert row["hldg_qty"] == "3"
+        assert row["prpr"] == "59000"
+        assert row["pchs_avg_pric"] == "124500"
+        assert row["evlu_amt"] == "177000"
+        assert row["ord_psbl_qty"] == "3"
+        # 부호가 붙은 값도 정규화되되 부호는 남는다.
+        assert row["evlu_pfls_amt"] == "-196888"
+        # 수익률은 패딩이 없는 소수라 원본 유지.
+        assert row["evlu_pfls_rt"] == "-52.71"
+
+    async def test_summary_maps_to_kis_output2_contract(self):
+        api = _make_api(_BOTH)
+
+        result = await api.get_account_balance()
+
+        summary = result.data["output2"][0]
+        assert summary["tot_evlu_amt"] == "25789890"
+        assert summary["evlu_pfls_smtl_amt"] == "8138825"
+        assert summary["pchs_amt_smtl_amt"] == "17598258"
+        # 예수금은 kt00001 에서 온다.
+        assert summary["dnca_tot_amt"] == "17534"
+        assert summary["ord_psbl_cash"] == "12000"
+
+    async def test_sends_exchange_and_query_type(self):
+        api = _make_api(_BOTH)
+
+        await api.get_account_balance(exchange=Exchange.NXT)
+
+        calls = {c.kwargs["api_id"]: c.kwargs["data"] for c in api.call_api.call_args_list}
+        assert calls["kt00018"]["dmst_stex_tp"] == "NXT"
+        assert calls["kt00018"]["qry_tp"] == "1"
+        assert calls["kt00001"]["qry_tp"] == "2"
+
+    async def test_krx_is_default_exchange(self):
+        api = _make_api(_BOTH)
+
+        await api.get_account_balance()
+
+        calls = {c.kwargs["api_id"]: c.kwargs["data"] for c in api.call_api.call_args_list}
+        assert calls["kt00018"]["dmst_stex_tp"] == "KRX"
+
+    async def test_empty_holdings_is_success_with_empty_list(self):
+        api = _make_api({
+            "kt00018": _ok({"tot_evlt_amt": "000000000000000", "acnt_evlt_remn_indv_tot": [], "return_code": 0}),
+            "kt00001": _ok(_KT00001),
+        })
+
+        result = await api.get_account_balance()
+
+        # 보유 종목이 없는 것은 오류가 아니다.
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert result.data["output1"] == []
+
+    async def test_skips_rows_without_stock_code(self):
+        api = _make_api({
+            "kt00018": _ok({"acnt_evlt_remn_indv_tot": [{"stk_nm": "이름만"}], "return_code": 0}),
+            "kt00001": _ok(_KT00001),
+        })
+
+        result = await api.get_account_balance()
+
+        assert result.data["output1"] == []
+
+
+class TestFailureHandling:
+    async def test_balance_failure_propagates(self):
+        api = _make_api({
+            "kt00018": ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="권한없음", data=None),
+            "kt00001": _ok(_KT00001),
+        })
+
+        result = await api.get_account_balance()
+
+        assert result.rt_cd == ErrorCode.API_ERROR.value
+
+    async def test_deposit_failure_keeps_holdings_but_omits_cash(self):
+        """예수금 조회가 실패해도 보유 종목 조회는 살린다(전량매도 경로가 막히지 않게).
+
+        단 모르는 예수금을 0 으로 채워 넣지는 않는다 — 키 자체를 넣지 않는다.
+        """
+        api = _make_api({
+            "kt00018": _ok(_KT00018),
+            "kt00001": ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="일시오류", data=None),
+        })
+
+        result = await api.get_account_balance()
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert len(result.data["output1"]) == 1
+        summary = result.data["output2"][0]
+        assert "dnca_tot_amt" not in summary
+        assert summary["tot_evlu_amt"] == "25789890"

--- a/tests/unit_test/brokers/kiwoom/test_kiwoom_client_delegation.py
+++ b/tests/unit_test/brokers/kiwoom/test_kiwoom_client_delegation.py
@@ -1,6 +1,6 @@
-"""KiwoomApiClient 가 시세 메서드를 quotations API 로 위임하는지 확인한다.
+"""KiwoomApiClient 가 시세·계좌 메서드를 각 API 로 위임하는지 확인한다.
 
-Phase 4 범위는 시세뿐이므로 계좌·주문은 여전히 "기능 미구현" 을 돌려줘야 한다 —
+Phase 4~5 범위는 시세·계좌뿐이므로 주문은 여전히 "기능 미구현" 을 돌려줘야 한다 —
 골격이 조용히 잘못된 값을 흘리지 않는다는 현재의 안전 속성을 유지하기 위함이다.
 """
 from unittest.mock import AsyncMock, MagicMock
@@ -15,6 +15,7 @@ def _client():
     env.get_access_token = AsyncMock(return_value="tok")
     client = KiwoomApiClient(env, logger=MagicMock())
     client._quotations = MagicMock()
+    client._account = MagicMock()
     return client
 
 
@@ -63,12 +64,22 @@ class TestQuotationDelegation:
         )
 
 
+class TestAccountDelegation:
+    async def test_get_account_balance_delegates(self):
+        client = _client()
+        client._account.get_account_balance = AsyncMock(return_value=_ok({"output1": []}))
+
+        result = await client.get_account_balance(exchange=Exchange.NXT)
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        client._account.get_account_balance.assert_awaited_once_with(exchange=Exchange.NXT)
+
+
 class TestStillUnimplemented:
-    async def test_account_and_order_remain_unsupported(self):
+    async def test_order_remains_unsupported(self):
         client = _client()
 
         for coro in (
-            client.get_account_balance(),
             client.place_stock_order("005930", "1000", "1", True),
             client.cancel_stock_order(),
         ):

--- a/todo_list.md
+++ b/todo_list.md
@@ -389,7 +389,11 @@
   - 실측 함정 2건: ① 키움 시세 값은 **부호 접두**가 붙는다(`+70100`/`-69500`) — OHLC·현재가는 절대값 정규화, 전일대비는 부호 보존. ② `ResStockFullInfoApiOutput` 에 **없는 키로 매핑하면 pydantic 이 조용히 버린다** — 실제로 `hts_kor_isnm`(종목명)·`roe` 를 매핑했다가 값이 소리 없이 유실되는 것을 확인했고, 매핑 대상이 모델에 실재하는지 검사하는 테스트로 고정했다. 종목명은 KIS 경로와 동일하게 `StockCodeRepository` 담당.
   - 키움에는 KIS `inquire-price` 대응 API 가 없어 현재가도 ka10001 로 처리하되, data 형태는 KIS 계약(`{'output': ...}`)에 맞췄다. 주/월/년봉은 별도 api-id 라 명시적으로 거절한다(1차 범위는 일봉).
   - `BrokerBootstrap` 은 여전히 `broker=` 를 넘기지 않아 앱 조립 경로 영향 없음. 계좌·주문은 `_unsupported` 유지(테스트로 고정).
-- [ ] Phase 5~6: 계좌·주문 API 구현. 서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘기고, 키움 전용 기능은 공통 인터페이스에 끼워 넣지 말고 `capabilities`/브로커별 확장으로 분리(계획서 방침).
+- [~] **Phase 5 계좌 API 완료 (2026-08-23)**: `kiwoom_account_api.py` 가 kt00018(계좌평가잔고내역) + kt00001(예수금상세현황)을 합쳐 KIS `get_account_balance` 계약(`{"output1": [...], "output2": [{...}]}`)으로 변환한다. 소비처(`order_execution_service`·`fill_reconciliation_service`·`balance.js`)가 KIS 필드명을 직접 읽으므로 브로커 교체 시에도 그대로 동작해야 한다.
+  - 실측 함정 2건: ① 금액·수량이 **0 좌측패딩**으로 온다(`000000025789890`, 부호는 앞에 `-00000000196888`) — 평문 정수로 정규화. ② **종목코드에 `A` 접두**가 붙는다(`A005930`) — 떼지 않으면 `pdno` 로 종목을 찾지 못한다.
+  - 예수금은 별도 API 라 실패해도 잔고 조회는 살린다(전량매도 같은 output1 소비 경로가 막히지 않게). 단 모르는 예수금을 0 으로 채우지 않고 **키 자체를 넣지 않는다**. ⚠️ 현재 `balance.js` 가 `summary.dnca_tot_amt || 0` 로 읽어 화면에는 0원으로 보인다 — 예수금 장애를 화면에서 구분하려면 프런트 후속 작업 필요.
+  - 계좌번호는 body 에 없다 — 키움은 토큰(appkey)에 계좌가 묶여 있어 KIS 의 `CANO`/`ACNT_PRDT_CD` 에 해당하는 자리가 없다(계획서 "계좌번호를 KiwoomEnv 에서 공급" 항목은 이 API 들에는 해당 없음).
+- [ ] Phase 6: 주문 API 구현. 서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘기고, 키움 전용 기능은 공통 인터페이스에 끼워 넣지 말고 `capabilities`/브로커별 확장으로 분리(계획서 방침).
 - [ ] Phase 7: `KiwoomClient` 완성 + wrapper 연결 → 계획서의 1차 완료 기준(토큰·현재가/일봉/분봉·잔고/예수금·매수/매도 mock 테스트 + 단위·통합 전체 통과) 충족.
 - [ ] 외부 선행 조건(**사용자 액션**): 키움 계좌 · `openapi.kiwoom.com` API 사용신청(실전/모의 키 별도) · 모의투자 신청 · 실전 호출 IP 등록 확인 → `config/config.yaml` 의 `kiwoom.paper/real` 입력. 이게 없으면 Phase 4 이후는 mock 테스트까지만 진행 가능하고 스모크 테스트는 막힌다.
 - [ ] Phase 8~9(2차): WebSocket · 조건검색 등 키움 특화 기능 — 1차 완료 후 재판단.


### PR DESCRIPTION
## 요약

K-1 Phase 5(계좌 API). `kt00018`(계좌평가잔고내역) + `kt00001`(예수금상세현황)을 합쳐
**KIS `get_account_balance` 계약**(`{"output1": [...], "output2": [{...}]}`)으로 변환한다.

소비처가 KIS 필드명을 직접 읽기 때문에(`order_execution_service` → `pdno`/`hldg_qty`,
`fill_reconciliation_service` → `output1`, `balance.js` → `tot_evlu_amt`/`dnca_tot_amt`/`evlu_pfls_rt`)
브로커를 바꿔도 그대로 동작하도록 매핑 대상을 실제 소비 필드에서 역산했다.

주문은 Phase 6 범위라 `"기능 미구현"` 을 유지한다.

## 스펙 출처

Phase 4와 동일하게 [`Kiwoom-Securities/kiwoom-rest-api`](https://github.com/Kiwoom-Securities/Kiwoom-REST-API) 의 `kiwoom/_data/kiwoom_api_spec.json`.

| api-id | 명 | Method | URL | 필수 body |
|---|---|---|---|---|
| kt00018 | 계좌평가잔고내역요청 | POST | `/api/dostk/acnt` | `qry_tp`(1:합산), `dmst_stex_tp`(KRX/NXT) |
| kt00001 | 예수금상세현황요청 | POST | `/api/dostk/acnt` | `qry_tp`(2:일반조회) |

보유 종목 배열 키는 `acnt_evlt_remn_indv_tot`.

## 공식 response_example 에서 발견한 함정 2건

**① 금액·수량이 0 으로 좌측패딩돼 온다**
`"tot_evlt_amt": "000000025789890"`, 부호는 맨 앞 — `"evltv_prft": "-00000000196888"`.
평문 정수로 정규화한다(`25789890`, `-196888`). 수익률(`-52.71`)처럼 패딩 없는 소수는 원본 유지.

**② 종목코드에 `A` 접두가 붙는다**
`"stk_cd": "A005930"`. 떼지 않으면 `pdno` 로 종목을 찾지 못해 전량매도·대사 경로가 조용히 빈다.

## 설계 판단

- **예수금 실패는 fail-soft.** 예수금은 별도 API 라, 실패해도 보유 종목 조회는 살린다 — 전량매도처럼 `output1` 만 쓰는 경로가 예수금 장애로 막히면 더 나쁘다. 다만 **모르는 예수금을 0 으로 채우지 않고 키 자체를 넣지 않는다.**
- 잔고(kt00018) 자체가 실패하면 그대로 실패를 전파한다.
- **계좌번호를 body 에 넣지 않는다.** 키움은 토큰(appkey)에 계좌가 묶여 있어 KIS 의 `CANO`/`ACNT_PRDT_CD` 에 해당하는 자리가 없다. 계획서의 "계좌번호를 `KiwoomEnv` 에서 공급" 항목은 이 두 API 에는 해당하지 않는다.
- `BrokerBootstrap` 은 여전히 `broker=` 를 넘기지 않으므로 앱 조립 경로 영향 없음.

## 알려진 한계

예수금 조회가 실패하면 `dnca_tot_amt` 키가 빠지는데, `balance.js` 가 `summary.dnca_tot_amt || 0` 로 읽어 **화면에는 0원으로 보인다.** 장애를 화면에서 구분하려면 프런트 후속 작업이 필요하다 — 이번 PR 범위(브로커 계층) 밖이라 `todo_list.md` 에 남겼다.

## 테스트

TDD로 테스트 선작성 → 실패 확인 → 구현. 신규 9건(계좌 8 + 위임 1).

- `test_kiwoom_account_api.py` — 패딩 정규화 · `A` 접두 제거 · 거래소 구분 · 빈 잔고 · 종목코드 없는 행 스킵 · 잔고 실패 전파 · 예수금 fail-soft
- `test_kiwoom_client_delegation.py` — 시세/계좌 위임 + 주문 미구현 유지 (Phase 4 파일에서 이름 변경)
- `pytest tests/unit_test` — **7979 passed**
- `pytest tests/integration_test` — **283 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb)_