### PR TITLE
test: 커버리지 70% 미만 6개 파일 단위 TC 보강

### DIFF
--- a/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
+++ b/tests/unit_test/services/test_gemini_youtube_video_analyzer_service.py
@@ -1,5 +1,7 @@
 """Gemini YouTube URL fallback 분석 서비스 단위 테스트."""
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from common.types import ErrorCode
 from services.gemini_youtube_video_analyzer_service import (
@@ -112,3 +114,120 @@ async def test_build_digest_keeps_going_when_one_video_fails():
     assert result.data["video_count"] == 1
     assert result.data["failed_summary_count"] == 1
     assert result.data["videos"][0]["video_id"] == "v2"
+
+
+async def test_build_digest_fails_when_api_key_missing():
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="", http_client=AsyncMock())
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    assert result.data is None
+
+
+async def test_build_digest_fails_when_api_key_has_non_ascii_characters():
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="키-한글", http_client=AsyncMock())
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+async def test_build_digest_reports_empty_when_video_list_is_none():
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=AsyncMock())
+
+    result = await svc.build_digest(None, report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.EMPTY_VALUES.value
+
+
+async def test_summarize_url_uses_own_http_client_when_none_injected(monkeypatch):
+    posted = {}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            posted["init"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers=None, json=None, timeout=None):
+            posted["url"] = url
+            posted["headers"] = headers
+            return _Response({"output_text": "자체 클라이언트 요약"})
+
+    monkeypatch.setattr(
+        "services.gemini_youtube_video_analyzer_service.httpx.AsyncClient", FakeClient
+    )
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key")
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["videos"][0]["summary"] == "자체 클라이언트 요약"
+    assert posted["url"].endswith("/v1beta/interactions")
+    assert posted["headers"]["x-goog-api-key"] == "test-key"
+
+
+async def test_build_digest_falls_back_to_step_texts_when_output_text_missing():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({
+        "steps": [
+            {"content": [{"text": " 첫 문단 "}, {"text": ""}, {"no_text": 1}]},
+            {"content": "리스트 아님"},
+            "스텝 아님",
+            {"content": [{"text": "둘째 문단"}]},
+        ]
+    }))
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=http)
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.SUCCESS.value
+    assert result.data["videos"][0]["summary"] == "첫 문단\n둘째 문단"
+
+
+async def test_build_digest_fails_when_response_body_is_empty():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({"output_text": "   "}))
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=http)
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+async def test_build_digest_fails_on_http_error_status():
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_Response({}, status_code=500))
+    svc = GeminiYoutubeVideoAnalyzerService(api_key="test-key", http_client=http)
+
+    result = await svc.build_digest([_video()], report_date="20260810")
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+
+
+@pytest.mark.parametrize("steps", ["문자열", None, {}, 3])
+def test_extract_text_from_steps_returns_empty_for_non_list(steps):
+    assert GeminiYoutubeVideoAnalyzerService._extract_text_from_steps(steps) == ""
+
+
+def test_parse_response_returns_empty_string_summary_for_non_dict_payload():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value=["not", "a", "dict"])
+
+    with pytest.raises(ValueError):
+        GeminiYoutubeVideoAnalyzerService._parse_response(response)
+
+
+def test_format_digest_text_uses_fallback_labels():
+    text = GeminiYoutubeVideoAnalyzerService._format_digest_text([
+        {"video_id": "v9", "summary": "요약"},
+    ])
+
+    assert "[채널] v9" in text
+    assert text.endswith("요약")

--- a/tests/unit_test/services/test_market_cap_gap_service.py
+++ b/tests/unit_test/services/test_market_cap_gap_service.py
@@ -1,7 +1,10 @@
+import sys
+from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 import sqlite3
 
+import pandas as pd
 import pytest
 
 from common.types import ErrorCode, ResCommonResponse
@@ -458,3 +461,537 @@ async def test_fetch_snapshots_empty_symbols_makes_no_request(monkeypatch):
 
     assert await YahooUsMarketCapProvider().fetch_snapshots([]) == []
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# PykrxKoreanMarketCapProvider — 로컬 DB / pykrx fallback 경로
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_returns_empty_for_empty_codes(tmp_path):
+    provider = PykrxKoreanMarketCapProvider(db_path=tmp_path / "missing.db")
+
+    assert await provider.fetch_market_caps([], "20260625") == {}
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_skips_local_db_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "pykrx", None)
+    provider = PykrxKoreanMarketCapProvider(
+        db_path=tmp_path / "missing.db", logger=MagicMock()
+    )
+
+    caps = await provider.fetch_market_caps(["005930"], "20260625")
+
+    assert caps == {}
+    provider._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_logs_when_local_db_query_fails(tmp_path, monkeypatch):
+    db_path = tmp_path / "stocks.db"
+    sqlite3.connect(db_path).close()  # daily_prices 테이블이 없는 DB
+    monkeypatch.setitem(sys.modules, "pykrx", None)
+    provider = PykrxKoreanMarketCapProvider(db_path=db_path, logger=MagicMock())
+
+    caps = await provider.fetch_market_caps(["005930"], "20260625")
+
+    assert caps == {}
+    assert provider._logger.warning.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_skips_invalid_and_nonpositive_caps(tmp_path, monkeypatch):
+    db_path = tmp_path / "stocks.db"
+    con = sqlite3.connect(db_path)
+    con.execute("CREATE TABLE daily_prices (code TEXT, trade_date TEXT, market_cap INTEGER)")
+    con.executemany(
+        "INSERT INTO daily_prices VALUES (?, ?, ?)",
+        [
+            ("005930", "20260625", "not-a-number"),
+            ("035420", "20260625", 0.5),
+            ("000660", "20260625", 5_000_000_000_000),
+        ],
+    )
+    con.commit()
+    con.close()
+    monkeypatch.setitem(sys.modules, "pykrx", None)
+    provider = PykrxKoreanMarketCapProvider(db_path=db_path, logger=MagicMock())
+
+    caps = await provider.fetch_market_caps(["005930", "035420", "000660"], "20260625")
+
+    # 억 단위 미만이 아니므로 그대로 사용하고, 파싱 실패/0 이하 종목은 제외한다.
+    assert caps == {"000660": 5_000_000_000_000}
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_reads_market_cap_from_pykrx(tmp_path, monkeypatch):
+    frames = {
+        "20260625": pd.DataFrame({"시가총액": [480_000_000_000_000]}, index=["005930"]),
+    }
+    calls = []
+
+    def _fake_get_market_cap_by_ticker(date, market="ALL"):
+        calls.append(date)
+        if date == "20260626":
+            raise RuntimeError("pykrx down")
+        if date not in frames:
+            return pd.DataFrame()
+        return frames[date]
+
+    monkeypatch.setattr(
+        "pykrx.stock.get_market_cap_by_ticker", _fake_get_market_cap_by_ticker, raising=False
+    )
+    provider = PykrxKoreanMarketCapProvider(
+        db_path=tmp_path / "missing.db", lookback_days=3, logger=MagicMock()
+    )
+
+    caps = await provider.fetch_market_caps(["005930"], "20260626")
+
+    assert caps == {"005930": 480_000_000_000_000}
+    assert calls[0] == "20260626"
+    provider._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_skips_unparsable_pykrx_rows(tmp_path, monkeypatch):
+    df = pd.DataFrame({"시가총액": ["bad", 0]}, index=["005930", "000660"])
+    monkeypatch.setattr(
+        "pykrx.stock.get_market_cap_by_ticker",
+        lambda date, market="ALL": df,
+        raising=False,
+    )
+    provider = PykrxKoreanMarketCapProvider(
+        db_path=tmp_path / "missing.db", lookback_days=0, logger=MagicMock()
+    )
+
+    # 035420 은 pykrx 결과에 아예 없는 종목이다.
+    assert await provider.fetch_market_caps(["005930", "000660", "035420"], "20260625") == {}
+
+
+@pytest.mark.asyncio
+async def test_korean_fallback_provider_falls_back_to_today_for_invalid_report_date(
+    tmp_path, monkeypatch
+):
+    seen = []
+
+    def _fake(date, market="ALL"):
+        seen.append(date)
+        return pd.DataFrame()
+
+    monkeypatch.setattr("pykrx.stock.get_market_cap_by_ticker", _fake, raising=False)
+    provider = PykrxKoreanMarketCapProvider(
+        db_path=tmp_path / "missing.db", lookback_days=0, logger=MagicMock()
+    )
+
+    assert await provider.fetch_market_caps(["005930"], "not-a-date") == {}
+    assert seen == [datetime.now().strftime("%Y%m%d")]
+
+
+# ---------------------------------------------------------------------------
+# YahooUsMarketCapProvider — 크럼/차트/환율 경로
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status={self.status_code}")
+
+
+def _client_factory(handler):
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            return handler(url, params or {})
+
+    return FakeClient
+
+
+@pytest.mark.asyncio
+async def test_fetch_quotes_returns_empty_when_request_fails(monkeypatch):
+    def _handler(url, params):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_quotes(["NVDA"]) == []
+    provider._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_quotes_skips_rows_without_symbol_or_market_cap(monkeypatch):
+    rows = [
+        "문자열 행",
+        {"symbol": "", "marketCap": 100},
+        {"symbol": "MU", "marketCap": 0},
+        {"symbol": "AAPL", "marketCap": "invalid"},
+        {"symbol": "NVDA", "longName": "NVIDIA Corp", "marketCap": 3_000_000_000_000},
+    ]
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient",
+        _client_factory(lambda url, params: _FakeResponse(
+            payload={"quoteResponse": {"result": rows}}
+        )),
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    quotes = await provider.fetch_quotes(["NVDA", "MU", "AAPL"])
+
+    assert [quote.symbol for quote in quotes] == ["NVDA"]
+    assert quotes[0].name == "NVIDIA Corp"
+    assert quotes[0].currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_fetch_raw_returns_empty_when_result_is_not_a_list(monkeypatch):
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient",
+        _client_factory(lambda url, params: _FakeResponse(
+            payload={"quoteResponse": {"result": {"symbol": "NVDA"}}}
+        )),
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_quotes(["NVDA"]) == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_quotes_gives_up_when_crumb_request_raises(monkeypatch):
+    def _handler(url, params):
+        if "fc.yahoo.com" in url:
+            raise RuntimeError("cookie blocked")
+        return _FakeResponse(401)
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_quotes(["NVDA"]) == []
+    assert provider._logger.warning.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_quotes_gives_up_when_crumb_endpoint_returns_error(monkeypatch):
+    def _handler(url, params):
+        if "getcrumb" in url:
+            return _FakeResponse(500)
+        if "fc.yahoo.com" in url:
+            return _FakeResponse(200)
+        return _FakeResponse(403)
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_quotes(["NVDA"]) == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_quotes_gives_up_when_crumb_body_is_blank(monkeypatch):
+    def _handler(url, params):
+        if "getcrumb" in url:
+            return _FakeResponse(200, text="   ")
+        if "fc.yahoo.com" in url:
+            return _FakeResponse(200)
+        return _FakeResponse(401)
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_quotes(["NVDA"]) == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_usdkrw_reads_first_positive_rate(monkeypatch):
+    rows = ["문자열 행", {"regularMarketPrice": "invalid"}, {"bid": 0}, {"bid": 1380.5}]
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient",
+        _client_factory(lambda url, params: _FakeResponse(
+            payload={"quoteResponse": {"result": rows}}
+        )),
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_usdkrw() == 1380.5
+
+
+@pytest.mark.asyncio
+async def test_fetch_usdkrw_falls_back_to_chart_price_when_quote_fails(monkeypatch):
+    def _handler(url, params):
+        if "v8/finance/chart" in url:
+            return _FakeResponse(payload={
+                "chart": {"result": [{"meta": {"regularMarketPrice": 1375.0}}]}
+            })
+        raise RuntimeError("quote blocked")
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_usdkrw() == 1375.0
+    provider._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_usdkrw_falls_back_to_chart_price_when_quote_rows_are_empty(monkeypatch):
+    def _handler(url, params):
+        if "v8/finance/chart" in url:
+            return _FakeResponse(payload={
+                "chart": {"result": [{"meta": {"previousClose": 1370.0}}]}
+            })
+        return _FakeResponse(payload={"quoteResponse": {"result": []}})
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider.fetch_usdkrw() == 1370.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chart_payload",
+    [
+        {"chart": {"result": []}},
+        {"chart": {"result": [{"meta": {"regularMarketPrice": "invalid"}}]}},
+        {"chart": {"result": [{"meta": {"regularMarketPrice": 0}}]}},
+        {"chart": {"result": [{}]}},
+    ],
+)
+async def test_fetch_chart_price_returns_none_for_unusable_payloads(monkeypatch, chart_payload):
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient",
+        _client_factory(lambda url, params: _FakeResponse(payload=chart_payload)),
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider._fetch_chart_price("KRW=X") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_chart_price_returns_none_when_request_fails(monkeypatch):
+    def _handler(url, params):
+        raise RuntimeError("chart blocked")
+
+    monkeypatch.setattr(
+        "services.market_cap_gap_service.httpx.AsyncClient", _client_factory(_handler)
+    )
+    provider = YahooUsMarketCapProvider(logger=MagicMock())
+
+    assert await provider._fetch_chart_price("KRW=X") is None
+    provider._logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "문자열 행",
+        {"regularMarketPrice": 10.0},
+        {"symbol": "AAPL", "regularMarketPrice": "invalid"},
+        {"symbol": "AAPL", "regularMarketPrice": 0},
+    ],
+)
+def test_to_snapshot_returns_none_for_unusable_rows(row):
+    assert YahooUsMarketCapProvider._to_snapshot(row) is None
+
+
+def test_to_snapshot_defaults_unparsable_numbers():
+    snapshot = YahooUsMarketCapProvider._to_snapshot({
+        "symbol": "aapl",
+        "regularMarketPrice": 189.5,
+        "regularMarketChangePercent": "invalid",
+        "regularMarketVolume": "invalid",
+        "marketCap": "invalid",
+    })
+
+    assert snapshot.symbol == "AAPL"
+    assert snapshot.name == "AAPL"
+    assert snapshot.change_rate == 0.0
+    assert snapshot.volume == 0
+    assert snapshot.market_cap == 0
+
+
+# ---------------------------------------------------------------------------
+# MarketCapGapService — 국내 시총/ADR/비교 경로
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_korean_caps_use_fallback_when_broker_raises_or_returns_bad_values():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(side_effect=[
+        RuntimeError("broker down"),
+        _domestic_response("not-a-number"),
+    ])
+    korean_provider = SimpleNamespace()
+    korean_provider.fetch_market_caps = AsyncMock(return_value={"005930": 480_000_000_000_000})
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=None),
+        korean_provider=korean_provider,
+        logger=MagicMock(),
+    )
+
+    items = await service._fetch_korean_caps("20260625")
+
+    assert [item["symbol"] for item in items] == ["005930"]
+    korean_provider.fetch_market_caps.assert_awaited_once_with(["005930", "000660"], "20260625")
+    service._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_korean_caps_drop_nonpositive_broker_values():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(return_value=_domestic_response(0))
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=None),
+        korean_provider=None,
+        logger=MagicMock(),
+    )
+
+    assert await service._fetch_korean_caps("20260625") == []
+
+
+@pytest.mark.asyncio
+async def test_korean_caps_ignore_nonpositive_fallback_values():
+    broker = SimpleNamespace()
+    broker.get_market_cap = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="fail", data=None
+    ))
+    korean_provider = SimpleNamespace()
+    korean_provider.fetch_market_caps = AsyncMock(return_value={"005930": 0, "000660": None})
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=None),
+        korean_provider=korean_provider,
+        logger=MagicMock(),
+    )
+
+    assert await service._fetch_korean_caps("20260625") == []
+
+
+def test_read_price_skips_unparsable_and_nonpositive_values():
+    assert MarketCapGapService._read_price({"a": "bad", "b": 0, "c": "1500"}, "a", "b", "c") == 1500.0
+    assert MarketCapGapService._read_price({"a": "bad"}, "a", "missing") == 0.0
+    assert MarketCapGapService._read_price(SimpleNamespace(price=None), "price") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_adr_gap_is_none_without_fx_rate():
+    service = MarketCapGapService(
+        broker=SimpleNamespace(),
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=None),
+        korean_provider=None,
+    )
+
+    assert await service._build_adr_gap(None) is None
+
+
+@pytest.mark.asyncio
+async def test_adr_gap_is_none_when_domestic_price_lookup_raises():
+    broker = SimpleNamespace()
+    broker.get_current_price = AsyncMock(side_effect=RuntimeError("broker down"))
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=1380.0),
+        korean_provider=None,
+        logger=MagicMock(),
+    )
+
+    assert await service._build_adr_gap(1380.0) is None
+    service._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_adr_gap_is_none_when_domestic_price_is_zero():
+    broker = SimpleNamespace()
+    broker.get_current_price = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"output": {"stck_prpr": "0"}}
+    ))
+    broker.get_overseas_price = AsyncMock()
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=1380.0),
+        korean_provider=None,
+        logger=MagicMock(),
+    )
+
+    assert await service._build_adr_gap(1380.0) is None
+    broker.get_overseas_price.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_adr_gap_is_none_when_every_adr_symbol_lookup_fails():
+    broker = SimpleNamespace()
+    broker.get_current_price = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value, msg1="OK", data={"stck_prpr": "2076000"}
+    ))
+    broker.get_overseas_price = AsyncMock(side_effect=[
+        RuntimeError("overseas down"),
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="OK",
+            data=SimpleNamespace(price=0, last=0, last_price=0),
+        ),
+    ])
+    service = MarketCapGapService(
+        broker=broker,
+        us_provider=StaticUsMarketCapProvider(quotes=[], usdkrw=1380.0),
+        korean_provider=None,
+        logger=MagicMock(),
+    )
+
+    assert await service._build_adr_gap(1380.0) is None
+    assert broker.get_overseas_price.await_count == 2
+    service._logger.warning.assert_called_once()
+
+
+def test_build_comparisons_skips_nonpositive_korean_and_missing_us_caps():
+    korean = [
+        {"symbol": "005930", "name": "삼성전자", "market_cap_krw": 0},
+        {"symbol": "000660", "name": "SK하이닉스", "market_cap_krw": 200_000_000_000_000},
+    ]
+    us = [
+        {"symbol": "MU", "name": "Micron", "market_cap_krw": None},
+        {"symbol": "NVDA", "name": "NVIDIA", "market_cap_krw": 400_000_000_000_000},
+    ]
+
+    comparisons = MarketCapGapService._build_comparisons(korean, us)
+
+    assert [item["us_symbol"] for item in comparisons] == ["NVDA"]
+    assert comparisons[0]["ratio"] == 2.0
+
+
+def test_build_default_uses_yahoo_and_pykrx_providers():
+    service = MarketCapGapService.build_default(broker=SimpleNamespace(), logger=MagicMock())
+
+    assert isinstance(service._us_provider, YahooUsMarketCapProvider)
+    assert isinstance(service._korean_provider, PykrxKoreanMarketCapProvider)

--- a/tests/unit_test/task/background/intraday/test_market_index_threshold_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_market_index_threshold_alert_task.py
@@ -1,10 +1,33 @@
+import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from common.types import ErrorCode, ResCommonResponse
+from interfaces.schedulable_task import TaskPriority, TaskState
 from task.background.intraday.market_index_threshold_alert_task import MarketIndexThresholdAlertTask
+
+_UNSET = object()
+
+
+def _build_task(*, broker, alert_service=None, market_open=True, market_calendar=_UNSET):
+    if alert_service is None:
+        alert_service = MagicMock()
+        alert_service.on_index_change = AsyncMock()
+    market_clock = MagicMock()
+    market_clock.get_current_kst_time.return_value = datetime(2026, 8, 3, 10, 0)
+    market_clock.is_market_operating_hours.return_value = market_open
+    if market_calendar is _UNSET:
+        market_calendar = MagicMock()
+        market_calendar.is_business_day = AsyncMock(return_value=True)
+    return MarketIndexThresholdAlertTask(
+        broker=broker,
+        market_status_alert_service=alert_service,
+        market_clock=market_clock,
+        market_calendar_service=market_calendar,
+        logger=MagicMock(),
+    )
 
 
 @pytest.mark.asyncio
@@ -43,3 +66,183 @@ async def test_tick_forwards_signed_kospi_and_kosdaq_change_rates():
     assert broker.inquire_time_indexchartprice.await_args_list[1].args == ("1001", 60)
     assert alert_service.on_index_change.await_args_list[0].args == ("0001", "코스피", 5.1)
     assert alert_service.on_index_change.await_args_list[1].args == ("1001", "코스닥", -8.2)
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_index_when_quote_response_fails():
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock(side_effect=[
+        ResCommonResponse(rt_cd=ErrorCode.API_ERROR.value, msg1="조회 실패", data=None),
+        ResCommonResponse(
+            rt_cd=ErrorCode.SUCCESS.value,
+            msg1="정상",
+            data={"summary": {"bstp_nmix_prdy_ctrt": "1.2", "prdy_vrss_sign": "2"}},
+        ),
+    ])
+    alert_service = MagicMock()
+    alert_service.on_index_change = AsyncMock()
+    task = _build_task(broker=broker, alert_service=alert_service)
+
+    await task._tick()
+
+    assert alert_service.on_index_change.await_count == 1
+    assert alert_service.on_index_change.await_args.args == ("1001", "코스닥", 1.2)
+    task._logger.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_index_when_change_rate_is_missing():
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data={"summary": {"bstp_nmix_prdy_ctrt": ""}},
+    ))
+    alert_service = MagicMock()
+    alert_service.on_index_change = AsyncMock()
+    task = _build_task(broker=broker, alert_service=alert_service)
+
+    await task._tick()
+
+    alert_service.on_index_change.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_logs_warning_when_change_rate_reaches_threshold_zone():
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock(return_value=ResCommonResponse(
+        rt_cd=ErrorCode.SUCCESS.value,
+        msg1="정상",
+        data={"summary": {"bstp_nmix_prdy_ctrt": "4.6", "prdy_vrss_sign": "2"}},
+    ))
+    alert_service = MagicMock()
+    alert_service.on_index_change = AsyncMock()
+    task = _build_task(broker=broker, alert_service=alert_service)
+
+    await task._tick()
+
+    assert task._logger.warning.call_count == 2
+    assert alert_service.on_index_change.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tick_does_nothing_outside_market_operating_hours():
+    broker = MagicMock()
+    broker.inquire_time_indexchartprice = AsyncMock()
+    task = _build_task(broker=broker, market_open=False)
+
+    await task._tick()
+
+    broker.inquire_time_indexchartprice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_market_open_check_treats_missing_calendar_as_business_day():
+    task = _build_task(broker=MagicMock(), market_calendar=None)
+
+    assert await task._is_market_open_now() is True
+
+
+@pytest.mark.asyncio
+async def test_market_open_check_returns_false_on_holiday():
+    calendar = MagicMock()
+    calendar.is_business_day = AsyncMock(return_value=False)
+    task = _build_task(broker=MagicMock(), market_calendar=calendar)
+
+    assert await task._is_market_open_now() is False
+
+
+@pytest.mark.parametrize(
+    "summary, expected",
+    [
+        ({"bstp_nmix_prdy_ctrt": "1,234.5", "prdy_vrss_sign": "2"}, 1234.5),
+        ({"bstp_nmix_prdy_ctrt": "3.3", "prdy_vrss_sign": "down"}, -3.3),
+        ({"bstp_nmix_prdy_ctrt": "-2.0", "prdy_vrss_sign": "2"}, -2.0),
+        ({"bstp_nmix_prdy_ctrt": "abc"}, None),
+        ({}, None),
+    ],
+)
+def test_signed_change_rate_parsing(summary, expected):
+    assert MarketIndexThresholdAlertTask._signed_change_rate(summary) == expected
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_tick_logs_error_and_exits_on_cancel():
+    task = _build_task(broker=MagicMock())
+    task._tick = AsyncMock(side_effect=[None, RuntimeError("boom"), asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.market_index_threshold_alert_task.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await task._loop()
+
+    assert task._tick.await_count == 3
+    assert task.state == TaskState.RUNNING
+    task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_tick_while_suspended():
+    task = _build_task(broker=MagicMock())
+    task._tick = AsyncMock()
+    task._state = TaskState.SUSPENDED
+    sleep_mock = AsyncMock(side_effect=[None, asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.market_index_threshold_alert_task.asyncio.sleep",
+        sleep_mock,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await task._loop()
+
+    task._tick.assert_not_awaited()
+    assert task.state == TaskState.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_stop_cancels_running_loop():
+    task = _build_task(broker=MagicMock())
+    task._tick = AsyncMock()
+
+    await task.start()
+    first_task = task._task
+    await task.start()
+    assert task._task is first_task
+
+    await task.stop()
+
+    assert task._task is None
+    assert task.state == TaskState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_stop_without_start_only_marks_stopped():
+    task = _build_task(broker=MagicMock())
+
+    await task.stop()
+
+    assert task._task is None
+    assert task.state == TaskState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_toggle_state_and_progress():
+    task = _build_task(broker=MagicMock())
+
+    await task.suspend()
+    assert task.state == TaskState.SUSPENDED
+    assert task.get_progress() == {"running": False}
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+
+def test_task_identity_exposes_name_and_priority():
+    task = _build_task(broker=MagicMock())
+
+    assert task.task_name == "market_index_threshold_alert"
+    assert task.priority == TaskPriority.HIGH

--- a/tests/unit_test/task/background/intraday/test_market_timing_daily_update_task.py
+++ b/tests/unit_test/task/background/intraday/test_market_timing_daily_update_task.py
@@ -1,9 +1,10 @@
+import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from interfaces.schedulable_task import TaskState
+from interfaces.schedulable_task import TaskPriority, TaskState
 from task.background.intraday.market_timing_daily_update_task import MarketTimingDailyUpdateTask
 
 
@@ -91,3 +92,172 @@ async def test_start_stop_cancels_background_loop():
     assert task.state == TaskState.IDLE
     await task.stop()
     assert task.state == TaskState.STOPPED
+
+
+def _make_task(*, calendar=None, market_clock=None, universe=None):
+    if market_clock is None:
+        market_clock = MagicMock()
+        market_clock.get_current_kst_time.return_value = datetime(2026, 8, 18, 8, 40)
+        market_clock.get_market_open_time.return_value = datetime(2026, 8, 18, 9, 0)
+    if universe is None:
+        universe = MagicMock()
+        universe.refresh_market_timing = AsyncMock(return_value={})
+    return MarketTimingDailyUpdateTask(
+        universe_service=universe,
+        market_clock=market_clock,
+        market_calendar_service=calendar,
+        logger=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_once_reports_error_when_business_day_check_raises():
+    calendar = MagicMock()
+    calendar.is_business_day = AsyncMock(side_effect=RuntimeError("calendar down"))
+    universe = MagicMock()
+    universe.refresh_market_timing = AsyncMock()
+    task = _make_task(calendar=calendar, universe=universe)
+
+    result = await task.run_once()
+
+    assert result == {"ok": False, "error": "calendar down", "date": "20260818"}
+    universe.refresh_market_timing.assert_not_awaited()
+    task._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_once_without_calendar_refreshes_directly():
+    universe = MagicMock()
+    universe.refresh_market_timing = AsyncMock(return_value={"KOSPI": True})
+    task = _make_task(calendar=None, universe=universe)
+
+    result = await task.run_once()
+
+    universe.refresh_market_timing.assert_awaited_once()
+    assert result["markets"] == {"KOSPI": True}
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_returns_false_without_market_clock():
+    task = MarketTimingDailyUpdateTask(
+        universe_service=MagicMock(),
+        market_clock=None,
+        logger=MagicMock(),
+    )
+
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_returns_false_on_non_business_day():
+    calendar = MagicMock()
+    calendar.is_business_day = AsyncMock(return_value=False)
+    task = _make_task(calendar=calendar)
+
+    assert await task._should_run_now() is False
+
+
+@pytest.mark.asyncio
+async def test_should_run_now_returns_false_when_business_day_check_raises():
+    calendar = MagicMock()
+    calendar.is_business_day = AsyncMock(side_effect=RuntimeError("calendar down"))
+    task = _make_task(calendar=calendar)
+
+    assert await task._should_run_now() is False
+    task._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_once_when_due_then_logs_error_and_exits_on_cancel():
+    task = _make_task()
+    task._should_run_now = AsyncMock(
+        side_effect=[True, RuntimeError("boom"), asyncio.CancelledError()]
+    )
+    task.run_once = AsyncMock()
+
+    with patch(
+        "task.background.intraday.market_timing_daily_update_task.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await task._loop()
+
+    task.run_once.assert_awaited_once()
+    assert task.state == TaskState.IDLE
+    task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_run_while_suspended():
+    task = _make_task()
+    task._should_run_now = AsyncMock()
+    task.run_once = AsyncMock()
+    task._state = TaskState.SUSPENDED
+    sleep_mock = AsyncMock(side_effect=[None, asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.market_timing_daily_update_task.asyncio.sleep",
+        sleep_mock,
+    ):
+        await task._loop()
+
+    task._should_run_now.assert_not_awaited()
+    task.run_once.assert_not_awaited()
+    assert task.state == TaskState.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_run_when_not_due():
+    task = _make_task()
+    task._should_run_now = AsyncMock(side_effect=[False, asyncio.CancelledError()])
+    task.run_once = AsyncMock()
+
+    with patch(
+        "task.background.intraday.market_timing_daily_update_task.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await task._loop()
+
+    task.run_once.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_after_stop_resets_state_to_idle():
+    task = _make_task()
+
+    await task.stop()
+    assert task.state == TaskState.STOPPED
+
+    await task.start()
+    assert task.state == TaskState.IDLE
+    first_task = task._task
+    await task.start()
+    assert task._task is first_task
+
+    await task.stop()
+    assert task._task is None
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_toggle_state():
+    task = _make_task()
+
+    await task.suspend()
+    assert task.state == TaskState.SUSPENDED
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+
+def test_task_identity_and_progress_defaults():
+    task = _make_task()
+
+    assert task.task_name == "market_timing_daily_update"
+    assert task.priority == TaskPriority.NORMAL
+    assert task.get_progress() == {
+        "running": False,
+        "last_checked_date": None,
+        "last_result": {"ok": True},
+    }

--- a/tests/unit_test/task/background/intraday/test_overseas_favorite_price_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_overseas_favorite_price_alert_task.py
@@ -1,6 +1,9 @@
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from interfaces.schedulable_task import TaskPriority, TaskState
 
 from common.types import ErrorCode, ResCommonResponse
 from repositories.favorite_repository import MARKET_OVERSEAS_US
@@ -141,3 +144,122 @@ async def test_skips_symbol_when_change_rate_is_missing():
     await task._tick()
 
     alert_service.handle_price_tick.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_blank_symbols_without_calling_broker():
+    broker = MagicMock()
+    broker.get_overseas_price = AsyncMock(return_value=_price_response(189.5, 5.3))
+    task, _, alert_service = _build_task(symbols=["", "   ", None, "AAPL"], broker=broker)
+
+    await task._tick()
+
+    broker.get_overseas_price.assert_awaited_once_with("AAPL", exchange="NASD")
+    alert_service.handle_price_tick.assert_awaited_once()
+
+
+def test_exchange_falls_back_to_default_without_code_repository():
+    task = OverseasFavoritePriceAlertTask(
+        favorite_repository=MagicMock(),
+        broker=MagicMock(),
+        alert_service=MagicMock(),
+        market_clock=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    assert task._exchange_of("AAPL") == OverseasFavoritePriceAlertTask.DEFAULT_EXCHANGE
+
+
+def test_market_open_check_treats_missing_calendar_as_trading_day():
+    market_clock = MagicMock()
+    market_clock.is_market_operating_hours.return_value = True
+    task = OverseasFavoritePriceAlertTask(
+        favorite_repository=MagicMock(),
+        broker=MagicMock(),
+        alert_service=MagicMock(),
+        market_clock=market_clock,
+        logger=MagicMock(),
+    )
+
+    assert task._is_market_open_now() is True
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_tick_logs_error_and_exits_on_cancel():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+    task._logger = MagicMock()
+    task._tick = AsyncMock(side_effect=[None, RuntimeError("boom"), asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.overseas_favorite_price_alert_task.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await task._loop()
+
+    assert task._tick.await_count == 3
+    task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_tick_while_suspended():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+    task._tick = AsyncMock()
+    task._state = TaskState.SUSPENDED
+    sleep_mock = AsyncMock(side_effect=[None, asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.overseas_favorite_price_alert_task.asyncio.sleep",
+        sleep_mock,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await task._loop()
+
+    task._tick.assert_not_awaited()
+    assert task.state == TaskState.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_stop_clears_background_task():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+
+    await task.start()
+    first_task = task._task
+    await task.start()
+    assert task._task is first_task
+
+    await task.stop()
+
+    assert task._task is None
+    assert task.state == TaskState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_stop_without_start_only_marks_stopped():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+
+    await task.stop()
+
+    assert task._task is None
+    assert task.state == TaskState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_toggle_state_and_progress():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+
+    await task.suspend()
+    assert task.state == TaskState.SUSPENDED
+    assert task.get_progress() == {"running": False}
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+
+def test_task_identity_exposes_name_and_priority():
+    task, _, _ = _build_task(symbols=[], broker=MagicMock())
+
+    assert task.task_name == "overseas_favorite_price_alert"
+    assert task.priority == TaskPriority.HIGH

--- a/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
+++ b/tests/unit_test/task/background/intraday/test_theme_intraday_leader_alert_task.py
@@ -1,10 +1,12 @@
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from common.types import ErrorCode, ResCommonResponse
+from interfaces.schedulable_task import TaskPriority, TaskState
 from task.background.intraday.theme_intraday_leader_alert_task import (
     ThemeIntradayLeaderAlertTask,
 )
@@ -205,3 +207,295 @@ async def test_latest_report_is_refreshed_each_minute_without_extra_telegram():
     latest = deps.task.get_latest_report()
     assert latest["captured_at"] == "20260706 10:14"
     assert latest["data"][0]["normalized_name"] == "반도체"
+
+
+@pytest.mark.asyncio
+async def test_tick_returns_without_market_clock():
+    task = ThemeIntradayLeaderAlertTask(
+        ranking_task=MagicMock(),
+        theme_daily_leader_service=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    await task._tick()
+
+    assert task.get_latest_report() == {"captured_at": None, "data": []}
+
+
+@pytest.mark.asyncio
+async def test_market_open_check_skips_on_non_business_day():
+    deps = _make_task()
+    deps.mcs.is_business_day = AsyncMock(return_value=False)
+
+    assert await deps.task._is_market_open_now() is False
+
+
+@pytest.mark.asyncio
+async def test_market_open_check_skips_when_calendar_raises():
+    deps = _make_task()
+    deps.mcs.is_business_day = AsyncMock(side_effect=RuntimeError("calendar down"))
+
+    assert await deps.task._is_market_open_now() is False
+    deps.task._logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_market_open_check_passes_without_calendar_service():
+    deps = _make_task()
+    deps.task._mcs = None
+
+    assert await deps.task._is_market_open_now() is True
+
+
+@pytest.mark.asyncio
+async def test_send_report_marks_empty_theme_error_without_telegram():
+    deps = _make_task()
+
+    await deps.task._send_report("20260706 10:00")
+
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+    assert deps.task.get_progress()["last_error"] == "intraday_theme_empty"
+    assert deps.task.get_progress()["last_report_slot"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_report_keeps_existing_error_when_theme_data_empty():
+    deps = _make_task()
+    deps.task._progress["last_error"] = "intraday_ranking_empty"
+
+    await deps.task._send_report("20260706 10:00")
+
+    assert deps.task.get_progress()["last_error"] == "intraday_ranking_empty"
+
+
+@pytest.mark.asyncio
+async def test_send_report_without_telegram_reporter_still_marks_slot():
+    deps = _make_task()
+    deps.task._telegram_reporter = None
+    deps.task._latest_report = {"captured_at": "x", "data": [{"normalized_name": "반도체"}]}
+
+    await deps.task._send_report("20260706 10:00")
+
+    assert deps.task.get_progress()["last_report_slot"] == "20260706 10:00"
+    assert deps.task.get_progress()["sent_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_marks_error_when_theme_service_response_fails():
+    deps = _make_task(service_response=ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="테마 생성 실패", data=None
+    ))
+
+    await deps.task._tick()
+
+    assert deps.task.get_progress()["last_error"] == "theme_service_error:테마 생성 실패"
+    deps.telegram_reporter.send_daily_theme_report.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_marks_error_when_theme_service_returns_nothing():
+    deps = _make_task()
+    deps.theme_service.build_intraday_theme_report = AsyncMock(return_value=None)
+
+    await deps.task._tick()
+
+    assert deps.task.get_progress()["last_error"] == "theme_service_error:응답 없음"
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_resend_report_for_already_sent_slot():
+    deps = _make_task()
+
+    await deps.task._tick()
+    assert deps.telegram_reporter.send_daily_theme_report.await_count == 1
+
+    deps.clock.now = datetime(2026, 7, 6, 10, 11, 0)
+    await deps.task._tick()
+
+    assert deps.telegram_reporter.send_daily_theme_report.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_build_rankings_skips_items_without_code():
+    deps = _make_task(basic_rankings={
+        "rise": [{"hts_kor_isnm": "코드없음"}],
+        "trading_value": [],
+        "volume": [],
+    })
+
+    rankings = await deps.task._build_intraday_rankings("20260706 10:10")
+
+    assert rankings["all_stocks"] == []
+    assert rankings["report_date"] == "20260706"
+
+
+@pytest.mark.asyncio
+async def test_build_rankings_supports_sync_refresh_hook():
+    deps = _make_task()
+    deps.ranking_task.refresh_basic_ranking = MagicMock(return_value=None)
+
+    rankings = await deps.task._build_intraday_rankings("20260706 10:10")
+
+    deps.ranking_task.refresh_basic_ranking.assert_called_once_with(notify=False)
+    assert len(rankings["all_stocks"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_build_rankings_without_refresh_hook():
+    deps = _make_task()
+    del deps.ranking_task.refresh_basic_ranking
+
+    rankings = await deps.task._build_intraday_rankings("20260706 10:10")
+
+    assert len(rankings["all_stocks"]) == 2
+
+
+def test_basic_ranking_items_returns_empty_without_getter():
+    deps = _make_task()
+    del deps.ranking_task.get_basic_ranking_cache
+
+    assert deps.task._get_basic_ranking_items("rise") == []
+
+
+def test_basic_ranking_items_returns_empty_on_failed_response():
+    deps = _make_task()
+    deps.ranking_task.get_basic_ranking_cache.side_effect = None
+    deps.ranking_task.get_basic_ranking_cache.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value, msg1="실패", data=None
+    )
+
+    assert deps.task._get_basic_ranking_items("rise") == []
+
+
+def test_basic_ranking_items_unwraps_dict_output():
+    deps = _make_task()
+    deps.ranking_task.get_basic_ranking_cache.side_effect = None
+    deps.ranking_task.get_basic_ranking_cache.return_value = _make_response(
+        {"output": [{"stck_shrn_iscd": "005930"}]}
+    )
+
+    assert deps.task._get_basic_ranking_items("rise") == [{"stck_shrn_iscd": "005930"}]
+
+
+def test_normalize_stock_fills_name_and_trade_value():
+    deps = _make_task()
+
+    stock = deps.task._normalize_stock({
+        "code": "005930",
+        "name": "삼성전자",
+        "stck_prpr": "80,000",
+        "acml_vol": "1,000",
+    })
+
+    assert stock["stck_shrn_iscd"] == "005930"
+    assert stock["mksc_shrn_iscd"] == "005930"
+    assert stock["hts_kor_isnm"] == "삼성전자"
+    assert stock["acml_tr_pbmn"] == str(80000 * 1000)
+
+
+def test_normalize_stock_accepts_object_with_to_dict():
+    deps = _make_task()
+    item = MagicMock()
+    item.to_dict.return_value = {"iscd": "000660", "stck_prpr": "0", "acml_vol": "0"}
+
+    stock = deps.task._normalize_stock(item)
+
+    assert stock["stck_shrn_iscd"] == "000660"
+    assert "acml_tr_pbmn" not in stock
+
+
+@pytest.mark.parametrize("value, expected", [("1,000", 1000), ("", 0), (None, 0), ("abc", 0)])
+def test_to_int_parsing(value, expected):
+    assert ThemeIntradayLeaderAlertTask._to_int(value) == expected
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_tick_logs_error_and_exits_on_cancel():
+    deps = _make_task()
+    task = deps.task
+    task._tick = AsyncMock(side_effect=[None, RuntimeError("boom"), asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.theme_intraday_leader_alert_task.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await task._loop()
+
+    assert task._tick.await_count == 3
+    assert task.get_progress()["last_error"] == "boom"
+    assert task.get_progress()["running"] is False
+    task._logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_tick_while_suspended():
+    deps = _make_task()
+    task = deps.task
+    task._tick = AsyncMock()
+    task._state = TaskState.SUSPENDED
+    sleep_mock = AsyncMock(side_effect=[None, asyncio.CancelledError()])
+
+    with patch(
+        "task.background.intraday.theme_intraday_leader_alert_task.asyncio.sleep",
+        sleep_mock,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await task._loop()
+
+    task._tick.assert_not_awaited()
+    assert task.state == TaskState.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_stop_clears_tasks():
+    deps = _make_task()
+    task = deps.task
+
+    await task.start()
+    assert len(task._tasks) == 1
+    await task.start()
+    assert len(task._tasks) == 1
+
+    await task.stop()
+
+    assert task._tasks == []
+    assert task.state == TaskState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_restart_after_stop_resets_state_to_idle():
+    deps = _make_task()
+    task = deps.task
+
+    await task.stop()
+    assert task.state == TaskState.STOPPED
+
+    await task.start()
+    assert task.state == TaskState.IDLE
+
+    await task.stop()
+
+
+@pytest.mark.asyncio
+async def test_suspend_only_applies_while_running_and_resume_restores_idle():
+    deps = _make_task()
+    task = deps.task
+
+    await task.suspend()
+    assert task.state == TaskState.IDLE
+
+    task._state = TaskState.RUNNING
+    await task.suspend()
+    assert task.state == TaskState.SUSPENDED
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+    await task.resume()
+    assert task.state == TaskState.IDLE
+
+
+def test_task_priority_is_low():
+    deps = _make_task()
+
+    assert deps.task.priority == TaskPriority.LOW


### PR DESCRIPTION
## 배경

전체 테스트 커버리지(`pytest --cov=. --cov-config=.coveragerc`) 기준 70% 미만이던 파일 6개의 미커버 경로를 채운다.
**프로덕션 코드 변경은 없고 테스트만 추가**했다.

## 커버리지 변화

| 파일 | before | after |
|---|---:|---:|
| `services/market_cap_gap_service.py` | 67.37% | 99.36% |
| `task/background/intraday/theme_intraday_leader_alert_task.py` | 67.99% | 97.48% |
| `task/background/intraday/market_index_threshold_alert_task.py` | 57.14% | 99.11% |
| `task/background/intraday/market_timing_daily_update_task.py` | 64.17% | 98.33% |
| `task/background/intraday/overseas_favorite_price_alert_task.py` | 68.29% | 99.19% |
| `services/gemini_youtube_video_analyzer_service.py` | 66.67% | 100.00% |

- 70% 미만 파일: 6개 → **0개**
- 전체 커버리지: 90.44% → 91.06%

남은 미커버는 `market_cap_gap_service.py` 의 `Protocol` 선언부 `...` 3줄(실행 불가)과
`theme_intraday_leader_alert_task.py` 의 `if TYPE_CHECKING:` 블록 2줄뿐이다.

## 추가한 테스트

- **market_cap_gap_service**: pykrx/로컬 DB fallback(import 실패·조회 예외·빈 DataFrame·파싱 실패·0 이하 값), Yahoo crumb 재시도 실패 경로, chart 가격 fallback, `fetch_usdkrw`, `_to_snapshot` 예외 처리, 국내 시총 조회 실패 경로, ADR gap 실패 경로, 비교 스킵 조건, `build_default` 조립
- **theme_intraday_leader_alert_task**: start/stop/suspend/resume·`_loop`, 영업일 확인 실패·예외, 리포트 발송 스킵 조건, 랭킹 캐시 정규화 헬퍼
- **market_index_threshold_alert_task**: 라이프사이클·`_loop`, 지수 조회 실패·등락률 누락, 임계 근접 로깅, 부호 파싱 예외
- **market_timing_daily_update_task**: 라이프사이클·`_loop`, 영업일 확인 예외/휴장, `market_clock` 미주입
- **overseas_favorite_price_alert_task**: 라이프사이클·`_loop`, 빈 심볼 스킵, 거래소/캘린더 기본값
- **gemini_youtube_video_analyzer_service**: API key 검증(빈 값·비 ASCII), 자체 httpx client 경로, `steps` 기반 응답 파싱, 빈 응답/HTTP 오류

## 검증

```
pytest tests/unit_test  -> 8107 passed
pytest tests/integration_test -> 291 passed
```

`conftest.py` 의 `fast_sleep` autouse fixture 가 `asyncio.sleep` 을 전역 모킹하므로,
`_loop()` 테스트는 각 모듈 경로의 `asyncio.sleep` 을 개별 패치하고 `CancelledError` 로 종료시킨다.


---
_Generated by [Claude Code](https://claude.ai/code/session_017HDPTrnAqHLTUpmyL35Rq6)_