### PR TITLE
feat(web): 미국장 목록의 종목명(심볼) 클릭 시 현재가 화면으로 이동

### DIFF
--- a/tests/frontend/harness.mjs
+++ b/tests/frontend/harness.mjs
@@ -70,6 +70,18 @@ function formatMarketCap(val) {
   return num.toLocaleString() + '억';
 }
 
+/**
+ * 미국장 종목 라벨을 /overseas-stock 링크로 감싼다. innerHtml 은 호출부가 이미 이스케이프한 조각.
+ */
+function overseasStockLink(symbol, innerHtml, exchange) {
+  const ticker = String(symbol ?? '').trim().toUpperCase();
+  if (!ticker) return innerHtml;
+  const market = String(exchange ?? '').trim().toUpperCase();
+  const query = `symbol=${encodeURIComponent(ticker)}`
+    + (market ? `&exchange=${encodeURIComponent(market)}` : '');
+  return `<a href="/overseas-stock?${query}" target="_blank" class="stock-link">${innerHtml}</a>`;
+}
+
 async function readJsonResponse(res) {
   if (!res.ok) return { json: null, error: `HTTP ${res.status}` };
   try {
@@ -91,6 +103,7 @@ export function applyCommonStubs(window) {
   window.formatTradingValue = formatTradingValue;
   window.formatMarketCap = formatMarketCap;
   window.readJsonResponse = readJsonResponse;
+  window.overseasStockLink = overseasStockLink;
   window.showError = (el, message) => { if (el) el.innerHTML = `<p class="error">${escapeHtml(message)}</p>`; };
   window.showLoading = (el, message) => { if (el) el.innerHTML = `<p class="loading">${escapeHtml(message)}</p>`; };
 }

--- a/tests/frontend/run_overseas_dom_tests.mjs
+++ b/tests/frontend/run_overseas_dom_tests.mjs
@@ -871,4 +871,120 @@ test("보정을 적용하면 apply=true 로 부르고 원장을 다시 읽는다
     "보정 후 원장 표가 낡은 채로 남으면 안 됨");
 });
 
+/* ── 종목 클릭 → 미국장 현재가 화면(/overseas-stock) 이동 ── */
+
+function stockLinks(containerId, window) {
+  return Array.from(
+    window.document.getElementById(containerId).querySelectorAll("a.stock-link"),
+  ).map((a) => ({ href: a.getAttribute("href"), text: a.textContent.trim() }));
+}
+
+test("주요 대형주 표의 심볼·종목명이 현재가 화면 링크다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return { ok: true, json: async () => ({
+      rt_cd: "0",
+      data: { fx_rate: 1400, items: [{ symbol: "NVDA", name: "NVIDIA", market_cap_usd: 3e12, market_cap_krw: 4.2e15 }] },
+    }) };
+  };
+
+  await window.loadOverseasMarketCap();
+
+  const links = stockLinks("overseas-marketcap-result", window);
+  assert(links.length === 2, `회귀: 심볼/종목명 셀이 링크가 아님 (${links.length}개)`);
+  assert(links.every((l) => l.href === "/overseas-stock?symbol=NVDA"),
+    `회귀: 현재가 화면 링크가 아님 (${JSON.stringify(links)})`);
+});
+
+test("잔고 표의 심볼·종목명은 조회한 거래소를 붙여 현재가 화면으로 간다", async () => {
+  const window = makeWindow();
+  const orderSel = window.document.getElementById("overseas-order-exchange");
+  orderSel.insertAdjacentHTML("beforeend", '<option value="NYSE">NYSE</option>');
+  orderSel.value = "NYSE";
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return { ok: true, json: async () => ({
+      rt_cd: "0",
+      data: { output1: [{ ovrs_pdno: "BRK", ovrs_item_name: "Berkshire", ovrs_cblc_qty: "2", now_pric2: "500.00" }] },
+    }) };
+  };
+
+  await window.loadOverseasBalance();
+
+  const links = stockLinks("overseas-balance-result", window);
+  assert(links.length === 2, `회귀: 잔고 심볼/종목명 셀이 링크가 아님 (${links.length}개)`);
+  assert(links.every((l) => l.href === "/overseas-stock?symbol=BRK&exchange=NYSE"),
+    `회귀: 잔고 링크에 거래소가 빠짐 (${JSON.stringify(links)})`);
+});
+
+test("즐겨찾기 행의 심볼·종목명은 해당 거래소로 현재가 화면에 간다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    if (url.includes("/api/favorite")) {
+      return { ok: true, json: async () => ([
+        { code: "BRK", name: "Berkshire", exchange: "NYSE", price: 500.0, rate: -0.5 },
+      ]) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+
+  await window.loadOverseasFavorites();
+
+  const links = stockLinks("overseas-favorite-body", window);
+  assert(links.length === 2, `회귀: 즐겨찾기 심볼/종목명 셀이 링크가 아님 (${links.length}개)`);
+  assert(links.every((l) => l.href === "/overseas-stock?symbol=BRK&exchange=NYSE"),
+    `회귀: 즐겨찾기 링크가 거래소를 잃음 (${JSON.stringify(links)})`);
+  // 삭제 버튼은 계속 동작해야 한다 (링크가 행 액션을 가리면 안 됨).
+  assert(window.document.querySelector("#overseas-favorite-body [data-overseas-fav-remove]"),
+    "삭제 버튼이 남아 있어야 함");
+});
+
+test("USD 거래 기록의 심볼은 기록된 거래소로 현재가 화면에 간다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return tradesResponse(SAMPLE_SUMMARY, [tradeRow({ symbol: "BRK", exchange: "NYSE" })]);
+  };
+
+  await window.loadOverseasTrades();
+
+  const links = stockLinks("overseas-trades-result", window);
+  assert(links.length === 1, `회귀: 거래 기록 심볼이 링크가 아님 (${links.length}개)`);
+  assert(links[0].href === "/overseas-stock?symbol=BRK&exchange=NYSE",
+    `회귀: 거래 기록 링크가 잘못됨 (${links[0].href})`);
+});
+
+test("종목명이 HTML 을 담고 있어도 링크 안에서 문자열로만 남는다", async () => {
+  const window = makeWindow();
+  window.fetchWithTimeout = async (url) => {
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return { ok: true, json: async () => ({
+      rt_cd: "0",
+      data: { fx_rate: 1400, items: [{
+        symbol: '"><img src=x onerror="window.__pwned=1">',
+        name: "<script>window.__pwned2=1</script>",
+        market_cap_usd: 1e9, market_cap_krw: 1.4e12,
+      }] },
+    }) };
+  };
+
+  await window.loadOverseasMarketCap();
+  await flush();
+
+  assert(window.__pwned === undefined, "회귀: 심볼이 링크 속성을 탈출해 HTML 로 해석됨");
+  assert(window.__pwned2 === undefined, "회귀: 종목명이 스크립트로 해석됨");
+});
+
 await run();

--- a/tests/frontend/run_overseas_marketcap_dom_tests.mjs
+++ b/tests/frontend/run_overseas_marketcap_dom_tests.mjs
@@ -82,6 +82,22 @@ test("시가총액 행을 순위·심볼·섹터·USD/원화로 렌더한다", a
   assert(text.includes("4,200조"), "회귀: 원화 환산이 조/억 표기로 표시되지 않음");
 });
 
+test("심볼·종목명을 미국장 현재가 화면 링크로 렌더한다", async () => {
+  const window = await makeWindow();
+  window.fetchWithTimeout = async () => okPayload([APPLE]);
+
+  await window.loadOverseasTopMarketCap(30);
+
+  const link = window.document.querySelector("#overseas-marketcap-result a.stock-link");
+  assert(link, "회귀: 종목 셀이 현재가 화면으로 가는 링크가 아님");
+  assert(
+    link.getAttribute("href") === "/overseas-stock?symbol=AAPL",
+    `회귀: 링크가 /overseas-stock 심볼 조회로 가지 않음 (${link.getAttribute("href")})`,
+  );
+  assert(link.textContent.includes("AAPL"), "링크에 심볼이 포함되어야 함");
+  assert(link.textContent.includes("Apple Inc."), "회귀: 종목명이 링크 밖에 남아 클릭되지 않음");
+});
+
 test("서버의 updated_at 을 최신 업데이트 시간으로 표시한다", async () => {
   const window = await makeWindow();
   window.fetchWithTimeout = async () => okPayload([APPLE], 1400, Date.UTC(2026, 6, 31, 13, 5, 30) / 1000);

--- a/tests/frontend/run_overseas_ranking_dom_tests.mjs
+++ b/tests/frontend/run_overseas_ranking_dom_tests.mjs
@@ -80,6 +80,22 @@ test("랭킹 행을 순위·심볼·섹터·등락률·거래량·거래대금�
   assert(text.includes("$2.47B"), "회귀: 거래대금 축약 표기 실패");
 });
 
+test("심볼·종목명을 미국장 현재가 화면 링크로 렌더한다", async () => {
+  const window = await makeWindow();
+  window.fetchWithTimeout = async () => okPayload([APPLE]);
+
+  await window.loadOverseasRanking("rise");
+
+  const link = window.document.querySelector("#overseas-ranking-result a.stock-link");
+  assert(link, "회귀: 종목 셀이 현재가 화면으로 가는 링크가 아님");
+  assert(
+    link.getAttribute("href") === "/overseas-stock?symbol=AAPL",
+    `회귀: 링크가 /overseas-stock 심볼 조회로 가지 않음 (${link.getAttribute("href")})`,
+  );
+  assert(link.textContent.includes("AAPL"), "링크에 심볼이 포함되어야 함");
+  assert(link.textContent.includes("Apple Inc."), "회귀: 종목명이 링크 밖에 남아 클릭되지 않음");
+});
+
 test("카테고리 탭이 요청 경로와 active 클래스에 반영된다", async () => {
   const window = await makeWindow();
   const urls = [];

--- a/tests/frontend/run_overseas_stock_dom_tests.mjs
+++ b/tests/frontend/run_overseas_stock_dom_tests.mjs
@@ -30,9 +30,9 @@ const SCAFFOLD = `
 </div>
 `;
 
-function makeWindow() {
+function makeWindow(search = "") {
   const dom = new JSDOM(`<!DOCTYPE html><html><body>${SCAFFOLD}</body></html>`, {
-    url: "http://localhost/overseas-stock",
+    url: `http://localhost/overseas-stock${search}`,
     runScripts: "dangerously",
   });
   const { window } = dom;
@@ -164,6 +164,86 @@ test("조회 실패 응답은 에러 문구로 보여주고 차트를 그리지 
   const html = window.document.getElementById("overseas-stock-result").innerHTML;
   assert(html.includes("조회할 수 없는 종목입니다."), "실패 메시지가 표시되지 않음");
   assert(window.__chartCalls.length === 0, "조회 실패인데 차트를 그림");
+});
+
+/* ── 목록에서 종목을 클릭해 들어오는 경로(?symbol=...) ── */
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/** 조회 URL 만 관찰하는 창. market-mode 는 항상 enabled 로 답한다. */
+function linkEntryWindow(search, stocks) {
+  const window = makeWindow(search);
+  window.ALL_OVERSEAS_STOCKS = stocks;
+  const urls = [];
+  window.fetchWithTimeout = async (url) => {
+    urls.push(url);
+    if (url.includes("/api/market-mode")) {
+      return { ok: true, json: async () => ({ enabled_market_modes: ["overseas_us"] }) };
+    }
+    return { ok: true, json: async () => quoteResponse() };
+  };
+  return { window, urls };
+}
+
+test("?symbol=&exchange= 로 들어오면 그 거래소로 바로 조회한다", async () => {
+  const { window, urls } = linkEntryWindow("?symbol=brk&exchange=NYSE", null);
+
+  window.initOverseasStockPage();
+  await flush();
+  await flush();
+
+  assert(window.document.getElementById("overseas-stock-symbol").value === "BRK",
+    "심볼 입력이 대문자로 채워져야 함");
+  assert(window.document.getElementById("overseas-stock-exchange").value === "NYSE",
+    "거래소 셀렉트가 쿼리 값으로 맞춰져야 함");
+  assert(urls.some((url) => url.includes("/api/overseas/stock/BRK") && url.includes("exchange=NYSE")),
+    `회귀: 링크의 거래소가 조회에 반영되지 않음 (${JSON.stringify(urls)})`);
+});
+
+test("?symbol= 만 있으면 심볼 목록에서 거래소를 채워 조회한다", async () => {
+  const { window, urls } = linkEntryWindow("?symbol=BRK", [
+    { s: "AAPL", n: "Apple Inc.", e: "NASD" },
+    { s: "BRK", n: "Berkshire", e: "NYSE" },
+  ]);
+
+  window.initOverseasStockPage();
+  await flush();
+  await flush();
+
+  assert(urls.some((url) => url.includes("/api/overseas/stock/BRK") && url.includes("exchange=NYSE")),
+    `회귀: 거래소 없는 링크가 기본값(NASD)으로 조회됨 (${JSON.stringify(urls)})`);
+});
+
+test("심볼 목록이 늦게 도착해도 준비되면 조회한다", async () => {
+  const { window, urls } = linkEntryWindow("?symbol=BRK", null);
+
+  window.initOverseasStockPage();
+  await flush();
+  assert(!urls.some((url) => url.includes("/api/overseas/stock/")),
+    "회귀: 거래소를 모르는 채로 먼저 조회함");
+
+  window.ALL_OVERSEAS_STOCKS = [{ s: "BRK", n: "Berkshire", e: "NYSE" }];
+  window.document.dispatchEvent(new window.CustomEvent("all-overseas-stocks-ready", {
+    detail: window.ALL_OVERSEAS_STOCKS,
+  }));
+  await flush();
+  await flush();
+
+  assert(urls.some((url) => url.includes("/api/overseas/stock/BRK") && url.includes("exchange=NYSE")),
+    `회귀: 목록이 도착해도 조회가 걸리지 않음 (${JSON.stringify(urls)})`);
+});
+
+test("지원하지 않는 거래소 값은 무시하고 기본 거래소로 조회한다", async () => {
+  const { window, urls } = linkEntryWindow("?symbol=AAPL&exchange=TSE", []);
+
+  window.initOverseasStockPage();
+  await flush();
+  await flush();
+
+  assert(window.document.getElementById("overseas-stock-exchange").value === "NASD",
+    "회귀: 셀렉트에 없는 값이 들어가 거래소가 비어버림");
+  assert(urls.some((url) => url.includes("exchange=NASD")),
+    `회귀: 지원하지 않는 거래소가 그대로 조회에 쓰임 (${JSON.stringify(urls)})`);
 });
 
 await run();

--- a/view/web/static/js/common.js
+++ b/view/web/static/js/common.js
@@ -129,6 +129,21 @@ function escapeHtml(value) {
     })[char]);
 }
 
+/**
+ * 미국장 종목 라벨을 현재가 화면(/overseas-stock) 링크로 감싼다.
+ * 국내 목록의 `/stock?code=` 링크와 같은 규약(stock-link, 새 탭)이다.
+ * `innerHtml` 은 호출부에서 이미 이스케이프한 조각이고, 거래소를 모르면 생략한다
+ * (현재가 화면이 심볼 목록에서 채운다).
+ */
+function overseasStockLink(symbol, innerHtml, exchange) {
+    const ticker = String(symbol ?? '').trim().toUpperCase();
+    if (!ticker) return innerHtml;
+    const market = String(exchange ?? '').trim().toUpperCase();
+    const query = `symbol=${encodeURIComponent(ticker)}`
+        + (market ? `&exchange=${encodeURIComponent(market)}` : '');
+    return `<a href="/overseas-stock?${query}" target="_blank" class="stock-link">${innerHtml}</a>`;
+}
+
 function showError(targetEl, message) {
     if (targetEl) targetEl.innerHTML = `<p class="error">${escapeHtml(message)}</p>`;
 }

--- a/view/web/static/js/overseas.js
+++ b/view/web/static/js/overseas.js
@@ -228,8 +228,8 @@ async function loadOverseasMarketCap() {
         const rows = items.map((item, index) => `
             <tr>
                 <td>${index + 1}</td>
-                <td>${escapeHtml(item.symbol || '-')}</td>
-                <td>${escapeHtml(item.name || '-')}</td>
+                <td>${overseasStockLink(item.symbol, escapeHtml(item.symbol || '-'))}</td>
+                <td>${overseasStockLink(item.symbol, escapeHtml(item.name || '-'))}</td>
                 <td>${_formatUsdMarketCap(item.market_cap_usd)}</td>
                 <td>${_formatKrwMarketCap(item.market_cap_krw)}</td>
             </tr>
@@ -272,14 +272,17 @@ async function loadOverseasBalance() {
         }
         const data = json.data || {};
         const rows = Array.isArray(data.output1) ? data.output1 : (Array.isArray(data) ? data : []);
-        const body = rows.map(row => `
-            <tr>
-                <td>${escapeHtml(row.ovrs_pdno || row.pdno || row.symbol || '-')}</td>
-                <td>${escapeHtml(row.ovrs_item_name || row.prdt_name || row.name || '-')}</td>
-                <td>${_formatNumber(row.ovrs_cblc_qty || row.hldg_qty || row.qty)}</td>
-                <td>${_formatUsd(row.now_pric2 || row.price || row.ovrs_now_pric1)}</td>
-            </tr>
-        `).join('');
+        const body = rows.map(row => {
+            const symbol = row.ovrs_pdno || row.pdno || row.symbol || '';
+            return `
+                <tr>
+                    <td>${overseasStockLink(symbol, escapeHtml(symbol || '-'), exchange)}</td>
+                    <td>${overseasStockLink(symbol, escapeHtml(row.ovrs_item_name || row.prdt_name || row.name || '-'), exchange)}</td>
+                    <td>${_formatNumber(row.ovrs_cblc_qty || row.hldg_qty || row.qty)}</td>
+                    <td>${_formatUsd(row.now_pric2 || row.price || row.ovrs_now_pric1)}</td>
+                </tr>
+            `;
+        }).join('');
         resultDiv.innerHTML = `
             <div class="card">
                 <h3>미국주식 잔고 <span style="color:#aaa;font-size:0.85rem;">${escapeHtml(exchange)} USD</span></h3>
@@ -454,7 +457,7 @@ async function loadOverseasTrades() {
             : '';
         const body = trades.map(trade => `
             <tr${String(trade.status) === 'CANCELED' ? ' style="opacity:0.55;"' : ''}>
-                <td>${escapeHtml(trade.symbol || '-')}</td>
+                <td>${overseasStockLink(trade.symbol, escapeHtml(trade.symbol || '-'), trade.exchange)}</td>
                 <td>${escapeHtml(trade.exchange || '-')}</td>
                 <td>${escapeHtml(trade.buy_date || '-')}</td>
                 <td>${_formatUsd(trade.buy_price)}</td>
@@ -701,8 +704,8 @@ function _buildOverseasFavoriteRow(item) {
     const rateStr = Number.isFinite(rate) ? `${rate > 0 ? '+' : ''}${rate.toFixed(2)}%` : '-';
     const symbol = escapeHtml(item.code || '');
     return `<tr>
-        <td style="font-weight:bold;">${symbol}</td>
-        <td>${escapeHtml(item.name || '-')}</td>
+        <td style="font-weight:bold;">${overseasStockLink(item.code, symbol, item.exchange)}</td>
+        <td>${overseasStockLink(item.code, escapeHtml(item.name || '-'), item.exchange)}</td>
         <td>${escapeHtml(item.exchange || '-')}</td>
         <td class="${rateClass}">${_formatUsd(item.price)}</td>
         <td class="${rateClass}">${rateStr}</td>

--- a/view/web/static/js/overseas_autocomplete.js
+++ b/view/web/static/js/overseas_autocomplete.js
@@ -28,7 +28,11 @@ function _ensureOverseasStocksLoaded() {
                 { detail: window.ALL_OVERSEAS_STOCKS },
             ));
         })
-        .catch(() => { window.ALL_OVERSEAS_STOCKS = []; })
+        .catch(() => {
+            // 목록을 기다리는 화면(링크 진입한 현재가 조회)이 영영 멈추지 않도록 실패도 알린다.
+            window.ALL_OVERSEAS_STOCKS = [];
+            document.dispatchEvent(new CustomEvent('all-overseas-stocks-ready', { detail: [] }));
+        })
         .finally(() => { _overseasStocksLoading = false; });
 }
 

--- a/view/web/static/js/overseas_marketcap.js
+++ b/view/web/static/js/overseas_marketcap.js
@@ -71,7 +71,7 @@ function _renderOverseasMarketCap(div, data) {
         return `
             <tr>
                 <td>${escapeHtml(row.rank)}</td>
-                <td><strong>${escapeHtml(row.symbol)}</strong> <span style="color:#888; font-size:0.85rem;">${escapeHtml(row.name)}</span></td>
+                <td>${overseasStockLink(row.symbol, `<strong>${escapeHtml(row.symbol)}</strong> <span style="color:#888; font-size:0.85rem;">${escapeHtml(row.name)}</span>`)}</td>
                 <td>${escapeHtml(row.sector || '-')}</td>
                 <td>${_capUsdPrice(row.price)} <small class="${rate.color}">(${rate.text})</small></td>
                 <td>${_capUsdAmount(row.market_cap_usd)}</td>

--- a/view/web/static/js/overseas_ranking.js
+++ b/view/web/static/js/overseas_ranking.js
@@ -59,7 +59,7 @@ function _renderOverseasRanking(div, data, category) {
         return `
             <tr>
                 <td>${escapeHtml(row.rank)}</td>
-                <td><strong>${escapeHtml(row.symbol)}</strong> <span style="color:#888; font-size:0.85rem;">${escapeHtml(row.name)}</span></td>
+                <td>${overseasStockLink(row.symbol, `<strong>${escapeHtml(row.symbol)}</strong> <span style="color:#888; font-size:0.85rem;">${escapeHtml(row.name)}</span>`)}</td>
                 <td>${escapeHtml(row.sector || '-')}</td>
                 <td>${_rankUsdPrice(row.price)}</td>
                 <td class="${rate.color}">${rate.text}</td>

--- a/view/web/static/js/overseas_stock.js
+++ b/view/web/static/js/overseas_stock.js
@@ -148,15 +148,50 @@ function _initOverseasStockAutocomplete() {
     if (typeof _ensureOverseasStocksLoaded === 'function') _ensureOverseasStocksLoaded();
 }
 
+/** 목록에서 넘어온 링크는 거래소가 빠질 수 있다 — 심볼 목록에서 채운다. */
+function _resolveOverseasStockExchange(symbol) {
+    const stocks = window.ALL_OVERSEAS_STOCKS;
+    if (!Array.isArray(stocks)) return '';
+    const found = stocks.find(stock => String(stock?.s || '').toUpperCase() === symbol);
+    return found ? String(found.e || '').trim().toUpperCase() : '';
+}
+
+/** 셀렉트에 있는 거래소만 반영한다. 없는 값이면 기본값을 그대로 둔다. */
+function _applyOverseasStockExchange(exchange) {
+    const select = document.getElementById('overseas-stock-exchange');
+    if (!select || !exchange) return '';
+    if (!Array.from(select.options).some(option => option.value === exchange)) return '';
+    select.value = exchange;
+    return exchange;
+}
+
+function _searchOverseasStockFromLink(symbol, exchange) {
+    const resolved = _applyOverseasStockExchange(exchange || _resolveOverseasStockExchange(symbol));
+    void searchOverseasStock(symbol, resolved || undefined);
+}
+
 function initOverseasStockPage() {
     _initOverseasStockAutocomplete();
 
-    const symbol = new URLSearchParams(window.location.search).get('symbol');
-    if (symbol) {
-        const input = document.getElementById('overseas-stock-symbol');
-        if (input) input.value = symbol.toUpperCase();
-        void searchOverseasStock(symbol);
+    const params = new URLSearchParams(window.location.search);
+    const symbol = (params.get('symbol') || '').trim().toUpperCase();
+    if (!symbol) return;
+
+    const input = document.getElementById('overseas-stock-symbol');
+    if (input) input.value = symbol;
+
+    const exchange = (params.get('exchange') || '').trim().toUpperCase();
+    if (!exchange && !Array.isArray(window.ALL_OVERSEAS_STOCKS)) {
+        // 거래소를 모르는 링크는 심볼 목록이 와야 판단할 수 있다. 목록 로드는 실패해도
+        // 같은 이벤트로 끝나므로(빈 목록) 조회가 영영 걸리지 않는 일은 없다.
+        document.addEventListener(
+            'all-overseas-stocks-ready',
+            () => _searchOverseasStockFromLink(symbol, ''),
+            { once: true },
+        );
+        return;
     }
+    _searchOverseasStockFromLink(symbol, exchange);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/view/web/templates/base.html
+++ b/view/web/templates/base.html
@@ -48,7 +48,7 @@
     {% block head_scripts %}
     <!-- 차트 라이브러리는 필요한 페이지에서만 로드 -->
     {% endblock %}
-    <script src="/static/js/common.js?v=11"></script>
+    <script src="/static/js/common.js?v=12"></script>
 </head>
 <body data-view-market="{{ view_market|default('common') }}" data-user-role="{{ user_role|default('') }}">
 

--- a/view/web/templates/overseas.html
+++ b/view/web/templates/overseas.html
@@ -155,6 +155,6 @@
 
 {% block scripts %}
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/overseas_autocomplete.js?v=1"></script>
-<script src="/static/js/overseas.js?v=9"></script>
+<script src="/static/js/overseas_autocomplete.js?v=2"></script>
+<script src="/static/js/overseas.js?v=10"></script>
 {% endblock %}

--- a/view/web/templates/overseas_marketcap.html
+++ b/view/web/templates/overseas_marketcap.html
@@ -17,5 +17,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/overseas_marketcap.js?v=2"></script>
+<script src="/static/js/overseas_marketcap.js?v=3"></script>
 {% endblock %}

--- a/view/web/templates/overseas_ranking.html
+++ b/view/web/templates/overseas_ranking.html
@@ -24,5 +24,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/overseas_ranking.js?v=1"></script>
+<script src="/static/js/overseas_ranking.js?v=2"></script>
 {% endblock %}

--- a/view/web/templates/overseas_stock.html
+++ b/view/web/templates/overseas_stock.html
@@ -42,6 +42,6 @@
 {% block scripts %}
 <script src="/static/js/candle_chart.js?v=6"></script>
 <script src="/static/js/autocomplete.js?v=2"></script>
-<script src="/static/js/overseas_autocomplete.js?v=1"></script>
-<script src="/static/js/overseas_stock.js?v=1"></script>
+<script src="/static/js/overseas_autocomplete.js?v=2"></script>
+<script src="/static/js/overseas_stock.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## 배경

국내 목록 화면은 종목명(코드)이 `/stock?code=` 링크라 클릭하면 현재가 화면으로 넘어간다.
미국장 화면들은 심볼·종목명이 평문 `<td>` 라 클릭할 수 없었다.
`/overseas-stock` 전용 현재가 화면은 #885 에서 이미 추가돼 있으므로, 미국장 목록의 종목 셀을 그 화면으로 연결한다.

## 변경 내용

- **`common.js`**: `overseasStockLink(symbol, innerHtml, exchange)` 추가.
  국내 `stock-link` 와 같은 규약(새 탭)으로 `/overseas-stock?symbol=..[&exchange=..]` 앵커를 만든다.
  `innerHtml` 은 호출부가 이미 이스케이프한 조각이고, 심볼이 없으면 원문을 그대로 돌려준다.
- **링크 적용**
  - `/overseas-marketcap` · `/overseas-ranking` 의 심볼·종목명 셀 (S&P500 유니버스에 거래소 정보가 없어 symbol 만 전달)
  - `/overseas` 의 주요 대형주 표, 잔고 표, 즐겨찾기 행, USD 거래 기록 (각각 알고 있는 거래소를 함께 전달)
  - 미체결 주문·체결 대사 표는 주문 단위 기록이라 국내와 동일하게 링크하지 않았다.
- **`overseas_stock.js`**: `?exchange=` 쿼리 수용. 없으면 `ALL_OVERSEAS_STOCKS` 에서 심볼→거래소를 채우고,
  목록이 아직 없으면 `all-overseas-stocks-ready` 를 한 번 기다린 뒤 조회한다.
  셀렉트에 없는 거래소 값은 무시해 기본값을 유지한다.
- **`overseas_autocomplete.js`**: 심볼 목록 로드 실패 시에도 ready 이벤트를 발행해, 위 대기가 풀리지 않는 경우를 없앤다.
- 템플릿 캐시버스터 `?v=` 증가 (`base.html`, `overseas*.html`).

## 테스트

TDD 로 진행했다 — jsdom 회귀 테스트를 먼저 실패시킨 뒤 구현했다.

- 신규 jsdom 회귀 10건
  - 시가총액/랭킹: 심볼·종목명이 한 앵커 안에서 `/overseas-stock?symbol=..` 로 연결되는지
  - 대형주/잔고/즐겨찾기/거래기록: 링크 개수와 거래소 파라미터, 즐겨찾기 삭제 버튼 유지
  - 현재가 화면: `?exchange=` 반영 / 목록에서 거래소 채움 / 목록 지연 도착 / 지원하지 않는 거래소 무시
  - 심볼·종목명이 HTML 을 담아도 링크 속성을 탈출하지 못하는지
- `pytest tests/unit_test -q` → **7993 passed**
- `pytest tests/integration_test -q` → **291 passed** (jsdom 회귀 스위트 17개 포함)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3gYp17eEWxua1bJHMCHUp)_