### PR TITLE
fix: 즐겨찾기 현재가/등락률 폴백 신선도 검증

### DIFF
--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -33,6 +33,34 @@ def _extract_price_rate(data) -> tuple:
     return getattr(data, "stck_prpr", None), getattr(data, "prdy_ctrt", None)
 
 
+def _apply_price_rate(entry: dict, data) -> bool:
+    """추출한 (현재가, 등락률)을 entry에 반영하고 완전한 값인지 여부를 반환.
+
+    현재가가 비어 있으면 반영하지 않는다(다음 단계에서 다시 조회).
+    현재가만 있고 등락률이 없으면 값은 남기되 미완료로 보고, 이후 단계가
+    현재가·등락률을 함께 가진 소스를 찾으면 통째로 덮어쓴다.
+    """
+    price, rate = _extract_price_rate(data)
+    if price in (None, ""):
+        return False
+    entry["price"] = price
+    entry["rate"] = rate
+    return rate not in (None, "")
+
+
+def _snapshot_trade_date(snap) -> str:
+    """일봉 스냅샷의 기준 거래일(YYYYMMDD)을 반환."""
+    if not isinstance(snap, dict):
+        return ""
+    trade_date = snap.get("_trade_date")
+    if trade_date:
+        return str(trade_date)
+    output = snap.get("output")
+    if isinstance(output, dict):
+        return str(output.get("stck_bsop_date") or "")
+    return str(getattr(output, "stck_bsop_date", "") or "")
+
+
 class FavoriteService:
     def __init__(
         self,
@@ -42,6 +70,7 @@ class FavoriteService:
         stock_repository=None,
         rs_rating_service=None,
         overseas_stock_code_repository=None,
+        market_calendar_service=None,
     ):
         self.repository = repository
         self.stock_code_repository = stock_code_repository
@@ -49,6 +78,7 @@ class FavoriteService:
         self.stock_repository = stock_repository
         self.rs_rating_service = rs_rating_service
         self.overseas_stock_code_repository = overseas_stock_code_repository
+        self.market_calendar_service = market_calendar_service
 
     async def get_all(self, market: str = MARKET_DOMESTIC) -> list:
         codes = await self.repository.get_all(market=market)
@@ -159,11 +189,8 @@ class FavoriteService:
             still_missing = []
             responses = await asyncio.gather(*[_fetch(c) for c in missing])
             for code, resp in zip(missing, responses):
-                if resp and resp.rt_cd == "0" and resp.data:
-                    price, rate = _extract_price_rate(resp.data)
-                    result[code]["price"] = price
-                    result[code]["rate"] = rate
-                else:
+                if not (resp and resp.rt_cd == "0" and resp.data
+                        and _apply_price_rate(result[code], resp.data)):
                     still_missing.append(code)
             missing = still_missing
 
@@ -172,16 +199,14 @@ class FavoriteService:
             still_missing = []
             for code in missing:
                 cached = self.stock_repository.get_current_price(code, max_age_sec=3.0, count_stats=False)
-                if cached:
-                    price, rate = _extract_price_rate(cached)
-                    result[code]["price"] = price
-                    result[code]["rate"] = rate
-                else:
+                if not (cached and _apply_price_rate(result[code], cached)):
                     still_missing.append(code)
             missing = still_missing
 
         # 3단계: DB 스냅샷 (장마감 후 일봉)
+        # 최근 거래일보다 오래된 스냅샷은 현재가/등락률로 쓰지 않는다 (MarketDataService와 동일 기준).
         if missing and self.stock_repository:
+            latest_trading_date = await self._get_latest_trading_date()
             still_missing = []
             snapshot_tasks = [self.stock_repository.get_latest_daily_snapshot(code) for code in missing]
             snapshots = await asyncio.gather(*snapshot_tasks, return_exceptions=True)
@@ -189,9 +214,11 @@ class FavoriteService:
                 if isinstance(snap, Exception) or not snap:
                     still_missing.append(code)
                     continue
-                price, rate = _extract_price_rate(snap)
-                result[code]["price"] = price
-                result[code]["rate"] = rate
+                if latest_trading_date and _snapshot_trade_date(snap) != latest_trading_date:
+                    still_missing.append(code)
+                    continue
+                if not _apply_price_rate(result[code], snap):
+                    still_missing.append(code)
             missing = still_missing
 
         # 4단계: RS Rating 점수 조회 및 병합
@@ -225,6 +252,15 @@ class FavoriteService:
                     result[code]["minervini_stage"] = stage
 
         return list(result.values())
+
+    async def _get_latest_trading_date(self):
+        """최근 거래일(YYYYMMDD). 캘린더 서비스가 없거나 실패하면 None (검증 생략)."""
+        if not self.market_calendar_service:
+            return None
+        try:
+            return await self.market_calendar_service.get_latest_trading_date()
+        except Exception:
+            return None
 
     async def _get_overseas_details(self) -> list:
         """미국장 관심종목에 종목명·거래소·현재가·등락률을 붙여 반환.

--- a/tests/unit_test/services/test_favorite_service.py
+++ b/tests/unit_test/services/test_favorite_service.py
@@ -438,3 +438,103 @@ async def test_get_with_details_overseas_empty(mock_repo, mock_stock_code_repo):
         stock_code_repository=mock_stock_code_repo,
     )
     assert await svc.get_with_details(market="overseas_us") == []
+
+
+async def test_get_with_details_falls_back_when_query_service_returns_empty_price(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """1단계 응답이 rt_cd=0이어도 현재가가 비어 있으면 다음 단계로 폴백해야 한다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_query = AsyncMock()
+    mock_query.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data={"output": {"stck_prpr": "", "prdy_ctrt": ""}}
+    )
+    mock_stock_repo.get_current_price.return_value = {
+        "output": {"stck_prpr": "70000", "prdy_ctrt": "2.5"}
+    }
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        stock_repository=mock_stock_repo,
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "70000"
+    assert result[0]["rate"] == "2.5"
+
+
+async def test_get_with_details_keeps_price_but_retries_when_rate_missing(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """등락률이 없는 불완전 응답은 다음 단계에서 완전한 값으로 대체되어야 한다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_query = AsyncMock()
+    mock_query.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data={"output": {"stck_prpr": "69000"}}
+    )
+    mock_stock_repo.get_current_price.return_value = {
+        "output": {"stck_prpr": "70000", "prdy_ctrt": "2.5"}
+    }
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        stock_repository=mock_stock_repo,
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "70000"
+    assert result[0]["rate"] == "2.5"
+
+
+async def test_get_with_details_skips_outdated_daily_snapshot(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """최근 거래일보다 오래된 일봉 스냅샷은 현재가/등락률로 쓰지 않는다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_stock_repo.get_current_price.return_value = None
+    mock_stock_repo.get_latest_daily_snapshot.return_value = {
+        "output": {"stck_prpr": "71000", "prdy_ctrt": "1.2"},
+        "_trade_date": "20260814",
+    }
+    mock_mcs = MagicMock()
+    mock_mcs.get_latest_trading_date = AsyncMock(return_value="20260821")
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_repository=mock_stock_repo,
+        market_calendar_service=mock_mcs,
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] is None
+    assert result[0]["rate"] is None
+
+
+async def test_get_with_details_uses_daily_snapshot_of_latest_trading_date(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """최근 거래일 일봉 스냅샷은 그대로 사용한다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_stock_repo.get_current_price.return_value = None
+    mock_stock_repo.get_latest_daily_snapshot.return_value = {
+        "output": {"stck_prpr": "71000", "prdy_ctrt": "1.2"},
+        "_trade_date": "20260821",
+    }
+    mock_mcs = MagicMock()
+    mock_mcs.get_latest_trading_date = AsyncMock(return_value="20260821")
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_repository=mock_stock_repo,
+        market_calendar_service=mock_mcs,
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "71000"
+    assert result[0]["rate"] == "1.2"

--- a/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
+++ b/tests/unit_test/view/web/bootstrap/test_wiring_phase.py
@@ -57,6 +57,7 @@ def test_wiring_phase_wires_indicator_and_favorite_collaborators():
     assert ctx.favorite_service.stock_repository is ctx.stock_repository
     assert ctx.favorite_service.rs_rating_service is ctx.rs_rating_service
     assert ctx.favorite_service.minervini_stage_service is ctx.minervini_stage_service
+    assert ctx.favorite_service.market_calendar_service is ctx._mcs
 
 
 def test_wiring_phase_links_minervini_circular_pair():

--- a/view/web/bootstrap/wiring_phase.py
+++ b/view/web/bootstrap/wiring_phase.py
@@ -35,6 +35,7 @@ class WiringPhase:
         ctx.favorite_service.stock_query_service = ctx.stock_query_service
         ctx.favorite_service.stock_repository = ctx.stock_repository
         ctx.favorite_service.rs_rating_service = getattr(ctx, "rs_rating_service", None)
+        ctx.favorite_service.market_calendar_service = getattr(ctx, "_mcs", None)
         ctx.favorite_service.minervini_stage_service = getattr(
             ctx, "minervini_stage_service", None
         )


### PR DESCRIPTION
## 배경

즐겨찾기 목록에서 **일부 종목만** 현재가·등락률이 실제와 다르게 표시되는 현상 확인 요청.

`FavoriteService.get_with_details()` 는 종목별로 3단계 폴백(1: StockQueryService → 2: 메모리 캐시 → 3: DB 일봉 스냅샷)을 타는데, 어느 단계에서 값을 얻었는지가 종목마다 달라 한 화면에 서로 다른 시점의 데이터가 섞여 나온다. 그 중 아래 세 가지가 실제와 다른 값을 만들어내는 코드 결함이다.

## 변경 내용

**1) 빈 응답을 성공으로 간주하던 문제 (1·2단계)**

`rt_cd == "0"` 이고 `data` 가 있으면 현재가가 비어 있어도 해당 종목을 해결된 것으로 처리해 `still_missing` 에 넣지 않았다. 결과적으로 `price/rate` 가 `None` 으로 고정되어 화면에 `-` 만 표시되고, 값을 갖고 있는 2·3단계로 폴백하지 않았다. 현재가가 비어 있으면 다음 단계로 넘기도록 수정.

**2) 등락률 없는 불완전 소스**

WebSocket 틱만 수신된 캐시(`_source="tick"`)처럼 현재가만 있고 `prdy_ctrt` 가 없는 소스는, 현재가는 남기되 미완료로 표시해 이후 단계가 현재가·등락률을 함께 가진 소스를 찾으면 통째로 대체하도록 했다. 현재가/등락률은 항상 같은 소스에서 쌍으로 채워진다.

**3) DB 일봉 스냅샷에 거래일 검증 없음 (3단계) — 영향이 가장 큼**

`get_latest_daily_snapshot()` 은 `daily_prices` 의 마지막 행을 `ORDER BY trade_date DESC LIMIT 1` 로 그냥 반환한다. 3단계는 이 값을 **날짜 확인 없이** 현재가·등락률로 사용하고 있었다. 해당 종목의 일봉 수집이 며칠 전에 끊겼으면 수 일~수 주 전 종가와 그날의 등락률이 "현재가"로 표시된다.

`MarketDataService.get_current_price()` 는 같은 스냅샷을 쓸 때 이미 `_trade_date == 최근 거래일` 검증을 하고 있다. 동일 기준을 `FavoriteService` 3단계에도 적용하고, 어긋나면 값을 채우지 않는다(`-` 표시).

이를 위해 `MarketCalendarService` 를 `FavoriteService` 의 선택 의존성으로 추가하고 `WiringPhase` 에서 주입한다. 미주입 시에는 검증을 생략해 기존 동작을 유지한다.

## 테스트

TDD 로 실패 테스트 4건 선작성 후 구현:

- `test_get_with_details_falls_back_when_query_service_returns_empty_price`
- `test_get_with_details_keeps_price_but_retries_when_rate_missing`
- `test_get_with_details_skips_outdated_daily_snapshot`
- `test_get_with_details_uses_daily_snapshot_of_latest_trading_date`
- `test_wiring_phase_wires_indicator_and_favorite_collaborators` 에 캘린더 주입 검증 추가

```
pytest tests/unit_test        → 8519 passed
pytest tests/integration_test →  291 passed
```

## 이번 PR 범위 밖 (별도 확인 필요)

- **장 시작 전 0.00%**: 장전(09:00 이전)·비거래일에 KIS 현재가 API 는 `stck_prpr = 전일 종가`, `prdy_ctrt = 0.00` 을 돌려준다. 이 값을 받은 종목은 `0.00%`, DB 스냅샷으로 간 종목은 직전 세션 등락률이 떠서 같은 표에 두 기준이 섞인다. 장전에 어느 쪽을 정답으로 볼지는 표시 정책 결정이 필요해 손대지 않았다.
- **스트리밍 종목 캐시 TTL 무제한**: `StockPriceRepository.get_current_price()` 는 `is_streaming` 인 종목에 대해 `max_age_sec` 을 `float('inf')` 로 무시한다. 즐겨찾기는 페이지 진입 시 MEDIUM 우선순위로 구독(`mark_streaming`)되므로, 웹소켓이 끊기거나 장 마감으로 틱이 멈춰도 마지막 캐시 값이 무기한 반환된다. 설계상 의도된 동작(모듈 docstring 명시)이라 상한 도입은 별도 논의가 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyykUArMSAdkmXsvaGCj8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyykUArMSAdkmXsvaGCj8L)_