### PR TITLE
키움 전 계층 통과 검증 (K-1 Phase 7, 앱 조립 잠금 유지)

### DIFF
--- a/tests/integration_test/brokers/test_it_kiwoom_wrapper_pipeline.py
+++ b/tests/integration_test/brokers/test_it_kiwoom_wrapper_pipeline.py
@@ -1,0 +1,211 @@
+"""키움 전 계층 통과 검증 (K-1 Phase 7).
+
+검증 범위 (httpx 만 mock, 나머지는 실제 객체):
+  BrokerAPIWrapper("kiwoom") → ClientWithCache → ClientWithRetryQueue
+    → KiwoomApiClient → Kiwoom{Quotations,Account,Trading}Api
+      → KiwoomApiBase._execute_request → [MOCK: _async_session.post]
+
+기존 `test_it_kiwoom_broker_api_wrapper.py` 는 클라이언트가 "생성되는지" 만 봤다.
+여기서는 래핑 계층을 실제로 통과해 값이 온전히 돌아오는지, 그리고 주문 경로가
+재시도 큐를 타지 않는지를 본다 — 재시도되면 중복 주문이 난다.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from brokers.broker_api_wrapper import BrokerAPIWrapper
+from common.types import ErrorCode, Exchange
+
+
+def _http_response(payload, status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = {}
+    resp.text = json.dumps(payload, ensure_ascii=False)
+    resp.content = resp.text.encode("utf-8")
+    resp.json = lambda: payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _env():
+    env = MagicMock()
+    env.is_paper_trading = True
+    env.get_base_url.return_value = "https://mockapi.kiwoom.com"
+    env.get_access_token = AsyncMock(return_value="tok")
+    return env
+
+
+@pytest.fixture
+def kiwoom_wrapper():
+    """실제 KiwoomApiClient 를 쓰되 종목 저장소만 mock 한다."""
+    with patch("brokers.broker_api_wrapper.StockCodeRepository"):
+        wrapper = BrokerAPIWrapper(
+            broker="kiwoom",
+            env=_env(),
+            logger=MagicMock(),
+            market_clock=MagicMock(),
+        )
+    yield wrapper
+
+
+def _patch_all_sessions(wrapper, responder):
+    """키움 하위 API 3종의 httpx 세션 post 를 한 번에 갈아끼운다.
+
+    래핑 계층(cache/retry) 너머의 실제 client 를 찾아 들어간다.
+    """
+    client = wrapper._client
+    while not hasattr(client, "_quotations"):
+        client = getattr(client, "_client", None)
+        assert client is not None, "래핑 계층 안에서 KiwoomApiClient 를 찾지 못했다"
+
+    posts = []
+
+    async def fake_post(url, headers=None, json=None, **kwargs):
+        posts.append({"url": url, "api_id": (headers or {}).get("api-id"), "body": json})
+        return responder((headers or {}).get("api-id"))
+
+    for api in (client._quotations, client._account, client._trading):
+        api._async_session.post = AsyncMock(side_effect=fake_post)
+    return posts
+
+
+_KA10001 = {
+    "stk_cd": "005930", "cur_prc": "+70100", "open_pric": "69800",
+    "high_pric": "70500", "low_pric": "-69600", "trde_qty": "9263135",
+    "return_code": 0, "return_msg": "정상",
+}
+_KT00018 = {
+    "tot_evlt_amt": "000000025789890",
+    "acnt_evlt_remn_indv_tot": [
+        {"stk_cd": "A005930", "stk_nm": "삼성전자", "rmnd_qty": "000000000000003",
+         "cur_prc": "000000059000", "pur_pric": "000000000124500", "prft_rt": "-52.71"},
+    ],
+    "return_code": 0,
+}
+_KT00001 = {"entr": "000000000017534", "return_code": 0}
+_KT10000 = {"ord_no": "00024", "return_code": 0}
+
+
+def _default_responder(api_id):
+    return _http_response({
+        "ka10001": _KA10001,
+        "kt00018": _KT00018,
+        "kt00001": _KT00001,
+        "kt10000": _KT10000,
+    }.get(api_id, {"return_code": 0}))
+
+
+class TestQuotationPipeline:
+    async def test_current_price_survives_cache_and_retry_layers(self, kiwoom_wrapper):
+        _patch_all_sessions(kiwoom_wrapper, _default_responder)
+
+        result = await kiwoom_wrapper.get_current_price("005930")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        # 부호 정규화가 래핑 계층을 지나서도 유지돼야 한다.
+        assert result.data["output"].stck_prpr == "70100"
+
+    async def test_minute_chart_reaches_kiwoom_api(self, kiwoom_wrapper):
+        """Phase 4 에서 새로 만든 메서드가 래퍼 프록시를 통과하는지 확인한다."""
+        posts = _patch_all_sessions(kiwoom_wrapper, lambda api_id: _http_response({
+            "stk_min_pole_chart_qry": [
+                {"cntr_tm": "20250908153000", "open_pric": "1", "high_pric": "2",
+                 "low_pric": "3", "cur_prc": "4", "trde_qty": "5"},
+            ],
+            "return_code": 0,
+        }))
+
+        result = await kiwoom_wrapper._client.get_intraday_minutes("005930", tick_scope="5")
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert posts[-1]["api_id"] == "ka10080"
+        assert posts[-1]["body"]["tic_scope"] == "5"
+
+
+class TestAccountPipeline:
+    async def test_balance_merges_two_apis_through_layers(self, kiwoom_wrapper):
+        posts = _patch_all_sessions(kiwoom_wrapper, _default_responder)
+
+        result = await kiwoom_wrapper.get_account_balance()
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        # 잔고 + 예수금 두 API 를 모두 호출한다.
+        assert {p["api_id"] for p in posts} == {"kt00018", "kt00001"}
+        holding = result.data["output1"][0]
+        # A 접두 제거와 패딩 정규화가 계층을 지나 유지된다.
+        assert holding["pdno"] == "005930"
+        assert holding["hldg_qty"] == "3"
+        assert result.data["output2"][0]["dnca_tot_amt"] == "17534"
+
+
+class TestOrderPipeline:
+    async def test_order_reaches_kiwoom_and_returns_order_number(self, kiwoom_wrapper):
+        posts = _patch_all_sessions(kiwoom_wrapper, _default_responder)
+
+        result = await kiwoom_wrapper.place_stock_order("005930", 70000, 1, is_buy=True)
+
+        assert result.rt_cd == ErrorCode.SUCCESS.value
+        assert result.data["output"]["ODNO"] == "00024"
+        assert posts[-1]["api_id"] == "kt10000"
+        assert posts[-1]["body"]["trde_tp"] == "0"
+
+    def test_order_methods_bypass_the_retry_queue(self, kiwoom_wrapper):
+        """주문은 멱등하지 않다 — 재시도 큐를 타면 중복 주문이 난다.
+
+        `_EXCLUDED_METHODS` 는 메서드명 기준이라 키움에도 그대로 적용돼야 한다.
+        호출 횟수만 세면 비즈니스 오류가 애초에 재시도 대상이 아니라 통과해버리므로,
+        래퍼가 큐 경로(`queued`)를 반환하지 않는다는 구조 자체를 본다.
+        """
+        retry_layer = kiwoom_wrapper._client
+        while type(retry_layer).__name__ != "ClientWithRetryQueue":
+            retry_layer = getattr(retry_layer, "_client", None)
+            assert retry_layer is not None, "재시도 계층을 찾지 못했다"
+
+        assert retry_layer.place_stock_order.__name__ != "queued", (
+            "주문이 재시도 큐를 타고 있다 — 중복 주문 위험"
+        )
+        assert retry_layer.cancel_stock_order.__name__ != "queued"
+        # 대조군: 조회는 큐를 타는 것이 정상이다.
+        assert retry_layer.get_current_price.__name__ == "queued"
+
+    async def test_order_failure_is_sent_once(self, kiwoom_wrapper):
+        calls = {"n": 0}
+
+        def failing(api_id):
+            calls["n"] += 1
+            return _http_response({"return_code": 1, "return_msg": "증거금 부족"})
+
+        _patch_all_sessions(kiwoom_wrapper, failing)
+
+        result = await kiwoom_wrapper.place_stock_order("005930", 70000, 1, is_buy=True)
+
+        assert result.rt_cd != ErrorCode.SUCCESS.value
+        assert calls["n"] == 1, f"주문이 {calls['n']}회 전송됐다 — 중복 주문 위험"
+
+    async def test_nxt_market_order_never_reaches_network(self, kiwoom_wrapper):
+        posts = _patch_all_sessions(kiwoom_wrapper, _default_responder)
+
+        result = await kiwoom_wrapper.place_stock_order(
+            "005930", 0, 1, is_buy=True, exchange=Exchange.NXT,
+        )
+
+        assert result.rt_cd == ErrorCode.INVALID_INPUT.value
+        assert posts == []
+
+
+class TestBootstrapLockRemains:
+    def test_broker_bootstrap_does_not_select_kiwoom(self):
+        """Phase 7 은 배선만이고 앱 조립 경로는 여전히 한국투자다.
+
+        실계좌 스모크 검증 전까지 키움이 운영 경로에 들어오면 안 된다.
+        """
+        source = __import__("pathlib").Path("view/web/bootstrap/broker_bootstrap.py").read_text(
+            encoding="utf-8"
+        )
+
+        assert "kiwoom" not in source.lower(), (
+            "BrokerBootstrap 이 키움을 선택하기 시작했다 — 스모크 검증 없이 운영 경로에 "
+            "들어오면 안 된다. 의도한 변경이라면 이 테스트를 함께 갱신할 것."
+        )

--- a/todo_list.md
+++ b/todo_list.md
@@ -398,7 +398,12 @@
   - **주문번호 없는 성공 응답은 성공으로 통과시키지 않는다**(PARSING_ERROR) — 통과시키면 이후 체결 대사가 조용히 빈다.
   - 취소는 스펙대로 `cncl_qty="0"` 이 잔량 전부 취소다. 테스트는 실제 주문을 호출하지 않는다(계획서 Phase 6 검증 기준).
 - [x] **Phase 4~6 완료로 `KiwoomApiClient` 의 REST `_unsupported` 경로는 모두 해소됐다.** WebSocket 계열은 Phase 8 미착수라 여전히 골격이며, "성공한 척하지 않는다"(`connect_websocket`/`subscribe_realtime_price` 가 False 반환)를 테스트로 고정했다 — 무틱을 정상으로 오인하지 않기 위함. 서비스 계층에는 `ResCommonResponse`/공통 도메인 타입으로 변환해 넘기고, 키움 전용 기능은 공통 인터페이스에 끼워 넣지 말고 `capabilities`/브로커별 확장으로 분리(계획서 방침).
-- [ ] Phase 7: `KiwoomClient` 완성 + wrapper 연결 → 계획서의 1차 완료 기준(토큰·현재가/일봉/분봉·잔고/예수금·매수/매도 mock 테스트 + 단위·통합 전체 통과) 충족.
+- [~] **Phase 7 배선 검증 완료 (2026-08-23, 앱 조립 잠금 유지)**: wrapper 분기 자체는 스켈레톤(#866)에 이미 있었으므로 남은 실질 작업은 **전 계층 통과 검증**이었다. `tests/integration_test/brokers/test_it_kiwoom_wrapper_pipeline.py` 가 httpx 만 mock 하고 `BrokerAPIWrapper("kiwoom") → ClientWithCache → ClientWithRetryQueue → KiwoomApiClient → 하위 API → KiwoomApiBase` 를 실제로 통과시킨다(현재가·분봉·잔고+예수금 병합·주문).
+  - **주문이 재시도 큐를 타지 않는다는 것을 구조로 고정했다** — 호출 횟수만 세면 비즈니스 오류가 애초에 재시도 대상이 아니라 통과해버리므로, 래퍼가 큐 경로(`queued`)를 반환하지 않는지를 본다. `place_stock_order` 를 `_EXCLUDED_METHODS` 에서 빼고 돌려 실제로 실패하는 것을 확인했다. 재시도되면 중복 주문이 난다.
+  - `_METHOD_BUDGET_CATEGORIES` 미등록 메서드(`get_intraday_minutes`)는 기본값 `quotation` 으로 떨어져 budget 우회 구멍은 없음을 확인했다.
+  - **`BrokerBootstrap` 잠금 유지** — 여전히 `broker=` 를 넘기지 않아 앱 조립 경로에서 키움이 선택되지 않는다. 이 잠금이 풀리는 것을 테스트로 감시한다(`test_broker_bootstrap_does_not_select_kiwoom`). 실계좌 스모크 검증 전까지 운영 경로에 넣지 않는다.
+  - ⚠️ **1차 완료 선언은 보류한다.** 계획서 완료 기준의 mock 항목은 모두 충족했으나 **실제 키움 서버 응답을 한 번도 보지 못했다** — 전부 공식 스펙 예시 기반이다. 스펙만으로도 함정 4건(부호 접두·0 좌측패딩·종목코드 `A` 접두·매핑 유실)이 나왔으므로 실 응답에서 추가 발견 가능성이 높다. 아래 키 발급 후 스모크가 끝나야 1차 완료다.
+- [ ] ~~Phase 7~~ 1차 완료 판정 (스모크 후)  — 계획서의 1차 완료 기준(토큰·현재가/일봉/분봉·잔고/예수금·매수/매도 mock 테스트 + 단위·통합 전체 통과) 충족.
 - [ ] 외부 선행 조건(**사용자 액션**): 키움 계좌 · `openapi.kiwoom.com` API 사용신청(실전/모의 키 별도) · 모의투자 신청 · 실전 호출 IP 등록 확인 → `config/config.yaml` 의 `kiwoom.paper/real` 입력. 이게 없으면 Phase 4 이후는 mock 테스트까지만 진행 가능하고 스모크 테스트는 막힌다.
 - [ ] Phase 8~9(2차): WebSocket · 조건검색 등 키움 특화 기능 — 1차 완료 후 재판단.
 - ※ 우선순위: 크리티컬 패스는 여전히 **엣지(수익성) 입증**이라 K-1 은 그 아래다. 다만 2-4 무틱(≈55%)이 KIS측 계정·상품군 단위 미전송으로 확정돼 자체 코드로 해소 불가이므로, **키움 실시간이 대체 틱 소스가 되는지**는 2-4 의 유일한 자체 우회로로서 평가 가치가 있다(계획서 2차 범위). 이 각도를 세우려면 Phase 8 까지 가야 하므로 착수 결정 시 범위를 그렇게 잡을지 먼저 정할 것.


### PR DESCRIPTION
## 요약

K-1 Phase 7. **wrapper 분기 자체는 스켈레톤(#866)에 이미 있었으므로** 남은 실질 작업은 배선이 아니라 **전 계층 통과 검증**이었다.

`BrokerBootstrap` 잠금은 유지한다 — 실계좌 스모크 검증 전까지 키움이 운영 경로에 들어오지 않는다.

## 무엇을 검증하나

`httpx` 만 mock 하고 나머지는 실제 객체로 통과시킨다:

```
BrokerAPIWrapper("kiwoom") → ClientWithCache → ClientWithRetryQueue
  → KiwoomApiClient → Kiwoom{Quotations,Account,Trading}Api
    → KiwoomApiBase._execute_request → [MOCK: _async_session.post]
```

기존 `test_it_kiwoom_broker_api_wrapper.py` 는 클라이언트가 **생성되는지** 만 봤다(`KiwoomApiClient` 자체가 mock). 여기서는 래핑 계층을 실제로 통과해 **값이 온전히 돌아오는지** 를 본다 — Phase 4~6 에서 잡은 정규화(부호 접두 제거, `A` 접두 제거, 0 패딩 해제)가 cache/retry 계층 너머에서도 유지되는지.

## 핵심 발견 — 주문 재시도 가드를 구조로 고정

주문은 멱등하지 않아 재시도 큐를 타면 **중복 주문**이 난다. `_EXCLUDED_METHODS` 가 메서드명 기준이라 키움에도 자동 적용되지만, 이걸 **호출 횟수로만 검증하면 약한 테스트**가 된다 — 비즈니스 오류(`return_code: 1`)는 애초에 재시도 대상이 아니라 가드가 없어도 1회로 통과한다.

그래서 래퍼가 큐 경로(`queued`)를 반환하지 않는다는 **구조 자체**를 본다:

```python
assert retry_layer.place_stock_order.__name__ != "queued"
assert retry_layer.get_current_price.__name__ == "queued"   # 대조군
```

**검증**: `place_stock_order` 를 `_EXCLUDED_METHODS` 에서 빼고 돌려 실제로 실패하는 것을 확인한 뒤 복원했다.

## 확인한 것 하나 더

`get_intraday_minutes`(Phase 4 신규)는 `_METHOD_BUDGET_CATEGORIES` 에 없지만, 미등록 메서드는 기본값 `"quotation"` 으로 떨어진다 — **budget 우회 구멍은 없다.**

## 잠금 유지 감시

`test_broker_bootstrap_does_not_select_kiwoom` 이 `broker_bootstrap.py` 에 `kiwoom` 이 등장하는 순간 실패한다. 의도한 변경이라면 테스트를 함께 갱신하게 되므로, 잠금이 조용히 풀리지 않는다.

## ⚠️ 1차 완료는 선언하지 않는다

계획서 완료 기준의 mock 항목(토큰·시세·잔고/예수금·주문·전체 테스트)은 모두 충족했다. 그러나 **실제 키움 서버 응답을 한 번도 보지 못했다** — 전부 공식 스펙 예시 기반이다.

스펙만으로도 함정 4건(부호 접두 · 0 좌측패딩 · 종목코드 `A` 접두 · 매핑 유실)이 나왔으므로 실 응답에서 추가 발견 가능성이 높다. **키움 API 키 발급(사용자 액션) 후 스모크가 끝나야 1차 완료다.**

## 테스트

- `test_it_kiwoom_wrapper_pipeline.py` (신규 8건) — 시세/분봉/잔고 병합/주문 파이프라인 · 주문 재시도 가드 · NXT 시장가 차단 · 조립 잠금 감시
- `pytest tests/unit_test` — **7993 passed**
- `pytest tests/integration_test` — **291 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrzAA5ZC62c4dWCR4fBivb)_