### PR TITLE
fix: 장외 시간 즐겨찾기 등락률을 직전 세션 기준으로 통일

### DIFF
--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -146,10 +146,11 @@ class FavoriteService:
     async def get_with_details(self, market: str = MARKET_DOMESTIC) -> list:
         """관심종목 목록에 종목명·현재가·등락률을 포함하여 반환.
 
-        1단계: StockQueryService 현재가 조회 (신선 WebSocket snapshot 우선, REST fallback)
-        2단계: StockRepository 메모리 캐시 (stock_price_repository, 즉시)
-        3단계: StockRepository DB 스냅샷 (장마감 후 일봉 데이터)
-        stock_query_service 없으면 종목명만 반환 (graceful degradation).
+        조회 소스는 장 운영 여부에 따라 순서가 바뀐다.
+        장중: StockQueryService(신선 WebSocket snapshot 우선, REST fallback)
+              → 메모리 캐시 → DB 일봉 스냅샷
+        장외: DB 일봉 스냅샷(최근 거래일) → StockQueryService → 메모리 캐시
+        모든 소스가 비면 종목명만 반환 (graceful degradation).
         """
         if market == MARKET_OVERSEAS_US:
             return await self._get_overseas_details()
@@ -173,53 +174,22 @@ class FavoriteService:
 
         missing = list(codes)
 
-        # 1단계: StockQueryService 현재가 조회 (5초 timeout)
-        if missing and self.stock_query_service:
-            async def _fetch(code):
-                try:
-                    return await asyncio.wait_for(
-                        self.stock_query_service.get_current_price(
-                            code, count_stats=False, caller="FavoriteService"
-                        ),
-                        timeout=5.0,
-                    )
-                except Exception:
-                    return None
+        # 장이 닫혀 있으면 최근 거래일 일봉을 먼저 쓴다.
+        # 장 시작 전·비거래일의 현재가 API 는 전일 종가에 등락률 0.00 을 얹어 돌려주므로,
+        # 라이브 값을 그대로 쓰면 직전 세션 등락률이 뜨는 종목과 한 표에 섞인다.
+        if await self._is_market_open():
+            stages = (self._fill_from_query_service,
+                      self._fill_from_memory_cache,
+                      self._fill_from_daily_snapshot)
+        else:
+            stages = (self._fill_from_daily_snapshot,
+                      self._fill_from_query_service,
+                      self._fill_from_memory_cache)
 
-            still_missing = []
-            responses = await asyncio.gather(*[_fetch(c) for c in missing])
-            for code, resp in zip(missing, responses):
-                if not (resp and resp.rt_cd == "0" and resp.data
-                        and _apply_price_rate(result[code], resp.data)):
-                    still_missing.append(code)
-            missing = still_missing
-
-        # 2단계: 메모리 캐시 (서비스 미주입/조회 실패 시 graceful fallback)
-        if missing and self.stock_repository:
-            still_missing = []
-            for code in missing:
-                cached = self.stock_repository.get_current_price(code, max_age_sec=3.0, count_stats=False)
-                if not (cached and _apply_price_rate(result[code], cached)):
-                    still_missing.append(code)
-            missing = still_missing
-
-        # 3단계: DB 스냅샷 (장마감 후 일봉)
-        # 최근 거래일보다 오래된 스냅샷은 현재가/등락률로 쓰지 않는다 (MarketDataService와 동일 기준).
-        if missing and self.stock_repository:
-            latest_trading_date = await self._get_latest_trading_date()
-            still_missing = []
-            snapshot_tasks = [self.stock_repository.get_latest_daily_snapshot(code) for code in missing]
-            snapshots = await asyncio.gather(*snapshot_tasks, return_exceptions=True)
-            for code, snap in zip(missing, snapshots):
-                if isinstance(snap, Exception) or not snap:
-                    still_missing.append(code)
-                    continue
-                if latest_trading_date and _snapshot_trade_date(snap) != latest_trading_date:
-                    still_missing.append(code)
-                    continue
-                if not _apply_price_rate(result[code], snap):
-                    still_missing.append(code)
-            missing = still_missing
+        for stage in stages:
+            if not missing:
+                break
+            missing = await stage(result, missing)
 
         # 4단계: RS Rating 점수 조회 및 병합
         if self.rs_rating_service:
@@ -252,6 +222,75 @@ class FavoriteService:
                     result[code]["minervini_stage"] = stage
 
         return list(result.values())
+
+    async def _fill_from_query_service(self, result: dict, missing: list) -> list:
+        """StockQueryService 현재가 조회 (종목당 5초 timeout)."""
+        if not self.stock_query_service:
+            return missing
+
+        async def _fetch(code):
+            try:
+                return await asyncio.wait_for(
+                    self.stock_query_service.get_current_price(
+                        code, count_stats=False, caller="FavoriteService"
+                    ),
+                    timeout=5.0,
+                )
+            except Exception:
+                return None
+
+        still_missing = []
+        responses = await asyncio.gather(*[_fetch(c) for c in missing])
+        for code, resp in zip(missing, responses):
+            if not (resp and resp.rt_cd == "0" and resp.data
+                    and _apply_price_rate(result[code], resp.data)):
+                still_missing.append(code)
+        return still_missing
+
+    async def _fill_from_memory_cache(self, result: dict, missing: list) -> list:
+        """StockRepository 메모리 캐시 (서비스 미주입/조회 실패 시 graceful fallback)."""
+        if not self.stock_repository:
+            return missing
+
+        still_missing = []
+        for code in missing:
+            cached = self.stock_repository.get_current_price(code, max_age_sec=3.0, count_stats=False)
+            if not (cached and _apply_price_rate(result[code], cached)):
+                still_missing.append(code)
+        return still_missing
+
+    async def _fill_from_daily_snapshot(self, result: dict, missing: list) -> list:
+        """DB 일봉 스냅샷.
+
+        최근 거래일보다 오래된 스냅샷은 현재가/등락률로 쓰지 않는다
+        (MarketDataService.get_current_price 와 동일 기준).
+        """
+        if not self.stock_repository:
+            return missing
+
+        latest_trading_date = await self._get_latest_trading_date()
+        still_missing = []
+        snapshot_tasks = [self.stock_repository.get_latest_daily_snapshot(code) for code in missing]
+        snapshots = await asyncio.gather(*snapshot_tasks, return_exceptions=True)
+        for code, snap in zip(missing, snapshots):
+            if isinstance(snap, Exception) or not snap:
+                still_missing.append(code)
+                continue
+            if latest_trading_date and _snapshot_trade_date(snap) != latest_trading_date:
+                still_missing.append(code)
+                continue
+            if not _apply_price_rate(result[code], snap):
+                still_missing.append(code)
+        return still_missing
+
+    async def _is_market_open(self) -> bool:
+        """장 운영 중 여부. 캘린더 서비스가 없거나 실패하면 True (라이브 우선, 기존 동작)."""
+        if not self.market_calendar_service:
+            return True
+        try:
+            return bool(await self.market_calendar_service.is_market_open_now())
+        except Exception:
+            return True
 
     async def _get_latest_trading_date(self):
         """최근 거래일(YYYYMMDD). 캘린더 서비스가 없거나 실패하면 None (검증 생략)."""

--- a/tests/unit_test/services/test_favorite_service.py
+++ b/tests/unit_test/services/test_favorite_service.py
@@ -538,3 +538,92 @@ async def test_get_with_details_uses_daily_snapshot_of_latest_trading_date(
 
     assert result[0]["price"] == "71000"
     assert result[0]["rate"] == "1.2"
+
+
+def _mcs(latest_trading_date="20260821", market_open=False):
+    mcs = MagicMock()
+    mcs.get_latest_trading_date = AsyncMock(return_value=latest_trading_date)
+    mcs.is_market_open_now = AsyncMock(return_value=market_open)
+    return mcs
+
+
+async def test_get_with_details_prefers_daily_snapshot_when_market_closed(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """장 시작 전·비거래일에는 라이브 0.00% 대신 직전 세션 일봉 등락률을 쓴다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_query = AsyncMock()
+    # 장전 KIS 현재가 API 응답: 전일 종가 + 등락률 0.00
+    mock_query.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data={"output": {"stck_prpr": "71000", "prdy_ctrt": "0.00"}}
+    )
+    mock_stock_repo.get_latest_daily_snapshot.return_value = {
+        "output": {"stck_prpr": "71000", "prdy_ctrt": "4.03"},
+        "_trade_date": "20260821",
+    }
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        stock_repository=mock_stock_repo,
+        market_calendar_service=_mcs(market_open=False),
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "71000"
+    assert result[0]["rate"] == "4.03"
+    mock_query.get_current_price.assert_not_called()
+
+
+async def test_get_with_details_prefers_live_price_while_market_open(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """장중에는 일봉 스냅샷이 있어도 라이브 현재가를 우선한다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_query = AsyncMock()
+    mock_query.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data={"output": {"stck_prpr": "72500", "prdy_ctrt": "2.11"}}
+    )
+    mock_stock_repo.get_latest_daily_snapshot.return_value = {
+        "output": {"stck_prpr": "71000", "prdy_ctrt": "4.03"},
+        "_trade_date": "20260821",
+    }
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        stock_repository=mock_stock_repo,
+        market_calendar_service=_mcs(market_open=True),
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "72500"
+    assert result[0]["rate"] == "2.11"
+    mock_stock_repo.get_latest_daily_snapshot.assert_not_called()
+
+
+async def test_get_with_details_falls_back_to_live_when_market_closed_and_no_snapshot(
+    mock_repo, mock_stock_code_repo, mock_stock_repo
+):
+    """장이 닫혀 있어도 최근 거래일 스냅샷이 없으면 라이브 값으로 폴백한다."""
+    mock_repo.get_all.return_value = ["005930"]
+    mock_query = AsyncMock()
+    mock_query.get_current_price.return_value = ResCommonResponse(
+        rt_cd="0", msg1="성공", data={"output": {"stck_prpr": "71000", "prdy_ctrt": "0.00"}}
+    )
+    mock_stock_repo.get_latest_daily_snapshot.return_value = None
+
+    svc = FavoriteService(
+        repository=mock_repo,
+        stock_code_repository=mock_stock_code_repo,
+        stock_query_service=mock_query,
+        stock_repository=mock_stock_repo,
+        market_calendar_service=_mcs(market_open=False),
+    )
+    result = await svc.get_with_details()
+
+    assert result[0]["price"] == "71000"
+    assert result[0]["rate"] == "0.00"
+    mock_query.get_current_price.assert_called_once()


### PR DESCRIPTION
## 배경

#897 후속. 즐겨찾기 목록의 남은 불일치를 정리한다.

장 시작 전(09:00 이전)·비거래일에 KIS 현재가 API 는 **전일 종가를 현재가로, 등락률은 `0.00`** 으로 돌려준다. 반면 DB 일봉 스냅샷으로 채워진 종목은 직전 세션의 실제 등락률이 뜬다. 그 결과 같은 표에 `0.00%` 와 `+4.03%` 가 섞여 어느 쪽이 맞는지 알 수 없었다 (신고된 스크린샷의 삼성전자·SK하이닉스가 전자, 나머지가 후자).

#897 은 "오래된 일봉을 쓰지 않는다"만 고쳤고, 이 기준 혼재는 그대로 남아 있었다.

## 변경 내용

네이버·HTS 의 장전 표시 방식(직전 세션 등락률)에 맞춰, **장이 닫혀 있으면 최근 거래일 일봉 스냅샷을 먼저 조회**하도록 소스 우선순위를 바꾼다.

| 상황 | 조회 순서 |
|---|---|
| 장중 | StockQueryService → 메모리 캐시 → DB 일봉 스냅샷 (기존과 동일) |
| 장외 | **DB 일봉 스냅샷(최근 거래일)** → StockQueryService → 메모리 캐시 |

- 장 마감 후에도 같은 순서가 적용되지만, 그때 최근 거래일은 당일이라 표시 값은 종전과 같다. 일봉 수집 전이면 #897 의 거래일 검증에 걸려 라이브로 폴백한다.
- 장외인데 최근 거래일 스냅샷이 없으면 라이브 값으로 폴백한다 (값이 아예 없는 것보다 낫다).
- `market_calendar_service` 미주입 시에는 장중으로 간주해 기존 동작을 유지한다.

순서 교체를 위해 각 단계를 `_fill_from_query_service` / `_fill_from_memory_cache` / `_fill_from_daily_snapshot` 메서드로 분리했다. 단계별 로직 자체는 그대로다.

## 테스트

TDD 로 실패 테스트 선작성 후 구현:

- `test_get_with_details_prefers_daily_snapshot_when_market_closed` — 장외에서 라이브 `0.00%` 대신 일봉 `4.03%` 를 쓰고, 현재가 API 를 아예 호출하지 않는지 검증
- `test_get_with_details_prefers_live_price_while_market_open` — 장중에는 스냅샷이 있어도 라이브 우선, 스냅샷 조회 안 함
- `test_get_with_details_falls_back_to_live_when_market_closed_and_no_snapshot` — 장외 + 스냅샷 없음 → 라이브 폴백

```
pytest tests/unit_test        → 8523 passed
pytest tests/integration_test →  291 passed
```

## 남은 항목 (이번 PR 범위 밖)

- **스트리밍 종목 캐시 TTL 무제한** — `StockPriceRepository.get_current_price()` 는 `is_streaming` 종목에 대해 `max_age_sec` 을 `float('inf')` 로 무시한다. 다만 `StockQueryService` 가 스트림 snapshot 이 오래되면 `force_fresh=True` 로 이 캐시를 건너뛰고 구독까지 해지하므로, 실제 노출 구간은 `price_stream_service` 미주입 경로 정도로 좁다. 모듈 docstring 에 의도된 설계로 명시돼 있고 상한값을 정할 관측 데이터가 없어 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyykUArMSAdkmXsvaGCj8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyykUArMSAdkmXsvaGCj8L)_