### PR TITLE
fix: exclude reconciled force close from virtual summary

### DIFF
--- a/services/virtual_trade_service.py
+++ b/services/virtual_trade_service.py
@@ -141,23 +141,37 @@ class VirtualTradeService:
         df = self._repo._read()
         total_trades = len(df)
         sold_df = df[df['status'] == 'SOLD']
-        
-        if sold_df.empty:
-            return {"total_trades": total_trades, "win_rate": 0, "avg_return": 0}
+
+        if 'reason' in sold_df.columns:
+            reason_series = sold_df['reason'].fillna('').astype(str)
+            force_closed_count = int((reason_series == _FORCE_CLOSE_REASON).sum())
+            natural_sold_df = sold_df[reason_series != _FORCE_CLOSE_REASON]
+        else:
+            force_closed_count = 0
+            natural_sold_df = sold_df
+
+        if natural_sold_df.empty:
+            return {
+                "total_trades": total_trades,
+                "win_rate": 0,
+                "avg_return": 0,
+                "force_closed_count": force_closed_count,
+            }
 
         if apply_cost:
-            returns = sold_df.apply(lambda row: self.calculate_return(row['buy_price'], row['sell_price'], row['qty'], True), axis=1)
+            returns = natural_sold_df.apply(lambda row: self.calculate_return(row['buy_price'], row['sell_price'], row['qty'], True), axis=1)
         else:
-            returns = sold_df['return_rate']
+            returns = natural_sold_df['return_rate']
 
         win_trades = len(returns[returns > 0])
-        win_rate = (win_trades / len(sold_df) * 100)
+        win_rate = (win_trades / len(natural_sold_df) * 100)
         avg_return = returns.mean()
 
         return {
             "total_trades": total_trades,
             "win_rate": round(win_rate, 1),
-            "avg_return": round(avg_return, 2)
+            "avg_return": round(avg_return, 2),
+            "force_closed_count": force_closed_count,
         }
 
     def get_daily_change(self, strategy: str, current_return: float, *, _data: dict | None = None) -> tuple[float | None, str | None]:

--- a/tests/unit_test/services/test_virtual_trade_service.py
+++ b/tests/unit_test/services/test_virtual_trade_service.py
@@ -99,6 +99,38 @@ def test_get_summary(virtual_trade_service, mock_repo):
     assert res_default == res_cost
 
 
+def test_get_summary_excludes_reconciled_force_close(virtual_trade_service, mock_repo):
+    """대사 강제종결은 웹 요약 승률/평균수익률에서 제외하고 별도 카운트한다."""
+    df = pd.DataFrame([
+        {
+            'status': 'SOLD',
+            'buy_price': 1000,
+            'sell_price': 1200,
+            'qty': 1,
+            'return_rate': 20.0,
+            'reason': '',
+        },
+        {
+            'status': 'SOLD',
+            'buy_price': 1000,
+            'sell_price': 0,
+            'qty': 1,
+            'return_rate': -100.0,
+            'reason': 'reconciled_force_close',
+        },
+    ])
+    mock_repo._read.return_value = df
+
+    res = virtual_trade_service.get_summary(apply_cost=False)
+
+    assert res == {
+        "total_trades": 2,
+        "win_rate": 100.0,
+        "avg_return": 20.0,
+        "force_closed_count": 1,
+    }
+
+
 def test_get_daily_change(virtual_trade_service, mock_repo, mock_clock):
     """get_daily_change 일일 수익률 변화 로직 테스트"""
     # 데이터 부족 시 None 반환


### PR DESCRIPTION
## Summary
- exclude reconciled_force_close rows from virtual summary win rate and average return calculations
- expose force_closed_count from the service summary
- add regression coverage for reconciled force-close rows

## Tests
- pytest tests/unit_test/services/test_virtual_trade_service.py -v -n0
- pytest tests/unit_test -v
- pytest tests/integration_test -v