### PR TITLE
Reconcile force-exit no-position sell failures

### DIFF
--- a/services/order_execution_service.py
+++ b/services/order_execution_service.py
@@ -11,6 +11,7 @@ from core.loggers.trace_context import trace_scope, get_trace_id, new_trace_id
 from core.performance_profiler import PerformanceProfiler
 from core.market_clock import MarketClock
 from repositories.streaming_stock_repo import StreamingType
+from repositories.virtual_trade_repository import _FORCE_CLOSE_REASON
 from services.notification_service import NotificationService, NotificationCategory, NotificationLevel
 from services.market_calendar_service import MarketCalendarService
 from services.price_subscription_service import SubscriptionPriority
@@ -298,6 +299,56 @@ class OrderExecutionService:
     @staticmethod
     def _is_reconcile_source(source: str) -> bool:
         return (source or "").startswith("reconcile:")
+
+    @staticmethod
+    def _is_force_exit_source(source: str) -> bool:
+        return str(source or "").startswith("strategy_force_exit:")
+
+    @staticmethod
+    def _is_no_broker_position_sell_failure(message: str) -> bool:
+        text = str(message or "")
+        return any(
+            marker in text
+            for marker in (
+                "잔고내역이 없습니다",
+                "잔고 내역이 없습니다",
+                "보유수량",
+                "보유 수량",
+                "매도가능수량",
+                "매도 가능 수량",
+                "insufficient position",
+                "no position",
+            )
+        )
+
+    async def _reconcile_force_exit_sell_failure_if_no_position(
+        self,
+        *,
+        stock_code: str,
+        source: str,
+        message: str,
+    ) -> None:
+        if (
+            not self._virtual_trade_service
+            or not self._is_force_exit_source(source)
+            or not self._is_no_broker_position_sell_failure(message)
+        ):
+            return
+
+        strategy_name, is_strategy = self._strategy_name_from_source(source)
+        if not is_strategy or not strategy_name:
+            return
+
+        self.logger.warning(
+            f"[Reconciliation] 강제청산 SELL 실패가 브로커 잔고 없음으로 확인되어 로컬 HOLD를 강제 종결: "
+            f"strategy={strategy_name}, code={stock_code}, msg={message}"
+        )
+        await self._virtual_trade_service.log_sell_by_strategy_async(
+            strategy_name,
+            stock_code,
+            0,
+            reason=_FORCE_CLOSE_REASON,
+        )
 
     async def _persist_virtual_trade_for_terminal_report(self, context, report):
         return await self._fill_reconciliation._persist_virtual_trade_for_terminal_report(context, report)
@@ -609,6 +660,11 @@ class OrderExecutionService:
                     f"주식 매도 주문 실패: 종목={stock_code}, 결과={{'rt_cd': '{rt_cd}', 'msg1': '{msg1}'}}")
                 if self._virtual_trade_service:
                     await self._virtual_trade_service.log_order_failure_async("SELL", stock_code, price, qty, msg1)
+                    await self._reconcile_force_exit_sell_failure_if_no_position(
+                        stock_code=stock_code,
+                        source=source,
+                        message=msg1,
+                    )
                 if self._notification_service and not self._is_strategy_source(source):
                     await self._notification_service.emit(NotificationCategory.SYSTEM, NotificationLevel.ERROR, "매도 주문 실패",
                                         f"{stock_code} - {msg1}",

--- a/tests/unit_test/services/test_order_execution_service.py
+++ b/tests/unit_test/services/test_order_execution_service.py
@@ -330,6 +330,68 @@ async def test_handle_place_sell_order_trading_service_failure(handler, mock_bro
 
 
 @pytest.mark.asyncio
+async def test_force_exit_sell_failure_with_no_position_reconciles_strategy_hold(
+    handler,
+    mock_broker_api_wrapper,
+):
+    """강제청산 SELL이 '잔고/보유 없음'으로 거절되면 해당 전략 HOLD를 강제 대사한다."""
+    virtual_trade_service = AsyncMock()
+    handler._virtual_trade_service = virtual_trade_service
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="Business Error: 모의투자 잔고내역이 없습니다.",
+        data=None,
+    )
+
+    result = await handler.handle_place_sell_order(
+        "011200",
+        0,
+        45,
+        source="strategy_force_exit:larry_williams_vbo",
+    )
+
+    assert result.rt_cd == ErrorCode.API_ERROR.value
+    virtual_trade_service.log_order_failure_async.assert_awaited_once_with(
+        "SELL",
+        "011200",
+        0,
+        45,
+        "Business Error: 모의투자 잔고내역이 없습니다.",
+    )
+    virtual_trade_service.log_sell_by_strategy_async.assert_awaited_once_with(
+        "larry_williams_vbo",
+        "011200",
+        0,
+        reason="reconciled_force_close",
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_force_exit_sell_failure_does_not_reconcile_local_hold(
+    handler,
+    mock_broker_api_wrapper,
+):
+    """일반 전략 SELL 실패는 로컬 HOLD를 자동 강제종결하지 않는다."""
+    virtual_trade_service = AsyncMock()
+    handler._virtual_trade_service = virtual_trade_service
+    mock_broker_api_wrapper.place_stock_order.return_value = ResCommonResponse(
+        rt_cd=ErrorCode.API_ERROR.value,
+        msg1="거래정지",
+        data=None,
+    )
+
+    await handler.handle_place_sell_order(
+        "011200",
+        0,
+        45,
+        source="strategy:larry_williams_vbo",
+    )
+
+    virtual_trade_service.log_order_failure_async.assert_awaited_once()
+    virtual_trade_service.log_sell_by_strategy_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_strategy_sell_failure_does_not_emit_duplicate_system_notification(
     handler,
     mock_broker_api_wrapper,


### PR DESCRIPTION
## Summary
- force-exit SELL failures caused by no broker position now reconcile the matching strategy HOLD as reconciled_force_close
- non-force-exit strategy sell failures still only record failure and do not mutate local HOLD
- cleaned local HMM stale HOLD in virtual_trade.db after backing up the DB

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test/services/test_order_execution_service.py -v -n0
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v