### PR TITLE
Fix pre-open market regime date

### DIFF
--- a/services/market_regime_service.py
+++ b/services/market_regime_service.py
@@ -138,9 +138,14 @@ class MarketRegimeService:
         query_end_date = as_of_date
         if as_of_date is None:
             now = self._tm.get_current_kst_time()
+            before_open = False
+            try:
+                before_open = now < self._tm.get_market_open_time(now)
+            except Exception:
+                before_open = False
             query_end_date = (
                 previous_trading_day_str(now)
-                if self._tm.is_market_operating_hours()
+                if self._tm.is_market_operating_hours() or before_open
                 else now.strftime("%Y%m%d")
             )
 

--- a/tests/unit_test/services/test_market_regime_service.py
+++ b/tests/unit_test/services/test_market_regime_service.py
@@ -26,8 +26,11 @@ def _make_service(closes, *, today="20260514"):
         return_value=ResCommonResponse(rt_cd=ErrorCode.SUCCESS.value, msg1="ok", data=_build_ohlcv(closes))
     )
     tm = MagicMock()
-    tm.get_current_kst_time = MagicMock(return_value=datetime.strptime(today, "%Y%m%d"))
+    tm.get_current_kst_time = MagicMock(return_value=datetime.strptime(today, "%Y%m%d").replace(hour=16))
     tm.is_market_operating_hours = MagicMock(return_value=False)
+    tm.get_market_open_time = MagicMock(
+        return_value=datetime.strptime(today, "%Y%m%d").replace(hour=9)
+    )
     cfg = MarketRegimeConfig(
         kospi_index_code="0001",
         kosdaq_index_code="1001",
@@ -85,6 +88,24 @@ async def test_classify_live_forces_fresh_closed_ohlcv():
         end_date="20260513",
     )
     assert snap.data_date == "20260108"
+
+
+@pytest.mark.asyncio
+async def test_classify_before_open_uses_previous_trading_day():
+    """개장 전 일간 마켓 타이밍은 당일 미확정 일봉 대신 직전 확정 일봉까지만 조회한다."""
+    closes = [100, 101, 102, 103, 104, 106, 108, 110]
+    svc, sqs = _make_service(closes)
+    svc._tm.get_current_kst_time.return_value = datetime(2026, 8, 24, 8, 40)
+    svc._tm.is_market_operating_hours.return_value = False
+    svc._tm.get_market_open_time.return_value = datetime(2026, 8, 24, 9, 0)
+
+    await svc.classify("KOSPI")
+
+    sqs.get_recent_daily_index_ohlcv.assert_awaited_once_with(
+        "0001",
+        limit=12,
+        end_date="20260821",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Use the previous trading day for live market regime OHLCV queries before market open
- Add a regression test for the 08:40 pre-open market timing update path

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_market_regime_service.py -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v