### PR TITLE
Split strategy schedulers by market

### DIFF
--- a/task/background/intraday/strategy_scheduler_task_adapter.py
+++ b/task/background/intraday/strategy_scheduler_task_adapter.py
@@ -19,13 +19,21 @@ class StrategySchedulerTaskAdapter(SchedulableTask):
     전략에서 발생하는 매수/매도 주문은 foreground 우선순위로 실행된다.
     """
 
-    def __init__(self, scheduler: StrategyScheduler, market_clock: Optional["MarketClock"] = None):
+    def __init__(
+        self,
+        scheduler: StrategyScheduler,
+        market_clock: Optional["MarketClock"] = None,
+        market: str = "",
+    ):
         self._scheduler = scheduler
         self._market_clock = market_clock
+        self._market = str(market or "").strip()
         self._state: TaskState = TaskState.IDLE
 
     @property
     def task_name(self) -> str:
+        if self._market:
+            return f"{self._market}_strategy_scheduler"
         return "strategy_scheduler"
 
     @property

--- a/tests/integration_test/test_it_scheduler_status_market_tasks.py
+++ b/tests/integration_test/test_it_scheduler_status_market_tasks.py
@@ -14,6 +14,7 @@ class _OverseasIntradayVBOTask:
 
 def test_it_scheduler_status_exposes_overseas_market_tasks(paper_client, mock_paper_ctx):
     mock_paper_ctx.scheduler = None
+    mock_paper_ctx.strategy_schedulers = {"domestic": None, "overseas_us": None}
     mock_paper_ctx.enabled_market_modes = ["domestic", "overseas_us"]
     mock_paper_ctx.background_scheduler = MagicMock()
     mock_paper_ctx.background_scheduler.get_task.side_effect = (
@@ -28,6 +29,7 @@ def test_it_scheduler_status_exposes_overseas_market_tasks(paper_client, mock_pa
     body = response.json()
     assert body["running"] is False
     assert body["strategies"] == []
+    assert [item["market"] for item in body["schedulers"]] == ["domestic", "overseas_us"]
     assert body["market_tasks"][0]["name"] == "overseas_intraday_vbo"
     assert body["market_tasks"][0]["market"] == "overseas_us"
     assert body["market_tasks"][0]["running"] is True

--- a/tests/unit_test/task/background/intraday/test_strategy_scheduler_task_adapter.py
+++ b/tests/unit_test/task/background/intraday/test_strategy_scheduler_task_adapter.py
@@ -33,6 +33,12 @@ def test_task_name(adapter):
     assert adapter.task_name == "strategy_scheduler"
 
 
+def test_market_scoped_task_name(mock_strategy_scheduler):
+    adapter = StrategySchedulerTaskAdapter(mock_strategy_scheduler, market="domestic")
+
+    assert adapter.task_name == "domestic_strategy_scheduler"
+
+
 def test_priority(adapter):
     assert adapter.priority == TaskPriority.NORMAL
 

--- a/tests/unit_test/test_scheduler_route_status.py
+++ b/tests/unit_test/test_scheduler_route_status.py
@@ -25,6 +25,7 @@ async def test_scheduler_status_includes_overseas_market_task_without_domestic_s
     )
     ctx = SimpleNamespace(
         scheduler=None,
+        strategy_schedulers={"domestic": None, "overseas_us": None},
         background_scheduler=background_scheduler,
         enabled_market_modes=["domestic", "overseas_us"],
     )
@@ -36,6 +37,7 @@ async def test_scheduler_status_includes_overseas_market_task_without_domestic_s
 
     assert status["running"] is False
     assert status["strategies"] == []
+    assert [item["market"] for item in status["schedulers"]] == ["domestic", "overseas_us"]
     assert status["market_tasks"] == [
         {
             "name": "overseas_intraday_vbo",

--- a/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
+++ b/tests/unit_test/view/web/bootstrap/test_strategy_factory.py
@@ -67,9 +67,11 @@ def test_strategy_factory_creates_scheduler(patched_factory_deps):
     from view.web.bootstrap.strategy_factory import StrategyFactory
 
     ctx = _make_fake_context()
+    ctx.strategy_schedulers = {}
     StrategyFactory(ctx).build()
 
     assert ctx.scheduler is patched_factory_deps["StrategyScheduler"].return_value
+    assert ctx.strategy_schedulers["domestic"] is ctx.scheduler
 
 
 def test_strategy_factory_wires_live_expansion_gate_with_journal_provider(patched_factory_deps):
@@ -148,10 +150,11 @@ def test_strategy_factory_registers_adapter_to_background_scheduler(patched_fact
     from view.web.bootstrap.strategy_factory import StrategyFactory
 
     ctx = _make_fake_context()
+    ctx.strategy_schedulers = {}
     StrategyFactory(ctx).build()
 
     patched_factory_deps["StrategySchedulerTaskAdapter"].assert_called_once_with(
-        ctx.scheduler, market_clock=ctx.market_clock
+        ctx.scheduler, market_clock=ctx.market_clock, market="domestic"
     )
     ctx.background_scheduler.register.assert_called_once_with(
         patched_factory_deps["StrategySchedulerTaskAdapter"].return_value

--- a/tests/unit_test/view/web/routes/test_web_routes_scheduler.py
+++ b/tests/unit_test/view/web/routes/test_web_routes_scheduler.py
@@ -10,11 +10,14 @@ from urllib.parse import quote
 @pytest.mark.asyncio
 async def test_scheduler_endpoints(web_client, mock_web_ctx):
     """스케줄러 관련 엔드포인트 테스트"""
+    mock_web_ctx.strategy_schedulers = {"domestic": mock_web_ctx.scheduler}
+
     # Status
     mock_web_ctx.scheduler.get_status = MagicMock(return_value={"running": False})
     response = web_client.get("/api/scheduler/status")
     assert response.status_code == 200
     assert response.json()["running"] is False
+    assert response.json()["schedulers"][0]["market"] == "domestic"
 
     # Start
     response = web_client.post("/api/scheduler/start")
@@ -138,6 +141,7 @@ async def test_scheduler_strategy_control_with_larry_williams_cb(web_client, moc
 async def test_scheduler_not_initialized(web_client, mock_web_ctx):
     """스케줄러 미초기화 상태 테스트"""
     mock_web_ctx.scheduler = None
+    mock_web_ctx.strategy_schedulers = {"domestic": None, "overseas_us": None}
 
     assert web_client.get("/api/scheduler/status").json()["running"] is False
     assert web_client.post("/api/scheduler/start").status_code == 503
@@ -145,6 +149,34 @@ async def test_scheduler_not_initialized(web_client, mock_web_ctx):
     assert web_client.post("/api/scheduler/strategy/A/start").status_code == 503
     assert web_client.post("/api/scheduler/strategy/A/stop").status_code == 503
     assert web_client.get("/api/scheduler/history").json()["history"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_market_query_uses_requested_scheduler(web_client, mock_web_ctx):
+    """market 파라미터로 국내/미국장 전략 스케줄러를 분리 조회한다."""
+    domestic_scheduler = MagicMock()
+    domestic_scheduler.get_status.return_value = {"running": False, "strategies": []}
+    overseas_scheduler = MagicMock()
+    overseas_scheduler.get_status.return_value = {
+        "running": True,
+        "dry_run": True,
+        "strategies": [{"name": "USVBO", "holdings": []}],
+    }
+    mock_web_ctx.scheduler = domestic_scheduler
+    mock_web_ctx.strategy_schedulers = {
+        "domestic": domestic_scheduler,
+        "overseas_us": overseas_scheduler,
+    }
+
+    response = web_client.get("/api/scheduler/status?market=overseas_us")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["market"] == "overseas_us"
+    assert data["running"] is True
+    assert data["strategies"][0]["market"] == "overseas_us"
+    assert [item["market"] for item in data["schedulers"]] == ["domestic", "overseas_us"]
+    overseas_scheduler.get_status.assert_called()
 
 @pytest.mark.asyncio
 async def test_scheduler_strategy_control_failure(web_client, mock_web_ctx):

--- a/view/web/bootstrap/strategy_factory.py
+++ b/view/web/bootstrap/strategy_factory.py
@@ -37,7 +37,7 @@ class StrategyFactory:
             ctx.logger.info(
                 "[StrategyFactory] market_mode=overseas_us — 해외주식 v1은 자동전략을 비활성화합니다."
             )
-            ctx.scheduler = None
+            self._set_scheduler("overseas_us", None)
             return
         if not (ctx.runtime_mode & RuntimeMode.TRADING):
             ctx.logger.info(
@@ -45,7 +45,7 @@ class StrategyFactory:
                 ctx.runtime_mode,
             )
             return
-        ctx.scheduler = StrategyScheduler(
+        scheduler = StrategyScheduler(
             virtual_trade_service=ctx.virtual_trade_service,
             order_execution_service=ctx.order_execution_service,
             stock_query_service=ctx.stock_query_service,
@@ -75,6 +75,7 @@ class StrategyFactory:
                 logger=ctx.logger,
             ),
         )
+        self._set_scheduler("domestic", scheduler)
 
         # 오닐 스퀴즈 돌파 전략 등록
         osb_strategy = OneilSqueezeBreakoutStrategy(
@@ -83,7 +84,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('OneilSqueezeBreakout'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=osb_strategy,
             interval_minutes=3,
             max_positions=5,
@@ -104,7 +105,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('OneilPocketPivot'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=pp_strategy,
             interval_minutes=3,
             max_positions=5,
@@ -122,7 +123,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('HighTightFlag'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=htf_strategy,
             interval_minutes=3,
             max_positions=5,
@@ -139,7 +140,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('FirstPullback'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=fp_strategy,
             interval_minutes=3,
             max_positions=5,
@@ -157,7 +158,7 @@ class StrategyFactory:
             logger=get_strategy_logger('LarryWilliamsVBO'),
             trade_history_provider=ctx.virtual_trade_service.get_all_trades,
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=vbo_strategy,
             interval_minutes=5,
             max_positions=3,
@@ -176,7 +177,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('RSI2Pullback'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=rsi2_strategy,
             interval_minutes=5,
             max_positions=5,
@@ -194,7 +195,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('LarryWilliamsCB'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=lwcb_strategy,
             interval_minutes=5,
             max_positions=5,
@@ -215,7 +216,7 @@ class StrategyFactory:
             market_clock=ctx.market_clock,
             logger=get_strategy_logger('InverseEtfRegime'),
         )
-        ctx.scheduler.register(StrategySchedulerConfig(
+        scheduler.register(StrategySchedulerConfig(
             strategy=inverse_etf_strategy,
             interval_minutes=5,
             max_positions=1,            # 단일 종목 슬리브
@@ -230,6 +231,22 @@ class StrategyFactory:
         ctx.logger.info("웹 앱: 전략 스케줄러 초기화 완료 (수동 시작 대기)")
 
         # StrategyScheduler를 BackgroundScheduler에 어댑터로 등록
-        if ctx.background_scheduler and ctx.scheduler:
-            adapter = StrategySchedulerTaskAdapter(ctx.scheduler, market_clock=ctx.market_clock)
+        if ctx.background_scheduler and scheduler:
+            adapter = StrategySchedulerTaskAdapter(
+                scheduler,
+                market_clock=ctx.market_clock,
+                market="domestic",
+            )
             ctx.background_scheduler.register(adapter)
+
+    def _set_scheduler(self, market: str, scheduler) -> None:
+        ctx = self._ctx
+        setter = getattr(ctx, "set_strategy_scheduler", None)
+        if callable(setter):
+            setter(market, scheduler)
+            return
+        schedulers = getattr(ctx, "strategy_schedulers", None)
+        if isinstance(schedulers, dict):
+            schedulers[market] = scheduler
+        if market == "domestic":
+            ctx.scheduler = scheduler

--- a/view/web/routes/scheduler.py
+++ b/view/web/routes/scheduler.py
@@ -32,13 +32,18 @@ _MARKET_TASK_DEFINITIONS = (
     },
 )
 
+_MARKET_LABELS = {
+    "domestic": "한국장",
+    "overseas_us": "미국장",
+}
 
-def _save_scheduler_state_later(ctx) -> None:
+
+def _save_scheduler_state_later(scheduler) -> None:
     """상태 저장은 응답 경로를 막지 않도록 백그라운드에서 수행한다."""
-    asyncio.create_task(asyncio.to_thread(ctx.scheduler._save_scheduler_state))
+    asyncio.create_task(asyncio.to_thread(scheduler._save_scheduler_state))
 
 
-def _market_task_status(ctx) -> list[dict]:
+def _market_task_status(ctx, market: str | None = None) -> list[dict]:
     """StrategyScheduler 밖에서 도는 시장별 전략성 태스크를 상태 API에 노출한다."""
     background_scheduler = getattr(ctx, "background_scheduler", None)
     if background_scheduler is None:
@@ -46,6 +51,8 @@ def _market_task_status(ctx) -> list[dict]:
 
     items = []
     for definition in _MARKET_TASK_DEFINITIONS:
+        if market and definition["market"] != market:
+            continue
         task = background_scheduler.get_task(definition["name"])
         if task is None:
             continue
@@ -62,23 +69,73 @@ def _market_task_status(ctx) -> list[dict]:
     return items
 
 
+def _enabled_scheduler_markets(ctx) -> list[str]:
+    enabled = getattr(ctx, "enabled_market_modes", None)
+    if not isinstance(enabled, list) or not enabled:
+        enabled = ["domestic"]
+    markets = []
+    for market in [*enabled, "domestic", "overseas_us"]:
+        if market not in markets:
+            markets.append(market)
+    return markets
+
+
+def _get_strategy_scheduler(ctx, market: str = "domestic"):
+    schedulers = getattr(ctx, "strategy_schedulers", None)
+    if isinstance(schedulers, dict):
+        scheduler = schedulers.get(market)
+        if scheduler is not None:
+            return scheduler
+    getter = getattr(ctx, "get_strategy_scheduler", None)
+    getter_module = type(getter).__module__ if getter is not None else ""
+    if callable(getter) and not getter_module.startswith("unittest.mock"):
+        return getter(market)
+    if market == "domestic":
+        return getattr(ctx, "scheduler", None)
+    return None
+
+
+def _scheduler_status_payload(ctx, market: str, scheduler) -> dict:
+    if scheduler is None:
+        status = {"running": False, "dry_run": False, "strategies": []}
+    else:
+        status = scheduler.get_status()
+
+    status = dict(status or {})
+    strategies = []
+    for strategy in status.get("strategies", []) or []:
+        item = dict(strategy)
+        item.setdefault("market", market)
+        item.setdefault("market_label", _MARKET_LABELS.get(market, market))
+        strategies.append(item)
+    status["strategies"] = strategies
+    status["market"] = market
+    status["market_label"] = _MARKET_LABELS.get(market, market)
+    status["has_scheduler"] = scheduler is not None
+    status["market_tasks"] = _market_task_status(ctx, market)
+    return status
+
+
+def _status_for_market(ctx, market: str) -> dict:
+    return _scheduler_status_payload(ctx, market, _get_strategy_scheduler(ctx, market))
+
+
+def _all_scheduler_statuses(ctx) -> list[dict]:
+    return [_status_for_market(ctx, market) for market in _enabled_scheduler_markets(ctx)]
+
+
 @router.get("/scheduler/status")
-async def get_scheduler_status():
+async def get_scheduler_status(market: str | None = None):
     """스케줄러 상태 조회."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
-        return {
-            "running": False,
-            "strategies": [],
-            "market_tasks": _market_task_status(ctx),
-        }
-    
-    status = await asyncio.to_thread(ctx.scheduler.get_status)
+    selected_market = market or "domestic"
+    status = await asyncio.to_thread(_status_for_market, ctx, selected_market)
+    status["schedulers"] = await asyncio.to_thread(_all_scheduler_statuses, ctx)
     status["market_tasks"] = _market_task_status(ctx)
     
     # [BugFix] 보유 종목명 보정
     mapper = getattr(ctx, 'stock_code_repository', None)
-    if mapper:
+    if mapper and selected_market == "domestic":
         for s in status.get("strategies", []):
             for hold in s.get("holdings", []):
                 code = str(hold.get("code", ""))
@@ -94,10 +151,11 @@ async def get_scheduler_status():
 async def start_scheduler():
     """스케줄러 시작 (상태 저장 — 재시작 시 자동 복원)."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx)
+    if not scheduler:
         raise HTTPException(status_code=503, detail="스케줄러가 초기화되지 않았습니다")
-    await ctx.scheduler.start()
-    _save_scheduler_state_later(ctx)
+    await scheduler.start()
+    _save_scheduler_state_later(scheduler)
     return {"success": True}
 
 
@@ -105,72 +163,82 @@ async def start_scheduler():
 async def stop_scheduler():
     """스케줄러 정지 (수동 정지 — 재시작 시 자동 실행 안 함)."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx)
+    if not scheduler:
         raise HTTPException(status_code=503, detail="스케줄러가 초기화되지 않았습니다")
-    await ctx.scheduler.stop(save_state=False)
-    ctx.scheduler.clear_saved_state()
+    await scheduler.stop(save_state=False)
+    scheduler.clear_saved_state()
     return {"success": True}
 
 
 @router.post("/scheduler/strategy/{name:path}/start")
-async def start_strategy(name: str):
+async def start_strategy(name: str, market: str = "domestic"):
     """개별 전략 활성화 (상태 저장 — 재시작 시 자동 복원)."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx, market)
+    if not scheduler:
         raise HTTPException(status_code=503, detail="스케줄러가 초기화되지 않았습니다")
-    if not await ctx.scheduler.start_strategy(name):
+    if not await scheduler.start_strategy(name):
         raise HTTPException(status_code=404, detail=f"전략 '{name}'을 찾을 수 없습니다")
-    _save_scheduler_state_later(ctx)
+    _save_scheduler_state_later(scheduler)
     return {"success": True}
 
 
 @router.post("/scheduler/strategy/{name:path}/stop")
-async def stop_strategy(name: str):
+async def stop_strategy(name: str, market: str = "domestic"):
     """개별 전략 비활성화 (상태 저장 — 재시작 시 반영)."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx, market)
+    if not scheduler:
         raise HTTPException(status_code=503, detail="스케줄러가 초기화되지 않았습니다")
-    if not await ctx.scheduler.stop_strategy(name):
+    if not await scheduler.stop_strategy(name):
         raise HTTPException(status_code=404, detail=f"전략 '{name}'을 찾을 수 없습니다")
-    _save_scheduler_state_later(ctx)
+    _save_scheduler_state_later(scheduler)
     return {"success": True}
 
 
 @router.post("/scheduler/strategy/{name:path}/max-positions")
-async def update_strategy_max_positions(name: str, req: UpdateMaxPositionsRequest):
+async def update_strategy_max_positions(
+    name: str,
+    req: UpdateMaxPositionsRequest,
+    market: str = "domestic",
+):
     """개별 전략의 최대 포지션 수 동적 변경."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx, market)
+    if not scheduler:
         raise HTTPException(status_code=503, detail="스케줄러가 초기화되지 않았습니다")
     
-    success = await ctx.scheduler.update_max_positions(name, req.max_positions)
+    success = await scheduler.update_max_positions(name, req.max_positions)
     if not success:
         raise HTTPException(status_code=400, detail="최대 포지션 수 변경 실패 (1 이상이어야 함)")
     return {"success": True}
 
 @router.get("/scheduler/history")
-async def get_scheduler_history(strategy: str = None):
+async def get_scheduler_history(strategy: str = None, market: str = "domestic"):
     """스케줄러 시그널 실행 이력 조회. ?strategy=전략명 으로 필터 가능."""
     ctx = _get_ctx()
     t_start = ctx.pm.start_timer()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx, market)
+    if not scheduler:
         return {"history": []}
 
-    history = ctx.scheduler.get_signal_history(strategy)
+    history = scheduler.get_signal_history(strategy)
 
     ctx.pm.log_timer("get_scheduler_history", t_start)
     return {"history": history}
 
 @router.get("/scheduler/stream")
-async def stream_scheduler_signals(request: Request):
+async def stream_scheduler_signals(request: Request, market: str = "domestic"):
     """SSE 스트리밍: 스케줄러 시그널 실행 이력을 실시간으로 브라우저에 전달."""
     ctx = _get_ctx()
-    if not ctx.scheduler:
+    scheduler = _get_strategy_scheduler(ctx, market)
+    if not scheduler:
         return StreamingResponse(
             iter([": no scheduler\n\n"]), media_type="text/event-stream"
         )
 
-    queue = ctx.scheduler.create_subscriber_queue()
+    queue = scheduler.create_subscriber_queue()
 
     async def event_generator():
         try:
@@ -187,7 +255,7 @@ async def stream_scheduler_signals(request: Request):
         except asyncio.CancelledError:
             pass
         finally:
-            ctx.scheduler.remove_subscriber_queue(queue)
+            scheduler.remove_subscriber_queue(queue)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 

--- a/view/web/static/js/scheduler.js
+++ b/view/web/static/js/scheduler.js
@@ -21,7 +21,11 @@ function fetchSchedulerJson(url, options = {}, timeoutMs = 8000) {
 }
 
 function syncSchedulerRealtimeState(data) {
-    if (data && data.running) {
+    const schedulers = (data && data.schedulers) || [];
+    const marketTasks = (data && data.market_tasks) || [];
+    const hasRunningScheduler = data && (data.running || schedulers.some(item => item.running));
+    const hasRunningMarketTask = marketTasks.some(task => task.running || task.state === 'running');
+    if (hasRunningScheduler || hasRunningMarketTask) {
         if (!schedulerPollingId) {
             startSchedulerPolling();
         }
@@ -70,12 +74,13 @@ async function loadSchedulerStatus() {
 function renderSchedulerStatus(data) {
     const badge = document.getElementById('scheduler-status-badge');
     const info = document.getElementById('scheduler-info');
-    const strategiesDiv = document.getElementById('scheduler-strategies');
 
+    const schedulers = data.schedulers || [data];
     const marketTasks = data.market_tasks || [];
+    const hasRunningScheduler = schedulers.some(item => item.running);
     const hasRunningMarketTask = marketTasks.some(task => task.running || task.state === 'running');
 
-    if (data.running) {
+    if (hasRunningScheduler) {
         badge.textContent = '실행 중';
         badge.className = 'badge open';
     } else if (hasRunningMarketTask) {
@@ -86,18 +91,61 @@ function renderSchedulerStatus(data) {
         badge.className = 'badge closed';
     }
 
-    const dryLabel = data.running
-        ? (data.dry_run ? '국내 자동전략 dry-run: CSV만 기록' : '국내 자동전략 실제 주문 실행')
-        : '국내 자동전략 정지';
-    info.textContent = dryLabel;
+    const activeSchedulers = schedulers.filter(item => item.running).length;
+    const activeMarketTasks = marketTasks.filter(task => task.running || task.state === 'running').length;
+    info.textContent = `전략 스케줄러 ${activeSchedulers}/${schedulers.length} 실행 | 시장 태스크 ${activeMarketTasks}/${marketTasks.length} 실행`;
+    renderSchedulerSections(schedulers);
     renderMarketTasks(marketTasks);
+}
 
-    if (!data.strategies || data.strategies.length === 0) {
-        strategiesDiv.innerHTML = '<div class="card"><span>등록된 전략이 없습니다.</span></div>';
+function jsString(value) {
+    return String(value ?? '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function renderSchedulerSections(schedulers) {
+    const strategiesDiv = document.getElementById('scheduler-strategies');
+    if (!strategiesDiv) return;
+
+    if (!schedulers || schedulers.length === 0) {
+        strategiesDiv.innerHTML = '<div class="card"><span>등록된 전략 스케줄러가 없습니다.</span></div>';
         return;
     }
 
-    strategiesDiv.innerHTML = data.strategies.map(s => {
+    strategiesDiv.innerHTML = schedulers.map(section => renderSchedulerSection(section)).join('');
+}
+
+function renderSchedulerSection(section) {
+    const market = section.market || 'domestic';
+    const marketLabel = section.market_label || market;
+    const runningBadge = section.running
+        ? '<span class="badge open">실행 중</span>'
+        : '<span class="badge closed">정지</span>';
+    const modeText = section.has_scheduler
+        ? (section.dry_run ? 'dry-run: CSV만 기록' : '실제 주문 실행')
+        : '스케줄러 미구성';
+    const strategies = section.strategies || [];
+
+    let bodyHtml = '';
+    if (!section.has_scheduler) {
+        bodyHtml = '<div class="card"><span>이 시장의 StrategyScheduler가 아직 구성되지 않았습니다.</span></div>';
+    } else if (strategies.length === 0) {
+        bodyHtml = '<div class="card"><span>등록된 전략이 없습니다.</span></div>';
+    } else {
+        bodyHtml = strategies.map(s => renderStrategyCard(s, market)).join('');
+    }
+
+    return `
+    <section style="margin-bottom:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin:8px 0;">
+            <h4 style="margin:0;color:var(--text-primary);">${escapeHtml(marketLabel)}</h4>
+            ${runningBadge}
+            <span class="badge paper">${escapeHtml(modeText)}</span>
+        </div>
+        ${bodyHtml}
+    </section>`;
+}
+
+function renderStrategyCard(s, market) {
         const displayName = s.display_name || s.name;
         const enabledBadge = s.enabled
             ? '<span class="badge open">활성</span>'
@@ -107,10 +155,10 @@ function renderSchedulerStatus(data) {
             : '';
         const adminAllowed = typeof window.hasRequiredRole !== 'function'
             || window.hasRequiredRole('admin');
-        const positionBadge = `<span class="badge ${s.current_holds >= s.max_positions ? 'closed' : 'paper'}" style="cursor:${adminAllowed ? 'pointer' : 'default'};" ${adminAllowed ? `onclick="updateMaxPositions('${s.name}', ${s.max_positions})"` : ''} title="${adminAllowed ? '클릭하여 최대 포지션 수 변경' : 'admin 권한 필요'}">포지션 ${s.current_holds}/${s.max_positions} ✏️</span>`;
+        const positionBadge = `<span class="badge ${s.current_holds >= s.max_positions ? 'closed' : 'paper'}" style="cursor:${adminAllowed ? 'pointer' : 'default'};" ${adminAllowed ? `onclick="updateMaxPositions('${jsString(s.name)}', ${s.max_positions}, '${jsString(market)}')"` : ''} title="${adminAllowed ? '클릭하여 최대 포지션 수 변경' : 'admin 권한 필요'}">포지션 ${s.current_holds}/${s.max_positions} ✏️</span>`;
         const toggleBtn = s.enabled
-            ? `<button class="btn btn-sell" data-required-role="admin" ${adminAllowed ? '' : 'disabled'} style="padding:4px 12px;font-size:0.85em;" onclick="stopStrategy('${s.name}')">정지</button>`
-            : `<button class="btn btn-buy" data-required-role="admin" ${adminAllowed ? '' : 'disabled'} style="padding:4px 12px;font-size:0.85em;" onclick="startStrategy('${s.name}')">시작</button>`;
+            ? `<button class="btn btn-sell" data-required-role="admin" ${adminAllowed ? '' : 'disabled'} style="padding:4px 12px;font-size:0.85em;" onclick="stopStrategy('${jsString(s.name)}', '${jsString(market)}')">정지</button>`
+            : `<button class="btn btn-buy" data-required-role="admin" ${adminAllowed ? '' : 'disabled'} style="padding:4px 12px;font-size:0.85em;" onclick="startStrategy('${jsString(s.name)}', '${jsString(market)}')">시작</button>`;
         // 보유 종목 리스트 렌더링
         let holdingsHtml = '';
         if (s.holdings && s.holdings.length > 0) {
@@ -142,7 +190,6 @@ function renderSchedulerStatus(data) {
                 실행 주기: ${s.interval_minutes}분 | 마지막 실행: ${s.last_run || '-'}
             </div>
         </div>`;
-    }).join('');
 }
 
 function renderMarketTasks(tasks) {
@@ -208,9 +255,9 @@ async function stopScheduler() {
     }
 }
 
-async function startStrategy(name) {
+async function startStrategy(name, market = 'domestic') {
     try {
-        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/start`, { method: 'POST' });
+        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/start?market=${encodeURIComponent(market)}`, { method: 'POST' });
         if (data.success) {
             refreshSchedulerStatusSoon();
         }
@@ -219,9 +266,9 @@ async function startStrategy(name) {
     }
 }
 
-async function stopStrategy(name) {
+async function stopStrategy(name, market = 'domestic') {
     try {
-        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/stop`, { method: 'POST' });
+        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/stop?market=${encodeURIComponent(market)}`, { method: 'POST' });
         if (data.success) {
             refreshSchedulerStatusSoon();
         }
@@ -230,7 +277,7 @@ async function stopStrategy(name) {
     }
 }
 
-async function updateMaxPositions(name, currentMax) {
+async function updateMaxPositions(name, currentMax, market = 'domestic') {
     const newVal = prompt(`'${name}' 전략의 최대 보유 포지션 수를 입력하세요:`, currentMax);
     if (newVal === null) return; // Cancelled
     
@@ -241,7 +288,7 @@ async function updateMaxPositions(name, currentMax) {
     }
 
     try {
-        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/max-positions`, {
+        const data = await fetchSchedulerJson(`/api/scheduler/strategy/${encodeURIComponent(name)}/max-positions?market=${encodeURIComponent(market)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ max_positions: parsed })

--- a/view/web/templates/scheduler.html
+++ b/view/web/templates/scheduler.html
@@ -12,7 +12,7 @@
             </div>
         </div>
 
-        <h3 style="margin:16px 0 8px; color:var(--text-primary);">국내 자동전략</h3>
+        <h3 style="margin:16px 0 8px; color:var(--text-primary);">시장별 전략 스케줄러</h3>
         <div id="scheduler-strategies"></div>
 
         <h3 style="margin:16px 0 8px; color:var(--text-primary);">시장별 백그라운드 전략</h3>
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/scheduler.js?v=7"></script>
+<script src="/static/js/scheduler.js?v=8"></script>
 <script>
     loadSchedulerStatus();
 </script>

--- a/view/web/web_app_initializer.py
+++ b/view/web/web_app_initializer.py
@@ -146,6 +146,10 @@ class WebAppContext:
         self.order_policy_service: OrderPolicyService = None
         self.execution_flow_service: ExecutionFlowService = None
         self.position_sizing_service: PositionSizingService = None
+        self.strategy_schedulers: dict[str, StrategyScheduler | None] = {
+            "domestic": None,
+            "overseas_us": None,
+        }
         self.scheduler: StrategyScheduler = None
         self.oneil_universe_service: OneilUniverseService = None
         self.ranking_task: RankingTask = None
@@ -415,6 +419,36 @@ class WebAppContext:
         from view.web.bootstrap.strategy_factory import StrategyFactory
         StrategyFactory(self).build()
 
+    def set_strategy_scheduler(self, market: str, scheduler: StrategyScheduler | None) -> None:
+        """시장별 StrategyScheduler 슬롯을 갱신한다."""
+        market_key = str(market or "domestic")
+        self.strategy_schedulers[market_key] = scheduler
+        if market_key == "domestic":
+            self.scheduler = scheduler
+
+    def get_strategy_scheduler(self, market: str = "domestic") -> StrategyScheduler | None:
+        """시장별 StrategyScheduler를 반환한다. 기존 ctx.scheduler는 국내장 alias로 유지한다."""
+        market_key = str(market or "domestic")
+        scheduler = self.strategy_schedulers.get(market_key)
+        if scheduler is None and market_key == "domestic":
+            return self.scheduler
+        return scheduler
+
+    def iter_strategy_schedulers(self):
+        """등록된 시장별 StrategyScheduler를 (market, scheduler) 순서쌍으로 반환한다."""
+        seen: set[int] = set()
+        for market, scheduler in self.strategy_schedulers.items():
+            if scheduler is None:
+                continue
+            ident = id(scheduler)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            yield market, scheduler
+        scheduler = self.scheduler
+        if scheduler is not None and id(scheduler) not in seen:
+            yield "domestic", scheduler
+
     async def ensure_strategy_states_loaded(self):
         """등록된 전략 중 `load_state()` 를 가진 전략의 state 를 명시적으로 await 로드한다.
 
@@ -428,26 +462,28 @@ class WebAppContext:
           실전에서는 stale/유실 state 로 신규 주문이 나가는 위험이 더 크다.
         - env 미설정: 보수적으로 fail-OPEN 동작.
         """
-        if self.scheduler is None:
+        schedulers = list(self.iter_strategy_schedulers())
+        if not schedulers:
             return
         is_paper = True
         if self.env is not None:
             is_paper = bool(getattr(self.env, "is_paper_trading", True))
         failed: list[tuple[str, BaseException]] = []
-        for cfg in getattr(self.scheduler, "_strategies", []):
-            strategy = getattr(cfg, "strategy", None)
-            load_fn = getattr(strategy, "load_state", None)
-            if load_fn is None:
-                continue
-            try:
-                await load_fn()
-            except Exception as exc:
-                name = getattr(strategy, "name", "?")
-                if self.logger:
-                    self.logger.error(
-                        f"[WebAppContext] strategy.load_state() 실패 ({name}): {exc}"
-                    )
-                failed.append((name, exc))
+        for market, scheduler in schedulers:
+            for cfg in getattr(scheduler, "_strategies", []):
+                strategy = getattr(cfg, "strategy", None)
+                load_fn = getattr(strategy, "load_state", None)
+                if load_fn is None:
+                    continue
+                try:
+                    await load_fn()
+                except Exception as exc:
+                    name = getattr(strategy, "name", "?")
+                    if self.logger:
+                        self.logger.error(
+                            f"[WebAppContext] strategy.load_state() 실패 ({market}:{name}): {exc}"
+                        )
+                    failed.append((f"{market}:{name}", exc))
         if failed and not is_paper:
             names = ", ".join(name for name, _ in failed)
             raise RuntimeError(


### PR DESCRIPTION
## Summary
- add market-scoped strategy scheduler registry while keeping ctx.scheduler as the domestic alias
- expose scheduler status/control per market and render Korean/US sections in the UI
- scope the background task adapter name for the domestic strategy scheduler

## Tests
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/unit_test -v
- C:\Users\Kyungsoo\anaconda3\envs\py310\python.exe -m pytest tests/integration_test -v
- node --check view\web\static\js\scheduler.js