### PR TITLE
Show US market scheduler task status

### DIFF
--- a/tests/integration_test/test_it_scheduler_status_market_tasks.py
+++ b/tests/integration_test/test_it_scheduler_status_market_tasks.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from interfaces.schedulable_task import TaskPriority, TaskState
+
+
+class _OverseasIntradayVBOTask:
+    task_name = "overseas_intraday_vbo"
+    priority = TaskPriority.NORMAL
+    state = TaskState.RUNNING
+
+    def get_progress(self):
+        return {"running": True, "watch_count": 10}
+
+
+def test_it_scheduler_status_exposes_overseas_market_tasks(paper_client, mock_paper_ctx):
+    mock_paper_ctx.scheduler = None
+    mock_paper_ctx.enabled_market_modes = ["domestic", "overseas_us"]
+    mock_paper_ctx.background_scheduler = MagicMock()
+    mock_paper_ctx.background_scheduler.get_task.side_effect = (
+        lambda name: _OverseasIntradayVBOTask()
+        if name == "overseas_intraday_vbo"
+        else None
+    )
+
+    response = paper_client.get("/api/scheduler/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["running"] is False
+    assert body["strategies"] == []
+    assert body["market_tasks"][0]["name"] == "overseas_intraday_vbo"
+    assert body["market_tasks"][0]["market"] == "overseas_us"
+    assert body["market_tasks"][0]["running"] is True
+    assert body["market_tasks"][0]["live_trading"] is False

--- a/tests/unit_test/test_scheduler_route_status.py
+++ b/tests/unit_test/test_scheduler_route_status.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from interfaces.schedulable_task import TaskPriority, TaskState
+from view.web import api_common
+from view.web.routes.scheduler import get_scheduler_status
+
+
+class _Task:
+    task_name = "overseas_intraday_vbo"
+    priority = TaskPriority.NORMAL
+    state = TaskState.RUNNING
+
+    def get_progress(self):
+        return {"running": True, "watch_count": 10}
+
+
+@pytest.mark.asyncio
+async def test_scheduler_status_includes_overseas_market_task_without_domestic_scheduler():
+    background_scheduler = MagicMock()
+    background_scheduler.get_task.side_effect = (
+        lambda name: _Task() if name == "overseas_intraday_vbo" else None
+    )
+    ctx = SimpleNamespace(
+        scheduler=None,
+        background_scheduler=background_scheduler,
+        enabled_market_modes=["domestic", "overseas_us"],
+    )
+    api_common.set_ctx(ctx)
+    try:
+        status = await get_scheduler_status()
+    finally:
+        api_common.set_ctx(None)
+
+    assert status["running"] is False
+    assert status["strategies"] == []
+    assert status["market_tasks"] == [
+        {
+            "name": "overseas_intraday_vbo",
+            "display_name": "미국장 장중 VBO",
+            "market": "overseas_us",
+            "market_label": "미국장",
+            "mode": "paper",
+            "live_trading": False,
+            "state": "running",
+            "running": True,
+            "priority": 50,
+            "progress": {"running": True, "watch_count": 10},
+        }
+    ]

--- a/view/web/routes/scheduler.py
+++ b/view/web/routes/scheduler.py
@@ -13,9 +13,53 @@ class UpdateMaxPositionsRequest(BaseModel):
     max_positions: int
 
 
+_MARKET_TASK_DEFINITIONS = (
+    {
+        "name": "overseas_intraday_vbo",
+        "display_name": "미국장 장중 VBO",
+        "market": "overseas_us",
+        "market_label": "미국장",
+        "mode": "paper",
+        "live_trading": False,
+    },
+    {
+        "name": "overseas_dryrun",
+        "display_name": "미국장 마감 후 Dry-run",
+        "market": "overseas_us",
+        "market_label": "미국장",
+        "mode": "dry-run",
+        "live_trading": False,
+    },
+)
+
+
 def _save_scheduler_state_later(ctx) -> None:
     """상태 저장은 응답 경로를 막지 않도록 백그라운드에서 수행한다."""
     asyncio.create_task(asyncio.to_thread(ctx.scheduler._save_scheduler_state))
+
+
+def _market_task_status(ctx) -> list[dict]:
+    """StrategyScheduler 밖에서 도는 시장별 전략성 태스크를 상태 API에 노출한다."""
+    background_scheduler = getattr(ctx, "background_scheduler", None)
+    if background_scheduler is None:
+        return []
+
+    items = []
+    for definition in _MARKET_TASK_DEFINITIONS:
+        task = background_scheduler.get_task(definition["name"])
+        if task is None:
+            continue
+        state = getattr(task, "state", None)
+        state_value = getattr(state, "value", state)
+        progress = task.get_progress() if hasattr(task, "get_progress") else {}
+        items.append({
+            **definition,
+            "state": state_value,
+            "running": state_value == "running" or bool(progress.get("running")),
+            "priority": int(getattr(task, "priority", 0)),
+            "progress": progress,
+        })
+    return items
 
 
 @router.get("/scheduler/status")
@@ -23,9 +67,14 @@ async def get_scheduler_status():
     """스케줄러 상태 조회."""
     ctx = _get_ctx()
     if not ctx.scheduler:
-        return {"running": False, "strategies": []}
+        return {
+            "running": False,
+            "strategies": [],
+            "market_tasks": _market_task_status(ctx),
+        }
     
     status = await asyncio.to_thread(ctx.scheduler.get_status)
+    status["market_tasks"] = _market_task_status(ctx)
     
     # [BugFix] 보유 종목명 보정
     mapper = getattr(ctx, 'stock_code_repository', None)

--- a/view/web/static/js/scheduler.js
+++ b/view/web/static/js/scheduler.js
@@ -72,16 +72,25 @@ function renderSchedulerStatus(data) {
     const info = document.getElementById('scheduler-info');
     const strategiesDiv = document.getElementById('scheduler-strategies');
 
+    const marketTasks = data.market_tasks || [];
+    const hasRunningMarketTask = marketTasks.some(task => task.running || task.state === 'running');
+
     if (data.running) {
         badge.textContent = '실행 중';
+        badge.className = 'badge open';
+    } else if (hasRunningMarketTask) {
+        badge.textContent = '시장 태스크 실행';
         badge.className = 'badge open';
     } else {
         badge.textContent = '정지';
         badge.className = 'badge closed';
     }
 
-    const dryLabel = data.dry_run ? 'dry-run: CSV만 기록' : '실제 주문 실행';
+    const dryLabel = data.running
+        ? (data.dry_run ? '국내 자동전략 dry-run: CSV만 기록' : '국내 자동전략 실제 주문 실행')
+        : '국내 자동전략 정지';
     info.textContent = dryLabel;
+    renderMarketTasks(marketTasks);
 
     if (!data.strategies || data.strategies.length === 0) {
         strategiesDiv.innerHTML = '<div class="card"><span>등록된 전략이 없습니다.</span></div>';
@@ -131,6 +140,47 @@ function renderSchedulerStatus(data) {
             ${holdingsHtml}
             <div style="margin-top:8px;color:var(--text-secondary);font-size:0.9em;">
                 실행 주기: ${s.interval_minutes}분 | 마지막 실행: ${s.last_run || '-'}
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function renderMarketTasks(tasks) {
+    const marketTasksDiv = document.getElementById('scheduler-market-tasks');
+    if (!marketTasksDiv) return;
+
+    if (!tasks || tasks.length === 0) {
+        marketTasksDiv.innerHTML = '<div class="card"><span>등록된 시장별 백그라운드 전략이 없습니다.</span></div>';
+        return;
+    }
+
+    marketTasksDiv.innerHTML = tasks.map(task => {
+        const running = task.running || task.state === 'running';
+        const stateBadge = running
+            ? '<span class="badge open">실행 중</span>'
+            : '<span class="badge closed">대기</span>';
+        const modeBadge = task.live_trading
+            ? '<span class="badge closed">실주문</span>'
+            : '<span class="badge paper">관찰/Paper</span>';
+        const progress = task.progress || {};
+        const watchCount = progress.watch_count ?? progress.watch ?? progress.candidates;
+        const progressText = watchCount != null
+            ? `감시 ${Number(watchCount).toLocaleString()}개`
+            : `상태 ${escapeHtml(task.state || '-')}`;
+
+        return `
+        <div class="card" style="margin-bottom:8px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
+                <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                    <h3 style="margin:0;color:var(--text-primary);">${escapeHtml(task.display_name || task.name)}</h3>
+                    <span class="badge paper">${escapeHtml(task.market_label || task.market || '시장')}</span>
+                    ${stateBadge}
+                    ${modeBadge}
+                </div>
+                <span class="badge paper">${escapeHtml(task.mode || 'background')}</span>
+            </div>
+            <div style="margin-top:8px;color:var(--text-secondary);font-size:0.9em;">
+                ${progressText} | 실주문 자동매매: ${task.live_trading ? '허용' : '잠금'}
             </div>
         </div>`;
     }).join('');

--- a/view/web/templates/scheduler.html
+++ b/view/web/templates/scheduler.html
@@ -12,8 +12,11 @@
             </div>
         </div>
 
-        <h3 style="margin:16px 0 8px; color:var(--text-primary);">등록된 전략</h3>
+        <h3 style="margin:16px 0 8px; color:var(--text-primary);">국내 자동전략</h3>
         <div id="scheduler-strategies"></div>
+
+        <h3 style="margin:16px 0 8px; color:var(--text-primary);">시장별 백그라운드 전략</h3>
+        <div id="scheduler-market-tasks"></div>
 
         <h3 style="margin:24px 0 8px; color:var(--text-primary);">시그널 실행 이력</h3>
         <div id="scheduler-history-tabs" class="sub-nav-container" style="margin-bottom:12px;"></div>
@@ -39,7 +42,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/scheduler.js?v=6"></script>
+<script src="/static/js/scheduler.js?v=7"></script>
 <script>
     loadSchedulerStatus();
 </script>


### PR DESCRIPTION
## Summary
- expose overseas market background task status from /api/scheduler/status
- show domestic scheduler and market-specific background tasks separately in scheduler UI
- add unit/integration coverage for US intraday VBO status visibility

## Tests
- python -m pytest tests/unit_test/test_scheduler_route_status.py -v
- python -m pytest tests/integration_test/test_it_scheduler_status_market_tasks.py -v
- node --check view/web/static/js/scheduler.js
- python -m pytest tests/unit_test -v
- python -m pytest tests/integration_test -v