### PR TITLE
Improve VBO entry guard and fill notifications

### DIFF
--- a/repositories/sp500_repository.py
+++ b/repositories/sp500_repository.py
@@ -11,9 +11,14 @@ TABLE_NAME = "sp500"
 def _write_minimal_db(db_path: str, logger=None):
     """빈/손상된 DB 대신 최소 유효 DB를 써서 앱이 시작되도록 합니다."""
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
     conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL")
     try:
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
         conn.execute(
             f"CREATE TABLE {TABLE_NAME} (심볼 TEXT, 종목명 TEXT, 섹터 TEXT)"
@@ -95,8 +100,8 @@ class SP500Repository:
 
     def _read_df(self):
         conn = sqlite3.connect(self._db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
         try:
+            conn.execute("PRAGMA journal_mode=WAL")
             return pd.read_sql(f"SELECT * FROM {TABLE_NAME}", conn, dtype={"심볼": str})
         finally:
             conn.close()

--- a/services/fill_reconciliation_service.py
+++ b/services/fill_reconciliation_service.py
@@ -285,6 +285,7 @@ class FillReconciliationService:
             stock_name = strategy_notification.get("stock_name") or context.stock_code
             requested_price = strategy_notification.get("price") or context.price
             requested_qty = strategy_notification.get("qty") or context.qty
+            display_order_qty = self._display_order_qty(context, requested_qty)
             reason = strategy_notification.get("reason") or ""
             if context.side == OrderSide.SELL:
                 actual_return_rate = self._calculate_return_rate(
@@ -300,7 +301,7 @@ class FillReconciliationService:
             if context.state == OrderState.FILLED:
                 level = NotificationLevel.CRITICAL
                 title = f"[{strategy_name}] {stock_name} {side_label} 체결 완료"
-                status_line = f"상태: 체결 완료({context.filled_qty}/{context.qty}주)"
+                status_line = f"상태: 체결 완료({context.filled_qty}/{display_order_qty}주)"
             else:
                 level = NotificationLevel.ERROR
                 title = f"[{strategy_name}] {stock_name} {side_label} 실패"
@@ -310,8 +311,8 @@ class FillReconciliationService:
             fill_total_text = self._format_fill_total_won(context, displayed_fill_price)
             message = (
                 f"종목: {stock_name}({context.stock_code})\n"
-                f"주문: {requested_price_text} × {requested_qty}주\n"
-                f"평균체결가: {fill_price_text} × {context.filled_qty}/{context.qty}주\n"
+                f"주문: {requested_price_text} × {display_order_qty}주\n"
+                f"평균체결가: {fill_price_text} × {context.filled_qty}/{display_order_qty}주\n"
                 f"총체결금액: {fill_total_text}\n"
                 f"사유: {reason}\n"
                 f"{status_line}"
@@ -319,6 +320,8 @@ class FillReconciliationService:
             if context.state != OrderState.FILLED and metadata.get("reason"):
                 message = f"{message}\n실패: {metadata['reason']}"
             metadata.update(strategy_notification)
+            metadata["requested_qty"] = requested_qty
+            metadata["qty"] = display_order_qty
 
         try:
             await self._notification_service.emit(
@@ -331,6 +334,16 @@ class FillReconciliationService:
             self._terminal_notification_sent.add(dedup_key)
         except Exception as exc:  # noqa: BLE001 - 알림 실패가 주문 상태 반영을 막지 않도록 격리
             self.logger.warning(f"주문 terminal 알림 발행 실패: {exc}")
+
+    @staticmethod
+    def _display_order_qty(context: OrderContext, requested_qty) -> int:
+        try:
+            requested = int(requested_qty or 0)
+        except (TypeError, ValueError):
+            requested = 0
+        if context.state == OrderState.FILLED:
+            return max(context.qty, context.filled_qty, requested)
+        return max(context.qty, requested)
 
     # ── 가상매매 영구 기록 (terminal report 시) ──────────────────────
     async def _persist_virtual_trade_for_terminal_report(

--- a/strategies/larry_williams_vbo_strategy.py
+++ b/strategies/larry_williams_vbo_strategy.py
@@ -46,6 +46,7 @@ class LarryWilliamsVBOConfig(BaseStrategyConfig):
     min_market_cap: int = 200_000_000_000         # 시가총액 하한 (2,000억)
     confidence_threshold: float = 120.0           # 스냅샷 체결강도 하한 (%)
     program_buy_ratio: float = 0.10               # 프로그램 순매수 / 거래대금 하한
+    max_entry_extension_pct: float = 2.0          # Target 대비 최대 추격 진입 허용폭 (%)
     stop_loss_pct: float = -3.0                   # 칼손절 기준 (%)
     allow_reentry: bool = False                   # 당일 동일 종목 재진입 금지
 
@@ -208,6 +209,9 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
                     )
                     continue
 
+                if not self._passes_entry_extension_filter(current, target, log_data):
+                    continue
+
                 # 7) 스냅샷 체결강도 >= 120%
                 cgld = await self._get_execution_strength(code)
                 log_data["execution_strength"] = cgld
@@ -365,6 +369,10 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
         target = open_price + rng * self._cfg.k_value
         if current < target:
             stats["reject_below_target"] += 1
+            return None
+
+        if not self._passes_entry_extension_filter(current, target, {}, emit_log=False):
+            stats["reject_entry_extension_too_high"] += 1
             return None
 
         stats["signal"] += 1
@@ -727,6 +735,33 @@ class LarryWilliamsVBOStrategy(LiveStrategy):
             self._logger.warning({"event": "program_filter_error", "code": log_data.get("code"), "error": str(e)})
             return False
 
+        return True
+
+    def _passes_entry_extension_filter(
+        self,
+        current: int,
+        target: float,
+        log_data: dict,
+        *,
+        emit_log: bool = True,
+    ) -> bool:
+        """Target 대비 과도하게 벌어진 추격 진입을 차단한다."""
+        max_pct = self._cfg.max_entry_extension_pct
+        if max_pct is None or max_pct <= 0:
+            return True
+        if target <= 0:
+            return True
+
+        extension_pct = (current - target) / target * 100.0
+        log_data["entry_extension_pct"] = round(extension_pct, 2)
+        if extension_pct > max_pct:
+            if emit_log:
+                self._log_entry_rejected(
+                    log_data,
+                    "entry_extension_too_high",
+                    f"목표가 대비 추격폭({extension_pct:.2f}%) > {max_pct:.2f}%",
+                )
+            return False
         return True
 
     def _log_entry_rejected(self, log_data: dict, reason: str, message: str) -> None:

--- a/tests/unit_test/services/test_fill_reconciliation_service.py
+++ b/tests/unit_test/services/test_fill_reconciliation_service.py
@@ -259,6 +259,52 @@ async def test_strategy_final_notification_labels_average_fill_price_and_total_a
 
 
 @pytest.mark.asyncio
+async def test_strategy_final_notification_does_not_display_overfilled_ratio(
+    broker, fsm, reporter, fixed_now
+):
+    notification = AsyncMock()
+    svc = _make_service(
+        broker=broker,
+        fsm=fsm,
+        reporter=reporter,
+        fixed_now=fixed_now,
+        notification_service=notification,
+    )
+    ctx = fsm.register(_make_context(
+        order_key="KRX:011200:BUY",
+        stock_code="011200",
+        side=OrderSide.BUY,
+        source="strategy:래리윌리엄스VBO",
+        price=22550,
+        qty=88,
+        strategy_notification={
+            "strategy_name": "래리윌리엄스VBO",
+            "stock_name": "HMM",
+            "code": "011200",
+            "action": "BUY",
+            "price": 22550,
+            "qty": 88,
+            "reason": "VBO돌파",
+        },
+    ))
+    fsm.transition(ctx.order_key, OrderState.SUBMITTED, broker_order_no="B0001")
+
+    await svc.apply_execution_report(OrderExecutionReport(
+        broker_order_no="B0001", stock_code="011200", side=OrderSide.BUY,
+        fill_qty=89, fill_price=22550, cumulative_filled_qty=89, remaining_qty=0,
+    ))
+
+    notification.emit.assert_awaited_once()
+    args, kwargs = notification.emit.await_args
+    message = args[3]
+    assert "주문: 22,550원 × 89주" in message
+    assert "평균체결가: 22,550원 × 89/89주" in message
+    assert "89/88주" not in message
+    assert kwargs["metadata"]["qty"] == 89
+    assert kwargs["metadata"]["requested_qty"] == 88
+
+
+@pytest.mark.asyncio
 async def test_apply_execution_report_rejected_emits_failure_notification(
     broker, fsm, reporter, fixed_now
 ):

--- a/tests/unit_test/strategies/test_larry_williams_vbo_evaluate_single.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_evaluate_single.py
@@ -33,12 +33,14 @@ def _market_clock(hh: int, mm: int):
     return mc
 
 
-def _make_strategy(hh: int = 10, mm: int = 0) -> LarryWilliamsVBOStrategy:
+def _make_strategy(hh: int = 10, mm: int = 0, **cfg_kwargs) -> LarryWilliamsVBOStrategy:
+    cfg = {"k_value": 0.5}
+    cfg.update(cfg_kwargs)
     s = LarryWilliamsVBOStrategy(
         stock_query_service=MagicMock(),
         market_clock=_market_clock(hh, mm),
         universe_service=None,
-        config=LarryWilliamsVBOConfig(k_value=0.5),
+        config=LarryWilliamsVBOConfig(**cfg),
         logger=MagicMock(),
     )
     return s
@@ -74,6 +76,18 @@ async def test_evaluate_single_returns_none_when_below_target():
 
     sig = await s.evaluate_single("005930", snapshot)
     assert sig is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_single_returns_none_when_entry_too_far_above_target():
+    s = _make_strategy(10, 0, max_entry_extension_pct=2.0)
+    _seed(s, "005930", range_value=1000.0)
+    snapshot = {"open": 70000.0, "price": "72000"}  # target = 70500, +2.13%
+
+    sig = await s.evaluate_single("005930", snapshot)
+
+    assert sig is None
+    assert s._shadow_eval_stats["005930"]["reject_entry_extension_too_high"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
+++ b/tests/unit_test/strategies/test_larry_williams_vbo_strategy.py
@@ -186,6 +186,48 @@ class TestLarryWilliamsVBOStrategy(unittest.IsolatedAsyncioTestCase):
         signals = await strategy.scan()
         self.assertEqual(signals, [])
 
+    async def test_scan_rejects_entry_too_far_above_target(self):
+        """목표가 대비 추격 폭이 2%를 초과하면 BUY 신호 없음."""
+        strategy, sqs, _ = self._make_strategy(k_value=0.5, max_entry_extension_pct=2.0)
+        sqs.get_top_trading_value_stocks.return_value = self._pool_b()
+        strategy._load_pool_b = AsyncMock(return_value=[{
+            "code": "005930", "name": "삼성전자", "market": "",
+            "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+        }])
+        # Range=2000, Target=71000, current=72500 → 목표가 대비 +2.11%
+        sqs.get_recent_daily_ohlcv.return_value = _ohlcv_resp(high=72000, low=70000)
+        sqs.handle_get_current_stock_price.return_value = _price_resp(
+            current=72500, open_price=70000,
+            pgtr_ntby_qty=700_000, acml_tr_pbmn=50_000_000_000,
+        )
+        sqs.get_stock_conclusion.return_value = _conclusion_resp(130.0)
+
+        signals = await strategy.scan()
+
+        self.assertEqual(signals, [])
+        sqs.get_stock_conclusion.assert_not_awaited()
+
+    async def test_scan_allows_entry_within_target_extension(self):
+        """목표가 대비 추격 폭이 2% 이하면 기존 VBO BUY 신호를 유지한다."""
+        strategy, sqs, _ = self._make_strategy(k_value=0.5, max_entry_extension_pct=2.0)
+        sqs.get_top_trading_value_stocks.return_value = self._pool_b()
+        strategy._load_pool_b = AsyncMock(return_value=[{
+            "code": "005930", "name": "삼성전자", "market": "",
+            "market_cap": 500_000_000_000, "avg_5d_tv": 50_000_000_000,
+        }])
+        # Range=2000, Target=71000, current=72400 → 목표가 대비 +1.97%
+        sqs.get_recent_daily_ohlcv.return_value = _ohlcv_resp(high=72000, low=70000)
+        sqs.handle_get_current_stock_price.return_value = _price_resp(
+            current=72400, open_price=70000,
+            pgtr_ntby_qty=700_000, acml_tr_pbmn=50_000_000_000,
+        )
+        sqs.get_stock_conclusion.return_value = _conclusion_resp(130.0)
+
+        signals = await strategy.scan()
+
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(signals[0].code, "005930")
+
     async def test_scan_uses_intraday_open_fallback_when_current_price_open_is_zero(self):
         """상세 현재가의 시가가 0이면 당일 첫 분봉 시가로 VBO 타깃을 계산한다."""
         strategy, sqs, _ = self._make_strategy(now_time=_kst(10, 0), k_value=0.5)


### PR DESCRIPTION
## Summary
- add a 2% max target-extension guard to Larry Williams VBO entries to avoid chase buys
- show terminal strategy notifications with a reconciled display quantity when fills exceed the requested/context quantity
- harden SP500Repository recovery for corrupted SQLite files discovered during full unit tests

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests\integration_test -v