### PR TITLE
Fix force-exit sells using broker holdings

### DIFF
--- a/scheduler/strategy_scheduler.py
+++ b/scheduler/strategy_scheduler.py
@@ -308,6 +308,11 @@ class StrategyScheduler:
                 return
 
             positions = await self._get_broker_position_map_for_force_exit()
+            if positions is None:
+                self._logger.error(
+                    f"[Scheduler] 강제 청산 재시도 취소(잔고 확인 실패): code={signal.code}"
+                )
+                return
             broker_qty = positions.get(str(signal.code), 0)
             if broker_qty <= 0:
                 self._logger.warning(
@@ -1601,8 +1606,30 @@ class StrategyScheduler:
         }
 
         broker_positions = await self._get_broker_position_map_for_force_exit()
-        if not broker_positions:
+        if broker_positions is None:
             return list(merged.values())
+
+        broker_capped: Dict[str, dict] = {}
+        for code, hold in merged.items():
+            broker_qty = broker_positions.get(code, 0)
+            if broker_qty <= 0:
+                self._logger.warning(
+                    f"[Scheduler] force-exit local HOLD skipped because broker has no position: "
+                    f"strategy={strategy_name}, code={code}, local_qty={hold.get('qty')}"
+                )
+                continue
+
+            local_qty = self._parse_position_qty(hold.get("qty"))
+            sell_qty = min(local_qty, broker_qty) if local_qty > 0 else broker_qty
+            capped = dict(hold)
+            capped["qty"] = sell_qty
+            broker_capped[code] = capped
+            if local_qty != sell_qty:
+                self._logger.warning(
+                    f"[Scheduler] force-exit local HOLD qty capped by broker position: "
+                    f"strategy={strategy_name}, code={code}, local_qty={local_qty}, broker_qty={broker_qty}"
+                )
+        merged = broker_capped
 
         today_prefix = self._current_signal_date_prefix()
         candidate_codes = {
@@ -1689,20 +1716,20 @@ class StrategyScheduler:
 
         return True
 
-    async def _get_broker_position_map_for_force_exit(self) -> Dict[str, int]:
+    async def _get_broker_position_map_for_force_exit(self) -> Optional[Dict[str, int]]:
         try:
             broker = getattr(self._oes, "broker_api_wrapper", None)
             if broker is None:
-                return {}
+                return None
             resp = await broker.get_account_balance()
             if not resp or resp.rt_cd != ErrorCode.SUCCESS.value:
-                return {}
+                return None
             data = resp.data or {}
             holdings = data.get("output1") if isinstance(data, dict) else None
             return self._normalize_broker_position_map(holdings or [])
         except Exception as e:
             self._logger.warning(f"[Scheduler] force-exit broker balance lookup failed: {e}")
-            return {}
+            return None
 
     @staticmethod
     def _normalize_broker_position_map(holdings: list) -> Dict[str, int]:

--- a/tests/unit_test/test_strategy_scheduler_force_exit.py
+++ b/tests/unit_test/test_strategy_scheduler_force_exit.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from common.types import ErrorCode, ResCommonResponse
+from scheduler.strategy_scheduler import StrategyScheduler, StrategySchedulerConfig
+
+
+class _StrategyStub:
+    name = "larry_williams_vbo"
+
+
+def _make_scheduler(*, broker_positions: dict[str, int]) -> StrategyScheduler:
+    scheduler = StrategyScheduler.__new__(StrategyScheduler)
+    scheduler._logger = Mock()
+    scheduler._signal_history = []
+    scheduler.stock_code_repository = Mock()
+    scheduler.stock_code_repository.get_name_by_code.side_effect = lambda code: code
+    scheduler._get_strategy_holdings = Mock(return_value=[
+        {
+            "strategy": "larry_williams_vbo",
+            "code": "011200",
+            "name": "HMM",
+            "buy_price": 22550,
+            "qty": 45,
+            "status": "HOLD",
+        }
+    ])
+    scheduler._get_broker_position_map_for_force_exit = AsyncMock(return_value=broker_positions)
+    return scheduler
+
+
+@pytest.mark.asyncio
+async def test_force_liquidation_skips_local_hold_when_broker_has_no_position():
+    scheduler = _make_scheduler(broker_positions={"011200": 0})
+    cfg = StrategySchedulerConfig(strategy=_StrategyStub(), force_exit_on_close=True)
+
+    holdings = await scheduler._get_force_liquidation_holdings(cfg)
+
+    assert holdings == []
+
+
+@pytest.mark.asyncio
+async def test_force_liquidation_caps_local_hold_to_broker_position_qty():
+    scheduler = _make_scheduler(broker_positions={"011200": 44})
+    cfg = StrategySchedulerConfig(strategy=_StrategyStub(), force_exit_on_close=True)
+
+    holdings = await scheduler._get_force_liquidation_holdings(cfg)
+
+    assert len(holdings) == 1
+    assert holdings[0]["code"] == "011200"
+    assert holdings[0]["qty"] == 44
+
+
+@pytest.mark.asyncio
+async def test_force_liquidation_uses_local_hold_when_broker_lookup_fails():
+    scheduler = _make_scheduler(broker_positions={})
+    scheduler._get_broker_position_map_for_force_exit = AsyncMock(return_value=None)
+    cfg = StrategySchedulerConfig(strategy=_StrategyStub(), force_exit_on_close=True)
+
+    holdings = await scheduler._get_force_liquidation_holdings(cfg)
+
+    assert len(holdings) == 1
+    assert holdings[0]["code"] == "011200"
+    assert holdings[0]["qty"] == 45
+
+
+@pytest.mark.asyncio
+async def test_force_exit_broker_position_lookup_returns_none_on_balance_failure():
+    scheduler = StrategyScheduler.__new__(StrategyScheduler)
+    scheduler._logger = Mock()
+    broker = Mock()
+    broker.get_account_balance = AsyncMock(
+        return_value=ResCommonResponse(
+            rt_cd=ErrorCode.API_ERROR.value,
+            msg1="모의투자 잔고내역이 없습니다.",
+            data=None,
+        )
+    )
+    scheduler._oes = Mock(broker_api_wrapper=broker)
+
+    positions = await scheduler._get_broker_position_map_for_force_exit()
+
+    assert positions is None


### PR DESCRIPTION
## Summary
- skip force-exit local HOLD rows when broker balance has no matching position
- cap force-exit sell quantity to broker-held quantity
- preserve local HOLD fallback when broker balance lookup fails

## Tests
- python -m pytest tests/unit_test/test_strategy_scheduler_force_exit.py -v -n0
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v